### PR TITLE
[gitlab] Do not use -e in agent.version invoke task calls

### DIFF
--- a/.gitlab/deploy_6/container.yml
+++ b/.gitlab/deploy_6/container.yml
@@ -14,7 +14,7 @@
   stage: deploy6
   dependencies: []
   before_script:
-    - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv -e agent.version --major-version 6 --url-safe)"; fi
+    - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv agent.version --major-version 6 --url-safe)"; fi
     - export IMG_SOURCES="${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6${JMX}-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6${JMX}-arm64"
     - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}${JMX}"
   parallel:

--- a/.gitlab/deploy_7/container.yml
+++ b/.gitlab/deploy_7/container.yml
@@ -14,7 +14,7 @@
   stage: deploy7
   dependencies: []
   before_script:
-    - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv -e agent.version --major-version 7 --url-safe)"; fi
+    - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv agent.version --major-version 7 --url-safe)"; fi
     - export IMG_BASE_SRC="${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
     - export IMG_LINUX_SOURCES="${IMG_BASE_SRC}-7${JMX}-amd64,${IMG_BASE_SRC}-7${JMX}-arm64"
     - export IMG_WINDOWS_SOURCES="${IMG_BASE_SRC}-7${JMX}-win1809${SERVERCORE}-amd64,${IMG_BASE_SRC}-7${JMX}-winltsc2022${SERVERCORE}-amd64"
@@ -55,7 +55,7 @@ deploy_containers-dogstatsd:
     !reference [.on_deploy_a7_manual_auto_on_rc]
   dependencies: []
   before_script:
-    - export VERSION="$(inv -e agent.version --major-version 7 --url-safe)"
+    - export VERSION="$(inv agent.version --major-version 7 --url-safe)"
     - export IMG_SOURCES="${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64"
     - export IMG_DESTINATIONS="${DSD_REPOSITORY}:${VERSION}"
 

--- a/.gitlab/deploy_dca.yml
+++ b/.gitlab/deploy_dca.yml
@@ -14,7 +14,7 @@
   stage: deploy_dca
   dependencies: []
   before_script:
-    - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv -e agent.version --major-version 7 --url-safe)"; fi
+    - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv agent.version --major-version 7 --url-safe)"; fi
     - if [[ "$CLUSTER_AGENT_REPOSITORY" == "" ]]; then export CLUSTER_AGENT_REPOSITORY="cluster-agent"; fi
     - export IMG_BASE_SRC="${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
     - export IMG_SOURCES="${IMG_BASE_SRC}-amd64,${IMG_BASE_SRC}-arm64"

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -47,7 +47,7 @@ k8s-e2e-tags-6:
   extends: .k8s_e2e_template
   rules: !reference [.on_deploy_stable_or_beta_repo_branch_a6_manual]
   script:
-    - AGENT_VERSION=$(inv -e agent.version --major-version 6)
+    - AGENT_VERSION=$(inv agent.version --major-version 6)
     - DCA_VERSION=$(inv -e cluster-agent.version)
     - inv -e e2e-tests --agent-image=datadog/agent:${AGENT_VERSION} --dca-image=datadog/cluster-agent:${DCA_VERSION} --argo-workflow=default
 
@@ -55,7 +55,7 @@ k8s-e2e-tags-7:
   extends: .k8s_e2e_template
   rules: !reference [.on_deploy_stable_or_beta_repo_branch_a7_manual]
   script:
-    - AGENT_VERSION=$(inv -e agent.version --major-version 7)
+    - AGENT_VERSION=$(inv agent.version --major-version 7)
     - DCA_VERSION=$(inv -e cluster-agent.version)
     - inv -e e2e-tests --agent-image=datadog/agent:${AGENT_VERSION} --dca-image=datadog/cluster-agent:${DCA_VERSION} --argo-workflow=default
 

--- a/tools/windows/DatadogAgentInstaller/WixSetup.Tests/AgentVersionTests.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup.Tests/AgentVersionTests.cs
@@ -32,7 +32,7 @@ namespace WixSetup.Tests
         [Fact]
         public void Should_Parse_Nightly_Version_OmnibusFormat_Correctly()
         {
-            // Output of inv -e agent.version --omnibus-format on a nightly
+            // Output of inv agent.version --omnibus-format on a nightly
             var packageVersion = "7.40.0~rc.2+git.309.1240df2";
             var version = new Datadog.AgentVersion(packageVersion);
             version.PackageVersion.Should().Be(packageVersion);
@@ -45,7 +45,7 @@ namespace WixSetup.Tests
         [Fact]
         public void Should_Parse_Nightly_Version_UrlSafe_Correctly()
         {
-            // Output of inv -e agent.version --url-safe on an RC
+            // Output of inv agent.version --url-safe on an RC
             var packageVersion = "7.43.1-rc.3.git.485.14b9337";
             var version = new Datadog.AgentVersion(packageVersion);
             version.PackageVersion.Should().Be(packageVersion);


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Follow-up of #16279 and #17160: removes `-e` in all pipeline invocations of `invoke agent.version` (except in `setup_agent_version` where it's fine).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Since #16279, `invoke -e agent.version` in CI prints the `aws s3 cp` command run to retrieve the version cache, which breaks following steps that rely on its output.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

n/a

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
