### PR TITLE
Fix potentital use of uninitialized memory

### DIFF
--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -520,7 +520,7 @@ char **Three::getCheckWarnings(RtLoaderPyObject *check)
         if (warn == NULL) {
             setError("there was an error browsing 'warnings' list: " + _fetchPythonError());
 
-            for (int jdx = 0; jdx < numWarnings && warnings[jdx]; jdx++) {
+            for (int jdx = 0; jdx < idx; jdx++) {
                 _free(warnings[jdx]);
             }
             _free(warnings);

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -513,7 +513,7 @@ char **Two::getCheckWarnings(RtLoaderPyObject *check)
         if (warn == NULL) {
             setError("there was an error browsing 'warnings' list: " + _fetchPythonError());
 
-            for (int jdx = 0; jdx < numWarnings && warnings[jdx]; jdx++) {
+            for (int jdx = 0; jdx < idx; jdx++) {
                 _free(warnings[jdx]);
             }
             _free(warnings);


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This fixes potential use of uninitialized memory when PyList_GetItem returns NULL.

This code path is impossible to hit in practice with the current versions of Python, as long as the object is a list and index is in bounds, which is ensured by the prior call to PyList_Size. These functions do not use the Python sequence protocol, so evil python code can not supply incorrect length or throw an unexpected exception either.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

This change was tested by artificially introducing a coding error that made numWarnings larger than the actual list length. I don't believe we can achieve this in any way without modifying the code, thus `skip-qa`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
