### PR TITLE
[CWS] use legacy gopsutil for smaps reading in snapshot

### DIFF
--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -83,9 +83,6 @@ func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *ActivityTreeStat
 	}
 	files = append(files, mmapedFiles...)
 
-	seclog.Infof("AD: snapshotting %d files", len(files))
-	seclog.Infof("AD: files: %v", files)
-
 	// often the mmaped files are already nearly sorted, so we take the quick win and de-duplicate without sorting
 	files = slices.Compact(files)
 

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -131,6 +131,8 @@ func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *ActivityTreeStat
 	return nil
 }
 
+const MAX_MMAPED_FILES = 128
+
 func snapshotMemoryMappedFiles(pid int32, processEventPath string) ([]string, error) {
 	fakeprocess := legacyprocess.Process{Pid: pid}
 	stats, err := fakeprocess.MemoryMaps(false)
@@ -140,6 +142,10 @@ func snapshotMemoryMappedFiles(pid int32, processEventPath string) ([]string, er
 
 	files := make([]string, 0, len(*stats))
 	for _, mm := range *stats {
+		if len(files) >= MAX_MMAPED_FILES {
+			break
+		}
+
 		if len(mm.Path) == 0 {
 			continue
 		}

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -137,7 +137,7 @@ func snapshotMemoryMappedFiles(pid int32, processEventPath string) ([]string, er
 		return nil, err
 	}
 
-	files := make([]string, 0, len(*stats))
+	files := make([]string, 0, MAX_MMAPED_FILES)
 	for _, mm := range *stats {
 		if len(files) >= MAX_MMAPED_FILES {
 			break

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -105,7 +105,7 @@ func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *ActivityTreeStat
 		evt.Type = uint32(model.FileOpenEventType)
 
 		resolvedPath, err = filepath.EvalSymlinks(f)
-		if err != nil && len(resolvedPath) != 0 {
+		if err == nil && len(resolvedPath) != 0 {
 			evt.Open.File.SetPathnameStr(resolvedPath)
 		} else {
 			evt.Open.File.SetPathnameStr(f)

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -87,7 +86,7 @@ func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *ActivityTreeStat
 	seclog.Infof("AD: snapshotting %d files", len(files))
 	seclog.Infof("AD: files: %v", files)
 
-	sort.Strings(files)
+	// often the mmaped files are already nearly sorted, so we take the quick win and de-duplicate without sorting
 	files = slices.Compact(files)
 
 	// insert files

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -82,6 +82,9 @@ func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *ActivityTreeStat
 	}
 	files = append(files, mmapedFiles...)
 
+	seclog.Infof("AD: snapshotting %d files", len(files))
+	seclog.Infof("AD: files: %v", files)
+
 	// insert files
 	var fileinfo os.FileInfo
 	var resolvedPath string

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -21,6 +22,7 @@ import (
 	legacyprocess "github.com/DataDog/gopsutil/process"
 	"github.com/prometheus/procfs"
 	"github.com/shirou/gopsutil/v3/process"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
@@ -84,6 +86,9 @@ func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *ActivityTreeStat
 
 	seclog.Infof("AD: snapshotting %d files", len(files))
 	seclog.Infof("AD: files: %v", files)
+
+	sort.Strings(files)
+	files = slices.Compact(files)
 
 	// insert files
 	var fileinfo os.FileInfo

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -133,9 +133,15 @@ func snapshotMemoryMappedFiles(pid int32, processEventPath string) ([]string, er
 
 	files := make([]string, 0, len(*stats))
 	for _, mm := range *stats {
-		if mm.Path != processEventPath {
-			files = append(files, mm.Path)
+		if len(mm.Path) == 0 {
+			continue
 		}
+
+		if mm.Path != processEventPath {
+			continue
+		}
+
+		files = append(files, mm.Path)
 	}
 	return files, nil
 }


### PR DESCRIPTION
### What does this PR do?

The upstream version uses `ioutil.ReadFile` to read the whole file at once instead of streaming it like the datadog fork. This can cause memory issues. This PR reverts to using the fork for this specific operation while we work on an upstream PR.

This PR also limits the amount of mmaped files collected, to 128 for now.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
