### PR TITLE
Add way to log trace_pipe from tests

### DIFF
--- a/pkg/ebpf/ebpftest/bpfdebug_linux.go
+++ b/pkg/ebpf/ebpftest/bpfdebug_linux.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package ebpftest
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+)
+
+// LogTracePipe logs all messages read from /sys/kernel/[debug/]/tracing/trace_pipe during the test.
+// This function will set the environment variable BPF_DEBUG=true for the duration of the test.
+func LogTracePipe(t *testing.T) {
+	logTracePipe(t, nil)
+}
+
+// LogTracePipeSelf logs only messages from the current process read from /sys/kernel/[debug/]/tracing/trace_pipe during the test.
+// This function will set the environment variable BPF_DEBUG=true for the duration of the test.
+func LogTracePipeSelf(t *testing.T) {
+	LogTracePipeProcess(t, getpid())
+}
+
+// LogTracePipeProcess logs only messages from the provided process read from /sys/kernel/[debug/]/tracing/trace_pipe during the test.
+// This function will set the environment variable BPF_DEBUG=true for the duration of the test.
+func LogTracePipeProcess(t *testing.T, pid uint32) {
+	logTracePipe(t, func(ev *TraceEvent) bool {
+		return ev.PID == pid
+	})
+}
+
+// LogTracePipeFilter logs only messages that pass `filterFn` read from /sys/kernel/[debug/]/tracing/trace_pipe during the test.
+// This function will set the environment variable BPF_DEBUG=true for the duration of the test.
+func LogTracePipeFilter(t *testing.T, filterFn func(ev *TraceEvent) bool) {
+	logTracePipe(t, filterFn)
+}
+
+func getpid() uint32 {
+	p, err := os.Readlink(filepath.Join(util.HostProc(), "/self"))
+	if err == nil {
+		if pid, err := strconv.ParseInt(p, 10, 32); err == nil {
+			return uint32(pid)
+		}
+	}
+	return uint32(os.Getpid())
+}
+
+func logTracePipe(t *testing.T, filterFn func(ev *TraceEvent) bool) {
+	t.Setenv("BPF_DEBUG", "true")
+	tp, err := NewTracePipe()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tp.Close() })
+
+	ready := make(chan struct{})
+	go func() {
+		close(ready)
+		logs, errs := tp.Channel()
+		for {
+			select {
+			case log, ok := <-logs:
+				if !ok {
+					return
+				}
+				if filterFn == nil || filterFn(log) {
+					t.Logf("trace_pipe: %s", log)
+				}
+			case err, ok := <-errs:
+				if !ok {
+					return
+				}
+				t.Logf("trace_pipe: error: %s\n", err)
+			}
+		}
+	}()
+	<-ready
+}

--- a/pkg/ebpf/ebpftest/bpfdebug_unsupported.go
+++ b/pkg/ebpf/ebpftest/bpfdebug_unsupported.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux
+
+package ebpftest
+
+import "testing"
+
+// LogTracePipe is unsupported
+func LogTracePipe(t *testing.T) {
+}
+
+// LogTracePipeSelf is unsupported
+func LogTracePipeSelf(t *testing.T) {
+}
+
+// LogTracePipeProcess is unsupported
+func LogTracePipeProcess(t *testing.T, pid uint32) {
+}
+
+// LogTracePipeFilter is unsupported
+func LogTracePipeFilter(t *testing.T, filterFn func(ev *TraceEvent) bool) {
+}

--- a/pkg/ebpf/ebpftest/trace_pipe.go
+++ b/pkg/ebpf/ebpftest/trace_pipe.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package ebpftest
+
+// TraceEvent contains the raw event as well as the contents of
+// every field as string, as defined under "Output format" in
+// https://www.kernel.org/doc/Documentation/trace/ftrace.txt
+type TraceEvent struct {
+	Raw       string
+	Task      string
+	PID       uint32
+	CPU       string
+	Flags     string
+	Timestamp string
+	Function  string
+	Message   string
+}
+
+func (t TraceEvent) String() string {
+	return t.Raw
+}

--- a/pkg/ebpf/ebpftest/trace_pipe_linux.go
+++ b/pkg/ebpf/ebpftest/trace_pipe_linux.go
@@ -1,0 +1,126 @@
+// Copyright 2017 Kinvolk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ebpftest
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/ebpf-manager/tracefs"
+)
+
+// TracePipe to read from /sys/kernel/[debug/]tracing/trace_pipe
+// Note that data can be read only once, i.e. if you have more than
+// one tracer / channel, only one will receive an event:
+// "Once data is read from this file, it is consumed, and will not be
+// read again with a sequential read."
+// https://www.kernel.org/doc/Documentation/trace/ftrace.txt
+type TracePipe struct {
+	file   *os.File
+	reader *bufio.Reader
+	stop   chan struct{}
+}
+
+// NewTracePipe instantiates a new trace pipe
+func NewTracePipe() (*TracePipe, error) {
+	f, err := tracefs.OpenFile("trace_pipe", os.O_RDONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	return &TracePipe{
+		file:   f,
+		reader: bufio.NewReader(f),
+		stop:   make(chan struct{}),
+	}, nil
+}
+
+// A line from trace_pipe looks like (leading spaces included):
+// `        chromium-15581 [000] d... 92783.722567: : Hello, World!`
+var traceLineRegexp = regexp.MustCompile(`(.{16})-(\d+) +\[(\d{3})\] (.{4,5}) +(\d+\.\d+)\: (.*?)\: (.*)`)
+
+func parseTraceLine(raw string) (*TraceEvent, error) {
+	if raw == "\n" {
+		return nil, nil
+	}
+	fields := traceLineRegexp.FindStringSubmatch(raw)
+	if len(fields) != 8 {
+		return nil, fmt.Errorf("received unexpected input %q", raw)
+	}
+	pid, _ := strconv.ParseUint(fields[2], 10, 32)
+
+	return &TraceEvent{
+		Raw:       raw,
+		Task:      strings.Trim(fields[1], " "),
+		PID:       uint32(pid),
+		CPU:       fields[3],
+		Flags:     fields[4],
+		Timestamp: fields[5],
+		Function:  fields[6],
+		Message:   fields[7],
+	}, nil
+}
+
+// ReadLine reads a line
+func (t *TracePipe) ReadLine() (*TraceEvent, error) {
+	line, err := t.reader.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	traceEvent, err := parseTraceLine(line)
+	if err != nil {
+		return nil, err
+	}
+	return traceEvent, nil
+}
+
+// Channel returns a channel of events and another for errors
+func (t *TracePipe) Channel() (<-chan *TraceEvent, <-chan error) {
+	channelEvents := make(chan *TraceEvent)
+	channelErrors := make(chan error)
+	go func() {
+		for {
+			select {
+			case <-t.stop:
+				close(channelEvents)
+				close(channelErrors)
+				return
+			default:
+			}
+			traceEvent, err := t.ReadLine()
+			if err != nil {
+				if errors.Is(err, io.EOF) || errors.Is(err, fs.ErrClosed) {
+					continue
+				}
+				channelErrors <- err
+			} else if traceEvent != nil {
+				channelEvents <- traceEvent
+			}
+		}
+	}()
+	return channelEvents, channelErrors
+}
+
+// Close the trace pipe
+func (t *TracePipe) Close() error {
+	close(t.stop)
+	return t.file.Close()
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adds a way to log the output of `/sys/kernel/tracing/trace_pipe` within a test. 
Adds functions to filter to specific processes, or a custom filter function.

### Motivation

Increased ability to debug test failures.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
