### PR TITLE
[process] fast stat based solution for `getFDCount`

### DIFF
--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -11,6 +11,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -709,8 +710,19 @@ func (p *probe) getLinkWithAuthCheck(pidPath string, file string) string {
 func (p *probe) getFDCount(pidPath string) int32 {
 	path := filepath.Join(pidPath, "fd")
 
-	if err := p.ensurePathReadable(path); err != nil {
+	fi, err := os.Lstat(path)
+	if err != nil {
 		return -1
+	}
+
+	if err := p.ensurePathReadableFromFileInfo(fi); err != nil {
+		return -1
+	}
+
+	// Starting with kernel 6.2, we can use a simpler fast path
+	// see https://github.com/torvalds/linux/commit/f1f1f2569901ec5b9d425f2e91c09a0e320768f3
+	if count := fi.Size(); count > 0 {
+		return int32(count)
 	}
 
 	d, err := os.Open(path)
@@ -754,6 +766,15 @@ func (p *probe) ensurePathReadable(path string) error {
 	info, err := os.Lstat(path)
 	if err != nil {
 		return err
+	}
+
+	return p.ensurePathReadableFromFileInfo(info)
+}
+
+func (p *probe) ensurePathReadableFromFileInfo(info fs.FileInfo) error {
+	// User is (effectively or actually) root
+	if p.euid == 0 {
+		return nil
 	}
 
 	// File mode is world readable and not a symlink

--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -705,6 +705,7 @@ func (p *probe) getLinkWithAuthCheck(pidPath string, file string) string {
 	return str
 }
 
+// PROC_SUPER_MAGIC is the superblock magic value (its unique identifier) of procfs filesystem
 const PROC_SUPER_MAGIC = 0x9fa0
 
 // getFDCount gets num_fds from /proc/(pid)/fd WITHOUT using the native Readdirnames(),

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -1267,3 +1267,22 @@ func resetNiceValues(procs map[int32]*Process) {
 		p.Stats.Nice = 0
 	}
 }
+
+func BenchmarkGetFDCount(b *testing.B) {
+	probe := getProbe()
+	defer probe.Close()
+
+	for i := 0; i < 100; i++ {
+		f, err := os.Open("/proc/self/comm")
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer f.Close()
+	}
+
+	b.Run("self_proc", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = probe.getFDCount("/proc/self")
+		}
+	})
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

`getFDCount` is often found in system-probe profiles, this PR improves the situation on recent kernels.

According to https://elixir.bootlin.com/linux/latest/source/fs/proc/fd.c#L348 (sadly I was not able to find further official documentation). You can get the amount of fds by reading the statx attribute on `/proc/$PID/fd`. This provide a buffer-free, one syscall only solution for `getFDCount`.

Sadly this is available starting only with kernel 6.2 (https://github.com/torvalds/linux/commit/f1f1f2569901ec5b9d425f2e91c09a0e320768f3)

This PR uses this fact to implement `getFDCount` using this new fast path, and falling back on the old/slow way if the fast way fails (old kernel mainly).

#### Performance impact:

| HOST_PROC fs type | Kernel Version | Impact |
| --- | ---- | --- |
| procfs | < 6.2 | no impact (same amount of syscalls) |
| procfs | >= 6.2 | positive impact (one lstat, one statfs) |
| others | any | negative impact (one statfs more than before) |

I feel like this kind of impact knowing that the third row is mostly used in tests, and is a small impact anyway.

Benchmark on a 6.2 kernel:
```
before this PR:
BenchmarkGetFDCount/self_proc-2         	   23752	     52405 ns/op	    8552 B/op	       7 allocs/op
with this PR:
BenchmarkGetFDCount/self_proc-2         	  240015	      4738 ns/op	     256 B/op	       4 allocs/op
```
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

This PR needs to be QA-ed:
- on kernels < 6.2 ensuring everything still works as expected (correct amount of fd reported)
- on kernels >= 6.2 ensuring the correct amount of fd is reported (ubuntu 23.04 can be used for this)

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
