### PR TITLE
[usm] Add ability to report payload telemetry

### DIFF
--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -16,7 +16,6 @@ import (
 
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/datadog-agent/pkg/network"
-	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
 
@@ -124,17 +123,18 @@ func FormatCompilationTelemetry(telByAsset map[string]network.RuntimeCompilation
 
 // FormatConnectionTelemetry converts telemetry from its internal representation to a protobuf message
 func FormatConnectionTelemetry(tel map[network.ConnTelemetryType]int64) map[string]int64 {
-	if tel == nil {
-		return nil
-	}
-
 	// Fetch USM payload telemetry
-	ret := telemetry.ReportPayloadTelemetry("")
+	ret := GetUSMPayloadTelemetry()
 
 	// Merge it with NPM telemetry
 	for k, v := range tel {
 		ret[string(k)] = v
 	}
+
+	if len(ret) == 0 {
+		return nil
+	}
+
 	return ret
 }
 

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -16,6 +16,7 @@ import (
 
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
 
@@ -127,7 +128,10 @@ func FormatConnectionTelemetry(tel map[network.ConnTelemetryType]int64) map[stri
 		return nil
 	}
 
-	ret := make(map[string]int64)
+	// Fetch USM payload telemetry
+	ret := telemetry.ReportPayloadTelemetry("")
+
+	// Merge it with NPM telemetry
 	for k, v := range tel {
 		ret[string(k)] = v
 	}

--- a/pkg/network/encoding/usm_payload_telemetry.go
+++ b/pkg/network/encoding/usm_payload_telemetry.go
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package encoding
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
+)
+
+// GetUSMPayloadTelemetry returns a map with all metrics that are meant to be sent as payload telemetry.
+//
+// In order to emit a new payload metric, make sure to use the option `telemetry.OptTelemetry`.
+// Example:
+// myMetric := telemetry.NewMetric("metric_name", telemetry.OptTelemetry)
+//
+// Finally, make sure to add an entry to pkg/network/event_common.go for the sake of documentation.
+func GetUSMPayloadTelemetry() map[string]int64 {
+	all := telemetry.ReportPayloadTelemetry("")
+	result := make(map[string]int64, len(all))
+
+	// Only return metrics that are explicitly declared in pkg/network/event_common.go
+	for _, metricName := range network.USMPayloadTelemetry {
+		v, ok := all[string(metricName)]
+		if !ok {
+			continue
+		}
+
+		result[string(metricName)] = v
+	}
+
+	return result
+}

--- a/pkg/network/encoding/usm_payload_telemetry.go
+++ b/pkg/network/encoding/usm_payload_telemetry.go
@@ -12,9 +12,9 @@ import (
 
 // GetUSMPayloadTelemetry returns a map with all metrics that are meant to be sent as payload telemetry.
 //
-// In order to emit a new payload metric, make sure to use the option `telemetry.OptTelemetry`.
+// In order to emit a new payload metric, make sure to use the option `telemetry.OptPayloadTelemetry`.
 // Example:
-// myMetric := telemetry.NewMetric("metric_name", telemetry.OptTelemetry)
+// myMetric := telemetry.NewMetric("metric_name", telemetry.OptPayloadTelemetry)
 //
 // Finally, make sure to add an entry to pkg/network/event_common.go for the sake of documentation.
 func GetUSMPayloadTelemetry() map[string]int64 {

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -160,6 +160,9 @@ const (
 	ConnsBpfMapSize                 ConnTelemetryType = "conns_bpf_map_size"
 	ConntrackSamplingPercent        ConnTelemetryType = "conntrack_sampling_percent"
 	NPMDriverFlowsMissedMaxExceeded ConnTelemetryType = "driver_flows_missed_max_exceeded"
+
+	// USM Payload Telemetry
+	USMHTTPHits ConnTelemetryType = "usm.http.total_hits"
 )
 
 //revive:enable
@@ -188,6 +191,11 @@ var (
 		MonotonicUDPSendsProcessed,
 		MonotonicUDPSendsMissed,
 		MonotonicDNSPacketsDropped,
+	}
+
+	// USMPayloadTelemetry lists all USM metrics that are sent as payload telemetry
+	USMPayloadTelemetry = []ConnTelemetryType{
+		USMHTTPHits,
 	}
 )
 

--- a/pkg/network/protocols/http/telemetry.go
+++ b/pkg/network/protocols/http/telemetry.go
@@ -52,7 +52,7 @@ func NewTelemetry() (*Telemetry, error) {
 		joinedIncomplete: metricGroup.NewMetric("joined_incomplete"),
 
 		// these metrics are also exported as statsd metrics
-		totalHits: metricGroup.NewMetric("total_hits", libtelemetry.OptStatsd),
+		totalHits: metricGroup.NewMetric("total_hits", libtelemetry.OptStatsd, libtelemetry.OptTelemetry),
 		dropped:   metricGroup.NewMetric("dropped", libtelemetry.OptStatsd),
 		rejected:  metricGroup.NewMetric("rejected", libtelemetry.OptStatsd),
 		malformed: metricGroup.NewMetric("malformed", libtelemetry.OptStatsd),

--- a/pkg/network/protocols/http/telemetry.go
+++ b/pkg/network/protocols/http/telemetry.go
@@ -52,7 +52,7 @@ func NewTelemetry() (*Telemetry, error) {
 		joinedIncomplete: metricGroup.NewMetric("joined_incomplete"),
 
 		// these metrics are also exported as statsd metrics
-		totalHits: metricGroup.NewMetric("total_hits", libtelemetry.OptStatsd, libtelemetry.OptTelemetry),
+		totalHits: metricGroup.NewMetric("total_hits", libtelemetry.OptStatsd, libtelemetry.OptPayloadTelemetry),
 		dropped:   metricGroup.NewMetric("dropped", libtelemetry.OptStatsd),
 		rejected:  metricGroup.NewMetric("rejected", libtelemetry.OptStatsd),
 		malformed: metricGroup.NewMetric("malformed", libtelemetry.OptStatsd),

--- a/pkg/network/protocols/telemetry/options.go
+++ b/pkg/network/protocols/telemetry/options.go
@@ -15,8 +15,8 @@ const (
 	// OptExpvar designates a metric that should be emitted using expvar
 	OptExpvar = "_expvar"
 
-	// OptTelemetry designates a metric that should be emitted as agent payload telemetry
-	OptTelemetry = "_telemetry"
+	// OptPayloadTelemetry designates a metric that should be emitted as agent payload telemetry
+	OptPayloadTelemetry = "_telemetry"
 
 	// OptGauge represents a gauge-type metric
 	OptGauge = "_gauge"

--- a/pkg/network/protocols/telemetry/reporters.go
+++ b/pkg/network/protocols/telemetry/reporters.go
@@ -38,10 +38,10 @@ func ReportStatsd() {
 
 var telemetryDelta deltaCalculator
 
-// ReportPayloadTelemetry returns a map with all metrics tagged with `OptTelemetry`
+// ReportPayloadTelemetry returns a map with all metrics tagged with `OptPayloadTelemetry`
 // The return format is consistent with what we use in the protobuf messages sent to the backend
 func ReportPayloadTelemetry(clientID string) map[string]int64 {
-	metrics := GetMetrics(OptTelemetry)
+	metrics := GetMetrics(OptPayloadTelemetry)
 	previousValues := telemetryDelta.GetState(clientID)
 	result := make(map[string]int64, len(metrics))
 	for _, metric := range metrics {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add ability to report payload metrics using the `protocols/telemetry` library.

In order to use it, simply use the option `telemetry.OptPayloadTelemetry` when creating a metric. For example:
```
m := telemetry.NewMetric("metric_name", telemetry.OptPayloadTelemetry)
```

### Motivation

We want to be able to graph certain metrics by OrgID in our backend

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Changes covered by unit tests

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
