### PR TITLE
[CSPM] Fix missing field from rego input context for k8s rules

### DIFF
--- a/pkg/compliance/k8sconfig/loader.go
+++ b/pkg/compliance/k8sconfig/loader.go
@@ -435,6 +435,9 @@ func (l *loader) pushError(err error) {
 }
 
 func (l *loader) parseBool(v string) bool {
+	if v == "" {
+		return true
+	}
 	b, err := strconv.ParseBool(v)
 	if err != nil {
 		l.pushError(err)

--- a/pkg/compliance/resolver.go
+++ b/pkg/compliance/resolver.go
@@ -221,7 +221,9 @@ func (r *defaultResolver) ResolveInputs(ctx_ context.Context, rule *Rule) (Resol
 		}
 
 		resolvingContext.InputSpecs[tagName] = spec
-		resolvingContext.KubernetesCluster = kubernetesCluster
+		if kubernetesCluster != "" {
+			resolvingContext.KubernetesCluster = kubernetesCluster
+		}
 
 		if r, ok := result.([]interface{}); ok && reflect.ValueOf(r).IsNil() {
 			result = nil


### PR DESCRIPTION
### What does this PR do?

Fixes two issues in our compliance pkg:
- resolved k8sconfig did not resolve properly boolean process flags when no argument is given
- `input.context.kubernetes_cluster` field is missing from rego input when required

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
