### PR TITLE
[CWS] fix secprofile unstable guards

### DIFF
--- a/pkg/security/security_profile/profile/manager.go
+++ b/pkg/security/security_profile/profile/manager.go
@@ -692,6 +692,7 @@ func (m *SecurityProfileManager) tryAutolearn(profile *SecurityProfile, event *m
 			profile.lastAnomalyNano[event.GetEventType()] = profile.loadedNano
 			lastAnomalyNano = profile.loadedNano
 		}
+
 		if time.Duration(event.TimestampRaw-lastAnomalyNano) >= m.config.RuntimeSecurity.AnomalyDetectionMinimumStablePeriod {
 			return StableProfile
 		}
@@ -710,6 +711,9 @@ func (m *SecurityProfileManager) tryAutolearn(profile *SecurityProfile, event *m
 
 	// check if the unstable size limit was reached
 	if profile.ActivityTree.Stats.ApproximateSize() >= m.config.RuntimeSecurity.AnomalyDetectionUnstableProfileSizeThreshold {
+		if newEntry, err := profile.ActivityTree.Contains(event, nodeType); err == nil && newEntry {
+			profile.lastAnomalyNano[event.GetEventType()] = event.TimestampRaw
+		}
 		m.incrementEventFilteringStat(event.GetEventType(), UnstableProfile, NA)
 		return UnstableProfile
 	}


### PR DESCRIPTION
### What does this PR do?

The issue was that checks for unstable state (both time and size threshold) were made AFTER the "stable" check, resulting of a profile lifecycle of:
learning -> unstable (because of it's size reached the limit) -> stable (because the last event for a given evt type was done more than <stable_period>) -> generates anomalies.
NB: the unstable state for time threshold was impossible to met.

I also merged exec, fork and exit events as exec ones for the stability calculation (I even wander if we should simply drop fork/exit beforehand or not)


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
