### PR TITLE
[corechecks/snmp] Add User Profiles support

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -725,8 +725,13 @@ func GetProfileForSysObjectID(profiles profileConfigMap, sysObjectID string) (st
 			if !found {
 				continue
 			}
-			if matchedProfile, ok := tmpSysOidToProfile[oidPattern]; ok {
-				return "", fmt.Errorf("profile %s has the same sysObjectID (%s) as %s", profile, oidPattern, matchedProfile)
+			if prevMatchedProfile, ok := tmpSysOidToProfile[oidPattern]; ok {
+				if profiles[prevMatchedProfile].isUserProfile && !profConfig.isUserProfile {
+					continue
+				}
+				if profiles[prevMatchedProfile].isUserProfile == profConfig.isUserProfile {
+					return "", fmt.Errorf("profile %s has the same sysObjectID (%s) as %s", profile, oidPattern, prevMatchedProfile)
+				}
 			}
 			tmpSysOidToProfile[oidPattern] = profile
 			matchedOids = append(matchedOids, oidPattern)

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_profile.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_profile.go
@@ -10,4 +10,6 @@ type profileConfigMap map[string]profileConfig
 type profileConfig struct {
 	DefinitionFile string            `yaml:"definition_file"`
 	Definition     profileDefinition `yaml:"definition"`
+
+	isUserProfile bool `yaml:"-"`
 }

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/profile_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/profile_test.go
@@ -23,6 +23,15 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
+func getMetricFromProfile(p profileDefinition, metricName string) *MetricsConfig {
+	for _, m := range p.Metrics {
+		if m.Symbol.Name == metricName {
+			return &m
+		}
+	}
+	return nil
+}
+
 func fixtureProfileDefinitionMap() profileConfigMap {
 	metrics := []MetricsConfig{
 		{Symbol: SymbolConfig{OID: "1.3.6.1.4.1.3375.2.1.1.2.1.44.0", Name: "sysStatMemoryTotal", ScaleFactor: 2}, ForcedType: "gauge"},
@@ -158,6 +167,7 @@ func fixtureProfileDefinitionMap() profileConfigMap {
 					},
 				},
 			},
+			isUserProfile: true,
 		},
 		"another_profile": profileConfig{
 			Definition: profileDefinition{
@@ -170,6 +180,7 @@ func fixtureProfileDefinitionMap() profileConfigMap {
 				},
 				Metadata: MetadataConfig{},
 			},
+			isUserProfile: true,
 		},
 	}
 }
@@ -183,9 +194,11 @@ func Test_getDefaultProfilesDefinitionFiles(t *testing.T) {
 	expectedProfileConfig := profileConfigMap{
 		"f5-big-ip": {
 			DefinitionFile: filepath.Join(confdPath, "snmp.d", "profiles", "f5-big-ip.yaml"),
+			isUserProfile:  true,
 		},
 		"another_profile": {
 			DefinitionFile: filepath.Join(confdPath, "snmp.d", "profiles", "another_profile.yaml"),
+			isUserProfile:  true,
 		},
 	}
 
@@ -393,7 +406,8 @@ func Test_getMostSpecificOid(t *testing.T) {
 }
 
 func Test_resolveProfileDefinitionPath(t *testing.T) {
-	SetConfdPathAndCleanProfiles()
+	defaultTestConfdPath, _ := filepath.Abs(filepath.Join("..", "test", "user_profiles.d"))
+	config.Datadog.Set("confd_path", defaultTestConfdPath)
 
 	absPath, _ := filepath.Abs(filepath.Join("tmp", "myfile.yaml"))
 	tests := []struct {
@@ -407,9 +421,19 @@ func Test_resolveProfileDefinitionPath(t *testing.T) {
 			expectedPath:       absPath,
 		},
 		{
-			name:               "relative path",
-			definitionFilePath: "myfile.yaml",
-			expectedPath:       filepath.Join(config.Datadog.Get("confd_path").(string), "snmp.d", "profiles", "myfile.yaml"),
+			name:               "relative path with default profile",
+			definitionFilePath: "p2.yaml",
+			expectedPath:       filepath.Join(config.Datadog.Get("confd_path").(string), "snmp.d", "default_profiles", "p2.yaml"),
+		},
+		{
+			name:               "relative path with user profile",
+			definitionFilePath: "p3.yaml",
+			expectedPath:       filepath.Join(config.Datadog.Get("confd_path").(string), "snmp.d", "profiles", "p3.yaml"),
+		},
+		{
+			name:               "relative path with user profile precedence",
+			definitionFilePath: "p1.yaml",
+			expectedPath:       filepath.Join(config.Datadog.Get("confd_path").(string), "snmp.d", "profiles", "p1.yaml"),
 		},
 	}
 	for _, tt := range tests {
@@ -431,14 +455,39 @@ func Test_loadDefaultProfiles(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%p", defaultProfiles), fmt.Sprintf("%p", defaultProfiles2))
 }
 
+func Test_loadDefaultProfiles_withUserProfiles(t *testing.T) {
+	globalProfileConfigMap = nil
+	defaultTestConfdPath, _ := filepath.Abs(filepath.Join("..", "test", "user_profiles.d"))
+	config.Datadog.Set("confd_path", defaultTestConfdPath)
+
+	defaultProfiles, err := loadDefaultProfiles()
+	assert.Nil(t, err)
+
+	assert.Len(t, defaultProfiles, 3)
+	assert.NotNil(t, defaultProfiles)
+
+	p1 := defaultProfiles["p1"].Definition // user p1 overrides datadog p1
+	p2 := defaultProfiles["p2"].Definition // datadog p2
+	p3 := defaultProfiles["p3"].Definition // user p3
+
+	assert.Equal(t, "p1_user", p1.Device.Vendor) // overrides datadog p1 profile
+	assert.NotNil(t, getMetricFromProfile(p1, "p1_metric_override"))
+
+	assert.Equal(t, "p2_datadog", p2.Device.Vendor)
+	assert.NotNil(t, getMetricFromProfile(p2, "p2_metric"))
+
+	assert.Equal(t, "p3_user", p3.Device.Vendor)
+	assert.NotNil(t, getMetricFromProfile(p3, "p3_metric"))
+}
+
 func Test_loadDefaultProfiles_invalidDir(t *testing.T) {
 	invalidPath, _ := filepath.Abs(filepath.Join(".", "tmp", "invalidPath"))
 	config.Datadog.Set("confd_path", invalidPath)
 	globalProfileConfigMap = nil
 
 	defaultProfiles, err := loadDefaultProfiles()
-	assert.Contains(t, err.Error(), "failed to get default profile definitions: failed to read dir")
-	assert.Nil(t, defaultProfiles)
+	assert.Nil(t, err)
+	assert.Len(t, defaultProfiles, 0)
 }
 
 func Test_loadDefaultProfiles_invalidExtendProfile(t *testing.T) {

--- a/pkg/collector/corechecks/snmp/internal/test/user_profiles.d/snmp.d/default_profiles/_base.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/user_profiles.d/snmp.d/default_profiles/_base.yaml
@@ -1,0 +1,6 @@
+# Base profile that should only contain any items we want to provide for all profiles.
+
+metric_tags:
+  - OID: 1.3.6.1.2.1.1.5.0
+    symbol: sysName
+    tag: base_datadog

--- a/pkg/collector/corechecks/snmp/internal/test/user_profiles.d/snmp.d/default_profiles/p1.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/user_profiles.d/snmp.d/default_profiles/p1.yaml
@@ -1,0 +1,14 @@
+# Profile for F5 BIG-IP devices
+#
+extends:
+  - _base.yaml
+
+device:
+  vendor: "p2_datadog"
+
+sysobjectid: 1.2.3.*
+
+metrics:
+  - symbol:
+      OID: 1.2.3.5
+      name: p1_metric

--- a/pkg/collector/corechecks/snmp/internal/test/user_profiles.d/snmp.d/default_profiles/p2.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/user_profiles.d/snmp.d/default_profiles/p2.yaml
@@ -1,0 +1,14 @@
+# Profile for F5 BIG-IP devices
+#
+extends:
+  - _base.yaml
+
+device:
+  vendor: "p2_datadog"
+
+sysobjectid: 1.2.3.*
+
+metrics:
+  - symbol:
+      OID: 1.2.3.5
+      name: p2_metric

--- a/pkg/collector/corechecks/snmp/internal/test/user_profiles.d/snmp.d/profiles/p1.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/user_profiles.d/snmp.d/profiles/p1.yaml
@@ -1,0 +1,12 @@
+extends:
+  - _base.yaml
+
+device:
+  vendor: "p1_user"
+
+sysobjectid: 1.3.6.1.4.1.3375.2.1.3.4.*
+
+metrics:
+  - symbol:
+      OID: 1.2.3.5
+      name: p1_metric_override

--- a/pkg/collector/corechecks/snmp/internal/test/user_profiles.d/snmp.d/profiles/p3.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/user_profiles.d/snmp.d/profiles/p3.yaml
@@ -1,0 +1,14 @@
+# Profile for F5 BIG-IP devices
+#
+extends:
+  - _base.yaml
+
+device:
+  vendor: "p3_user"
+
+sysobjectid: 1.3.6.1.4.1.3375.2.1.3.4.*
+
+metrics:
+  - symbol:
+      OID: 1.2.3
+      name: p3_metric

--- a/releasenotes/notes/snmp_add_user_profiles-a3cb283bae7d5e86.yaml
+++ b/releasenotes/notes/snmp_add_user_profiles-a3cb283bae7d5e86.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    [corechecks/snmp] Add ``user_profiles`` directory support.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add User Profiles support

- `profiles` is used for user profiles
- `default_profiles` will contain datadog ootb profiles
- `profiles` (user) have precedence over `default_profiles`
- If the same sysObjectID is used in both `profiles` and `default_profiles`, the one from `profiles` will take precedence. The same sysObjectID cannot be used in the same profile folder as before.
- `extends` will favour profiles from users `profiles` folder

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Separate default and user profiles and provide a specific folder where users can add their profiles.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1/ Check that all the feature changes described in PR Description works:
- `profiles` (user) have precedence over `default_profiles`
- If the same sysObjectID is used in both `profiles` and `default_profiles`, the one from `profiles` will take precedence. The same sysObjectID cannot be used in the same profile folder as before.
- `extends` will favour profiles from users `profiles` folder

2/ ⚠️ Test that the SNMP integration works as expected when users migrate from previous versions.
For example:
- Make sure that `snmp.d/profiles` (user) does not contain the OOTB profiles anymore
- Make sure that the OOTB are now in `snmp.d/default_profiles` folder
- Make sure that user profiles work as expected after the migration
- Make sure that default profiles work as expected after the migration
- Test as much cases as possible to detect any behaviour that might lead to a breaking change.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
