### PR TITLE
Make `nettop` available

### DIFF
--- a/cmd/process-agent/README.md
+++ b/cmd/process-agent/README.md
@@ -32,10 +32,3 @@ You can now run the Agent on the command-line:
 ```
 ./bin/process-agent/process-agent -config $PATH_TO_PROCESS_CONFIG_FILE
 ```
-
-## Development
-The easiest way to build and test is inside a Vagrant VM. You can provision the VM by running `./pkg/process/tools/dev_setup.sh` and SSHing into the VM with `vagrant ssh` (vagrant must be installed.)
-
-The VM will mount your local $GOPATH, so you can edit source code with your editor of choice.
-
-For development on the system-probe, `rake ebpf:nettop` will run a small testing program which periodically prints statistics about TCP/UDP traffic inside the VM.

--- a/pkg/network/ebpf/README.md
+++ b/pkg/network/ebpf/README.md
@@ -15,8 +15,3 @@ tracer-bpf also provides a Go library that provides a simple API for loading the
 tracer-bpf does not have any run-time dependencies on kernel headers and is not tied to a specific kernel version or kernel configuration. This is quite unusual for eBPF programs using kprobes: for example, eBPF programs using kprobes with [bcc](https://github.com/iovisor/bcc) are compiled on the fly and depend on kernel headers. And [perf tools](https://perf.wiki.kernel.org) compiled for one kernel version cannot be used on another kernel version.
 
 To adapt to the currently running kernel at run-time, tracer-bpf creates a series of TCP connections with known parameters (such as known IP addresses and ports) and discovers where those parameters are stored in the [kernel struct sock](https://github.com/torvalds/linux/blob/v4.4/include/net/sock.h#L248). The offsets of the struct sock fields vary depending on the kernel version and kernel configuration. Since an eBPF programs cannot loop, tracer-bpf does not directly iterate over the possible offsets. It is instead controlled from userspace by the Go library using a state machine.
-
-## Development
-
-`make nettop` will run a small testing program which
-periodically prints statistics about TCP/UDP traffic.

--- a/pkg/network/nettop/main.go
+++ b/pkg/network/nettop/main.go
@@ -6,24 +6,34 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/network"
-	"github.com/DataDog/datadog-agent/pkg/network/config"
+	networkConfig "github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer"
 )
 
 func main() {
+	cfgpath := flag.String("config", "/etc/datadog-agent/datadog.yaml", "The Datadog main configuration file path")
+	flag.Parse()
+
 	if supported, err := tracer.IsTracerSupportedByOS(nil); !supported {
 		fmt.Fprintf(os.Stderr, "system-probe is not supported: %s\n", err)
 		os.Exit(1)
 	}
 
-	cfg := config.New()
+	config.Datadog.SetConfigFile(*cfgpath)
+	if _, err := config.Load(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+	cfg := networkConfig.New()
 	fmt.Printf("-- Config: %+v --\n", cfg)
 	cfg.BPFDebug = true
 

--- a/pkg/network/nettop/readme.md
+++ b/pkg/network/nettop/readme.md
@@ -7,8 +7,6 @@ It loads the eBPF probes to watch for connections on the current host
 ## Build
 
 ```bash
-# At the root of the repository
-# First, build the system-probe to compile the eBPF programs.
-PATH=/usr/lib/llvm-12/bin:$PATH inv -e system-probe.build
+inv -e system-probe.object-files
 go build -tags linux_bpf,linux ./pkg/network/nettop
 ```

--- a/pkg/network/nettop/readme.md
+++ b/pkg/network/nettop/readme.md
@@ -3,3 +3,12 @@
 Nettop is a simple tool to ease testing the eBPF package.
 
 It loads the eBPF probes to watch for connections on the current host
+
+## Build
+
+```bash
+# At the root of the repository
+# First, build the system-probe to compile the eBPF programs.
+PATH=/usr/lib/llvm-12/bin:$PATH inv -e system-probe.build
+go build -tags linux_bpf,linux ./pkg/network/nettop
+```


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Make `pkg/network/nettop/main.go` available.
- Remove old documents.

### Motivation

Fix this panic.

``` bash
$ sudo ./nettop 
-- Config: &{Config:{BPFDebug:false BPFDir:/opt/datadog-agent/embedded/share/system-probe/ebpf JavaDir:/opt/datadog-agent/embedded/share/system-probe/java ExcludedBPFLinuxVersions:[] ProcRoot:/proc EnableTracepoints:false EnableCORE:true BTFPath: EnableRuntimeCompiler:false EnableKernelHeaderDownload:false KernelHeadersDirs:[] KernelHeadersDownloadDir:/var/tmp/datadog-agent/system-probe/kernel-headers RuntimeCompilerOutputDir:/var/tmp/datadog-agent/system-probe/build AptConfigDir:/etc/apt YumReposDir:/etc/yum.repos.d ZypperReposDir:/etc/zypp/repos.d AllowPrecompiledFallback:true AllowRuntimeCompiledFallback:true AttachKprobesWithKprobeEventsABI:false} NPMEnabled:false ServiceMonitoringEnabled:false DataStreamsEnabled:false CollectTCPv4Conns:true CollectTCPv6Conns:true CollectUDPv4Conns:true CollectUDPv6Conns:true CollectLocalDNS:false DNSInspection:true CollectDNSStats:true CollectDNSDomains:true DNSTimeout:15s MaxDNSStats:20000 EnableHTTPMonitoring:false EnableHTTP2Monitoring:false EnableKafkaMonitoring:false EnableHTTPSMonitoring:false EnableGoTLSSupport:false EnableJavaTLSSupport:false MaxTrackedHTTPConnections:1024 HTTPNotificationThreshold:512 HTTPMaxRequestFragment:160 JavaAgentDebug:false JavaAgentArgs:dd.appsec.enabled=false,dd.trace.enabled=false,dd.usm.enabled=true JavaAgentAllowRegex: JavaAgentBlockRegex: UDPConnTimeout:30s UDPStreamTimeout:2m0s TCPConnTimeout:2m0s TCPClosedTimeout:1s MaxTrackedConnections:65536 MaxClosedConnectionsBuffered:65536 ClosedConnectionFlushThreshold:0 MaxDNSStatsBuffered:75000 MaxHTTPStatsBuffered:100000 MaxKafkaStatsBuffered:100000 MaxConnectionsStateBuffered:75000 ClientStateExpiry:2m0s EnableConntrack:true IgnoreConntrackInitFailure:false ConntrackMaxStateSize:131072 ConntrackRateLimit:500 ConntrackRateLimitInterval:3s ConntrackInitTimeout:10s EnableConntrackAllNamespaces:true EnableEbpfConntracker:true AllowNetlinkConntrackerFallback:true ClosedChannelSize:500 ExcludedSourceConnections:map[] ExcludedDestinationConnections:map[] OffsetGuessThreshold:400 EnableMonotonicCount:false EnableGatewayLookup:true RecordedQueryTypes:[] HTTPReplaceRules:[] EnableProcessEventMonitoring:false MaxProcessesTracked:1024 EnableRootNetNs:true HTTPMapCleanerInterval:5m0s HTTPIdleConnectionTTL:30s ProtocolClassificationEnabled:true EnableHTTPStatsByStatusCode:false} --
panic: Trying to access features before detection has run

goroutine 1 [running]:
github.com/DataDog/datadog-agent/pkg/config.IsFeaturePresent({0x1d55d8c?, 0x0?})
        /home/ubuntu/workspace/datadog-agent/pkg/config/environment_detection.go:69 +0xf2
github.com/DataDog/datadog-agent/pkg/util/fargate.IsFargateInstance()
        /home/ubuntu/workspace/datadog-agent/pkg/util/fargate/detection.go:16 +0x25
github.com/DataDog/datadog-agent/pkg/network/tracer/connection/fentry.LoadTracer(_, _, {{0x0, 0x0, 0x0}, 0x0, {0x0, 0x0, 0x0}, {0xc0003a8600, ...}, ...}, ...)
        /home/ubuntu/workspace/datadog-agent/pkg/network/tracer/connection/fentry/tracer.go:32 +0x35
github.com/DataDog/datadog-agent/pkg/network/tracer/connection.NewTracer(0xc0000bcc80, 0xc00005ee80)
        /home/ubuntu/workspace/datadog-agent/pkg/network/tracer/connection/tracer.go:164 +0x996
github.com/DataDog/datadog-agent/pkg/network/tracer.newTracer(0xc0000bcc80)
        /home/ubuntu/workspace/datadog-agent/pkg/network/tracer/tracer.go:160 +0x446
github.com/DataDog/datadog-agent/pkg/network/tracer.NewTracer(0x240bb00?)
        /home/ubuntu/workspace/datadog-agent/pkg/network/tracer/tracer.go:105 +0x19
main.main()
        /home/ubuntu/workspace/datadog-agent/pkg/network/nettop/main.go:30 +0xea
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

At the root of this repository, we need to build system-probe with clang v12.0 to compile eBPF programs.
Then, build `nettop`!

```bash
$ inv -e system-probe.object-files
$ go build -tags linux_bpf,linux ./pkg/network/nettop
```

```bash
$ sudo ./nettop 
-- Config: &{Config:{BPFDebug:false BPFDir:/opt/datadog-agent/embedded/share/system-probe/ebpf JavaDir:/opt/datadog-agent/embedded/share/system-probe/java ExcludedBPFLinuxVersions:[] ProcRoot:/proc EnableTracepoints:false EnableCORE:true BTFPath: EnableRuntimeCompiler:false EnableKernelHeaderDownload:false KernelHeadersDirs:[] KernelHeadersDownloadDir:/var/tmp/datadog-agent/system-probe/kernel-headers RuntimeCompilerOutputDir:/var/tmp/datadog-agent/system-probe/build AptConfigDir:/etc/apt YumReposDir:/etc/yum.repos.d ZypperReposDir:/etc/zypp/repos.d AllowPrecompiledFallback:true AllowRuntimeCompiledFallback:true AttachKprobesWithKprobeEventsABI:false} NPMEnabled:false ServiceMonitoringEnabled:false DataStreamsEnabled:false CollectTCPv4Conns:true CollectTCPv6Conns:true CollectUDPv4Conns:true CollectUDPv6Conns:true CollectLocalDNS:false DNSInspection:true CollectDNSStats:true CollectDNSDomains:true DNSTimeout:15s MaxDNSStats:20000 EnableHTTPMonitoring:false EnableHTTP2Monitoring:false EnableKafkaMonitoring:false EnableHTTPSMonitoring:false EnableGoTLSSupport:false EnableJavaTLSSupport:false MaxTrackedHTTPConnections:1024 HTTPNotificationThreshold:512 HTTPMaxRequestFragment:160 JavaAgentDebug:false JavaAgentArgs:dd.appsec.enabled=false,dd.trace.enabled=false,dd.usm.enabled=true JavaAgentAllowRegex: JavaAgentBlockRegex: UDPConnTimeout:30s UDPStreamTimeout:2m0s TCPConnTimeout:2m0s TCPClosedTimeout:1s MaxTrackedConnections:65536 MaxClosedConnectionsBuffered:65536 ClosedConnectionFlushThreshold:0 MaxDNSStatsBuffered:75000 MaxHTTPStatsBuffered:100000 MaxKafkaStatsBuffered:100000 MaxConnectionsStateBuffered:75000 ClientStateExpiry:2m0s EnableConntrack:true IgnoreConntrackInitFailure:false ConntrackMaxStateSize:131072 ConntrackRateLimit:500 ConntrackRateLimitInterval:3s ConntrackInitTimeout:10s EnableConntrackAllNamespaces:true EnableEbpfConntracker:true AllowNetlinkConntrackerFallback:true ClosedChannelSize:500 ExcludedSourceConnections:map[] ExcludedDestinationConnections:map[] OffsetGuessThreshold:400 EnableMonotonicCount:false EnableGatewayLookup:true RecordedQueryTypes:[] HTTPReplaceRules:[] EnableProcessEventMonitoring:false MaxProcessesTracked:1024 EnableRootNetNs:true HTTPMapCleanerInterval:5m0s HTTPIdleConnectionTTL:30s ProtocolClassificationEnabled:true EnableHTTPStatsByStatusCode:false} --
Initialization complete. Starting nettop
-- 2023-06-04 23:21:21.888598102 +0000 UTC m=+3.297916788 --
-- 2023-06-04 23:21:26.889601483 +0000 UTC m=+8.298920177 --
[TCPv4] [PID: 732212] [127.0.0.1:58660 ⇄ 127.0.0.1:5000] (outgoing) 282 B sent (+282 B), 5.4 kB received (+5.4 kB), 0 retransmits (+0), RTT 55µs (± 31µs), 1 established (+1), 1 closed (+1), last update epoch: 1296829887371323, cookie: 4251991361, protocol: {Api:Unknown Application:HTTP Encryption:Unknown}, netns: 4026531840
[TCPv4] [PID: 732212] [172.31.5.0:36362 ⇄ self-signed.badssl.com:443] (outgoing) 524 B sent (+524 B), 978 B received (+978 B), 0 retransmits (+0), RTT 29.423ms (± 11.085ms), 1 established (+1), 1 closed (+1), last update epoch: 1296831057405943, cookie: 1180716145, protocol: {Api:Unknown Application:Unknown Encryption:TLS}, netns: 4026531840
[TCPv4] [PID: 732212] [172.31.5.0:60330 ⇄ self-signed.badssl.com:443] (outgoing) 799 B sent (+799 B), 2.1 kB received (+2.1 kB), 0 retransmits (+0), RTT 26.621ms (± 5.746ms), 1 established (+1), 1 closed (+1), last update epoch: 1296831058011500, cookie: 2943873349, protocol: {Api:Unknown Application:Unknown Encryption:TLS}, netns: 4026531840
[UDPv4] [PID: 1478063] [172.31.5.0:35613 ⇄ 172.31.0.2:53] (outgoing) 51 B sent (+51 B), 146 B received (+146 B), last update epoch: 1296830864496751, cookie: 3025752324, protocol: {Api:Unknown Application:Unknown Encryption:Unknown}, netns: 4026531840
[UDPv4] [PID: 1478063] [172.31.5.0:57709 ⇄ 172.31.0.2:53] (outgoing) 51 B sent (+51 B), 67 B received (+67 B), last update epoch: 1296830990774852, cookie: 3168607792, protocol: {Api:Unknown Application:Unknown Encryption:Unknown}, netns: 4026531840
[TCPv4] [PID: 732212] [127.0.0.1:5000 ⇄ 127.0.0.1:58660] (incoming) 5.4 kB sent (+5.4 kB), 282 B received (+282 B), 0 retransmits (+0), RTT 38µs (± 18µs), 1 established (+1), 1 closed (+1), last update epoch: 1296829887441769, cookie: 4252050049, protocol: {Api:Unknown Application:HTTP Encryption:Unknown}, netns: 4026531840
[TCPv4] [PID: 1960442] [172.31.5.0:33492 ⇄ 169.254.169.254:80] (outgoing) 164 B sent (+164 B), 218 B received (+218 B), 0 retransmits (+0), RTT 157µs (± 84µs), 1 established (+1), 1 closed (+1), last update epoch: 1296831059554254, cookie: 1434268067, protocol: {Api:Unknown Application:HTTP Encryption:Unknown}, netns: 4026531840
[TCPv4] [PID: 1960442] [172.31.5.0:33504 ⇄ 169.254.169.254:80] (outgoing) 177 B sent (+177 B), 216 B received (+216 B), 0 retransmits (+0), RTT 103µs (± 54µs), 1 established (+1), 1 closed (+1), last update epoch: 1296831060522416, cookie: 1091519894, protocol: {Api:Unknown Application:HTTP Encryption:Unknown}, netns: 4026531840
[UDPv4] [PID: 732215] [127.0.0.1:46206 ⇄ 127.0.0.1:8125] (outgoing) 1.6 kB sent (+1.6 kB), 0 B received (+0 B), last update epoch: 1296833443578844, cookie: 1451004277, protocol: {Api:Unknown Application:Unknown Encryption:Unknown}, netns: 4026531840
[UDPv4] [PID: 732212] [127.0.0.1:8125 ⇄ 127.0.0.1:46206] (incoming) 0 B sent (+0 B), 1.6 kB received (+1.6 kB), last update epoch: 1296833443620446, cookie: 1450851387, protocol: {Api:Unknown Application:Unknown Encryption:Unknown}, netns: 4026531840
[TCPv4] [PID: 1935386] [172.31.5.0:22 ⇄ 61.120.204.220:38629] (incoming) 212 B sent (+212 B), 208 B received (+208 B), 0 retransmits (+0), RTT 161.475ms (± 653µs), 0 established (+0), 0 closed (+0), last update epoch: 1296833429687337, cookie: 3863587489, protocol: {Api:Unknown Application:Unknown Encryption:Unknown}, netns: 4026531840
[UDPv4] [PID: 732212] [127.0.0.1:8125 ⇄ 127.0.0.1:50102] (incoming) 0 B sent (+0 B), 84 B received (+84 B), last update epoch: 1296829874570338, cookie: 4092494146, protocol: {Api:Unknown Application:Unknown Encryption:Unknown}, netns: 4026531840
[UDPv4] [PID: 732212] [127.0.0.1:8125 ⇄ 127.0.0.1:35784] (incoming) 0 B sent (+0 B), 2.8 kB received (+2.8 kB), last update epoch: 1296833349349576, cookie: 3304320426, protocol: {Api:Unknown Application:Unknown Encryption:Unknown}, netns: 4026531840
[UDPv4] [PID: 732213] [127.0.0.1:50102 ⇄ 127.0.0.1:8125] (outgoing) 84 B sent (+84 B), 0 B received (+0 B), last update epoch: 1296829874533578, cookie: 4237018240, protocol: {Api:Unknown Application:Unknown Encryption:Unknown}, netns: 4026531840
[TCPv4] [PID: 1935386] [127.0.0.1:33006 ⇄ 127.0.0.1:37455] (outgoing) 27 B sent (+27 B), 6 B received (+6 B), 0 retransmits (+0), RTT 12.925ms (± 18.479ms), 0 established (+0), 0 closed (+0), last update epoch: 1296833429617969, cookie: 2152344447, protocol: {Api:Unknown Application:Unknown Encryption:Unknown}, netns: 4026531840
[TCPv4] [PID: 1935447] [127.0.0.1:37455 ⇄ 127.0.0.1:32996] (incoming) 94 B sent (+94 B), 25 B received (+25 B), 0 retransmits (+0), RTT 42µs (± 14µs), 0 established (+0), 0 closed (+0), last update epoch: 1296832408716665, cookie: 3866933928, protocol: {Api:Unknown Application:Unknown Encryption:Unknown}, netns: 4026531840
[TCPv4] [PID: 1935386] [127.0.0.1:32996 ⇄ 127.0.0.1:37455] (outgoing) 25 B sent (+25 B), 94 B received (+94 B), 0 retransmits (+0), RTT 9.937ms (± 15.197ms), 0 established (+0), 0 closed (+0), last update epoch: 1296832408692239, cookie: 3866911762, protocol: {Api:Unknown Application:Unknown Encryption:Unknown}, netns: 4026531840
[UDPv4] [PID: 732211] [127.0.0.1:35784 ⇄ 127.0.0.1:8125] (outgoing) 2.8 kB sent (+2.8 kB), 0 B received (+0 B), last update epoch: 1296833349333952, cookie: 3304381210, protocol: {Api:Unknown Application:Unknown Encryption:Unknown}, netns: 4026531840
[TCPv4] [PID: 1935569] [127.0.0.1:37455 ⇄ 127.0.0.1:33006] (incoming) 6 B sent (+6 B), 27 B received (+27 B), 0 retransmits (+0), RTT 6.768ms (± 12.041ms), 0 established (+0), 0 closed (+0), last update epoch: 1296833429593934, cookie: 2152440916, protocol: {Api:Unknown Application:Unknown Encryption:Unknown}, netns: 4026531840
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
