### PR TITLE
convert remaining users of old `golang-lru` to new generics based version

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -981,7 +981,6 @@ core,github.com/hashicorp/go-multierror,MPL-2.0,"Copyright © 2014-2018 HashiCor
 core,github.com/hashicorp/go-retryablehttp,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/go-rootcerts,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/go-version,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
-core,github.com/hashicorp/golang-lru,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/golang-lru/simplelru,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/golang-lru/v2,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/golang-lru/v2/simplelru,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"

--- a/comp/dogstatsd/mapper/mapper_cache.go
+++ b/comp/dogstatsd/mapper/mapper_cache.go
@@ -6,16 +6,16 @@
 package mapper
 
 import (
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 type mapperCache struct {
-	cache *lru.Cache
+	cache *lru.Cache[string, *MapResult]
 }
 
 // newMapperCache creates a new mapperCache
 func newMapperCache(size int) (*mapperCache, error) {
-	cache, err := lru.New(size)
+	cache, err := lru.New[string, *MapResult](size)
 	if err != nil {
 		return &mapperCache{}, err
 	}
@@ -27,7 +27,7 @@ func newMapperCache(size int) (*mapperCache, error) {
 // - a boolean indicating if a match has been found
 func (m *mapperCache) get(metricName string) (*MapResult, bool) {
 	if result, ok := m.cache.Get(metricName); ok {
-		return result.(*MapResult), true
+		return result, true
 	}
 	return nil, false
 }

--- a/go.mod
+++ b/go.mod
@@ -129,7 +129,6 @@ require (
 	github.com/h2non/filetype v1.1.3
 	github.com/hashicorp/consul/api v1.20.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hashicorp/golang-lru/v2 v2.0.2
 	github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95
 	github.com/iceber/iouring-go v0.0.0-20220609112130-b1dc8dd9fbfd
@@ -385,6 +384,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.2 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/serf v0.10.1 // indirect
 	github.com/huandu/xstrings v1.3.3 // indirect

--- a/pkg/network/netlink/conntrack_debug.go
+++ b/pkg/network/netlink/conntrack_debug.go
@@ -47,20 +47,12 @@ func (ctr *realConntracker) DumpCachedTable(ctx context.Context) (map[uint32][]D
 	ns := uint32(0)
 	table[ns] = []DebugConntrackEntry{}
 
-	for _, k := range keys {
+	for _, ck := range keys {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
 
-		ck, ok := k.(connKey)
-		if !ok {
-			continue
-		}
-		v, ok := ctr.cache.cache.Peek(ck)
-		if !ok {
-			continue
-		}
-		te, ok := v.(*translationEntry)
+		te, ok := ctr.cache.cache.Peek(ck)
 		if !ok {
 			continue
 		}

--- a/pkg/network/netlink/conntracker_test.go
+++ b/pkg/network/netlink/conntracker_test.go
@@ -264,10 +264,9 @@ func TestConntrackCacheAdd(t *testing.T) {
 		}
 
 		for _, te := range tests {
-			v, ok := cache.cache.Get(te.k)
+			tr, ok := cache.cache.Get(te.k)
 			require.True(t, ok, "translation entry not found for key %+v", te.k)
-			require.NotNil(t, v)
-			tr := v.(*translationEntry)
+			require.NotNil(t, tr)
 			require.Equal(t, te.expectedReplSrcIP, tr.IPTranslation.ReplSrcIP.String())
 			require.Equal(t, te.expectedReplSrcPort, tr.IPTranslation.ReplSrcPort)
 			require.NotNil(t, tr.orphan)
@@ -346,9 +345,8 @@ func TestConntrackCacheAdd(t *testing.T) {
 		}
 
 		for _, te := range tests {
-			v, ok := cache.cache.Get(te.k)
+			tr, ok := cache.cache.Get(te.k)
 			require.True(t, ok, "translation entry not found for key %+v", te.k)
-			tr := v.(*translationEntry)
 			require.Equal(t, te.expectedReplSrcIP, tr.IPTranslation.ReplSrcIP.String())
 			require.Equal(t, te.expectedReplSrcPort, tr.IPTranslation.ReplSrcPort)
 			require.NotNil(t, tr.orphan)
@@ -422,7 +420,7 @@ func crossCheckCacheOrphans(t *testing.T, cc *conntrackCache) {
 		o := l.Value.(*orphanEntry)
 		v, ok := cc.cache.Get(o.key)
 		require.True(t, ok)
-		require.Equal(t, l, v.(*translationEntry).orphan)
+		require.Equal(t, l, v.orphan)
 	}
 }
 

--- a/pkg/network/tracer/gateway_lookup.go
+++ b/pkg/network/tracer/gateway_lookup.go
@@ -13,7 +13,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/hashicorp/golang-lru/simplelru"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"github.com/vishvananda/netns"
 
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -50,7 +50,7 @@ type gatewayLookup struct {
 	procRoot            string
 	rootNetNs           netns.NsHandle
 	routeCache          network.RouteCache
-	subnetCache         *simplelru.LRU // interface index to subnet cache
+	subnetCache         *simplelru.LRU[int, interface{}] // interface index to subnet cache
 	subnetForHwAddrFunc func(net.HardwareAddr) (network.Subnet, error)
 }
 
@@ -99,7 +99,7 @@ func newGatewayLookup(config *config.Config) *gatewayLookup {
 		log.Warnf("using truncated route cache size of %d instead of %d", routeCacheSize, config.MaxTrackedConnections)
 	}
 
-	gl.subnetCache, _ = simplelru.NewLRU(maxSubnetCacheSize, nil)
+	gl.subnetCache, _ = simplelru.NewLRU[int, interface{}](maxSubnetCacheSize, nil)
 	gl.routeCache = network.NewRouteCache(int(routeCacheSize), router)
 	return gl
 }

--- a/pkg/util/trivy/cache.go
+++ b/pkg/util/trivy/cache.go
@@ -21,7 +21,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/cache"
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/utils"
-	"github.com/hashicorp/golang-lru/simplelru"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
 )
 
 // telemetryTick is the frequency at which the cache usage metrics are collected.
@@ -238,7 +238,7 @@ func (c *TrivyCache) GetBlob(id string) (types.BlobInfo, error) {
 
 // PersistentCache is a cache that uses a persistent database for storage.
 type PersistentCache struct {
-	lruCache                     *simplelru.LRU
+	lruCache                     *simplelru.LRU[string, struct{}]
 	db                           PersistentDB
 	mutex                        sync.RWMutex
 	currentCachedObjectTotalSize int
@@ -259,8 +259,8 @@ func NewPersistentCache(
 		maximumCachedObjectSize:      maxCachedObjectSize,
 	}
 
-	lruCache, err := simplelru.NewLRU(maxCacheSize, func(key interface{}, _ interface{}) {
-		persistentCache.lastEvicted = key.(string)
+	lruCache, err := simplelru.NewLRU(maxCacheSize, func(key string, _ struct{}) {
+		persistentCache.lastEvicted = key
 	})
 	if err != nil {
 		return nil, err
@@ -311,7 +311,7 @@ func (c *PersistentCache) Keys() []string {
 	defer c.mutex.RUnlock()
 	keys := make([]string, c.lruCache.Len())
 	for i, key := range c.lruCache.Keys() {
-		keys[i] = key.(string)
+		keys[i] = key
 	}
 	return keys
 }
@@ -494,7 +494,7 @@ func (c *PersistentCache) removeOldestKeyFromMemory() (string, bool) {
 	if ok {
 		telemetry.SBOMCacheEntries.Dec()
 	}
-	return key.(string), ok
+	return key, ok
 }
 
 // GetCurrentCachedObjectTotalSize returns the current cached object total size.


### PR DESCRIPTION
### What does this PR do?

The goal of this PR is to reduce the dependency on the old version of github.com/hashicorp/golang-lru, reducing our need to bundle multiple versions of the same library.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
