### PR TITLE
npm: Changed dns resolution to get a set of IPs rather than a list.

### DIFF
--- a/pkg/network/dns/cache.go
+++ b/pkg/network/dns/cache.go
@@ -100,7 +100,7 @@ func (c *reverseDNSCache) Add(translation *translation) bool {
 	return true
 }
 
-func (c *reverseDNSCache) Get(ips []util.Address) map[util.Address][]Hostname {
+func (c *reverseDNSCache) Get(ips map[util.Address]struct{}) map[util.Address][]Hostname {
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
@@ -141,12 +141,12 @@ func (c *reverseDNSCache) Get(ips []util.Address) map[util.Address][]Hostname {
 		}
 	}
 
-	for _, ip := range ips {
+	for ip := range ips {
 		collectNamesForIP(ip)
 	}
 
 	// Update stats for telemetry
-	cacheTelemetry.lookups.Add(int64((len(resolved) + len(unresolved))))
+	cacheTelemetry.lookups.Add(int64(len(resolved) + len(unresolved)))
 	cacheTelemetry.resolved.Add(int64(len(resolved)))
 	cacheTelemetry.oversized.Add(int64(len(oversized)))
 

--- a/pkg/network/dns/cache_test.go
+++ b/pkg/network/dns/cache_test.go
@@ -33,7 +33,11 @@ func TestMultipleIPsForSameName(t *testing.T) {
 	cache.Add(datadogIPs)
 
 	localhost := util.AddressFromString("127.0.0.1")
-	connections := []util.Address{localhost, datadog1, datadog2}
+	connections := map[util.Address]struct{}{
+		localhost: {},
+		datadog1:  {},
+		datadog2:  {},
+	}
 	actual := cache.Get(connections)
 	expected := map[util.Address][]Hostname{
 		datadog1: {ToHostname("datadoghq.com")},
@@ -55,7 +59,10 @@ func TestMultipleNamesForSameIP(t *testing.T) {
 	cache.Add(tr2)
 
 	localhost := util.AddressFromString("127.0.0.1")
-	connections := []util.Address{localhost, raddr}
+	connections := map[util.Address]struct{}{
+		localhost: {},
+		raddr:     {},
+	}
 
 	names := cache.Get(connections)
 	expected := []Hostname{ToHostname("i-03e46c9ff42db4abc"), ToHostname("ip-172-22-116-123.ec2.internal")}
@@ -93,9 +100,11 @@ func TestDNSCacheExpiration(t *testing.T) {
 	assert.Equal(t, 3, cache.Len())
 
 	// Bump host-a and host-b in-use flag
-	stats := []util.Address{
-		laddr1, raddr1,
-		laddr2, raddr2,
+	stats := map[util.Address]struct{}{
+		laddr1: {},
+		raddr1: {},
+		laddr2: {},
+		raddr2: {},
 	}
 	cache.Get(stats)
 
@@ -104,10 +113,13 @@ func TestDNSCacheExpiration(t *testing.T) {
 	cache.Expire(t3)
 	assert.Equal(t, 2, cache.Len())
 
-	stats = []util.Address{
-		laddr1, raddr1,
-		laddr2, raddr2,
-		laddr3, raddr3,
+	stats = map[util.Address]struct{}{
+		laddr1: {},
+		raddr1: {},
+		laddr2: {},
+		raddr2: {},
+		laddr3: {},
+		raddr3: {},
 	}
 	names := cache.Get(stats)
 	assert.Contains(t, names[raddr1], ToHostname("host-a"))
@@ -120,7 +132,7 @@ func TestDNSCacheExpiration(t *testing.T) {
 	assert.Equal(t, 2, cache.Len())
 
 	// All entries should be allowed to expire now
-	cache.Get([]util.Address{})
+	cache.Get(map[util.Address]struct{}{})
 	cache.Expire(t4)
 	assert.Equal(t, 0, cache.Len())
 }
@@ -150,11 +162,10 @@ func TestDNSCacheTelemetry(t *testing.T) {
 	}
 	assert.Equal(t, expected["ips"], cacheTelemetry.length.Load())
 
-	conns := []util.Address{
-		util.AddressFromString("127.0.0.1"),
-		util.AddressFromString("192.168.0.1"),
-		util.AddressFromString("127.0.0.1"),
-		util.AddressFromString("192.168.0.2"),
+	conns := map[util.Address]struct{}{
+		util.AddressFromString("127.0.0.1"):   {},
+		util.AddressFromString("192.168.0.1"): {},
+		util.AddressFromString("192.168.0.2"): {},
 	}
 
 	// Attempt to resolve IPs
@@ -171,7 +182,7 @@ func TestDNSCacheTelemetry(t *testing.T) {
 
 	// Expire IP
 	t2 := t1.Add(ttl + 1*time.Millisecond)
-	cache.Get([]util.Address{})
+	cache.Get(map[util.Address]struct{}{})
 	cache.Expire(t2)
 	expected = map[string]int64{
 		"lookups":   3,
@@ -197,9 +208,9 @@ func TestDNSCacheMerge(t *testing.T) {
 	ttl := 100 * time.Millisecond
 	cache := newReverseDNSCache(1000, disableAutomaticExpiration)
 
-	conns := []util.Address{
-		util.AddressFromString("127.0.0.1"),
-		util.AddressFromString("192.168.0.1"),
+	conns := map[util.Address]struct{}{
+		util.AddressFromString("127.0.0.1"):   {},
+		util.AddressFromString("192.168.0.1"): {},
 	}
 
 	t1 := newTranslation("host-b")
@@ -225,8 +236,8 @@ func TestDNSCacheMerge_MixedCaseNames(t *testing.T) {
 	ttl := 100 * time.Millisecond
 	cache := newReverseDNSCache(1000, disableAutomaticExpiration)
 
-	conns := []util.Address{
-		util.AddressFromString("192.168.0.1"),
+	conns := map[util.Address]struct{}{
+		util.AddressFromString("192.168.0.1"): {},
 	}
 
 	tr := newTranslation("host.name.com")
@@ -258,8 +269,9 @@ func TestGetOversizedDNS(t *testing.T) {
 		})
 	}
 
-	conns := []util.Address{addr}
-
+	conns := map[util.Address]struct{}{
+		addr: {},
+	}
 	result := cache.Get(conns)
 	assert.Len(t, result[addr], 5)
 	assert.Len(t, cache.data[addr].names, 5)
@@ -271,7 +283,6 @@ func TestGetOversizedDNS(t *testing.T) {
 		})
 	}
 
-	conns = []util.Address{addr}
 	result = cache.Get(conns)
 	assert.Len(t, result[addr], 0)
 	assert.Len(t, cache.data[addr].names, 10)
@@ -320,19 +331,19 @@ func randomAddressGen() func() util.Address {
 	}
 }
 
-func payloadGen(size int, resolveRatio float64, added []util.Address) []util.Address {
+func payloadGen(size int, resolveRatio float64, added []util.Address) map[util.Address]struct{} {
 	var (
 		addrGen = randomAddressGen()
-		stats   = make([]util.Address, size)
+		stats   = make(map[util.Address]struct{}, size)
 	)
 
 	for i := 0; i < size; i++ {
 		if rand.Float64() <= resolveRatio {
-			stats[i] = added[rand.Intn(len(added))]
+			stats[added[rand.Intn(len(added))]] = struct{}{}
 			continue
 		}
 
-		stats[i] = addrGen()
+		stats[addrGen()] = struct{}{}
 	}
 
 	return stats

--- a/pkg/network/dns/null.go
+++ b/pkg/network/dns/null.go
@@ -18,7 +18,7 @@ func NewNullReverseDNS() ReverseDNS {
 
 type nullReverseDNS struct{}
 
-func (nullReverseDNS) Resolve(_ []util.Address) map[util.Address][]Hostname {
+func (nullReverseDNS) Resolve(_ map[util.Address]struct{}) map[util.Address][]Hostname {
 	return nil
 }
 

--- a/pkg/network/dns/snooper.go
+++ b/pkg/network/dns/snooper.go
@@ -114,7 +114,7 @@ func newSocketFilterSnooper(cfg *config.Config, source packetSource) (*socketFil
 }
 
 // Resolve IPs to DNS addresses
-func (s *socketFilterSnooper) Resolve(ips []util.Address) map[util.Address][]Hostname {
+func (s *socketFilterSnooper) Resolve(ips map[util.Address]struct{}) map[util.Address][]Hostname {
 	return s.cache.Get(ips)
 }
 

--- a/pkg/network/dns/types.go
+++ b/pkg/network/dns/types.go
@@ -65,7 +65,7 @@ type StatsByKeyByNameByType map[Key]map[Hostname]map[QueryType]Stats
 
 // ReverseDNS translates IPs to names
 type ReverseDNS interface {
-	Resolve([]util.Address) map[util.Address][]Hostname
+	Resolve(map[util.Address]struct{}) map[util.Address][]Hostname
 	GetDNSStats() StatsByKeyByNameByType
 	Start() error
 	Close()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Reduced allocation pressure in hot-code-path.
Instead of passing a list (with possible duplications), we're now passing a set of addresses, to reduce allocations.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We're copying all IPs (source and dest) in a connection batch, so we resolve them. However, since the agent captures traffic on the same host, it is very likely to see the same address multiple times, while there is some caching later in the process, we are allocating multiple entries without any reason.


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
