### PR TITLE
npm: Remove redundant err return

### DIFF
--- a/pkg/network/tracer/connection/tcp_close_consumer.go
+++ b/pkg/network/tracer/connection/tcp_close_consumer.go
@@ -40,7 +40,7 @@ type tcpCloseConsumer struct {
 	ch           *cookieHasher
 }
 
-func newTCPCloseConsumer(perfHandler *ddebpf.PerfHandler, batchManager *perfBatchManager) (*tcpCloseConsumer, error) {
+func newTCPCloseConsumer(perfHandler *ddebpf.PerfHandler, batchManager *perfBatchManager) *tcpCloseConsumer {
 	return &tcpCloseConsumer{
 		perfHandler:  perfHandler,
 		batchManager: batchManager,

--- a/pkg/network/tracer/connection/tcp_close_consumer_test.go
+++ b/pkg/network/tracer/connection/tcp_close_consumer_test.go
@@ -19,8 +19,7 @@ func TestTcpCloseConsumerStopRace(t *testing.T) {
 	pf := ebpf.NewPerfHandler(10)
 	require.NotNil(t, pf)
 
-	c, err := newTCPCloseConsumer(pf, nil)
-	require.NoError(t, err)
+	c := newTCPCloseConsumer(pf, nil)
 	require.NotNil(t, c)
 
 	c.Stop()

--- a/pkg/network/tracer/connection/tracer.go
+++ b/pkg/network/tracer/connection/tracer.go
@@ -187,10 +187,7 @@ func NewTracer(config *config.Config, bpfTelemetry *errtelemetry.EBPFTelemetry) 
 		return nil, fmt.Errorf("could not create connection batch maanager: %w", err)
 	}
 
-	closeConsumer, err := newTCPCloseConsumer(perfHandlerTCP, batchMgr)
-	if err != nil {
-		return nil, fmt.Errorf("could not create TCPCloseConsumer: %w", err)
-	}
+	closeConsumer := newTCPCloseConsumer(perfHandlerTCP, batchMgr)
 
 	tr := &tracer{
 		m:              m,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Removes redundant returned `err` argument from the function 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Fixing a bug introduced in #17511
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
