### PR TITLE
[AP-2139] Add amazonlinux2023 to the kitchen tests

### DIFF
--- a/.gitlab/kitchen_testing/amazonlinux.yml
+++ b/.gitlab/kitchen_testing/amazonlinux.yml
@@ -21,8 +21,8 @@
 
 .kitchen_scenario_amazonlinux_a6_x64:
   variables:
-    KITCHEN_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15"
-    KITCHEN_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15"
+    KITCHEN_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
+    KITCHEN_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     DEFAULT_KITCHEN_OSVERS: "amazonlinux2-5-10"
   extends:
     - .kitchen_agent_a6
@@ -32,8 +32,8 @@
 
 .kitchen_scenario_amazonlinux_a7_x64:
   variables:
-    KITCHEN_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15"
-    KITCHEN_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15"
+    KITCHEN_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
+    KITCHEN_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     DEFAULT_KITCHEN_OSVERS: "amazonlinux2-5-10"
   extends:
     - .kitchen_agent_a7
@@ -43,8 +43,8 @@
 
 .kitchen_scenario_amazonlinux_a6_arm64:
   variables:
-    KITCHEN_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15"
-    KITCHEN_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15"
+    KITCHEN_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
+    KITCHEN_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     DEFAULT_KITCHEN_OSVERS: "amazonlinux2-5-10"
   extends:
     - .kitchen_agent_a6
@@ -54,8 +54,8 @@
 
 .kitchen_scenario_amazonlinux_a7_arm64:
   variables:
-    KITCHEN_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15"
-    KITCHEN_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15"
+    KITCHEN_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
+    KITCHEN_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     DEFAULT_KITCHEN_OSVERS: "amazonlinux2-5-10"
   extends:
     - .kitchen_agent_a7

--- a/.gitlab/kitchen_testing/amazonlinux.yml
+++ b/.gitlab/kitchen_testing/amazonlinux.yml
@@ -23,7 +23,7 @@
   variables:
     KITCHEN_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     KITCHEN_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
-    DEFAULT_KITCHEN_OSVERS: "amazonlinux2-5-10"
+    DEFAULT_KITCHEN_OSVERS: "amazonlinux2023"
   extends:
     - .kitchen_agent_a6
     - .kitchen_os_amazonlinux
@@ -34,7 +34,7 @@
   variables:
     KITCHEN_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     KITCHEN_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
-    DEFAULT_KITCHEN_OSVERS: "amazonlinux2-5-10"
+    DEFAULT_KITCHEN_OSVERS: "amazonlinux2023"
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_amazonlinux
@@ -45,7 +45,7 @@
   variables:
     KITCHEN_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     KITCHEN_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
-    DEFAULT_KITCHEN_OSVERS: "amazonlinux2-5-10"
+    DEFAULT_KITCHEN_OSVERS: "amazonlinux2023"
   extends:
     - .kitchen_agent_a6
     - .kitchen_os_amazonlinux
@@ -56,7 +56,7 @@
   variables:
     KITCHEN_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
     KITCHEN_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
-    DEFAULT_KITCHEN_OSVERS: "amazonlinux2-5-10"
+    DEFAULT_KITCHEN_OSVERS: "amazonlinux2023"
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_amazonlinux


### PR DESCRIPTION
### What does this PR do?
Add Amazon Linux 2023 to the kitchen tests

### Motivation
Test support on Amazon Linux 2023

### Additional Notes

### Possible Drawbacks / Trade-offs
This will increase the CI cost 


### Describe how to test/QA your changes
No QA

### Reviewer's Checklist
n/a

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
