### PR TITLE
[CWS] Activity Tree paths reducer

### DIFF
--- a/cmd/security-agent/subcommands/runtime/activity_dump.go
+++ b/cmd/security-agent/subcommands/runtime/activity_dump.go
@@ -325,7 +325,7 @@ func generateEncodingFromActivityDump(log log.Component, config config.Component
 
 	} else {
 		// encoding request will be handled locally
-		ad := dump.NewEmptyActivityDump()
+		ad := dump.NewEmptyActivityDump(nil)
 
 		// open and parse input file
 		if err := ad.Decode(activityDumpArgs.file); err != nil {

--- a/pkg/security/secl/model/utils.go
+++ b/pkg/security/secl/model/utils.go
@@ -12,8 +12,11 @@ import (
 	"regexp"
 )
 
+// ContainerIDPatternStr is the pattern of a container ID
+var ContainerIDPatternStr = fmt.Sprintf(`([[:xdigit:]]{%v})`, sha256.Size*2)
+
 // containerIDPattern is the pattern of a container ID
-var containerIDPattern = regexp.MustCompile(fmt.Sprintf(`([[:xdigit:]]{%v})`, sha256.Size*2))
+var containerIDPattern = regexp.MustCompile(ContainerIDPatternStr)
 
 // FindContainerID extracts the first sub string that matches the pattern of a container ID
 func FindContainerID(s string) string {

--- a/pkg/security/security_profile/activity_tree/activity_tree_test.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_test.go
@@ -56,7 +56,7 @@ func TestInsertFileEvent(t *testing.T) {
 			},
 			FieldHandlers: &model.DefaultFieldHandlers{},
 		}
-		pan.InsertFileEvent(&event.Open.File, event, Unknown, stats, false)
+		pan.InsertFileEvent(&event.Open.File, event, Unknown, stats, false, nil)
 	}
 
 	var builder strings.Builder

--- a/pkg/security/security_profile/activity_tree/paths_reducer.go
+++ b/pkg/security/security_profile/activity_tree/paths_reducer.go
@@ -1,0 +1,156 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package activity_tree
+
+import (
+	"regexp"
+	"strconv"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
+
+// PathsReducer is used to reduce the paths in an activity tree according to predefined heuristics
+type PathsReducer struct {
+	patterns        *regexp.Regexp
+	callbackFuncs   map[int]func(ctx *callbackContext)
+	callbackIndexes []int
+}
+
+// PatternReducer is used to reduce the paths in an activity tree according to a given pattern
+type PatternReducer struct {
+	Pattern            string
+	GroupIndexCallback int
+	GroupCount         int
+	Callback           func(ctx *callbackContext)
+}
+
+// callbackContext is the input struct for the callback function
+type callbackContext struct {
+	start       int
+	end         int
+	path        string
+	fileEvent   *model.FileEvent
+	processNode *ProcessNode
+}
+
+// NewPathsReducer returns a new PathsReducer
+func NewPathsReducer() *PathsReducer {
+	patterns := getPathsReducerPatterns()
+	patternsCount := len(patterns)
+
+	r := &PathsReducer{
+		callbackFuncs:   make(map[int]func(ctx *callbackContext), patternsCount),
+		callbackIndexes: make([]int, patternsCount),
+	}
+
+	var fullPattern string
+	var groupCount int
+	for i, pattern := range patterns {
+		if i > 0 {
+			fullPattern += "|"
+		}
+		fullPattern += pattern.Pattern
+
+		r.callbackFuncs[groupCount+pattern.GroupIndexCallback] = pattern.Callback
+		r.callbackIndexes[patternsCount-1-i] = pattern.GroupIndexCallback + groupCount
+		groupCount += pattern.GroupCount
+	}
+
+	r.patterns = regexp.MustCompile(fullPattern)
+	return r
+}
+
+// ReducePath reduces a path according to the predefined heuristics
+func (r *PathsReducer) ReducePath(path string, fileEvent *model.FileEvent, node *ProcessNode) string {
+	ctx := &callbackContext{
+		path:        path,
+		fileEvent:   fileEvent,
+		processNode: node,
+	}
+
+	allMatches := r.patterns.FindAllStringSubmatchIndex(path, -1)
+	for matchSet := len(allMatches) - 1; matchSet >= 0; matchSet-- {
+		matches := allMatches[matchSet]
+		for _, i := range r.callbackIndexes {
+			if r.callbackFuncs[i] != nil && matches[2*i] != -1 && matches[2*i+1] != -1 {
+				ctx.start = matches[2*i]
+				ctx.end = matches[2*i+1]
+				r.callbackFuncs[i](ctx)
+			}
+		}
+	}
+	return ctx.path
+}
+
+// getPathsReducerPatterns returns the patterns used to reduce the paths in an activity tree
+func getPathsReducerPatterns() []PatternReducer {
+	return []PatternReducer{
+		{
+			Pattern:            "(/proc/(\\d+))", // process PID
+			GroupIndexCallback: 2,
+			GroupCount:         2,
+			Callback: func(ctx *callbackContext) {
+				// compute pid from path
+				pid, err := strconv.Atoi(ctx.path[ctx.start:ctx.end])
+				if err != nil {
+					return
+				}
+				// replace the pid in the path between start and end with a * only if the replaced pid is not the pid of the process node
+				if ctx.processNode.Process.Pid == uint32(pid) {
+					ctx.path = ctx.path[:ctx.start] + "self" + ctx.path[ctx.end:]
+				} else {
+					ctx.path = ctx.path[:ctx.start] + "*" + ctx.path[ctx.end:]
+				}
+			},
+		},
+		{
+			Pattern:            "(/task/(\\d+))", // process TID
+			GroupIndexCallback: 2,
+			GroupCount:         2,
+			Callback: func(ctx *callbackContext) {
+				ctx.path = ctx.path[:ctx.start] + "*" + ctx.path[ctx.end:]
+			},
+		},
+		{
+			Pattern:            "((kubepods-|cri-containerd-)([^/]*)\\.(slice|scope))", // kubernetes cgroup
+			GroupIndexCallback: 3,
+			GroupCount:         4,
+			Callback: func(ctx *callbackContext) {
+				if ctx.fileEvent.Filesystem == "sysfs" {
+					ctx.path = ctx.path[:ctx.start] + "*" + ctx.path[ctx.end:]
+				}
+			},
+		},
+		{
+			Pattern:            model.ContainerIDPatternStr, // container ID
+			GroupIndexCallback: 1,
+			GroupCount:         1,
+			Callback: func(ctx *callbackContext) {
+				ctx.path = ctx.path[:ctx.start] + "*" + ctx.path[ctx.end:]
+			},
+		},
+		{
+			Pattern:            "(/sys/devices/virtual/block/(dm-|loop)([0-9]+))", // block devices
+			GroupIndexCallback: 3,
+			GroupCount:         3,
+			Callback: func(ctx *callbackContext) {
+				if ctx.fileEvent.Filesystem == "sysfs" {
+					ctx.path = ctx.path[:ctx.start] + "*" + ctx.path[ctx.end:]
+				}
+			},
+		},
+		{
+			Pattern:            "(secrets/kubernetes.io/serviceaccount/([0-9._]+))", // service account token date
+			GroupIndexCallback: 2,
+			GroupCount:         2,
+			Callback: func(ctx *callbackContext) {
+				ctx.path = ctx.path[:ctx.start] + "*" + ctx.path[ctx.end:]
+			},
+		},
+	}
+}

--- a/pkg/security/security_profile/activity_tree/paths_reducer_test.go
+++ b/pkg/security/security_profile/activity_tree/paths_reducer_test.go
@@ -1,0 +1,235 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package activity_tree
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
+
+type input struct {
+	path        string
+	fileEvent   *model.FileEvent
+	processNode *ProcessNode
+}
+
+var tests = []struct {
+	name  string
+	input input
+	want  string
+}{
+	{
+		name: "proc_1",
+		input: input{
+			path:      "/host/proc/2144/smaps",
+			fileEvent: &model.FileEvent{},
+			processNode: &ProcessNode{
+				Process: model.Process{
+					PIDContext: model.PIDContext{
+						Pid: 2144,
+					},
+				},
+			},
+		},
+		want: "/host/proc/self/smaps",
+	},
+	{
+		name: "proc_2",
+		input: input{
+			path:      "/proc/2144/status",
+			fileEvent: &model.FileEvent{},
+			processNode: &ProcessNode{
+				Process: model.Process{
+					PIDContext: model.PIDContext{
+						Pid: 2,
+					},
+				},
+			},
+		},
+		want: "/proc/*/status",
+	},
+	{
+		name: "proc_3",
+		input: input{
+			path:      "/proc/self/exe",
+			fileEvent: &model.FileEvent{},
+			processNode: &ProcessNode{
+				Process: model.Process{
+					PIDContext: model.PIDContext{
+						Pid: 2,
+					},
+				},
+			},
+		},
+		want: "/proc/self/exe",
+	},
+	{
+		name: "proc_4",
+		input: input{
+			path:      "/host/proc/1/smaps",
+			fileEvent: &model.FileEvent{},
+			processNode: &ProcessNode{
+				Process: model.Process{
+					PIDContext: model.PIDContext{
+						Pid: 2144,
+					},
+				},
+			},
+		},
+		want: "/host/proc/*/smaps",
+	},
+	{
+		name: "proc_task_1",
+		input: input{
+			path:      "/host/proc/2144/task/2144/smaps",
+			fileEvent: &model.FileEvent{},
+			processNode: &ProcessNode{
+				Process: model.Process{
+					PIDContext: model.PIDContext{
+						Pid: 2144,
+					},
+				},
+			},
+		},
+		want: "/host/proc/self/task/*/smaps",
+	},
+	{
+		name: "proc_task_1",
+		input: input{
+			path:      "/host/proc/self/task/2144/smaps",
+			fileEvent: &model.FileEvent{},
+			processNode: &ProcessNode{
+				Process: model.Process{
+					PIDContext: model.PIDContext{
+						Pid: 2,
+					},
+				},
+			},
+		},
+		want: "/host/proc/self/task/*/smaps",
+	},
+	{
+		name: "cgroup_1",
+		input: input{
+			path: "/sys/fs/cgroup/kubepods.slice/kubepods-pod13asf23dasf3.slice/kubepods.slice/cri-containerd-3i47135.scope/cpuset.threads",
+			fileEvent: &model.FileEvent{
+				Filesystem: "sysfs",
+			},
+		},
+		want: "/sys/fs/cgroup/kubepods.slice/kubepods-*.slice/kubepods.slice/cri-containerd-*.scope/cpuset.threads",
+	},
+	{
+		name: "proc_cgroup_1",
+		input: input{
+			path: "/host/proc/1/root/sys/fs/cgroup/kubepods.slice/kubepods-pod13asf23dasf3.slice/kubepods.slice/cri-containerd-3i47135.scope/cpuset.threads",
+			fileEvent: &model.FileEvent{
+				Filesystem: "sysfs",
+			},
+			processNode: &ProcessNode{
+				Process: model.Process{
+					PIDContext: model.PIDContext{
+						Pid: 2,
+					},
+				},
+			},
+		},
+		want: "/host/proc/*/root/sys/fs/cgroup/kubepods.slice/kubepods-*.slice/kubepods.slice/cri-containerd-*.scope/cpuset.threads",
+	},
+	{
+		name: "container_id_1",
+		input: input{
+			path: "/var/run/docker/overlay2/47c1f1930c1831f2359c6d276912c583be1cda5924233cf273022b91763a20f7/merged/etc/passwd",
+			fileEvent: &model.FileEvent{
+				Filesystem: "sysfs",
+			},
+		},
+		want: "/var/run/docker/overlay2/*/merged/etc/passwd",
+	},
+	{
+		name: "block_device_1",
+		input: input{
+			path: "/host/proc/self/root/sys/devices/virtual/block/dm-0",
+			fileEvent: &model.FileEvent{
+				Filesystem: "sysfs",
+			},
+		},
+		want: "/host/proc/self/root/sys/devices/virtual/block/dm-*",
+	},
+	{
+		name: "block_device_2",
+		input: input{
+			path: "/sys/devices/virtual/block/loop1234",
+			fileEvent: &model.FileEvent{
+				Filesystem: "sysfs",
+			},
+		},
+		want: "/sys/devices/virtual/block/loop*",
+	},
+	{
+		name: "k8s_service_account_secret_1",
+		input: input{
+			path: "/run/secrets/kubernetes.io/serviceaccount/..2023_05_25_09_34_13.734441344/token",
+		},
+		want: "/run/secrets/kubernetes.io/serviceaccount/*/token",
+	},
+}
+
+func TestPathsReducer_ReducePath(t *testing.T) {
+	r := NewPathsReducer()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, r.ReducePath(tt.input.path, tt.input.fileEvent, tt.input.processNode), "ReducePath(%v)", tt.input)
+		})
+	}
+}
+
+// ---------------------------
+// | Output of the benchmark |
+// ---------------------------
+//
+// BenchmarkPathsReducer_ReducePath
+// BenchmarkPathsReducer_ReducePath/proc_1
+// BenchmarkPathsReducer_ReducePath/proc_1-16         	  652135	      2072 ns/op	     555 B/op	       4 allocs/op
+// BenchmarkPathsReducer_ReducePath/proc_2
+// BenchmarkPathsReducer_ReducePath/proc_2-16         	  724998	      1690 ns/op	     549 B/op	       4 allocs/op
+// BenchmarkPathsReducer_ReducePath/proc_3
+// BenchmarkPathsReducer_ReducePath/proc_3-16         	  618006	      1974 ns/op	      48 B/op	       1 allocs/op
+// BenchmarkPathsReducer_ReducePath/proc_4
+// BenchmarkPathsReducer_ReducePath/proc_4-16         	  654654	      2148 ns/op	     556 B/op	       4 allocs/op
+// BenchmarkPathsReducer_ReducePath/proc_task_1
+// BenchmarkPathsReducer_ReducePath/proc_task_1-16    	  481893	      2703 ns/op	     839 B/op	       6 allocs/op
+// BenchmarkPathsReducer_ReducePath/proc_task_1#01
+// BenchmarkPathsReducer_ReducePath/proc_task_1#01-16 	  334278	      3932 ns/op	     563 B/op	       4 allocs/op
+// BenchmarkPathsReducer_ReducePath/cgroup_1
+// BenchmarkPathsReducer_ReducePath/cgroup_1-16       	  102973	     11161 ns/op	    1012 B/op	       6 allocs/op
+// BenchmarkPathsReducer_ReducePath/proc_cgroup_1
+// BenchmarkPathsReducer_ReducePath/proc_cgroup_1-16  	   94389	     12676 ns/op	    1417 B/op	       8 allocs/op
+// BenchmarkPathsReducer_ReducePath/container_id_1
+// BenchmarkPathsReducer_ReducePath/container_id_1-16 	  173617	      6567 ns/op	     580 B/op	       4 allocs/op
+// BenchmarkPathsReducer_ReducePath/block_device_1
+// BenchmarkPathsReducer_ReducePath/block_device_1-16 	  403512	      3135 ns/op	     595 B/op	       4 allocs/op
+// BenchmarkPathsReducer_ReducePath/block_device_2
+// BenchmarkPathsReducer_ReducePath/block_device_2-16 	 1000000	      1135 ns/op	     565 B/op	       4 allocs/op
+// BenchmarkPathsReducer_ReducePath/k8s_service_account_secret_1
+// BenchmarkPathsReducer_ReducePath/k8s_service_account_secret_1-16         	  478562	      2477 ns/op	     595 B/op	       4 allocs/op
+
+func BenchmarkPathsReducer_ReducePath(b *testing.B) {
+	r := NewPathsReducer()
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(caseB *testing.B) {
+			for i := 0; i < caseB.N; i++ {
+				r.ReducePath(tt.input.path, tt.input.fileEvent, tt.input.processNode)
+			}
+		})
+	}
+}

--- a/pkg/security/security_profile/activity_tree/process_node.go
+++ b/pkg/security/security_profile/activity_tree/process_node.go
@@ -147,12 +147,16 @@ newSyscallLoop:
 
 // InsertFileEvent inserts the provided file event in the current node. This function returns true if a new entry was
 // added, false if the event was dropped.
-func (pn *ProcessNode) InsertFileEvent(fileEvent *model.FileEvent, event *model.Event, generationType NodeGenerationType, stats *ActivityTreeStats, dryRun bool) bool {
+func (pn *ProcessNode) InsertFileEvent(fileEvent *model.FileEvent, event *model.Event, generationType NodeGenerationType, stats *ActivityTreeStats, dryRun bool, reducer *PathsReducer) bool {
 	var filePath string
 	if generationType != Snapshot {
 		filePath = event.FieldHandlers.ResolveFilePath(event, fileEvent)
 	} else {
 		filePath = fileEvent.PathnameStr
+	}
+
+	if reducer != nil {
+		filePath = reducer.ReducePath(filePath, fileEvent, pn)
 	}
 
 	parent, nextParentIndex := ExtractFirstParent(filePath)
@@ -162,22 +166,22 @@ func (pn *ProcessNode) InsertFileEvent(fileEvent *model.FileEvent, event *model.
 
 	child, ok := pn.Files[parent]
 	if ok {
-		return child.InsertFileEvent(fileEvent, event, fileEvent.PathnameStr[nextParentIndex:], generationType, stats, dryRun)
+		return child.InsertFileEvent(fileEvent, event, filePath[nextParentIndex:], generationType, stats, dryRun, filePath)
 	}
 
 	if !dryRun {
 		// create new child
 		if len(fileEvent.PathnameStr) <= nextParentIndex+1 {
 			// this is the last child, add the fileEvent context at the leaf of the files tree.
-			node := NewFileNode(fileEvent, event, parent, generationType)
+			node := NewFileNode(fileEvent, event, parent, generationType, filePath)
 			node.MatchedRules = model.AppendMatchedRule(node.MatchedRules, event.Rules)
 			stats.FileNodes++
 			pn.Files[parent] = node
 		} else {
 			// This is an intermediary node in the branch that leads to the leaf we want to add. Create a node without the
 			// fileEvent context.
-			newChild := NewFileNode(nil, nil, parent, generationType)
-			newChild.InsertFileEvent(fileEvent, event, fileEvent.PathnameStr[nextParentIndex:], generationType, stats, dryRun)
+			newChild := NewFileNode(nil, nil, parent, generationType, filePath)
+			newChild.InsertFileEvent(fileEvent, event, fileEvent.PathnameStr[nextParentIndex:], generationType, stats, dryRun, filePath)
 			stats.FileNodes++
 			pn.Files[parent] = newChild
 		}

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -31,10 +31,10 @@ import (
 )
 
 // snapshot uses procfs to retrieve information about the current process
-func (pn *ProcessNode) snapshot(owner ActivityTreeOwner, stats *ActivityTreeStats, newEvent func() *model.Event) {
+func (pn *ProcessNode) snapshot(owner ActivityTreeOwner, stats *ActivityTreeStats, newEvent func() *model.Event, reducer *PathsReducer) {
 	// call snapshot for all the children of the current node
 	for _, child := range pn.Children {
-		child.snapshot(owner, stats, newEvent)
+		child.snapshot(owner, stats, newEvent, reducer)
 		// iterate slowly
 		time.Sleep(50 * time.Millisecond)
 	}
@@ -48,7 +48,7 @@ func (pn *ProcessNode) snapshot(owner ActivityTreeOwner, stats *ActivityTreeStat
 
 	// snapshot files
 	if owner.IsEventTypeValid(model.FileOpenEventType) {
-		pn.snapshotFiles(p, stats, newEvent)
+		pn.snapshotFiles(p, stats, newEvent, reducer)
 	}
 
 	// snapshot sockets
@@ -57,7 +57,7 @@ func (pn *ProcessNode) snapshot(owner ActivityTreeOwner, stats *ActivityTreeStat
 	}
 }
 
-func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *ActivityTreeStats, newEvent func() *model.Event) {
+func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *ActivityTreeStats, newEvent func() *model.Event, reducer *PathsReducer) {
 	// list the files opened by the process
 	fileFDs, err := p.OpenFiles()
 	if err != nil {
@@ -120,7 +120,7 @@ func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *ActivityTreeStat
 		evt.Open.File.Mode = evt.Open.File.FileFields.Mode
 		// TODO: add open flags by parsing `/proc/[pid]/fdinfo/fd` + O_RDONLY|O_CLOEXEC for the shared libs
 
-		_ = pn.InsertFileEvent(&evt.Open.File, evt, Snapshot, stats, false)
+		_ = pn.InsertFileEvent(&evt.Open.File, evt, Snapshot, stats, false, reducer)
 	}
 }
 

--- a/pkg/security/security_profile/dump/activity_dump.go
+++ b/pkg/security/security_profile/dump/activity_dump.go
@@ -114,13 +114,13 @@ func NewActivityDumpLoadConfig(evt []model.EventType, timeout time.Duration, wai
 }
 
 // NewEmptyActivityDump returns a new zero-like instance of an ActivityDump
-func NewEmptyActivityDump() *ActivityDump {
+func NewEmptyActivityDump(pathsReducer *activity_tree.PathsReducer) *ActivityDump {
 	ad := &ActivityDump{
 		Mutex:           &sync.Mutex{},
 		StorageRequests: make(map[config.StorageFormat][]config.StorageRequest),
 		DNSNames:        utils.NewStringKeys(nil),
 	}
-	ad.ActivityTree = activity_tree.NewActivityTree(ad, "activity_dump")
+	ad.ActivityTree = activity_tree.NewActivityTree(ad, pathsReducer, "activity_dump")
 	return ad
 }
 
@@ -129,7 +129,7 @@ type WithDumpOption func(ad *ActivityDump)
 
 // NewActivityDump returns a new instance of an ActivityDump
 func NewActivityDump(adm *ActivityDumpManager, options ...WithDumpOption) *ActivityDump {
-	ad := NewEmptyActivityDump()
+	ad := NewEmptyActivityDump(adm.pathsReducer)
 	now := time.Now()
 	ad.Metadata = mtdt.Metadata{
 		AgentVersion:      version.AgentVersion,
@@ -179,7 +179,7 @@ func NewActivityDumpFromMessage(msg *api.ActivityDumpMessage) (*ActivityDump, er
 		return nil, fmt.Errorf("couldn't parse timeout [%s]: %w", metadata.GetTimeout(), err)
 	}
 
-	ad := NewEmptyActivityDump()
+	ad := NewEmptyActivityDump(nil)
 	ad.Host = msg.GetHost()
 	ad.Service = msg.GetService()
 	ad.Source = msg.GetSource()
@@ -829,7 +829,12 @@ func (ad *ActivityDump) DecodeProtobuf(reader io.Reader) error {
 		return fmt.Errorf("couldn't decode protobuf activity dump file: %w", err)
 	}
 
-	protoToActivityDump(ad, inter)
+	var pathsReducer *activity_tree.PathsReducer
+	if ad.adm != nil {
+		pathsReducer = ad.adm.pathsReducer
+	}
+
+	protoToActivityDump(ad, pathsReducer, inter)
 
 	return nil
 }
@@ -849,7 +854,12 @@ func (ad *ActivityDump) DecodeProfileProtobuf(reader io.Reader) error {
 		return fmt.Errorf("couldn't decode protobuf activity dump file: %w", err)
 	}
 
-	securityProfileProtoToActivityDump(ad, inter)
+	var reducer *activity_tree.PathsReducer
+	if ad.adm != nil {
+		reducer = ad.adm.pathsReducer
+	}
+
+	securityProfileProtoToActivityDump(ad, reducer, inter)
 
 	return nil
 }
@@ -872,7 +882,7 @@ func (ad *ActivityDump) DecodeJSON(reader io.Reader) error {
 		return fmt.Errorf("couldn't decode json file: %w", err)
 	}
 
-	protoToActivityDump(ad, inter)
+	protoToActivityDump(ad, ad.adm.pathsReducer, inter)
 
 	return nil
 }

--- a/pkg/security/security_profile/dump/activity_dump_profile_proto_dec_v1.go
+++ b/pkg/security/security_profile/dump/activity_dump_profile_proto_dec_v1.go
@@ -15,7 +15,7 @@ import (
 	mtdt "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree/metadata"
 )
 
-func securityProfileProtoToActivityDump(dest *ActivityDump, ad *proto.SecurityProfile) {
+func securityProfileProtoToActivityDump(dest *ActivityDump, pathsReducer *activity_tree.PathsReducer, ad *proto.SecurityProfile) {
 	if ad == nil {
 		return
 	}
@@ -26,6 +26,6 @@ func securityProfileProtoToActivityDump(dest *ActivityDump, ad *proto.SecurityPr
 	copy(dest.Tags, ad.Tags)
 	dest.StorageRequests = make(map[config.StorageFormat][]config.StorageRequest)
 
-	dest.ActivityTree = activity_tree.NewActivityTree(dest, "activity_dump")
+	dest.ActivityTree = activity_tree.NewActivityTree(dest, pathsReducer, "activity_dump")
 	activity_tree.ProtoDecodeActivityTree(dest.ActivityTree, ad.Tree)
 }

--- a/pkg/security/security_profile/dump/activity_dump_proto_dec_v1.go
+++ b/pkg/security/security_profile/dump/activity_dump_proto_dec_v1.go
@@ -15,7 +15,7 @@ import (
 	mtdt "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree/metadata"
 )
 
-func protoToActivityDump(dest *ActivityDump, ad *adproto.SecDump) {
+func protoToActivityDump(dest *ActivityDump, pathsReducer *activity_tree.PathsReducer, ad *adproto.SecDump) {
 	if ad == nil {
 		return
 	}
@@ -29,6 +29,6 @@ func protoToActivityDump(dest *ActivityDump, ad *adproto.SecDump) {
 	copy(dest.Tags, ad.Tags)
 	dest.StorageRequests = make(map[config.StorageFormat][]config.StorageRequest)
 
-	dest.ActivityTree = activity_tree.NewActivityTree(dest, "activity_dump")
+	dest.ActivityTree = activity_tree.NewActivityTree(dest, pathsReducer, "activity_dump")
 	activity_tree.ProtoDecodeActivityTree(dest.ActivityTree, ad.Tree)
 }

--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -80,6 +80,7 @@ type ActivityDumpManager struct {
 	contextTags         []string
 	hostname            string
 	lastStoppedDumpTime time.Time
+	pathsReducer        *activity_tree.PathsReducer
 }
 
 // Start runs the ActivityDumpManager
@@ -286,6 +287,7 @@ func NewActivityDumpManager(config *config.Config, statsdClient statsd.ClientInt
 		snapshotQueue:          make(chan *ActivityDump, 100),
 		ignoreFromSnapshot:     make(map[string]bool),
 		dumpLimiter:            limiter,
+		pathsReducer:           activity_tree.NewPathsReducer(),
 	}
 
 	adm.storage, err = NewActivityDumpStorageManager(config, statsdClient, adm)

--- a/pkg/security/security_profile/profile/manager.go
+++ b/pkg/security/security_profile/profile/manager.go
@@ -138,6 +138,7 @@ type SecurityProfileManager struct {
 	cacheMiss        *atomic.Uint64
 
 	eventFiltering map[eventFilteringEntry]*atomic.Uint64
+	pathsReducer   *activity_tree.PathsReducer
 }
 
 // NewSecurityProfileManager returns a new instance of SecurityProfileManager
@@ -191,6 +192,7 @@ func NewSecurityProfileManager(config *config.Config, statsdClient statsd.Client
 		cacheHit:                   atomic.NewUint64(0),
 		cacheMiss:                  atomic.NewUint64(0),
 		eventFiltering:             make(map[eventFilteringEntry]*atomic.Uint64),
+		pathsReducer:               activity_tree.NewPathsReducer(),
 	}
 	m.initMetricsMap()
 
@@ -467,7 +469,7 @@ func (m *SecurityProfileManager) OnNewProfileEvent(selector cgroupModel.Workload
 	profile.loadedInKernel = false
 
 	// decode the content of the profile
-	ProtoToSecurityProfile(profile, newProfile)
+	ProtoToSecurityProfile(profile, m.pathsReducer, newProfile)
 	profile.ActivityTree.DNSMatchMaxDepth = m.config.RuntimeSecurity.SecurityProfileDNSMatchMaxDepth
 
 	// compute activity tree initial stats

--- a/pkg/security/security_profile/profile/manager_test.go
+++ b/pkg/security/security_profile/profile/manager_test.go
@@ -14,12 +14,13 @@ import (
 	"time"
 	"unsafe"
 
+	"go.uber.org/atomic"
+	"gotest.tools/assert"
+
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
-	"go.uber.org/atomic"
-	"gotest.tools/assert"
 )
 
 type testIteration struct {
@@ -591,7 +592,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 		t.Run(ti.name, func(t *testing.T) {
 			if ti.newProfile || profile == nil {
 				profile = NewSecurityProfile(cgroupModel.WorkloadSelector{Image: "image", Tag: "tag"}, []model.EventType{model.ExecEventType, model.DNSEventType})
-				profile.ActivityTree = activity_tree.NewActivityTree(profile, "security_profile")
+				profile.ActivityTree = activity_tree.NewActivityTree(profile, nil, "security_profile")
 				profile.Instances = append(profile.Instances, &cgroupModel.CacheEntry{
 					ContainerContext: model.ContainerContext{
 						ID: defaultContainerID,
@@ -622,7 +623,7 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 				assert.Equal(t, ti.result, spm.tryAutolearn(profile, event))
 			}
 
-			//TODO: also check profile stats and global metrics
+			// TODO: also check profile stats and global metrics
 		})
 	}
 }

--- a/pkg/security/security_profile/profile/profile_proto_dec_v1.go
+++ b/pkg/security/security_profile/profile/profile_proto_dec_v1.go
@@ -16,7 +16,7 @@ import (
 )
 
 // ProtoToSecurityProfile decodes a Security Profile from its protobuf representation
-func ProtoToSecurityProfile(output *SecurityProfile, input *proto.SecurityProfile) {
+func ProtoToSecurityProfile(output *SecurityProfile, pathsReducer *activity_tree.PathsReducer, input *proto.SecurityProfile) {
 	if input == nil {
 		return
 	}
@@ -31,6 +31,6 @@ func ProtoToSecurityProfile(output *SecurityProfile, input *proto.SecurityProfil
 	output.Syscalls = make([]uint32, len(input.Syscalls))
 	copy(output.Syscalls, input.Syscalls)
 
-	output.ActivityTree = activity_tree.NewActivityTree(output, "security_profile")
+	output.ActivityTree = activity_tree.NewActivityTree(output, pathsReducer, "security_profile")
 	activity_tree.ProtoDecodeActivityTree(output.ActivityTree, input.Tree)
 }

--- a/pkg/security/tests/activity_dumps_encoding_test.go
+++ b/pkg/security/tests/activity_dumps_encoding_test.go
@@ -22,7 +22,7 @@ import (
 var v1testdata []byte
 
 func getTestDataActivityDump(tb testing.TB) *dump.ActivityDump {
-	ad := dump.NewEmptyActivityDump()
+	ad := dump.NewEmptyActivityDump(nil)
 	if err := ad.DecodeFromReader(bytes.NewReader(v1testdata), config.Protobuf); err != nil {
 		tb.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestProtobufDecoding(t *testing.T) {
 }
 
 func decodeAD(buffer *bytes.Buffer) (*dump.ActivityDump, error) {
-	decoded := dump.NewEmptyActivityDump()
+	decoded := dump.NewEmptyActivityDump(nil)
 	if err := decoded.DecodeProtobuf(bytes.NewReader(buffer.Bytes())); err != nil {
 		return nil, err
 	}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -1834,7 +1834,7 @@ func DecodeSecurityProfile(path string) (*profile.SecurityProfile, error) {
 	if newProfile == nil {
 		return nil, errors.New("Profile creation")
 	}
-	profile.ProtoToSecurityProfile(newProfile, protoProfile)
+	profile.ProtoToSecurityProfile(newProfile, nil, protoProfile)
 	return newProfile, nil
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR introduces the ability to reduce the paths we insert in a dump or profile in order to prevent obvious patterns from blowing up our configured thresholds. The following patterns were added:
- `(/proc/(\d+))` and `(/task/(\d+))` are used to prevent a process `{PID}` from being inserted in a dump. An additional check was added to replace the number by `self` instead of `*` when applicable.
- `((kubepods-|cri-containerd-)([^/]*)\.(slice|scope))` and `([[:xdigit:]]{64})` are used to prevent generated cgroup paths from being inserted. An additional check on the filesystem was added.
- `(/sys/devices/virtual/block/(dm-|loop)([0-9]+))` was added to prevent block device names from being inserted.
- `(secrets/kubernetes.io/serviceaccount/([0-9._]+))` as added to prevent dates from being added.

#### Benchmark output

```
BenchmarkPathsReducer_ReducePath
BenchmarkPathsReducer_ReducePath/proc_1
BenchmarkPathsReducer_ReducePath/proc_1-16         	  652135	      2072 ns/op	     555 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/proc_2
BenchmarkPathsReducer_ReducePath/proc_2-16         	  724998	      1690 ns/op	     549 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/proc_3
BenchmarkPathsReducer_ReducePath/proc_3-16         	  618006	      1974 ns/op	      48 B/op	       1 allocs/op
BenchmarkPathsReducer_ReducePath/proc_4
BenchmarkPathsReducer_ReducePath/proc_4-16         	  654654	      2148 ns/op	     556 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/proc_task_1
BenchmarkPathsReducer_ReducePath/proc_task_1-16    	  481893	      2703 ns/op	     839 B/op	       6 allocs/op
BenchmarkPathsReducer_ReducePath/proc_task_1#01
BenchmarkPathsReducer_ReducePath/proc_task_1#01-16 	  334278	      3932 ns/op	     563 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/cgroup_1
BenchmarkPathsReducer_ReducePath/cgroup_1-16       	  102973	     11161 ns/op	    1012 B/op	       6 allocs/op
BenchmarkPathsReducer_ReducePath/proc_cgroup_1
BenchmarkPathsReducer_ReducePath/proc_cgroup_1-16  	   94389	     12676 ns/op	    1417 B/op	       8 allocs/op
BenchmarkPathsReducer_ReducePath/container_id_1
BenchmarkPathsReducer_ReducePath/container_id_1-16 	  173617	      6567 ns/op	     580 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/block_device_1
BenchmarkPathsReducer_ReducePath/block_device_1-16 	  403512	      3135 ns/op	     595 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/block_device_2
BenchmarkPathsReducer_ReducePath/block_device_2-16 	 1000000	      1135 ns/op	     565 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/k8s_service_account_secret_1
BenchmarkPathsReducer_ReducePath/k8s_service_account_secret_1-16         	  478562	      2477 ns/op	     595 B/op	       4 allocs/op
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This will help keep the dumps and profiles size in check in some obvious cases.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
