### PR TITLE
Fix missing base WriteHeader on telemetryWriter

### DIFF
--- a/pkg/clusteragent/api/handler_telemetry.go
+++ b/pkg/clusteragent/api/handler_telemetry.go
@@ -53,6 +53,7 @@ type telemetryWriterWrapper struct {
 }
 
 func (w *telemetryWriterWrapper) WriteHeader(statusCode int) {
+	w.ResponseWriter.WriteHeader(statusCode)
 	forwarded := w.Header().Get(respForwarded)
 	if forwarded == "" {
 		forwarded = "false"


### PR DESCRIPTION
### What does this PR do?

Fix missing base WriteHeader on telemetryWriter

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

```
curl -v -k -H "Authorization: Bearer $DD_CLUSTER_AGENT_AUTH_TOKEN" https://<cluster-agent-service>:5005/api/v1/annotations/node/unknown-node
```

The Cluster Agent should answer with status code `500`, not `200`.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
