### PR TITLE
regression detector: change baseline variant from latest main to merge base

### DIFF
--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -119,23 +119,6 @@ docker_build_agent7:
     TAG_SUFFIX: -7
     BUILD_ARG: --target test --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_amd64.deb
 
-single_machine_performance-push-main-sha:
-  stage: container_build
-  rules:
-    - !reference [.on_main_a7]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:docker"]
-  needs:
-    - docker_build_agent7
-  script:
-    - echo -n ${CI_COMMIT_SHA} > .main_sha
-    - SMP_ACCOUNT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-account-id --with-decryption --query "Parameter.Value" --out text)
-    - SMP_AGENT_TEAM_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-agent-team-id --with-decryption --query "Parameter.Value" --out text)
-    - aws configure set aws_access_key_id $(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-bot-access-key-id --with-decryption --query "Parameter.Value" --out text) --profile single-machine-performance
-    - aws configure set aws_secret_access_key $(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-bot-access-key --with-decryption --query "Parameter.Value" --out text) --profile single-machine-performance
-    - aws configure set region us-west-2 --profile single-machine-performance
-    - aws s3 cp --profile single-machine-performance --only-show-errors .main_sha s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/latest_main_sha
-
 single_machine_performance-amd64-a7:
   extends: .docker_publish_job_definition
   stage: container_build

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -119,49 +119,6 @@ docker_build_agent7:
     TAG_SUFFIX: -7
     BUILD_ARG: --target test --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_amd64.deb
 
-# # Task below does not work because no runner is allocated to it.
-# single_machine_performance-compute-baseline_sha:
-#   stage: container_build
-#   rules:
-#     - !reference [.on_a7]
-#     # NOTE(geoffrey.oxberry@datadoghq.com): Assume for now it's sensible to compare main against itself.
-#     # - !reference [.if_not_main_branch]    # Use this line if comparing main against itself does not make sense.
-#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES # !reference [.docker_build_job_definition_amd64, image]
-#   artifacts:
-#     expire_in: 1 week
-#     paths:
-#       - "${CI_COMMIT_SHA}-baseline_sha"
-#     when: always
-#   script:
-#     - git fetch origin
-#     - echo -n $(git merge-base ${CI_COMMIT_SHA} origin/main) > "${CI_COMMIT_SHA}-baseline_sha"
-#     - SMP_ACCOUNT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-account-id --with-decryption --query "Parameter.Value" --out text)
-#     - SMP_AGENT_TEAM_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-agent-team-id --with-decryption --query "Parameter.Value" --out text)
-#     - aws configure set aws_access_key_id $(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-bot-access-key-id --with-decryption --query "Parameter.Value" --out text) --profile single-machine-performance
-#     - aws configure set aws_secret_access_key $(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-bot-access-key --with-decryption --query "Parameter.Value" --out text) --profile single-machine-performance
-#     - aws configure set region us-west-2 --profile single-machine-performance
-#     - aws s3 cp --profile single-machine-performance --only-show-errors "${CI_COMMIT_SHA}-baseline_sha" "s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/"
-#     # NOTE(geoffrey.oxberry@datadoghq.com): For the purposes of standing up a
-#     # minimum viable product, assume a container has already been built for the
-#     # merge base -- this assumption is actually true if the target branch of the
-#     # pull request is `main`. If not, we need to (sort of) extend
-#     # .docker_build_on_job_definition, .docker_build_job_definition_amd64, and
-#     # docker_build_agent7. Using the `extends:` keyword won't actually work
-#     # because it'll reverse deep merge settings, so instead this hypothetical
-#     # build task could use `!reference` tags liberally, except for the `script`
-#     # keyword, which would be some suitably modified version of the contents of
-#     # `.docker_build_on_job_definition:script`. As far as I can tell, we only need
-#     # to build a container if the target branch is *not* `main`; it may make sense
-#     # to simply exclude that case.
-#     #
-#     # If we need to build that container, we probably also need to publish it,
-#     # which could be done by suitably modifying a *renamed copy* of
-#     # `single_machine_performance-amd64-a7` (because we still need the existing
-#     # version of that task). If we need to inject a different version of the
-#     # shell variables that relies in some way on outputs from another SMP job in
-#     # Agent CI, we can use the `before_script` hook to `export` the variable
-#     # with the value we need.
-
 single_machine_performance-push-main-sha:
   stage: container_build
   rules:

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -119,45 +119,45 @@ docker_build_agent7:
     TAG_SUFFIX: -7
     BUILD_ARG: --target test --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_amd64.deb
 
-
-single_machine_performance-compute-baseline_sha:
-  stage: container_build
-  rules:
-    - !reference [.on_a7]
-    # NOTE(geoffrey.oxberry@datadoghq.com): Assume for now it's sensible to compare main against itself.
-    # - !reference [.if_not_main_branch]    # Use this line if comparing main against itself makes sense.
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES # !reference [.docker_build_job_definition_amd64, image]
-  artifacts:
-    expire_in: 1 week
-    paths:
-      - "${CI_COMMIT_SHA}-baseline_sha"
-    when: always
-  script:
-    - git fetch origin
-    - echo -n $(git merge-base ${CI_COMMIT_SHA} origin/main) > "${CI_COMMIT_SHA}-baseline_sha"
-    - SMP_ACCOUNT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-account-id --with-decryption --query "Parameter.Value" --out text)
-    - SMP_AGENT_TEAM_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-agent-team-id --with-decryption --query "Parameter.Value" --out text)
-    - aws configure set aws_access_key_id $(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-bot-access-key-id --with-decryption --query "Parameter.Value" --out text) --profile single-machine-performance
-    - aws configure set aws_secret_access_key $(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-bot-access-key --with-decryption --query "Parameter.Value" --out text) --profile single-machine-performance
-    - aws configure set region us-west-2 --profile single-machine-performance
-    - aws s3 cp --profile single-machine-performance --only-show-errors "${CI_COMMIT_SHA}-baseline_sha" "s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/"
-    # NOTE(geoffrey.oxberry@datadoghq.com): For the purposes of standing up a
-    # minimum viable product, assume a container has already been built for the
-    # merge base. If not, we need to (sort of) extend
-    # .docker_build_on_job_definition, .docker_build_job_definition_amd64, and
-    # docker_build_agent7. Using the `extends:` keyword won't actually work
-    # because it'll reverse deep merge settings, so instead this hypothetical
-    # build task could use `!reference` tags liberally, except for the `script`
-    # keyword, which would be some suitably modified version of the contents of
-    # `.docker_build_on_job_definition:script`.
-    #
-    # If we need to build that container, we probably also need to publish it,
-    # which could be done by suitably modifying a *renamed copy* of
-    # `single_machine_performance-amd64-a7` (because we still need the existing
-    # version of that task). If we need to inject a different version of the
-    # shell variables that relies in some way on outputs from another SMP job in
-    # Agent CI, we can use the `before_script` hook to `export` the variable
-    # with the value we need.
+# # Task below does not work because no runner is allocated to it.
+# single_machine_performance-compute-baseline_sha:
+#   stage: container_build
+#   rules:
+#     - !reference [.on_a7]
+#     # NOTE(geoffrey.oxberry@datadoghq.com): Assume for now it's sensible to compare main against itself.
+#     # - !reference [.if_not_main_branch]    # Use this line if comparing main against itself makes sense.
+#   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES # !reference [.docker_build_job_definition_amd64, image]
+#   artifacts:
+#     expire_in: 1 week
+#     paths:
+#       - "${CI_COMMIT_SHA}-baseline_sha"
+#     when: always
+#   script:
+#     - git fetch origin
+#     - echo -n $(git merge-base ${CI_COMMIT_SHA} origin/main) > "${CI_COMMIT_SHA}-baseline_sha"
+#     - SMP_ACCOUNT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-account-id --with-decryption --query "Parameter.Value" --out text)
+#     - SMP_AGENT_TEAM_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-agent-team-id --with-decryption --query "Parameter.Value" --out text)
+#     - aws configure set aws_access_key_id $(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-bot-access-key-id --with-decryption --query "Parameter.Value" --out text) --profile single-machine-performance
+#     - aws configure set aws_secret_access_key $(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-bot-access-key --with-decryption --query "Parameter.Value" --out text) --profile single-machine-performance
+#     - aws configure set region us-west-2 --profile single-machine-performance
+#     - aws s3 cp --profile single-machine-performance --only-show-errors "${CI_COMMIT_SHA}-baseline_sha" "s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/"
+#     # NOTE(geoffrey.oxberry@datadoghq.com): For the purposes of standing up a
+#     # minimum viable product, assume a container has already been built for the
+#     # merge base. If not, we need to (sort of) extend
+#     # .docker_build_on_job_definition, .docker_build_job_definition_amd64, and
+#     # docker_build_agent7. Using the `extends:` keyword won't actually work
+#     # because it'll reverse deep merge settings, so instead this hypothetical
+#     # build task could use `!reference` tags liberally, except for the `script`
+#     # keyword, which would be some suitably modified version of the contents of
+#     # `.docker_build_on_job_definition:script`.
+#     #
+#     # If we need to build that container, we probably also need to publish it,
+#     # which could be done by suitably modifying a *renamed copy* of
+#     # `single_machine_performance-amd64-a7` (because we still need the existing
+#     # version of that task). If we need to inject a different version of the
+#     # shell variables that relies in some way on outputs from another SMP job in
+#     # Agent CI, we can use the `before_script` hook to `export` the variable
+#     # with the value we need.
 
 single_machine_performance-push-main-sha:
   stage: container_build

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -126,7 +126,7 @@ single_machine_performance-compute-baseline_sha:
     - !reference [.on_a7]
     # NOTE(geoffrey.oxberry@datadoghq.com): Assume for now it's sensible to compare main against itself.
     # - !reference [.if_not_main_branch]    # Use this line if comparing main against itself makes sense.
-  image: !reference [.docker_build_job_definition_amd64, image]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES # !reference [.docker_build_job_definition_amd64, image]
   artifacts:
     expire_in: 1 week
     paths:

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -119,6 +119,27 @@ docker_build_agent7:
     TAG_SUFFIX: -7
     BUILD_ARG: --target test --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_amd64.deb
 
+single_machine_performance-compute-baseline_sha:
+  stage: container_build
+  rules:
+    - !reference [.on_a7]
+    - !reference [.if_not_main_branch]
+  image: !reference [.docker_build_job_definition_amd64, image]
+  artifacts:
+    expire_in: 1 week
+    paths:
+      - "${CI_COMMIT_SHA}-baseline_sha"
+    when: always
+  script:
+    - git fetch origin
+    - echo -n $(git merge-base ${CI_COMMIT_SHA} origin/main) > "${CI_COMMIT_SHA}-baseline_sha"
+    - SMP_ACCOUNT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-account-id --with-decryption --query "Parameter.Value" --out text)
+    - SMP_AGENT_TEAM_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-agent-team-id --with-decryption --query "Parameter.Value" --out text)
+    - aws configure set aws_access_key_id $(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-bot-access-key-id --with-decryption --query "Parameter.Value" --out text) --profile single-machine-performance
+    - aws configure set aws_secret_access_key $(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-bot-access-key --with-decryption --query "Parameter.Value" --out text) --profile single-machine-performance
+    - aws configure set region us-west-2 --profile single-machine-performance
+    - aws s3 cp --profile single-machine-performance --only-show-errors "${CI_COMMIT_SHA}-baseline_sha" "s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/"
+
 single_machine_performance-push-main-sha:
   stage: container_build
   rules:

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -119,11 +119,13 @@ docker_build_agent7:
     TAG_SUFFIX: -7
     BUILD_ARG: --target test --build-arg PYTHON_VERSION=3 --build-arg DD_AGENT_ARTIFACT=datadog-agent_7*_amd64.deb
 
+
 single_machine_performance-compute-baseline_sha:
   stage: container_build
   rules:
     - !reference [.on_a7]
-    - !reference [.if_not_main_branch]
+    # NOTE(geoffrey.oxberry@datadoghq.com): Assume for now it's sensible to compare main against itself.
+    # - !reference [.if_not_main_branch]    # Use this line if comparing main against itself makes sense.
   image: !reference [.docker_build_job_definition_amd64, image]
   artifacts:
     expire_in: 1 week
@@ -139,6 +141,23 @@ single_machine_performance-compute-baseline_sha:
     - aws configure set aws_secret_access_key $(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-bot-access-key --with-decryption --query "Parameter.Value" --out text) --profile single-machine-performance
     - aws configure set region us-west-2 --profile single-machine-performance
     - aws s3 cp --profile single-machine-performance --only-show-errors "${CI_COMMIT_SHA}-baseline_sha" "s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/"
+    # NOTE(geoffrey.oxberry@datadoghq.com): For the purposes of standing up a
+    # minimum viable product, assume a container has already been built for the
+    # merge base. If not, we need to (sort of) extend
+    # .docker_build_on_job_definition, .docker_build_job_definition_amd64, and
+    # docker_build_agent7. Using the `extends:` keyword won't actually work
+    # because it'll reverse deep merge settings, so instead this hypothetical
+    # build task could use `!reference` tags liberally, except for the `script`
+    # keyword, which would be some suitably modified version of the contents of
+    # `.docker_build_on_job_definition:script`.
+    #
+    # If we need to build that container, we probably also need to publish it,
+    # which could be done by suitably modifying a *renamed copy* of
+    # `single_machine_performance-amd64-a7` (because we still need the existing
+    # version of that task). If we need to inject a different version of the
+    # shell variables that relies in some way on outputs from another SMP job in
+    # Agent CI, we can use the `before_script` hook to `export` the variable
+    # with the value we need.
 
 single_machine_performance-push-main-sha:
   stage: container_build

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -125,7 +125,7 @@ docker_build_agent7:
 #   rules:
 #     - !reference [.on_a7]
 #     # NOTE(geoffrey.oxberry@datadoghq.com): Assume for now it's sensible to compare main against itself.
-#     # - !reference [.if_not_main_branch]    # Use this line if comparing main against itself makes sense.
+#     # - !reference [.if_not_main_branch]    # Use this line if comparing main against itself does not make sense.
 #   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES # !reference [.docker_build_job_definition_amd64, image]
 #   artifacts:
 #     expire_in: 1 week

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -143,13 +143,16 @@ docker_build_agent7:
 #     - aws s3 cp --profile single-machine-performance --only-show-errors "${CI_COMMIT_SHA}-baseline_sha" "s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/"
 #     # NOTE(geoffrey.oxberry@datadoghq.com): For the purposes of standing up a
 #     # minimum viable product, assume a container has already been built for the
-#     # merge base. If not, we need to (sort of) extend
+#     # merge base -- this assumption is actually true if the target branch of the
+#     # pull request is `main`. If not, we need to (sort of) extend
 #     # .docker_build_on_job_definition, .docker_build_job_definition_amd64, and
 #     # docker_build_agent7. Using the `extends:` keyword won't actually work
 #     # because it'll reverse deep merge settings, so instead this hypothetical
 #     # build task could use `!reference` tags liberally, except for the `script`
 #     # keyword, which would be some suitably modified version of the contents of
-#     # `.docker_build_on_job_definition:script`.
+#     # `.docker_build_on_job_definition:script`. As far as I can tell, we only need
+#     # to build a container if the target branch is *not* `main`; it may make sense
+#     # to simply exclude that case.
 #     #
 #     # If we need to build that container, we probably also need to publish it,
 #     # which could be done by suitably modifying a *renamed copy* of

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -58,7 +58,7 @@ single-machine-performance-regression_detector:
     - echo "Computing baseline..."
     - echo "Checking if image exists for commit ${BASELINE_SHA}..."
     # TODO(geoffrey.oxberry@datadoghq.com): Make the statement below a multiline statement after debugging
-    - while [[ ! $(aws --profile single-machine-performance ecr describe-images --repository-name "${SMP_AGENT_TEAM_ID}-agent" --image-ids imageTag="${BASELINE_SHA}-7-amd64") ]]; do echo "No image exists for ${BASELINE_SHA} - checking predecessor of ${BASELINE_SHA} next"; BASELINE_SHA=$(git rev-parse ${BASELINE_SHA}^); echo "Checking if image exists for commit ${BASELINE_SHA}..."; done
+    - while [[ ! $(aws --profile single-machine-performance ecr describe-images --repository-name "${SMP_AGENT_TEAM_ID}-agent" --image-ids imageTag="${BASELINE_SHA}-7-amd64" 2> /dev/null) ]]; do echo "No image exists for ${BASELINE_SHA} - checking predecessor of ${BASELINE_SHA} next"; BASELINE_SHA=$(git rev-parse ${BASELINE_SHA}^); echo "Checking if image exists for commit ${BASELINE_SHA}..."; done
     - echo "Image exists for commit ${BASELINE_SHA}"
     - echo "Baseline SHA is ${BASELINE_SHA}"
     - echo -n "${BASELINE_SHA}" > "${CI_COMMIT_SHA}-baseline_sha"

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -5,13 +5,13 @@ single-machine-performance-regression_detector:
   needs:
     - job: single_machine_performance-amd64-a7
       artifacts: false
-    # - job: single_machine_performance-compute-baseline_sha
-    #   artifacts: true
   artifacts:
     expire_in: 1 weeks
     paths:
-      - submission_metadata
-      - ${CI_COMMIT_SHA}-baseline_sha
+      - submission_metadata              # for provenance, debugging
+      - ${CI_COMMIT_SHA}-baseline_sha    # for provenance, debugging
+      - outputs/report.md                # for debugging, also on S3
+      - outputs/report.html              # for debugging, also on S3
     when: always
   variables:
     SMP_VERSION: 0.7.3
@@ -25,7 +25,7 @@ single-machine-performance-regression_detector:
   # 'comparison'. We are guaranteed by the structure of the pipeline that
   # 'comparison' exists, not so much with 'baseline' as it has to come from main
   # merge pipeline run. This is solved in datadog-agent by updating a file in S3
-  # with the SHA of the latest passing build from main. It's solved in Vector by
+  # with the SHA of the merge base from main. It's solved in Vector by
   # building Vector twice for each Regression Detector run.
   #
   # We allow failure for now. _Unfortunately_ this also means that if the
@@ -33,13 +33,15 @@ single-machine-performance-regression_detector:
   # flagged.
   allow_failure: true
   script:
+    # Ensure output files exist for artifact downloads step
+    - mkdir outputs              # Also needed for smp job sync step
+    - touch outputs/report.md    # Will be emitted by smp job sync
+    - touch outputs/report.html  # Will be emitted by smp job sync
     # Compute merge base of current commit and `main`
     - git fetch origin
     - SMP_MERGE_BASE=$(git merge-base ${CI_COMMIT_SHA} origin/main)
     - echo -n "${SMP_MERGE_BASE}" > "${CI_COMMIT_SHA}-baseline_sha"
     - echo "Merge base is $(cat ${CI_COMMIT_SHA}-baseline_sha)"
-    - echo "CI_MERGE_REQUEST_TARGET_BRANCH_NAME=${CI_MERGE_REQUEST_TARGET_NAME}"
-    # - if [[ "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" != "main" ]]; then echo "The regression detector does not pull requests to a base branch that is not 'main'"; echo "(In GitLab terminology, 'base branch' is the 'target branch of a merge request.')"; exit 1; fi
     # Setup AWS credentials for single-machine-performance AWS account
     - AWS_NAMED_PROFILE="single-machine-performance"
     - SMP_ACCOUNT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-account-id --with-decryption --query "Parameter.Value" --out text)
@@ -84,7 +86,6 @@ single-machine-performance-regression_detector:
             --wait-delay-seconds 60
             --submission-metadata submission_metadata
     # Now that the job is completed pull the analysis report, output it to stdout.
-    - mkdir outputs
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --aws-named-profile ${AWS_NAMED_PROFILE}
             job sync
             --submission-metadata submission_metadata

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -56,17 +56,8 @@ single-machine-performance-regression_detector:
     # Download smp binary and prepare it for use
     - aws --profile single-machine-performance s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-musl/smp smp
     - chmod +x smp
-    # # # Submit job, using the SHA of the last successful main commit as baseline.
-    # # # This will have been built in a separate pipeline run. The comparison will
-    # # # have been built previously in this pipeline run.
-    # - aws --profile ${AWS_NAMED_PROFILE} s3 cp --only-show-errors s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/latest_main_sha .latest_main_sha
-    # - BASELINE_SHA=$(cat .latest_main_sha)
     # Copy the merge base SHA to SMP for debugging purposes later
     - aws s3 cp --profile single-machine-performance --only-show-errors "${CI_COMMIT_SHA}-baseline_sha" "s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/"
-    # NOTE(geoffrey.oxberry@datadoghq.com): To use the merge-base baseline SHA, uncomment the line
-    # starting with `BASELINE_SHA=` below, and comment out the `BASELINE_SHA=` line above, along with
-    # the accompanying aws s3 cp command immediately above that line.
-    # - BASELINE_SHA=$(cat "${CI_COMMIT_SHA}-baseline_sha")
     - BASELINE_SHA="${SMP_MERGE_BASE}"  # NOTE(geoffrey.oxberry@datadoghq.com): cat the echoed file once computing merge commit is separate job
     - BASELINE_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${BASELINE_SHA}-7-amd64
     - echo "${BASELINE_SHA} | ${BASELINE_IMAGE}"

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -52,8 +52,6 @@ single-machine-performance-regression_detector:
     # Download smp binary and prepare it for use
     - aws --profile single-machine-performance s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-musl/smp smp
     - chmod +x smp
-    # Copy the merge base SHA to SMP for debugging purposes later
-    - aws s3 cp --profile single-machine-performance --only-show-errors "${CI_COMMIT_SHA}-baseline_sha" "s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/"
     - BASELINE_SHA="${SMP_MERGE_BASE}"  # NOTE(geoffrey.oxberry@datadoghq.com): cat the echoed file once computing merge commit is separate job
     - echo "Computing baseline..."
     - echo "Checking if image exists for commit ${BASELINE_SHA}..."
@@ -62,6 +60,8 @@ single-machine-performance-regression_detector:
     - echo "Image exists for commit ${BASELINE_SHA}"
     - echo "Baseline SHA is ${BASELINE_SHA}"
     - echo -n "${BASELINE_SHA}" > "${CI_COMMIT_SHA}-baseline_sha"
+    # Copy the baseline SHA to SMP for debugging purposes later
+    - aws s3 cp --profile single-machine-performance --only-show-errors "${CI_COMMIT_SHA}-baseline_sha" "s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/"
     - BASELINE_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${BASELINE_SHA}-7-amd64
     - echo "${BASELINE_SHA} | ${BASELINE_IMAGE}"
     - COMPARISON_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${CI_COMMIT_SHA}-7-amd64

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -52,7 +52,7 @@ single-machine-performance-regression_detector:
     # Download smp binary and prepare it for use
     - aws --profile single-machine-performance s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-musl/smp smp
     - chmod +x smp
-    - BASELINE_SHA="${SMP_MERGE_BASE}"  # NOTE(geoffrey.oxberry@datadoghq.com): cat the echoed file once computing merge commit is separate job
+    - BASELINE_SHA="${SMP_MERGE_BASE}"
     - echo "Computing baseline..."
     - echo "Checking if image exists for commit ${BASELINE_SHA}..."
     - while [[ ! $(aws ecr describe-images --profile single-machine-performance --registry-id "${SMP_ACCOUNT_ID}" --repository-name "${SMP_AGENT_TEAM_ID}-agent" --image-ids imageTag="${BASELINE_SHA}-7-amd64") ]]; do echo "No image exists for ${BASELINE_SHA} - checking predecessor of ${BASELINE_SHA} next"; BASELINE_SHA=$(git rev-parse ${BASELINE_SHA}^); echo "Checking if image exists for commit ${BASELINE_SHA}..."; done

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -107,7 +107,7 @@ single-machine-performance-regression_detector:
     - dpkg -i dd-package.deb
     - rm dd-package.deb
     - apt-get update
-    - dd-package --bucket binaries.ddbuild.io --package devtools/dd-package-dev
+    - dd-package --bucket binaries.ddbuild.io --package devtools/dd-package-dev --distribution "20.04"
     # Kludge from https://gitlab.com/gitlab-org/gitlab-runner/-/issues/4645#note_287636439 to avoid
     # doubled output
     - echo ""
@@ -117,7 +117,8 @@ single-machine-performance-regression_detector:
     - "# beneath the error message in the GitLab CI logs                               #"
     - "#################################################################################"
     - echo ""
-    - dd-package --bucket binaries.ddbuild.io --package devtools/pr-commenter
+    # Pinned version of pr-commenter taken from https://github.com/DataDog/dogweb/blob/b2a891c2a2186b8fecd27ca9b13ebabe5f289a4a/tasks/gitlab/k8s-diff-helper.sh#L22
+    - dd-package --bucket binaries.ddbuild.io --package devtools/pr-commenter --distribution "20.04" --version "14692290-a6440fd1"
     # Post HTML report to GitHub
     - cat outputs/report.html | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME"
     # Finally, exit 1 if the job signals a regression else 0.

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -40,8 +40,7 @@ single-machine-performance-regression_detector:
     # Compute merge base of current commit and `main`
     - git fetch origin
     - SMP_MERGE_BASE=$(git merge-base ${CI_COMMIT_SHA} origin/main)
-    - echo -n "${SMP_MERGE_BASE}" > "${CI_COMMIT_SHA}-baseline_sha"
-    - echo "Merge base is $(cat ${CI_COMMIT_SHA}-baseline_sha)"
+    - echo "Merge base is ${SMP_MERGE_BASE}"
     # Setup AWS credentials for single-machine-performance AWS account
     - AWS_NAMED_PROFILE="single-machine-performance"
     - SMP_ACCOUNT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-account-id --with-decryption --query "Parameter.Value" --out text)
@@ -56,6 +55,13 @@ single-machine-performance-regression_detector:
     # Copy the merge base SHA to SMP for debugging purposes later
     - aws s3 cp --profile single-machine-performance --only-show-errors "${CI_COMMIT_SHA}-baseline_sha" "s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/"
     - BASELINE_SHA="${SMP_MERGE_BASE}"  # NOTE(geoffrey.oxberry@datadoghq.com): cat the echoed file once computing merge commit is separate job
+    - echo "Computing baseline..."
+    - echo "Checking if image exists for commit ${BASELINE_SHA}..."
+    # TODO(geoffrey.oxberry@datadoghq.com): Make the statement below a multiline statement after debugging
+    - while [[ ! $(aws --profile single-machine-performance ecr describe-images --repository-name "${SMP_AGENT_TEAM_ID}-agent" --image-ids imageTag="${BASELINE_SHA}-7-amd64") ]]; do echo "No image exists for ${BASELINE_SHA} - checking predecessor of ${BASELINE_SHA} next"; BASELINE_SHA=$(git rev-parse ${BASELINE_SHA}^); echo "Checking if image exists for commit ${BASELINE_SHA}..."; done
+    - echo "Image exists for commit ${BASELINE_SHA}"
+    - echo "Baseline SHA is ${BASELINE_SHA}"
+    - echo -n "${BASELINE_SHA}" > "${CI_COMMIT_SHA}-baseline_sha"
     - BASELINE_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${BASELINE_SHA}-7-amd64
     - echo "${BASELINE_SHA} | ${BASELINE_IMAGE}"
     - COMPARISON_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${CI_COMMIT_SHA}-7-amd64

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -55,7 +55,6 @@ single-machine-performance-regression_detector:
     - BASELINE_SHA="${SMP_MERGE_BASE}"  # NOTE(geoffrey.oxberry@datadoghq.com): cat the echoed file once computing merge commit is separate job
     - echo "Computing baseline..."
     - echo "Checking if image exists for commit ${BASELINE_SHA}..."
-    # TODO(geoffrey.oxberry@datadoghq.com): Make the statement below a multiline statement after debugging
     - while [[ ! $(aws ecr describe-images --profile single-machine-performance --registry-id "${SMP_ACCOUNT_ID}" --repository-name "${SMP_AGENT_TEAM_ID}-agent" --image-ids imageTag="${BASELINE_SHA}-7-amd64") ]]; do echo "No image exists for ${BASELINE_SHA} - checking predecessor of ${BASELINE_SHA} next"; BASELINE_SHA=$(git rev-parse ${BASELINE_SHA}^); echo "Checking if image exists for commit ${BASELINE_SHA}..."; done
     - echo "Image exists for commit ${BASELINE_SHA}"
     - echo "Baseline SHA is ${BASELINE_SHA}"

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -11,6 +11,7 @@ single-machine-performance-regression_detector:
     expire_in: 1 weeks
     paths:
       - submission_metadata
+      - ${CI_COMMIT_SHA}-baseline_sha
     when: always
   variables:
     SMP_VERSION: 0.7.3
@@ -32,10 +33,19 @@ single-machine-performance-regression_detector:
   # flagged.
   allow_failure: true
   script:
-    # Setup AWS credentials for single-machine-performance AWS account
+    # Compute merge base of current commit and `main`
     - git fetch origin
-    - echo -n $(git merge-base ${CI_COMMIT_SHA} origin/main) > "${CI_COMMIT_SHA}-baseline_sha"
+    - SMP_MERGE_BASE=$(git merge-base ${CI_COMMIT_SHA} origin/main)
+    - echo -n "${SMP_MERGE_BASE}" > "${CI_COMMIT_SHA}-baseline_sha"
     - echo "Merge base is $(cat ${CI_COMMIT_SHA}-baseline_sha)"
+    - |
+      if [[ "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME}" != "main" ]]
+      then
+        echo "The regression detector does not pull requests to a base branch that is not `main`"
+        echo "(In GitLab terminology, 'base branch' is the 'target branch of a merge request.')"
+        exit 1
+      fi
+    # Setup AWS credentials for single-machine-performance AWS account
     - AWS_NAMED_PROFILE="single-machine-performance"
     - SMP_ACCOUNT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-account-id --with-decryption --query "Parameter.Value" --out text)
     - SMP_ECR_URL=${SMP_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com
@@ -46,15 +56,18 @@ single-machine-performance-regression_detector:
     # Download smp binary and prepare it for use
     - aws --profile single-machine-performance s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-musl/smp smp
     - chmod +x smp
-    # Submit job, using the SHA of the last successful main commit as baseline.
-    # This will have been built in a separate pipeline run. The comparison will
-    # have been built previously in this pipeline run.
-    - aws --profile ${AWS_NAMED_PROFILE} s3 cp --only-show-errors s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/latest_main_sha .latest_main_sha
-    - BASELINE_SHA=$(cat .latest_main_sha)
+    # # # Submit job, using the SHA of the last successful main commit as baseline.
+    # # # This will have been built in a separate pipeline run. The comparison will
+    # # # have been built previously in this pipeline run.
+    # - aws --profile ${AWS_NAMED_PROFILE} s3 cp --only-show-errors s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/latest_main_sha .latest_main_sha
+    # - BASELINE_SHA=$(cat .latest_main_sha)
+    # Copy the merge base SHA to SMP for debugging purposes later
+    - aws s3 cp --profile single-machine-performance --only-show-errors "${CI_COMMIT_SHA}-baseline_sha" "s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/"
     # NOTE(geoffrey.oxberry@datadoghq.com): To use the merge-base baseline SHA, uncomment the line
     # starting with `BASELINE_SHA=` below, and comment out the `BASELINE_SHA=` line above, along with
     # the accompanying aws s3 cp command immediately above that line.
-    #- BASELINE_SHA=$(cat "${CI_COMMIT_SHA}-baseline_sha")
+    # - BASELINE_SHA=$(cat "${CI_COMMIT_SHA}-baseline_sha")
+    - BASELINE_SHA="${SMP_MERGE_BASE}"  # NOTE(geoffrey.oxberry@datadoghq.com): cat the echoed file once computing merge commit is separate job
     - BASELINE_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${BASELINE_SHA}-7-amd64
     - echo "${BASELINE_SHA} | ${BASELINE_IMAGE}"
     - COMPARISON_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${CI_COMMIT_SHA}-7-amd64

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -38,7 +38,8 @@ single-machine-performance-regression_detector:
     - SMP_MERGE_BASE=$(git merge-base ${CI_COMMIT_SHA} origin/main)
     - echo -n "${SMP_MERGE_BASE}" > "${CI_COMMIT_SHA}-baseline_sha"
     - echo "Merge base is $(cat ${CI_COMMIT_SHA}-baseline_sha)"
-    - if [[ "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" != "main" ]]; then echo "The regression detector does not pull requests to a base branch that is not 'main'"; echo "(In GitLab terminology, 'base branch' is the 'target branch of a merge request.')"; exit 1; fi
+    - echo "CI_MERGE_REQUEST_TARGET_BRANCH_NAME=${CI_MERGE_REQUEST_TARGET_NAME}"
+    # - if [[ "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" != "main" ]]; then echo "The regression detector does not pull requests to a base branch that is not 'main'"; echo "(In GitLab terminology, 'base branch' is the 'target branch of a merge request.')"; exit 1; fi
     # Setup AWS credentials for single-machine-performance AWS account
     - AWS_NAMED_PROFILE="single-machine-performance"
     - SMP_ACCOUNT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-account-id --with-decryption --query "Parameter.Value" --out text)

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -5,8 +5,8 @@ single-machine-performance-regression_detector:
   needs:
     - job: single_machine_performance-amd64-a7
       artifacts: false
-    - job: single_machine_performance-compute-baseline_sha
-      artifacts: true
+    # - job: single_machine_performance-compute-baseline_sha
+    #   artifacts: true
   artifacts:
     expire_in: 1 weeks
     paths:
@@ -33,6 +33,9 @@ single-machine-performance-regression_detector:
   allow_failure: true
   script:
     # Setup AWS credentials for single-machine-performance AWS account
+    - git fetch origin
+    - echo -n $(git merge-base ${CI_COMMIT_SHA} origin/main) > "${CI_COMMIT_SHA}-baseline_sha"
+    - echo "Merge base is $(cat ${CI_COMMIT_SHA}-baseline_sha)"
     - AWS_NAMED_PROFILE="single-machine-performance"
     - SMP_ACCOUNT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-account-id --with-decryption --query "Parameter.Value" --out text)
     - SMP_ECR_URL=${SMP_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -56,7 +56,7 @@ single-machine-performance-regression_detector:
     - echo "Computing baseline..."
     - echo "Checking if image exists for commit ${BASELINE_SHA}..."
     # TODO(geoffrey.oxberry@datadoghq.com): Make the statement below a multiline statement after debugging
-    - while [[ ! $(aws --profile single-machine-performance ecr describe-images --repository-name "${SMP_AGENT_TEAM_ID}-agent" --image-ids imageTag="${BASELINE_SHA}-7-amd64" 2> /dev/null) ]]; do echo "No image exists for ${BASELINE_SHA} - checking predecessor of ${BASELINE_SHA} next"; BASELINE_SHA=$(git rev-parse ${BASELINE_SHA}^); echo "Checking if image exists for commit ${BASELINE_SHA}..."; done
+    - while [[ ! $(aws ecr describe-images --profile single-machine-performance --registry-id "${SMP_ACCOUNT_ID}" --repository-name "${SMP_AGENT_TEAM_ID}-agent" --image-ids imageTag="${BASELINE_SHA}-7-amd64") ]]; do echo "No image exists for ${BASELINE_SHA} - checking predecessor of ${BASELINE_SHA} next"; BASELINE_SHA=$(git rev-parse ${BASELINE_SHA}^); echo "Checking if image exists for commit ${BASELINE_SHA}..."; done
     - echo "Image exists for commit ${BASELINE_SHA}"
     - echo "Baseline SHA is ${BASELINE_SHA}"
     - echo -n "${BASELINE_SHA}" > "${CI_COMMIT_SHA}-baseline_sha"

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -38,7 +38,7 @@ single-machine-performance-regression_detector:
     - SMP_MERGE_BASE=$(git merge-base ${CI_COMMIT_SHA} origin/main)
     - echo -n "${SMP_MERGE_BASE}" > "${CI_COMMIT_SHA}-baseline_sha"
     - echo "Merge base is $(cat ${CI_COMMIT_SHA}-baseline_sha)"
-    - if [[ "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" != "main" ]]; then echo "The regression detector does not pull requests to a base branch that is not `main`"; echo "(In GitLab terminology, 'base branch' is the 'target branch of a merge request.')"; exit 1; fi
+    - if [[ "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" != "main" ]]; then echo "The regression detector does not pull requests to a base branch that is not 'main'"; echo "(In GitLab terminology, 'base branch' is the 'target branch of a merge request.')"; exit 1; fi
     # Setup AWS credentials for single-machine-performance AWS account
     - AWS_NAMED_PROFILE="single-machine-performance"
     - SMP_ACCOUNT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-account-id --with-decryption --query "Parameter.Value" --out text)

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -5,6 +5,8 @@ single-machine-performance-regression_detector:
   needs:
     - job: single_machine_performance-amd64-a7
       artifacts: false
+    - job: single_machine_performance-compute-baseline_sha
+      artifacts: true
   artifacts:
     expire_in: 1 weeks
     paths:
@@ -46,6 +48,10 @@ single-machine-performance-regression_detector:
     # have been built previously in this pipeline run.
     - aws --profile ${AWS_NAMED_PROFILE} s3 cp --only-show-errors s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/latest_main_sha .latest_main_sha
     - BASELINE_SHA=$(cat .latest_main_sha)
+    # NOTE(geoffrey.oxberry@datadoghq.com): To use the merge-base baseline SHA, uncomment the line
+    # starting with `BASELINE_SHA=` below, and comment out the `BASELINE_SHA=` line above, along with
+    # the accompanying aws s3 cp command immediately above that line.
+    #- BASELINE_SHA=$(cat "${CI_COMMIT_SHA}-baseline_sha")
     - BASELINE_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${BASELINE_SHA}-7-amd64
     - echo "${BASELINE_SHA} | ${BASELINE_IMAGE}"
     - COMPARISON_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${CI_COMMIT_SHA}-7-amd64

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -38,13 +38,7 @@ single-machine-performance-regression_detector:
     - SMP_MERGE_BASE=$(git merge-base ${CI_COMMIT_SHA} origin/main)
     - echo -n "${SMP_MERGE_BASE}" > "${CI_COMMIT_SHA}-baseline_sha"
     - echo "Merge base is $(cat ${CI_COMMIT_SHA}-baseline_sha)"
-    - |
-      if [[ "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME}" != "main" ]]
-      then
-        echo "The regression detector does not pull requests to a base branch that is not `main`"
-        echo "(In GitLab terminology, 'base branch' is the 'target branch of a merge request.')"
-        exit 1
-      fi
+    - if [[ "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" != "main" ]]; then echo "The regression detector does not pull requests to a base branch that is not `main`"; echo "(In GitLab terminology, 'base branch' is the 'target branch of a merge request.')"; exit 1; fi
     # Setup AWS credentials for single-machine-performance AWS account
     - AWS_NAMED_PROFILE="single-machine-performance"
     - SMP_ACCOUNT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-account-id --with-decryption --query "Parameter.Value" --out text)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR changes a GitLab CI configuration that runs the Single Machine Performance (SMP) regression detector so that it runs on the head of the PR (as the comparison variant) and the most recent commit of `main` (as a baseline variant) that satisfies both the following two criteria:

* is accessible from the commit history of PR's HEAD
* has a container image in SMP's ECR (which mirrors parts of Agent CI's ECR)

To compute the SHA of the baseline variant, the regression detector job configuration starts at the merge base of the PR with `main` and queries SMP's ECR to see if an image exists for that commit. If such an image does not exist, the ECR query repeats on the first parent of the commit queried in the previous iteration. The iteration terminates when one of the following three criteria are satisfied (in decreasing order of precedence):

* an image exists for the commit
* the commit has no ancestors in `main`
* the CI job times out

If this loop terminates due to the second or third criteria, the regression detector will not be run on the PR. This situation can occur due to an age-based image expiration policy in ECR if the merge base commit is sufficiently old. In that scenario, rebasing the PR onto a sufficiently recent commit in `main` is recommended.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We'd like to run the regression detector to compare a PR with its merge base because that comparison is easier to reason about than the current regression detector configuration. The current regression detector configuration compares a PR with the latest version of `main`, which may contain commits that are not in the PR.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Ideally, to account for interactions resulting from merging the PR into `main`, we would compare that hypothetical merge commit to its parent from `main`. The approach proposed in this PR neglects those interactions. Both the execution time of that "ideal" approach and the developer effort required to implement it are prohibitive, which motivates the approach taken in this PR.

We believe the risks in neglecting these merge interactions can be mitigated by running a variation of the same analysis nightly that compares successive commits in `main` after the fact, if necessary. To limit review burden and development effort, we consider implementing that mitigation strategy out of scope of this PR; we mention it here for completeness.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

Using the merge base commit as the baseline variant costs additional developer effort and slightly increases maintenance burden and complexity. We believe this cost is worthwhile because this change will make regression detector results easier to explain.

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Once complete, the changes in this PR can be tested by running the Agent CI pipeline and examining the regression detector output.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
