### PR TITLE
[USM] gnuTLS non blocking socket

### DIFF
--- a/pkg/network/ebpf/c/prebuilt/usm.c
+++ b/pkg/network/ebpf/c/prebuilt/usm.c
@@ -443,6 +443,8 @@ cleanup:
 }
 
 // size_t gnutls_record_discard_queued(gnutls_session_t session)
+// when DTLS (UDP) gnutls_record_discard_queued() could be used to discard the previously enqueued data
+// gnutls doc : https://www.gnutls.org/manual/gnutls.html#Asynchronous-operation 6.5.1
 SEC("uprobe/gnutls_record_discard_queued")
 int uprobe__gnutls_record_discard_queued(struct pt_regs *ctx) {
     // userspace call can discard the queue after gnutls_record_send has been interrupted

--- a/pkg/network/ebpf/c/prebuilt/usm.c
+++ b/pkg/network/ebpf/c/prebuilt/usm.c
@@ -16,6 +16,7 @@
 #include "protocols/kafka/kafka-parsing.h"
 
 #define SO_SUFFIX_SIZE 3
+#define GNUTLS_E_AGAIN -28
 
 SEC("socket/protocol_dispatcher")
 int socket__protocol_dispatcher(struct __sk_buff *skb) {
@@ -444,6 +445,8 @@ cleanup:
 // size_t gnutls_record_discard_queued(gnutls_session_t session)
 SEC("uprobe/gnutls_record_discard_queued")
 int uprobe__gnutls_record_discard_queued(struct pt_regs *ctx) {
+    // userspace call can discard the queue after gnutls_record_send has been interrupted
+    // gnutls doc : https://www.gnutls.org/manual/gnutls.html#Asynchronous-operation 6.5.1
     u64 pid_tgid = bpf_get_current_pid_tgid();
     ssl_write_args_t *args = bpf_map_lookup_elem(&ssl_write_args, &pid_tgid);
     if (args == NULL) {
@@ -463,7 +466,7 @@ int uprobe__gnutls_record_send(struct pt_regs *ctx) {
     args.buf = (void *)PT_REGS_PARM2(ctx);
     u64 pid_tgid = bpf_get_current_pid_tgid();
     log_debug("uprobe/gnutls_record_send: pid=%llu ctx=%llx\n", pid_tgid, args.ctx);
-    // buffer could be NULL during non-blocking socket mode, asynchronous gnutls mode
+    // buffer could be NULL for the non-blocking asynchronous socket mode used by GnuTLS
     // buffer pointer from the previous call should be used
     if (args.buf != NULL) {
         bpf_map_update_with_telemetry(ssl_write_args, &pid_tgid, &args, BPF_ANY);
@@ -477,9 +480,10 @@ int uretprobe__gnutls_record_send(struct pt_regs *ctx) {
     ssize_t write_len = (ssize_t)PT_REGS_RC(ctx);
     log_debug("uretprobe/gnutls_record_send: pid=%llu len=%d\n", pid_tgid, write_len);
     if (write_len <= 0) {
-        if (write_len == -28) { // GNUTLS_E_AGAIN
+        if (write_len == GNUTLS_E_AGAIN) {
             // don't cleanup if non-blocking socket mode enabled
             // we need to use buffer from the previous call
+            // gnutls doc : https://www.gnutls.org/manual/gnutls.html#Asynchronous-operation 6.5.1
             return 0;
         }
         goto cleanup;

--- a/pkg/network/ebpf/c/prebuilt/usm.c
+++ b/pkg/network/ebpf/c/prebuilt/usm.c
@@ -449,7 +449,11 @@ int uprobe__gnutls_record_send(struct pt_regs *ctx) {
     args.buf = (void *)PT_REGS_PARM2(ctx);
     u64 pid_tgid = bpf_get_current_pid_tgid();
     log_debug("uprobe/gnutls_record_send: pid=%llu ctx=%llx\n", pid_tgid, args.ctx);
-    bpf_map_update_with_telemetry(ssl_write_args, &pid_tgid, &args, BPF_ANY);
+    // buffer could be NULL during non-blocking socket mode, asynchronous gnutls mode
+    // buffer pointer from the previous call should be used
+    if (args.buf != NULL) {
+        bpf_map_update_with_telemetry(ssl_write_args, &pid_tgid, &args, BPF_ANY);
+    }
     return 0;
 }
 
@@ -459,6 +463,11 @@ int uretprobe__gnutls_record_send(struct pt_regs *ctx) {
     ssize_t write_len = (ssize_t)PT_REGS_RC(ctx);
     log_debug("uretprobe/gnutls_record_send: pid=%llu len=%d\n", pid_tgid, write_len);
     if (write_len <= 0) {
+        if (write_len == -28) { // GNUTLS_E_AGAIN
+            // don't cleanup if non-blocking socket mode enabled
+            // we need to use buffer from the previous call
+            return 0;
+        }
         goto cleanup;
     }
 

--- a/pkg/network/ebpf/c/runtime/usm.c
+++ b/pkg/network/ebpf/c/runtime/usm.c
@@ -456,6 +456,8 @@ cleanup:
 }
 
 // size_t gnutls_record_discard_queued(gnutls_session_t session)
+// when DTLS (UDP) gnutls_record_discard_queued() could be used to discard the previously enqueued data
+// gnutls doc : https://www.gnutls.org/manual/gnutls.html#Asynchronous-operation 6.5.1
 SEC("uprobe/gnutls_record_discard_queued")
 int uprobe__gnutls_record_discard_queued(struct pt_regs *ctx) {
     // userspace call can discard the queue after gnutls_record_send has been interrupted

--- a/pkg/network/ebpf/c/runtime/usm.c
+++ b/pkg/network/ebpf/c/runtime/usm.c
@@ -454,6 +454,20 @@ cleanup:
     return 0;
 }
 
+// size_t gnutls_record_discard_queued(gnutls_session_t session)
+SEC("uprobe/gnutls_record_discard_queued")
+int uprobe__gnutls_record_discard_queued(struct pt_regs *ctx) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    ssl_write_args_t *args = bpf_map_lookup_elem(&ssl_write_args, &pid_tgid);
+    if (args == NULL) {
+        return 0;
+    }
+    if (args->ctx == (void *)PT_REGS_PARM1(ctx)) {
+        bpf_map_delete_elem(&ssl_write_args, &pid_tgid);
+    }
+    return 0;
+}
+
 // ssize_t gnutls_record_send (gnutls_session_t session, const void * data, size_t data_size)
 SEC("uprobe/gnutls_record_send")
 int uprobe__gnutls_record_send(struct pt_regs *ctx) {

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -131,6 +131,15 @@ var cryptoProbes = []manager.ProbesSelector{
 }
 
 var gnuTLSProbes = []manager.ProbesSelector{
+	&manager.BestEffort{
+		Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					EBPFFuncName: "uprobe__gnutls_record_discard_queued",
+				},
+			},
+		},
+	},
 	&manager.AllOf{
 		Selectors: []manager.ProbesSelector{
 			&manager.ProbeSelector{


### PR DESCRIPTION
### What does this PR do?

When non blocking socket are enabled gnutls API will propagate EAGAIN and return GNUTLS_E_AGAIN.
gnutls_record_send() could be called (after been interrupted) with buffer NULL and len 0, in this ca
when DTLS (UDP) gnutls_record_discard_queued() could be used to discard the previously enqueued data
gnutls doc : https://www.gnutls.org/manual/gnutls.html#Asynchronous-operation 6.5.1

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

gnuTLS non blocking test is missing (static binary vs install dev packages ?)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
