### PR TITLE
Adjust default value for Oracle check interval

### DIFF
--- a/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
@@ -2,9 +2,9 @@
 #
 init_config:
 
-  ## @param min_collection_interval - int - optional - default:10
+  ## @param min_collection_interval - int - optional - default:15
   ## Active session sampling interval in seconds
-  # min_collection_interval: <interval_in_seconds>
+  min_collection_interval: 10
 
 ## Every instance is scheduled independent of the others.
 #

--- a/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
@@ -2,9 +2,9 @@
 #
 init_config:
 
-  ## @param min_collection_interval - int - optional - default:15
+  ## @param min_collection_interval - int - optional - default:10
   ## Active session sampling interval in seconds
-  min_collection_interval: 10
+  # min_collection_interval: <interval_in_seconds>
 
 ## Every instance is scheduled independent of the others.
 #

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -277,6 +277,10 @@ func (c *Check) Configure(integrationConfigDigest uint64, rawInstance integratio
 	c.agentVersion = agentVersion.GetNumberAndPre()
 
 	c.checkInterval = float64(c.config.InitConfig.MinCollectionInterval)
+	//if c.checkInterval == 15 {
+	c.checkInterval = 10
+	c.config.InitConfig.MinCollectionInterval = 10
+	//}
 	c.tags = c.config.Tags
 	c.tags = append(c.tags, fmt.Sprintf("dbms:%s", common.IntegrationName), fmt.Sprintf("ddagentversion:%s", c.agentVersion))
 
@@ -285,7 +289,7 @@ func (c *Check) Configure(integrationConfigDigest uint64, rawInstance integratio
 }
 
 func oracleFactory() check.Check {
-	return &Check{CheckBase: core.NewCheckBase(common.IntegrationNameScheduler)}
+	return &Check{CheckBase: core.NewCheckBaseWithInterval(common.IntegrationNameScheduler, 10*time.Second)}
 }
 
 func init() {

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -277,10 +277,6 @@ func (c *Check) Configure(integrationConfigDigest uint64, rawInstance integratio
 	c.agentVersion = agentVersion.GetNumberAndPre()
 
 	c.checkInterval = float64(c.config.InitConfig.MinCollectionInterval)
-	//if c.checkInterval == 15 {
-	c.checkInterval = 10
-	c.config.InitConfig.MinCollectionInterval = 10
-	//}
 	c.tags = c.config.Tags
 	c.tags = append(c.tags, fmt.Sprintf("dbms:%s", common.IntegrationName), fmt.Sprintf("ddagentversion:%s", c.agentVersion))
 


### PR DESCRIPTION
### What does this PR do?

Adjust interval for Oracle checks to 10s. (The default is 15s.)

### Motivation

Align the interval to match the existing database integrations. The default interval of 15s was causing problems with graph interpolation in MySQL, SQL Server and Postgres integrations. Also, a lower sampling interval is conducive to capturing more statements for statement statistics.

### Describe how to test/QA your changes

Check that there's no default interval:

```
init_config:
```

Check if the check is being started every 10s:

```
./bin/agent/agent run -c bin/agent/dist/datadog.yaml | grep -i "oracle-dbm.*running"
2023-06-09 09:36:33 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:38 in CheckStarted) | check:oracle-dbm | Running check...
2023-06-09 09:36:34 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:57 in CheckFinished) | check:oracle-dbm | Done running check
2023-06-09 09:36:43 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:38 in CheckStarted) | check:oracle-dbm | Running check...
2023-06-09 09:36:44 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:57 in CheckFinished) | check:oracle-dbm | Done running check
2023-06-09 09:36:53 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:38 in CheckStarted) | check:oracle-dbm | Running check...
2023-06-09 09:36:54 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:57 in CheckFinished) | check:oracle-dbm | Done running check
2023-06-09 09:37:03 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:38 in CheckStarted) | check:oracle-dbm | Running check...
2023-06-09 09:37:04 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:57 in CheckFinished) | check:oracle-dbm | Done running check
2023-06-09 09:37:13 CEST | CORE | INFO | (pkg/collector/worker/check_logger.go:38 in CheckStarted) | check:oracle-dbm | Running check...
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
