### PR TITLE
[CWS] introduction of fentry basic support for CWS probe

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -288,6 +288,7 @@ func InitSystemProbeConfig(cfg Config) {
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.classifier_priority"), 10)
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.classifier_handle"), 0)
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "event_stream.use_ring_buffer"), true)
+	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "event_stream.use_fentry"), false)
 	eventMonitorBindEnv(cfg, join(evNS, "event_stream.buffer_size"))
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "envs_with_value"), []string{"LD_PRELOAD", "LD_LIBRARY_PATH", "PATH", "HISTSIZE", "HISTFILESIZE"})
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "runtime_compilation.enabled"), false)

--- a/pkg/ebpf/bytecode/asset_reader_bindata.go
+++ b/pkg/ebpf/bytecode/asset_reader_bindata.go
@@ -16,6 +16,7 @@ import (
 
 //go:embed build/runtime-security.o
 //go:embed build/runtime-security-syscall-wrapper.o
+//go:embed build/runtime-security-fentry.o
 //go:embed build/runtime-security-offset-guesser.o
 var bindata embed.FS
 

--- a/pkg/security/ebpf/c/include/constants/fentry_macro.h
+++ b/pkg/security/ebpf/c/include/constants/fentry_macro.h
@@ -1,0 +1,18 @@
+#ifndef _CONSTANTS_FENTRY_MACRO_H_
+#define _CONSTANTS_FENTRY_MACRO_H_
+
+#ifdef USE_FENTRY
+
+#define HOOK_ENTRY(func_name) SEC("fentry/" func_name)
+typedef unsigned long long ctx_t;
+#define CTX_PARM1(ctx) (void *)(ctx[0])
+
+#else
+
+#define HOOK_ENTRY(func_name) SEC("kprobe/" func_name)
+typedef struct pt_regs ctx_t;
+#define CTX_PARM1(ctx) PT_REGS_PARM1(ctx)
+
+#endif
+
+#endif

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -44,7 +44,7 @@ SYSCALL_KPROBE4(execveat, int, fd, const char *, filename, const char **, argv, 
     return trace__sys_execveat(ctx, argv, env);
 }
 
-int __attribute__((always_inline)) handle_interpreted_exec_event(ctx_t *ctx, struct syscall_cache_t *syscall, struct file *file) {
+int __attribute__((always_inline)) handle_interpreted_exec_event(struct pt_regs *ctx, struct syscall_cache_t *syscall, struct file *file) {
     struct inode *interpreter_inode;
     bpf_probe_read(&interpreter_inode, sizeof(interpreter_inode), &file->f_inode);
 
@@ -501,7 +501,7 @@ int kprobe_parse_args_envs(struct pt_regs *ctx) {
     return 0;
 }
 
-int __attribute__((always_inline)) fetch_interpreter(ctx_t *ctx, struct linux_binprm *bprm) {
+int __attribute__((always_inline)) fetch_interpreter(struct pt_regs *ctx, struct linux_binprm *bprm) {
     struct syscall_cache_t *syscall = peek_current_or_impersonated_exec_syscall();
     if (!syscall) {
         return 0;
@@ -592,7 +592,7 @@ int kprobe_setup_arg_pages(struct pt_regs *ctx) {
     return 0;
 }
 
-int __attribute__((always_inline)) send_exec_event(struct pt_regs *ctx) {
+int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
     struct syscall_cache_t *syscall = pop_current_or_impersonated_exec_syscall();
     if (!syscall) {
         return 0;
@@ -687,7 +687,7 @@ int __attribute__((always_inline)) send_exec_event(struct pt_regs *ctx) {
 }
 
 HOOK_ENTRY("mprotect_fixup")
-int hook_mprotect_fixup(struct pt_regs *ctx) {
+int hook_mprotect_fixup(ctx_t *ctx) {
     return send_exec_event(ctx);
 }
 

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -531,8 +531,8 @@ int __attribute__((always_inline)) fetch_interpreter(ctx_t *ctx, struct linux_bi
 }
 
 SEC("kprobe/setup_new_exec")
-int kprobe_setup_new_exec_interp(ctx_t *ctx) {
-    struct linux_binprm *bprm = (struct linux_binprm *) CTX_PARM1(ctx);
+int kprobe_setup_new_exec_interp(struct pt_regs *ctx) {
+    struct linux_binprm *bprm = (struct linux_binprm *) PT_REGS_PARM1(ctx);
     return fetch_interpreter(ctx, bprm);
 }
 
@@ -577,7 +577,7 @@ int kprobe_setup_new_exec_args_envs(struct pt_regs *ctx) {
 }
 
 SEC("kprobe/setup_arg_pages")
-int kprobe_setup_arg_pages(ctx_t *ctx) {
+int kprobe_setup_arg_pages(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_current_or_impersonated_exec_syscall();
     if (!syscall) {
         return 0;

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -5,6 +5,7 @@
 #include "constants/offsets/filesystem.h"
 #include "helpers/filesystem.h"
 #include "helpers/syscalls.h"
+#include "constants/fentry_macro.h"
 
 int __attribute__((always_inline)) trace__sys_execveat(struct pt_regs *ctx, const char **argv, const char **env) {
     struct syscall_cache_t syscall = {
@@ -43,7 +44,7 @@ SYSCALL_KPROBE4(execveat, int, fd, const char *, filename, const char **, argv, 
     return trace__sys_execveat(ctx, argv, env);
 }
 
-int __attribute__((always_inline)) handle_interpreted_exec_event(struct pt_regs *ctx, struct syscall_cache_t *syscall, struct file *file) {
+int __attribute__((always_inline)) handle_interpreted_exec_event(ctx_t *ctx, struct syscall_cache_t *syscall, struct file *file) {
     struct inode *interpreter_inode;
     bpf_probe_read(&interpreter_inode, sizeof(interpreter_inode), &file->f_inode);
 
@@ -99,7 +100,7 @@ SYSCALL_KPROBE0(vfork) {
 
 #define DO_FORK_STRUCT_INPUT 1
 
-int __attribute__((always_inline)) handle_do_fork(struct pt_regs *ctx) {
+int __attribute__((always_inline)) handle_do_fork(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_FORK);
     if (!syscall) {
         return 0;
@@ -110,7 +111,7 @@ int __attribute__((always_inline)) handle_do_fork(struct pt_regs *ctx) {
     LOAD_CONSTANT("do_fork_input", input);
 
     if (input == DO_FORK_STRUCT_INPUT) {
-        void *args = (void *)PT_REGS_PARM1(ctx);
+        void *args = (void *)CTX_PARM1(ctx);
         int exit_signal;
         bpf_probe_read(&exit_signal, sizeof(int), (void *)args + 32);
 
@@ -118,7 +119,7 @@ int __attribute__((always_inline)) handle_do_fork(struct pt_regs *ctx) {
             syscall->fork.is_thread = 0;
         }
     } else {
-        u64 flags = (u64)PT_REGS_PARM1(ctx);
+        u64 flags = (u64)CTX_PARM1(ctx);
         if ((flags & SIGCHLD) == SIGCHLD) {
             syscall->fork.is_thread = 0;
         }
@@ -127,20 +128,22 @@ int __attribute__((always_inline)) handle_do_fork(struct pt_regs *ctx) {
     return 0;
 }
 
-SEC("kprobe/kernel_clone")
-int kprobe_kernel_clone(struct pt_regs *ctx) {
+HOOK_ENTRY("kernel_clone")
+int hook_kernel_clone(ctx_t *ctx) {
     return handle_do_fork(ctx);
 }
 
-SEC("kprobe/do_fork")
-int kprobe_do_fork(struct pt_regs *ctx) {
+#ifndef USE_FENTRY
+HOOK_ENTRY("do_fork")
+int hook_do_fork(ctx_t *ctx) {
     return handle_do_fork(ctx);
 }
 
-SEC("kprobe/_do_fork")
-int kprobe__do_fork(struct pt_regs *ctx) {
+HOOK_ENTRY("_do_fork")
+int hook__do_fork(ctx_t *ctx) {
     return handle_do_fork(ctx);
 }
+#endif
 
 SEC("tracepoint/sched/sched_process_fork")
 int sched_process_fork(struct _tracepoint_sched_process_fork *args) {
@@ -225,8 +228,8 @@ int sched_process_fork(struct _tracepoint_sched_process_fork *args) {
     return 0;
 }
 
-SEC("kprobe/do_coredump")
-int kprobe_do_coredump(struct pt_regs *ctx) {
+HOOK_ENTRY("do_coredump")
+int hook_do_coredump(ctx_t *ctx) {
     u64 key = bpf_get_current_pid_tgid();
     u8 in_coredump = 1;
 
@@ -235,8 +238,8 @@ int kprobe_do_coredump(struct pt_regs *ctx) {
     return 0;
 }
 
-SEC("kprobe/do_exit")
-int kprobe_do_exit(struct pt_regs *ctx) {
+HOOK_ENTRY("do_exit")
+int hook_do_exit(ctx_t *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 tgid = pid_tgid >> 32;
     u32 pid = pid_tgid;
@@ -267,7 +270,7 @@ int kprobe_do_exit(struct pt_regs *ctx) {
         struct proc_cache_t *pc = fill_process_context(&event.process);
         fill_container_context(pc, &event.container);
         fill_span_context(&event.span);
-        event.exit_code = (u32)PT_REGS_PARM1(ctx);
+        event.exit_code = (u32)(u64)CTX_PARM1(ctx);
         u8 *in_coredump = (u8 *)bpf_map_lookup_elem(&tasks_in_coredump, &pid_tgid);
         if (in_coredump) {
             event.exit_code |= 0x80;
@@ -284,9 +287,9 @@ int kprobe_do_exit(struct pt_regs *ctx) {
     return 0;
 }
 
-SEC("kprobe/exit_itimers")
-int kprobe_exit_itimers(struct pt_regs *ctx) {
-    void *signal = (void *)PT_REGS_PARM1(ctx);
+HOOK_ENTRY("exit_itimers")
+int hook_exit_itimers(ctx_t *ctx) {
+    void *signal = (void *)CTX_PARM1(ctx);
 
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 tgid = pid_tgid >> 32;
@@ -309,18 +312,20 @@ int kprobe_exit_itimers(struct pt_regs *ctx) {
     return 0;
 }
 
-SEC("kprobe/prepare_binprm")
-int kprobe_prepare_binprm(struct pt_regs *ctx) {
+#ifndef USE_FENTRY
+HOOK_ENTRY("prepare_binprm")
+int hook_prepare_binprm(ctx_t *ctx) {
+    return fill_exec_context();
+}
+#endif
+
+HOOK_ENTRY("bprm_execve")
+int hook_bprm_execve(ctx_t *ctx) {
     return fill_exec_context();
 }
 
-SEC("kprobe/bprm_execve")
-int kprobe_bprm_execve(struct pt_regs *ctx) {
-    return fill_exec_context();
-}
-
-SEC("kprobe/security_bprm_check")
-int kprobe_security_bprm_check(struct pt_regs *ctx) {
+HOOK_ENTRY("security_bprm_check")
+int hook_security_bprm_check(ctx_t *ctx) {
     return fill_exec_context();
 }
 
@@ -496,7 +501,7 @@ int kprobe_parse_args_envs(struct pt_regs *ctx) {
     return 0;
 }
 
-int __attribute__((always_inline)) fetch_interpreter(struct pt_regs *ctx, struct linux_binprm *bprm) {
+int __attribute__((always_inline)) fetch_interpreter(ctx_t *ctx, struct linux_binprm *bprm) {
     struct syscall_cache_t *syscall = peek_current_or_impersonated_exec_syscall();
     if (!syscall) {
         return 0;
@@ -526,8 +531,8 @@ int __attribute__((always_inline)) fetch_interpreter(struct pt_regs *ctx, struct
 }
 
 SEC("kprobe/setup_new_exec")
-int kprobe_setup_new_exec_interp(struct pt_regs *ctx) {
-    struct linux_binprm *bprm = (struct linux_binprm *) PT_REGS_PARM1(ctx);
+int kprobe_setup_new_exec_interp(ctx_t *ctx) {
+    struct linux_binprm *bprm = (struct linux_binprm *) CTX_PARM1(ctx);
     return fetch_interpreter(ctx, bprm);
 }
 
@@ -572,7 +577,7 @@ int kprobe_setup_new_exec_args_envs(struct pt_regs *ctx) {
 }
 
 SEC("kprobe/setup_arg_pages")
-int kprobe_setup_arg_pages(struct pt_regs *ctx) {
+int kprobe_setup_arg_pages(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_current_or_impersonated_exec_syscall();
     if (!syscall) {
         return 0;
@@ -681,8 +686,8 @@ int __attribute__((always_inline)) send_exec_event(struct pt_regs *ctx) {
     return 0;
 }
 
-SEC("kprobe/mprotect_fixup")
-int kprobe_mprotect_fixup(struct pt_regs *ctx) {
+HOOK_ENTRY("mprotect_fixup")
+int hook_mprotect_fixup(struct pt_regs *ctx) {
     return send_exec_event(ctx);
 }
 

--- a/pkg/security/ebpf/loader.go
+++ b/pkg/security/ebpf/loader.go
@@ -23,15 +23,17 @@ type ProbeLoader struct {
 	bytecodeReader    bytecode.AssetReader
 	useSyscallWrapper bool
 	useRingBuffer     bool
+	useFentry         bool
 	statsdClient      statsd.ClientInterface
 }
 
 // NewProbeLoader returns a new Loader
-func NewProbeLoader(config *config.Config, useSyscallWrapper, useRingBuffer bool, statsdClient statsd.ClientInterface) *ProbeLoader {
+func NewProbeLoader(config *config.Config, useSyscallWrapper, useRingBuffer bool, useFentry bool, statsdClient statsd.ClientInterface) *ProbeLoader {
 	return &ProbeLoader{
 		config:            config,
 		useSyscallWrapper: useSyscallWrapper,
 		useRingBuffer:     useRingBuffer,
+		useFentry:         useFentry,
 		statsdClient:      statsdClient,
 	}
 }
@@ -61,7 +63,9 @@ func (l *ProbeLoader) Load() (bytecode.AssetReader, bool, error) {
 	// fallback to pre-compiled version
 	if l.bytecodeReader == nil {
 		asset := "runtime-security"
-		if l.useSyscallWrapper {
+		if l.useFentry {
+			asset += "-fentry"
+		} else if l.useSyscallWrapper {
 			asset += "-syscall-wrapper"
 		}
 

--- a/pkg/security/ebpf/manager.go
+++ b/pkg/security/ebpf/manager.go
@@ -48,9 +48,9 @@ func NewDefaultOptions() manager.Options {
 }
 
 // NewRuntimeSecurityManager returns a new instance of the runtime security module manager
-func NewRuntimeSecurityManager(supportsRingBuffers bool) *manager.Manager {
+func NewRuntimeSecurityManager(supportsRingBuffers, useFentry bool) *manager.Manager {
 	manager := &manager.Manager{
-		Probes: probes.AllProbes(),
+		Probes: probes.AllProbes(useFentry),
 		Maps:   probes.AllMaps(),
 	}
 	if supportsRingBuffers {

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -54,13 +54,13 @@ func computeDefaultEventsRingBufferSize() uint32 {
 }
 
 // AllProbes returns the list of all the probes of the runtime security module
-func AllProbes() []*manager.Probe {
+func AllProbes(fentry bool) []*manager.Probe {
 	if len(allProbes) > 0 {
 		return allProbes
 	}
 
 	allProbes = append(allProbes, getAttrProbes()...)
-	allProbes = append(allProbes, getExecProbes()...)
+	allProbes = append(allProbes, getExecProbes(fentry)...)
 	allProbes = append(allProbes, getLinkProbe()...)
 	allProbes = append(allProbes, getMkdirProbes()...)
 	allProbes = append(allProbes, getMountProbes()...)

--- a/pkg/security/ebpf/probes/builder.go
+++ b/pkg/security/ebpf/probes/builder.go
@@ -48,9 +48,3 @@ func withSkipIfFentry(skip bool) psbOption {
 		psb.skipIfFentry = skip
 	}
 }
-
-func withUID(uid string) psbOption {
-	return func(psb *probeSelectorBuilder) {
-		psb.uid = uid
-	}
-}

--- a/pkg/security/ebpf/probes/builder.go
+++ b/pkg/security/ebpf/probes/builder.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package probes
+
+import (
+	"fmt"
+
+	manager "github.com/DataDog/ebpf-manager"
+)
+
+type probeSelectorBuilder struct {
+	uid          string
+	skipIfFentry bool
+}
+
+type psbOption func(*probeSelectorBuilder)
+
+func kprobeOrFentry(funcName string, fentry bool, options ...psbOption) *manager.ProbeSelector {
+	psb := &probeSelectorBuilder{
+		uid:          SecurityAgentUID,
+		skipIfFentry: false,
+	}
+
+	for _, opt := range options {
+		opt(psb)
+	}
+
+	if fentry && psb.skipIfFentry {
+		return nil
+	}
+
+	return &manager.ProbeSelector{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          psb.uid,
+			EBPFFuncName: fmt.Sprintf("hook_%s", funcName),
+		},
+	}
+}
+
+func withSkipIfFentry(skip bool) psbOption {
+	return func(psb *probeSelectorBuilder) {
+		psb.skipIfFentry = skip
+	}
+}
+
+func withUID(uid string) psbOption {
+	return func(psb *probeSelectorBuilder) {
+		psb.uid = uid
+	}
+}

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -71,7 +71,7 @@ var SnapshotSelectors = []manager.ProbesSelector{
 var selectorsPerEventTypeStore map[eval.EventType][]manager.ProbesSelector
 
 // GetSelectorsPerEventType returns the list of probes that should be activated for each event
-func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
+func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSelector {
 	if selectorsPerEventTypeStore != nil {
 		return selectorsPerEventTypeStore
 	}
@@ -83,31 +83,31 @@ func GetSelectorsPerEventType() map[eval.EventType][]manager.ProbesSelector {
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "sys_exit"}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "sched_process_fork"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_exit"}},
+				kprobeOrFentry("do_exit", fentry),
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_prepare_binprm"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_bprm_execve"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_bprm_check"}},
+					kprobeOrFentry("prepare_binprm", fentry, withSkipIfFentry(true)),
+					kprobeOrFentry("bprm_execve", fentry),
+					kprobeOrFentry("security_bprm_check", fentry, withSkipIfFentry(true)),
 				}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_setup_new_exec_interp"}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID + "_a", EBPFFuncName: "kprobe_setup_new_exec_args_envs"}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_setup_arg_pages"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mprotect_fixup"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_exit_itimers"}},
+				kprobeOrFentry("mprotect_fixup", fentry),
+				kprobeOrFentry("exit_itimers", fentry),
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_open"}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_dentry_open"}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_commit_creds"}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_switch_task_namespaces"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_coredump"}},
+				kprobeOrFentry("do_coredump", fentry),
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_cgroup_procs_write"}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_cgroup1_procs_write"}},
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe__do_fork"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_fork"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_kernel_clone"}},
+				kprobeOrFentry("_do_fork", fentry, withSkipIfFentry(true)),
+				kprobeOrFentry("do_fork", fentry, withSkipIfFentry(true)),
+				kprobeOrFentry("kernel_clone", fentry),
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_cgroup_tasks_write"}},

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -104,12 +104,6 @@ func getExecProbes(fentry bool) []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kretprobe_alloc_pid",
-			},
-		},
-		{
-			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				UID:          SecurityAgentUID,
 				EBPFFuncName: "kprobe_switch_task_namespaces",
 			},
 		},
@@ -117,18 +111,6 @@ func getExecProbes(fentry bool) []*manager.Probe {
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook_do_coredump",
-			},
-		},
-		{
-			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe_switch_task_namespaces",
-			},
-		},
-		{
-			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe_do_coredump",
 			},
 		},
 	}

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -9,131 +9,153 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// execProbes holds the list of probes used to track processes execution
-var execProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_prepare_binprm",
+func getExecProbes(fentry bool) []*manager.Probe {
+	var execProbes = []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_bprm_execve",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_bprm_execve",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_security_bprm_check",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_security_bprm_check",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "sched_process_fork",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "sched_process_fork",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_do_exit",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_do_exit",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_kernel_clone",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_do_fork",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_cgroup_procs_write",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe__do_fork",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_cgroup1_procs_write",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_kernel_clone",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_cgroup_tasks_write",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_cgroup_procs_write",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_cgroup1_tasks_write",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_cgroup1_procs_write",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_exit_itimers",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_cgroup_tasks_write",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_setup_new_exec_interp",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_cgroup1_tasks_write",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID + "_a",
+				EBPFFuncName: "kprobe_setup_new_exec_args_envs",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_exit_itimers",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_setup_arg_pages",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_setup_new_exec_interp",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_mprotect_fixup",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID + "_a",
-			EBPFFuncName: "kprobe_setup_new_exec_args_envs",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_commit_creds",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_setup_arg_pages",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kretprobe_alloc_pid",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_mprotect_fixup",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_switch_task_namespaces",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_commit_creds",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_do_coredump",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_switch_task_namespaces",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_switch_task_namespaces",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_do_coredump",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_do_coredump",
+			},
 		},
-	},
-}
+	}
 
-func getExecProbes() []*manager.Probe {
+	if !fentry {
+		execProbes = append(execProbes, []*manager.Probe{
+			{
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					UID:          SecurityAgentUID,
+					EBPFFuncName: "hook_prepare_binprm",
+				},
+			},
+			{
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					UID:          SecurityAgentUID,
+					EBPFFuncName: "hook_do_fork",
+				},
+			},
+			{
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					UID:          SecurityAgentUID,
+					EBPFFuncName: "hook__do_fork",
+				},
+			},
+		}...)
+	}
+
 	execProbes = append(execProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,

--- a/pkg/security/ebpf/tests/helpers_test.go
+++ b/pkg/security/ebpf/tests/helpers_test.go
@@ -61,7 +61,7 @@ func newVM(t *testing.T) *baloum.VM {
 		t.Fatal(err)
 	}
 
-	loader := secebpf.NewProbeLoader(&config.Config{}, useSyscallWrapper, false, &statsd.NoOpClient{})
+	loader := secebpf.NewProbeLoader(&config.Config{}, useSyscallWrapper, false, false, &statsd.NoOpClient{})
 	reader, _, err := loader.Load()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/security/probe/config/config.go
+++ b/pkg/security/probe/config/config.go
@@ -92,6 +92,9 @@ type Config struct {
 	// EventStreamBufferSize specifies the buffer size of the eBPF map used for events
 	EventStreamBufferSize int
 
+	// EventStreamUseFentry specifies whether to use eBPF fentry when available instead of kprobes
+	EventStreamUseFentry bool
+
 	// RuntimeCompilationEnabled defines if the runtime-compilation is enabled
 	RuntimeCompilationEnabled bool
 
@@ -150,6 +153,7 @@ func NewConfig() (*Config, error) {
 		NetworkClassifierHandle:      uint16(getInt("network.classifier_handle")),
 		EventStreamUseRingBuffer:     getBool("event_stream.use_ring_buffer"),
 		EventStreamBufferSize:        getInt("event_stream.buffer_size"),
+		EventStreamUseFentry:         getBool("event_stream.use_fentry"),
 		EnvsWithValue:                getStringSlice("envs_with_value"),
 		NetworkEnabled:               getBool("network.enabled"),
 		StatsPollingInterval:         time.Duration(getInt("events_stats.polling_interval")) * time.Second,

--- a/pkg/security/probe/constantfetch/offset_guesser.go
+++ b/pkg/security/probe/constantfetch/offset_guesser.go
@@ -190,7 +190,10 @@ func (og *OffsetGuesser) FinishAndGetResults() (map[string]uint64, error) {
 		},
 	}
 
-	for _, probe := range probes.AllProbes() {
+	for _, probe := range probes.AllProbes(true) {
+		options.ExcludedFunctions = append(options.ExcludedFunctions, probe.ProbeIdentificationPair.EBPFFuncName)
+	}
+	for _, probe := range probes.AllProbes(false) {
 		options.ExcludedFunctions = append(options.ExcludedFunctions, probe.ProbeIdentificationPair.EBPFFuncName)
 	}
 	options.ExcludedFunctions = append(options.ExcludedFunctions, probes.GetAllTCProgramFunctions()...)

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -114,6 +114,8 @@ type PlatformProbe struct {
 	isRuntimeDiscarded bool
 	constantOffsets    map[string]uint64
 	runtimeCompiled    bool
+
+	useFentry bool
 }
 
 func (p *Probe) detectKernelVersion() error {
@@ -225,7 +227,7 @@ func (p *Probe) Init() error {
 		return err
 	}
 
-	loader := ebpf.NewProbeLoader(p.Config.Probe, useSyscallWrapper, p.UseRingBuffers(), p.StatsdClient)
+	loader := ebpf.NewProbeLoader(p.Config.Probe, useSyscallWrapper, p.UseRingBuffers(), p.useFentry, p.StatsdClient)
 	defer loader.Close()
 
 	bytecodeReader, runtimeCompiled, err := loader.Load()
@@ -1061,7 +1063,7 @@ func (p *Probe) updateProbes(ruleEventTypes []eval.EventType) error {
 	var activatedProbes []manager.ProbesSelector
 
 	// extract probe to activate per the event types
-	for eventType, selectors := range probes.GetSelectorsPerEventType() {
+	for eventType, selectors := range probes.GetSelectorsPerEventType(p.useFentry) {
 		if (eventType == "*" || slices.Contains(eventTypes, eventType) || p.isNeededForActivityDump(eventType)) && p.validEventTypeForConfig(eventType) {
 			activatedProbes = append(activatedProbes, selectors...)
 		}
@@ -1411,6 +1413,7 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 			erpcRequest:               &erpc.ERPCRequest{},
 			isRuntimeDiscarded:        !opts.DontDiscardRuntime,
 			generatedAnomalyDetection: make(map[model.EventType]*atomic.Uint64),
+			useFentry:                 config.Probe.EventStreamUseFentry,
 		},
 	}
 
@@ -1440,7 +1443,7 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 	useRingBuffers := p.UseRingBuffers()
 	useMmapableMaps := p.kernelVersion.HaveMmapableMaps()
 
-	p.Manager = ebpf.NewRuntimeSecurityManager(useRingBuffers)
+	p.Manager = ebpf.NewRuntimeSecurityManager(useRingBuffers, p.useFentry)
 
 	p.ensureConfigDefaults()
 

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -781,3 +781,11 @@ def print_failed_tests(_, output_dir):
 
     if fail_count > 0:
         raise Exit(code=1)
+
+
+@task
+def print_fentry_stats(ctx):
+    fentry_o_path = "pkg/ebpf/bytecode/build/runtime-security-fentry.o"
+
+    for kind in ["kprobe", "kretprobe", "fentry", "fexit"]:
+        ctx.run(f"readelf -W -S {fentry_o_path} 2> /dev/null | grep PROGBITS | grep {kind} | wc -l")

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -130,8 +130,11 @@ def gen_mocks(ctx):
 
 
 @task
-def run_functional_tests(ctx, testsuite, verbose=False, testflags=''):
+def run_functional_tests(ctx, testsuite, verbose=False, testflags='', fentry=False):
     cmd = '{testsuite} {verbose_opt} {testflags}'
+    if fentry:
+        cmd = "DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_USE_FENTRY=true " + cmd
+
     if os.getuid() != 0:
         cmd = 'sudo -E PATH={path} ' + cmd
 
@@ -401,6 +404,7 @@ def functional_tests(
     testflags='',
     skip_linters=False,
     kernel_release=None,
+    fentry=False,
 ):
     build_functional_tests(
         ctx,
@@ -418,6 +422,7 @@ def functional_tests(
         testsuite=output,
         verbose=verbose,
         testflags=testflags,
+        fentry=fentry,
     )
 
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -183,6 +183,20 @@ def ninja_security_ebpf_programs(nw, build_dir, debug, kernel_release):
     )
     outfiles.append(syscall_wrapper_outfile)
 
+    # fentry + syscall wrapper
+    root, ext = os.path.splitext(outfile)
+    syscall_wrapper_outfile = f"{root}-fentry{ext}"
+    ninja_ebpf_program(
+        nw,
+        infile=infile,
+        outfile=syscall_wrapper_outfile,
+        variables={
+            "flags": security_flags + " -DUSE_SYSCALL_WRAPPER=1 -DUSE_FENTRY=1",
+            "kheaders": kheaders,
+        },
+    )
+    outfiles.append(syscall_wrapper_outfile)
+
     # offset guesser
     offset_guesser_outfile = os.path.join(build_dir, "runtime-security-offset-guesser.o")
     ninja_ebpf_program(


### PR DESCRIPTION
### What does this PR do?

This PR introduces the basis of the new fentry based CWS probe. It includes configuration, and the necessary macros for a seamless transition and code that works for both modes.

On the other hand this PR still does not support:
- syscall hooking
- fexit (kretprobe), it works but still need to find a solution for the position of the ret value
- hooking on function that need to `bpf_tailcall` to other functions

This PR does not convert all hooks yet, this will come in later PRs

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
