### PR TITLE
[WIP][CWS] - Use a limitReader instead of plain reader to enforce size limit on the policy loaded

### DIFF
--- a/pkg/security/rconfig/policies.go
+++ b/pkg/security/rconfig/policies.go
@@ -15,9 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
-	"github.com/skydive-project/go-debouncer"
-
 	"github.com/DataDog/datadog-agent/pkg/config/remote"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
@@ -29,9 +26,7 @@ import (
 const (
 	securityAgentRCPollInterval = time.Second * 1
 	debounceDelay               = 5 * time.Second
-	maxPolicySize          = 1 * 1024 * 1024 // Mb
-	errBigPolicy           = "the policy is too big and has been rejected, expected no more than %d bytes"
-
+	maxPolicySize               = 1 * 1024 * 1024 // Mb
 )
 
 // RCPolicyProvider defines a remote config policy provider

--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -7,10 +7,11 @@ package rules
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/DataDog/datadog-agent/pkg/security/secl/validators"
 	"github.com/hashicorp/go-multierror"
 	"gopkg.in/yaml.v2"
-	"io"
 )
 
 // PolicyDef represents a policy file definition

--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -7,11 +7,11 @@ package rules
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/validators"
 	"github.com/hashicorp/go-multierror"
 	"gopkg.in/yaml.v2"
+	"io"
 )
 
 // PolicyDef represents a policy file definition


### PR DESCRIPTION
### What does this PR do?

Use the [LimitReader](https://pkg.go.dev/io#LimitedReader) to wrap the current reader and prevent loading in memory any policy greater than 1 Mb

### Motivation

When a policy is received from RC, it gets read without minding about its size. This change aims at truncating the policy to 1Mb. In case this happens, the yaml.decode function will error as it will not be a valid yaml

### Possible Drawbacks / Trade-offs

- One huge rule may prevent the whole policy from being loaded 

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
