### PR TITLE
Fix duplicate prebuilt module in use during tests

### DIFF
--- a/pkg/network/ebpf/bpf_module.go
+++ b/pkg/network/ebpf/bpf_module.go
@@ -11,12 +11,14 @@ import (
 	"fmt"
 	"sync"
 
+	"golang.org/x/exp/maps"
+
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 )
 
 // prebuiltModulesInUse is a global object which is responsible for keeping a list of all the prebuilt ebpf assets in use.
 // This is used to report ebpf asset telemetry
-var prebuiltModulesInUse = []string{}
+var prebuiltModulesInUse = map[string]struct{}{}
 var telemetrymu sync.Mutex
 
 func ModuleFileName(moduleName string, debug bool) string {
@@ -35,8 +37,7 @@ func readModule(bpfDir, moduleName string, debug bool) (bytecode.AssetReader, er
 
 	telemetrymu.Lock()
 	defer telemetrymu.Unlock()
-	prebuiltModulesInUse = append(prebuiltModulesInUse, moduleName)
-
+	prebuiltModulesInUse[moduleName] = struct{}{}
 	return ebpfReader, nil
 }
 
@@ -83,7 +84,5 @@ func GetModulesInUse() []string {
 	telemetrymu.Lock()
 	defer telemetrymu.Unlock()
 
-	result := make([]string, len(prebuiltModulesInUse))
-	copy(result, prebuiltModulesInUse)
-	return result
+	return maps.Keys(prebuiltModulesInUse)
 }


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Use map to prevent duplicates of the same asset name for prebuilt module in use telemetry.

### Motivation

Because this is a global object, and the tests load prebuilt modules a bunch, you could previously end up with a long list of the same string. Example output:

```
&{{[] 0xc0013ada10} map[] map[closed_conn_dropped:0 conn_dropped:0 conns_bpf_map_size:18 conns_closed:1 kprobes_missed:0 kprobes_triggered:2] map[conntrack:{true 10 2032871} oomKill:{false 0 0} runtimeSecurity:{false 0 0} tcpQueueLength:{false 0 0} tracer:{true 10 3072361} usm:{true 10 2701840}] 2 map[tracer:1 usm:1] [offset-guess offset-guess offset-guess offset-guess offset-guess offset-guess offset-guess offset-guess offset-guess offset-guess offset-guess offset-guess offset-guess offset-guess tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns usm tracer dns usm tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns tracer offset-guess dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns offset-guess dns tracer offset-guess dns usm tracer offset-guess dns usm tracer offset-guess dns usm tracer offset-guess dns usm tracer offset-guess dns usm tracer offset-guess dns usm tracer offset-guess dns usm tracer offset-guess dns usm tracer offset-guess dns usm tracer offset-guess dns usm tracer offset-guess dns usm tracer offset-guess dns usm tracer offset-guess dns usm tracer offset-guess dns usm tracer offset-guess dns usm tracer offset-guess dns usm tracer offset-guess dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns dns] map[] map[] map[] map[]}
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
