### PR TITLE
Adds jmxfetch test documenting first-config-wins behavior for jvm options

### DIFF
--- a/pkg/jmxfetch/jmxfetch_test.go
+++ b/pkg/jmxfetch/jmxfetch_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 //go:build jmx
 
 package jmxfetch

--- a/pkg/jmxfetch/jmxfetch_test.go
+++ b/pkg/jmxfetch/jmxfetch_test.go
@@ -1,0 +1,62 @@
+//go:build jmx
+
+package jmxfetch
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitConfigJavaOptions(t *testing.T) {
+	j := JMXFetch{}
+
+	var initConfig integration.Data = []byte(`java_options: -Xmx200m`)
+
+	j.ConfigureFromInitConfig(initConfig)
+
+	require.Contains(t, j.JavaOptions, "Xmx200m")
+}
+
+func TestConflictingInitConfigJavaOptions(t *testing.T) {
+	j := JMXFetch{}
+
+	var configOne integration.Data = []byte(`java_options: -Xmx200m`)
+	var configTwo integration.Data = []byte(`java_options: -Xmx444m`)
+
+	j.ConfigureFromInitConfig(configOne)
+	j.ConfigureFromInitConfig(configTwo)
+
+	// First config wins
+	require.Contains(t, j.JavaOptions, "Xmx200m")
+	require.NotContains(t, j.JavaOptions, "Xmx444m")
+}
+
+func TestConflictingInstanceJavaOptions(t *testing.T) {
+	j := JMXFetch{}
+
+	var configOne integration.Data = []byte(`java_options: -Xmx200m`)
+	var configTwo integration.Data = []byte(`java_options: -Xmx444m`)
+
+	j.ConfigureFromInstance(configOne)
+	j.ConfigureFromInstance(configTwo)
+
+	// First config wins
+	require.Contains(t, j.JavaOptions, "Xmx200m")
+	require.NotContains(t, j.JavaOptions, "Xmx444m")
+}
+
+func TestConflictingInstanceInitJavaOptions(t *testing.T) {
+	j := JMXFetch{}
+
+	var configOne integration.Data = []byte(`java_options: -Xmx200m`)
+	var configTwo integration.Data = []byte(`java_options: -Xmx444m`)
+
+	j.ConfigureFromInitConfig(configOne)
+	j.ConfigureFromInstance(configTwo)
+
+	// First config wins
+	require.Contains(t, j.JavaOptions, "Xmx200m")
+	require.NotContains(t, j.JavaOptions, "Xmx444m")
+}


### PR DESCRIPTION
### What does this PR do?
Adds a test documenting the (surprising) behavior that if multiple jmx configurations pass `java_options`, only the first one will have any effect

### Motivation
Documentation

### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
