### PR TITLE
[CSPM] Add export log for APT and systemd timers for unattended upgrades compliance

### DIFF
--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/compliance/aptconfig"
 	"github.com/DataDog/datadog-agent/pkg/compliance/k8sconfig"
 	"github.com/DataDog/datadog-agent/pkg/compliance/metrics"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -177,6 +178,12 @@ func (a *Agent) Start() error {
 		wg.Done()
 	}()
 
+	wg.Add(1)
+	go func() {
+		a.runAptConfigurationExport(ctx)
+		wg.Done()
+	}()
+
 	go func() {
 		<-ctx.Done()
 		wg.Wait()
@@ -300,6 +307,34 @@ func (a *Agent) runKubernetesConfigurationsExport(ctx context.Context) {
 		k8sResourceType, k8sResourceData := k8sconfig.LoadConfiguration(ctx, a.opts.HostRoot)
 		k8sResourceLog := NewResourceLog(a.opts.Hostname, k8sResourceType, k8sResourceData)
 		a.opts.Reporter.ReportEvent(k8sResourceLog)
+		if sleepAborted(ctx, runTicker.C) {
+			return
+		}
+	}
+}
+
+func (a *Agent) runAptConfigurationExport(ctx context.Context) {
+	ruleFilterModel := module.NewRuleFilterModel()
+	seclRuleFilter := rules.NewSECLRuleFilter(ruleFilterModel)
+	accepted, err := seclRuleFilter.IsRuleAccepted(&rules.RuleDefinition{
+		Filters: []string{aptconfig.SeclFilter},
+	})
+	if !accepted || err != nil {
+		return
+	}
+
+	runTicker := time.NewTicker(a.opts.CheckInterval)
+	defer runTicker.Stop()
+
+	for i := 0; ; i++ {
+		seed := fmt.Sprintf("%s%s%d", a.opts.Hostname, "apt-configuration", i)
+		jitter := randomJitter(seed, a.opts.RunJitterMax)
+		if sleepAborted(ctx, time.After(jitter)) {
+			return
+		}
+		aptResourceType, aptResourceData := aptconfig.LoadConfiguration(ctx, a.opts.HostRoot)
+		aptResourceLog := NewResourceLog(a.opts.Hostname, aptResourceType, aptResourceData)
+		a.opts.Reporter.ReportEvent(aptResourceLog)
 		if sleepAborted(ctx, runTicker.C) {
 			return
 		}

--- a/pkg/compliance/aptconfig/aptconfig.go
+++ b/pkg/compliance/aptconfig/aptconfig.go
@@ -292,7 +292,7 @@ func parseSystemdConf(str string) map[string]string {
 		} else if section != "" {
 			parts := strings.SplitN(line, "=", 2)
 			if len(parts) == 2 {
-				conf[section+":"+parts[0]] = parts[1]
+				conf[section+"/"+parts[0]] = parts[1]
 			}
 		}
 	}

--- a/pkg/compliance/aptconfig/aptconfig.go
+++ b/pkg/compliance/aptconfig/aptconfig.go
@@ -1,0 +1,300 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package aptconfig
+
+import (
+	"context"
+	"io"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// SeclFilter only selects ubuntu hosts for now on which is want to test out
+// and apply unattended upgrades checks.
+const SeclFilter = `os.id == "ubuntu"`
+
+const (
+	resourceType = "host_apt_config"
+
+	aptConfFile         = "/etc/apt/apt.conf"
+	aptConfFragmentsDir = "/etc/apt/apt.conf.d"
+	systemdConfDir      = "/etc/systemd/system"
+)
+
+// LoadConfiguration exports the aggregated APT configuration file and parts
+// of the systemd configuration files related to APT timers.
+func LoadConfiguration(ctx context.Context, hostroot string) (string, interface{}) {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Warnf("could not parse APT configuration properly: %v", err)
+		}
+	}()
+
+	aptConfDir := filepath.Join(hostroot, aptConfFragmentsDir)
+
+	aptConfFiles, _ := filepath.Glob(filepath.Join(aptConfDir, "*"))
+	sort.Strings(aptConfFiles)
+	aptConfFiles = append([]string{""}, aptConfFiles...)
+
+	aptConfs := make(map[string]interface{})
+	for _, path := range aptConfFiles {
+		data, err := readFileLimit(hostroot, path)
+		if err == nil {
+			conf := parseAPTConfiguration(data)
+			for k, v := range conf {
+				aptConfs[k] = v
+			}
+		}
+	}
+
+	systemdConfDir := filepath.Join(hostroot, systemdConfDir)
+	systemdTimersConfs := make(map[string]interface{})
+	var systemdConfFiles []string
+	_ = filepath.Walk(systemdConfDir, func(path string, info fs.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		base := filepath.Base(path)
+		if base == "apt-daily-upgrade.timer" || base == "apt-daily.timer" {
+			systemdConfFiles = append(systemdConfFiles, path)
+		}
+		return nil
+	})
+	sort.Strings(systemdConfFiles)
+
+	for _, path := range systemdConfFiles {
+		data, err := readFileLimit(hostroot, path)
+		if err == nil {
+			base := filepath.Base(path)
+			conf := parseSystemdConf(data)
+			systemdTimersConfs[base] = conf
+		}
+	}
+
+	resourceData := map[string]interface{}{
+		"apt": aptConfs,
+		"systemd": map[string]interface{}{
+			"timers": systemdTimersConfs,
+		},
+	}
+
+	return resourceType, resourceData
+}
+
+type tokenType int
+
+const (
+	eos tokenType = iota
+	literal
+	blockStart
+	blockEnd
+	data
+	equal
+	comment
+	comma
+	parseError
+)
+
+type token struct {
+	kind  tokenType
+	value string
+}
+
+func parseAPTConfiguration(str string) map[string]interface{} {
+	conf := make(map[string]interface{})
+	var cursor []string
+	var key string
+loop:
+	for {
+		var tok token
+		str, tok = nextTokenAPT(str)
+		switch tok.kind {
+		case blockStart:
+			cursor = append(cursor, key)
+		case blockEnd:
+			if len(cursor) > 0 {
+				cursor = cursor[:len(cursor)-1]
+			}
+			key = ""
+		case literal:
+			key = strings.Join(append(cursor, tok.value), "::")
+		case data:
+			if key != "" {
+				if v, ok := conf[key]; ok {
+					if a, ok := v.([]string); ok {
+						conf[key] = append(a, tok.value)
+					} else if s, ok := v.(string); ok {
+						conf[key] = append([]string{s}, tok.value)
+					}
+				} else {
+					conf[key] = tok.value
+				}
+			}
+		case comment, comma:
+		case eos:
+			break loop
+		default:
+			break loop
+		}
+	}
+	return conf
+}
+
+// man apt.conf.5: https://manpages.ubuntu.com/manpages/trusty/man5/apt.conf.5.html
+//
+//	> Syntactically the configuration language is modeled after what the ISC
+//	> tools such as bind and dhcp use. Lines starting with // are treated as
+//	> comments (ignored), as well as all text between /* and */, just like C/C++
+//	> comments. Each line is of the form APT::Get::Assume-Yes "true";. The
+//	> quotation marks and trailing semicolon are required. The value must be on
+//	> one line, and there is no kind of string concatenation. Values must not
+//	> include backslashes or extra quotation marks. Option names are made up of
+//	> alphanumeric characters and the characters "/-:._+". A new scope can be
+//	> opened with curly braces, like this:
+func nextTokenAPT(str string) (string, token) {
+	str = eatWhitespace(str)
+	if len(str) == 0 {
+		return "", token{kind: eos}
+	}
+	var t token
+	c := str[0]
+	i := 0
+	switch {
+	case c == '/' && strings.HasPrefix(str, "/*"):
+		t.kind = comment
+		i = 2
+		for _, r := range str[2:] {
+			i++
+			if r == '*' && strings.HasPrefix(str[i:], "*/") {
+				i++
+				break
+			}
+		}
+	case c == '/' && strings.HasPrefix(str, "//"):
+		t.kind = comment
+		i = 2
+		for _, r := range str[2:] {
+			i++
+			if r == '\n' {
+				break
+			}
+		}
+	case c == '#':
+		t.kind = comment
+		i = 1
+		for _, r := range str[1:] {
+			i++
+			if r == '\n' {
+				break
+			}
+		}
+	case (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'):
+		t.kind = literal
+		i = 1
+		for _, r := range str[1:] {
+			if !isLiteral(r) {
+				break
+			}
+			i++
+		}
+	case c == '{':
+		t.kind = blockStart
+		i = 1
+	case c == ';':
+		t.kind = comma
+		i = 1
+	case c == '}':
+		t.kind = blockEnd
+		i = 1
+	case c == '"':
+		ok := false
+		t.kind = data
+		i = 1
+		for _, r := range str[1:] {
+			if r == '"' {
+				if value, err := strconv.Unquote(str[:1+i]); err == nil {
+					ok = true
+					t.value = value
+					i++
+					break
+				}
+			}
+			i++
+		}
+		if !ok {
+			t.kind = parseError
+		}
+	}
+	if i == 0 {
+		t.kind = parseError
+	} else if t.kind != data {
+		t.value = str[:i]
+	}
+	return str[i:], t
+}
+
+func isLiteral(r rune) bool {
+	return (r >= 'A' && r <= 'Z') ||
+		(r >= 'a' && r <= 'z') ||
+		(r >= '0' && r <= '9') ||
+		(r == '/') || (r == '-') || (r == ':') || (r == '.') || (r == '_') || (r == '+')
+}
+
+func eatWhitespace(str string) string {
+	i := 0
+	for _, r := range str {
+		if !unicode.IsSpace(r) {
+			break
+		}
+		i++
+	}
+	return str[i:]
+}
+
+func readFileLimit(hostroot, path string) (string, error) {
+	const maxSize = 64 * 1024
+	path = filepath.Join(hostroot, path)
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	data, err := ioutil.ReadAll(io.LimitReader(f, maxSize))
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// systemd configuration syntax:
+// https://www.freedesktop.org/software/systemd/man/systemd.syntax.html
+func parseSystemdConf(str string) map[string]string {
+	lines := strings.Split(str, "\n")
+	conf := make(map[string]string)
+	var section = ""
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") {
+			section = strings.Replace(line[1:], "]", "", 1)
+		} else if section != "" {
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) == 2 {
+				conf[section+":"+parts[0]] = parts[1]
+			}
+		}
+	}
+	return conf
+}

--- a/pkg/compliance/aptconfig/aptconfig_test.go
+++ b/pkg/compliance/aptconfig/aptconfig_test.go
@@ -6,11 +6,100 @@
 package aptconfig
 
 import (
-	"context"
+	"io"
+	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestAptConfigLoader(t *testing.T) {
-	hostroot := ""
-	LoadConfiguration(context.Background(), hostroot)
+func TestAptConfigParser(t *testing.T) {
+	f, err := os.Open("testdata/apt.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conf := parseAPTConfiguration(string(data))
+	expected := map[string]interface{}{
+		"APT::Move-Autobit-Sections": []string{
+			"oldlibs",
+			"contrib/oldlibs",
+			"non-free/oldlibs",
+			"restricted/oldlibs",
+			"universe/oldlibs",
+			"multiverse/oldlibs",
+		},
+		"APT::Never-MarkAuto-Sections": []string{
+			"metapackages",
+			"contrib/metapackages",
+			"non-free/metapackages",
+			"restricted/metapackages",
+			"universe/metapackages",
+			"multiverse/metapackages",
+		},
+		"APT::NeverAutoRemove": []string{
+			"^firmware-linux.*",
+			"^linux-firmware$",
+			"^linux-image-[a-z0-9]*$",
+			"^linux-image-[a-z0-9]*-[a-z0-9]*$",
+		},
+		"APT::Periodic::Enable":               "0",
+		"APT::Periodic::Unattended-Upgrade":   "1",
+		"APT::Periodic::Update-Package-Lists": "1",
+		"APT::Update::Post-Invoke":            "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true",
+		"APT::Update::Post-Invoke-Success":    "/usr/bin/test -e /usr/share/dbus-1/system-services/org.freedesktop.PackageKit.service \u0026\u0026 /usr/bin/test -S /var/run/dbus/system_bus_socket \u0026\u0026 /usr/bin/gdbus call --system --dest org.freedesktop.PackageKit --object-path /org/freedesktop/PackageKit --timeout 4 --method org.freedesktop.PackageKit.StateHasChanged cache-update \u003e /dev/null; /bin/echo \u003e /dev/null",
+		"APT::VersionedKernelPackages": []string{
+			"linux-.*",
+			"kfreebsd-.*",
+			"gnumach-.*",
+			".*-modules",
+			".*-kernel",
+		},
+		"Acquire::Changelogs::AlwaysOnline":         "true",
+		"Acquire::CompressionTypes::Order::":        "gz",
+		"Acquire::GzipIndexes":                      "true",
+		"Acquire::Languages":                        "none",
+		"Acquire::http::User-Agent-Non-Interactive": "true",
+		"Apt::AutoRemove::SuggestsImportant":        "false",
+		"DPkg::Post-Invoke": []string{
+			"/usr/bin/test -e /usr/share/dbus-1/system-services/org.freedesktop.PackageKit.service \u0026\u0026 /usr/bin/test -S /var/run/dbus/system_bus_socket \u0026\u0026 /usr/bin/gdbus call --system --dest org.freedesktop.PackageKit --object-path /org/freedesktop/PackageKit --timeout 4 --method org.freedesktop.PackageKit.StateHasChanged cache-update \u003e /dev/null; /bin/echo \u003e /dev/null",
+			"rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true",
+		},
+		"DPkg::Pre-Install-Pkgs":  "/usr/sbin/dpkg-preconfigure --apt || true",
+		"Dir::Cache::pkgcache":    "",
+		"Dir::Cache::srcpkgcache": "",
+		"Unattended-Upgrade::Allowed-Origins": []string{
+			"${distro_id}:${distro_codename}",
+			"${distro_id}:${distro_codename}-security",
+			"${distro_id}ESMApps:${distro_codename}-apps-security",
+			"${distro_id}ESM:${distro_codename}-infra-security",
+		},
+		"Unattended-Upgrade::DevRelease": "auto",
+	}
+	assert.Equal(t, expected, conf)
+}
+
+func TestSystemdConfigParser(t *testing.T) {
+	f, err := os.Open("testdata/apt-daily.timer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conf := parseSystemdConf(string(data))
+	expected := map[string]string{
+		"Install/WantedBy":         "timers.target",
+		"Unit/Description":         "Message of the Day",
+		"Timer/OnCalendar":         "00,12:00:00",
+		"Timer/RandomizedDelaySec": "12h",
+		"Timer/Persistent":         "true",
+		"Timer/OnStartupSec":       "1min",
+	}
+	assert.Equal(t, expected, conf)
+
 }

--- a/pkg/compliance/aptconfig/aptconfig_test.go
+++ b/pkg/compliance/aptconfig/aptconfig_test.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package aptconfig
+
+import (
+	"context"
+	"testing"
+)
+
+func TestAptConfigLoader(t *testing.T) {
+	hostroot := ""
+	LoadConfiguration(context.Background(), hostroot)
+}

--- a/pkg/compliance/aptconfig/testdata/apt-daily.timer
+++ b/pkg/compliance/aptconfig/testdata/apt-daily.timer
@@ -1,0 +1,13 @@
+[Install]
+WantedBy=timers.target
+[Unit]
+Description=Message of the Day
+
+[Timer]
+OnCalendar=00,12:00:00
+RandomizedDelaySec=12h
+Persistent=true
+OnStartupSec=1min
+
+[Install]
+WantedBy=timers.target

--- a/pkg/compliance/aptconfig/testdata/apt.conf
+++ b/pkg/compliance/aptconfig/testdata/apt.conf
@@ -1,0 +1,211 @@
+Acquire::Changelogs::AlwaysOnline "true";
+Acquire::http::User-Agent-Non-Interactive "true";
+APT
+{
+  NeverAutoRemove
+  {
+    "^firmware-linux.*";
+    "^linux-firmware$";
+    "^linux-image-[a-z0-9]*$";
+    "^linux-image-[a-z0-9]*-[a-z0-9]*$";
+  };
+
+  VersionedKernelPackages
+  {
+    # kernels
+    "linux-.*";
+    "kfreebsd-.*";
+    "gnumach-.*";
+    # (out-of-tree) modules
+    ".*-modules";
+    ".*-kernel";
+  };
+
+  Never-MarkAuto-Sections
+  {
+    "metapackages";
+    "contrib/metapackages";
+    "non-free/metapackages";
+    "restricted/metapackages";
+    "universe/metapackages";
+    "multiverse/metapackages";
+  };
+
+  Move-Autobit-Sections
+  {
+    "oldlibs";
+    "contrib/oldlibs";
+    "non-free/oldlibs";
+    "restricted/oldlibs";
+    "universe/oldlibs";
+    "multiverse/oldlibs";
+  };
+};
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Unattended-Upgrade "1";
+// THIS FILE IS USED TO INFORM PACKAGEKIT
+// THAT THE UPDATE-INFO MIGHT HAVE CHANGED
+
+// Whenever dpkg is called we might have different updates
+// i.e. if an user removes a package that had an update
+DPkg::Post-Invoke {
+"/usr/bin/test -e /usr/share/dbus-1/system-services/org.freedesktop.PackageKit.service && /usr/bin/test -S /var/run/dbus/system_bus_socket && /usr/bin/gdbus call --system --dest org.freedesktop.PackageKit --object-path /org/freedesktop/PackageKit --timeout 4 --method org.freedesktop.PackageKit.StateHasChanged cache-update > /dev/null; /bin/echo > /dev/null";
+};
+
+// When Apt's cache is updated (i.e. apt-cache update)
+APT::Update::Post-Invoke-Success {
+"/usr/bin/test -e /usr/share/dbus-1/system-services/org.freedesktop.PackageKit.service && /usr/bin/test -S /var/run/dbus/system_bus_socket && /usr/bin/gdbus call --system --dest org.freedesktop.PackageKit --object-path /org/freedesktop/PackageKit --timeout 4 --method org.freedesktop.PackageKit.StateHasChanged cache-update > /dev/null; /bin/echo > /dev/null";
+};
+// Automatically upgrade packages from these (origin:archive) pairs
+//
+// Note that in Ubuntu security updates may pull in new dependencies
+// from non-security sources (e.g. chromium). By allowing the release
+// pocket these get automatically pulled in.
+Unattended-Upgrade::Allowed-Origins {
+    "${distro_id}:${distro_codename}";
+    "${distro_id}:${distro_codename}-security";
+    // Extended Security Maintenance; doesn't necessarily exist for
+    // every release and this system may not have it installed, but if
+    // available, the policy for updates is such that unattended-upgrades
+    // should also install from here by default.
+    "${distro_id}ESMApps:${distro_codename}-apps-security";
+    "${distro_id}ESM:${distro_codename}-infra-security";
+//  "${distro_id}:${distro_codename}-updates";
+//  "${distro_id}:${distro_codename}-proposed";
+//  "${distro_id}:${distro_codename}-backports";
+};
+
+// Python regular expressions, matching packages to exclude from upgrading
+Unattended-Upgrade::Package-Blacklist {
+    // The following matches all packages starting with linux-
+//  "linux-";
+
+    // Use $ to explicitely define the end of a package name. Without
+    // the $, "libc6" would match all of them.
+//  "libc6$";
+//  "libc6-dev$";
+//  "libc6-i686$";
+
+    // Special characters need escaping
+//  "libstdc\+\+6$";
+
+    // The following matches packages like xen-system-amd64, xen-utils-4.1,
+    // xenstore-utils and libxenstore3.0
+//  "(lib)?xen(store)?";
+
+    // For more information about Python regular expressions, see
+    // https://docs.python.org/3/howto/regex.html
+};
+
+// This option controls whether the development release of Ubuntu will be
+// upgraded automatically. Valid values are "true", "false", and "auto".
+Unattended-Upgrade::DevRelease "auto";
+
+// This option allows you to control if on a unclean dpkg exit
+// unattended-upgrades will automatically run
+//   dpkg --force-confold --configure -a
+// The default is true, to ensure updates keep getting installed
+//Unattended-Upgrade::AutoFixInterruptedDpkg "true";
+
+// Split the upgrade into the smallest possible chunks so that
+// they can be interrupted with SIGTERM. This makes the upgrade
+// a bit slower but it has the benefit that shutdown while a upgrade
+// is running is possible (with a small delay)
+//Unattended-Upgrade::MinimalSteps "true";
+
+// Install all updates when the machine is shutting down
+// instead of doing it in the background while the machine is running.
+// This will (obviously) make shutdown slower.
+// Unattended-upgrades increases logind's InhibitDelayMaxSec to 30s.
+// This allows more time for unattended-upgrades to shut down gracefully
+// or even install a few packages in InstallOnShutdown mode, but is still a
+// big step back from the 30 minutes allowed for InstallOnShutdown previously.
+// Users enabling InstallOnShutdown mode are advised to increase
+// InhibitDelayMaxSec even further, possibly to 30 minutes.
+//Unattended-Upgrade::InstallOnShutdown "false";
+
+// Send email to this address for problems or packages upgrades
+// If empty or unset then no email is sent, make sure that you
+// have a working mail setup on your system. A package that provides
+// 'mailx' must be installed. E.g. "user@example.com"
+//Unattended-Upgrade::Mail "";
+
+// Set this value to one of:
+//    "always", "only-on-error" or "on-change"
+// If this is not set, then any legacy MailOnlyOnError (boolean) value
+// is used to chose between "only-on-error" and "on-change"
+//Unattended-Upgrade::MailReport "on-change";
+
+// Remove unused automatically installed kernel-related packages
+// (kernel images, kernel headers and kernel version locked tools).
+//Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
+
+// Do automatic removal of newly unused dependencies after the upgrade
+//Unattended-Upgrade::Remove-New-Unused-Dependencies "true";
+
+// Do automatic removal of unused packages after the upgrade
+// (equivalent to apt-get autoremove)
+//Unattended-Upgrade::Remove-Unused-Dependencies "false";
+
+// Automatically reboot *WITHOUT CONFIRMATION* if
+//  the file /var/run/reboot-required is found after the upgrade
+//Unattended-Upgrade::Automatic-Reboot "false";
+
+// Automatically reboot even if there are users currently logged in
+// when Unattended-Upgrade::Automatic-Reboot is set to true
+//Unattended-Upgrade::Automatic-Reboot-WithUsers "true";
+
+// If automatic reboot is enabled and needed, reboot at the specific
+// time instead of immediately
+//  Default: "now"
+//Unattended-Upgrade::Automatic-Reboot-Time "02:00";
+
+// Use apt bandwidth limit feature, this example limits the download
+// speed to 70kb/sec
+//Acquire::http::Dl-Limit "70";
+
+// Enable logging to syslog. Default is False
+// Unattended-Upgrade::SyslogEnable "false";
+
+// Specify syslog facility. Default is daemon
+// Unattended-Upgrade::SyslogFacility "daemon";
+
+// Download and install upgrades only on AC power
+// (i.e. skip or gracefully stop updates on battery)
+// Unattended-Upgrade::OnlyOnACPower "true";
+
+// Download and install upgrades only on non-metered connection
+// (i.e. skip or gracefully stop updates on a metered connection)
+// Unattended-Upgrade::Skip-Updates-On-Metered-Connections "true";
+
+// Verbose logging
+// Unattended-Upgrade::Verbose "false";
+
+// Print debugging information both in unattended-upgrades and
+// in unattended-upgrade-shutdown
+// Unattended-Upgrade::Debug "false";
+
+// Allow package downgrade if Pin-Priority exceeds 1000
+// Unattended-Upgrade::Allow-downgrade "false";
+
+// When APT fails to mark a package to be upgraded or installed try adjusting
+// candidates of related packages to help APT's resolver in finding a solution
+// where the package can be upgraded or installed.
+// This is a workaround until APT's resolver is fixed to always find a
+// solution if it exists. (See Debian bug #711128.)
+// The fallback is enabled by default, except on Debian's sid release because
+// uninstallable packages are frequent there.
+// Disabling the fallback speeds up unattended-upgrades when there are
+// uninstallable packages at the expense of rarely keeping back packages which
+// could be upgraded or installed.
+// Unattended-Upgrade::Allow-APT-Mark-Fallback "true";
+// Pre-configure all packages with debconf before they are installed.
+// If you don't like it, comment it out.
+DPkg::Pre-Install-Pkgs {"/usr/sbin/dpkg-preconfigure --apt || true";};
+Apt::AutoRemove::SuggestsImportant "false";
+DPkg::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };
+APT::Update::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };
+Dir::Cache::pkgcache ""; Dir::Cache::srcpkgcache "";
+APT::Periodic::Enable "0";
+Acquire::GzipIndexes "true"; Acquire::CompressionTypes::Order:: "gz";
+Acquire::Languages "none";


### PR DESCRIPTION
### What does this PR do?

This PR introduces minimal parsing utility to be able to parse and export APT configuration as well as related systemd timers (apt-daily.timer and apt-daily-upgrade.timer) to be able to evaluate the correct configuration of unattended upgrades.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
