### PR TITLE
Remove a no more used SBOM check config parameter

### DIFF
--- a/pkg/collector/corechecks/sbom/check.go
+++ b/pkg/collector/corechecks/sbom/check.go
@@ -31,11 +31,10 @@ func init() {
 
 // Config holds the container_image check configuration
 type Config struct {
-	ChunkSize                       int  `yaml:"chunk_size"`
-	NewSBOMMaxLatencySeconds        int  `yaml:"new_sbom_max_latency_seconds"`
-	ContainerPeriodicRefreshSeconds int  `yaml:"periodic_refresh_seconds"`
-	HostSBOM                        bool `yaml:"host_sbom"`
-	HostPeriodicRefreshSeconds      int  `yaml:"host_periodic_refresh_seconds"`
+	ChunkSize                       int `yaml:"chunk_size"`
+	NewSBOMMaxLatencySeconds        int `yaml:"new_sbom_max_latency_seconds"`
+	ContainerPeriodicRefreshSeconds int `yaml:"periodic_refresh_seconds"`
+	HostPeriodicRefreshSeconds      int `yaml:"host_periodic_refresh_seconds"`
 }
 
 type configValueRange struct {


### PR DESCRIPTION
### What does this PR do?

Remove the `host_sbom` `sbom` check configuration parameter.

### Motivation

It’s not used any more since https://github.com/DataDog/datadog-agent/pull/16847/commits/abb733da86c44b907853192c255fa06688c40d9a (#16847).

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

If it compiles, it’s fine.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
