### PR TITLE
[Gohai][ASC-471] implement cpu collection using sysctl syscall

### DIFF
--- a/pkg/gohai/cpu/cpu_darwin.go
+++ b/pkg/gohai/cpu/cpu_darwin.go
@@ -6,38 +6,51 @@
 package cpu
 
 import (
-	"os/exec"
-	"strconv"
-	"strings"
+	"fmt"
+
+	"golang.org/x/sys/unix"
 )
 
-var cpuMap = map[string]string{
+var cpuMapString = map[string]string{
 	"machdep.cpu.vendor":       "vendor_id",
 	"machdep.cpu.brand_string": "model_name",
-	"hw.physicalcpu":           "cpu_cores",
-	"hw.logicalcpu":            "cpu_logical_processors",
-	"hw.cpufrequency":          "mhz",
-	"machdep.cpu.family":       "family",
-	"machdep.cpu.model":        "model",
-	"machdep.cpu.stepping":     "stepping",
 }
 
-func getCPUInfo() (cpuInfo map[string]string, err error) {
-	cpuInfo = make(map[string]string)
+var cpuMapInt32 = map[string]string{
+	"machdep.cpu.family":   "family",
+	"machdep.cpu.model":    "model",
+	"machdep.cpu.stepping": "stepping",
+	"hw.physicalcpu":       "cpu_cores",
+	"hw.logicalcpu":        "cpu_logical_processors",
+}
 
-	for option, key := range cpuMap {
-		out, err := exec.Command("sysctl", "-n", option).Output()
-		if err == nil {
-			cpuInfo[key] = strings.Trim(string(out), "\n")
+// use `man 3 sysctl` to see the type returned when using each option
+func getCPUInfo() (map[string]string, error) {
+	cpuInfo := make(map[string]string)
+
+	// type returned by sysctl is string
+	for option, key := range cpuMapString {
+		if value, err := unix.Sysctl(option); err == nil {
+			cpuInfo[key] = value
 		}
 	}
 
-	if len(cpuInfo["mhz"]) != 0 {
-		mhz, err := strconv.Atoi(cpuInfo["mhz"])
-		if err == nil {
-			cpuInfo["mhz"] = strconv.Itoa(mhz / 1000000)
+	// type returned by sysctl is int32
+	for option, key := range cpuMapInt32 {
+		if value, err := unix.SysctlUint32(option); err == nil {
+			rendered := fmt.Sprintf("%d", value)
+			cpuInfo[key] = rendered
 		}
 	}
 
-	return
+	// type returned by sysctl is int64
+	option := "hw.cpufrequency"
+	if value, err := unix.SysctlUint64(option); err == nil {
+		// the value is in Hz
+		mhz := value / 1000000
+		rendered := fmt.Sprintf("%d", mhz)
+		cpuInfo["mhz"] = rendered
+	}
+
+	return cpuInfo, nil
 }

--- a/releasenotes/notes/gohai-darwin-cpu-native-a931acf4d9d543ae.yaml
+++ b/releasenotes/notes/gohai-darwin-cpu-native-a931acf4d9d543ae.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Cpu metadata are now collected without executing the sysctl tool on Darwin.
+    Cpu metadata are now collected without running the sysctl binary on Darwin.

--- a/releasenotes/notes/gohai-darwin-cpu-native-a931acf4d9d543ae.yaml
+++ b/releasenotes/notes/gohai-darwin-cpu-native-a931acf4d9d543ae.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Cpu metadata are now collected without running the sysctl binary on Darwin.
+    CPU metadata is now collected without running the `sysctl` binary on Darwin.

--- a/releasenotes/notes/gohai-darwin-cpu-native-a931acf4d9d543ae.yaml
+++ b/releasenotes/notes/gohai-darwin-cpu-native-a931acf4d9d543ae.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Cpu metadata are now collected without executing the sysctl tool on Darwin.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Implement CPU metadata collection using `sysctl` syscall instead of executing the `sysctl` binary.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Eventually remove all shell-outs in Gohai to have a native and more reliable way to collect data.
No parsing / cleaning of the output, just get the plain value with the correct type directly.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Note that with the binary it was possible to have silent failures (ie. it just printed nothing), now we can always know whether there was an error. In the current version we don't handle errors but when the new API is implemented we will have more precise error handling.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Check that the values are the same as with the `sysctl` binary.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
