### PR TITLE
Add encoding info to tailer info for the agent status verbose page

### DIFF
--- a/pkg/logs/internal/decoder/file_decoder.go
+++ b/pkg/logs/internal/decoder/file_decoder.go
@@ -42,19 +42,28 @@ func NewDecoderFromSourceWithPattern(source *sources.ReplaceableSource, multiLin
 			lineParser = dockerfile.New()
 		}
 	default:
+		encodingInfo := status.NewMappedInfo("Encoding")
 		switch source.Config().Encoding {
 		case config.UTF16BE:
 			lineParser = encodedtext.New(encodedtext.UTF16BE)
 			framing = framer.UTF16BENewline
+			encodingInfo.SetMessage("Encoding", "utf-16-be")
+			tailerInfo.Register(encodingInfo)
 		case config.UTF16LE:
 			lineParser = encodedtext.New(encodedtext.UTF16LE)
 			framing = framer.UTF16LENewline
+			encodingInfo.SetMessage("Encoding", "utf-16-le")
+			tailerInfo.Register(encodingInfo)
 		case config.SHIFTJIS:
 			lineParser = encodedtext.New(encodedtext.SHIFTJIS)
 			framing = framer.SHIFTJISNewline
+			encodingInfo.SetMessage("Encoding", "shift-jis")
+			tailerInfo.Register(encodingInfo)
 		default:
 			lineParser = noop.New()
 			framing = framer.UTF8Newline
+			encodingInfo.SetMessage("Encoding", "utf-8")
+			tailerInfo.Register(encodingInfo)
 		}
 	}
 

--- a/pkg/logs/internal/decoder/file_decoder.go
+++ b/pkg/logs/internal/decoder/file_decoder.go
@@ -48,23 +48,20 @@ func NewDecoderFromSourceWithPattern(source *sources.ReplaceableSource, multiLin
 			lineParser = encodedtext.New(encodedtext.UTF16BE)
 			framing = framer.UTF16BENewline
 			encodingInfo.SetMessage("Encoding", "utf-16-be")
-			tailerInfo.Register(encodingInfo)
 		case config.UTF16LE:
 			lineParser = encodedtext.New(encodedtext.UTF16LE)
 			framing = framer.UTF16LENewline
 			encodingInfo.SetMessage("Encoding", "utf-16-le")
-			tailerInfo.Register(encodingInfo)
 		case config.SHIFTJIS:
 			lineParser = encodedtext.New(encodedtext.SHIFTJIS)
 			framing = framer.SHIFTJISNewline
 			encodingInfo.SetMessage("Encoding", "shift-jis")
-			tailerInfo.Register(encodingInfo)
 		default:
 			lineParser = noop.New()
 			framing = framer.UTF8Newline
 			encodingInfo.SetMessage("Encoding", "utf-8")
-			tailerInfo.Register(encodingInfo)
 		}
+		tailerInfo.Register(encodingInfo)
 	}
 
 	return NewDecoderWithFraming(source, lineParser, framing, multiLinePattern, tailerInfo)

--- a/pkg/logs/internal/tailers/file/tailer.go
+++ b/pkg/logs/internal/tailers/file/tailer.go
@@ -141,7 +141,7 @@ func NewTailer(outputChan chan *message.Message, file *File, sleepDuration time.
 	bytesRead := status.NewCountInfo("Bytes Read")
 	info.Register(bytesRead)
 
-	t := &Tailer{
+	return &Tailer{
 		file:                   file,
 		outputChan:             outputChan,
 		decoder:                decoder,
@@ -160,8 +160,6 @@ func NewTailer(outputChan chan *message.Message, file *File, sleepDuration time.
 		info:                   info,
 		bytesRead:              bytesRead,
 	}
-
-	return t
 }
 
 // NewRotatedTailer creates a new tailer that replaces this one, writing

--- a/pkg/logs/internal/tailers/file/tailer.go
+++ b/pkg/logs/internal/tailers/file/tailer.go
@@ -141,8 +141,6 @@ func NewTailer(outputChan chan *message.Message, file *File, sleepDuration time.
 	bytesRead := status.NewCountInfo("Bytes Read")
 	info.Register(bytesRead)
 
-	encodingInfo := status.NewMappedInfo("Encoding")
-
 	t := &Tailer{
 		file:                   file,
 		outputChan:             outputChan,
@@ -161,14 +159,6 @@ func NewTailer(outputChan chan *message.Message, file *File, sleepDuration time.
 		didFileRotate:          atomic.NewBool(false),
 		info:                   info,
 		bytesRead:              bytesRead,
-	}
-
-	if t.file.Source.Config().Encoding != "" {
-		encodingInfo.SetMessage("Encoding", t.file.Source.Config().Encoding)
-		info.Register(encodingInfo)
-	} else {
-		encodingInfo.SetMessage("Encoding", "utf-8")
-		info.Register(encodingInfo)
 	}
 
 	return t


### PR DESCRIPTION
### What does this PR do?
Adding encoding information to the agent verbose status page:
![image](https://p-qkfgo2.t2.n0.cdn.getcloudapp.com/items/xQuE9Pdk/5821625d-e05e-4133-b97e-9b76b6f3fbc4.jpg?source=viewer&v=3c78589c9ac76cd3033ceb19b81ec443)

### Motivation
Giving more information for what type of encoding user is using for easier troubleshooting. Especially on misapplied encoding cases

### Additional Notes

### Describe how to test/QA your changes
Set up some log collection for the agent.
Configure the log collection to use a specific type of encoding.
Once log is collected, uses: ```datadog-agent status -v```
Within the tailer information for that log collection, there should be a encoder section displaying what type of encoding it is.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
