### PR TITLE
Adding shared pool monitoring for Oracle databases

### DIFF
--- a/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
@@ -164,6 +164,15 @@ instances:
       #
       # collect_comments: true
 
+    ## Configure collection of shared memory usage
+    #
+    # shared_memory:
+
+        ## @param enabled - boolean - optional - default: true. Requires `dbm: true`.
+        ## Enable collection of database shared memory usages
+        #
+        # enabled: true
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -43,6 +43,10 @@ type ProcessMemoryConfig struct {
 	Enabled bool `yaml:"enabled"`
 }
 
+type SharedMemoryConfig struct {
+	Enabled bool `yaml:"enabled"`
+}
+
 type ExecutionPlansConfig struct {
 	Enabled bool `yaml:"enabled"`
 }
@@ -74,6 +78,7 @@ type InstanceConfig struct {
 	SysMetrics             SysMetricsConfig     `yaml:"sysmetrics"`
 	Tablespaces            TablespacesConfig    `yaml:"tablespaces"`
 	ProcessMemory          ProcessMemoryConfig  `yaml:"process_memory"`
+	SharedMemory           SharedMemoryConfig   `yaml:"shared_memory"`
 	ExecutionPlans         ExecutionPlansConfig `yaml:"execution_plans"`
 	AgentSQLTrace          AgentSQLTrace        `yaml:"agent_sql_trace"`
 }
@@ -110,6 +115,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	instance.SysMetrics.Enabled = true
 	instance.Tablespaces.Enabled = true
 	instance.ProcessMemory.Enabled = true
+	instance.SharedMemory.Enabled = true
 	// Defaults end
 
 	if err := yaml.Unmarshal(rawInstance, &instance); err != nil {

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -116,6 +116,12 @@ func (c *Check) Run() error {
 				}
 			}
 		}
+		if c.config.SharedMemory.Enabled {
+			err := c.SharedMemory()
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	if c.config.AgentSQLTrace.Enabled {

--- a/pkg/collector/corechecks/oracle-dbm/processes.go
+++ b/pkg/collector/corechecks/oracle-dbm/processes.go
@@ -51,10 +51,10 @@ func (c *Check) ProcessMemory() error {
 		if r.Program.Valid {
 			tags = append(tags, "program:"+r.Program.String)
 		}
-		sender.Gauge(fmt.Sprintf("%s.process.pga_used_mem", common.IntegrationName), r.PGAUsedMem, "", tags)
-		sender.Gauge(fmt.Sprintf("%s.process.pga_alloc_mem", common.IntegrationName), r.PGAAllocMem, "", tags)
-		sender.Gauge(fmt.Sprintf("%s.process.pga_freeable_mem", common.IntegrationName), r.PGAFreeableMem, "", tags)
-		sender.Gauge(fmt.Sprintf("%s.process.pga_max_mem", common.IntegrationName), r.PGAMaxMem, "", tags)
+		sender.Gauge(fmt.Sprintf("%s.process.pga_used_memory", common.IntegrationName), r.PGAUsedMem, "", tags)
+		sender.Gauge(fmt.Sprintf("%s.process.pga_allocated_memory", common.IntegrationName), r.PGAAllocMem, "", tags)
+		sender.Gauge(fmt.Sprintf("%s.process.pga_freeable_memory", common.IntegrationName), r.PGAFreeableMem, "", tags)
+		sender.Gauge(fmt.Sprintf("%s.process.pga_max_memory", common.IntegrationName), r.PGAMaxMem, "", tags)
 	}
 	sender.Commit()
 	return nil

--- a/pkg/collector/corechecks/oracle-dbm/shared_memory.go
+++ b/pkg/collector/corechecks/oracle-dbm/shared_memory.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package oracle
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/common"
+)
+
+const QUERY_SHM = `SELECT 
+    c.name pdb_name, s.name, ROUND(bytes/1024/1024,2) size_
+  FROM v$sgainfo s, v$containers c
+  WHERE 
+    c.con_id(+) = s.con_id
+    AND s.name NOT IN ('Maximum SGA Size','Startup overhead in Shared Pool','Granule Size','Shared IO Pool Size')
+`
+
+type SHMRow struct {
+	PdbName sql.NullString `db:"PDB_NAME"`
+	Memory  string         `db:"NAME"`
+	Size    float64        `db:"SIZE_"`
+}
+
+func (c *Check) SharedMemory() error {
+	rows := []SHMRow{}
+	err := c.db.Select(&rows, QUERY_SHM)
+	if err != nil {
+		return fmt.Errorf("failed to collect shared memory info: %w", err)
+	}
+	sender, err := c.GetSender()
+	if err != nil {
+		return fmt.Errorf("failed to initialize sender: %w", err)
+	}
+	for _, r := range rows {
+		tags := appendPDBTag(c.tags, r.PdbName)
+		//tags = append(tags, `memory:"`+r.Memory+`"`)
+		memoryTag := strings.ReplaceAll(r.Memory, " ", "_")
+		memoryTag = strings.ToLower(memoryTag)
+		memoryTag = strings.ReplaceAll(memoryTag, "_size", "")
+		tags = append(tags, fmt.Sprintf("memory:%s", memoryTag))
+		sender.Gauge(fmt.Sprintf("%s.shared_memory.size", common.IntegrationName), r.Size, "", tags)
+	}
+	sender.Commit()
+	return nil
+}

--- a/pkg/collector/corechecks/oracle-dbm/shared_memory.go
+++ b/pkg/collector/corechecks/oracle-dbm/shared_memory.go
@@ -39,7 +39,6 @@ func (c *Check) SharedMemory() error {
 	}
 	for _, r := range rows {
 		tags := appendPDBTag(c.tags, r.PdbName)
-		//tags = append(tags, `memory:"`+r.Memory+`"`)
 		memoryTag := strings.ReplaceAll(r.Memory, " ", "_")
 		memoryTag = strings.ToLower(memoryTag)
 		memoryTag = strings.ReplaceAll(memoryTag, "_size", "")

--- a/pkg/collector/corechecks/oracle-dbm/sql/setup-rds.sql
+++ b/pkg/collector/corechecks/oracle-dbm/sql/setup-rds.sql
@@ -20,3 +20,4 @@ exec rdsadmin.rdsadmin_util.grant_sys_object('CDB_TABLESPACE_USAGE_METRICS','DAT
 exec rdsadmin.rdsadmin_util.grant_sys_object('CDB_TABLESPACES','DATADOG','SELECT',p_grant_option => false); 
 exec rdsadmin.rdsadmin_util.grant_sys_object('V_$SQLCOMMAND','DATADOG','SELECT',p_grant_option => false);
 exec rdsadmin.rdsadmin_util.grant_sys_object('V_$DATAFILE','DATADOG','SELECT',p_grant_option => false);
+exec rdsadmin.rdsadmin_util.grant_sys_object('V_$SGAINFO','DATADOG','SELECT',p_grant_option => false);

--- a/pkg/collector/corechecks/oracle-dbm/sql/setup.sql
+++ b/pkg/collector/corechecks/oracle-dbm/sql/setup.sql
@@ -19,6 +19,7 @@ grant select on v_$con_sysmetric to c##datadog ;
 grant select on cdb_tablespace_usage_metrics to c##datadog ;
 grant select on cdb_tablespaces to c##datadog ;
 grant select on v_$process to c##datadog ;
+grant select on v_$sgainfo to c##datadog ;
 
 CREATE OR REPLACE VIEW dd_session AS
 SELECT 

--- a/releasenotes/notes/oracle-shared-memoy-06e54ebb7173317b.yaml
+++ b/releasenotes/notes/oracle-shared-memoy-06e54ebb7173317b.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add monitoring of shared memory (system global area - SGA) for Oracle databases.

--- a/releasenotes/notes/oracle-shared-memoy-06e54ebb7173317b.yaml
+++ b/releasenotes/notes/oracle-shared-memoy-06e54ebb7173317b.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    Add shared memory (a.k.a. system global area - SGA) for Oracle databases.
+    Add shared memory (a.k.a. system global area - SGA) metric for Oracle databases: `oracle.shared_memory.size`

--- a/releasenotes/notes/oracle-shared-memoy-06e54ebb7173317b.yaml
+++ b/releasenotes/notes/oracle-shared-memoy-06e54ebb7173317b.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    Add monitoring of shared memory (system global area - SGA) for Oracle databases.
+    Add shared memory (a.k.a. system global area - SGA) for Oracle databases.


### PR DESCRIPTION
### What does this PR do?

Add shared memory monitoring (a.k.a system global area - SGA) for Oracle databases.

### Motivation

Shared memory consists of different pools that store different types of data: SQL cache, buffer cache, JVM cache, etc. The cache sizes are dynamic by default. The growth and shrinking provides valuable information for performance analysis.


### Describe how to test/QA your changes

Check if shared memory is correctly displayed in frontend.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
