### PR TITLE
[CWS] fix activity tree for busybox utils

### DIFF
--- a/pkg/security/resolvers/process/resolver.go
+++ b/pkg/security/resolvers/process/resolver.go
@@ -888,7 +888,7 @@ func GetProcessArgv(pr *model.Process) ([]string, bool) {
 	return pr.Argv, pr.ArgsTruncated
 }
 
-// GetProcessArgv0 returns the first arg of the event
+// GetProcessArgv0 returns the first arg of the event and whether the process arguments are truncated
 func GetProcessArgv0(pr *model.Process) (string, bool) {
 	if pr.ArgsEntry == nil {
 		return pr.Argv0, pr.ArgsTruncated

--- a/pkg/security/secl/model/process_cache_entry.go
+++ b/pkg/security/secl/model/process_cache_entry.go
@@ -39,28 +39,6 @@ func (pc *ProcessCacheEntry) SetAncestor(parent *ProcessCacheEntry) {
 	parent.Retain()
 }
 
-// GetNextAncestorBinary returns the first ancestor with a different binary
-func (pc *ProcessContext) GetNextAncestorBinary() *ProcessCacheEntry {
-	current := pc
-	ancestor := pc.Ancestor
-	for ancestor != nil {
-		if ancestor.FileEvent.Inode == 0 {
-			return nil
-		}
-		if current.FileEvent.Inode != ancestor.FileEvent.Inode {
-			return ancestor
-		}
-		current = &ancestor.ProcessContext
-		ancestor = ancestor.Ancestor
-	}
-	return nil
-}
-
-// GetNextAncestorBinary returns the first ancestor with a different binary
-func (pc *ProcessCacheEntry) GetNextAncestorBinary() *ProcessCacheEntry {
-	return pc.ProcessContext.GetNextAncestorBinary()
-}
-
 // HasCompleteLineage returns false if, from the entry, we cannot ascend the ancestors list to PID 1
 func (pc *ProcessCacheEntry) HasCompleteLineage() bool {
 	for pc != nil {

--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -306,7 +306,7 @@ func isValidRootNode(entry *model.ProcessContext) bool {
 	return !isContainerRuntimePrefix(entry.FileEvent.BasenameStr)
 }
 
-// GetNextAncestorBinary returns the first ancestor with a different binary, or a different argv0 in the case of busybox
+// GetNextAncestorBinaryOrArgv0 returns the first ancestor with a different binary, or a different argv0 in the case of busybox processes
 func GetNextAncestorBinaryOrArgv0(entry *model.ProcessContext) *model.ProcessCacheEntry {
 	if entry == nil {
 		return nil

--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -549,10 +549,10 @@ func (adm *ActivityDumpManager) SearchTracedProcessCacheEntryCallback(ad *Activi
 
 		// compute the list of ancestors, we need to start inserting them from the root
 		ancestors := []*model.ProcessCacheEntry{entry}
-		parent := entry.GetNextAncestorBinary()
+		parent := activity_tree.GetNextAncestorBinaryOrArgv0(&entry.ProcessContext)
 		for parent != nil {
 			ancestors = append([]*model.ProcessCacheEntry{parent}, ancestors...)
-			parent = parent.GetNextAncestorBinary()
+			parent = activity_tree.GetNextAncestorBinaryOrArgv0(&parent.ProcessContext)
 		}
 
 		for _, parent = range ancestors {


### PR DESCRIPTION
Busybox utils were all added to an activity tree as root nodes. This PR fixes this by checking for busybox utils when walking a process hierarchy.    

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
