### PR TITLE
[CWS] Fix offsets fallbacks for kernels > 5.15

### DIFF
--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -81,6 +81,12 @@ var (
 	Kernel5_15 = kernel.VersionCode(5, 15, 0)
 	// Kernel5_16 is the KernelVersion representation of kernel version 5.16
 	Kernel5_16 = kernel.VersionCode(5, 16, 0)
+	// Kernel5_17 is the KernelVersion representation of kernel version 5.17
+	Kernel5_17 = kernel.VersionCode(5, 17, 0)
+	// Kernel5_18 is the KernelVersion representation of kernel version 5.18
+	Kernel5_18 = kernel.VersionCode(5, 18, 0)
+	// Kernel5_19 is the KernelVersion representation of kernel version 5.19
+	Kernel5_19 = kernel.VersionCode(5, 19, 0)
 )
 
 // Version defines a kernel version helper

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -242,8 +242,10 @@ func getSignalTTYOffset(kv *kernel.Version) uint64 {
 		return 368
 	case kv.IsUbuntuKernel() && kv.IsInRangeCloseOpen(kernel.Kernel4_16, kernel.Kernel4_19):
 		return 376
-	case kv.IsUbuntuKernel():
+	case kv.IsUbuntuKernel() && kv.Code < kernel.Kernel5_19:
 		return 400 + getNoHzOffset()
+	case kv.IsUbuntuKernel() && kv.Code >= kernel.Kernel5_19:
+		return 408 + getNoHzOffset()
 	case kv.Code >= kernel.Kernel5_16:
 		return 416
 	}
@@ -291,8 +293,10 @@ func getBpfMapIDOffset(kv *kernel.Version) uint64 {
 	switch {
 	case kv.IsInRangeCloseOpen(kernel.Kernel5_15, kernel.Kernel5_16):
 		return 52
-	case kv.Code >= kernel.Kernel5_16:
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_16, kernel.Kernel5_19):
 		return 60
+	case kv.Code >= kernel.Kernel5_19:
+		return 68
 	default:
 		return 48
 	}
@@ -331,8 +335,10 @@ func getBpfMapNameOffset(kv *kernel.Version) uint64 {
 		nameOffset = 80
 	case kv.IsInRangeCloseOpen(kernel.Kernel5_15, kernel.Kernel5_16):
 		nameOffset = 88
-	case kv.Code >= kernel.Kernel5_16:
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_16, kernel.Kernel5_19):
 		nameOffset = 96
+	case kv.Code >= kernel.Kernel5_19:
+		nameOffset = 104
 	case kv.Code != 0 && kv.Code < kernel.Kernel4_15:
 		return ErrorSentinel
 	}
@@ -444,8 +450,10 @@ func getBpfProgAuxNameOffset(kv *kernel.Version) uint64 {
 		nameOffset = 504
 	case kv.IsInRangeCloseOpen(kernel.Kernel5_13, kernel.Kernel5_16):
 		nameOffset = 528
-	case kv.Code != 0 && kv.Code >= kernel.Kernel5_16:
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_16, kernel.Kernel5_17):
 		nameOffset = 544
+	case kv.Code != 0 && kv.Code >= kernel.Kernel5_17:
+		nameOffset = 528
 	}
 
 	return nameOffset
@@ -633,12 +641,14 @@ func getNetDeviceIfindexOffset(kv *kernel.Version) uint64 {
 	case kv.IsSuse15Kernel():
 		offset = 256
 
-	case kv.Code >= kernel.Kernel4_14 && kv.Code < kernel.Kernel5_8:
+	case kv.IsInRangeCloseOpen(kernel.Kernel4_14, kernel.Kernel5_8):
 		offset = 264
-	case kv.Code >= kernel.Kernel5_8 && kv.Code < kernel.Kernel5_12:
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_8, kernel.Kernel5_12):
 		offset = 256
-	case kv.Code >= kernel.Kernel5_12:
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_12, kernel.Kernel5_17):
 		offset = 208
+	case kv.Code >= kernel.Kernel5_17:
+		offset = 216
 	}
 
 	return offset
@@ -709,16 +719,16 @@ func getSocketSockOffset(kv *kernel.Version) uint64 {
 }
 
 func getNFConnCTNetOffset(kv *kernel.Version) uint64 {
-	offset := uint64(144)
-
 	switch {
 	case kv.IsCOSKernel():
-		offset = 168
+		return 168
 	case kv.IsRH7Kernel():
-		offset = 240
+		return 240
+	case kv.Code >= kernel.Kernel5_19:
+		return 136
+	default:
+		return 144
 	}
-
-	return offset
 }
 
 func getSockCommonSKCFamilyOffset(kv *kernel.Version) uint64 {
@@ -738,8 +748,10 @@ func getFlowi4SAddrOffset(kv *kernel.Version) uint64 {
 
 	case kv.IsInRangeCloseOpen(kernel.Kernel5_0, kernel.Kernel5_1):
 		offset = 32
-	case kv.Code >= kernel.Kernel5_1:
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_1, kernel.Kernel5_18):
 		offset = 40
+	case kv.Code >= kernel.Kernel5_18:
+		offset = 48
 	}
 
 	return offset
@@ -801,6 +813,8 @@ func getIoKcbCtxOffset(kv *kernel.Version) uint64 {
 		return 80
 	case kv.IsUbuntuKernel() && kv.IsInRangeCloseOpen(kernel.Kernel5_4, kernel.Kernel5_5):
 		return 96
+	case kv.Code >= kernel.Kernel5_16:
+		return 88
 	default:
 		return 80
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix some missing constants on recent kernels
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
