### PR TITLE
[CSPM] Allow specifying multiple k8s components of the same kind

### DIFF
--- a/pkg/compliance/k8sconfig/loader.go
+++ b/pkg/compliance/k8sconfig/loader.go
@@ -86,17 +86,29 @@ func (l *loader) load(ctx context.Context, loadProcesses procsLoader) (string, *
 	for _, proc := range loadProcesses(ctx) {
 		switch proc.name {
 		case "etcd":
-			node.Components.Etcd = l.newK8sEtcdConfig(proc.flags)
+			if c := l.newK8sEtcdConfig(proc.flags); c != nil {
+				node.Components.Etcd = append(node.Components.Etcd, c)
+			}
 		case "kube-apiserver", "apiserver":
-			node.Components.KubeApiserver = l.newK8sKubeApiserverConfig(proc.flags)
+			if c := l.newK8sKubeApiserverConfig(proc.flags); c != nil {
+				node.Components.KubeApiserver = append(node.Components.KubeApiserver, c)
+			}
 		case "kube-controller-manager", "kube-controller", "controller-manager":
-			node.Components.KubeControllerManager = l.newK8sKubeControllerManagerConfig(proc.flags)
+			if c := l.newK8sKubeControllerManagerConfig(proc.flags); c != nil {
+				node.Components.KubeControllerManager = append(node.Components.KubeControllerManager, c)
+			}
 		case "kube-scheduler":
-			node.Components.KubeScheduler = l.newK8sKubeSchedulerConfig(proc.flags)
+			if c := l.newK8sKubeSchedulerConfig(proc.flags); c != nil {
+				node.Components.KubeScheduler = append(node.Components.KubeScheduler, c)
+			}
 		case "kubelet":
-			node.Components.Kubelet = l.newK8sKubeletConfig(proc.flags)
+			if c := l.newK8sKubeletConfig(proc.flags); c != nil {
+				node.Components.Kubelet = append(node.Components.Kubelet, c)
+			}
 		case "kube-proxy":
-			node.Components.KubeProxy = l.newK8sKubeProxyConfig(proc.flags)
+			if c := l.newK8sKubeProxyConfig(proc.flags); c != nil {
+				node.Components.KubeProxy = append(node.Components.KubeProxy, c)
+			}
 		}
 	}
 

--- a/pkg/compliance/k8sconfig/types.go
+++ b/pkg/compliance/k8sconfig/types.go
@@ -16,12 +16,12 @@ type K8sNodeConfig struct {
 	KubeletService     *K8sConfigFileMeta   `json:"kubeletService,omitempty"`
 	AdminKubeconfig    *K8sKubeconfigMeta   `json:"adminKubeconfig,omitempty"`
 	Components         struct {
-		Etcd                  *K8sEtcdConfig                  `json:"etcd,omitempty"`
-		KubeApiserver         *K8sKubeApiserverConfig         `json:"kubeApiserver,omitempty"`
-		KubeControllerManager *K8sKubeControllerManagerConfig `json:"kubeControllerManager,omitempty"`
-		Kubelet               *K8sKubeletConfig               `json:"kubelet,omitempty"`
-		KubeProxy             *K8sKubeProxyConfig             `json:"kubeProxy,omitempty"`
-		KubeScheduler         *K8sKubeSchedulerConfig         `json:"kubeScheduler,omitempty"`
+		Etcd                  []*K8sEtcdConfig                  `json:"etcd,omitempty"`
+		KubeApiserver         []*K8sKubeApiserverConfig         `json:"kubeApiserver,omitempty"`
+		KubeControllerManager []*K8sKubeControllerManagerConfig `json:"kubeControllerManager,omitempty"`
+		Kubelet               []*K8sKubeletConfig               `json:"kubelet,omitempty"`
+		KubeProxy             []*K8sKubeProxyConfig             `json:"kubeProxy,omitempty"`
+		KubeScheduler         []*K8sKubeSchedulerConfig         `json:"kubeScheduler,omitempty"`
 	} `json:"components"`
 	Manifests struct {
 		Etcd                 *K8sConfigFileMeta `json:"etcd,omitempty"`


### PR DESCRIPTION
### What does this PR do?

Fixes a non-anticipated usecase where a given node would run multiple of the same k8s components.

### Motivation

Even if this usecase is quite marginal, we still want to be able to support it in the future.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
