### PR TITLE
system-probe: Avoid unnecessary allocations for trace logs in hot-code-paths

### DIFF
--- a/pkg/network/encoding/http2.go
+++ b/pkg/network/encoding/http2.go
@@ -6,6 +6,7 @@
 package encoding
 
 import (
+	"github.com/cihub/seelog"
 	"github.com/gogo/protobuf/proto"
 
 	model "github.com/DataDog/agent-payload/v5/process"
@@ -99,7 +100,9 @@ func newHTTP2Encoder(payload *network.Connections) *http2Encoder {
 	// this allows us to skip encoding orphan HTTP2 objects that can't be matched to a connection
 	for _, conn := range payload.Conns {
 		for _, key := range network.ConnectionKeysFromConnectionStats(conn) {
-			log.Tracef("Payload has a connection %v and was converted to http2 key %v", conn, key)
+			if log.ShouldLog(seelog.TraceLvl) {
+				log.Tracef("Payload has a connection %v and was converted to http2 key %v", conn, key)
+			}
 			encoder.aggregations[key] = nil
 		}
 	}
@@ -118,7 +121,9 @@ func (e *http2Encoder) buildAggregations(payload *network.Connections) {
 		aggregation, ok := e.aggregations[key.ConnectionKey]
 		if !ok {
 			// if there is no matching connection don't even bother to serialize HTTP2 data
-			log.Tracef("Found http2 orphan connection %v", key.ConnectionKey)
+			if log.ShouldLog(seelog.TraceLvl) {
+				log.Tracef("Found http2 orphan connection %v", key.ConnectionKey)
+			}
 			e.orphanEntries++
 			continue
 		}

--- a/pkg/network/encoding/kafka.go
+++ b/pkg/network/encoding/kafka.go
@@ -7,6 +7,7 @@ package encoding
 
 import (
 	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/types"
@@ -78,7 +79,9 @@ func newKafkaEncoder(payload *network.Connections) *kafkaEncoder {
 	// this allows us to skip encoding orphan Kafka objects that can't be matched to a connection
 	for _, conn := range payload.Conns {
 		for _, key := range network.ConnectionKeysFromConnectionStats(conn) {
-			log.Tracef("Payload has a connection %v and was converted to kafka key %v", conn, key)
+			if log.ShouldLog(seelog.TraceLvl) {
+				log.Tracef("Payload has a connection %v and was converted to kafka key %v", conn, key)
+			}
 			encoder.aggregations[key] = nil
 		}
 	}
@@ -111,7 +114,9 @@ func (e *kafkaEncoder) buildAggregations(payload *network.Connections) {
 		aggregation, ok := e.aggregations[key.ConnectionKey]
 		if !ok {
 			// if there is no matching connection don't even bother to serialize Kafka data
-			log.Tracef("Found kafka orphan connection %v", key.ConnectionKey)
+			if log.ShouldLog(seelog.TraceLvl) {
+				log.Tracef("Found kafka orphan connection %v", key.ConnectionKey)
+			}
 			e.orphanEntries++
 			continue
 		}

--- a/pkg/network/go/bininspect/symbols.go
+++ b/pkg/network/go/bininspect/symbols.go
@@ -15,6 +15,8 @@ import (
 	"io"
 	"math"
 
+	"github.com/cihub/seelog"
+
 	"github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -182,7 +184,7 @@ func getSymbols(f *elf.File, typ elf.SectionType, wanted map[string]struct{}) ([
 
 func GetAllSymbolsByName(elfFile *elf.File, symbolSet common.StringSet) (map[string]elf.Symbol, error) {
 	regularSymbols, regularSymbolsErr := getSymbols(elfFile, elf.SHT_SYMTAB, symbolSet)
-	if regularSymbolsErr != nil {
+	if regularSymbolsErr != nil && log.ShouldLog(seelog.TraceLvl) {
 		log.Tracef("Failed getting regular symbols of elf file: %s", regularSymbolsErr)
 	}
 
@@ -190,7 +192,7 @@ func GetAllSymbolsByName(elfFile *elf.File, symbolSet common.StringSet) (map[str
 	var dynamicSymbolsErr error
 	if len(regularSymbols) != len(symbolSet) {
 		dynamicSymbols, dynamicSymbolsErr = getSymbols(elfFile, elf.SHT_DYNSYM, symbolSet)
-		if dynamicSymbolsErr != nil {
+		if dynamicSymbolsErr != nil && log.ShouldLog(seelog.TraceLvl) {
 			log.Tracef("Failed getting dynamic symbols of elf file: %s", dynamicSymbolsErr)
 		}
 	}

--- a/pkg/network/netlink/conntracker.go
+++ b/pkg/network/netlink/conntracker.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cihub/seelog"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"golang.org/x/sys/unix"
 
@@ -377,7 +378,9 @@ func (cc *conntrackCache) Add(c Con, orphan bool) (evicts int) {
 		}
 	}
 
-	log.Tracef("%s", c)
+	if log.ShouldLog(seelog.TraceLvl) {
+		log.Tracef("%s", c)
+	}
 
 	registerTuple(&c.Origin, &c.Reply)
 	registerTuple(&c.Reply, &c.Origin)
@@ -397,7 +400,9 @@ func (cc *conntrackCache) removeOrphans(now time.Time) (removed int64) {
 
 		cc.cache.Remove(o.key)
 		removed++
-		log.Tracef("removed orphan %+v", o.key)
+		if log.ShouldLog(seelog.TraceLvl) {
+			log.Tracef("removed orphan %+v", o.key)
+		}
 	}
 
 	return removed

--- a/pkg/network/netlink/consumer.go
+++ b/pkg/network/netlink/consumer.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/cihub/seelog"
 	"github.com/mdlayher/netlink"
 	"github.com/pkg/errors"
 	"github.com/vishvananda/netns"
@@ -204,7 +205,9 @@ func (c *Consumer) isPeerNS(conn *netlink.Conn, ns netns.NsHandle) bool {
 		return false
 	}
 
-	log.Tracef("netlink reply: %v", msgs)
+	if log.ShouldLog(seelog.TraceLvl) {
+		log.Tracef("netlink reply: %v", msgs)
+	}
 
 	if msgs[0].Header.Type == netlink.Error {
 		return false

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cihub/seelog"
+
 	"github.com/DataDog/datadog-agent/pkg/network/dns"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/kafka"
@@ -404,9 +406,9 @@ func (ns *networkState) getConnsByCookie(conns []ConnectionStats) map[StatCookie
 			continue
 		}
 
-		log.TraceFunc(func() string {
-			return fmt.Sprintf("duplicate connection in collection: cookie: %d, c1: %+v, c2: %+v", c.Cookie, *c, conns[i])
-		})
+		if log.ShouldLog(seelog.TraceLvl) {
+			log.Tracef("duplicate connection in collection: cookie: %d, c1: %+v, c2: %+v", c.Cookie, *c, conns[i])
+		}
 
 		if ns.mergeConnectionStats(c, &conns[i]) {
 			// cookie collision

--- a/pkg/network/tracer/connection/tracer.go
+++ b/pkg/network/tracer/connection/tracer.go
@@ -17,6 +17,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/cihub/seelog"
 	"github.com/cilium/ebpf"
 	"github.com/twmb/murmur3"
 	"golang.org/x/sys/unix"
@@ -424,7 +425,9 @@ func (t *tracer) getEBPFTelemetry() *netebpf.Telemetry {
 	if err := mp.Lookup(unsafe.Pointer(&zero), unsafe.Pointer(telemetry)); err != nil {
 		// This can happen if we haven't initialized the telemetry object yet
 		// so let's just use a trace log
-		log.Tracef("error retrieving the telemetry struct: %s", err)
+		if log.ShouldLog(seelog.TraceLvl) {
+			log.Tracef("error retrieving the telemetry struct: %s", err)
+		}
 		return nil
 	}
 	return telemetry

--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -302,7 +302,9 @@ func (e *ebpfConntracker) delete(key *netebpf.ConntrackTuple) {
 	start := time.Now()
 	if err := e.ctMap.Delete(unsafe.Pointer(key)); err != nil {
 		if errors.Is(err, ebpf.ErrKeyNotExist) {
-			log.Tracef("connection does not exist in ebpf conntrack map: %s", key)
+			if log.ShouldLog(seelog.TraceLvl) {
+				log.Tracef("connection does not exist in ebpf conntrack map: %s", key)
+			}
 			return
 		}
 		log.Warnf("unable to delete conntrack entry from eBPF map: %s", err)

--- a/pkg/network/tracer/process_cache.go
+++ b/pkg/network/tracer/process_cache.go
@@ -8,11 +8,11 @@
 package tracer
 
 import (
-	"fmt"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/cihub/seelog"
 	lru "github.com/hashicorp/golang-lru/v2"
 
 	smodel "github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -207,9 +207,9 @@ func (pc *processCache) add(p *process) {
 	pc.Lock()
 	defer pc.Unlock()
 
-	log.TraceFunc(func() string {
-		return fmt.Sprintf("adding process %+v to process cache", p)
-	})
+	if log.ShouldLog(seelog.TraceLvl) {
+		log.Tracef("adding process %+v to process cache", p)
+	}
 
 	evicted := pc.cache.Add(processCacheKey{pid: p.Pid, startTime: p.StartTime}, p)
 	pl, _ := pc.cacheByPid[p.Pid]

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -331,9 +331,9 @@ func (t *Tracer) addProcessInfo(c *network.ConnectionStats) {
 		return
 	}
 
-	log.TraceFunc(func() string {
-		return fmt.Sprintf("got process cache entry for pid %d: %+v", c.Pid, p)
-	})
+	if log.ShouldLog(seelog.TraceLvl) {
+		log.Tracef("got process cache entry for pid %d: %+v", c.Pid, p)
+	}
 
 	if c.Tags == nil {
 		c.Tags = make(map[string]struct{})

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cihub/seelog"
 	"github.com/cilium/ebpf"
 	"go.uber.org/atomic"
 
@@ -371,8 +372,9 @@ func (t *Tracer) Stop() {
 func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, error) {
 	t.bufferLock.Lock()
 	defer t.bufferLock.Unlock()
-	log.Tracef("GetActiveConnections clientID=%s", clientID)
-
+	if log.ShouldLog(seelog.TraceLvl) {
+		log.Tracef("GetActiveConnections clientID=%s", clientID)
+	}
 	t.ebpfTracer.FlushPending()
 	latestTime, active, err := t.getConnections(t.activeBuffer)
 	if err != nil {
@@ -559,7 +561,9 @@ func (t *Tracer) removeEntries(entries []network.ConnectionStats) {
 
 	t.state.RemoveConnections(toRemove)
 
-	log.Debugf("Removed %d connection entries in %s", len(toRemove), time.Now().Sub(now))
+	if log.ShouldLog(seelog.DebugLvl) {
+		log.Debugf("Removed %d connection entries in %s", len(toRemove), time.Now().Sub(now))
+	}
 }
 
 func (t *Tracer) timeoutForConn(c *network.ConnectionStats) uint64 {

--- a/pkg/network/usm/shared_libraries.go
+++ b/pkg/network/usm/shared_libraries.go
@@ -20,10 +20,10 @@ import (
 
 	"go.uber.org/atomic"
 
+	"github.com/DataDog/gopsutil/process"
+	"github.com/cihub/seelog"
 	"github.com/twmb/murmur3"
 	"golang.org/x/sys/unix"
-
-	"github.com/DataDog/gopsutil/process"
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
@@ -200,7 +200,9 @@ func (w *soWatcher) Start() {
 		}
 		mmaps, err := proc.MemoryMaps(true)
 		if err != nil {
-			log.Tracef("process %d maps parsing failed %s", pid, err)
+			if log.ShouldLog(seelog.TraceLvl) {
+				log.Tracef("process %d maps parsing failed %s", pid, err)
+			}
 			return nil
 		}
 
@@ -337,7 +339,9 @@ func (r *soRegistry) register(root, libPath string, pid uint32, rule soRule) {
 	if err != nil {
 		// short living process can hit here
 		// as we receive the openat() syscall info after receiving the EXIT netlink process
-		log.Tracef("can't create path identifier %s", err)
+		if log.ShouldLog(seelog.TraceLvl) {
+			log.Tracef("can't create path identifier %s", err)
+		}
 		return
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Checking the log level before calling trace-level-logs to avoid unnecessary allocations for trace logs in hot-code-paths 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Avoid unnecessary allocations for trace logs in hot-code-paths.
Guards log.Tracef statements to prevent unnecessary allocations when trace logs are disabled.

Applying #10065

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

```go
func BenchmarkTraceLog(b *testing.B) {
	b.ReportAllocs()
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		log.Trace("this is my log very long long string")
	}
}

func BenchmarkTraceLog2(b *testing.B) {
	b.ReportAllocs()
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		if log.ShouldLog(seelog.TraceLvl) {
			log.Trace("this is my log very long long string")
		}
	}
}

func BenchmarkTraceLog3(b *testing.B) {
	b.ReportAllocs()
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		log.TraceFunc(func() string {
			return "this is my log very long long string"
		})
	}
}
```

The output:
```
BenchmarkTraceLog
BenchmarkTraceLog-16     	13521062	        78.83 ns/op	      90 B/op	       2 allocs/op
BenchmarkTraceLog2
BenchmarkTraceLog2-16    	1000000000	         0.4468 ns/op	       0 B/op	       0 allocs/op
BenchmarkTraceLog3
BenchmarkTraceLog3-16    	60898656	        21.00 ns/op	      16 B/op	       1 allocs/op
```
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
