### PR TITLE
pkg/trace/pb: do not use reflection for shallow copy

### DIFF
--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -11,7 +11,6 @@ replace github.com/docker/distribution => github.com/docker/distribution v2.8.1+
 
 require (
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.46.0-rc.1
-	github.com/DataDog/datadog-agent/pkg/proto v0.46.0-rc.1
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.46.0-rc.1
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.46.0-rc.1
 	github.com/DataDog/datadog-agent/pkg/util/log v0.46.0-rc.1

--- a/pkg/trace/pb/span_utils.go
+++ b/pkg/trace/pb/span_utils.go
@@ -5,10 +5,47 @@
 
 package pb
 
-import (
-	"github.com/DataDog/datadog-agent/pkg/proto/utils"
-)
+// spanCopiedFields records the fields that are copied in ShallowCopy.
+// This should match exactly the fields set in (*Span).ShallowCopy.
+// This is used by tests to enforce the correctness of ShallowCopy.
+var spanCopiedFields = map[string]struct{}{
+	"Service":    {},
+	"Name":       {},
+	"Resource":   {},
+	"TraceID":    {},
+	"SpanID":     {},
+	"ParentID":   {},
+	"Start":      {},
+	"Duration":   {},
+	"Error":      {},
+	"Meta":       {},
+	"Metrics":    {},
+	"Type":       {},
+	"MetaStruct": {},
+}
 
-var copySpan = utils.ProtoCopier((*Span)(nil))
-
-func (s *Span) ShallowCopy() *Span { return copySpan(s).(*Span) }
+// ShallowCopy returns a shallow copy of the copy-able portion of a Span. These are the
+// public fields which will have a Get* method for them. The completeness of this
+// method is enforced by the init function above. Instead of using pkg/proto/utils.ProtoCopier,
+// which incurs heavy reflection cost for every copy at runtime, we use reflection once at
+// startup to ensure our method is complete.
+func (s *Span) ShallowCopy() *Span {
+	if s == nil {
+		return &Span{}
+	}
+	return &Span{
+		Service:    s.Service,
+		Name:       s.Name,
+		Resource:   s.Resource,
+		TraceID:    s.TraceID,
+		SpanID:     s.SpanID,
+		ParentID:   s.ParentID,
+		Start:      s.Start,
+		Duration:   s.Duration,
+		Error:      s.Error,
+		Meta:       s.Meta,
+		Metrics:    s.Metrics,
+		Type:       s.Type,
+		MetaStruct: s.MetaStruct,
+	}
+}

--- a/pkg/trace/pb/tracer_payload_utils.go
+++ b/pkg/trace/pb/tracer_payload_utils.go
@@ -5,10 +5,31 @@
 
 package pb
 
-import (
-	"github.com/DataDog/datadog-agent/pkg/proto/utils"
-)
+// traceChunkCopiedFields records the fields that are copied in ShallowCopy.
+// This should match exactly the fields set in (*TraceChunk).ShallowCopy.
+// This is used by tests to enforce the correctness of ShallowCopy.
+var traceChunkCopiedFields = map[string]struct{}{
+	"Priority":     {},
+	"Origin":       {},
+	"Spans":        {},
+	"Tags":         {},
+	"DroppedTrace": {},
+}
 
-var copyTraceChunk = utils.ProtoCopier((*TraceChunk)(nil))
-
-func (t *TraceChunk) ShallowCopy() *TraceChunk { return copyTraceChunk(t).(*TraceChunk) }
+// ShallowCopy returns a shallow copy of the copy-able portion of a TraceChunk. These are the
+// public fields which will have a Get* method for them. The completeness of this
+// method is enforced by the init function above. Instead of using pkg/proto/utils.ProtoCopier,
+// which incurs heavy reflection cost for every copy at runtime, we use reflection once at
+// startup to ensure our method is complete.
+func (t *TraceChunk) ShallowCopy() *TraceChunk {
+	if t == nil {
+		return nil
+	}
+	return &TraceChunk{
+		Priority:     t.Priority,
+		Origin:       t.Origin,
+		Spans:        t.Spans,
+		Tags:         t.Tags,
+		DroppedTrace: t.DroppedTrace,
+	}
+}

--- a/pkg/trace/pb/utils_test.go
+++ b/pkg/trace/pb/utils_test.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package pb
+
+import (
+	fmt "fmt"
+	reflect "reflect"
+	"testing"
+)
+
+func TestShallowCopy(t *testing.T) {
+	// These tests ensure that the ShallowCopy functions for Span and TraceChunk
+	// copy all of the available fields.
+	t.Run("span", func(t *testing.T) {
+		typ := reflect.TypeOf(&Span{})
+		for i := 0; i < typ.Elem().NumField(); i++ {
+			field := typ.Elem().Field(i)
+			if field.PkgPath != `` {
+				continue
+			}
+			method, ok := typ.MethodByName(`Get` + field.Name)
+			if !ok ||
+				method.Type.NumIn() != 1 ||
+				method.Type.NumOut() != 1 ||
+				method.Type.Out(0) != field.Type {
+				continue
+			}
+			if _, ok := spanCopiedFields[field.Name]; !ok {
+				panic(fmt.Sprintf("pkg/trace/pb/span_utils.go: ShallowCopy needs to be updated for new Span fields. Missing: %s", field.Name))
+			}
+		}
+	})
+
+	t.Run("trace-chunk", func(t *testing.T) {
+		typ := reflect.TypeOf(&TraceChunk{})
+		for i := 0; i < typ.Elem().NumField(); i++ {
+			field := typ.Elem().Field(i)
+			if field.PkgPath != `` {
+				continue
+			}
+			method, ok := typ.MethodByName(`Get` + field.Name)
+			if !ok ||
+				method.Type.NumIn() != 1 ||
+				method.Type.NumOut() != 1 ||
+				method.Type.Out(0) != field.Type {
+				continue
+			}
+			if _, ok := traceChunkCopiedFields[field.Name]; !ok {
+				panic(fmt.Sprintf("pkg/trace/pb/tracer_payload_utils.go: ShallowCopy needs to be updated for new TraceChunk fields. Missing: %s", field.Name))
+			}
+		}
+	})
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This commit creates a hand-written ShallowCopy method for the Span type, as well as adding a runtime-startup check to ensure we are correctly copying all relevant fields from the span.

### Motivation

The reflection used in the `ProtoCopier` is too expensive, and is causing significant overhead in the processing of spans.


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

Type issues are caught at startup (runtime) and not at compile-time. This is not great, but should still allow us to catch any issues.

### Describe how to test/QA your changes

This will be run through the same performance tests that caught the performance issue to verify that it solves the issue.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
