### PR TITLE
system-probe: Remove redundant call for IsAdjusted

### DIFF
--- a/cmd/system-probe/config/adjust.go
+++ b/cmd/system-probe/config/adjust.go
@@ -17,11 +17,11 @@ var adjustMtx sync.Mutex
 
 // Adjust makes changes to the raw config based on deprecations and inferences.
 func Adjust(cfg config.Config) {
-	if IsAdjusted(cfg) {
-		return
-	}
 	adjustMtx.Lock()
 	defer adjustMtx.Unlock()
+	if cfg.GetBool(spNS("adjusted")) {
+		return
+	}
 
 	deprecateString(cfg, spNS("log_level"), "log_level")
 	deprecateString(cfg, spNS("log_file"), "log_file")
@@ -47,13 +47,6 @@ func Adjust(cfg config.Config) {
 	adjustSecurity(cfg)
 
 	cfg.Set(spNS("adjusted"), true)
-}
-
-// IsAdjusted returns whether the configuration has already been adjusted by Adjust
-func IsAdjusted(cfg config.Config) bool {
-	adjustMtx.Lock()
-	defer adjustMtx.Unlock()
-	return cfg.GetBool(spNS("adjusted"))
 }
 
 // validateString validates the string configuration value at `key` using a custom provided function `valFn`.

--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -84,9 +84,7 @@ func key(pieces ...string) string {
 // NewConfig creates a config with ebpf-related settings
 func NewConfig() *Config {
 	cfg := aconfig.SystemProbe
-	if !sysconfig.IsAdjusted(cfg) {
-		sysconfig.Adjust(cfg)
-	}
+	sysconfig.Adjust(cfg)
 
 	return &Config{
 		BPFDebug:                 cfg.GetBool(key(spNS, "bpf_debug")),

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -256,9 +256,7 @@ func join(pieces ...string) string {
 // New creates a config for the network tracer
 func New() *Config {
 	cfg := ddconfig.SystemProbe
-	if !sysconfig.IsAdjusted(cfg) {
-		sysconfig.Adjust(cfg)
-	}
+	sysconfig.Adjust(cfg)
 
 	c := &Config{
 		Config: *ebpf.NewConfig(),

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -374,6 +374,7 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 	log.Tracef("GetActiveConnections clientID=%s", clientID)
 
 	t.ebpfTracer.FlushPending()
+	// Set a limit and do that periodically.
 	latestTime, err := t.getConnections(t.activeBuffer)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving connections: %s", err)

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -186,9 +186,7 @@ func NewConfig() (*Config, error) {
 }
 
 func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
-	if !sysconfig.IsAdjusted(coreconfig.SystemProbe) {
-		sysconfig.Adjust(coreconfig.SystemProbe)
-	}
+	sysconfig.Adjust(coreconfig.SystemProbe)
 
 	rsConfig := &RuntimeSecurityConfig{
 		RuntimeEnabled: coreconfig.SystemProbe.GetBool("runtime_security_config.enabled"),

--- a/pkg/security/probe/config/config.go
+++ b/pkg/security/probe/config/config.go
@@ -137,9 +137,7 @@ type Config struct {
 
 // NewConfig returns a new Config object
 func NewConfig() (*Config, error) {
-	if !sysconfig.IsAdjusted(coreconfig.SystemProbe) {
-		sysconfig.Adjust(coreconfig.SystemProbe)
-	}
+	sysconfig.Adjust(coreconfig.SystemProbe)
 
 	setEnv()
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Removes redundant call for `IsAdjusted` before calling `Adjust`, as `Adjust` is calling `IsAdjusted` by itself.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Remove redundant code.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
