### PR TITLE
Update the `test-infra-definitions` dependency in `test/new-e2e`

### DIFF
--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -10,7 +10,7 @@ replace github.com/DataDog/datadog-agent/test/fakeintake => ../fakeintake
 
 require (
 	github.com/DataDog/datadog-agent/test/fakeintake v0.46.0-rc.2
-	github.com/DataDog/test-infra-definitions v0.0.0-20230608123532-949c05dac7e9
+	github.com/DataDog/test-infra-definitions v0.0.0-20230609191500-6e0f7d96fc6d
 	github.com/aws/aws-sdk-go-v2 v1.18.0
 	github.com/aws/aws-sdk-go-v2/config v1.18.25
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.36.4

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -1,7 +1,7 @@
 github.com/DataDog/agent-payload/v5 v5.0.73 h1:fnCnAR+nWY+q//fBZSab4cDFFng0scPEfmLdl9ngmQY=
 github.com/DataDog/agent-payload/v5 v5.0.73/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
-github.com/DataDog/test-infra-definitions v0.0.0-20230608123532-949c05dac7e9 h1:viUxY/ySGeI/s/fvmClGp5z806X61LusKuwmXWA/Bdg=
-github.com/DataDog/test-infra-definitions v0.0.0-20230608123532-949c05dac7e9/go.mod h1:VlLmT/PmwpWNV6o0tKFzWuPtHuN9YBb73WjS5SjhFzY=
+github.com/DataDog/test-infra-definitions v0.0.0-20230609191500-6e0f7d96fc6d h1:yGaxgraAYx9WaM4ODDuxAJtc60Gnj6xOrcfffOfIEvc=
+github.com/DataDog/test-infra-definitions v0.0.0-20230609191500-6e0f7d96fc6d/go.mod h1:VlLmT/PmwpWNV6o0tKFzWuPtHuN9YBb73WjS5SjhFzY=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=

--- a/test/new-e2e/utils/e2e/client/fakeintake.go
+++ b/test/new-e2e/utils/e2e/client/fakeintake.go
@@ -29,6 +29,6 @@ func NewFakeintake(exporter *infraFakeintake.ConnectionExporter) *Fakeintake {
 
 //lint:ignore U1000 Ignore unused function as this function is call using reflection
 func (fi *Fakeintake) initService(t *testing.T, data *infraFakeintake.ClientData) error {
-	fi.Client = fakeintake.NewClient("http://" + data.URL)
+	fi.Client = fakeintake.NewClient("http://" + data.Host)
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Upgrade the `test-infra-definitions` dependency in `test/new-e2e`.

### Motivation

DataDog/test-infra-definitions#133 introduced a change that requires an update in this repo.
Let’s fix that as soon as possible rather than letting it pending.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Validate that the `new-e2e` tests are passing.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
