### PR TITLE
[Gohai][ASC-571][ASC-549] Implement the new API for the memory package

### DIFF
--- a/pkg/gohai/gohai_test.go
+++ b/pkg/gohai/gohai_test.go
@@ -54,11 +54,6 @@ type gohaiPayload struct {
 		MountedOn string `json:"mounted_on"`
 		Name      string `json:"name"`
 	} `json:"filesystem"`
-	Memory struct {
-		// SwapTotal is not reported on Windows
-		SwapTotal string `json:"swap_total"`
-		Total     string `json:"total"`
-	} `json:"memory"`
 	Network struct {
 		Interfaces []struct {
 			Ipv4        []string `json:"ipv4"`
@@ -133,11 +128,6 @@ func TestGohaiSerialization(t *testing.T) {
 		assert.NotEmpty(t, payload.Filesystem[0].KbSize, 0)
 		assert.NotEmpty(t, payload.Filesystem[0].Name, 0)
 	}
-	if runtime.GOOS != "windows" {
-		// Not reported on Windows
-		assert.NotEmpty(t, payload.Memory.SwapTotal)
-	}
-	assert.NotEmpty(t, payload.Memory.Total)
 
 	if assert.NotEmpty(t, payload.Network.Interfaces) {
 		for _, itf := range payload.Network.Interfaces {

--- a/pkg/gohai/memory/memory_darwin.go
+++ b/pkg/gohai/memory/memory_darwin.go
@@ -11,49 +11,43 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/gohai/utils"
 )
 
-func getMemoryInfo() (memoryInfo map[string]string, err error) {
-	memoryInfo = make(map[string]string)
-
+func getTotalBytes() (uint64, error) {
 	out, err := exec.Command("sysctl", "-n", "hw.memsize").Output()
-	if err == nil {
-		memoryInfo["total"] = strings.Trim(string(out), "\n")
+	if err != nil {
+		return 0, fmt.Errorf("sysctl: %w", err)
 	}
 
-	out, err = exec.Command("sysctl", "-n", "vm.swapusage").Output()
-	if err == nil {
-		swap := regexp.MustCompile("total = ").Split(string(out), 2)[1]
-		memoryInfo["swap_total"] = strings.Split(swap, " ")[0]
+	v := strings.Trim(string(out), "\n")
+	mem, e := strconv.ParseUint(v, 10, 64)
+	if e != nil {
+		return 0, fmt.Errorf("could not parse memory size: %w", e)
 	}
 
-	return
+	return mem, nil // mem is in bytes
 }
 
-func getMemoryInfoByte() (uint64, uint64, []string, error) {
-	memInfo, err := getMemoryInfo()
-	var mem, swap uint64
-	warnings := []string{}
-
-	// mem is already in bytes but `swap_total` use the format "5120,00M"
-	if v, ok := memInfo["swap_total"]; ok {
-		idx := strings.IndexAny(v, ",.") // depending on the locale either a comma or dot is used
-		swapTotal, e := strconv.ParseUint(v[0:idx], 10, 64)
-		if e == nil {
-			swap = swapTotal * 1024 * 1024 // swapTotal is in mb
-		} else {
-			warnings = append(warnings, fmt.Sprintf("could not parse swap size: %s", e))
-		}
+func getTotalSwapKb() (uint64, error) {
+	out, err := exec.Command("sysctl", "-n", "vm.swapusage").Output()
+	if err != nil {
+		return 0, fmt.Errorf("sysctl: %w", err)
 	}
 
-	if v, ok := memInfo["total"]; ok {
-		t, e := strconv.ParseUint(v, 10, 64)
-		if e == nil {
-			mem = t // mem is returned in bytes
-		} else {
-			warnings = append(warnings, fmt.Sprintf("could not parse memory size: %s", e))
-		}
+	swap := regexp.MustCompile("total = ").Split(string(out), 2)[1]
+	v := strings.Split(swap, " ")[0]
+	idx := strings.IndexAny(v, ",.") // depending on the locale either a comma or dot is used
+	swapTotal, err := strconv.ParseUint(v[0:idx], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("could not parse swap size: %w", err)
 	}
 
-	return mem, swap, warnings, err
+	return swapTotal * 1024, nil // swapTotal is in mb
+}
+
+func (info *Info) fillMemoryInfo() {
+	info.TotalBytes = utils.NewValueFrom(getTotalBytes())
+	info.SwapTotalKb = utils.NewValueFrom(getTotalSwapKb())
 }

--- a/pkg/gohai/memory/memory_linux.go
+++ b/pkg/gohai/memory/memory_linux.go
@@ -61,6 +61,7 @@ func (info *Info) fillMemoryInfo() {
 
 	file, err := os.Open("/proc/meminfo")
 	if err == nil {
+		defer file.Close()
 		totalBytes, swapTotalKb, err = parseMemoryInfo(file)
 	} else {
 		err = fmt.Errorf("could not open /proc/meminfo: %w", err)

--- a/pkg/gohai/memory/memory_linux.go
+++ b/pkg/gohai/memory/memory_linux.go
@@ -8,75 +8,69 @@ package memory
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/gohai/utils"
 )
 
-var memMap = map[string]string{
-	"MemTotal":  "total",
-	"SwapTotal": "swap_total",
-}
-
-func getMemoryInfo() (memoryInfo map[string]string, err error) {
-	file, err := os.Open("/proc/meminfo")
-
-	if err != nil {
-		return
-	}
-
+func parseMemoryInfo(reader io.Reader) (totalBytes utils.Value[uint64], swapTotalKb utils.Value[uint64], err error) {
 	var lines []string
-	scanner := bufio.NewScanner(file)
-
+	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		lines = append(lines, scanner.Text())
 	}
 
 	if scanner.Err() != nil {
-		err = scanner.Err()
+		err = fmt.Errorf("could not read /proc/meminfo: %w", scanner.Err())
 		return
 	}
 
-	memoryInfo = make(map[string]string)
-
+	totalBytes = utils.NewErrorValue[uint64](fmt.Errorf("'MemTotal' not found in /proc/meminfo"))
+	swapTotalKb = utils.NewErrorValue[uint64](fmt.Errorf("'SwapTotal' not found in /proc/meminfo"))
 	for _, line := range lines {
 		pair := regexp.MustCompile(": +").Split(line, 2)
 		values := regexp.MustCompile(" +").Split(pair[1], 2)
 
-		key, ok := memMap[pair[0]]
-		if ok {
-			memoryInfo[key] = fmt.Sprintf("%s%s", values[0], values[1])
+		switch pair[0] {
+		case "MemTotal":
+			val, parseErr := strconv.ParseUint(values[0], 10, 64)
+			if parseErr == nil {
+				// val is in kb
+				totalBytes = utils.NewValue(val * 1024)
+			} else {
+				totalBytes = utils.NewErrorValue[uint64](fmt.Errorf("could not parse total size: %w", parseErr))
+			}
+		case "SwapTotal":
+			val, parseErr := strconv.ParseUint(values[0], 10, 64)
+			if parseErr == nil {
+				swapTotalKb = utils.NewValue(val)
+			} else {
+				swapTotalKb = utils.NewErrorValue[uint64](fmt.Errorf("could not parse total swap size: %w", parseErr))
+			}
 		}
 	}
 
 	return
 }
 
-func getMemoryInfoByte() (mem uint64, swap uint64, warnings []string, err error) {
-	memInfo, err := getMemoryInfo()
+func (info *Info) fillMemoryInfo() {
+	var totalBytes, swapTotalKb utils.Value[uint64]
+
+	file, err := os.Open("/proc/meminfo")
+	if err == nil {
+		totalBytes, swapTotalKb, err = parseMemoryInfo(file)
+	} else {
+		err = fmt.Errorf("could not open /proc/meminfo: %w", err)
+	}
+
 	if err != nil {
-		return
+		totalBytes = utils.NewErrorValue[uint64](err)
+		swapTotalKb = utils.NewErrorValue[uint64](err)
 	}
 
-	memString := strings.TrimSuffix(strings.ToLower(utils.GetString(memInfo, "total")), "kb")
-	swapString := strings.TrimSuffix(strings.ToLower(utils.GetString(memInfo, "swap_total")), "kb")
-
-	t, e := strconv.ParseUint(memString, 10, 64)
-	if e == nil {
-		mem = t * 1024 // getMemoryInfo return values in KB
-	} else {
-		warnings = append(warnings, fmt.Sprintf("could not parse memory size: %s", e))
-	}
-
-	s, e := strconv.ParseUint(swapString, 10, 64)
-	if e == nil {
-		swap = s * 1024 // getMemoryInfo return values in KB
-	} else {
-		warnings = append(warnings, fmt.Sprintf("could not parse swap size: %s", e))
-	}
-
-	return mem, swap, warnings, err
+	info.TotalBytes = totalBytes
+	info.SwapTotalKb = swapTotalKb
 }

--- a/pkg/gohai/memory/memory_linux_test.go
+++ b/pkg/gohai/memory/memory_linux_test.go
@@ -5,8 +5,8 @@
 package memory
 
 import (
-	"testing"
 	"strings"
+	"testing"
 
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/gohai/memory/memory_linux_test.go
+++ b/pkg/gohai/memory/memory_linux_test.go
@@ -1,0 +1,35 @@
+// This file is licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2014-present Datadog, Inc.
+
+package memory
+
+import (
+	"testing"
+	"strings"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseMemoryInfo checks that parseMemoryInfo correctly reads the format from /proc/meminfo.
+// This format is described in the redhat doc:
+// https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/s2-proc-meminfo
+func TestParseMemoryInfo(t *testing.T) {
+	meminfo := `MemTotal:        1921988 kB
+MemFree:         1374408 kB
+SwapTotal:       1048572 kB
+AnonHugePages:         0 kB
+HugePages_Total:       0`
+	reader := strings.NewReader(meminfo)
+
+	totalBytes, swapTotalKb, err := parseMemoryInfo(reader)
+	require.NoError(t, err)
+
+	totalBytesVal, err := totalBytes.Value()
+	require.NoError(t, err)
+	require.EqualValues(t, 1921988*1024, totalBytesVal)
+
+	swapTotalKbVal, err := swapTotalKb.Value()
+	require.NoError(t, err)
+	require.EqualValues(t, 1048572, swapTotalKbVal)
+}

--- a/pkg/gohai/memory/memory_test.go
+++ b/pkg/gohai/memory/memory_test.go
@@ -1,0 +1,63 @@
+// This file is licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2014-present Datadog, Inc.
+package memory
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/gohai/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectMemory(t *testing.T) {
+	memInfo := CollectInfo()
+
+	_, err := memInfo.TotalBytes.Value()
+	if err != nil {
+		require.ErrorIs(t, err, utils.ErrNotCollectable)
+	}
+
+	_, err = memInfo.SwapTotalKb.Value()
+	if err != nil {
+		require.ErrorIs(t, err, utils.ErrNotCollectable)
+	}
+}
+
+func TestMemoryAsJSON(t *testing.T) {
+	memInfo := CollectInfo()
+	marshallable, _, err := memInfo.AsJSON()
+	require.NoError(t, err)
+
+	marshalled, err := json.Marshal(marshallable)
+	require.NoError(t, err)
+
+	// Any change to this datastructure should be notified to the backend
+	// team to ensure compatibility.
+	type Memory struct {
+		Total     string `json:"total"`
+		SwapTotal string `json:"swap_total"`
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(marshalled))
+	// do not ignore unknown fields
+	decoder.DisallowUnknownFields()
+
+	var decodedMem Memory
+	err = decoder.Decode(&decodedMem)
+	require.NoError(t, err)
+
+	// check that we read the full json
+	require.False(t, decoder.More())
+
+	if _, err = memInfo.TotalBytes.Value(); err == nil {
+		// the total field is just a number of bytes, without explicit units
+		require.Regexp(t, `^\d+$`, decodedMem.Total)
+	}
+	if _, err = memInfo.SwapTotalKb.Value(); err == nil {
+		// the swap total field is a number with unit kb
+		require.Regexp(t, `^\d+kb$`, decodedMem.SwapTotal)
+	}
+}

--- a/pkg/gohai/memory/memory_test.go
+++ b/pkg/gohai/memory/memory_test.go
@@ -63,6 +63,6 @@ func TestMemoryAsJSON(t *testing.T) {
 		// the swap total field is a number with unit kb
 		require.Equal(t, fmt.Sprintf("%dkb", swapTotalKb), decodedMem.SwapTotal)
 	} else {
-		require.Empty(t, decodedMem.Total)
+		require.Empty(t, decodedMem.SwapTotal)
 	}
 }

--- a/pkg/gohai/memory/memory_test.go
+++ b/pkg/gohai/memory/memory_test.go
@@ -6,6 +6,7 @@ package memory
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/gohai/utils"
@@ -52,12 +53,16 @@ func TestMemoryAsJSON(t *testing.T) {
 	// check that we read the full json
 	require.False(t, decoder.More())
 
-	if _, err = memInfo.TotalBytes.Value(); err == nil {
-		// the total field is just a number of bytes, without explicit units
-		require.Regexp(t, `^\d+$`, decodedMem.Total)
+	if totalBytes, err := memInfo.TotalBytes.Value(); err == nil {
+		require.Equal(t, fmt.Sprintf("%d", totalBytes), decodedMem.Total)
+	} else {
+		require.Empty(t, decodedMem.Total)
 	}
-	if _, err = memInfo.SwapTotalKb.Value(); err == nil {
+
+	if swapTotalKb, err := memInfo.SwapTotalKb.Value(); err == nil {
 		// the swap total field is a number with unit kb
-		require.Regexp(t, `^\d+kb$`, decodedMem.SwapTotal)
+		require.Equal(t, fmt.Sprintf("%dkb", swapTotalKb), decodedMem.SwapTotal)
+	} else {
+		require.Empty(t, decodedMem.Total)
 	}
 }

--- a/pkg/metadata/internal/gohai/gohai.go
+++ b/pkg/metadata/internal/gohai/gohai.go
@@ -48,7 +48,7 @@ func getGohaiInfo() *gohai {
 		log.Errorf("Failed to retrieve filesystem metadata: %s", err)
 	}
 
-	memoryPayload, err := new(memory.Memory).Collect()
+	memoryPayload, _, err := memory.CollectInfo().AsJSON()
 	if err == nil {
 		res.Memory = memoryPayload
 	} else {

--- a/pkg/metadata/inventories/host_metadata.go
+++ b/pkg/metadata/inventories/host_metadata.go
@@ -127,6 +127,7 @@ func getHostMetadata() *HostMetadata {
 	} else {
 		logWarnings(warnings)
 
+		// Value() returns the default value of the type in case of error so we can use it directly
 		memoryTotalKb, _ := memoryInfo.TotalBytes.Value()
 		metadata.MemoryTotalKb = memoryTotalKb / 1024
 		metadata.MemorySwapTotalKb, _ = memoryInfo.SwapTotalKb.Value()

--- a/pkg/metadata/inventories/host_metadata.go
+++ b/pkg/metadata/inventories/host_metadata.go
@@ -18,7 +18,7 @@ import (
 // for testing purpose
 var (
 	cpuGet      = cpu.Get
-	memoryGet   = memory.Get
+	memoryGet   = memory.CollectInfo
 	networkGet  = network.Get
 	platformGet = platform.Get
 )
@@ -120,14 +120,16 @@ func getHostMetadata() *HostMetadata {
 		metadata.CPUArchitecture = platformInfo.HardwarePlatform
 	}
 
-	memoryInfo, warnings, err := memoryGet()
+	memoryInfo := memoryGet()
+	_, warnings, err = memoryInfo.AsJSON()
 	if err != nil {
 		logErrorf("failed to retrieve host memory metadata from gohai: %s", err) //nolint:errcheck
 	} else {
 		logWarnings(warnings)
 
-		metadata.MemoryTotalKb = memoryInfo.TotalBytes / 1024
-		metadata.MemorySwapTotalKb = memoryInfo.SwapTotalBytes / 1024
+		memoryTotalKb, _ := memoryInfo.TotalBytes.Value()
+		metadata.MemoryTotalKb = memoryTotalKb / 1024
+		metadata.MemorySwapTotalKb, _ = memoryInfo.SwapTotalKb.Value()
 	}
 
 	networkInfo, warnings, err := networkGet()

--- a/pkg/metadata/inventories/host_metadata_test.go
+++ b/pkg/metadata/inventories/host_metadata_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/gohai/memory"
 	"github.com/DataDog/datadog-agent/pkg/gohai/network"
 	"github.com/DataDog/datadog-agent/pkg/gohai/platform"
+	gohaiutils "github.com/DataDog/datadog-agent/pkg/gohai/utils"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/util/dmi"
@@ -69,11 +70,11 @@ func cpuMock() (*cpu.Cpu, []string, error) {
 	}, nil, nil
 }
 
-func memoryMock() (*memory.Memory, []string, error) {
-	return &memory.Memory{
-		TotalBytes:     1234567890,
-		SwapTotalBytes: 1234567890,
-	}, nil, nil
+func memoryMock() *memory.Info {
+	return &memory.Info{
+		TotalBytes:  gohaiutils.NewValue[uint64](1234567890),
+		SwapTotalKb: gohaiutils.NewValue[uint64](1205632),
+	}
 }
 
 func networkMock() (*network.Network, []string, error) {
@@ -104,7 +105,7 @@ func platformMock() (*platform.Platform, []string, error) {
 func setupHostMetadataMock(t *testing.T) {
 	t.Cleanup(func() {
 		cpuGet = cpu.Get
-		memoryGet = memory.Get
+		memoryGet = memory.CollectInfo
 		networkGet = network.Get
 		platformGet = platform.Get
 
@@ -132,14 +133,14 @@ func TestGetHostMetadata(t *testing.T) {
 }
 
 func cpuErrorMock() (*cpu.Cpu, []string, error)                { return nil, nil, fmt.Errorf("err") }
-func memoryErrorMock() (*memory.Memory, []string, error)       { return nil, nil, fmt.Errorf("err") }
+func memoryErrorMock() *memory.Info                            { return &memory.Info{} }
 func networkErrorMock() (*network.Network, []string, error)    { return nil, nil, fmt.Errorf("err") }
 func platformErrorMock() (*platform.Platform, []string, error) { return nil, nil, fmt.Errorf("err") }
 
 func setupHostMetadataErrorMock(t *testing.T) {
 	t.Cleanup(func() {
 		cpuGet = cpu.Get
-		memoryGet = memory.Get
+		memoryGet = memory.CollectInfo
 		networkGet = network.Get
 		platformGet = platform.Get
 	})

--- a/releasenotes/notes/gohai-memory-new-api-fca268103be44369.yaml
+++ b/releasenotes/notes/gohai-memory-new-api-fca268103be44369.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+   Always send the swap size value in metadata as an integer in kilobytes. 
+
+fixes:
+  - |
+   Use a locale-independent format for the swap size sent in the metadata,
+   to avoid issues when parsing the value in the frontend.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Implement the new API for the memory package of Gohai, following what was described in the [Gohai design RFC](https://github.com/DataDog/architecture/pull/1064). 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Have a cleaner API for the memory package, which also reduce the risk of bugs when using the API and make sure the values have a standard format (cf issue explained below).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This PR also fixes a frontend bug: on Darwin when the host uses a locale with comma as decimal separator the collected total swap was a decimal value with a comma, which is incorrectly parsed and displayed by the frontend in the host info page.

This PR also adds some tests to guarantee the format is always the same.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

The format of the swap value on Darwin changes.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Check that the memory collection works properly on Linux, Darwin and Windows.
Check that on Darwin with a locale using comma as decimal separator, the swap total field in host info page is correctly displayed.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
