### PR TITLE
process-monitor: Change loading order.

### DIFF
--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -257,11 +257,6 @@ func (p *GoTLSProgram) Start() {
 		return
 	}
 
-	if err = p.procMonitor.monitor.Initialize(); err != nil {
-		log.Errorf("failed to initialize process monitor error: %s", err)
-		return
-	}
-
 	p.wg.Add(1)
 	go func() {
 		processSync := time.NewTicker(scanTerminatedProcessesInterval)

--- a/pkg/network/usm/ebpf_javatls.go
+++ b/pkg/network/usm/ebpf_javatls.go
@@ -253,11 +253,6 @@ func (p *JavaTLSProgram) Start() {
 		log.Errorf("process monitor Subscribe() error: %s", err)
 		return
 	}
-
-	if err = p.processMonitor.Initialize(); err != nil {
-		log.Errorf("failed to initialize process monitor error: %s", err)
-		return
-	}
 }
 
 func (p *JavaTLSProgram) Stop() {

--- a/pkg/network/usm/shared_libraries.go
+++ b/pkg/network/usm/shared_libraries.go
@@ -215,11 +215,6 @@ func (w *soWatcher) Start() {
 		return nil
 	})
 
-	if err := w.processMonitor.Initialize(); err != nil {
-		log.Errorf("can't initialize process monitor %s", err)
-		return
-	}
-
 	cleanupExit, err := w.processMonitor.SubscribeExit(w.registry.unregister)
 	if err != nil {
 		log.Errorf("can't subscribe to process monitor exit event %s", err)

--- a/pkg/network/usm/shared_libraries_test.go
+++ b/pkg/network/usm/shared_libraries_test.go
@@ -34,7 +34,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 	errtelemetry "github.com/DataDog/datadog-agent/pkg/network/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/process/monitor"
 )
+
+func launchProcessMonitor(t *testing.T) {
+	pm := monitor.GetProcessMonitor()
+	t.Cleanup(pm.Stop)
+	require.NoError(t, pm.Initialize())
+}
 
 func registerProcessTerminationUponCleanup(t *testing.T, cmd *exec.Cmd) {
 	t.Cleanup(func() {
@@ -80,6 +87,7 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetection() {
 		},
 	)
 	watcher.Start()
+	launchProcessMonitor(t)
 
 	// create files
 	clientBin := buildSOWatcherClientBin(t)
@@ -145,6 +153,7 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetectionWithPIDandRootNameSpace()
 		},
 	)
 	watcher.Start()
+	launchProcessMonitor(t)
 
 	time.Sleep(10 * time.Millisecond)
 	// simulate a slow (1 second) : open, write, close of the file
@@ -190,6 +199,7 @@ func (s *SharedLibrarySuite) TestSameInodeRegression() {
 		},
 	)
 	watcher.Start()
+	launchProcessMonitor(t)
 
 	clientBin := buildSOWatcherClientBin(t)
 	command1 := exec.Command(clientBin, fooPath1, fooPath2)
@@ -241,6 +251,7 @@ func (s *SharedLibrarySuite) TestSoWatcherLeaks() {
 		},
 	)
 	watcher.Start()
+	launchProcessMonitor(t)
 
 	// create files
 	clientBin := buildSOWatcherClientBin(t)
@@ -333,6 +344,7 @@ func (s *SharedLibrarySuite) TestSoWatcherProcessAlreadyHoldingReferences() {
 	registerProcessTerminationUponCleanup(t, command1)
 	time.Sleep(time.Second)
 	watcher.Start()
+	launchProcessMonitor(t)
 
 	require.Eventuallyf(t, func() bool {
 		// Checking both paths exist.


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

The refactor forced every user of process-monitor to call initialize. We ensured the initialized is being called only once. During the initialize phase we scanned all running processes and tried to trigger the callbacks. But since every user called initialize by itself, we had a race between registering callbacks and scanning the process list. Now we call initialize only once, at the monitor initialization, and by that ensuring no race exists, as callback registrations happens before calling the initialization

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Prevent races

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
