### PR TITLE
[USM] shared library add telemetry

### DIFF
--- a/pkg/network/usm/shared_libraries.go
+++ b/pkg/network/usm/shared_libraries.go
@@ -141,6 +141,7 @@ func newSOWatcher(perfHandler *ddebpf.PerfHandler, rules ...soRule) *soWatcher {
 		telemetry.OptStatsd,
 		telemetry.OptExpvar,
 		telemetry.OptMonotonic,
+		telemetry.OptPayloadTelemetry,
 	)
 	return &soWatcher{
 		wg:             sync.WaitGroup{},
@@ -163,8 +164,8 @@ func newSOWatcher(perfHandler *ddebpf.PerfHandler, rules ...soRule) *soWatcher {
 			libUnregisterPathIDNotFound: metricGroup.NewMetric("unregister_pathid_not_found"),
 		},
 
-		libHits:    metricGroup.NewMetric("hits", telemetry.OptPayloadTelemetry),
-		libMatches: metricGroup.NewMetric("matches", telemetry.OptPayloadTelemetry),
+		libHits:    metricGroup.NewMetric("hits"),
+		libMatches: metricGroup.NewMetric("matches"),
 	}
 }
 

--- a/pkg/network/usm/shared_libraries_test.go
+++ b/pkg/network/usm/shared_libraries_test.go
@@ -115,10 +115,18 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetection() {
 	}, time.Second*10, time.Second, "")
 
 	tel := telemetry.ReportPayloadTelemetry("1")
-	hits := tel["usm.shared_libraries.hits"]
-	matches := tel["usm.shared_libraries.matches"]
-	require.Equal(t, int64(1), matches, "usm.shared_libraries.matches doesn't match")
-	require.GreaterOrEqual(t, hits, matches, "usm.shared_libraries.hits is too low")
+	telEqual := func(t *testing.T, expected int64, m string) {
+		require.Equal(t, expected, tel[m], m)
+	}
+	require.GreaterOrEqual(t, tel["usm.shared_libraries.hits"], tel["usm.shared_libraries.matches"], "usm.shared_libraries.hits")
+	telEqual(t, 0, "usm.shared_libraries.already_registered")
+	telEqual(t, 0, "usm.shared_libraries.blocked")
+	telEqual(t, 1, "usm.shared_libraries.matches")
+	telEqual(t, 1, "usm.shared_libraries.registered")
+	telEqual(t, 0, "usm.shared_libraries.unregister_errors")
+	telEqual(t, 1, "usm.shared_libraries.unregister_no_callback")
+	telEqual(t, 0, "usm.shared_libraries.unregister_pathid_not_found")
+	telEqual(t, 1, "usm.shared_libraries.unregistered")
 }
 
 func (s *SharedLibrarySuite) TestSharedLibraryDetectionWithPIDandRootNameSpace() {
@@ -181,6 +189,20 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetectionWithPIDandRootNameSpace()
 	// must fail on the host
 	_, err = os.Stat(libpath)
 	require.Error(t, err)
+
+	tel := telemetry.ReportPayloadTelemetry("1")
+	telEqual := func(t *testing.T, expected int64, m string) {
+		require.Equal(t, expected, tel[m], m)
+	}
+	require.GreaterOrEqual(t, tel["usm.shared_libraries.hits"], tel["usm.shared_libraries.matches"], "usm.shared_libraries.hits")
+	telEqual(t, 0, "usm.shared_libraries.already_registered")
+	telEqual(t, 0, "usm.shared_libraries.blocked")
+	telEqual(t, 1, "usm.shared_libraries.matches")
+	telEqual(t, 1, "usm.shared_libraries.registered")
+	telEqual(t, 0, "usm.shared_libraries.unregister_errors")
+	telEqual(t, 1, "usm.shared_libraries.unregister_no_callback")
+	telEqual(t, 0, "usm.shared_libraries.unregister_pathid_not_found")
+	telEqual(t, 1, "usm.shared_libraries.unregistered")
 }
 
 func (s *SharedLibrarySuite) TestSameInodeRegression() {
@@ -236,6 +258,20 @@ func (s *SharedLibrarySuite) TestSameInodeRegression() {
 			checkPIDNotAssociatedWithPathID(watcher, fooPathID1, uint32(command1.Process.Pid)) &&
 			checkPIDNotAssociatedWithPathID(watcher, fooPathID2, uint32(command1.Process.Pid))
 	}, time.Second*10, time.Second, "")
+
+	tel := telemetry.ReportPayloadTelemetry("1")
+	telEqual := func(t *testing.T, expected int64, m string) {
+		require.Equal(t, expected, tel[m], m)
+	}
+	require.GreaterOrEqual(t, tel["usm.shared_libraries.hits"], tel["usm.shared_libraries.matches"], "usm.shared_libraries.hits")
+	telEqual(t, 0, "usm.shared_libraries.already_registered")
+	telEqual(t, 0, "usm.shared_libraries.blocked")
+	telEqual(t, 1, "usm.shared_libraries.matches")
+	telEqual(t, 1, "usm.shared_libraries.registered")
+	telEqual(t, 0, "usm.shared_libraries.unregister_errors")
+	telEqual(t, 1, "usm.shared_libraries.unregister_no_callback")
+	telEqual(t, 0, "usm.shared_libraries.unregister_pathid_not_found")
+	telEqual(t, 1, "usm.shared_libraries.unregistered")
 }
 
 func (s *SharedLibrarySuite) TestSoWatcherLeaks() {
@@ -319,6 +355,20 @@ func (s *SharedLibrarySuite) TestSoWatcherLeaks() {
 	}, time.Second*10, time.Second, "")
 
 	checkWatcherStateIsClean(t, watcher)
+
+	tel := telemetry.ReportPayloadTelemetry("1")
+	telEqual := func(t *testing.T, expected int64, m string) {
+		require.Equal(t, expected, tel[m], m)
+	}
+	require.GreaterOrEqual(t, tel["usm.shared_libraries.hits"], tel["usm.shared_libraries.matches"], "usm.shared_libraries.hits")
+	telEqual(t, 0, "usm.shared_libraries.already_registered")
+	telEqual(t, 0, "usm.shared_libraries.blocked")
+	telEqual(t, 1, "usm.shared_libraries.matches")
+	telEqual(t, 1, "usm.shared_libraries.registered")
+	telEqual(t, 0, "usm.shared_libraries.unregister_errors")
+	telEqual(t, 1, "usm.shared_libraries.unregister_no_callback")
+	telEqual(t, 0, "usm.shared_libraries.unregister_pathid_not_found")
+	telEqual(t, 1, "usm.shared_libraries.unregistered")
 }
 
 func (s *SharedLibrarySuite) TestSoWatcherProcessAlreadyHoldingReferences() {
@@ -390,6 +440,20 @@ func (s *SharedLibrarySuite) TestSoWatcherProcessAlreadyHoldingReferences() {
 	}, time.Second*10, time.Second, "")
 
 	checkWatcherStateIsClean(t, watcher)
+
+	tel := telemetry.ReportPayloadTelemetry("1")
+	telEqual := func(t *testing.T, expected int64, m string) {
+		require.Equal(t, expected, tel[m], m)
+	}
+	require.GreaterOrEqual(t, tel["usm.shared_libraries.hits"], tel["usm.shared_libraries.matches"], "usm.shared_libraries.hits")
+	telEqual(t, 0, "usm.shared_libraries.already_registered")
+	telEqual(t, 0, "usm.shared_libraries.blocked")
+	telEqual(t, 1, "usm.shared_libraries.matches")
+	telEqual(t, 1, "usm.shared_libraries.registered")
+	telEqual(t, 0, "usm.shared_libraries.unregister_errors")
+	telEqual(t, 1, "usm.shared_libraries.unregister_no_callback")
+	telEqual(t, 0, "usm.shared_libraries.unregister_pathid_not_found")
+	telEqual(t, 1, "usm.shared_libraries.unregistered")
 }
 
 func buildSOWatcherClientBin(t *testing.T) string {


### PR DESCRIPTION

### What does this PR do?

Add USM telemetry for shared_library events

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
