### PR TITLE
fix subscriptionId fetching on azure

### DIFF
--- a/pkg/util/cloudproviders/azure/azure.go
+++ b/pkg/util/cloudproviders/azure/azure.go
@@ -190,20 +190,21 @@ func GetPublicIPv4(ctx context.Context) (string, error) {
 	return publicIPv4Fetcher.FetchString(ctx)
 }
 
-var subscriptionIdFetcher = cachedfetch.Fetcher{
-	Name: "Azure Subscription ID",
-	Attempt: func(ctx context.Context) (interface{}, error) {
-		subscriptionID, err := getResponse(ctx,
-			metadataURL+"/metadata/instance/compute/subscriptionId?api-version=2017-04-02&format=text")
-		if err != nil {
-			return "", fmt.Errorf("failed to get Azure Subscription ID: %s", err)
-		}
-
-		return subscriptionID, nil
-	},
+type instanceMetadata struct {
+	SubscriptionID string `json:"subscriptionId"`
 }
 
 // GetSubscriptionID returns the subscription ID of the current Azure instance
 func GetSubscriptionID(ctx context.Context) (string, error) {
-	return subscriptionIdFetcher.FetchString(ctx)
+	body, err := instanceMetaFetcher.FetchString(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	var metadata instanceMetadata
+	if err := json.Unmarshal([]byte(body), &metadata); err != nil {
+		return "", err
+	}
+
+	return metadata.SubscriptionID, nil
 }


### PR DESCRIPTION
### What does this PR do?

For some reasons it seems fetching `/metadata/instance/compute/subscriptionId?api-version=2017-04-02&format=text` does not work (returns `{error: bad request}`). This PR fixes the issue by unmarshaling the compute metadata directly.

The fix implemented by this PR might needs to be applied to other azure fetchers as well.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
