### PR TITLE
Cloud Service implementation for Azure App Service

### DIFF
--- a/cmd/serverless-init/cloudservice/appservice.go
+++ b/cmd/serverless-init/cloudservice/appservice.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package cloudservice
+
+import (
+	"os"
+)
+
+// AppService has helper functions for getting specific Azure Container App data
+type AppService struct{}
+
+const (
+	WebsiteName = "WEBSITE_SITE_NAME"
+	RegionName  = "REGION_NAME"
+	RunZip      = "APPSVC_RUN_ZIP"
+)
+
+// GetTags returns a map of Azure-related tags
+func (a *AppService) GetTags() map[string]string {
+	appName := os.Getenv(WebsiteName)
+	region := os.Getenv(RegionName)
+
+	return map[string]string{
+		"app_name":   appName,
+		"region":     region,
+		"origin":     a.GetOrigin(),
+		"_dd.origin": a.GetOrigin(),
+	}
+}
+
+// GetOrigin returns the `origin` attribute type for the given
+// cloud service.
+func (a *AppService) GetOrigin() string {
+	return "appservice"
+}
+
+// GetPrefix returns the prefix that we're prefixing all
+// metrics with.
+func (a *AppService) GetPrefix() string {
+	return "azure.appservice"
+}
+
+func isAppService() bool {
+	_, exists := os.LookupEnv(RunZip)
+	return exists
+}

--- a/cmd/serverless-init/cloudservice/appservice_test.go
+++ b/cmd/serverless-init/cloudservice/appservice_test.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package cloudservice
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAppServiceTags(t *testing.T) {
+	service := &AppService{}
+
+	t.Setenv("WEBSITE_SITE_NAME", "test_site_name")
+	t.Setenv("REGION_NAME", "eastus")
+	t.Setenv("APPSVC_RUN_ZIP", "false")
+
+	tags := service.GetTags()
+
+	assert.Equal(t, map[string]string{
+		"app_name":   "test_site_name",
+		"origin":     "appservice",
+		"region":     "eastus",
+		"_dd.origin": "appservice",
+	}, tags)
+}

--- a/cmd/serverless-init/cloudservice/service.go
+++ b/cmd/serverless-init/cloudservice/service.go
@@ -48,5 +48,9 @@ func GetCloudServiceType() CloudService {
 		return &ContainerApp{}
 	}
 
+	if isAppService() {
+		return &AppService{}
+	}
+
 	return &LocalService{}
 }

--- a/releasenotes/notes/azure-app-service-e5eda454a14e1214.yaml
+++ b/releasenotes/notes/azure-app-service-e5eda454a14e1214.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Added a new Cloud Service implementation for web apps running in Azure App Service containers.

--- a/releasenotes/notes/azure-app-service-e5eda454a14e1214.yaml
+++ b/releasenotes/notes/azure-app-service-e5eda454a14e1214.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added a new Cloud Service implementation for web apps running in Azure App Service containers.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR is extending serverless Cloud Service support to web apps running in Azure App Service containers.

### Motivation

SLS-3574

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
