### PR TITLE
[CWS] cgroup resolver: use hashmap instead of LRU to track workload PIDs

### DIFF
--- a/pkg/security/resolvers/cgroup/model/model.go
+++ b/pkg/security/resolvers/cgroup/model/model.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -59,44 +58,45 @@ type CacheEntry struct {
 	sync.RWMutex
 	Deleted          *atomic.Bool
 	WorkloadSelector WorkloadSelector
-	PIDs             *simplelru.LRU[uint32, int8]
+	PIDs             map[uint32]int8
 }
 
 // NewCacheEntry returns a new instance of a CacheEntry
 func NewCacheEntry(id string, pids ...uint32) (*CacheEntry, error) {
-	pidsLRU, err := simplelru.NewLRU[uint32, int8](1000, nil)
-	if err != nil {
-		return nil, err
-	}
-
 	newCGroup := CacheEntry{
 		Deleted: atomic.NewBool(false),
 		ContainerContext: model.ContainerContext{
 			ID: id,
 		},
-		PIDs: pidsLRU,
+		PIDs: make(map[uint32]int8, 10),
 	}
 
 	for _, pid := range pids {
-		newCGroup.PIDs.Add(pid, 0)
+		newCGroup.PIDs[pid] = 1
 	}
 	return &newCGroup, nil
 }
 
-// GetPIDs returns the list of root pids for the current workload
+// GetPIDs returns the list of pids for the current workload
 func (cgce *CacheEntry) GetPIDs() []uint32 {
 	cgce.RLock()
 	defer cgce.RUnlock()
 
-	return cgce.PIDs.Keys()
+	pids := make([]uint32, len(cgce.PIDs))
+	i := 0
+	for k := range cgce.PIDs {
+		pids[i] = k
+	}
+
+	return pids
 }
 
-// RemovePID removes the provided root pid from the list of pids
+// RemovePID removes the provided pid from the list of pids
 func (cgce *CacheEntry) RemovePID(pid uint32) {
 	cgce.Lock()
 	defer cgce.Unlock()
 
-	cgce.PIDs.Remove(pid)
+	delete(cgce.PIDs, pid)
 }
 
 // AddPID adds a pid to the list of pids
@@ -104,7 +104,7 @@ func (cgce *CacheEntry) AddPID(pid uint32) {
 	cgce.Lock()
 	defer cgce.Unlock()
 
-	cgce.PIDs.Add(pid, 0)
+	cgce.PIDs[pid] = 1
 }
 
 // SetTags sets the tags for the provided workload

--- a/pkg/security/resolvers/cgroup/model/model.go
+++ b/pkg/security/resolvers/cgroup/model/model.go
@@ -86,6 +86,7 @@ func (cgce *CacheEntry) GetPIDs() []uint32 {
 	i := 0
 	for k := range cgce.PIDs {
 		pids[i] = k
+		i++
 	}
 
 	return pids

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -209,15 +209,10 @@ func (cr *Resolver) deleteWorkloadPID(pid uint32, workload *cgroupModel.CacheEnt
 	workload.Lock()
 	defer workload.Unlock()
 
-	for _, workloadPID := range workload.PIDs.Keys() {
-		if pid == workloadPID {
-			workload.PIDs.Remove(pid)
-			break
-		}
-	}
+	delete(workload.PIDs, pid)
 
 	// check if the workload should be deleted
-	if workload.PIDs.Len() <= 0 {
+	if len(workload.PIDs) <= 0 {
 		cr.workloads.Remove(workload.ID)
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

The issue with using a LRU to track cgroup/workload pids is that the creation of a lot of new processes could cause long running processes (such as the container init process) to be evicted from the LRU. The termination of the new processes could then cause the pids LRU to be emptied, causing the cgroup/workload to be released even though it still has processes running.
To fix this, change the cgroup resolver to use a hashmap instead of a LRU.
The pids of exited processes will be removed from this hashmap when the process cache is flushed to avoid leaking memory.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

QA on a host with a controlled number of cgroups:

- look at the `datadog.security_agent.runtime.cgroups_running` metric
- start a new container, the metric should have increased by 1
- in the container: create a bunch processes, for example using this cmdline `while true; do ls &> /dev/null; done`, let it run a few minutes then stop
- wait at least 2 minutes to wait for the process cache flush to happen
- verify that the metric's value hasn't decreased (nor increased)


<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
