### PR TITLE
Revert "[CWS][SEC-3735] Check self tests results in e2e tests"

### DIFF
--- a/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
@@ -126,16 +126,6 @@ class TestE2EDocker(unittest.TestCase):
                 self.fail("check ruleset_loaded timeouted")
             self.app.check_for_ignored_policies(self, attributes)
 
-        with Step(msg="check self_tests", emoji=":test_tube:"):
-            rule_id = "self_test"
-            event = self.app.wait_app_log(f"rule_id:{rule_id}")
-            attributes = event["data"][0]["attributes"]["attributes"]
-            self.assertEqual(rule_id, attributes["agent"]["rule_id"], "unable to find rule_id tag attribute")
-            self.assertTrue(
-                "failed_tests" not in attributes,
-                f"failed tests: {attributes['failed_tests']}" if "failed_tests" in attributes else "success",
-            )
-
         with Step(msg="wait for host tags (3m)", emoji=":alarm_clock:"):
             time.sleep(3 * 60)
 

--- a/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
@@ -133,16 +133,6 @@ class TestE2EKubernetes(unittest.TestCase):
                 self.fail("check ruleset_loaded timeouted")
             self.app.check_for_ignored_policies(self, attributes)
 
-        with Step(msg="check self_tests", emoji=":test_tube:"):
-            rule_id = "self_test"
-            event = self.app.wait_app_log(f"rule_id:{rule_id}")
-            attributes = event["data"][0]["attributes"]["attributes"]
-            self.assertEqual(rule_id, attributes["agent"]["rule_id"], "unable to find rule_id tag attribute")
-            self.assertTrue(
-                "failed_tests" not in attributes,
-                f"failed tests: {attributes['failed_tests']}" if "failed_tests" in attributes else "success",
-            )
-
         with Step(msg="wait for datadog.security_agent.runtime.running metric", emoji="\N{beer mug}"):
             self.app.wait_for_metric("datadog.security_agent.runtime.running", host=TestE2EKubernetes.hostname)
 


### PR DESCRIPTION
Reverts DataDog/datadog-agent#17387, Because the e2e tests are failing in the CI