### PR TITLE
[omnibus] Don't create RPM database if it doesn't exist already

### DIFF
--- a/omnibus/config/patches/rpm/rpmdb-no-create.patch
+++ b/omnibus/config/patches/rpm/rpmdb-no-create.patch
@@ -1,0 +1,25 @@
+--- a/lib/rpmdb.c
++++ b/lib/rpmdb.c
+@@ -463,6 +463,11 @@ static int openDatabase(const char * prefix,
+     if (db == NULL)
+ 	return 1;
+ 
++    /* Don't create db if it doesn't exist already */
++    struct stat st;
++    if (stat(rpmdbHome(db), &st) < 0)
++        return 1;
++
+     /* Try to ensure db home exists, error out if we can't even create */
+     rc = rpmioMkpath(rpmdbHome(db), 0755, getuid(), getgid());
+     if (rc == 0) {
+--- a/lib/rpmts.c
++++ b/lib/rpmts.c
+@@ -104,7 +104,7 @@ int rpmtsOpenDB(rpmts ts, int dbmode)
+     rc = rpmdbOpen(ts->rootDir, &ts->rdb, ts->dbmode, 0644);
+     if (rc) {
+ 	char * dn = rpmGetPath(ts->rootDir, "%{_dbpath}", NULL);
+-	rpmlog(RPMLOG_ERR, _("cannot open Packages database in %s\n"), dn);
++	rpmlog(RPMLOG_DEBUG, _("cannot open Packages database in %s\n"), dn);
+ 	free(dn);
+     }
+     return rc;

--- a/omnibus/config/software/rpm.rb
+++ b/omnibus/config/software/rpm.rb
@@ -49,6 +49,7 @@ build do
   env["CFLAGS"] << " -fPIC"
 
   patch source: "0001-Include-fcntl.patch", env: env # fix build
+  patch source: "rpmdb-no-create.patch", env: env # don't create db if it doesn't exist already
 
   update_config_guess
   


### PR DESCRIPTION
### What does this PR do?

On Linux distributions not using the RPM package manager (Debian, Ubuntu, etc.), the rpm probe of OpenSCAP could initialize the sqlite RPM database into the /var/lib/rpm, directory, as a side effect.

This change adds a new patch "rpmdb-no-create" to the RPM package.

This patch changes the openDatabase function to prevent creation of the RPM database when it doesn't exist already.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
