### PR TITLE
[process-agent] Create WorkloadMetaExtractor v1

### DIFF
--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -193,6 +193,8 @@ func setupProcesses(config Config) {
 
 	procBindEnvAndSetDefault(config, "process_config.cache_lookupid", false)
 
+	procBindEnvAndSetDefault(config, "process_config.language_detection.enabled", false)
+
 	processesAddOverrideOnce.Do(func() {
 		AddOverrideFunc(loadProcessTransforms)
 	})

--- a/pkg/languagedetection/detector.go
+++ b/pkg/languagedetection/detector.go
@@ -7,8 +7,6 @@ package languagedetection
 
 import (
 	"strings"
-
-	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
 // LanguageName is a string enum that represents a detected language name.
@@ -79,8 +77,15 @@ func languageNameFromCommandLine(cmdline []string) LanguageName {
 	return Unknown
 }
 
+// Process is an internal representation of a process struct.
+// It is used to prevent dependency loops.
+type Process struct {
+	Cmdline []string
+	Pid     int32
+}
+
 // DetectLanguage uses a combination of commandline parsing and binary analysis to detect a process' language
-func DetectLanguage(procs []*procutil.Process) []*Language {
+func DetectLanguage(procs []*Process) []*Language {
 	langs := make([]*Language, len(procs))
 	for i, proc := range procs {
 		languageName := languageNameFromCommandLine(proc.Cmdline)

--- a/pkg/languagedetection/detector.go
+++ b/pkg/languagedetection/detector.go
@@ -7,33 +7,20 @@ package languagedetection
 
 import (
 	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
-
-// LanguageName is a string enum that represents a detected language name.
-type LanguageName string
-
-const (
-	Node    LanguageName = "node"
-	Dotnet  LanguageName = "dotnet"
-	Python  LanguageName = "python"
-	Java    LanguageName = "java"
-	Unknown LanguageName = ""
-)
-
-// Language contains metadata collected from the call to `DetectLanguage`
-type Language struct {
-	Name LanguageName
-}
 
 type languageFromCLI struct {
-	name      LanguageName
+	name      languagemodels.LanguageName
 	validator func(exe string) bool
 }
 
 // knownPrefixes maps languages names to their prefix
 var knownPrefixes = map[string]languageFromCLI{
-	"python": {name: Python},
-	"java": {name: Java, validator: func(exe string) bool {
+	"python": {name: languagemodels.Python},
+	"java": {name: languagemodels.Java, validator: func(exe string) bool {
 		if exe == "javac" {
 			return false
 		}
@@ -43,18 +30,18 @@ var knownPrefixes = map[string]languageFromCLI{
 
 // exactMatches maps an exact exe name match to a prefix
 var exactMatches = map[string]languageFromCLI{
-	"py":     {name: Python},
-	"python": {name: Python},
+	"py":     {name: languagemodels.Python},
+	"python": {name: languagemodels.Python},
 
-	"java": {name: Java},
+	"java": {name: languagemodels.Java},
 
-	"npm":  {name: Node},
-	"node": {name: Node},
+	"npm":  {name: languagemodels.Node},
+	"node": {name: languagemodels.Node},
 
-	"dotnet": {name: Dotnet},
+	"dotnet": {name: languagemodels.Dotnet},
 }
 
-func languageNameFromCommandLine(cmdline []string) LanguageName {
+func languageNameFromCommandLine(cmdline []string) languagemodels.LanguageName {
 	exe := getExe(cmdline)
 
 	// First check to see if there is an exact match
@@ -74,22 +61,15 @@ func languageNameFromCommandLine(cmdline []string) LanguageName {
 		}
 	}
 
-	return Unknown
-}
-
-// Process is an internal representation of a process struct.
-// It is used to prevent dependency loops.
-type Process struct {
-	Cmdline []string
-	Pid     int32
+	return languagemodels.Unknown
 }
 
 // DetectLanguage uses a combination of commandline parsing and binary analysis to detect a process' language
-func DetectLanguage(procs []*Process) []*Language {
-	langs := make([]*Language, len(procs))
+func DetectLanguage(procs []*procutil.Process) []*languagemodels.Language {
+	langs := make([]*languagemodels.Language, len(procs))
 	for i, proc := range procs {
 		languageName := languageNameFromCommandLine(proc.Cmdline)
-		langs[i] = &Language{Name: languageName}
+		langs[i] = &languagemodels.Language{Name: languageName}
 	}
 	return langs
 }

--- a/pkg/languagedetection/detector_nix_test.go
+++ b/pkg/languagedetection/detector_nix_test.go
@@ -12,12 +12,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
-func makeProcess(cmdline []string) *procutil.Process {
-	return &procutil.Process{
+func makeProcess(cmdline []string) *Process {
+	return &Process{
 		Pid:     rand.Int31(),
 		Cmdline: cmdline,
 	}
@@ -157,7 +155,7 @@ func BenchmarkDetectLanguage(b *testing.B) {
 		{"javap", "-c", "MyClass"},
 	}
 
-	var procs []*procutil.Process
+	var procs []*Process
 	for _, command := range commands {
 		procs = append(procs, makeProcess(command))
 	}

--- a/pkg/languagedetection/detector_nix_test.go
+++ b/pkg/languagedetection/detector_nix_test.go
@@ -12,10 +12,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
-func makeProcess(cmdline []string) *Process {
-	return &Process{
+func makeProcess(cmdline []string) *procutil.Process {
+	return &procutil.Process{
 		Pid:     rand.Int31(),
 		Cmdline: cmdline,
 	}
@@ -25,62 +28,62 @@ func TestLanguageFromCommandline(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		cmdline  []string
-		expected LanguageName
+		expected languagemodels.LanguageName
 	}{
 		{
 			name:     "python2",
 			cmdline:  []string{"/opt/Python/2.7.11/bin/python2.7", "/opt/foo/bar/baz", "--config=asdf"},
-			expected: Python,
+			expected: languagemodels.Python,
 		},
 		{
 			name:     "Java",
 			cmdline:  []string{"/usr/bin/Java", "-Xfoo=true", "org.elasticsearch.bootstrap.Elasticsearch"},
-			expected: Java,
+			expected: languagemodels.Java,
 		},
 		{
 			name:     "Unknown",
 			cmdline:  []string{"mine-bitcoins", "--all"},
-			expected: Unknown,
+			expected: languagemodels.Unknown,
 		},
 		{
 			name:     "Python with space and special chars in path",
 			cmdline:  []string{"//..//path/\"\\ to/Python", "asdf"},
-			expected: Python,
+			expected: languagemodels.Python,
 		},
 		{
 			name:     "args in first element",
 			cmdline:  []string{"/usr/bin/Python myapp.py --config=/etc/mycfg.yaml"},
-			expected: Python,
+			expected: languagemodels.Python,
 		},
 		{
 			name:     "javac is not Java",
 			cmdline:  []string{"javac", "main.Java"},
-			expected: Unknown,
+			expected: languagemodels.Unknown,
 		},
 		{
 			name:     "py is Python",
 			cmdline:  []string{"py", "test.py"},
-			expected: Python,
+			expected: languagemodels.Python,
 		},
 		{
 			name:     "py is not a prefix",
 			cmdline:  []string{"pyret", "main.pyret"},
-			expected: Unknown,
+			expected: languagemodels.Unknown,
 		},
 		{
 			name:     "node",
 			cmdline:  []string{"node", "/etc/app/index.js"},
-			expected: Node,
+			expected: languagemodels.Node,
 		},
 		{
 			name:     "npm",
 			cmdline:  []string{"npm", "start"},
-			expected: Node,
+			expected: languagemodels.Node,
 		},
 		{
 			name:     "dotnet",
 			cmdline:  []string{"dotnet", "myApp"},
-			expected: Dotnet,
+			expected: languagemodels.Dotnet,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -155,7 +158,7 @@ func BenchmarkDetectLanguage(b *testing.B) {
 		{"javap", "-c", "MyClass"},
 	}
 
-	var procs []*Process
+	var procs []*procutil.Process
 	for _, command := range commands {
 		procs = append(procs, makeProcess(command))
 	}

--- a/pkg/languagedetection/detector_windows_test.go
+++ b/pkg/languagedetection/detector_windows_test.go
@@ -11,34 +11,36 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 )
 
 func TestLanguageFromCommandline(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		cmdline  []string
-		expected LanguageName
+		expected languagemodels.LanguageName
 		error    bool
 	}{
 		{
 			name:     "Python",
 			cmdline:  []string{"C:\\Program Files\\Python3.9\\Python.exe", "test.py"},
-			expected: Python,
+			expected: languagemodels.Python,
 		},
 		{
 			name:     "Java",
 			cmdline:  []string{"C:\\Program Files\\Java\\Java.exe", "main.Java"},
-			expected: Java,
+			expected: languagemodels.Java,
 		},
 		{
 			name:     "ingore javac",
 			cmdline:  []string{"C:\\Program Files\\Java\\javac.exe", "main.Java"},
-			expected: Unknown,
+			expected: languagemodels.Unknown,
 		},
 		{
 			name:     "dotnet",
 			cmdline:  []string{"dotnet", "BankApp.dll"},
-			expected: Dotnet,
+			expected: languagemodels.Dotnet,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/languagedetection/languagemodels/types.go
+++ b/pkg/languagedetection/languagemodels/types.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 package languagemodels
 
 // LanguageName is a string enum that represents a detected language name.

--- a/pkg/languagedetection/languagemodels/types.go
+++ b/pkg/languagedetection/languagemodels/types.go
@@ -1,0 +1,17 @@
+package languagemodels
+
+// LanguageName is a string enum that represents a detected language name.
+type LanguageName string
+
+const (
+	Node    LanguageName = "node"
+	Dotnet  LanguageName = "dotnet"
+	Python  LanguageName = "python"
+	Java    LanguageName = "java"
+	Unknown LanguageName = ""
+)
+
+// Language contains metadata collected from the call to `DetectLanguage`
+type Language struct {
+	Name LanguageName
+}

--- a/pkg/process/metadata/workloadmeta/extractor_test.go
+++ b/pkg/process/metadata/workloadmeta/extractor_test.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package workloadmeta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/languagedetection"
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
+)
+
+const (
+	Pid1 = 1000
+	Pid2 = 1001
+)
+
+func TestExtractor(t *testing.T) {
+	wlmExtractor := NewWorkloadMetaExtractor()
+
+	type testCase struct {
+		name     string
+		procs    map[int32]*procutil.Process
+		expected map[int32]*languagedetection.Language
+	}
+	for _, tc := range []testCase{
+		{
+			name: "java & python",
+			procs: map[int32]*procutil.Process{
+				Pid1: {
+					Pid:     Pid1,
+					Cmdline: []string{"java", "TestClass"},
+				},
+				Pid2: {
+					Pid:     Pid2,
+					Cmdline: []string{"python", "main.py"},
+				},
+			},
+			expected: map[int32]*languagedetection.Language{
+				Pid1: {Name: languagedetection.Java},
+				Pid2: {Name: languagedetection.Python},
+			},
+		},
+		{
+			// This TC is an edge case where the pid in the map doesn't match the pid in the process.
+			// In this case we should not panic.
+			name: "mismatched pid",
+			procs: map[int32]*procutil.Process{
+				Pid1: {
+					Pid:     Pid2,
+					Cmdline: []string{"dotnet"},
+				},
+			},
+			expected: map[int32]*languagedetection.Language{
+				Pid1: nil,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			wlmExtractor.Extract(tc.procs)
+			for pid, lang := range tc.expected {
+				proc := tc.procs[pid]
+				if lang == nil {
+					assert.Nil(t, proc.Language)
+					continue
+				}
+
+				assert.Equal(t, lang.Name, proc.Language.Name)
+			}
+		})
+	}
+}

--- a/pkg/process/metadata/workloadmeta/extractor_test.go
+++ b/pkg/process/metadata/workloadmeta/extractor_test.go
@@ -45,20 +45,6 @@ func TestExtractor(t *testing.T) {
 				Pid2: {Name: languagedetection.Python},
 			},
 		},
-		{
-			// This TC is an edge case where the pid in the map doesn't match the pid in the process.
-			// In this case we should not panic.
-			name: "mismatched pid",
-			procs: map[int32]*procutil.Process{
-				Pid1: {
-					Pid:     Pid2,
-					Cmdline: []string{"dotnet"},
-				},
-			},
-			expected: map[int32]*languagedetection.Language{
-				Pid1: nil,
-			},
-		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			wlmExtractor.Extract(tc.procs)

--- a/pkg/process/metadata/workloadmeta/extractor_test.go
+++ b/pkg/process/metadata/workloadmeta/extractor_test.go
@@ -69,7 +69,7 @@ func TestExtractor(t *testing.T) {
 	mockGrpcListener.AssertExpectations(t)
 	writeEvents.Unset()
 
-	// Assert that old events are evicted from the cache
+        // Assert that old events are evicted from the cache
 	_ = mockGrpcListener.On("writeEvents", []*ProcessEntity{
 		{
 			pid:      Pid1,

--- a/pkg/process/metadata/workloadmeta/extractor_test.go
+++ b/pkg/process/metadata/workloadmeta/extractor_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
-	"github.com/DataDog/datadog-agent/pkg/languagedetection"
+	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
@@ -45,12 +45,12 @@ func TestExtractor(t *testing.T) {
 		{
 			pid:      proc1.Pid,
 			cmdline:  proc1.Cmdline,
-			language: &languagedetection.Language{Name: languagedetection.Java},
+			language: &languagemodels.Language{Name: languagemodels.Java},
 		},
 		{
 			pid:      proc2.Pid,
 			cmdline:  proc2.Cmdline,
-			language: &languagedetection.Language{Name: languagedetection.Python},
+			language: &languagemodels.Language{Name: languagemodels.Python},
 		},
 	})
 	extractor.Extract(map[int32]*procutil.Process{
@@ -74,13 +74,13 @@ func TestExtractor(t *testing.T) {
 		{
 			pid:      Pid1,
 			cmdline:  proc1.Cmdline,
-			language: &languagedetection.Language{Name: languagedetection.Java},
+			language: &languagemodels.Language{Name: languagemodels.Java},
 		},
 	}, []*ProcessEntity{
 		{
 			pid:      Pid3,
 			cmdline:  proc3.Cmdline,
-			language: &languagedetection.Language{Name: languagedetection.Unknown},
+			language: &languagemodels.Language{Name: languagemodels.Unknown},
 		},
 	})
 	extractor.Extract(map[int32]*procutil.Process{

--- a/pkg/process/metadata/workloadmeta/extractor_test.go
+++ b/pkg/process/metadata/workloadmeta/extractor_test.go
@@ -70,7 +70,7 @@ func TestExtractor(t *testing.T) {
 	writeEvents.Unset()
 
 	// Assert that old events are evicted from the cache
-	writeEvents = mockGrpcListener.On("writeEvents", []*ProcessEntity{
+	_ = mockGrpcListener.On("writeEvents", []*ProcessEntity{
 		{
 			pid:      Pid1,
 			cmdline:  proc1.Cmdline,
@@ -88,7 +88,6 @@ func TestExtractor(t *testing.T) {
 		Pid3: proc3,
 	})
 	mockGrpcListener.AssertExpectations(t)
-
 }
 
 var _ mockableGrpcListener = (*mockGrpcListener)(nil)

--- a/pkg/process/metadata/workloadmeta/extractor_test.go
+++ b/pkg/process/metadata/workloadmeta/extractor_test.go
@@ -6,6 +6,7 @@
 package workloadmeta
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -125,4 +126,21 @@ type mockGrpcListener struct {
 
 func (m *mockGrpcListener) writeEvents(procsToDelete, procsToAdd []*ProcessEntity) {
 	m.Called(procsToDelete, procsToAdd)
+}
+
+func BenchmarkHashProcess(b *testing.B) {
+	b.Run("itoa", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			hashProcess(0, 0)
+		}
+	})
+	b.Run("sprintf", func(b *testing.B) {
+		hashProcess := func(pid int32, createTime int64) string {
+			return fmt.Sprintf("pid:%v|createTime:%v", pid, createTime)
+		}
+
+		for i := 0; i < b.N; i++ {
+			hashProcess(0, 0)
+		}
+	})
 }

--- a/pkg/process/metadata/workloadmeta/extractor_test.go
+++ b/pkg/process/metadata/workloadmeta/extractor_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
@@ -56,6 +57,16 @@ func TestExtractor(t *testing.T) {
 		Pid2: proc2,
 	})
 	mockGrpcListener.AssertExpectations(t)
+	assert.Equal(t, map[string]*ProcessEntity{
+		hashProcess(Pid1, proc1.Stats.CreateTime): {
+			pid:      proc1.Pid,
+			language: &languagemodels.Language{Name: languagemodels.Java},
+		},
+		hashProcess(Pid2, proc2.Stats.CreateTime): {
+			pid:      proc2.Pid,
+			language: &languagemodels.Language{Name: languagemodels.Python},
+		},
+	}, extractor.cache)
 	writeEvents.Unset()
 
 	// Assert that we write no duplicates
@@ -65,6 +76,16 @@ func TestExtractor(t *testing.T) {
 		Pid2: proc2,
 	})
 	mockGrpcListener.AssertExpectations(t)
+	assert.Equal(t, map[string]*ProcessEntity{
+		hashProcess(Pid1, proc1.Stats.CreateTime): {
+			pid:      proc1.Pid,
+			language: &languagemodels.Language{Name: languagemodels.Java},
+		},
+		hashProcess(Pid2, proc2.Stats.CreateTime): {
+			pid:      proc2.Pid,
+			language: &languagemodels.Language{Name: languagemodels.Python},
+		},
+	}, extractor.cache)
 	writeEvents.Unset()
 
 	// Assert that old events are evicted from the cache
@@ -83,6 +104,16 @@ func TestExtractor(t *testing.T) {
 		Pid2: proc2,
 		Pid3: proc3,
 	})
+	assert.Equal(t, map[string]*ProcessEntity{
+		hashProcess(Pid2, proc2.Stats.CreateTime): {
+			pid:      proc2.Pid,
+			language: &languagemodels.Language{Name: languagemodels.Python},
+		},
+		hashProcess(Pid3, proc3.Stats.CreateTime): {
+			pid:      proc3.Pid,
+			language: &languagemodels.Language{Name: languagemodels.Unknown},
+		},
+	}, extractor.cache)
 	mockGrpcListener.AssertExpectations(t)
 }
 

--- a/pkg/process/metadata/workloadmeta/extractor_test.go
+++ b/pkg/process/metadata/workloadmeta/extractor_test.go
@@ -44,12 +44,10 @@ func TestExtractor(t *testing.T) {
 	writeEvents := mockGrpcListener.On("writeEvents", []*ProcessEntity{}, []*ProcessEntity{
 		{
 			pid:      proc1.Pid,
-			cmdline:  proc1.Cmdline,
 			language: &languagemodels.Language{Name: languagemodels.Java},
 		},
 		{
 			pid:      proc2.Pid,
-			cmdline:  proc2.Cmdline,
 			language: &languagemodels.Language{Name: languagemodels.Python},
 		},
 	})
@@ -69,17 +67,15 @@ func TestExtractor(t *testing.T) {
 	mockGrpcListener.AssertExpectations(t)
 	writeEvents.Unset()
 
-        // Assert that old events are evicted from the cache
+	// Assert that old events are evicted from the cache
 	_ = mockGrpcListener.On("writeEvents", []*ProcessEntity{
 		{
 			pid:      Pid1,
-			cmdline:  proc1.Cmdline,
 			language: &languagemodels.Language{Name: languagemodels.Java},
 		},
 	}, []*ProcessEntity{
 		{
 			pid:      Pid3,
-			cmdline:  proc3.Cmdline,
 			language: &languagemodels.Language{Name: languagemodels.Unknown},
 		},
 	})

--- a/pkg/process/metadata/workloadmeta/grpc.go
+++ b/pkg/process/metadata/workloadmeta/grpc.go
@@ -1,0 +1,21 @@
+package workloadmeta
+
+type mockableGrpcListener interface {
+	writeEvents(procsToDelete, procsToAdd []*ProcessEntity)
+}
+
+var _ mockableGrpcListener = (*grpcListener)(nil)
+
+type grpcListener struct {
+	evts chan *ProcessEntity
+}
+
+func newGrpcListener() *grpcListener {
+	return &grpcListener{
+		evts: make(chan *ProcessEntity, 0),
+	}
+}
+
+func (l *grpcListener) writeEvents(procsToDelete, procsToAdd []*ProcessEntity) {
+	// TODO
+}

--- a/pkg/process/metadata/workloadmeta/grpc.go
+++ b/pkg/process/metadata/workloadmeta/grpc.go
@@ -9,18 +9,8 @@ type mockableGrpcListener interface {
 	writeEvents(procsToDelete, procsToAdd []*ProcessEntity)
 }
 
-var _ mockableGrpcListener = (*grpcListener)(nil)
+var _ mockableGrpcListener = (*noopGRPCListener)(nil)
 
-type grpcListener struct {
-	evts chan *ProcessEntity
-}
+type noopGRPCListener struct{}
 
-func newGrpcListener() *grpcListener {
-	return &grpcListener{
-		evts: make(chan *ProcessEntity, 0),
-	}
-}
-
-func (l *grpcListener) writeEvents(procsToDelete, procsToAdd []*ProcessEntity) {
-	// TODO
-}
+func (l *noopGRPCListener) writeEvents(procsToDelete, procsToAdd []*ProcessEntity) {}

--- a/pkg/process/metadata/workloadmeta/grpc.go
+++ b/pkg/process/metadata/workloadmeta/grpc.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 package workloadmeta
 
 type mockableGrpcListener interface {

--- a/pkg/process/metadata/workloadmeta/workloadmeta.go
+++ b/pkg/process/metadata/workloadmeta/workloadmeta.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 package workloadmeta
 
 import (
@@ -6,14 +11,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
-type WorkloadMetaExtractor struct {
-	enabled bool
-}
+// WorkloadMetaExtractor handles enriching processes with
+type WorkloadMetaExtractor struct{}
 
-func NewWorkloadMetaExtractor(ddconfig config.ConfigReader) *WorkloadMetaExtractor {
-	return &WorkloadMetaExtractor{
-		enabled: ddconfig.GetBool("process_config.language_detection.enabled"),
-	}
+// NewWorkloadMetaExtractor constructs the WorkloadMetaExtractor.
+func NewWorkloadMetaExtractor() *WorkloadMetaExtractor {
+	return &WorkloadMetaExtractor{}
 }
 
 func (w *WorkloadMetaExtractor) Extract(procs map[int32]*procutil.Process) {
@@ -32,4 +35,9 @@ func (w *WorkloadMetaExtractor) Extract(procs map[int32]*procutil.Process) {
 			proc.Language = lang
 		}
 	}
+}
+
+// Enabled returns wheither or not the extractor should be enabled
+func Enabled(ddconfig config.ConfigReader) bool {
+	return ddconfig.GetBool("process_config.language_detection.enabled")
 }

--- a/pkg/process/metadata/workloadmeta/workloadmeta.go
+++ b/pkg/process/metadata/workloadmeta/workloadmeta.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // WorkloadMetaExtractor handles enriching processes with
@@ -33,6 +34,7 @@ func (w *WorkloadMetaExtractor) Extract(procs map[int32]*procutil.Process) {
 		lang := languages[i]
 		if proc, ok := procs[proc.Pid]; ok {
 			proc.Language = lang
+			log.Trace("detected language", lang.Name, "for pid", proc.Pid)
 		}
 	}
 }

--- a/pkg/process/metadata/workloadmeta/workloadmeta.go
+++ b/pkg/process/metadata/workloadmeta/workloadmeta.go
@@ -6,42 +6,93 @@
 package workloadmeta
 
 import (
+	"fmt"
+	"sync"
+
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// ProcessEntity is a placeholder workloadmeta.ProcessEntity.
+// It does not contain all the fields that the final entity will contain.
+type ProcessEntity struct {
+	pid      int32
+	cmdline  []string
+	language *languagedetection.Language
+}
+
 // WorkloadMetaExtractor handles enriching processes with
-type WorkloadMetaExtractor struct{}
+type WorkloadMetaExtractor struct {
+	cache      map[string]*ProcessEntity
+	cacheMutex sync.RWMutex
+
+	grpcListener mockableGrpcListener
+}
 
 // NewWorkloadMetaExtractor constructs the WorkloadMetaExtractor.
 func NewWorkloadMetaExtractor() *WorkloadMetaExtractor {
-	return &WorkloadMetaExtractor{}
+	return &WorkloadMetaExtractor{
+		cache:        make(map[string]*ProcessEntity),
+		grpcListener: newGrpcListener(),
+	}
 }
 
+// Extract detects the process language, creates a process entity, and sends that entity to WorkloadMeta
 func (w *WorkloadMetaExtractor) Extract(procs map[int32]*procutil.Process) {
-	procsSlice := make([]*languagedetection.Process, 0, len(procs))
+	procsToDetect := make([]*languagedetection.Process, 0, len(procs))
+	newCache := make(map[string]*ProcessEntity, len(procs))
 	for pid, proc := range procs {
-		procsSlice = append(procsSlice, &languagedetection.Process{
+		hash := hashProcess(pid, proc.Stats.CreateTime)
+		if entity, ok := w.cache[hash]; ok {
+			newCache[hash] = entity
+			continue
+		}
+
+		procsToDetect = append(procsToDetect, &languagedetection.Process{
 			Pid:     pid,
 			Cmdline: proc.Cmdline,
 		})
 	}
 
-	languages := languagedetection.DetectLanguage(procsSlice)
-	for i, proc := range procsSlice {
-		lang := languages[i]
-		if proc, ok := procs[proc.Pid]; ok {
-			proc.Language = lang
-			if lang.Name != languagedetection.Unknown {
-				log.Trace("detected language", lang.Name, "for pid", proc.Pid)
-			}
+	newProcs := make([]*ProcessEntity, 0, len(procsToDetect))
+	languages := languagedetection.DetectLanguage(procsToDetect)
+	for i, lang := range languages {
+		pid := procsToDetect[i].Pid
+		proc := procs[procsToDetect[i].Pid]
+		entity := &ProcessEntity{
+			pid:      pid,
+			cmdline:  proc.Cmdline,
+			language: lang,
 		}
+		newProcs = append(newProcs, entity)
+		newCache[hashProcess(pid, proc.Stats.CreateTime)] = entity
 	}
+
+	oldProcs := getOldProcs(w.cache, newCache)
+	w.grpcListener.writeEvents(oldProcs, newProcs)
+
+	w.cacheMutex.Lock()
+	w.cache = newCache
+	w.cacheMutex.Unlock()
+}
+
+func getOldProcs(oldCache, newCache map[string]*ProcessEntity) []*ProcessEntity {
+	oldProcs := make([]*ProcessEntity, 0, len(oldCache))
+	for key, entity := range oldCache {
+		if _, ok := newCache[key]; ok {
+			continue
+		}
+		oldProcs = append(oldProcs, entity)
+	}
+	return oldProcs
 }
 
 // Enabled returns wheither or not the extractor should be enabled
 func Enabled(ddconfig config.ConfigReader) bool {
 	return ddconfig.GetBool("process_config.language_detection.enabled")
+}
+
+func hashProcess(pid int32, createTime int64) string {
+	return fmt.Sprintf("pid:%v|createTime:%v", pid, createTime)
 }

--- a/pkg/process/metadata/workloadmeta/workloadmeta.go
+++ b/pkg/process/metadata/workloadmeta/workloadmeta.go
@@ -1,0 +1,35 @@
+package workloadmeta
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/languagedetection"
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
+)
+
+type WorkloadMetaExtractor struct {
+	enabled bool
+}
+
+func NewWorkloadMetaExtractor(ddconfig config.ConfigReader) *WorkloadMetaExtractor {
+	return &WorkloadMetaExtractor{
+		enabled: ddconfig.GetBool("process_config.language_detection.enabled"),
+	}
+}
+
+func (w *WorkloadMetaExtractor) Extract(procs map[int32]*procutil.Process) {
+	procsSlice := make([]*languagedetection.Process, 0, len(procs))
+	for _, proc := range procs {
+		procsSlice = append(procsSlice, &languagedetection.Process{
+			Pid:     proc.Pid,
+			Cmdline: proc.Cmdline,
+		})
+	}
+
+	languages := languagedetection.DetectLanguage(procsSlice)
+	for i, proc := range procsSlice {
+		lang := languages[i]
+		if proc, ok := procs[proc.Pid]; ok {
+			proc.Language = lang
+		}
+	}
+}

--- a/pkg/process/metadata/workloadmeta/workloadmeta.go
+++ b/pkg/process/metadata/workloadmeta/workloadmeta.go
@@ -22,9 +22,9 @@ func NewWorkloadMetaExtractor() *WorkloadMetaExtractor {
 
 func (w *WorkloadMetaExtractor) Extract(procs map[int32]*procutil.Process) {
 	procsSlice := make([]*languagedetection.Process, 0, len(procs))
-	for _, proc := range procs {
+	for pid, proc := range procs {
 		procsSlice = append(procsSlice, &languagedetection.Process{
-			Pid:     proc.Pid,
+			Pid:     pid,
 			Cmdline: proc.Cmdline,
 		})
 	}

--- a/pkg/process/metadata/workloadmeta/workloadmeta.go
+++ b/pkg/process/metadata/workloadmeta/workloadmeta.go
@@ -34,7 +34,9 @@ func (w *WorkloadMetaExtractor) Extract(procs map[int32]*procutil.Process) {
 		lang := languages[i]
 		if proc, ok := procs[proc.Pid]; ok {
 			proc.Language = lang
-			log.Trace("detected language", lang.Name, "for pid", proc.Pid)
+			if lang.Name != languagedetection.Unknown {
+				log.Trace("detected language", lang.Name, "for pid", proc.Pid)
+			}
 		}
 	}
 }

--- a/pkg/process/metadata/workloadmeta/workloadmeta.go
+++ b/pkg/process/metadata/workloadmeta/workloadmeta.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection"
+	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
@@ -19,7 +20,7 @@ import (
 type ProcessEntity struct {
 	pid      int32
 	cmdline  []string
-	language *languagedetection.Language
+	language *languagemodels.Language
 }
 
 // WorkloadMetaExtractor handles enriching processes with
@@ -40,7 +41,7 @@ func NewWorkloadMetaExtractor() *WorkloadMetaExtractor {
 
 // Extract detects the process language, creates a process entity, and sends that entity to WorkloadMeta
 func (w *WorkloadMetaExtractor) Extract(procs map[int32]*procutil.Process) {
-	procsToDetect := make([]*languagedetection.Process, 0, len(procs))
+	procsToDetect := make([]*procutil.Process, 0, len(procs))
 	newCache := make(map[string]*ProcessEntity, len(procs))
 	for pid, proc := range procs {
 		hash := hashProcess(pid, proc.Stats.CreateTime)
@@ -49,10 +50,7 @@ func (w *WorkloadMetaExtractor) Extract(procs map[int32]*procutil.Process) {
 			continue
 		}
 
-		procsToDetect = append(procsToDetect, &languagedetection.Process{
-			Pid:     pid,
-			Cmdline: proc.Cmdline,
-		})
+		procsToDetect = append(procsToDetect, proc)
 	}
 
 	newProcs := make([]*ProcessEntity, 0, len(procsToDetect))

--- a/pkg/process/metadata/workloadmeta/workloadmeta.go
+++ b/pkg/process/metadata/workloadmeta/workloadmeta.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/languagedetection"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // ProcessEntity is a placeholder workloadmeta.ProcessEntity.
@@ -35,6 +36,7 @@ type WorkloadMetaExtractor struct {
 
 // NewWorkloadMetaExtractor constructs the WorkloadMetaExtractor.
 func NewWorkloadMetaExtractor() *WorkloadMetaExtractor {
+	log.Debug("Instantiated the WorkloadMetaExtractor")
 	return &WorkloadMetaExtractor{
 		cache:        make(map[string]*ProcessEntity),
 		grpcListener: newGrpcListener(),

--- a/pkg/process/metadata/workloadmeta/workloadmeta.go
+++ b/pkg/process/metadata/workloadmeta/workloadmeta.go
@@ -69,6 +69,8 @@ func (w *WorkloadMetaExtractor) Extract(procs map[int32]*procutil.Process) {
 		}
 		newEntities = append(newEntities, entity)
 		newCache[hashProcess(pid, proc.Stats.CreateTime)] = entity
+
+		log.Trace("detected language", lang.Name, "for pid", pid)
 	}
 
 	deadProcs := getDifference(w.cache, newCache)
@@ -90,7 +92,7 @@ func getDifference(oldCache, newCache map[string]*ProcessEntity) []*ProcessEntit
 	return oldProcs
 }
 
-// Enabled returns whether or not the extractor should be enabled
+// Enabled returns whether the extractor should be enabled
 func Enabled(ddconfig config.ConfigReader) bool {
 	return ddconfig.GetBool("process_config.language_detection.enabled")
 }

--- a/pkg/process/metadata/workloadmeta/workloadmeta.go
+++ b/pkg/process/metadata/workloadmeta/workloadmeta.go
@@ -86,7 +86,7 @@ func getOldProcs(oldCache, newCache map[string]*ProcessEntity) []*ProcessEntity 
 	return oldProcs
 }
 
-// Enabled returns wheither or not the extractor should be enabled
+// Enabled returns whether or not the extractor should be enabled
 func Enabled(ddconfig config.ConfigReader) bool {
 	return ddconfig.GetBool("process_config.language_detection.enabled")
 }

--- a/pkg/process/procutil/process_model.go
+++ b/pkg/process/procutil/process_model.go
@@ -8,6 +8,8 @@ package procutil
 import (
 	"github.com/DataDog/gopsutil/cpu"
 	"github.com/DataDog/gopsutil/process"
+
+	"github.com/DataDog/datadog-agent/pkg/languagedetection"
 )
 
 // Process holds all relevant metadata and metrics for a process
@@ -23,7 +25,8 @@ type Process struct {
 	Uids     []int32
 	Gids     []int32
 
-	Stats *Stats
+	Stats    *Stats
+	Language *languagedetection.Language
 }
 
 // DeepCopy creates a deep copy of Process

--- a/pkg/process/procutil/process_model.go
+++ b/pkg/process/procutil/process_model.go
@@ -9,7 +9,7 @@ import (
 	"github.com/DataDog/gopsutil/cpu"
 	"github.com/DataDog/gopsutil/process"
 
-	"github.com/DataDog/datadog-agent/pkg/languagedetection"
+	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 )
 
 // Process holds all relevant metadata and metrics for a process
@@ -26,7 +26,7 @@ type Process struct {
 	Gids     []int32
 
 	Stats    *Stats
-	Language *languagedetection.Language
+	Language *languagemodels.Language
 }
 
 // DeepCopy creates a deep copy of Process

--- a/pkg/process/procutil/process_model.go
+++ b/pkg/process/procutil/process_model.go
@@ -8,8 +8,6 @@ package procutil
 import (
 	"github.com/DataDog/gopsutil/cpu"
 	"github.com/DataDog/gopsutil/process"
-
-	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 )
 
 // Process holds all relevant metadata and metrics for a process
@@ -25,8 +23,7 @@ type Process struct {
 	Uids     []int32
 	Gids     []int32
 
-	Stats    *Stats
-	Language *languagemodels.Language
+	Stats *Stats
 }
 
 // DeepCopy creates a deep copy of Process

--- a/releasenotes/notes/create-wlm-extractor-e408e2826cc77be8.yaml
+++ b/releasenotes/notes/create-wlm-extractor-e408e2826cc77be8.yaml
@@ -1,10 +1,3 @@
-# Each section from every release note are combined when the
-# CHANGELOG.rst is rendered. So the text needs to be worded so that
-# it does not depend on any information only available in another
-# section. This may mean repeating some details, but each section
-# must be readable independently of the other.
-#
-# Each section note must be formatted as reStructuredText.
 ---
 features:
   - |

--- a/releasenotes/notes/create-wlm-extractor-e408e2826cc77be8.yaml
+++ b/releasenotes/notes/create-wlm-extractor-e408e2826cc77be8.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Added an experimental setting `process_config.language_detection.enabled`. This enables detecting languages for processes.
+    This feature is WIP.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
This PR creates the `WorkloadMetaExtractor` that calls the language detection library. At the moment, this data is not exposed anywhere, but the extractor can be used in the process check.

Whether or not the extractor is used can be determined by the `process_config.language_detection.enabled` feature flag. At the moment, this feature flag defaults to false.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Language detection PoC

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
With the following config:
```yaml
log_level: trace
process_config:
  process_collection: {enabled: true}
  language_detection: {enabled: true}
```
Run the process agent, and look for messages like: `detected language <language> for pid <pid>`

Also make sure that if `process_config.language_detection.enabled == false`, we do not see this debug message:
```
Instantiated the WorkloadMetaExtractor
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
