### PR TITLE
Adds DD_AZURE_RESOURCE_GROUP and DD_AZURE_SUBSCRIPTION_ID to env vars for Container Apps

### DIFF
--- a/cmd/serverless-init/cloudservice/appservice.go
+++ b/cmd/serverless-init/cloudservice/appservice.go
@@ -43,6 +43,11 @@ func (a *AppService) GetPrefix() string {
 	return "azure.appservice"
 }
 
+// Init is empty for AppService
+func (a *AppService) Init() error {
+	return nil
+}
+
 func isAppService() bool {
 	_, exists := os.LookupEnv(RunZip)
 	return exists

--- a/cmd/serverless-init/cloudservice/cloudrun.go
+++ b/cmd/serverless-init/cloudservice/cloudrun.go
@@ -54,6 +54,11 @@ func (c *CloudRun) GetPrefix() string {
 	return "gcp.run"
 }
 
+// Init is empty for CloudRun
+func (c *CloudRun) Init() error {
+	return nil
+}
+
 func isCloudRunService() bool {
 	_, exists := os.LookupEnv(serviceNameEnvVar)
 	return exists

--- a/cmd/serverless-init/cloudservice/containerapp.go
+++ b/cmd/serverless-init/cloudservice/containerapp.go
@@ -6,17 +6,24 @@
 package cloudservice
 
 import (
+	"fmt"
 	"os"
 	"strings"
 )
 
 // ContainerApp has helper functions for getting specific Azure Container App data
-type ContainerApp struct{}
+type ContainerApp struct {
+	SubscriptionId string
+	ResourceGroup  string
+}
 
 const (
 	ContainerAppNameEnvVar = "CONTAINER_APP_NAME"
 	ContainerAppDNSSuffix  = "CONTAINER_APP_ENV_DNS_SUFFIX"
 	ContainerAppRevision   = "CONTAINER_APP_REVISION"
+
+	AzureSubscriptionIdEnvVar = "DD_AZURE_SUBSCRIPTION_ID"
+	AzureResourceGroupEnvVar  = "DD_AZURE_RESOURCE_GROUP"
 )
 
 // GetTags returns a map of Azure-related tags
@@ -29,13 +36,23 @@ func (c *ContainerApp) GetTags() map[string]string {
 
 	revision := os.Getenv(ContainerAppRevision)
 
-	return map[string]string{
+	tags := map[string]string{
 		"app_name":   appName,
 		"region":     region,
 		"revision":   revision,
 		"origin":     c.GetOrigin(),
 		"_dd.origin": c.GetOrigin(),
 	}
+
+	if c.SubscriptionId != "" {
+		tags["subscription_id"] = c.SubscriptionId
+	}
+
+	if c.ResourceGroup != "" {
+		tags["resource_group"] = c.ResourceGroup
+	}
+
+	return tags
 }
 
 // GetOrigin returns the `origin` attribute type for the given
@@ -48,6 +65,35 @@ func (c *ContainerApp) GetOrigin() string {
 // metrics with.
 func (c *ContainerApp) GetPrefix() string {
 	return "azure.containerapp"
+}
+
+// NewContainerApp returns a new ContainerApp instance
+func NewContainerApp() *ContainerApp {
+	return &ContainerApp{
+		SubscriptionId: "",
+		ResourceGroup:  "",
+	}
+}
+
+// Init initializes ContainerApp specific code
+func (c *ContainerApp) Init() error {
+	// For ContainerApp, the customers must set DD_AZURE_SUBSCRIPTION_ID
+	// and DD_AZURE_RESOURCE_GROUP.
+	// These environment variables are optional for now. Once we go GA,
+	// return `false` if these are not set.
+	if subscriptionId, exists := os.LookupEnv(AzureSubscriptionIdEnvVar); exists {
+		c.SubscriptionId = subscriptionId
+	} else {
+		return fmt.Errorf("must set %v", AzureSubscriptionIdEnvVar)
+	}
+
+	if resourceGroup, exists := os.LookupEnv(AzureResourceGroupEnvVar); exists {
+		c.ResourceGroup = resourceGroup
+	} else {
+		return fmt.Errorf("must set %v", AzureResourceGroupEnvVar)
+	}
+
+	return nil
 }
 
 func isContainerAppService() bool {

--- a/cmd/serverless-init/cloudservice/containerapp_test.go
+++ b/cmd/serverless-init/cloudservice/containerapp_test.go
@@ -6,6 +6,7 @@
 package cloudservice
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,4 +28,50 @@ func TestGetContainerAppTags(t *testing.T) {
 		"revision":   "test_revision",
 		"_dd.origin": "containerapp",
 	}, tags)
+}
+
+func TestGetContainerAppTagsWithOptionalEnvVars(t *testing.T) {
+	service := NewContainerApp()
+
+	t.Setenv("CONTAINER_APP_NAME", "test_app_name")
+	t.Setenv("CONTAINER_APP_ENV_DNS_SUFFIX", "test.bluebeach.eastus.azurecontainerapps.io")
+	t.Setenv("CONTAINER_APP_REVISION", "test_revision")
+
+	t.Setenv("DD_AZURE_SUBSCRIPTION_ID", "test_subscription_id")
+	t.Setenv("DD_AZURE_RESOURCE_GROUP", "test_resource_group")
+
+	err := service.Init()
+	assert.NoError(t, err)
+
+	tags := service.GetTags()
+
+	assert.Equal(t, map[string]string{
+		"app_name":        "test_app_name",
+		"origin":          "containerapp",
+		"region":          "eastus",
+		"revision":        "test_revision",
+		"_dd.origin":      "containerapp",
+		"subscription_id": "test_subscription_id",
+		"resource_group":  "test_resource_group",
+	}, tags)
+
+	assert.Nil(t, err)
+}
+
+func TestInitHasErrorsWhenMissingEnvVars(t *testing.T) {
+	service := NewContainerApp()
+
+	t.Setenv("CONTAINER_APP_NAME", "test_app_name")
+	t.Setenv("CONTAINER_APP_ENV_DNS_SUFFIX", "test.bluebeach.eastus.azurecontainerapps.io")
+	t.Setenv("CONTAINER_APP_REVISION", "test_revision")
+
+	err := service.Init()
+	assert.Equal(t, fmt.Errorf("must set %v", AzureSubscriptionIdEnvVar), err)
+
+	// Set the missing environment variable. We also need to set DD_AZURE_RESOURCE_GROUP,
+	// so we should still error when we call Init() again.
+	t.Setenv("DD_AZURE_SUBSCRIPTION_ID", "test_subscription_id")
+
+	err = service.Init()
+	assert.Equal(t, fmt.Errorf("must set %v", AzureResourceGroupEnvVar), err)
 }

--- a/cmd/serverless-init/cloudservice/service.go
+++ b/cmd/serverless-init/cloudservice/service.go
@@ -20,6 +20,9 @@ type CloudService interface {
 	// gcp.run.{metric_name}. In this example, `gcp.run` is the
 	// prefix.
 	GetPrefix() string
+
+	// Init bootstraps the CloudService.
+	Init() error
 }
 
 type LocalService struct{}
@@ -39,13 +42,18 @@ func (l *LocalService) GetPrefix() string {
 	return "local"
 }
 
+// Init is not necessary for LocalService
+func (l *LocalService) Init() error {
+	return nil
+}
+
 func GetCloudServiceType() CloudService {
 	if isCloudRunService() {
 		return &CloudRun{}
 	}
 
 	if isContainerAppService() {
-		return &ContainerApp{}
+		return NewContainerApp()
 	}
 
 	if isAppService() {

--- a/cmd/serverless-init/cloudservice/service_test.go
+++ b/cmd/serverless-init/cloudservice/service_test.go
@@ -12,11 +12,11 @@ import (
 )
 
 func TestGetCloudServiceType(t *testing.T) {
-	assert.Equal(t, &LocalService{}, GetCloudServiceType())
+	assert.Equal(t, "local", GetCloudServiceType().GetOrigin())
 
 	t.Setenv(ContainerAppNameEnvVar, "test-name")
-	assert.Equal(t, &ContainerApp{}, GetCloudServiceType())
+	assert.Equal(t, "containerapp", GetCloudServiceType().GetOrigin())
 
 	t.Setenv(serviceNameEnvVar, "test-name")
-	assert.Equal(t, &CloudRun{}, GetCloudServiceType())
+	assert.Equal(t, "cloudrun", GetCloudServiceType().GetOrigin())
 }

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -43,6 +43,11 @@ func setup() (cloudservice.CloudService, *log.Config, *trace.ServerlessTraceAgen
 	setupProxy()
 
 	cloudService := cloudservice.GetCloudServiceType()
+
+	// Ignore errors for now. Once we go GA, check for errors
+	// and exit right away.
+	_ = cloudService.Init()
+
 	tags := tags.MergeWithOverwrite(tags.ArrayToMap(config.GetGlobalConfiguredTags(false)), cloudService.GetTags())
 	origin := cloudService.GetOrigin()
 	prefix := cloudService.GetPrefix()


### PR DESCRIPTION
Allow the user to set `DD_AZURE_RESOURCE_GROUP` and `DD_AZURE_SUBSCRIPTION_ID` to Container Apps.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Right now, setting these variables is optional. Once we go GA, we're going to force the setting of these variables, and exit if they aren't set.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
