### PR TITLE
Fix reporting of conflicting telemetry metrics

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -433,6 +433,8 @@ func startAgent(
 
 	opts := aggregator.DefaultAgentDemultiplexerOptions()
 	opts.EnableNoAggregationPipeline = pkgconfig.Datadog.GetBool("dogstatsd_no_aggregation_pipeline")
+	opts.UseDogstatsdContextLimiter = true
+	opts.DogstatsdMaxMetricsTags = pkgconfig.Datadog.GetInt("dogstatsd_max_metrics_tags")
 	demux = aggregator.InitAndStartAgentDemultiplexer(sharedForwarder, opts, hostnameDetected)
 
 	// Setup stats telemetry handler

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -66,6 +66,9 @@ type AgentDemultiplexerOptions struct {
 	EnableNoAggregationPipeline bool
 
 	DontStartForwarders bool // unit tests don't need the forwarders to be instanciated
+
+	UseDogstatsdContextLimiter bool
+	DogstatsdMaxMetricsTags    int
 }
 
 // DefaultAgentDemultiplexerOptions returns the default options to initialize an AgentDemultiplexer.
@@ -177,8 +180,8 @@ func initAgentDemultiplexer(sharedForwarder forwarder.Forwarder, options AgentDe
 	for i := 0; i < statsdPipelinesCount; i++ {
 		// the sampler
 		tagsStore := tags.NewStore(config.Datadog.GetBool("aggregator_use_tags_store"), fmt.Sprintf("timesampler #%d", i))
-		tagsLimiter := tags_limiter.New(config.Datadog.GetInt("dogstatsd_max_metrics_tags"))
-		contextsLimiter := limiter.FromConfig(statsdPipelinesCount)
+		tagsLimiter := tags_limiter.New(options.DogstatsdMaxMetricsTags)
+		contextsLimiter := limiter.FromConfig(statsdPipelinesCount, options.UseDogstatsdContextLimiter)
 
 		statsdSampler := NewTimeSampler(TimeSamplerID(i), bucketSize, tagsStore, contextsLimiter, tagsLimiter, agg.hostname)
 

--- a/pkg/aggregator/internal/limiter/config.go
+++ b/pkg/aggregator/internal/limiter/config.go
@@ -11,11 +11,15 @@ import (
 )
 
 // FromConfig builds new Limiter from the configuration.
-func FromConfig(pipelineCount int) *Limiter {
-	return fromConfig(pipelineCount, getCgroupMemoryLimit)
+func FromConfig(pipelineCount int, enabled bool) *Limiter {
+	return fromConfig(pipelineCount, enabled, getCgroupMemoryLimit)
 }
 
-func fromConfig(pipelineCount int, cgroupLimitGetter func() (uint64, error)) *Limiter {
+func fromConfig(pipelineCount int, enabled bool, cgroupLimitGetter func() (uint64, error)) *Limiter {
+	if !enabled {
+		return nil
+	}
+
 	// If all of the following are true:
 	//
 	// - dogstatsd_context_limiter.cgroup_memory_ratio is set to a valid value

--- a/pkg/aggregator/internal/limiter/config_test.go
+++ b/pkg/aggregator/internal/limiter/config_test.go
@@ -20,21 +20,25 @@ func TestConfig(t *testing.T) {
 	m := config.Mock(t)
 
 	// no configuration, disabled by default
-	l := fromConfig(1, func() (uint64, error) { return 0, mockError })
+	l := fromConfig(1, true, func() (uint64, error) { return 0, mockError })
 	assert.Nil(t, l)
 
 	// static limit
 	m.Set("dogstatsd_context_limiter.limit", 500)
-	l = fromConfig(1, func() (uint64, error) { return 0, mockError })
+	l = fromConfig(1, true, func() (uint64, error) { return 0, mockError })
 	assert.Equal(t, 500, l.global)
 
 	// fallback to static limit with error
 	m.Set("dogstatsd_context_limiter.cgroup_memory_ratio", 0.5)
-	l = fromConfig(1, func() (uint64, error) { return 0, mockError })
+	l = fromConfig(1, true, func() (uint64, error) { return 0, mockError })
 	assert.Equal(t, 500, l.global)
 
 	// memory based limit
 	m.Set("dogstatsd_context_limiter.bytes_per_context", 1500)
-	l = fromConfig(1, func() (uint64, error) { return 3_000_000, nil })
+	l = fromConfig(1, true, func() (uint64, error) { return 3_000_000, nil })
 	assert.Equal(t, 1000, l.global)
+
+	// non-core agents
+	l = fromConfig(1, false, func() (uint64, error) { return 3_000_000, nil })
+	assert.Nil(t, l)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Only use the limiter (and thus, send telemetry) from the core agent. Instances of the demultiplexer in other agents do not receive dogstatsd metrics.

### Motivation

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Configure context limiter and run the security agent.

```
log_level: debug
log_payloads: true
telemetry:
  enabled: true
dogstatsd_context_limiter:
  limit: 5
  key_tag_name: container_name
runtime_security_config:
  enabled: true
```

Check that `datadog.agent.aggregator.dogstatsd_context_limiter` metrics are not reported by the security agent, only by core.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
