### PR TITLE
Improves python check docs to use virtualenv and sort out PYTHONPATH when needed

### DIFF
--- a/docs/dev/agent_dev_env.md
+++ b/docs/dev/agent_dev_env.md
@@ -68,6 +68,8 @@ though).
 PYTHONPATH="./venv/lib/python3.8/site-packages:$PYTHONPATH" ./agent run ...
 ```
 
+See also some notes in [./checks](./checks) about running custom python checks.
+
 #### Invoke
 
 [Invoke](http://www.pyinvoke.org/) is a task runner written in Python

--- a/docs/dev/checks/README.md
+++ b/docs/dev/checks/README.md
@@ -131,6 +131,15 @@ checks code.
 Scenario: You have implemented a custom check called `hello_world` and you would
 like to run this with a local Agent build.
 
+Example contents of `hello_world.py`:
+```
+from datadog_checks.checks import AgentCheck
+
+class MyCheck(AgentCheck):
+    def check(self, instance):
+        self.gauge('hello.world', 1.23, tags=['foo:bar'])
+```
+
 1. Place the configuration file `hello_world.yaml` in the `dev/dist/conf.d/` folder.
 1. Place your Python code in the `dev/dist/` folder.
 1. Run `inv agent.build` as usual. This step copies the contents
@@ -146,13 +155,50 @@ dev/dist
 └── README.md
 ```
 
+This is sufficient to have the Agent correctly discover both the code and the
+configuration, but in order to actually run this, we must [discuss
+dependencies](https://xkcd.com/1987/)
+
+### Python Check Dependencies
+When `hello_world.py` runs, it loads in the `AgentCheck` class which provides
+some default functionality (eg, the `self.gauge` method)
+
+In order for python to find this package, we must do two things:
+1. Install the `integrations-core` dependencies
+2. Set the `PYTHONPATH` env var correctly to find those dependencies
+
+`datadog-checks-base` must be installed as a pre-req, and you can install via a
+`--user` install or a `virtualenv` install, as long as you set your `PYTHONPATH`
+correctly.
+
+#### Example for virtualenv
+(see also the notes in [../agent_dev_env.md](../agent_dev_env.md)):
+
+1. `python3 -m pip install virtualenv`
+1. `virtualenv $GOPATH/src/github.com/DataDog/datadog-agent/venv`
+1. Activate the virtualenv (OS-dependent)
+1. `python3 -m pip install ~/dev/integrations-core/datadog_checks_base[deps]`
+1. `PYTHONPATH="$PWD/venv/lib/python3.10/site-packages:$PYTHONPATH" inv agent.run`
+
+
+#### Example for user install
+1. `python3 -m pip install --user ~/dev/integrations-core/datadog_checks_base[deps]`
+1. `PYTHONPATH="$HOME/.local/lib/python3.10/site-packages:$PYTHONPATH" inv agent.run`
+
+#### Getting the right `PYTHONPATH`
+You want the `site-packages` directory that the `datadog_checks_base` got
+installed to.
+
+`python -m site` is very helpful to reference for the paths your current python
+is looking at.
+
 ### Standard Checks
 There are a number of checks that ship with a full build of the Agent, but when
 you're developing against a local build, you will not get any of these Python
 checks out of the box, you must install them.
 
 > Note the following instructions install Python packages to the Python user
-> install directory. This could conflict with existing packages.
+> install directory. Please see above for instructions on virtualenv
 
 The list of checks currently shipping with the Agent lives in the
 [integrations-core repo
@@ -171,8 +217,8 @@ Scenario: You want to test the `redisdb` check:
     ```
     python3 -m pip install --user ./redisdb
     ```
-    
-4. (Optional for some checks). Some checks have dependencies on other Python modules 
+
+4. (Optional for some checks). Some checks have dependencies on other Python modules
    that must be installed alongside the Python check. `redisdb` is one check that _does_ have
    dependencies, specifically on the open source `redisdb` package. In this case, we need to
    install the `deps` explicitly.
@@ -182,6 +228,8 @@ Scenario: You want to test the `redisdb` check:
 
 That's it! Your local build should now have the correct packages to be able to
 run the `redisdb` check.
+
+(You may need to set the correct `PYTHONPATH` when running the Agent, depending on your environment and which python is being used. There are instructions above.)
 
 #### "What is this `[deps]` thing?"
 The `[deps]` at the end of the package name instructs pip to install the

--- a/docs/dev/checks/README.md
+++ b/docs/dev/checks/README.md
@@ -132,7 +132,7 @@ Scenario: You have implemented a custom check called `hello_world` and you would
 like to run this with a local Agent build.
 
 Example contents of `hello_world.py`:
-```
+```python
 from datadog_checks.checks import AgentCheck
 
 class MyCheck(AgentCheck):
@@ -172,17 +172,17 @@ In order for python to find this package, we must do two things:
 correctly.
 
 #### Example for virtualenv
-(see also the notes in [../agent_dev_env.md](../agent_dev_env.md)):
+(see also the notes in [../agent_dev_env.md](../agent_dev_env.md#python-dependencies)):
 
 1. `python3 -m pip install virtualenv`
 1. `virtualenv $GOPATH/src/github.com/DataDog/datadog-agent/venv`
 1. Activate the virtualenv (OS-dependent)
-1. `python3 -m pip install ~/dev/integrations-core/datadog_checks_base[deps]`
+1. `python3 -m pip install '/path/to/integrations-core/datadog_checks_base[deps]'`
 1. `PYTHONPATH="$PWD/venv/lib/python3.10/site-packages:$PYTHONPATH" inv agent.run`
 
 
 #### Example for user install
-1. `python3 -m pip install --user ~/dev/integrations-core/datadog_checks_base[deps]`
+1. `python3 -m pip install --user '/path/to//integrations-core/datadog_checks_base[deps]'`
 1. `PYTHONPATH="$HOME/.local/lib/python3.10/site-packages:$PYTHONPATH" inv agent.run`
 
 #### Getting the right `PYTHONPATH`

--- a/docs/dev/checks/README.md
+++ b/docs/dev/checks/README.md
@@ -176,6 +176,8 @@ correctly.
 
 1. `python3 -m pip install virtualenv`
 1. `virtualenv $GOPATH/src/github.com/DataDog/datadog-agent/venv`
+    1. You may need a `-p python3` argument if the system has both `python2` and
+       `python3` bins.
 1. Activate the virtualenv (OS-dependent)
 1. `python3 -m pip install '/path/to/integrations-core/datadog_checks_base[deps]'`
 1. `PYTHONPATH="$PWD/venv/lib/python3.10/site-packages:$PYTHONPATH" inv agent.run`


### PR DESCRIPTION

### What does this PR do?
Improves the developer documentation when trying to run python checks locally

### Motivation
https://xkcd.com/1987/

### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
