### PR TITLE
[SBOM] Remove `DeleteBlobs` from the sbom cache

### DIFF
--- a/pkg/util/trivy/cache.go
+++ b/pkg/util/trivy/cache.go
@@ -211,7 +211,8 @@ func (c *TrivyCache) PutBlob(blobID string, blobInfo types.BlobInfo) error {
 	return trivyCachePut(c, blobID, blobInfo)
 }
 
-// Implements cache.Cache#DeleteBlobs and does nothing because we want to manage blobs by ourselves
+// Implements cache.Cache#DeleteBlobs does nothing because cache cleaning is
+// manager by CacheCleaner
 func (c *TrivyCache) DeleteBlobs(blobIDs []string) error {
 	return nil
 }

--- a/pkg/util/trivy/cache.go
+++ b/pkg/util/trivy/cache.go
@@ -211,9 +211,9 @@ func (c *TrivyCache) PutBlob(blobID string, blobInfo types.BlobInfo) error {
 	return trivyCachePut(c, blobID, blobInfo)
 }
 
-// Implements cache.Cache#DeleteBlobs
+// Implements cache.Cache#DeleteBlobs and does nothing because we want to manage blobs by ourselves
 func (c *TrivyCache) DeleteBlobs(blobIDs []string) error {
-	return c.Cache.Remove(blobIDs)
+	return nil
 }
 
 // Implements cache.Cache#Clear

--- a/pkg/util/trivy/cache.go
+++ b/pkg/util/trivy/cache.go
@@ -211,8 +211,8 @@ func (c *TrivyCache) PutBlob(blobID string, blobInfo types.BlobInfo) error {
 	return trivyCachePut(c, blobID, blobInfo)
 }
 
-// Implements cache.Cache#DeleteBlobs does nothing because cache cleaning is
-// manager by CacheCleaner
+// Implements cache.Cache#DeleteBlobs does nothing because the cache cleaning logic is
+// managed by CacheCleaner
 func (c *TrivyCache) DeleteBlobs(blobIDs []string) error {
 	return nil
 }

--- a/pkg/util/trivy/cache_test.go
+++ b/pkg/util/trivy/cache_test.go
@@ -10,7 +10,6 @@ package trivy
 import (
 	"context"
 	"encoding/json"
-	"strconv"
 	"strings"
 	"testing"
 	"time"

--- a/pkg/util/trivy/cache_test.go
+++ b/pkg/util/trivy/cache_test.go
@@ -67,40 +67,6 @@ func TestCustomBoltCache_Blobs(t *testing.T) {
 	require.Equal(t, blobInfo, storedBlobInfo)
 }
 
-func TestCustomBoltCache_DeleteBlobs(t *testing.T) {
-	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultCacheSize, defaultDiskSize)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, cache.Close())
-	}()
-
-	// Store 3 blobs with IDs "0", "1", "2"
-	for blobID, osName := range []string{"3.15", "3.16", "3.17"} {
-		blobInfo := types.BlobInfo{
-			SchemaVersion: 1,
-			OS: types.OS{
-				Family: "alpine",
-				Name:   osName,
-			},
-		}
-
-		err := cache.PutBlob(strconv.Itoa(blobID), blobInfo)
-		require.NoError(t, err)
-	}
-
-	// Delete 2 blobs
-	err = cache.DeleteBlobs([]string{"0", "1"})
-	require.NoError(t, err)
-
-	// Check that the deleted blobs are no longer there, but the other one is
-	_, err = cache.GetBlob("0")
-	require.Error(t, err)
-	_, err = cache.GetBlob("1")
-	require.Error(t, err)
-	_, err = cache.GetBlob("2")
-	require.NoError(t, err)
-}
-
 func TestCustomBoltCache_MissingBlobs(t *testing.T) {
 	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultCacheSize, defaultDiskSize)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR removes the function `DeleteBlobs` from the SBOM cache. This function is called by `ScanArtifact`: https://github.com/aquasecurity/trivy/blob/22a157380732d69b2f0bd1dea0e2bfcd5d856bf7/pkg/scanner/scan.go#LL147C1-L147C1

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
There is typically one `BlobInfo` per layer. If `BlobInfo`s are removed after scanning an image, then the next scan will not use the cached item making the cache less useful.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
More things to cache, needs to be evaluated on staging.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Two things to test:
- Make sure scanning SBOM collection works

Deploy the agent with sbom collection with custom cache enabled and internal telemetry. You need to update the helm chart as follows:
```
datadog:
    env:
      - name: DD_TELEMETRY_ENABLED
        value: "true"
      - name: DD_CONTAINER_IMAGE_COLLECTION_METADATA_ENABLED
        value: "true"
      - name: DD_SBOM_ENABLED
        value: "true"
      - name: DD_CONTAINER_IMAGE_COLLECTION_SBOM_ENABLED
        value: "true"
      - name: DD_RUNTIME_SECURITY_CONFIG_SBOM_ENABLED
        value: "true"
      - name: DD_SBOM_USE_CUSTOM_CACHE
        value: "false"
```
Call  `kubectl -n datadog-agent exec PODNAME -- agent workload-list -v | grep -i sbom`. 

- Make sure `datadog.agent.sbom_cached_objects_size` does not significantly increase (compared to datadog-agent 7.45.x).
- Make sure this function is called (you can add a log line in the function, build a new image and make sure you see this log line or use the debugger/profiling).
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
