### PR TITLE
[CWS][SEC-3735] Check self tests results in e2e tests

### DIFF
--- a/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
@@ -131,7 +131,10 @@ class TestE2EDocker(unittest.TestCase):
             event = self.app.wait_app_log(f"rule_id:{rule_id}")
             attributes = event["data"][0]["attributes"]["attributes"]
             self.assertEqual(rule_id, attributes["agent"]["rule_id"], "unable to find rule_id tag attribute")
-            self.assertTrue("failed_tests" not in attributes, f"failed tests: {attributes['failed_tests']}" if "failed_tests" in attributes else "success")
+            self.assertTrue(
+                "failed_tests" not in attributes,
+                f"failed tests: {attributes['failed_tests']}" if "failed_tests" in attributes else "success",
+            )
 
         with Step(msg="wait for host tags (3m)", emoji=":alarm_clock:"):
             time.sleep(3 * 60)

--- a/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
@@ -131,7 +131,7 @@ class TestE2EDocker(unittest.TestCase):
             event = self.app.wait_app_log(f"rule_id:{rule_id}")
             attributes = event["data"][0]["attributes"]["attributes"]
             self.assertEqual(rule_id, attributes["agent"]["rule_id"], "unable to find rule_id tag attribute")
-            self.assertTrue("failed_tests" not in attributes, "self_tests have failed")
+            self.assertTrue("failed_tests" not in attributes, f"failed tests: {attributes['failed_tests']}" if "failed_tests" in attributes else "success")
 
         with Step(msg="wait for host tags (3m)", emoji=":alarm_clock:"):
             time.sleep(3 * 60)

--- a/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
@@ -125,7 +125,7 @@ class TestE2EDocker(unittest.TestCase):
             else:
                 self.fail("check ruleset_loaded timeouted")
             self.app.check_for_ignored_policies(self, attributes)
-        
+
         with Step(msg="check self_tests", emoji=":test_tube:"):
             rule_id = "self_test"
             event = self.app.wait_app_log(f"rule_id:{rule_id}")

--- a/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
@@ -125,6 +125,14 @@ class TestE2EDocker(unittest.TestCase):
             else:
                 self.fail("check ruleset_loaded timeouted")
             self.app.check_for_ignored_policies(self, attributes)
+        
+        with Step(msg="check self_tests",emoji=":test_tube:"):
+            rule_id = "self_test"
+            event = self.app.wait_app_log(f"rule_id:{rule_id}")
+
+            attributes = event["data"][0]["attributes"]["attributes"]
+            self.assertEqual(rule_id, attributes["agent"]["rule_id"],"unable to find rule_id tag attribute")
+            self.assertEqual(0,len(attributes["failed_tests"]), f"failing test(s): {attributes["failed_tests"]}")
 
         with Step(msg="wait for host tags (3m)", emoji=":alarm_clock:"):
             time.sleep(3 * 60)

--- a/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
@@ -129,10 +129,9 @@ class TestE2EDocker(unittest.TestCase):
         with Step(msg="check self_tests",emoji=":test_tube:"):
             rule_id = "self_test"
             event = self.app.wait_app_log(f"rule_id:{rule_id}")
-
             attributes = event["data"][0]["attributes"]["attributes"]
             self.assertEqual(rule_id, attributes["agent"]["rule_id"],"unable to find rule_id tag attribute")
-            self.assertEqual(0,len(attributes["failed_tests"]), f"failing test(s): {attributes["failed_tests"]}")
+            self.assertTrue("failed_tests" not in attributes, "self_tests have failed")
 
         with Step(msg="wait for host tags (3m)", emoji=":alarm_clock:"):
             time.sleep(3 * 60)

--- a/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
@@ -126,11 +126,11 @@ class TestE2EDocker(unittest.TestCase):
                 self.fail("check ruleset_loaded timeouted")
             self.app.check_for_ignored_policies(self, attributes)
         
-        with Step(msg="check self_tests",emoji=":test_tube:"):
+        with Step(msg="check self_tests", emoji=":test_tube:"):
             rule_id = "self_test"
             event = self.app.wait_app_log(f"rule_id:{rule_id}")
             attributes = event["data"][0]["attributes"]["attributes"]
-            self.assertEqual(rule_id, attributes["agent"]["rule_id"],"unable to find rule_id tag attribute")
+            self.assertEqual(rule_id, attributes["agent"]["rule_id"], "unable to find rule_id tag attribute")
             self.assertTrue("failed_tests" not in attributes, "self_tests have failed")
 
         with Step(msg="wait for host tags (3m)", emoji=":alarm_clock:"):

--- a/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
@@ -138,7 +138,10 @@ class TestE2EKubernetes(unittest.TestCase):
             event = self.app.wait_app_log(f"rule_id:{rule_id}")
             attributes = event["data"][0]["attributes"]["attributes"]
             self.assertEqual(rule_id, attributes["agent"]["rule_id"], "unable to find rule_id tag attribute")
-            self.assertTrue("failed_tests" not in attributes, f"failed tests: {attributes['failed_tests']}" if "failed_tests" in attributes else "success")
+            self.assertTrue(
+                "failed_tests" not in attributes,
+                f"failed tests: {attributes['failed_tests']}" if "failed_tests" in attributes else "success",
+            )
 
         with Step(msg="wait for datadog.security_agent.runtime.running metric", emoji="\N{beer mug}"):
             self.app.wait_for_metric("datadog.security_agent.runtime.running", host=TestE2EKubernetes.hostname)

--- a/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
@@ -133,11 +133,11 @@ class TestE2EKubernetes(unittest.TestCase):
                 self.fail("check ruleset_loaded timeouted")
             self.app.check_for_ignored_policies(self, attributes)
         
-        with Step(msg="check self_tests",emoji=":test_tube:"):
+        with Step(msg="check self_tests", emoji=":test_tube:"):
             rule_id = "self_test"
             event = self.app.wait_app_log(f"rule_id:{rule_id}")
             attributes = event["data"][0]["attributes"]["attributes"]
-            self.assertEqual(rule_id, attributes["agent"]["rule_id"],"unable to find rule_id tag attribute")
+            self.assertEqual(rule_id, attributes["agent"]["rule_id"], "unable to find rule_id tag attribute")
             self.assertTrue("failed_tests" not in attributes, "self_tests have failed")
 
         with Step(msg="wait for datadog.security_agent.runtime.running metric", emoji="\N{beer mug}"):

--- a/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
@@ -138,7 +138,7 @@ class TestE2EKubernetes(unittest.TestCase):
             event = self.app.wait_app_log(f"rule_id:{rule_id}")
             attributes = event["data"][0]["attributes"]["attributes"]
             self.assertEqual(rule_id, attributes["agent"]["rule_id"], "unable to find rule_id tag attribute")
-            self.assertTrue("failed_tests" not in attributes, "self_tests have failed")
+            self.assertTrue("failed_tests" not in attributes, f"failed tests: {attributes['failed_tests']}" if "failed_tests" in attributes else "success")
 
         with Step(msg="wait for datadog.security_agent.runtime.running metric", emoji="\N{beer mug}"):
             self.app.wait_for_metric("datadog.security_agent.runtime.running", host=TestE2EKubernetes.hostname)

--- a/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
@@ -132,7 +132,7 @@ class TestE2EKubernetes(unittest.TestCase):
             else:
                 self.fail("check ruleset_loaded timeouted")
             self.app.check_for_ignored_policies(self, attributes)
-        
+
         with Step(msg="check self_tests", emoji=":test_tube:"):
             rule_id = "self_test"
             event = self.app.wait_app_log(f"rule_id:{rule_id}")

--- a/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
@@ -132,6 +132,14 @@ class TestE2EKubernetes(unittest.TestCase):
             else:
                 self.fail("check ruleset_loaded timeouted")
             self.app.check_for_ignored_policies(self, attributes)
+        
+        with Step(msg="check self_tests",emoji=":test_tube:"):
+            rule_id = "self_test"
+            event = self.app.wait_app_log(f"rule_id:{rule_id}")
+
+            attributes = event["data"][0]["attributes"]["attributes"]
+            self.assertEqual(rule_id, attributes["agent"]["rule_id"],"unable to find rule_id tag attribute")
+            self.assertEqual(0,len(attributes["failed_tests"]), f"failing test(s): {attributes["failed_tests"]}")
 
         with Step(msg="wait for datadog.security_agent.runtime.running metric", emoji="\N{beer mug}"):
             self.app.wait_for_metric("datadog.security_agent.runtime.running", host=TestE2EKubernetes.hostname)

--- a/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
@@ -136,10 +136,9 @@ class TestE2EKubernetes(unittest.TestCase):
         with Step(msg="check self_tests",emoji=":test_tube:"):
             rule_id = "self_test"
             event = self.app.wait_app_log(f"rule_id:{rule_id}")
-
             attributes = event["data"][0]["attributes"]["attributes"]
             self.assertEqual(rule_id, attributes["agent"]["rule_id"],"unable to find rule_id tag attribute")
-            self.assertEqual(0,len(attributes["failed_tests"]), f"failing test(s): {attributes["failed_tests"]}")
+            self.assertTrue("failed_tests" not in attributes, "self_tests have failed")
 
         with Step(msg="wait for datadog.security_agent.runtime.running metric", emoji="\N{beer mug}"):
             self.app.wait_for_metric("datadog.security_agent.runtime.running", host=TestE2EKubernetes.hostname)


### PR DESCRIPTION
This PR aims to check the self_tests's results in the end to end tests

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
