### PR TITLE
usm: encoding: Migrate http2 encoder

### DIFF
--- a/pkg/network/encoding/encoding.go
+++ b/pkg/network/encoding/encoding.go
@@ -15,8 +15,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/network"
-	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var (

--- a/pkg/network/encoding/encoding.go
+++ b/pkg/network/encoding/encoding.go
@@ -76,26 +76,14 @@ func modelConnections(conns *network.Connections) *model.Connections {
 	kafkaEncoder := newKafkaEncoder(conns)
 	defer kafkaEncoder.Close()
 	http2Encoder := newHTTP2Encoder(conns)
+	defer http2Encoder.Close()
+
 	ipc := make(ipCache, len(conns.Conns)/2)
 	dnsFormatter := newDNSFormatter(conns, ipc)
 	tagsSet := network.NewTagsSet()
 
 	for i, conn := range conns.Conns {
 		agentConns[i] = FormatConnection(conn, routeIndex, httpEncoder, http2Encoder, kafkaEncoder, dnsFormatter, ipc, tagsSet)
-	}
-
-	if http2Encoder != nil && http2Encoder.orphanEntries > 0 {
-		log.Debugf(
-			"detected orphan http2 aggregations. this may be caused by conntrack sampling or missed tcp close events. count=%d",
-			http2Encoder.orphanEntries,
-		)
-
-		telemetry.NewMetric(
-			"usm.http2.orphan_aggregations",
-			telemetry.OptMonotonic,
-			telemetry.OptExpvar,
-			telemetry.OptStatsd,
-		).Add(int64(http2Encoder.orphanEntries))
 	}
 
 	routes := make([]*model.Route, len(routeIndex))

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/twmb/murmur3"
 
 	model "github.com/DataDog/agent-payload/v5/process"
@@ -89,9 +88,7 @@ func FormatConnection(
 	c.HttpAggregations = httpStats
 
 	httpStats2, _, _ := http2Encoder.GetHTTP2AggregationsAndTags(conn)
-	if httpStats2 != nil {
-		c.Http2Aggregations, _ = proto.Marshal(httpStats2)
-	}
+	c.Http2Aggregations = httpStats2
 
 	c.DataStreamsAggregations = kafkaEncoder.GetKafkaAggregations(conn)
 

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -87,8 +87,8 @@ func FormatConnection(
 	httpStats, staticTags, dynamicTags := httpEncoder.GetHTTPAggregationsAndTags(conn)
 	c.HttpAggregations = httpStats
 
-	httpStats2, _, _ := http2Encoder.GetHTTP2AggregationsAndTags(conn)
-	c.Http2Aggregations = httpStats2
+	http2Stats, _, _ := http2Encoder.GetHTTP2AggregationsAndTags(conn)
+	c.Http2Aggregations = http2Stats
 
 	c.DataStreamsAggregations = kafkaEncoder.GetKafkaAggregations(conn)
 

--- a/pkg/network/encoding/http2.go
+++ b/pkg/network/encoding/http2.go
@@ -44,7 +44,8 @@ type http2Encoder struct {
 	// cached object
 	aggregations *model.HTTP2Aggregations
 
-	// list of *pointers* to maps so they can be returned to the pool
+	// A list of pointers to maps of the protobuf representation. We get the pointers from sync.Pool, and by the end
+	// of the operation, we put the objects back to the pool.
 	toRelease []*map[int32]*model.HTTPStats_Data
 }
 

--- a/pkg/network/encoding/http2.go
+++ b/pkg/network/encoding/http2.go
@@ -6,83 +6,46 @@
 package encoding
 
 import (
-	"github.com/cihub/seelog"
+	"sync"
+
 	"github.com/gogo/protobuf/proto"
 
 	model "github.com/DataDog/agent-payload/v5/process"
 
 	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
 	"github.com/DataDog/datadog-agent/pkg/network/types"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+var (
+	http2StatsDataPool = sync.Pool{
+		New: func() any {
+			return new(model.HTTPStats_Data)
+		},
+	}
+
+	http2StatsPool = sync.Pool{
+		New: func() any {
+			return new(model.HTTPStats)
+		},
+	}
+
+	http2StatusCodeMap = sync.Pool{
+		New: func() any {
+			m := make(map[int32]*model.HTTPStats_Data)
+			return &m
+		},
+	}
 )
 
 type http2Encoder struct {
-	aggregations   map[types.ConnectionKey]*http2AggregationWrapper
-	staticTags     map[types.ConnectionKey]uint64
-	dynamicTagsSet map[types.ConnectionKey]map[string]struct{}
+	byConnection *USMConnectionIndex[http.Key, *http.RequestStats]
 
-	orphanEntries int
-}
+	// cached object
+	aggregations *model.HTTP2Aggregations
 
-// aggregationWrapper is meant to handle collision scenarios where multiple
-// `ConnectionStats` objects may claim the same `HTTP2Aggregations` object because
-// they generate the same connection key
-// TODO: we should probably revisit/get rid of this if we ever replace socket
-// filters by kprobes, since in that case we would have access to PIDs, and
-// could incorporate that information in the `types.ConnectionKey` struct.
-type http2AggregationWrapper struct {
-	*model.HTTP2Aggregations
-
-	// we keep track of the source and destination ports of the first
-	// `ConnectionStats` to claim this `HTTP2Aggregations` object
-	sport, dport uint16
-}
-
-func (e *http2Encoder) GetHTTP2AggregationsAndTags(c network.ConnectionStats) (*model.HTTP2Aggregations, uint64, map[string]struct{}) {
-	if e == nil {
-		return nil, 0, nil
-	}
-
-	connectionKeys := network.ConnectionKeysFromConnectionStats(c)
-	for _, key := range connectionKeys {
-		if aggregation := e.aggregations[key]; aggregation != nil {
-			return e.aggregations[key].ValueFor(c), e.staticTags[key], e.dynamicTagsSet[key]
-		}
-	}
-	return nil, 0, nil
-}
-
-func (a *http2AggregationWrapper) ValueFor(c network.ConnectionStats) *model.HTTP2Aggregations {
-	if a == nil {
-		return nil
-	}
-
-	if a.sport == 0 && a.dport == 0 {
-		// This is the first time a ConnectionStats claim this aggregation. In
-		// this case we return the value and save the source and destination
-		// ports
-		a.sport = c.SPort
-		a.dport = c.DPort
-		return a.HTTP2Aggregations
-	}
-
-	if c.SPort == a.dport && c.DPort == a.sport {
-		// We have have a collision with another `ConnectionStats`, but this is a
-		// legit scenario where we're dealing with the opposite ends of the
-		// same connection, which means both server and client are in the same host.
-		// In this particular case it is correct to have both connections
-		// (client:server and server:client) referencing the same HTTP2 data.
-		return a.HTTP2Aggregations
-	}
-
-	// Return nil otherwise. This is to prevent multiple `ConnectionStats` with
-	// exactly the same source and destination addresses but different PIDs to
-	// "bind" to the same HTTP2Aggregations object, which would result in a
-	// overcount problem. (Note that this is due to the fact that
-	// `types.ConnectionKey` doesn't have a PID field.) This happens mostly in the
-	// context of pre-fork web servers, where multiple worker processes share the
-	// same socket
-	return nil
+	// list of *pointers* to maps so they can be returned to the pool
+	toRelease []*map[int32]*model.HTTPStats_Data
 }
 
 func newHTTP2Encoder(payload *network.Connections) *http2Encoder {
@@ -90,68 +53,45 @@ func newHTTP2Encoder(payload *network.Connections) *http2Encoder {
 		return nil
 	}
 
-	encoder := &http2Encoder{
-		aggregations:   make(map[types.ConnectionKey]*http2AggregationWrapper, len(payload.Conns)),
-		staticTags:     make(map[types.ConnectionKey]uint64, len(payload.Conns)),
-		dynamicTagsSet: make(map[types.ConnectionKey]map[string]struct{}, len(payload.Conns)),
+	return &http2Encoder{
+		byConnection: GroupByConnection("http2", payload.HTTP2, func(key http.Key) types.ConnectionKey {
+			return key.ConnectionKey
+		}),
+		aggregations: new(model.HTTP2Aggregations),
 	}
-
-	// pre-populate aggregation map with keys for all existent connections
-	// this allows us to skip encoding orphan HTTP2 objects that can't be matched to a connection
-	for _, conn := range payload.Conns {
-		for _, key := range network.ConnectionKeysFromConnectionStats(conn) {
-			if log.ShouldLog(seelog.TraceLvl) {
-				log.Tracef("Payload has a connection %v and was converted to http2 key %v", conn, key)
-			}
-			encoder.aggregations[key] = nil
-		}
-	}
-
-	encoder.buildAggregations(payload)
-	return encoder
 }
 
-func (e *http2Encoder) buildAggregations(payload *network.Connections) {
-	aggrSize := make(map[types.ConnectionKey]int)
-	for key := range payload.HTTP2 {
-		aggrSize[key.ConnectionKey]++
+func (e *http2Encoder) GetHTTP2AggregationsAndTags(c network.ConnectionStats) ([]byte, uint64, map[string]struct{}) {
+	if e == nil {
+		return nil, 0, nil
 	}
 
-	for key, stats := range payload.HTTP2 {
-		aggregation, ok := e.aggregations[key.ConnectionKey]
-		if !ok {
-			// if there is no matching connection don't even bother to serialize HTTP2 data
-			if log.ShouldLog(seelog.TraceLvl) {
-				log.Tracef("Found http2 orphan connection %v", key.ConnectionKey)
-			}
-			e.orphanEntries++
-			continue
-		}
+	connectionData := e.byConnection.Find(c)
+	if connectionData == nil || len(connectionData.Data) == 0 || connectionData.IsPIDCollision(c) {
+		return nil, 0, nil
+	}
 
-		if aggregation == nil {
-			aggregation = &http2AggregationWrapper{
-				HTTP2Aggregations: &model.HTTP2Aggregations{
-					EndpointAggregations: make([]*model.HTTPStats, 0, aggrSize[key.ConnectionKey]),
-				},
-			}
-			e.aggregations[key.ConnectionKey] = aggregation
-		}
+	return e.encodeData(connectionData)
+}
 
-		ms := &model.HTTPStats{
-			Path:              key.Path.Content,
-			FullPath:          key.Path.FullPath,
-			Method:            model.HTTPMethod(key.Method),
-			StatsByStatusCode: make(map[int32]*model.HTTPStats_Data, len(stats.Data)),
-		}
+func (e *http2Encoder) encodeData(connectionData *USMConnectionData[http.Key, *http.RequestStats]) ([]byte, uint64, map[string]struct{}) {
+	e.reset()
 
-		staticTags := e.staticTags[key.ConnectionKey]
-		var dynamicTags map[string]struct{}
+	var staticTags uint64
+	dynamicTags := make(map[string]struct{})
+
+	for _, kvPair := range connectionData.Data {
+		key := kvPair.Key
+		stats := kvPair.Value
+
+		ms := http2StatsPool.Get().(*model.HTTPStats)
+		ms.Path = key.Path.Content
+		ms.FullPath = key.Path.FullPath
+		ms.Method = model.HTTPMethod(key.Method)
+		ms.StatsByStatusCode = e.getDataMap(stats.Data)
+
 		for status, s := range stats.Data {
-			data, ok := ms.StatsByStatusCode[int32(status)]
-			if !ok {
-				ms.StatsByStatusCode[int32(status)] = &model.HTTPStats_Data{}
-				data = ms.StatsByStatusCode[int32(status)]
-			}
+			data := ms.StatsByStatusCode[int32(status)]
 			data.Count = uint32(s.Count)
 
 			if latencies := s.Latencies; latencies != nil {
@@ -162,22 +102,68 @@ func (e *http2Encoder) buildAggregations(payload *network.Connections) {
 			}
 
 			staticTags |= s.StaticTags
-
-			// It is a map to aggregate the same tag
-			if len(s.DynamicTags) > 0 {
-				if dynamicTags == nil {
-					dynamicTags = make(map[string]struct{})
-				}
-
-				for _, dynamicTag := range s.DynamicTags {
-					dynamicTags[dynamicTag] = struct{}{}
-				}
+			for _, dynamicTag := range s.DynamicTags {
+				dynamicTags[dynamicTag] = struct{}{}
 			}
 		}
 
-		e.staticTags[key.ConnectionKey] = staticTags
-		e.dynamicTagsSet[key.ConnectionKey] = dynamicTags
-
-		aggregation.EndpointAggregations = append(aggregation.EndpointAggregations, ms)
+		e.aggregations.EndpointAggregations = append(e.aggregations.EndpointAggregations, ms)
 	}
+
+	serializedData, _ := proto.Marshal(e.aggregations)
+	return serializedData, staticTags, dynamicTags
+}
+
+func (e *http2Encoder) Close() {
+	if e == nil {
+		return
+	}
+
+	e.reset()
+	e.byConnection.Close()
+}
+
+func (e *http2Encoder) getDataMap(stats map[uint16]*http.RequestStat) map[int32]*model.HTTPStats_Data {
+	resPtr := http2StatusCodeMap.Get().(*map[int32]*model.HTTPStats_Data)
+	e.toRelease = append(e.toRelease, resPtr)
+
+	res := *resPtr
+	for key := range stats {
+		res[int32(key)] = http2StatsDataPool.Get().(*model.HTTPStats_Data)
+	}
+	return res
+}
+
+func (e *http2Encoder) reset() {
+	if e == nil {
+		return
+	}
+
+	byEndpoint := e.aggregations.EndpointAggregations
+	for i, endpointAggregation := range byEndpoint {
+		byStatus := endpointAggregation.StatsByStatusCode
+		for _, s := range byStatus {
+			s.Reset()
+			http2StatsDataPool.Put(s)
+		}
+
+		// This is an idiom recognized and optimized by the Go compiler and results
+		// in clearing the whole map at once
+		// https://github.com/golang/go/issues/20138
+		for k := range byStatus {
+			delete(byStatus, k)
+		}
+
+		endpointAggregation.Reset()
+		http2StatsPool.Put(endpointAggregation)
+		byEndpoint[i] = nil
+	}
+
+	for i, mapPtr := range e.toRelease {
+		http2StatusCodeMap.Put(mapPtr)
+		e.toRelease[i] = nil
+	}
+
+	e.toRelease = e.toRelease[:0]
+	e.aggregations.EndpointAggregations = e.aggregations.EndpointAggregations[:0]
 }

--- a/pkg/network/encoding/http2_test.go
+++ b/pkg/network/encoding/http2_test.go
@@ -10,15 +10,29 @@ import (
 	"testing"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestFormatHTTP2Stats(t *testing.T) {
+type HTTP2Suite struct {
+	suite.Suite
+}
+
+func TestHTTP2Stats(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("the feature is only supported on linux.")
+	}
+	suite.Run(t, &HTTP2Suite{})
+}
+
+func (s *HTTP2Suite) TestFormatHTTP2Stats() {
+	t := s.T()
 	t.Run("status code", func(t *testing.T) {
 		testFormatHTTP2Stats(t, true)
 	})
@@ -75,7 +89,7 @@ func testFormatHTTP2Stats(t *testing.T, aggregateByStatusCode bool) {
 			httpKey2: http2Stats2,
 		},
 	}
-	out := &model.HTTPAggregations{
+	out := &model.HTTP2Aggregations{
 		EndpointAggregations: []*model.HTTPStats{
 			{
 				Path:              "/testpath-1",
@@ -99,14 +113,16 @@ func testFormatHTTP2Stats(t *testing.T, aggregateByStatusCode bool) {
 	}
 
 	http2Encoder := newHTTP2Encoder(in)
-	aggregations, tags, _ := http2Encoder.GetHTTP2AggregationsAndTags(in.Conns[0])
+	aggregations, tags, _ := getHTTP2Aggregations(t, http2Encoder, in.Conns[0])
+
 	require.NotNil(t, aggregations)
 	assert.ElementsMatch(t, out.EndpointAggregations, aggregations.EndpointAggregations)
 
 	assert.Equal(t, uint64((1<<len(statusCodes))-1), tags)
 }
 
-func TestFormatHTTP2StatsByPath(t *testing.T) {
+func (s *HTTP2Suite) TestFormatHTTP2StatsByPath() {
+	t := s.T()
 	t.Run("status code", func(t *testing.T) {
 		testFormatHTTP2StatsByPath(t, true)
 	})
@@ -159,10 +175,10 @@ func testFormatHTTP2StatsByPath(t *testing.T, aggregateByStatusCode bool) {
 		},
 	}
 	http2Encoder := newHTTP2Encoder(payload)
-	httpAggregations, tags, _ := http2Encoder.GetHTTP2AggregationsAndTags(payload.Conns[0])
+	http2Aggregations, tags, _ := getHTTP2Aggregations(t, http2Encoder, payload.Conns[0])
 
-	require.NotNil(t, httpAggregations)
-	endpointAggregations := httpAggregations.EndpointAggregations
+	require.NotNil(t, http2Aggregations)
+	endpointAggregations := http2Aggregations.EndpointAggregations
 	require.Len(t, endpointAggregations, 1)
 	assert.Equal(t, "/testpath", endpointAggregations[0].Path)
 	assert.Equal(t, model.HTTPMethod_Get, endpointAggregations[0].Method)
@@ -187,16 +203,17 @@ func testFormatHTTP2StatsByPath(t *testing.T, aggregateByStatusCode bool) {
 	assert.False(t, exists)
 }
 
-func TestIDCollisionRegressionHTTP2(t *testing.T) {
+func (s *HTTP2Suite) TestHTTP2IDCollisionRegression() {
+	t := s.T()
 	t.Run("status code", func(t *testing.T) {
-		testIDCollisionRegressionHTTP2(t, true)
+		testHTTP2IDCollisionRegression(t, true)
 	})
 	t.Run("status class", func(t *testing.T) {
-		testIDCollisionRegressionHTTP2(t, false)
+		testHTTP2IDCollisionRegression(t, false)
 	})
 }
 
-func testIDCollisionRegressionHTTP2(t *testing.T, aggregateByStatusCode bool) {
+func testHTTP2IDCollisionRegression(t *testing.T, aggregateByStatusCode bool) {
 	http2Stats := http.NewRequestStats(aggregateByStatusCode)
 	assert := assert.New(t)
 	connections := []network.ConnectionStats{
@@ -238,21 +255,21 @@ func testIDCollisionRegressionHTTP2(t *testing.T, aggregateByStatusCode bool) {
 
 	http2Encoder := newHTTP2Encoder(in)
 
-	// assert that the first connection matching the HTTP data will get
+	// assert that the first connection matching the HTTP2 data will get
 	// back a non-nil result
-	aggregations, _, _ := http2Encoder.GetHTTP2AggregationsAndTags(connections[0])
-	assert.NotNil(aggregations)
+	aggregations, _, _ := getHTTP2Aggregations(t, http2Encoder, connections[0])
 	assert.Equal("/", aggregations.EndpointAggregations[0].Path)
 	assert.Equal(uint32(1), aggregations.EndpointAggregations[0].StatsByStatusCode[int32(http2Stats.NormalizeStatusCode(104))].Count)
 
 	// assert that the other connections sharing the same (source,destination)
-	// addresses but different PIDs *won't* be associated with the HTTP stats
+	// addresses but different PIDs *won't* be associated with the HTTP2 stats
 	// object
-	aggregations, _, _ = http2Encoder.GetHTTP2AggregationsAndTags(connections[1])
-	assert.Nil(aggregations)
+	http2Blob, _, _ := http2Encoder.GetHTTP2AggregationsAndTags(connections[1])
+	assert.Nil(http2Blob)
 }
 
-func TestHTTP2LocalhostScenario(t *testing.T) {
+func (s *HTTP2Suite) TestHTTP2LocalhostScenario() {
+	t := s.T()
 	t.Run("status code", func(t *testing.T) {
 		testHTTP2LocalhostScenario(t, true)
 	})
@@ -292,7 +309,6 @@ func testHTTP2LocalhostScenario(t *testing.T, aggregateByStatusCode bool) {
 		true,
 		http.MethodGet,
 	)
-
 	http2Stats.AddRequest(103, 1.0, 0, nil)
 
 	in := &network.Connections{
@@ -326,13 +342,22 @@ func testHTTP2LocalhostScenario(t *testing.T, aggregateByStatusCode bool) {
 
 	// assert that both ends (client:server, server:client) of the connection
 	// will have HTTP2 stats
-	aggregations, _, _ := http2Encoder.GetHTTP2AggregationsAndTags(connections[0])
-	assert.NotNil(aggregations)
+	aggregations, _, _ := getHTTP2Aggregations(t, http2Encoder, in.Conns[0])
 	assert.Equal("/", aggregations.EndpointAggregations[0].Path)
 	assert.Equal(uint32(1), aggregations.EndpointAggregations[0].StatsByStatusCode[int32(http2Stats.NormalizeStatusCode(103))].Count)
 
-	aggregations, _, _ = http2Encoder.GetHTTP2AggregationsAndTags(connections[1])
-	assert.NotNil(aggregations)
+	aggregations, _, _ = getHTTP2Aggregations(t, http2Encoder, in.Conns[1])
 	assert.Equal("/", aggregations.EndpointAggregations[0].Path)
 	assert.Equal(uint32(1), aggregations.EndpointAggregations[0].StatsByStatusCode[int32(http2Stats.NormalizeStatusCode(103))].Count)
+}
+
+func getHTTP2Aggregations(t *testing.T, encoder *http2Encoder, c network.ConnectionStats) (*model.HTTP2Aggregations, uint64, map[string]struct{}) {
+	http2Blob, staticTags, dynamicTags := encoder.GetHTTP2AggregationsAndTags(c)
+	require.NotNil(t, http2Blob)
+
+	aggregations := new(model.HTTP2Aggregations)
+	err := proto.Unmarshal(http2Blob, aggregations)
+	require.NoError(t, err)
+
+	return aggregations, staticTags, dynamicTags
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Refactor the HTTP2 encoder by leveraging changes introduced in https://github.com/DataDog/datadog-agent/pull/16844
Optimize USM HTTP2 encoding codepath.
The main idea of this PR is reducing the number of live protobuf `model` objects in the heap at given time. The approach can be summarized as follows:

1. First we group USM data by connection calling `GroupByConnection`;
2. Then, during the encoding phase of each `network.ConnectionStats` we do the following:
  a. First we fetch all USM data for a given connection (which is done by calling `USMConnectionIndex.Find()`)
  b. Then, we generate all HTTP2 `model` objects for this specific connection
  c. After that, we serialize all objects into a blob of bytes
  d. The associated `model` objects are then moved to an object pool for later reuse.
 
<!-- In aggregate the changes in this PR have yielded a ~20% reduction in RSS and a ~10% reduction in CPU in our load test environment running an Kafka-heavy workload.
 
![rss](https://user-images.githubusercontent.com/692520/235477409-49168161-67be-4353-9217-8b341984ef39.png)
![cpu](https://user-images.githubusercontent.com/692520/235477450-44f34e32-32a8-4212-9990-7f951137b30f.png)
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Load test - 
CPU  - AVG down by 7%
![image](https://github.com/DataDog/datadog-agent/assets/17148247/0398acdc-8941-4fb1-b12b-e6920a412d80)

RSS - AVG down by 3%
![image](https://github.com/DataDog/datadog-agent/assets/17148247/91327bc3-3de2-4bf8-955c-7d434205c454)

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.

