### PR TITLE
[CWS] Allow computing the difference between 2 activity dumps

### DIFF
--- a/cmd/security-agent/flags/flags_common.go
+++ b/cmd/security-agent/flags/flags_common.go
@@ -44,6 +44,8 @@ const (
 	RemoteFormat      = "remote-format"
 	Input             = "input"
 	Remote            = "remote"
+	Origin            = "origin"
+	Target            = "target"
 
 	// Security Profile Subcommand
 	SecurityProfileInput = "input"

--- a/cmd/security-agent/subcommands/runtime/activity_dump.go
+++ b/cmd/security-agent/subcommands/runtime/activity_dump.go
@@ -9,6 +9,8 @@ package runtime
 
 import (
 	"fmt"
+	"os"
+	"sync"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
@@ -21,7 +23,9 @@ import (
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
+	"github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/dump"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -32,7 +36,9 @@ type activityDumpCliParams struct {
 	containerID              string
 	comm                     string
 	file                     string
+	file2                    string
 	timeout                  string
+	format                   string
 	differentiateArgs        bool
 	localStorageDirectory    string
 	localStorageFormats      []string
@@ -51,7 +57,7 @@ func activityDumpCommands(globalParams *command.GlobalParams) []*cobra.Command {
 	activityDumpCmd.AddCommand(generateCommands(globalParams)...)
 	activityDumpCmd.AddCommand(listCommands(globalParams)...)
 	activityDumpCmd.AddCommand(stopCommands(globalParams)...)
-
+	activityDumpCmd.AddCommand(diffCommands(globalParams)...)
 	return []*cobra.Command{activityDumpCmd}
 }
 
@@ -266,6 +272,154 @@ func generateEncodingCommands(globalParams *command.GlobalParams) []*cobra.Comma
 	)
 
 	return []*cobra.Command{activityDumpGenerateEncodingCmd}
+}
+
+func diffCommands(globalParams *command.GlobalParams) []*cobra.Command {
+	cliParams := &activityDumpCliParams{
+		GlobalParams: globalParams,
+	}
+
+	activityDumpDiffCmd := &cobra.Command{
+		Use:   "diff",
+		Short: "compute the diff between two activity dumps",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fxutil.OneShot(diffActivityDump,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewSecurityAgentParams(globalParams.ConfigFilePaths),
+					LogParams:    log.LogForOneShot(command.LoggerName, "info", true)}),
+				core.Bundle,
+			)
+		},
+	}
+
+	activityDumpDiffCmd.Flags().StringVar(
+		&cliParams.file,
+		flags.Origin,
+		"",
+		"path to the first activity dump file",
+	)
+
+	activityDumpDiffCmd.Flags().StringVar(
+		&cliParams.file2,
+		flags.Target,
+		"",
+		"path to the second activity dump file",
+	)
+
+	activityDumpDiffCmd.Flags().StringVar(
+		&cliParams.format,
+		"format",
+		"json",
+		"output formeat",
+	)
+
+	return []*cobra.Command{activityDumpDiffCmd}
+}
+
+const (
+	addedADNode   activity_tree.NodeGenerationType = 100
+	removedADNode activity_tree.NodeGenerationType = 101
+)
+
+func markADSubtree(n *activity_tree.ProcessNode, state activity_tree.NodeGenerationType) {
+	n.GenerationType = state
+	for _, child := range n.Children {
+		markADSubtree(child, state)
+	}
+}
+
+func diffADSubtree(p1, p2 []*activity_tree.ProcessNode, states map[utils.GraphID]bool) (nodes []*activity_tree.ProcessNode) {
+NEXT:
+	for _, n := range p2 {
+		for _, n2 := range p1 {
+			if n.Matches(&n2.Process, false) {
+				newNode := n
+				n.Children = diffADSubtree(n.Children, n2.Children, states)
+				nodes = append(nodes, newNode)
+				continue NEXT
+			}
+		}
+
+		nodes = append(nodes, n)
+		markADSubtree(n, addedADNode)
+		states[utils.NewGraphID(utils.NewNodeIDFromPtr(n))] = true
+	}
+
+NEXT2:
+	for _, n := range p1 {
+		for _, n2 := range p2 {
+			if n.Matches(&n2.Process, false) {
+				continue NEXT2
+			}
+		}
+
+		nodes = append(nodes, n)
+		markADSubtree(n, removedADNode)
+		states[utils.NewGraphID(utils.NewNodeIDFromPtr(n))] = false
+	}
+
+	return
+}
+
+func computeActivityDumpDiff(p1, p2 *dump.ActivityDump, states map[utils.GraphID]bool) *dump.ActivityDump {
+	return &dump.ActivityDump{
+		Mutex: new(sync.Mutex),
+		ActivityTree: &activity_tree.ActivityTree{
+			ProcessNodes: diffADSubtree(p1.ActivityTree.ProcessNodes, p2.ActivityTree.ProcessNodes, states),
+		},
+	}
+}
+
+func diffActivityDump(log log.Component, config config.Component, args *activityDumpCliParams) error {
+	ad := dump.NewEmptyActivityDump()
+	if err := ad.Decode(args.file); err != nil {
+		return err
+	}
+
+	ad2 := dump.NewEmptyActivityDump()
+	if err := ad2.Decode(args.file2); err != nil {
+		return err
+	}
+
+	states := make(map[utils.GraphID]bool)
+	diff := computeActivityDumpDiff(ad, ad2, states)
+
+	switch args.format {
+	case "dot":
+		graph := diff.ToGraph()
+		for i := range graph.Nodes {
+			n := graph.Nodes[i]
+			if state, found := states[n.ID]; found {
+				if state {
+					n.FillColor = "green"
+				} else {
+					n.FillColor = "red"
+				}
+			}
+		}
+		buffer, err := graph.EncodeDOT(dump.ActivityDumpGraphTemplate)
+		if err != nil {
+			return err
+		}
+		os.Stdout.Write(buffer.Bytes())
+	case "protobuf":
+		buffer, err := diff.EncodeProtobuf()
+		if err != nil {
+			return err
+		}
+		os.Stdout.Write(buffer.Bytes())
+	case "json":
+		buffer, err := diff.EncodeJSON("  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(buffer.String())
+	default:
+		return fmt.Errorf("unknown format '%s'", args.format)
+	}
+
+	return nil
 }
 
 func generateActivityDump(log log.Component, config config.Component, activityDumpArgs *activityDumpCliParams) error {

--- a/pkg/security/resolvers/netns/graph.go
+++ b/pkg/security/resolvers/netns/graph.go
@@ -61,12 +61,12 @@ func (nr *Resolver) generateGraph(dump []NetworkNamespaceDump, graphFile *os.Fil
 func (nr *Resolver) generateGraphDataFromDump(dump []NetworkNamespaceDump) utils.Graph {
 	g := utils.Graph{
 		Title: fmt.Sprintf("Network Namespace Dump (%s)", time.Now().Format("2006-01-02 15:04:05")),
-		Nodes: make(map[utils.GraphID]utils.Node),
+		Nodes: make(map[utils.GraphID]*utils.Node),
 	}
 
 	for _, netns := range dump {
 		// create namespace node
-		netnsNode := utils.Node{
+		netnsNode := &utils.Node{
 			ID:    utils.NewGraphID(utils.NewRandomNodeID()),
 			Label: fmt.Sprintf("%v [fd:%d][handle:%v]", netns.NsID, netns.HandleFD, netns.HandlePath),
 			Color: namespaceColor,
@@ -82,7 +82,7 @@ func (nr *Resolver) generateGraphDataFromDump(dump []NetworkNamespaceDump) utils
 
 		// create active and queued devices nodes
 		for _, dev := range netns.Devices {
-			devNode := utils.Node{
+			devNode := &utils.Node{
 				ID:        utils.NewGraphID(utils.NewRandomNodeID()),
 				Label:     fmt.Sprintf("%s [%d]", dev.IfName, dev.IfIndex),
 				FillColor: activeDeviceColor,
@@ -92,7 +92,7 @@ func (nr *Resolver) generateGraphDataFromDump(dump []NetworkNamespaceDump) utils
 			}
 			g.Nodes[devNode.ID] = devNode
 
-			devEdge := utils.Edge{
+			devEdge := &utils.Edge{
 				From:  netnsNode.ID,
 				To:    devNode.ID,
 				Color: namespaceColor,
@@ -100,7 +100,7 @@ func (nr *Resolver) generateGraphDataFromDump(dump []NetworkNamespaceDump) utils
 			g.Edges = append(g.Edges, devEdge)
 		}
 		for _, dev := range netns.DevicesInQueue {
-			devNode := utils.Node{
+			devNode := &utils.Node{
 				ID:        utils.NewGraphID(utils.NewRandomNodeID()),
 				Label:     fmt.Sprintf("%s [%d]", dev.IfName, dev.IfIndex),
 				FillColor: queuedDeviceColor,
@@ -110,7 +110,7 @@ func (nr *Resolver) generateGraphDataFromDump(dump []NetworkNamespaceDump) utils
 			}
 			g.Nodes[devNode.ID] = devNode
 
-			devEdge := utils.Edge{
+			devEdge := &utils.Edge{
 				From:  netnsNode.ID,
 				To:    devNode.ID,
 				Color: namespaceColor,

--- a/pkg/security/security_profile/activity_tree/activity_tree_graph.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_graph.go
@@ -39,7 +39,7 @@ var (
 func (at *ActivityTree) PrepareGraphData(title string, resolver *process.Resolver) utils.Graph {
 	data := utils.Graph{
 		Title: title,
-		Nodes: make(map[utils.GraphID]utils.Node),
+		Nodes: make(map[utils.GraphID]*utils.Node),
 	}
 
 	for _, p := range at.ProcessNodes {
@@ -60,7 +60,7 @@ func (at *ActivityTree) prepareProcessNode(p *ProcessNode, data *utils.Graph, re
 		}
 	}
 	panGraphID := utils.NewGraphID(utils.NewNodeIDFromPtr(p))
-	pan := utils.Node{
+	pan := &utils.Node{
 		ID:    panGraphID,
 		Label: p.getNodeLabel(args),
 		Size:  60,
@@ -79,7 +79,7 @@ func (at *ActivityTree) prepareProcessNode(p *ProcessNode, data *utils.Graph, re
 
 	for _, n := range p.Sockets {
 		socketNodeID := at.prepareSocketNode(n, data, panGraphID)
-		data.Edges = append(data.Edges, utils.Edge{
+		data.Edges = append(data.Edges, &utils.Edge{
 			From:  panGraphID,
 			To:    socketNodeID,
 			Color: networkColor,
@@ -89,7 +89,7 @@ func (at *ActivityTree) prepareProcessNode(p *ProcessNode, data *utils.Graph, re
 	for _, n := range p.DNSNames {
 		dnsNodeID, ok := at.prepareDNSNode(n, data, panGraphID)
 		if ok {
-			data.Edges = append(data.Edges, utils.Edge{
+			data.Edges = append(data.Edges, &utils.Edge{
 				From:  panGraphID,
 				To:    dnsNodeID,
 				Color: networkColor,
@@ -99,7 +99,7 @@ func (at *ActivityTree) prepareProcessNode(p *ProcessNode, data *utils.Graph, re
 
 	for _, f := range p.Files {
 		fileID := at.prepareFileNode(f, data, "", panGraphID)
-		data.Edges = append(data.Edges, utils.Edge{
+		data.Edges = append(data.Edges, &utils.Edge{
 			From:  panGraphID,
 			To:    fileID,
 			Color: fileColor,
@@ -108,7 +108,7 @@ func (at *ActivityTree) prepareProcessNode(p *ProcessNode, data *utils.Graph, re
 
 	if len(p.Syscalls) > 0 {
 		syscallsNodeID := at.prepareSyscallsNode(p, data)
-		data.Edges = append(data.Edges, utils.Edge{
+		data.Edges = append(data.Edges, &utils.Edge{
 			From:  utils.NewGraphID(utils.NewNodeIDFromPtr(p)),
 			To:    syscallsNodeID,
 			Color: processColor,
@@ -117,7 +117,7 @@ func (at *ActivityTree) prepareProcessNode(p *ProcessNode, data *utils.Graph, re
 
 	for _, child := range p.Children {
 		childID := at.prepareProcessNode(child, data, resolver)
-		data.Edges = append(data.Edges, utils.Edge{
+		data.Edges = append(data.Edges, &utils.Edge{
 			From:  panGraphID,
 			To:    childID,
 			Color: processColor,
@@ -138,7 +138,7 @@ func (at *ActivityTree) prepareDNSNode(n *DNSNode, data *utils.Graph, processID 
 	}
 	name += ")"
 
-	dnsNode := utils.Node{
+	dnsNode := &utils.Node{
 		ID:    processID.Derive(utils.NewNodeIDFromPtr(n)),
 		Label: name,
 		Size:  30,
@@ -159,7 +159,7 @@ func (at *ActivityTree) prepareSocketNode(n *SocketNode, data *utils.Graph, proc
 	targetID := processID.Derive(utils.NewNodeIDFromPtr(n))
 
 	// prepare main socket node
-	socketNode := utils.Node{
+	socketNode := &utils.Node{
 		ID:    targetID,
 		Label: n.Family,
 		Size:  30,
@@ -177,7 +177,7 @@ func (at *ActivityTree) prepareSocketNode(n *SocketNode, data *utils.Graph, proc
 
 	// prepare bind nodes
 	for i, node := range n.Bind {
-		bindNode := utils.Node{
+		bindNode := &utils.Node{
 			ID:    processID.Derive(utils.NewNodeIDFromPtr(n), utils.NewNodeID(uint64(i+1))),
 			Label: fmt.Sprintf("[%s]:%d", node.IP, node.Port),
 			Size:  30,
@@ -191,7 +191,7 @@ func (at *ActivityTree) prepareSocketNode(n *SocketNode, data *utils.Graph, proc
 		case ProfileDrift:
 			bindNode.FillColor = networkProfileDriftColor
 		}
-		data.Edges = append(data.Edges, utils.Edge{
+		data.Edges = append(data.Edges, &utils.Edge{
 			From:  targetID,
 			To:    bindNode.ID,
 			Color: networkColor,
@@ -204,7 +204,7 @@ func (at *ActivityTree) prepareSocketNode(n *SocketNode, data *utils.Graph, proc
 
 func (at *ActivityTree) prepareFileNode(f *FileNode, data *utils.Graph, prefix string, processID utils.GraphID) utils.GraphID {
 	mergedID := processID.Derive(utils.NewNodeIDFromPtr(f))
-	fn := utils.Node{
+	fn := &utils.Node{
 		ID:    mergedID,
 		Label: f.getNodeLabel(),
 		Size:  30,
@@ -223,7 +223,7 @@ func (at *ActivityTree) prepareFileNode(f *FileNode, data *utils.Graph, prefix s
 
 	for _, child := range f.Children {
 		childID := at.prepareFileNode(child, data, prefix+f.Name, processID)
-		data.Edges = append(data.Edges, utils.Edge{
+		data.Edges = append(data.Edges, &utils.Edge{
 			From:  mergedID,
 			To:    childID,
 			Color: fileColor,
@@ -239,7 +239,7 @@ func (at *ActivityTree) prepareSyscallsNode(p *ProcessNode, data *utils.Graph) u
 	}
 	label += "</TABLE>>"
 
-	syscallsNode := utils.Node{
+	syscallsNode := &utils.Node{
 		ID:        utils.NewGraphIDWithDescription("syscalls", utils.NewNodeIDFromPtr(p)),
 		Label:     label,
 		Size:      30,

--- a/pkg/security/security_profile/dump/activity_dump.go
+++ b/pkg/security/security_profile/dump/activity_dump.go
@@ -642,7 +642,7 @@ func (ad *ActivityDump) ToTranscodingRequestMessage() *api.TranscodingRequestMes
 func (ad *ActivityDump) Encode(format config.StorageFormat) (*bytes.Buffer, error) {
 	switch format {
 	case config.Json:
-		return ad.EncodeJSON()
+		return ad.EncodeJSON("")
 	case config.Protobuf:
 		return ad.EncodeProtobuf()
 	case config.Dot:
@@ -683,7 +683,7 @@ func (ad *ActivityDump) EncodeProfile() (*bytes.Buffer, error) {
 }
 
 // EncodeJSON encodes an activity dump in the ProtoJSON format
-func (ad *ActivityDump) EncodeJSON() (*bytes.Buffer, error) {
+func (ad *ActivityDump) EncodeJSON(indent string) (*bytes.Buffer, error) {
 	ad.Lock()
 	defer ad.Unlock()
 
@@ -693,6 +693,7 @@ func (ad *ActivityDump) EncodeJSON() (*bytes.Buffer, error) {
 	opts := protojson.MarshalOptions{
 		EmitUnpopulated: true,
 		UseProtoNames:   true,
+		Indent:          indent,
 	}
 
 	raw, err := opts.Marshal(pad)

--- a/pkg/security/security_profile/dump/graph.go
+++ b/pkg/security/security_profile/dump/graph.go
@@ -10,10 +10,10 @@ package dump
 import (
 	"bytes"
 	"fmt"
-	"text/template"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/process"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 // ActivityDumpGraphTemplate is the template used to generate graphs
@@ -39,8 +39,8 @@ var ActivityDumpGraphTemplate = `digraph {
 		{{ end }}
 }`
 
-// EncodeDOT encodes an activity dump in the DOT format
-func (ad *ActivityDump) EncodeDOT() (*bytes.Buffer, error) {
+// ToGraph convert the dump to a graph
+func (ad *ActivityDump) ToGraph() utils.Graph {
 	ad.Lock()
 	defer ad.Unlock()
 
@@ -49,10 +49,14 @@ func (ad *ActivityDump) EncodeDOT() (*bytes.Buffer, error) {
 	if ad.adm != nil {
 		resolver = ad.adm.processResolver
 	}
-	data := ad.ActivityTree.PrepareGraphData(title, resolver)
-	t := template.Must(template.New("tmpl").Parse(ActivityDumpGraphTemplate))
-	raw := bytes.NewBuffer(nil)
-	if err := t.Execute(raw, data); err != nil {
+	return ad.ActivityTree.PrepareGraphData(title, resolver)
+}
+
+// EncodeDOT encodes an activity dump in the DOT format
+func (ad *ActivityDump) EncodeDOT() (*bytes.Buffer, error) {
+	graph := ad.ToGraph()
+	raw, err := graph.EncodeDOT(ActivityDumpGraphTemplate)
+	if err != nil {
 		return nil, fmt.Errorf("couldn't encode %s in %s: %w", ad.getSelectorStr(), config.Dot, err)
 	}
 	return raw, nil

--- a/pkg/security/utils/graph.go
+++ b/pkg/security/utils/graph.go
@@ -6,8 +6,10 @@
 package utils
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
+	"text/template"
 	"unsafe"
 )
 
@@ -32,8 +34,18 @@ type Edge struct {
 // Graph describes a dot graph
 type Graph struct {
 	Title string
-	Nodes map[GraphID]Node
-	Edges []Edge
+	Nodes map[GraphID]*Node
+	Edges []*Edge
+}
+
+// EncodeDOT encodes an activity dump in the DOT format
+func (g *Graph) EncodeDOT(tmpl string) (*bytes.Buffer, error) {
+	t := template.Must(template.New("tmpl").Parse(tmpl))
+	raw := new(bytes.Buffer)
+	if err := t.Execute(raw, g); err != nil {
+		return nil, err
+	}
+	return raw, nil
 }
 
 // GraphID represents an ID used in a graph, combination of NodeIDs


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

security-agent runtime activity-dump diff --source /tmp/mydump.protobuf  --target /tmp/mydump.protobuf  --format dot > ... 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
