### PR TITLE
The skeleton of logging telemetry events from the cluster agent

### DIFF
--- a/pkg/clusteragent/admission/patch/provider.go
+++ b/pkg/clusteragent/admission/patch/provider.go
@@ -19,9 +19,9 @@ type patchProvider interface {
 	subscribe(kind TargetObjKind) chan PatchRequest
 }
 
-func newPatchProvider(rcClient *remote.Client, isLeaderNotif <-chan struct{}, clusterName string) (patchProvider, error) {
+func newPatchProvider(rcClient *remote.Client, isLeaderNotif <-chan struct{}, clusterId string, clusterName string) (patchProvider, error) {
 	if config.Datadog.GetBool("remote_configuration.enabled") {
-		return newRemoteConfigProvider(rcClient, isLeaderNotif, clusterName)
+		return newRemoteConfigProvider(rcClient, isLeaderNotif, clusterId, clusterName)
 	}
 	if config.Datadog.GetBool("admission_controller.auto_instrumentation.patcher.fallback_to_file_provider") {
 		// Use the file config provider for e2e testing only (it replaces RC as a source of configs)

--- a/pkg/clusteragent/admission/patch/rc_provider.go
+++ b/pkg/clusteragent/admission/patch/rc_provider.go
@@ -86,13 +86,17 @@ func (rcp *remoteConfigProvider) process(update map[string]state.APMTracingConfi
 		}
 		if ch, found := rcp.subscribers[req.K8sTarget.Kind]; found {
 			valid++
+			env := ""
+			if req.LibConfig.Env != nil {
+				env = *req.LibConfig.Env
+			}
 			rcp.telemetryCollector.SendEvent(&telemetry.ApmRemoteConfigEvent{
 				RequestType: "apm-remote-config-event",
 				ApiVersion:  "v2",
 				Payload: telemetry.ApmRemoteConfigEventPayload{
 					EventName: "agent.k8s.patch",
 					Tags: telemetry.ApmRemoteConfigEventTags{
-						Env:                 *req.LibConfig.Env,
+						Env:                 env,
 						RcId:                req.ID,
 						RcClientId:          rcp.client.ID,
 						RcRevision:          req.SchemaVersion,

--- a/pkg/clusteragent/admission/patch/rc_provider_test.go
+++ b/pkg/clusteragent/admission/patch/rc_provider_test.go
@@ -38,7 +38,7 @@ func TestProcess(t *testing.T) {
 `
 		return []byte(fmt.Sprintf(base, cluster, kind))
 	}
-	rcp, err := newRemoteConfigProvider(&remote.Client{}, make(chan struct{}), "dev")
+	rcp, err := newRemoteConfigProvider(&remote.Client{}, make(chan struct{}), "0090c771-add5-4313-948f-d1ab99b471d6", "dev")
 	require.NoError(t, err)
 	notifs := rcp.subscribe(KindDeployment)
 	in := map[string]state.APMTracingConfig{

--- a/pkg/clusteragent/admission/patch/start.go
+++ b/pkg/clusteragent/admission/patch/start.go
@@ -21,13 +21,14 @@ type ControllerContext struct {
 	K8sClient           kubernetes.Interface
 	RcClient            *remote.Client
 	ClusterName         string
+	ClusterId           string
 	StopCh              chan struct{}
 }
 
 // StartControllers starts the patch controllers
 func StartControllers(ctx ControllerContext) error {
 	log.Info("Starting patch controllers")
-	provider, err := newPatchProvider(ctx.RcClient, ctx.LeaderSubscribeFunc(), ctx.ClusterName)
+	provider, err := newPatchProvider(ctx.RcClient, ctx.LeaderSubscribeFunc(), ctx.ClusterId, ctx.ClusterName)
 	if err != nil {
 		return err
 	}

--- a/pkg/clusteragent/telemetry/collector.go
+++ b/pkg/clusteragent/telemetry/collector.go
@@ -8,12 +8,13 @@ package telemetry
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/config/utils"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"io"
 	"net/http"
 	"strconv"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -40,8 +41,8 @@ type ApmRemoteConfigEventTags struct {
 	Env                 string `json:"env"`
 	RcId                string `json:"rc_id"`
 	RcClientId          string `json:"rc_client_id"`
-	RcRevision          string `json:"rc_revision"`
-	RcVersion           int64  `json:"rc_version"`
+	RcRevision          int64  `json:"rc_revision"`
+	RcVersion           uint64 `json:"rc_version"`
 	KubernetesClusterId string `json:"k8s_cluster_id"`
 	KubernetesCluster   string `json:"k8s_cluster"`
 	KubernetesNamespace string `json:"k8s_namespace"`

--- a/pkg/clusteragent/telemetry/collector.go
+++ b/pkg/clusteragent/telemetry/collector.go
@@ -83,14 +83,14 @@ func NewNoopCollector() TelemetryCollector {
 func (collector *telemetryCollector) SendEvent(event *ApmRemoteConfigEvent) {
 	body, err := json.Marshal(event)
 	if err != nil {
-		log.Error("Error while trying to marshal a remote config event to JSON: %v", err)
+		log.Errorf("Error while trying to marshal a remote config event to JSON: %v", err)
 		return
 	}
 	bodyLen := strconv.Itoa(len(body))
 
 	req, err := http.NewRequest("POST", collector.host+"/api/v2/apmtelemetry", bytes.NewReader(body))
 	if err != nil {
-		log.Error("Error while trying to create a web request for a remote config event: %v", err)
+		log.Errorf("Error while trying to create a web request for a remote config event: %v", err)
 		return
 	}
 	if !config.Datadog.IsSet("api_key") {
@@ -103,7 +103,7 @@ func (collector *telemetryCollector) SendEvent(event *ApmRemoteConfigEvent) {
 
 	resp, err := collector.client.Do(req)
 	if err != nil {
-		log.Error("Failed to transmit remote config event to Datadog: %v", err)
+		log.Errorf("Failed to transmit remote config event to Datadog: %v", err)
 		return
 	}
 	// Unconditionally read the body and ignore any errors

--- a/pkg/clusteragent/telemetry/collector.go
+++ b/pkg/clusteragent/telemetry/collector.go
@@ -1,0 +1,116 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package telemetry
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"io"
+	"net/http"
+	"strconv"
+)
+
+const (
+	mainEndpointPrefix = "https://instrumentation-telemetry-intake."
+	mainEndpointUrlKey = "apm_config.telemetry.dd_url"
+)
+
+// ApmRemoteConfigEvent is used to report remote config updates to the Datadog backend
+type ApmRemoteConfigEvent struct {
+	RequestType string                      `json:"request_type"`
+	ApiVersion  string                      `json:"api_version"`
+	Payload     ApmRemoteConfigEventPayload `json:"payload,omitempty"`
+}
+
+// ApmRemoteConfigEventPayload contains the information on an individual remote config event
+type ApmRemoteConfigEventPayload struct {
+	EventName string                    `json:"event_name"`
+	Tags      ApmRemoteConfigEventTags  `json:"tags"`
+	Error     ApmRemoteConfigEventError `json:"error,omitempty"`
+}
+
+// ApmRemoteConfigEventTags store the information on an individual remote config event
+type ApmRemoteConfigEventTags struct {
+	Env                 string `json:"env"`
+	RcId                string `json:"rc_id"`
+	RcClientId          string `json:"rc_client_id"`
+	RcRevision          string `json:"rc_revision"`
+	RcVersion           int64  `json:"rc_version"`
+	KubernetesClusterId string `json:"k8s_cluster_id"`
+	KubernetesCluster   string `json:"k8s_cluster"`
+	KubernetesNamespace string `json:"k8s_namespace"`
+	KubernetesKind      string `json:"k8s_kind"`
+	KubernetesName      string `json:"k8s_name"`
+}
+
+// ApmRemoteConfigEventError stores the debugging information about remote config deployment failures
+type ApmRemoteConfigEventError struct {
+	Code    int    `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// TelemetryCollector is the interface used to send reports about startup to the instrumentation telemetry intake
+type TelemetryCollector interface {
+	SendEvent(event *ApmRemoteConfigEvent)
+}
+
+type telemetryCollector struct {
+	client    *http.Client
+	host      string
+	userAgent string
+}
+
+// NewCollector returns either collector, or a noop implementation if instrumentation telemetry is disabled
+func NewCollector() TelemetryCollector {
+	return &telemetryCollector{
+		client:    http.DefaultClient,
+		host:      utils.GetMainEndpoint(config.Datadog, mainEndpointPrefix, mainEndpointUrlKey),
+		userAgent: "Datadog Cluster Agent",
+	}
+}
+
+// NewNoopCollector returns a noop collector
+func NewNoopCollector() TelemetryCollector {
+	return &noopTelemetryCollector{}
+}
+
+func (collector *telemetryCollector) SendEvent(event *ApmRemoteConfigEvent) {
+	body, err := json.Marshal(event)
+	if err != nil {
+		log.Error("Error while trying to marshal a remote config event to JSON: %v", err)
+		return
+	}
+	bodyLen := strconv.Itoa(len(body))
+
+	req, err := http.NewRequest("POST", collector.host+"/api/v2/apmtelemetry", bytes.NewReader(body))
+	if err != nil {
+		log.Error("Error while trying to create a web request for a remote config event: %v", err)
+		return
+	}
+	if !config.Datadog.IsSet("api_key") {
+		return
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("User-Agent", collector.userAgent)
+	req.Header.Add("DD-API-KEY", config.Datadog.GetString("api_key"))
+	req.Header.Add("Content-Length", bodyLen)
+
+	resp, err := collector.client.Do(req)
+	if err != nil {
+		log.Error("Failed to transmit remote config event to Datadog: %v", err)
+		return
+	}
+	// Unconditionally read the body and ignore any errors
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+}
+
+type noopTelemetryCollector struct{}
+
+func (*noopTelemetryCollector) SendEvent(event *ApmRemoteConfigEvent) {}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR is the initial bare bones implementation of sending telemetry events to the Datadog backend from the cluster agent. When the cluster agent receives a remote config update, it will send an HTTP web request to the `/api/v2/apmtelemetry` Datadog endpoint and report the update.

This is currently at the point where I can run the cluster agent locally and confirm that the remote config update is stored in our staging database. I intend to flesh this out more in a follow-up PR and I am looking for reviewers' help in answering some of my questions below.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
[Jira link](https://datadoghq.atlassian.net/browse/AIT-7333)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

These are my questions right now. I would appreciate the reviewers' help in answering them. Otherwise I will also look for answers on my own.

- ~Since my work will involve multiple PRs, should I create a separate branch to temporarily keep these PRs outside of `main` during the code freeze?~ A: Created the feature branch `yakov.shapiro/cluster-agent-telemetry` to use during the code freeze.
- ~What do I do about the failing `team_label`, `release_note` and `milestone` CI checks?~ A: @ahmed-mez was kind enough to set these on this PR.
- ~Am I correct to make the cluster agent talk directly to the Datadog backend, or should the cluster agent be sending a request to the Datadog agent and the Datadog agent be forwarding it to the backend?~ A: this is fine per @ahmed-mez 
- ~@paullegranddc told me that we try to keep the trace agent codebase separate from the rest of the Datadog agent, so I copied the code from [the trace agent's collector.go](https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/telemetry/collector.go) instead of trying to refactor and reuse it. Is that a reasonable judgment call?~ A: Ahmed says there is not a compelling reason to keep the two codebases separately and it is OK for them to import the code from one another. However, looking over the trace agent collector.go and my new collector.go I feel there are enough differences (such as mine not relying on the trace agent config) that it is easier to keep them separate for now.
- In the trace agent collector [we check that telemetry is not disabled](https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/telemetry/collector.go#L83-L85) before we send any requests. Should I be doing this in the cluster agent too? Is the cluster agent going to have access to all the same config settings as the trace agent?
- ~I am using the default HttpClient instead of a [ResetClient in the trace agent](https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/telemetry/collector.go#L73), because I was not sure what to use as the reset interval for a ResetClient. Is that OK?~ A: Ahmed advised against this, I have now updated the code to use a ResetClient instead
- ~I was told by @hyperloglogy that the remote config revision is a string and the version is an integer. However, in the actual agent code `req.Revision` is an int64 and `req.SchemaVersion` is a string. Is `SchemaVersion` not the same as the config version? Am I not populating these fields correctly?~ A: `req.SchemaVersion` is unrelated, the remote config version is the `config.Metadata.Version`
- ~I could not quickly find the Kubernetes Cluster ID in the request object, is it something I can easily access?~ A: need to use `clustername.GetClusterID()`

Not included in this PR:

- Unit tests (I wanted to have a first review before investing time in them, in case this is not on the right track and the reviewers ask for a refactor)
- Sending any events other than `agent.k8s.patch` - are there places in the cluster agent codebase that they should be sent from?
- Skipping the web request if the config we received is the same as the currently deployed version
- Reporting an error to the backend if the attempt to patch the remote config has failed

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Start the cluster agent locally [as described on this wiki](https://datadoghq.atlassian.net/wiki/spaces/AO/pages/2983035648/Local+Cluster+Agent+Development)

Connect to the tracer telemetry intake Postgres DB [as described on this wiki](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2829190447/Postgres+Devops+Guide)

Confirm that starting the cluster agent causes an `agent.k8s.patch` event to be sent to the Datadog backend and written to the DB:

```
tracertelemetryintakedbus1staging=> select * from apm_remote_config_event where env = 'staging';
-[ RECORD 1 ]--------------+-----------------------------------------------------------------
apm_remote_config_event_id | 4aebc409-9c28-5cd5-9533-17377b623011
org_id                     | 2
event_name                 | agent.k8s.patch
env                        | staging
rc_id                      | 24e27a6f0e7c5d5ef303bef2e26e960090f3f54c95fc3543676c0139b287552e
rc_client_id               | se5xZW0iBHQR3fM-07hVP
rc_revision                | v1.0.0
rc_version                 | 1685457769594355579
k8s_cluster_id             |
k8s_cluster                | mcclusterson
k8s_namespace              | default
k8s_kind                   | deployment
k8s_name                   | test-app-deployment
error_message              |
error_code                 | 0
event_time                 | 2023-05-31 16:53:35.88278

Time: 1.050 ms
tracertelemetryintakedbus1staging=>
```

Note: when troubleshooting, you can try sending a web request to the backend with plain Curl as described in the test plan on https://github.com/DataDog/dd-go/pull/93062 to see if the problem is with the agent or with the backend.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
