### PR TITLE
fix auto multi-line integration config

### DIFF
--- a/pkg/logs/internal/launchers/container/tailerfactory/file.go
+++ b/pkg/logs/internal/launchers/container/tailerfactory/file.go
@@ -120,13 +120,16 @@ func (tf *factory) makeDockerFileSource(source *sources.LogSource) (*sources.Log
 
 	// New file source that inherits most of its parent's properties
 	fileSource := sources.NewLogSource(source.Name, &config.LogsConfig{
-		Type:            config.FileType,
-		Identifier:      containerID,
-		Path:            path,
-		Service:         serviceName,
-		Source:          sourceName,
-		Tags:            source.Config.Tags,
-		ProcessingRules: source.Config.ProcessingRules,
+		Type:                        config.FileType,
+		Identifier:                  containerID,
+		Path:                        path,
+		Service:                     serviceName,
+		Source:                      sourceName,
+		Tags:                        source.Config.Tags,
+		ProcessingRules:             source.Config.ProcessingRules,
+		AutoMultiLine:               source.Config.AutoMultiLine,
+		AutoMultiLineSampleSize:     source.Config.AutoMultiLineSampleSize,
+		AutoMultiLineMatchThreshold: source.Config.AutoMultiLineMatchThreshold,
 	})
 
 	// inform the file launcher that it should expect docker-formatted content
@@ -203,13 +206,16 @@ func (tf *factory) makeK8sFileSource(source *sources.LogSource) (*sources.LogSou
 	fileSource := sources.NewLogSource(
 		fmt.Sprintf("%s/%s/%s", pod.Namespace, pod.Name, container.Name),
 		&config.LogsConfig{
-			Type:            config.FileType,
-			Identifier:      containerID,
-			Path:            path,
-			Service:         serviceName,
-			Source:          sourceName,
-			Tags:            source.Config.Tags,
-			ProcessingRules: source.Config.ProcessingRules,
+			Type:                        config.FileType,
+			Identifier:                  containerID,
+			Path:                        path,
+			Service:                     serviceName,
+			Source:                      sourceName,
+			Tags:                        source.Config.Tags,
+			ProcessingRules:             source.Config.ProcessingRules,
+			AutoMultiLine:               source.Config.AutoMultiLine,
+			AutoMultiLineSampleSize:     source.Config.AutoMultiLineSampleSize,
+			AutoMultiLineMatchThreshold: source.Config.AutoMultiLineMatchThreshold,
 		})
 
 	switch source.Config.Type {

--- a/pkg/logs/internal/launchers/container/tailerfactory/file_test.go
+++ b/pkg/logs/internal/launchers/container/tailerfactory/file_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	dockerutilPkg "github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
@@ -85,11 +86,14 @@ func TestMakeFileSource_docker_success(t *testing.T) {
 		cop:              containersorpods.NewDecidedChooser(containersorpods.LogContainers),
 	}
 	source := sources.NewLogSource("test", &config.LogsConfig{
-		Type:       "docker",
-		Identifier: "abc",
-		Source:     "src",
-		Service:    "svc",
-		Tags:       []string{"tag!"},
+		Type:                        "docker",
+		Identifier:                  "abc",
+		Source:                      "src",
+		Service:                     "svc",
+		Tags:                        []string{"tag!"},
+		AutoMultiLine:               pointer.Ptr(true),
+		AutoMultiLineSampleSize:     123,
+		AutoMultiLineMatchThreshold: 0.123,
 	})
 	child, err := tf.makeFileSource(source)
 	require.NoError(t, err)
@@ -101,6 +105,9 @@ func TestMakeFileSource_docker_success(t *testing.T) {
 	require.Equal(t, source.Config.Service, child.Config.Service)
 	require.Equal(t, source.Config.Tags, child.Config.Tags)
 	require.Equal(t, sources.DockerSourceType, child.GetSourceType())
+	require.Equal(t, *source.Config.AutoMultiLine, true)
+	require.Equal(t, source.Config.AutoMultiLineSampleSize, 123)
+	require.Equal(t, source.Config.AutoMultiLineMatchThreshold, 0.123)
 }
 
 func TestMakeFileSource_docker_no_file(t *testing.T) {
@@ -179,11 +186,14 @@ func TestMakeK8sSource(t *testing.T) {
 	for _, sourceConfigType := range []string{"docker", "containerd"} {
 		t.Run("source.Config.Type="+sourceConfigType, func(t *testing.T) {
 			source := sources.NewLogSource("test", &config.LogsConfig{
-				Type:       sourceConfigType,
-				Identifier: "abc",
-				Source:     "src",
-				Service:    "svc",
-				Tags:       []string{"tag!"},
+				Type:                        sourceConfigType,
+				Identifier:                  "abc",
+				Source:                      "src",
+				Service:                     "svc",
+				Tags:                        []string{"tag!"},
+				AutoMultiLine:               pointer.Ptr(true),
+				AutoMultiLineSampleSize:     123,
+				AutoMultiLineMatchThreshold: 0.123,
 			})
 			child, err := tf.makeK8sFileSource(source)
 			require.NoError(t, err)
@@ -194,6 +204,9 @@ func TestMakeK8sSource(t *testing.T) {
 			require.Equal(t, "src", child.Config.Source)
 			require.Equal(t, "svc", child.Config.Service)
 			require.Equal(t, []string{"tag!"}, child.Config.Tags)
+			require.Equal(t, *child.Config.AutoMultiLine, true)
+			require.Equal(t, child.Config.AutoMultiLineSampleSize, 123)
+			require.Equal(t, child.Config.AutoMultiLineMatchThreshold, 0.123)
 			switch sourceConfigType {
 			case "docker":
 				require.Equal(t, sources.DockerSourceType, child.GetSourceType())

--- a/releasenotes/notes/fix-auto-multi-line-integration-config-35449268a4471c19.yaml
+++ b/releasenotes/notes/fix-auto-multi-line-integration-config-35449268a4471c19.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix an issue where ``auto_multi_line_detection``, ``auto_multi_line_sample_size``,
+    and ``auto_multi_line_match_threshold`` were not working when set though a pod
+    annotation or container label.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

When migrating to `CCA_IN_AD`, not all of the logs config options were copied over when converting from a docker/k8s source to a file source. Previously this worked because we would copy the previous config and apply overrides. Today, we create a new config and apply settings from the old config. As a result it's easy to miss things like this and these slipped through the cracks. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Bug fix.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

#### Docker

1. Run the agent in docker with `DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION=false`
2. run a logging container with a label like:
```
 labels:
    com.datadoghq.ad.logs: >-
      [{
        "source": "mySource",
        "service": "myService",
        "auto_multi_line_detection": true
      }]  
 ```
3. run `agent status -v` and look at the tailer stats. You should see a status message about auto multi line detection

Repeat 1-3 with `DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION=true` and the integration config `false` (should have the opposite behavior)

#### K8s

1. run the agent helm chart with
```
logs:
    autoMultiLineDetection: false
```
2. run a logging container in a pod with an annotation like:
```
ad.datadoghq.com/bash.logs: '[{"service": "myService", "source": "mySource", "auto_multi_line_detection": false}]'
```
3. run `agent status -v` and look at the tailer stats. You should see a status message about auto multi line detection

Repeat 1-3 with `logs.autoMultiLineDetection: true` and the integration config `false` (should have the opposite behavior)

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
