### PR TITLE
[DCA] Use `Leases` for `leaderelection` when they are available

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -427,5 +427,5 @@
 /tools/agent_QA/                        @DataDog/agent-metrics-logs
 
 /internal/tools/                        @DataDog/agent-platform
-/internal/third_party/client-go         @DataDog/DataDog/container-integrations
-/internal/third_party/kubernetes        @DataDog/DataDog/container-integrations
+/internal/third_party/client-go         @DataDog/container-integrations
+/internal/third_party/kubernetes        @DataDog/container-integrations

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -427,3 +427,5 @@
 /tools/agent_QA/                        @DataDog/agent-metrics-logs
 
 /internal/tools/                        @DataDog/agent-platform
+/internal/third_party/client-go         @DataDog/DataDog/container-integrations
+/internal/third_party/kubernetes        @DataDog/DataDog/container-integrations

--- a/internal/third_party/client-go/LICENSE
+++ b/internal/third_party/client-go/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/internal/third_party/client-go/tools/leaderelection/resourcelock/configmaplock.go
+++ b/internal/third_party/client-go/tools/leaderelection/resourcelock/configmaplock.go
@@ -1,0 +1,127 @@
+//go:build kubeapiserver
+// +build kubeapiserver
+
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Taken from https://github.com/kubernetes/client-go/blob/v0.27.0/tools/leaderelection/resourcelock/configmaplock.go
+// It was added because k8s.io/client-go/tools/leaderelection does not support ConfigMapLock anymore since v0.24 but
+// it is needed to run leaderlection on kube versions <= 1.14, which do not support LeaseLocks
+package resourcelock
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+const ConfigMapsResourceLock = "configmaps"
+
+type ConfigMapLock struct {
+	// ConfigMapMeta should contain a Name and a Namespace of a
+	// ConfigMapMeta object that the LeaderElector will attempt to lead.
+	ConfigMapMeta metav1.ObjectMeta
+	Client        corev1client.ConfigMapsGetter
+	LockConfig    rl.ResourceLockConfig
+	cm            *v1.ConfigMap
+}
+
+// Get returns the election record from a ConfigMap Annotation
+func (cml *ConfigMapLock) Get(ctx context.Context) (*rl.LeaderElectionRecord, []byte, error) {
+	var record rl.LeaderElectionRecord
+	cm, err := cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Get(ctx, cml.ConfigMapMeta.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+	cml.cm = cm
+	if cml.cm.Annotations == nil {
+		cml.cm.Annotations = make(map[string]string)
+	}
+	recordStr, found := cml.cm.Annotations[rl.LeaderElectionRecordAnnotationKey]
+	recordBytes := []byte(recordStr)
+	if found {
+		if err := json.Unmarshal(recordBytes, &record); err != nil {
+			return nil, nil, err
+		}
+	}
+	return &record, recordBytes, nil
+}
+
+// Create attempts to create a rl.LeaderElectionRecord annotation
+func (cml *ConfigMapLock) Create(ctx context.Context, ler rl.LeaderElectionRecord) error {
+	recordBytes, err := json.Marshal(ler)
+	if err != nil {
+		return err
+	}
+	cml.cm, err = cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Create(ctx, &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cml.ConfigMapMeta.Name,
+			Namespace: cml.ConfigMapMeta.Namespace,
+			Annotations: map[string]string{
+				rl.LeaderElectionRecordAnnotationKey: string(recordBytes),
+			},
+		},
+	}, metav1.CreateOptions{})
+	return err
+}
+
+// Update will update an existing annotation on a given resource.
+func (cml *ConfigMapLock) Update(ctx context.Context, ler rl.LeaderElectionRecord) error {
+	if cml.cm == nil {
+		return errors.New("configmap not initialized, call get or create first")
+	}
+	recordBytes, err := json.Marshal(ler)
+	if err != nil {
+		return err
+	}
+	if cml.cm.Annotations == nil {
+		cml.cm.Annotations = make(map[string]string)
+	}
+	cml.cm.Annotations[rl.LeaderElectionRecordAnnotationKey] = string(recordBytes)
+	cm, err := cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Update(ctx, cml.cm, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	cml.cm = cm
+	return nil
+}
+
+// RecordEvent in leader election while adding meta-data
+func (cml *ConfigMapLock) RecordEvent(s string) {
+	if cml.LockConfig.EventRecorder == nil {
+		return
+	}
+	events := fmt.Sprintf("%v %v", cml.LockConfig.Identity, s)
+	subject := &v1.ConfigMap{ObjectMeta: cml.cm.ObjectMeta}
+	// Populate the type meta, so we don't have to get it from the schema
+	subject.Kind = "ConfigMap"
+	subject.APIVersion = v1.SchemeGroupVersion.String()
+	cml.LockConfig.EventRecorder.Eventf(subject, v1.EventTypeNormal, "LeaderElection", events)
+}
+
+// Describe is used to convert details on current resource lock
+// into a string
+func (cml *ConfigMapLock) Describe() string {
+	return fmt.Sprintf("%v/%v", cml.ConfigMapMeta.Namespace, cml.ConfigMapMeta.Name)
+}
+
+// Identity returns the Identity of the lock
+func (cml *ConfigMapLock) Identity() string {
+	return cml.LockConfig.Identity
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -715,6 +715,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("leader_lease_duration", "60")
 	config.BindEnvAndSetDefault("leader_election", false)
 	config.BindEnvAndSetDefault("leader_lease_name", "datadog-leader-election")
+	config.BindEnvAndSetDefault("leader_election_default_resource", "configmap")
 	config.BindEnvAndSetDefault("kube_resources_namespace", "")
 	config.BindEnvAndSetDefault("kube_cache_sync_timeout_seconds", 5)
 

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -293,7 +293,7 @@ func CanUseLeases(client discovery.DiscoveryInterface) (bool, error) {
 	}
 
 	if resourceType != "" {
-		log.Warnf("Unknown resource lock for leader election [%s]. Using the discovery client to select the lock", config)
+		log.Warnf("Unknown resource lock for leader election [%s]. Using the discovery client to select the lock", resourceType)
 	}
 
 	return detectLeases(client)

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -15,13 +15,15 @@ import (
 	"time"
 
 	"golang.org/x/mod/semver"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
 	coordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/leaderelection"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
 
+	configmaplock "github.com/DataDog/datadog-agent/internal/third_party/client-go/tools/leaderelection/resourcelock"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
@@ -57,6 +59,7 @@ type LeaderEngine struct {
 	ServiceName         string
 	leaderIdentityMutex sync.RWMutex
 	leaderElector       *leaderelection.LeaderElector
+	lockType            string
 
 	// leaderIdentity is the HolderIdentity of the current leader.
 	leaderIdentity string
@@ -142,16 +145,21 @@ func (le *LeaderEngine) init() error {
 	}
 
 	le.coreClient = apiClient.Cl.CoreV1()
-	// Will be required once we migrate to Kubernetes deps >= 0.24
-	le.coordClient = nil
+	le.coordClient = apiClient.Cl.CoordinationV1()
 
-	// check if we can get ConfigMap.
-	_, err = le.coreClient.ConfigMaps(le.LeaderNamespace).Get(context.TODO(), le.LeaseName, metav1.GetOptions{})
-	if err != nil && errors.IsNotFound(err) == false {
-		log.Errorf("Cannot retrieve ConfigMap from the %s namespace: %s", le.LeaderNamespace, err)
+	usingLease, err := CanUseLease(apiClient.DiscoveryCl)
+	if err != nil {
+		log.Errorf("Unable to retrieve available resources: %v", err)
 		return err
 	}
-
+	if usingLease {
+		log.Debugf("leader election will use Leases to store the leader token")
+		le.lockType = rl.LeasesResourceLock
+	} else {
+		// for kubernetes <= 1.13
+		log.Debugf("leader election will use ConfigMaps to store the leader token")
+		le.lockType = configmaplock.ConfigMapsResourceLock
+	}
 	le.leaderElector, err = le.newElection()
 	if err != nil {
 		log.Errorf("Could not initialize the Leader Election process: %s", err)
@@ -257,18 +265,37 @@ func (le *LeaderEngine) Subscribe() <-chan struct{} {
 	return c
 }
 
-// GetLeaderElectionRecord is used in for the Flare and for the Status commands.
-func GetLeaderElectionRecord() (leaderDetails rl.LeaderElectionRecord, err error) {
-	var led rl.LeaderElectionRecord
-	client, err := apiserver.GetAPIClient()
+func CanUseLease(client discovery.DiscoveryInterface) (bool, error) {
+	resourceList, err := client.ServerResourcesForGroupVersion("coordination.k8s.io/v1")
+	if kerrors.IsNotFound(err) {
+		return false, nil
+	}
 	if err != nil {
-		return led, err
+		return false, err
+	}
+	for _, actualResource := range resourceList.APIResources {
+		if actualResource.Name == "leases" {
+			return true, nil
+		}
 	}
 
-	c := client.Cl.CoreV1()
+	return false, nil
+}
 
-	leaderNamespace := common.GetResourcesNamespace()
-	leaderElectionCM, err := c.ConfigMaps(leaderNamespace).Get(context.TODO(), config.Datadog.GetString("leader_lease_name"), metav1.GetOptions{})
+func getLeaseLeaderElectionRecord(client coordinationv1.CoordinationV1Interface) (rl.LeaderElectionRecord, error) {
+	var empty rl.LeaderElectionRecord
+	lease, err := client.Leases(common.GetResourcesNamespace()).Get(context.TODO(), config.Datadog.GetString("leader_lease_name"), metav1.GetOptions{})
+	if err != nil {
+		return empty, err
+	}
+	log.Debugf("LeaderElection lease is %#v", lease)
+	record := rl.LeaseSpecToLeaderElectionRecord(&lease.Spec)
+	return *record, nil
+}
+
+func getConfigMapLeaderElectionRecord(client corev1.CoreV1Interface) (rl.LeaderElectionRecord, error) {
+	var led rl.LeaderElectionRecord
+	leaderElectionCM, err := client.ConfigMaps(common.GetResourcesNamespace()).Get(context.TODO(), config.Datadog.GetString("leader_lease_name"), metav1.GetOptions{})
 	if err != nil {
 		return led, err
 	}
@@ -282,4 +309,21 @@ func GetLeaderElectionRecord() (leaderDetails rl.LeaderElectionRecord, err error
 		return led, err
 	}
 	return led, nil
+}
+
+// GetLeaderElectionRecord is used in for the Flare and for the Status commands.
+func GetLeaderElectionRecord() (leaderDetails rl.LeaderElectionRecord, err error) {
+	var led rl.LeaderElectionRecord
+	client, err := apiserver.GetAPIClient()
+	if err != nil {
+		return led, err
+	}
+	usingLease, err := CanUseLease(client.DiscoveryCl)
+	if err != nil {
+		return led, err
+	}
+	if usingLease {
+		return getLeaseLeaderElectionRecord(client.Cl.CoordinationV1())
+	}
+	return getConfigMapLeaderElectionRecord(client.Cl.CoreV1())
 }

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -286,14 +285,14 @@ func detectLeases(client discovery.DiscoveryInterface) (bool, error) {
 // CanUseLeases returns if leases can be used for leader election. If the resource is defined in the config
 // It uses it. Otherwise it uses the discovery client for leader election.
 func CanUseLeases(client discovery.DiscoveryInterface) (bool, error) {
-	config := config.Datadog.GetString("leader_election_default_resource")
-	if strings.Contains(config, "lease") {
+	resourceType := config.Datadog.GetString("leader_election_default_resource")
+	if resourceType == "lease" || resourceType == "leases" {
 		return true, nil
-	} else if strings.Contains(config, "configmap") {
+	} else if resourceType == "configmap" || resourceType == "configmaps" {
 		return false, nil
 	}
 
-	if config != "" {
+	if resourceType != "" {
 		log.Warnf("Unknown resource lock for leader election [%s]. Using the discovery client to select the lock", config)
 	}
 

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
@@ -12,46 +12,108 @@ import (
 	"encoding/json"
 	"strconv"
 
+	coordv1 "k8s.io/api/coordination/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	clientcoord "k8s.io/client-go/kubernetes/typed/coordination/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	ld "k8s.io/client-go/tools/leaderelection"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
 
+	configmaplock "github.com/DataDog/datadog-agent/internal/third_party/client-go/tools/leaderelection/resourcelock"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func (le *LeaderEngine) getCurrentLeader() (string, *v1.ConfigMap, error) {
+func NewReleaseLock(lockType string, ns string, name string, coreClient corev1.CoreV1Interface, coordinationClient clientcoord.CoordinationV1Interface, rlc rl.ResourceLockConfig) (rl.Interface, error) {
+	if lockType == configmaplock.ConfigMapsResourceLock {
+		return &configmaplock.ConfigMapLock{
+			ConfigMapMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+			},
+			Client:     coreClient,
+			LockConfig: rlc,
+		}, nil
+	} else {
+		return rl.New(lockType, ns, name, coreClient, coordinationClient, rlc)
+	}
+}
+
+func (le *LeaderEngine) getCurrentLeaderLease() (string, error) {
+	lease, err := le.coordClient.Leases(le.LeaderNamespace).Get(context.TODO(), le.LeaseName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	// leases do not store the leader election data in annotations but directly in the specs
+	leader := lease.Spec.HolderIdentity
+	if leader == nil {
+		log.Debugf("The lease/%s in the namespace %s doesn't have the field leader in its spec: no one is leading yet", le.LeaseName, le.LeaderNamespace)
+		return "", nil
+	}
+
+	return *leader, err
+
+}
+
+func (le *LeaderEngine) getCurrentLeaderConfigMap() (string, error) {
 	configMap, err := le.coreClient.ConfigMaps(le.LeaderNamespace).Get(context.TODO(), le.LeaseName, metav1.GetOptions{})
 	if err != nil {
-		return "", nil, err
+		return "", err
 	}
 
 	val, found := configMap.Annotations[rl.LeaderElectionRecordAnnotationKey]
 	if !found {
 		log.Debugf("The configmap/%s in the namespace %s doesn't have the annotation %q: no one is leading yet", le.LeaseName, le.LeaderNamespace, rl.LeaderElectionRecordAnnotationKey)
-		return "", configMap, nil
+		return "", nil
 	}
 
 	electionRecord := rl.LeaderElectionRecord{}
 	if err := json.Unmarshal([]byte(val), &electionRecord); err != nil {
-		return "", nil, err
+		return "", err
 	}
-	return electionRecord.HolderIdentity, configMap, err
+	return electionRecord.HolderIdentity, err
 }
 
-// newElection creates an election.
-// If `namespace`/`election` does not exist, it is created.
-func (le *LeaderEngine) newElection() (*ld.LeaderElector, error) {
-	// We first want to check if the ConfigMap the Leader Election is based on exists.
-	_, err := le.coreClient.ConfigMaps(le.LeaderNamespace).Get(context.TODO(), le.LeaseName, metav1.GetOptions{})
+func (le *LeaderEngine) getCurrentLeader() (string, error) {
+	if le.lockType == rl.LeasesResourceLock {
+		return le.getCurrentLeaderLease()
+	} else {
+		return le.getCurrentLeaderConfigMap()
+	}
+}
 
+func (le *LeaderEngine) CreateLeaderTokenIfNotExists() error {
+	if le.lockType == rl.LeasesResourceLock {
+		_, err := le.coordClient.Leases(le.LeaderNamespace).Get(context.TODO(), le.LeaseName, metav1.GetOptions{})
+
+		if err != nil {
+			if errors.IsNotFound(err) == false {
+				return err
+			}
+
+			_, err = le.coordClient.Leases(le.LeaderNamespace).Create(context.TODO(), &coordv1.Lease{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Lease",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      le.LeaseName,
+					Namespace: le.LeaderNamespace,
+				},
+			}, metav1.CreateOptions{})
+			if err != nil && !errors.IsConflict(err) {
+				return err
+			}
+		}
+	}
+	_, err := le.coreClient.ConfigMaps(le.LeaderNamespace).Get(context.TODO(), le.LeaseName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) == false {
-			return nil, err
+			return err
 		}
 
 		_, err = le.coreClient.ConfigMaps(le.LeaderNamespace).Create(context.TODO(), &v1.ConfigMap{
@@ -63,11 +125,21 @@ func (le *LeaderEngine) newElection() (*ld.LeaderElector, error) {
 			},
 		}, metav1.CreateOptions{})
 		if err != nil && !errors.IsConflict(err) {
-			return nil, err
+			return err
 		}
 	}
+	return err
+}
 
-	currentLeader, configMap, err := le.getCurrentLeader()
+// newElection creates an election.
+// If `namespace`/`election` does not exist, it is created.
+func (le *LeaderEngine) newElection() (*ld.LeaderElector, error) {
+	// We first want to check if the ConfigMap the Leader Election is based on exists.
+	if err := le.CreateLeaderTokenIfNotExists(); err != nil {
+		return nil, err
+	}
+
+	currentLeader, err := le.getCurrentLeader()
 	if err != nil {
 		return nil, err
 	}
@@ -104,10 +176,10 @@ func (le *LeaderEngine) newElection() (*ld.LeaderElector, error) {
 		EventRecorder: evRec,
 	}
 
-	leaderElectorInterface, err := rl.New(
-		rl.ConfigMapsResourceLock,
-		configMap.ObjectMeta.Namespace,
-		configMap.ObjectMeta.Name,
+	leaderElectorInterface, err := NewReleaseLock(
+		le.lockType,
+		le.LeaderNamespace,
+		le.LeaseName,
 		le.coreClient,
 		le.coordClient,
 		resourceLockConfig,

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
@@ -10,12 +10,14 @@ package leaderelection
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,6 +26,26 @@ import (
 
 	dderrors "github.com/DataDog/datadog-agent/pkg/errors"
 )
+
+func makeLeaderLease(name, namespace, leaderIdentity string, leaseDuration int) *coordinationv1.Lease {
+	duration := int32(leaseDuration)
+	acquiretime := metav1.NewMicroTime(time.Now())
+	renewtime := metav1.NewMicroTime(time.Now().Add(time.Duration(leaseDuration) * time.Second))
+	leasetransition := int32(1)
+	return &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity:       &leaderIdentity,
+			LeaseDurationSeconds: &duration,
+			AcquireTime:          &acquiretime,
+			RenewTime:            &renewtime,
+			LeaseTransitions:     &leasetransition,
+		},
+	}
+}
 
 func makeLeaderCM(name, namespace, leaderIdentity string, leaseDuration int) *v1.ConfigMap {
 	record := rl.LeaderElectionRecord{
@@ -60,10 +82,10 @@ func TestSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
-// TestNewLeaseAcquiring only test the proper creation of the lock,
+// TestNewLeaseAcquiring_ConfigMap only test the proper creation of the lock,
 // the acquisition of the leadership and that the ConfigMap contains is properly updated.
 // The leadership transition is tested as part of an end to end test.
-func TestNewLeaseAcquiring(t *testing.T) {
+func TestNewLeaseAcquiring_ConfigMap(t *testing.T) {
 	const leaseName = "datadog-leader-election"
 
 	client := fake.NewSimpleClientset()
@@ -76,6 +98,7 @@ func TestNewLeaseAcquiring(t *testing.T) {
 		coreClient:      client.CoreV1(),
 		coordClient:     client.CoordinationV1(),
 		leaderMetric:    &dummyGauge{},
+		lockType:        rl.ConfigMapsLeasesResourceLock,
 	}
 	_, err := client.CoreV1().ConfigMaps("default").Get(context.TODO(), leaseName, metav1.GetOptions{})
 	require.True(t, errors.IsNotFound(err))
@@ -88,7 +111,8 @@ func TestNewLeaseAcquiring(t *testing.T) {
 	require.Equal(t, newCm.Name, leaseName)
 	require.Nil(t, newCm.Annotations)
 
-	le.EnsureLeaderElectionRuns()
+	err = le.EnsureLeaderElectionRuns()
+	require.NoError(t, err)
 	Cm, err := client.CoreV1().ConfigMaps("default").Get(context.TODO(), leaseName, metav1.GetOptions{})
 	require.NoError(t, err)
 	require.Contains(t, Cm.Annotations[rl.LeaderElectionRecordAnnotationKey], "\"leaderTransitions\":1")
@@ -100,10 +124,11 @@ func TestNewLeaseAcquiring(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestSubscribe(t *testing.T) {
+func TestNewLeaseAcquiring_Lease(t *testing.T) {
 	const leaseName = "datadog-leader-election"
 
 	client := fake.NewSimpleClientset()
+
 	le := &LeaderEngine{
 		HolderIdentity:  "foo",
 		LeaseName:       leaseName,
@@ -112,50 +137,117 @@ func TestSubscribe(t *testing.T) {
 		coreClient:      client.CoreV1(),
 		coordClient:     client.CoordinationV1(),
 		leaderMetric:    &dummyGauge{},
+		lockType:        rl.LeasesResourceLock,
 	}
-
-	notif1 := le.Subscribe()
-	notif2 := le.Subscribe()
-	require.Len(t, le.subscribers, 2)
-
-	_, err := client.CoreV1().ConfigMaps("default").Get(context.TODO(), leaseName, metav1.GetOptions{})
+	_, err := client.CoordinationV1().Leases("default").Get(context.TODO(), leaseName, metav1.GetOptions{})
 	require.True(t, errors.IsNotFound(err))
 
 	le.leaderElector, err = le.newElection()
 	require.NoError(t, err)
 
-	le.EnsureLeaderElectionRuns()
+	newLease, err := client.CoordinationV1().Leases("default").Get(context.TODO(), leaseName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, newLease.Name, leaseName)
+	require.Nil(t, newLease.Annotations)
+
+	err = le.EnsureLeaderElectionRuns()
+	require.NoError(t, err)
+	lease, err := client.CoordinationV1().Leases("default").Get(context.TODO(), leaseName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, lease.Spec.LeaseTransitions)
+	require.Equal(t, int32(1), *lease.Spec.LeaseTransitions)
 	require.True(t, le.IsLeader())
 
-	counter1, counter2 := 0, 0
-	for {
-		select {
-		case <-notif1:
-			counter1++
-			if counter1 > 1 {
-				require.Fail(t, "Received too many notifications")
-				return
-			}
-
-		case <-notif2:
-			counter2++
-			if counter2 > 1 {
-				require.Fail(t, "Received too many notifications")
-				return
-			}
-
-		case <-time.After(5 * time.Second):
-			require.Fail(t, "Waiting on leader notification timed out")
-			return
-		}
-
-		if counter1 == 1 && counter2 == 1 {
-			break
-		}
-	}
+	// As a leader, GetLeaderIP should return an empty IP
+	ip, err := le.GetLeaderIP()
+	assert.Equal(t, "", ip)
+	assert.NoError(t, err)
 }
 
-func TestGetLeaderIPFollower(t *testing.T) {
+func TestSubscribe(t *testing.T) {
+	const leaseName = "datadog-leader-election"
+	for nb, tc := range []struct {
+		name         string
+		lockType     string
+		getTokenFunc func(client *fake.Clientset) error
+	}{
+		{
+			"subscribe_config_map",
+			rl.ConfigMapsLeasesResourceLock,
+			func(client *fake.Clientset) error {
+				_, err := client.CoreV1().ConfigMaps("default").Get(context.TODO(), leaseName, metav1.GetOptions{})
+				t.Logf("2 %v", err)
+				return err
+			},
+		},
+		{
+			"subscribe_lease",
+			rl.LeasesResourceLock,
+			func(client *fake.Clientset) error {
+				_, err := client.CoordinationV1().Leases("default").Get(context.TODO(), leaseName, metav1.GetOptions{})
+				t.Logf("2 %v", err)
+				return err
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("case %d: %s", nb, tc.name), func(t *testing.T) {
+			client := fake.NewSimpleClientset()
+			le := &LeaderEngine{
+				HolderIdentity:  "foo",
+				LeaseName:       leaseName,
+				LeaderNamespace: "default",
+				LeaseDuration:   1 * time.Second,
+				coreClient:      client.CoreV1(),
+				coordClient:     client.CoordinationV1(),
+				leaderMetric:    &dummyGauge{},
+				lockType:        rl.ConfigMapsLeasesResourceLock,
+			}
+
+			notif1 := le.Subscribe()
+			notif2 := le.Subscribe()
+			require.Len(t, le.subscribers, 2)
+
+			err := tc.getTokenFunc(client)
+			require.True(t, errors.IsNotFound(err))
+
+			le.leaderElector, err = le.newElection()
+			require.NoError(t, err)
+
+			le.EnsureLeaderElectionRuns()
+			require.True(t, le.IsLeader())
+
+			counter1, counter2 := 0, 0
+			for {
+				select {
+				case <-notif1:
+					counter1++
+					if counter1 > 1 {
+						require.Fail(t, "Received too many notifications")
+						return
+					}
+
+				case <-notif2:
+					counter2++
+					if counter2 > 1 {
+						require.Fail(t, "Received too many notifications")
+						return
+					}
+
+				case <-time.After(5 * time.Second):
+					require.Fail(t, "Waiting on leader notification timed out")
+					return
+				}
+
+				if counter1 == 1 && counter2 == 1 {
+					break
+				}
+			}
+		})
+	}
+
+}
+
+func TestGetLeaderIPFollower_ConfigMap(t *testing.T) {
 	const leaseName = "datadog-leader-election"
 	const endpointsName = "datadog-cluster-agent"
 
@@ -170,6 +262,7 @@ func TestGetLeaderIPFollower(t *testing.T) {
 		coreClient:      client.CoreV1(),
 		coordClient:     client.CoordinationV1(),
 		leaderMetric:    &dummyGauge{},
+		lockType:        rl.ConfigMapsLeasesResourceLock,
 	}
 
 	// Create leader-election configmap with current node as follower
@@ -217,6 +310,88 @@ func TestGetLeaderIPFollower(t *testing.T) {
 	cm, err := client.CoreV1().ConfigMaps("default").Get(context.TODO(), leaseName, metav1.GetOptions{})
 	require.NoError(t, err)
 	require.Contains(t, cm.Annotations[rl.LeaderElectionRecordAnnotationKey], "\"leaderTransitions\":1")
+
+	// We should be follower, and GetLeaderIP should return bar's IP
+	require.False(t, le.IsLeader())
+	ip, err := le.GetLeaderIP()
+	assert.NoError(t, err)
+	assert.Equal(t, "1.1.1.2", ip)
+
+	// Remove bar from endpoints
+	storedEndpoints.Subsets[0].Addresses = storedEndpoints.Subsets[0].Addresses[0:1]
+	_, err = client.CoreV1().Endpoints("default").Update(context.TODO(), storedEndpoints, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// GetLeaderIP will "gracefully" error out
+	ip, err = le.GetLeaderIP()
+	assert.Equal(t, "", ip)
+	assert.True(t, dderrors.IsNotFound(err))
+}
+
+func TestGetLeaderIPFollower_Lease(t *testing.T) {
+	const leaseName = "datadog-leader-election"
+	const endpointsName = "datadog-cluster-agent"
+
+	client := fake.NewSimpleClientset()
+
+	le := &LeaderEngine{
+		HolderIdentity:  "foo",
+		LeaseName:       leaseName,
+		ServiceName:     endpointsName,
+		LeaderNamespace: "default",
+		LeaseDuration:   120 * time.Second,
+		coreClient:      client.CoreV1(),
+		coordClient:     client.CoordinationV1(),
+		leaderMetric:    &dummyGauge{},
+		lockType:        rl.LeasesResourceLock,
+	}
+
+	// Create leader-election configmap with current node as follower
+	electionCM := makeLeaderLease(leaseName, "default", "bar", 120)
+	_, err := client.CoordinationV1().Leases("default").Create(context.TODO(), electionCM, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Create endpoints
+	endpoints := &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      endpointsName,
+			Namespace: "default",
+		},
+		Subsets: []v1.EndpointSubset{
+			{
+				Addresses: []v1.EndpointAddress{
+					{
+						IP: "1.1.1.1",
+						TargetRef: &v1.ObjectReference{
+							Kind:      "pod",
+							Namespace: "default",
+							Name:      "foo",
+						},
+					},
+					{
+						IP: "1.1.1.2",
+						TargetRef: &v1.ObjectReference{
+							Kind:      "pod",
+							Namespace: "default",
+							Name:      "bar",
+						},
+					},
+				},
+			},
+		},
+	}
+	storedEndpoints, err := client.CoreV1().Endpoints("default").Create(context.TODO(), endpoints, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Run leader election
+	le.leaderElector, err = le.newElection()
+	require.NoError(t, err)
+	err = le.EnsureLeaderElectionRuns()
+	require.NoError(t, err)
+	lease, err := client.CoordinationV1().Leases("default").Get(context.TODO(), leaseName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, lease.Spec.LeaseTransitions)
+	require.Equal(t, int32(1), *lease.Spec.LeaseTransitions)
 
 	// We should be follower, and GetLeaderIP should return bar's IP
 	require.False(t, le.IsLeader())

--- a/releasenotes-dca/notes/use-leases-leader-election-c278c71fb39c2c84.yaml
+++ b/releasenotes-dca/notes/use-leases-leader-election-c278c71fb39c2c84.yaml
@@ -1,8 +1,8 @@
 upgrade:
   - |
     Add support for leases in leader election which can be enabled by setting 
-    ``leader_election_default_resource`` to ``leases``, available since Kubernetes 1.14. 
-    If this parameter is empty then leader election automatically detects if leases
+    ``leader_election_default_resource`` to ``leases``, available since Kubernetes version 1.14. 
+    If this parameter is empty, leader election automatically detects if leases
     are available and uses them.
     Set ``leader_election_default_resource`` to ``configmap`` on clusters running
-    Kubernetes versions older than v1.14.
+    Kubernetes versions previous to 1.14.

--- a/releasenotes-dca/notes/use-leases-leader-election-c278c71fb39c2c84.yaml
+++ b/releasenotes-dca/notes/use-leases-leader-election-c278c71fb39c2c84.yaml
@@ -1,0 +1,8 @@
+upgrade:
+  - |
+    Add support for leases in leader election which can be enabled by setting 
+    ``leader_election_default_resource`` to ``leases``, available since Kubernetes 1.14. 
+    If this parameter is empty then leader election automatically detects if leases
+    are available and uses them.
+    Set ``leader_election_default_resource`` to ``configmap`` on clusters running
+    Kubernetes versions older than v1.14.

--- a/releasenotes/notes/use-leases-leader-election-c278c71fb39c2c84.yaml
+++ b/releasenotes/notes/use-leases-leader-election-c278c71fb39c2c84.yaml
@@ -1,0 +1,4 @@
+
+enhancements:
+  - |
+    Use ``leases.coordination/v1`` for cluster-agent leader election when they are available.

--- a/releasenotes/notes/use-leases-leader-election-c278c71fb39c2c84.yaml
+++ b/releasenotes/notes/use-leases-leader-election-c278c71fb39c2c84.yaml
@@ -1,4 +1,4 @@
 
 enhancements:
   - |
-    Use ``leases.coordination/v1`` for cluster-agent leader election when they are available.
+    Use ``leases.coordination/v1`` for Cluster Agent leader election when leases are available.

--- a/releasenotes/notes/use-leases-leader-election-c278c71fb39c2c84.yaml
+++ b/releasenotes/notes/use-leases-leader-election-c278c71fb39c2c84.yaml
@@ -1,4 +1,0 @@
-
-enhancements:
-  - |
-    Use ``leases.coordination/v1`` for Cluster Agent leader election when leases are available.

--- a/tasks/libs/copyright.py
+++ b/tasks/libs/copyright.py
@@ -38,6 +38,7 @@ PATH_EXCLUSION_REGEX = [
     '/internal/patch/grpc-go-insecure/',
     '/internal/patch/logr/funcr/funcr(_test){,1}.go',
     '/internal/patch/logr/funcr/internal/logr/',
+    '/internal/third_party/client-go/',
     '/internal/third_party/golang/',
     '/internal/third_party/kubernetes/',
     '/pkg/collector/corechecks/cluster/ksm/customresources/utils.go',

--- a/test/integration/util/leaderelection/leaderelection_test.go
+++ b/test/integration/util/leaderelection/leaderelection_test.go
@@ -236,11 +236,9 @@ func (suite *apiserverSuite) TestLeaderElectionMulti() {
 	}
 
 	c, err := apiserver.GetAPIClient()
-	usingLease, err := leaderelection.CanUseLeases(c.DiscoveryCl)
 	require.NoError(suite.T(), err)
-	require.Equal(suite.T(), usingLease, suite.usingLease)
 
-	if usingLease {
+	if suite.usingLease {
 		client := c.Cl.CoordinationV1()
 		require.Nil(suite.T(), err)
 		leasesList, err := client.Leases(metav1.NamespaceDefault).List(context.TODO(), metav1.ListOptions{})

--- a/test/integration/util/leaderelection/leaderelection_test.go
+++ b/test/integration/util/leaderelection/leaderelection_test.go
@@ -222,7 +222,7 @@ func (suite *apiserverSuite) TestLeaderElectionMulti() {
 	}
 
 	c, err := apiserver.GetAPIClient()
-	usingLease, err := leaderelection.CanUseLease(c.DiscoveryCl)
+	usingLease, err := leaderelection.CanUseLeases(c.DiscoveryCl)
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), usingLease, suite.usingLease)
 

--- a/test/integration/util/leaderelection/leaderelection_test.go
+++ b/test/integration/util/leaderelection/leaderelection_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,39 +35,89 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
 	"github.com/DataDog/datadog-agent/test/integration/utils"
+	"golang.org/x/mod/semver"
 )
 
 const setupTimeout = time.Second * 10
+const leaseMinVersion = "v1.14.0"
 
 type apiserverSuite struct {
 	suite.Suite
 	kubeConfigPath string
+	usingLease     bool
+}
+
+func getApiserverComposePath(version string) string {
+	return fmt.Sprintf("/tmp/apiserver-compose-%s.yaml", version)
+}
+
+func generateApiserverCompose(version string) error {
+	apiserverCompose, err := os.ReadFile("testdata/apiserver-compose.yaml")
+	if err != nil {
+		return err
+	}
+
+	newComposeFile := strings.Replace(string(apiserverCompose), "APIVERSION_PLACEHOLDER", version, -1)
+
+	err = os.WriteFile(getApiserverComposePath(version), []byte(newComposeFile), os.ModePerm)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func TestSuiteAPIServer(t *testing.T) {
-	mockConfig := config.Mock(t)
-	config.SetFeatures(t, config.Kubernetes)
-	s := &apiserverSuite{}
-
-	// Start compose stack
-	compose := &utils.ComposeConf{
-		ProjectName: "kube_events",
-		FilePath:    "testdata/apiserver-compose.yaml",
-		Variables:   map[string]string{},
+	tests := []struct {
+		name    string
+		version string
+	}{
+		{
+			"test version 1.18",
+			"v1.18.20",
+		},
+		{
+			"test version 1.13",
+			"v1.13.2",
+		},
 	}
-	output, err := compose.Start()
-	defer compose.Stop()
-	require.Nil(t, err, string(output))
+	for _, tt := range tests {
+		s := &apiserverSuite{}
+		require.True(t, semver.IsValid(tt.version))
+		if semver.Compare(tt.version, leaseMinVersion) < 0 {
+			s.usingLease = false
+		} else {
+			s.usingLease = true
+		}
 
-	// Init apiclient
-	pwd, err := os.Getwd()
-	require.Nil(t, err)
-	s.kubeConfigPath = filepath.Join(pwd, "testdata", "kubeconfig.json")
-	mockConfig.Set("kubernetes_kubeconfig_path", s.kubeConfigPath)
-	_, err = os.Stat(s.kubeConfigPath)
-	require.Nil(t, err, fmt.Sprintf("%v", err))
+		err := generateApiserverCompose(tt.version)
+		require.NoError(t, err)
+		defer func() {
+			os.Remove(getApiserverComposePath(tt.version))
+		}()
 
-	suite.Run(t, s)
+		mockConfig := config.Mock(t)
+		config.SetFeatures(t, config.Kubernetes)
+
+		// Start compose stack
+		compose := &utils.ComposeConf{
+			ProjectName: "kube_events",
+			FilePath:    getApiserverComposePath(tt.version),
+			Variables:   map[string]string{},
+		}
+		output, err := compose.Start()
+		defer compose.Stop()
+		require.Nil(t, err, string(output))
+
+		// Init apiclient
+		pwd, err := os.Getwd()
+		require.Nil(t, err)
+		s.kubeConfigPath = filepath.Join(pwd, "testdata", "kubeconfig.json")
+		mockConfig.Set("kubernetes_kubeconfig_path", s.kubeConfigPath)
+		_, err = os.Stat(s.kubeConfigPath)
+		require.Nil(t, err, fmt.Sprintf("%v", err))
+
+		suite.Run(t, s)
+	}
 }
 
 func (suite *apiserverSuite) SetupTest() {
@@ -171,24 +222,40 @@ func (suite *apiserverSuite) TestLeaderElectionMulti() {
 	}
 
 	c, err := apiserver.GetAPIClient()
-	client := c.Cl.CoreV1()
+	usingLease, err := leaderelection.CanUseLease(c.DiscoveryCl)
+	require.NoError(suite.T(), err)
+	require.Equal(suite.T(), usingLease, suite.usingLease)
 
-	require.Nil(suite.T(), err)
-	cmList, err := client.ConfigMaps(metav1.NamespaceDefault).List(context.TODO(), metav1.ListOptions{})
-	require.Nil(suite.T(), err)
-	// 1 ConfigMap
-	require.Len(suite.T(), cmList.Items, 1)
+	if usingLease {
+		client := c.Cl.CoordinationV1()
+		require.Nil(suite.T(), err)
+		leasesList, err := client.Leases(metav1.NamespaceDefault).List(context.TODO(), metav1.ListOptions{})
+		require.Nil(suite.T(), err)
+		// 1 Lease
+		require.Len(suite.T(), leasesList.Items, 1)
+		lease := leasesList.Items[0]
+		require.Equal(suite.T(), "datadog-leader-election", lease.Name)
+		require.NotNil(suite.T(), lease.Spec.HolderIdentity)
+		require.Equal(suite.T(), testCases[0].leaderEngine.HolderIdentity, *lease.Spec.HolderIdentity)
+	} else {
+		client := c.Cl.CoreV1()
+		require.Nil(suite.T(), err)
+		cmList, err := client.ConfigMaps(metav1.NamespaceDefault).List(context.TODO(), metav1.ListOptions{})
+		require.Nil(suite.T(), err)
+		// 1 ConfigMap
+		require.Len(suite.T(), cmList.Items, 1)
 
-	var leaderAnnotation string
-	var found bool
-	for _, cm := range cmList.Items {
-		if cm.Name == "datadog-leader-election" {
-			require.False(suite.T(), found, "only one configmap match")
-			leaderAnnotation, found = cm.Annotations[rl.LeaderElectionRecordAnnotationKey]
-			require.True(suite.T(), found)
+		var leaderAnnotation string
+		var found bool
+		for _, cm := range cmList.Items {
+			if cm.Name == "datadog-leader-election" {
+				require.False(suite.T(), found, "only one configmap match")
+				leaderAnnotation, found = cm.Annotations[rl.LeaderElectionRecordAnnotationKey]
+				require.True(suite.T(), found)
+			}
 		}
+		require.Nil(suite.T(), err)
+		expectedMessage := fmt.Sprintf(`"holderIdentity":"%s"`, testCases[0].leaderEngine.HolderIdentity)
+		assert.Contains(suite.T(), leaderAnnotation, expectedMessage)
 	}
-	require.Nil(suite.T(), err)
-	expectedMessage := fmt.Sprintf(`"holderIdentity":"%s"`, testCases[0].leaderEngine.HolderIdentity)
-	assert.Contains(suite.T(), leaderAnnotation, expectedMessage)
 }

--- a/test/integration/util/leaderelection/testdata/apiserver-compose.yaml
+++ b/test/integration/util/leaderelection/testdata/apiserver-compose.yaml
@@ -12,7 +12,7 @@ services:
       retries: 30
 
   apiserver:
-    image: registry.k8s.io/hyperkube:v1.18.20
+    image: registry.k8s.io/hyperkube:APIVERSION_PLACEHOLDER
     command: "kube-apiserver
         --apiserver-count=1
         --insecure-bind-address=0.0.0.0


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
From K8s 1.26, the leader election package doesn’t support anymore using a configmap/endpoint object to store the leader token. This PR uses Leases to store the leaderelection token. Since Leases were added in k8s 1.14, we add support for ConfigMapsLock with a custom configmapslock implementation.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We need to continue upgrade to recent kubernetes libraries version to use a supported version for bug and security fixes but we also need to support old kubernetes versions. We need to implement this fix to bump k8s versions.


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Merged in https://github.com/DataDog/datadog-agent/pull/16652 but reverted because of RBAC issues. Helm-chart and Operator have been updated.

Needs to be merged https://github.com/DataDog/helm-charts/pull/1108
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
Requires new RBACs to `list`, `watch`, `get` and `create` leases.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Testing requires a Kubernetes cluster with an old version (<= 1.14) and another one with a recent version.
You can deploy multiple cluster-agent and verify that they agree on the same leader after a few seconds. You can also delete the pod of the leader or add new replicas and verify that every cluster-agent views the same leader.
To find the leader for a given pod, you can execute kubectl exec cluster-agent-pod -- agent status | grep -i leader.

In order to deploy with an old kubernetes cluster, you will need to install a VM. If possible, with an architecture different from ARM. Then you will need to install an old version of minikube and docker if you do not use arm. I tested it with [minikube v1.13.0](https://github.com/kubernetes/minikube/releases/tag/v1.13.0). Finally, deploy your cluster with:
minikube start --kubernetes-version=v1.13.2 --driver=docker|none.
You can use the command kubectl api-resources to check if leases.coordination/v1 are available. They should not be.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
