### PR TITLE
[system-probe] Do not report closed/established empty tcp connections

### DIFF
--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -633,6 +633,14 @@ func (ns *networkState) getClient(clientID string) *client {
 	return c
 }
 
+func isEmptyConnection(c *ConnectionStats) bool {
+	return c.Last.RecvBytes == 0 &&
+		c.Last.SentBytes == 0 &&
+		c.Last.RecvPackets == 0 &&
+		c.Last.SentPackets == 0 &&
+		c.Last.Retransmits == 0
+}
+
 // mergeConnections return the connections and takes care of updating their last stat counters
 func (ns *networkState) mergeConnections(id string, active map[StatCookie]*ConnectionStats, buffer *clientBuffer) {
 	now := time.Now()
@@ -665,7 +673,7 @@ func (ns *networkState) mergeConnections(id string, active map[StatCookie]*Conne
 
 		ns.updateConnWithStats(client, cookie, closedConn)
 
-		if closedConn.Last.IsZero() {
+		if isEmptyConnection(closedConn) {
 			continue
 		}
 
@@ -682,7 +690,7 @@ func (ns *networkState) mergeConnections(id string, active map[StatCookie]*Conne
 		ns.createStatsForCookie(client, cookie)
 		ns.updateConnWithStats(client, cookie, c)
 
-		if c.Last.IsZero() {
+		if isEmptyConnection(c) {
 			continue
 		}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Drops connections even if tcp established/closed counters are non-zero for connections.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
