### PR TITLE
remove go_{tool,}_deps dependencies on windows jobs

### DIFF
--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -49,7 +49,7 @@
 
 .tests_windows_sysprobe:
   stage: source_test
-  needs: ["go_deps"]
+  needs: []
   tags: [ "runner:windows-docker", "windowsversion:1809" ]
   script:
     - $ErrorActionPreference = "Stop"

--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -1,7 +1,7 @@
 ---
 .tests_windows_base:
   stage: source_test
-  needs: ["go_deps", "go_tools_deps", "build_vcpkg_deps"]
+  needs: ["build_vcpkg_deps"]
   tags: ["runner:windows-docker", "windowsversion:1809"]
   before_script:
     - $vcpkgBlobSaSUrl = (aws ssm get-parameter --region us-east-1 --name ci.datadog-agent-buildimages.vcpkg_blob_sas_url --with-decryption --query "Parameter.Value" --out text)
@@ -36,7 +36,7 @@
 
 .lint_windows_base:
   stage: source_test
-  needs: ["go_deps", "go_tools_deps"]
+  needs: []
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:
     - $ErrorActionPreference = "Stop"


### PR DESCRIPTION
### What does this PR do?

windows CI jobs depends in `go_deps` and `go_tool_deps` but never use the provided archives (is it expected ?). This PR removes this dependencies

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
