### PR TITLE
[CWS] rework secprofile tryAutolearn

### DIFF
--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -8,6 +8,7 @@
 package activity_tree
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -164,7 +165,7 @@ func (at *ActivityTree) IsEmpty() bool {
 }
 
 // nolint: unused
-func (at *ActivityTree) debug(w io.Writer) {
+func (at *ActivityTree) Debug(w io.Writer) {
 	for _, root := range at.ProcessNodes {
 		root.debug(w, "")
 	}
@@ -249,7 +250,7 @@ func (at *ActivityTree) insert(event *model.Event, dryRun bool, generationType N
 	}
 	if node == nil {
 		// a process node couldn't be found or created for this event, ignore it
-		return false, err
+		return false, errors.New("a process node couldn't be found or created for this event")
 	}
 
 	// resolve fields

--- a/pkg/security/security_profile/activity_tree/process_node.go
+++ b/pkg/security/security_profile/activity_tree/process_node.go
@@ -73,7 +73,7 @@ func (pn *ProcessNode) debug(w io.Writer, prefix string) {
 	}
 	if len(pn.DNSNames) > 0 {
 		fmt.Fprintf(w, "%s  dns:\n", prefix)
-		for dnsName, _ := range pn.DNSNames {
+		for dnsName := range pn.DNSNames {
 			fmt.Fprintf(w, "%s    - %s\n", prefix, dnsName)
 		}
 	}

--- a/pkg/security/security_profile/activity_tree/process_node.go
+++ b/pkg/security/security_profile/activity_tree/process_node.go
@@ -71,6 +71,12 @@ func (pn *ProcessNode) debug(w io.Writer, prefix string) {
 			f.debug(w, fmt.Sprintf("%s    -", prefix))
 		}
 	}
+	if len(pn.DNSNames) > 0 {
+		fmt.Fprintf(w, "%s  dns:\n", prefix)
+		for dnsName, _ := range pn.DNSNames {
+			fmt.Fprintf(w, "%s    - %s\n", prefix, dnsName)
+		}
+	}
 	if len(pn.Children) > 0 {
 		fmt.Fprintf(w, "%s  children:\n", prefix)
 		for _, child := range pn.Children {

--- a/pkg/security/security_profile/profile/manager.go
+++ b/pkg/security/security_profile/profile/manager.go
@@ -44,14 +44,14 @@ type EventFilteringProfileState uint8
 const (
 	// NoProfile is used to count the events for which we didn't have a profile
 	NoProfile EventFilteringProfileState = iota
-	// UnstableProfile is used to count the events that didn't make it into a profile because their matching profile was
-	// unstable
-	UnstableProfile
+	// ProfileAtMaxSize is used to count the events that didn't make it into a profile because their matching profile
+	// reached the max size threshold
+	ProfileAtMaxSize
 	// UnstableEventType is used to count the events that didn't make it into a profile because their matching profile was
 	// unstable for their event type
 	UnstableEventType
-	// StableProfile is used to count the events linked to a stable profile
-	StableProfile
+	// StableEventType is used to count the events linked to a stable profile for their event type
+	StableEventType
 	// AutoLearning is used to count the event during the auto learning phase
 	AutoLearning
 	// WorkloadWarmup is used to count the learned events due to workload warm up time
@@ -62,12 +62,12 @@ func (efr EventFilteringProfileState) toTag() string {
 	switch efr {
 	case NoProfile:
 		return "profile_state:no_profile"
-	case UnstableProfile:
-		return "profile_state:unstable_profile"
+	case ProfileAtMaxSize:
+		return "profile_state:profile_at_max_size"
 	case UnstableEventType:
 		return "profile_state:unstable_event_type"
-	case StableProfile:
-		return "profile_state:stable_profile"
+	case StableEventType:
+		return "profile_state:stable_event_type"
 	case AutoLearning:
 		return "profile_state:auto_learning"
 	case WorkloadWarmup:
@@ -80,7 +80,7 @@ func (efr EventFilteringProfileState) toTag() string {
 type EventFilteringResult uint8
 
 const (
-	// Not applicable, for profil NoProfile and UnstableProfile state
+	// Not applicable, for profil NoProfile and ProfileAtMaxSize state
 	NA EventFilteringResult = iota
 	// InProfile is used to count the events that matched a profile
 	InProfile
@@ -101,7 +101,7 @@ func (efr EventFilteringResult) toTag() string {
 }
 
 var (
-	allEventFilteringProfileState = []EventFilteringProfileState{NoProfile, UnstableProfile, UnstableEventType, StableProfile, AutoLearning, WorkloadWarmup}
+	allEventFilteringProfileState = []EventFilteringProfileState{NoProfile, ProfileAtMaxSize, UnstableEventType, StableEventType, AutoLearning, WorkloadWarmup}
 	allEventFilteringResults      = []EventFilteringResult{InProfile, NotInProfile, NA}
 )
 
@@ -186,7 +186,16 @@ func NewSecurityProfileManager(config *config.Config, statsdClient statsd.Client
 		cacheMiss:                  atomic.NewUint64(0),
 		eventFiltering:             make(map[eventFilteringEntry]*atomic.Uint64),
 	}
+	m.initMetricsMap()
 
+	// register the manager to the provider(s)
+	for _, p := range m.providers {
+		p.SetOnNewProfileCallback(m.OnNewProfileEvent)
+	}
+	return m, nil
+}
+
+func (m *SecurityProfileManager) initMetricsMap() {
 	for i := model.EventType(0); i < model.MaxKernelEventType; i++ {
 		for _, state := range allEventFilteringProfileState {
 			for _, result := range allEventFilteringResults {
@@ -198,12 +207,6 @@ func NewSecurityProfileManager(config *config.Config, statsdClient statsd.Client
 			}
 		}
 	}
-
-	// register the manager to the provider(s)
-	for _, p := range m.providers {
-		p.SetOnNewProfileCallback(m.OnNewProfileEvent)
-	}
-	return m, nil
 }
 
 // Start runs the manager of Security Profiles
@@ -651,14 +654,16 @@ func (m *SecurityProfileManager) LookupEventInProfiles(event *model.Event) {
 	// check if the event should be injected in the profile automatically
 	profileState := m.tryAutolearn(profile, event)
 	switch profileState {
-	case UnstableProfile, NoProfile: // an error occurred
+	case NoProfile, ProfileAtMaxSize, UnstableEventType:
+		// an error occurred or we are in unstable state
+		// do not link the profile to avoid sending anomalies
 		return
 	case AutoLearning, WorkloadWarmup:
 		// the event was either already in the profile, or has just been inserted
 		FillProfileContextFromProfile(&event.SecurityProfileContext, profile)
 		event.AddToFlags(model.EventFlagsSecurityProfileInProfile)
 		return
-	case StableProfile:
+	case StableEventType:
 		// check if the event is in its profile
 		found, err := profile.ActivityTree.Contains(event, activity_tree.ProfileDrift)
 		if err != nil {
@@ -681,25 +686,41 @@ func (m *SecurityProfileManager) tryAutolearn(profile *SecurityProfile, event *m
 	var nodeType activity_tree.NodeGenerationType
 	var profileState EventFilteringProfileState
 
+	profile.eventTypeStateLock.Lock()
+	defer profile.eventTypeStateLock.Unlock()
+	eventState, ok := profile.eventTypeState[event.GetEventType()]
+	if !ok {
+		eventState = &EventTypeState{
+			lastAnomalyNano: profile.loadedNano,
+			state:           NoProfile,
+		}
+		profile.eventTypeState[event.GetEventType()] = eventState
+	} else if eventState.state == UnstableEventType {
+		// If for the given event type we already are on UnstableEventType, just return
+		// (once reached, this state is immutable)
+		m.incrementEventFilteringStat(event.GetEventType(), UnstableEventType, NA)
+		return UnstableEventType
+	}
+
 	// check if we are at the beginning of a workload lifetime
 	if event.ResolveEventTime().Sub(time.Unix(0, int64(event.ContainerContext.CreatedAt))) < m.config.RuntimeSecurity.AnomalyDetectionWorkloadWarmupPeriod {
 		nodeType = activity_tree.WorkloadWarmup
 		profileState = WorkloadWarmup
 	} else {
-		// have we reached the stable state time limit ?
-		lastAnomalyNano, ok := profile.lastAnomalyNano[event.GetEventType()]
-		if !ok {
-			profile.lastAnomalyNano[event.GetEventType()] = profile.loadedNano
-			lastAnomalyNano = profile.loadedNano
+		// If for the given event type we already are on StableEventType (and outside of the warmup period), just return
+		if eventState.state == StableEventType {
+			return StableEventType
 		}
 
-		if time.Duration(event.TimestampRaw-lastAnomalyNano) >= m.config.RuntimeSecurity.AnomalyDetectionMinimumStablePeriod {
-			return StableProfile
+		// did we reached the stable state time limit ?
+		if time.Duration(event.TimestampRaw-eventState.lastAnomalyNano) >= m.config.RuntimeSecurity.AnomalyDetectionMinimumStablePeriod {
+			eventState.state = StableEventType
+			return StableEventType
 		}
 
-		// have we reached the unstable time limit ?
+		// did we reached the unstable time limit ?
 		if time.Duration(event.TimestampRaw-profile.loadedNano) >= m.config.RuntimeSecurity.AnomalyDetectionUnstableProfileTimeThreshold {
-			m.incrementEventFilteringStat(event.GetEventType(), UnstableEventType, NA)
+			eventState.state = UnstableEventType
 			return UnstableEventType
 		}
 
@@ -707,24 +728,33 @@ func (m *SecurityProfileManager) tryAutolearn(profile *SecurityProfile, event *m
 		profileState = AutoLearning
 	}
 
-	// here we are either in AutoLearning or WorkloadWarmup
-
 	// check if the unstable size limit was reached
 	if profile.ActivityTree.Stats.ApproximateSize() >= m.config.RuntimeSecurity.AnomalyDetectionUnstableProfileSizeThreshold {
-		if newEntry, err := profile.ActivityTree.Contains(event, nodeType); err == nil && newEntry {
-			profile.lastAnomalyNano[event.GetEventType()] = event.TimestampRaw
+		// for each event type we want to reach either the StableEventType or UnstableEventType states, even
+		// if we already reach the AnomalyDetectionUnstableProfileSizeThreshold. That's why we have to keep
+		// rearming the lastAnomalyNano timer based on if it's something new or not.
+		found, err := profile.ActivityTree.Contains(event, nodeType)
+		if err != nil {
+			m.incrementEventFilteringStat(event.GetEventType(), NoProfile, NA)
+			return NoProfile
+		} else if !found {
+			eventState.lastAnomalyNano = event.TimestampRaw
+		} else if profileState == WorkloadWarmup {
+			// if it's NOT something's new AND we are on container warmup period, just pretend
+			// we are in learning/warmup phase (as we know, this event is already present on the profile)
+			return WorkloadWarmup
 		}
-		m.incrementEventFilteringStat(event.GetEventType(), UnstableProfile, NA)
-		return UnstableProfile
+		return ProfileAtMaxSize
 	}
 
+	// here we are either in AutoLearning or WorkloadWarmup
 	// try to insert the event in the profile
 	newEntry, err := profile.ActivityTree.Insert(event, nodeType)
 	if err != nil {
 		m.incrementEventFilteringStat(event.GetEventType(), NoProfile, NA)
 		return NoProfile
 	} else if newEntry {
-		profile.lastAnomalyNano[event.GetEventType()] = event.TimestampRaw
+		eventState.lastAnomalyNano = event.TimestampRaw
 		m.incrementEventFilteringStat(event.GetEventType(), profileState, NotInProfile)
 	} else { // no newEntry
 		m.incrementEventFilteringStat(event.GetEventType(), profileState, InProfile)

--- a/pkg/security/security_profile/profile/manager_test.go
+++ b/pkg/security/security_profile/profile/manager_test.go
@@ -1,0 +1,628 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package profile
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/security/config"
+	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
+	"go.uber.org/atomic"
+	"gotest.tools/assert"
+)
+
+type testIteration struct {
+	name                string                     // test name
+	result              EventFilteringProfileState // expected result
+	newProfile          bool                       // true if a new profile have to be generated for this test
+	containerCreatedAt  time.Duration              // time diff from t0
+	addFakeProcessNodes int64                      // number of fake process nodes to add (adds 1024 to approx size)
+	eventTimestampRaw   time.Duration              // time diff from t0
+	eventType           model.EventType            // only exec for now, TODO: add dns
+	eventProcessPath    string                     // exec path
+	eventDnsReq         string                     // dns request name (only for eventType == DNSEventType)
+	loopUntil           time.Duration              // if not 0, will loop until the given duration is reached
+	loopIncrement       time.Duration              // if loopUntil is not 0, will increment this duration at each loop
+}
+
+func craftFakeEvent(t0 time.Time, ti *testIteration, defaultContainerID string) *model.Event {
+	event := model.NewDefaultEvent().(*model.Event)
+	event.Type = uint32(ti.eventType)
+	event.ContainerContext.CreatedAt = uint64(t0.Add(ti.containerCreatedAt).Unix()) * 1000000000
+	event.TimestampRaw = uint64(t0.Add(ti.eventTimestampRaw).Unix()) * 1000000000
+	event.Timestamp = t0.Add(ti.eventTimestampRaw)
+
+	// setting process
+	event.ProcessCacheEntry = model.NewEmptyProcessCacheEntry(42, 42, false)
+	event.ProcessCacheEntry.ContainerID = defaultContainerID
+	event.ProcessCacheEntry.FileEvent.PathnameStr = ti.eventProcessPath
+	event.ProcessCacheEntry.FileEvent.Inode = 42
+	event.ProcessCacheEntry.Args = "foo"
+	event.ProcessContext = &event.ProcessCacheEntry.ProcessContext
+	switch ti.eventType {
+	case model.ExecEventType:
+		event.Exec.Process = &event.ProcessCacheEntry.ProcessContext.Process
+		break
+	case model.DNSEventType:
+		event.DNS.Name = ti.eventDnsReq
+		event.DNS.Type = 1  // A
+		event.DNS.Class = 1 // INET
+		event.DNS.Size = uint16(len(ti.eventDnsReq))
+		event.DNS.Count = 1
+		break
+	}
+
+	// setting process ancestor
+	event.ProcessCacheEntry.Ancestor = model.NewEmptyProcessCacheEntry(41, 41, false)
+	event.ProcessCacheEntry.Ancestor.FileEvent.PathnameStr = "runc"
+	event.ProcessCacheEntry.Ancestor.FileEvent.Inode = 41
+	event.ProcessCacheEntry.Ancestor.Args = "foo"
+	return event
+}
+
+func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
+	AnomalyDetectionMinimumStablePeriod := time.Hour
+	AnomalyDetectionWorkloadWarmupPeriod := time.Minute
+	AnomalyDetectionUnstableProfileTimeThreshold := time.Hour * 48
+	MaxNbProcess := int64(1000)
+	AnomalyDetectionUnstableProfileSizeThreshold := int64(unsafe.Sizeof(activity_tree.ProcessNode{})) * MaxNbProcess
+	defaultContainerID := "424242424242424242424242424242424242424242424242424242424242424"
+
+	tests := []testIteration{
+		// checking warmup period for exec:
+		{
+			name:                "warmup-exec/not-warmup",
+			result:              AutoLearning,
+			newProfile:          true,
+			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod - time.Second,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   0,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo0",
+		},
+		{
+			name:                "warmup-exec/warmup",
+			result:              WorkloadWarmup,
+			newProfile:          true,
+			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod + time.Second,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   0,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo0",
+		},
+		// and for dns:
+		{
+			name:                "warmup-dns/not-warmup",
+			result:              AutoLearning,
+			newProfile:          true,
+			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod - time.Second,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   0,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo0",
+			eventDnsReq:         "foo.bar",
+		},
+		{
+			name:                "warmup-dns/warmup",
+			result:              WorkloadWarmup,
+			newProfile:          true,
+			containerCreatedAt:  -AnomalyDetectionWorkloadWarmupPeriod + time.Second,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   0,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo0",
+			eventDnsReq:         "foo.baz",
+		},
+
+		// checking stable period for exec:
+		{
+			name:                "stable-exec/add-first-event",
+			result:              AutoLearning,
+			newProfile:          true,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   time.Second,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo0",
+		},
+		{
+			name:                "stable-exec/add-second-event",
+			result:              AutoLearning,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   time.Second * 2,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo1",
+		},
+		{
+			name:                "stable-exec/wait-stable-period",
+			result:              StableEventType,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   time.Second*2 + AnomalyDetectionMinimumStablePeriod,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo2",
+		},
+		{
+			name:                "stable-exec/still-stable",
+			result:              StableEventType,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   time.Second*3 + AnomalyDetectionMinimumStablePeriod,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo3",
+		},
+		{
+			name:                "stable-exec/dont-get-unstable",
+			result:              StableEventType,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   AnomalyDetectionUnstableProfileTimeThreshold + time.Minute,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo4",
+		},
+		// and for dns:
+		{
+			name:                "stable-dns/add-first-event",
+			result:              AutoLearning,
+			newProfile:          true,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   time.Second,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo",
+			eventDnsReq:         "foo0.bar",
+		},
+		{
+			name:                "stable-dns/add-second-event",
+			result:              AutoLearning,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   time.Second * 2,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo",
+			eventDnsReq:         "foo1.bar",
+		},
+		{
+			name:                "stable-dns/wait-stable-period",
+			result:              StableEventType,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   time.Second*2 + AnomalyDetectionMinimumStablePeriod,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo",
+			eventDnsReq:         "foo2.bar",
+		},
+		{
+			name:                "stable-dns/still-stable",
+			result:              StableEventType,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   time.Second*3 + AnomalyDetectionMinimumStablePeriod,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo",
+			eventDnsReq:         "foo3.bar",
+		},
+		{
+			name:                "stable-dns/dont-get-unstable",
+			result:              StableEventType,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   AnomalyDetectionUnstableProfileTimeThreshold + time.Minute,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo",
+			eventDnsReq:         "foo4.bar",
+		},
+
+		// checking unstable period for exec:
+		{
+			name:                "unstable-exec/wait-unstable-period",
+			result:              AutoLearning,
+			newProfile:          true,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   0,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo_",
+			loopUntil:           AnomalyDetectionUnstableProfileTimeThreshold - time.Second,
+			loopIncrement:       AnomalyDetectionMinimumStablePeriod - time.Second,
+		},
+		{
+			name:                "unstable-exec/still-unstable",
+			result:              UnstableEventType,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   AnomalyDetectionUnstableProfileTimeThreshold + time.Second,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo1",
+		},
+		{
+			name:                "unstable-exec/still-unstable-after-stable-period",
+			result:              UnstableEventType,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   AnomalyDetectionUnstableProfileTimeThreshold + AnomalyDetectionMinimumStablePeriod + time.Second,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo2",
+		},
+		// and for dns:
+		{
+			name:                "unstable-dns/wait-unstable-period",
+			result:              AutoLearning,
+			newProfile:          true,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   0,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo",
+			eventDnsReq:         ".foo.bar",
+			loopUntil:           AnomalyDetectionUnstableProfileTimeThreshold - time.Second,
+			loopIncrement:       AnomalyDetectionMinimumStablePeriod - time.Second,
+		},
+		{
+			name:                "unstable-dns/still-unstable",
+			result:              UnstableEventType,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   AnomalyDetectionUnstableProfileTimeThreshold + time.Second,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo",
+			eventDnsReq:         "foo1.bar",
+		},
+		{
+			name:                "unstable-dns/still-unstable-after-stable-period",
+			result:              UnstableEventType,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   AnomalyDetectionUnstableProfileTimeThreshold + AnomalyDetectionMinimumStablePeriod + time.Second,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo",
+			eventDnsReq:         "foo2.bar",
+		},
+
+		// checking max size threshold different cases for exec:
+		{
+			name:                "profile-at-max-size-exec/add-first-event",
+			result:              WorkloadWarmup,
+			newProfile:          true,
+			containerCreatedAt:  0,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   time.Second,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo0",
+		},
+		{
+			name:                "profile-at-max-size-exec/warmup-stable",
+			result:              WorkloadWarmup,
+			newProfile:          false,
+			containerCreatedAt:  0,
+			addFakeProcessNodes: MaxNbProcess,
+			eventTimestampRaw:   time.Second,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo0",
+		},
+		{
+			name:                "profile-at-max-size-exec/warmup-unstable",
+			result:              ProfileAtMaxSize,
+			newProfile:          false,
+			containerCreatedAt:  0,
+			addFakeProcessNodes: MaxNbProcess,
+			eventTimestampRaw:   time.Second,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo1",
+		},
+		{
+			name:                "profile-at-max-size-exec/stable",
+			result:              ProfileAtMaxSize,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: MaxNbProcess,
+			eventTimestampRaw:   time.Second,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo0",
+		},
+		{
+			name:                "profile-at-max-size-exec/unstable",
+			result:              ProfileAtMaxSize,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: MaxNbProcess,
+			eventTimestampRaw:   time.Second,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo1",
+		},
+		{
+			name:                "profile-at-max-size-exec/warmup-NOT-at-max-size",
+			result:              WorkloadWarmup,
+			newProfile:          true,
+			containerCreatedAt:  0,
+			addFakeProcessNodes: MaxNbProcess - 1,
+			eventTimestampRaw:   time.Second,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo2",
+		},
+		{
+			name:                "profile-at-max-size-exec/NOT-at-max-size",
+			result:              AutoLearning,
+			newProfile:          true,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: MaxNbProcess - 1,
+			eventTimestampRaw:   time.Second,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo2",
+		},
+		// and for dns:
+		{
+			name:                "profile-at-max-size-dns/add-first-event",
+			result:              WorkloadWarmup,
+			newProfile:          true,
+			containerCreatedAt:  0,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   time.Second,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo",
+			eventDnsReq:         "foo0.bar",
+		},
+		{
+			name:                "profile-at-max-size-dns/warmup-stable",
+			result:              WorkloadWarmup,
+			newProfile:          false,
+			containerCreatedAt:  0,
+			addFakeProcessNodes: MaxNbProcess,
+			eventTimestampRaw:   time.Second,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo",
+			eventDnsReq:         "foo0.bar",
+		},
+		{
+			name:                "profile-at-max-size-dns/warmup-unstable",
+			result:              ProfileAtMaxSize,
+			newProfile:          false,
+			containerCreatedAt:  0,
+			addFakeProcessNodes: MaxNbProcess,
+			eventTimestampRaw:   time.Second,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo",
+			eventDnsReq:         "foo1.bar",
+		},
+		{
+			name:                "profile-at-max-size-dns/stable",
+			result:              ProfileAtMaxSize,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: MaxNbProcess,
+			eventTimestampRaw:   time.Second,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo",
+			eventDnsReq:         "foo0.bar",
+		},
+		{
+			name:                "profile-at-max-size-dns/unstable",
+			result:              ProfileAtMaxSize,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: MaxNbProcess,
+			eventTimestampRaw:   time.Second,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo",
+			eventDnsReq:         "foo1.bar",
+		},
+		{
+			name:                "profile-at-max-size-dns/warmup-NOT-at-max-size",
+			result:              WorkloadWarmup,
+			newProfile:          true,
+			containerCreatedAt:  0,
+			addFakeProcessNodes: MaxNbProcess - 1,
+			eventTimestampRaw:   time.Second,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo",
+			eventDnsReq:         "foo2.bar",
+		},
+		{
+			name:                "profile-at-max-size-dns/NOT-at-max-size",
+			result:              AutoLearning,
+			newProfile:          true,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: MaxNbProcess - 1,
+			eventTimestampRaw:   time.Second,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo",
+			eventDnsReq:         "foo2.bar",
+		},
+
+		// checking from max-size to stable, for exec:
+		{
+			name:                "profile-at-max-size-to-stable-exec/max-size",
+			result:              ProfileAtMaxSize,
+			newProfile:          true,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: MaxNbProcess,
+			eventTimestampRaw:   time.Second,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo0",
+		},
+		{
+			name:                "profile-at-max-size-to-stable-exec/stable",
+			result:              StableEventType,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: MaxNbProcess,
+			eventTimestampRaw:   AnomalyDetectionUnstableProfileTimeThreshold + time.Second,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo1",
+		},
+		// and for dns:
+		{
+			name:                "profile-at-max-size-to-stable-dns/max-size",
+			result:              ProfileAtMaxSize,
+			newProfile:          true,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: MaxNbProcess,
+			eventTimestampRaw:   time.Second,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo",
+			eventDnsReq:         "foo0.bar",
+		},
+		{
+			name:                "profile-at-max-size-to-stable-dns/stable",
+			result:              StableEventType,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: MaxNbProcess,
+			eventTimestampRaw:   AnomalyDetectionUnstableProfileTimeThreshold + time.Second,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo",
+			eventDnsReq:         "foo1.bar",
+		},
+
+		// from checking max-size to unstable for exec:
+		{
+			name:                "profile-at-max-size-to-unstable-exec/max-size",
+			result:              ProfileAtMaxSize,
+			newProfile:          true,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: MaxNbProcess,
+			eventTimestampRaw:   time.Second,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo0",
+		},
+		{
+			name:                "profile-at-max-size-to-unstable-exec/unstable",
+			result:              ProfileAtMaxSize,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   0,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo_",
+			loopUntil:           AnomalyDetectionUnstableProfileTimeThreshold - time.Second,
+			loopIncrement:       AnomalyDetectionMinimumStablePeriod - time.Second,
+		},
+		{
+			name:                "profile-at-max-size-to-unstable-exec/unstable",
+			result:              UnstableEventType,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   AnomalyDetectionUnstableProfileTimeThreshold + time.Second,
+			eventType:           model.ExecEventType,
+			eventProcessPath:    "/bin/foo1",
+		},
+		// and for dns:
+		{
+			name:                "profile-at-max-size-to-unstable-dns/max-size",
+			result:              ProfileAtMaxSize,
+			newProfile:          true,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: MaxNbProcess,
+			eventTimestampRaw:   time.Second,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo0",
+			eventDnsReq:         "foo0.bar",
+		},
+		{
+			name:                "profile-at-max-size-to-unstable-dns/unstable",
+			result:              ProfileAtMaxSize,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   0,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo",
+			eventDnsReq:         ".foo.bar",
+			loopUntil:           AnomalyDetectionUnstableProfileTimeThreshold - time.Second,
+			loopIncrement:       AnomalyDetectionMinimumStablePeriod - time.Second,
+		},
+		{
+			name:                "profile-at-max-size-to-unstable-dns/unstable",
+			result:              UnstableEventType,
+			newProfile:          false,
+			containerCreatedAt:  time.Minute * -5,
+			addFakeProcessNodes: 0,
+			eventTimestampRaw:   AnomalyDetectionUnstableProfileTimeThreshold + time.Second,
+			eventType:           model.DNSEventType,
+			eventProcessPath:    "/bin/foo",
+			eventDnsReq:         "foo1.bar",
+		},
+	}
+
+	// Initial time reference
+	t0 := time.Now()
+
+	// secprofile manager, only use for config and stats
+	spm := &SecurityProfileManager{
+		eventFiltering: make(map[eventFilteringEntry]*atomic.Uint64),
+		config: &config.Config{
+			RuntimeSecurity: &config.RuntimeSecurityConfig{
+				AnomalyDetectionMinimumStablePeriod:          AnomalyDetectionMinimumStablePeriod,
+				AnomalyDetectionWorkloadWarmupPeriod:         AnomalyDetectionWorkloadWarmupPeriod,
+				AnomalyDetectionUnstableProfileTimeThreshold: AnomalyDetectionUnstableProfileTimeThreshold,
+				AnomalyDetectionUnstableProfileSizeThreshold: AnomalyDetectionUnstableProfileSizeThreshold,
+			},
+		},
+	}
+	spm.initMetricsMap()
+
+	var profile *SecurityProfile = nil
+	for _, ti := range tests {
+		t.Run(ti.name, func(t *testing.T) {
+			if ti.newProfile || profile == nil {
+				profile = NewSecurityProfile(cgroupModel.WorkloadSelector{Image: "image", Tag: "tag"}, []model.EventType{model.ExecEventType, model.DNSEventType})
+				profile.ActivityTree = activity_tree.NewActivityTree(profile, "security_profile")
+				profile.Instances = append(profile.Instances, &cgroupModel.CacheEntry{
+					ContainerContext: model.ContainerContext{
+						ID: defaultContainerID,
+					},
+					WorkloadSelector: cgroupModel.WorkloadSelector{Image: "image", Tag: "tag"},
+				})
+				profile.loadedNano = uint64(t0.Unix()) * 1000000000
+			}
+			profile.ActivityTree.Stats.ProcessNodes += ti.addFakeProcessNodes
+
+			if ti.loopUntil != 0 {
+				currentIncrement := time.Duration(0)
+				basePath := ti.eventProcessPath
+				baseDnsReq := ti.eventDnsReq
+				for currentIncrement < ti.loopUntil {
+					if ti.eventType == model.ExecEventType {
+						ti.eventProcessPath = basePath + fmt.Sprintf("%d", rand.Int())
+					} else if ti.eventType == model.DNSEventType {
+						ti.eventDnsReq = fmt.Sprintf("%d", rand.Int()) + baseDnsReq
+					}
+					ti.eventTimestampRaw = currentIncrement
+					event := craftFakeEvent(t0, &ti, defaultContainerID)
+					assert.Equal(t, ti.result, spm.tryAutolearn(profile, event))
+					currentIncrement += ti.loopIncrement
+				}
+			} else { // only run once
+				event := craftFakeEvent(t0, &ti, defaultContainerID)
+				assert.Equal(t, ti.result, spm.tryAutolearn(profile, event))
+			}
+
+			//TODO: also check profile stats and global metrics
+		})
+	}
+}

--- a/pkg/security/security_profile/profile/manager_test.go
+++ b/pkg/security/security_profile/profile/manager_test.go
@@ -39,8 +39,8 @@ type testIteration struct {
 func craftFakeEvent(t0 time.Time, ti *testIteration, defaultContainerID string) *model.Event {
 	event := model.NewDefaultEvent().(*model.Event)
 	event.Type = uint32(ti.eventType)
-	event.ContainerContext.CreatedAt = uint64(t0.Add(ti.containerCreatedAt).Unix()) * 1000000000
-	event.TimestampRaw = uint64(t0.Add(ti.eventTimestampRaw).Unix()) * 1000000000
+	event.ContainerContext.CreatedAt = uint64(t0.Add(ti.containerCreatedAt).UnixNano())
+	event.TimestampRaw = uint64(t0.Add(ti.eventTimestampRaw).UnixNano())
 	event.Timestamp = t0.Add(ti.eventTimestampRaw)
 
 	// setting process
@@ -598,7 +598,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 					},
 					WorkloadSelector: cgroupModel.WorkloadSelector{Image: "image", Tag: "tag"},
 				})
-				profile.loadedNano = uint64(t0.Unix()) * 1000000000
+				profile.loadedNano = uint64(t0.UnixNano())
 			}
 			profile.ActivityTree.Stats.ProcessNodes += ti.addFakeProcessNodes
 


### PR DESCRIPTION
### What does this PR do?

Rework needed to handle hands of corner cases.

Also, add 44 unitary tests around it


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
