### PR TITLE
[RCM] Fix rc config deletion

### DIFF
--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -215,11 +215,6 @@ func (c *Client) Close() {
 	c.close()
 }
 
-// UpdateApplyStatus updates the config's metadata to reflect its applied status
-func (c *Client) UpdateApplyStatus(cfgPath string, status state.ApplyStatus) {
-	c.state.UpdateApplyStatus(cfgPath, status)
-}
-
 // Subscribe subscribes to config updates of a product.
 func (c *Client) Subscribe(product string, fn func(update map[string]state.RawConfig)) {
 	c.m.Lock()
@@ -363,10 +358,9 @@ func (c *Client) newUpdateRequest() (*pbgo.ClientGetConfigsRequest, error) {
 	pbConfigState := make([]*pbgo.ConfigState, 0, len(state.Configs))
 	for _, f := range state.Configs {
 		pbConfigState = append(pbConfigState, &pbgo.ConfigState{
-			Id:         f.ID,
-			Version:    f.Version,
-			Product:    f.Product,
-			ApplyState: uint64(f.ApplyStatus.State),
+			Id:      f.ID,
+			Version: f.Version,
+			Product: f.Product,
 		})
 	}
 

--- a/pkg/remoteconfig/state/repository.go
+++ b/pkg/remoteconfig/state/repository.go
@@ -202,6 +202,7 @@ func (r *Repository) Update(update Update) ([]string, error) {
 			return nil, err
 		}
 
+		// 3.b and 3.c: Check if this configuration is either new or has been modified
 		storedMetadata, exists := r.metadata[path]
 		if exists && hashesEqual(targetFileMetadata.Hashes, storedMetadata.Hashes) {
 			continue

--- a/pkg/remoteconfig/state/repository.go
+++ b/pkg/remoteconfig/state/repository.go
@@ -180,6 +180,11 @@ func (r *Repository) Update(update Update) ([]string, error) {
 		for path := range configs {
 			if _, ok := clientConfigsMap[path]; !ok {
 				result.removed = append(result.removed, path)
+				parsedPath, err := parseConfigPath(path)
+				if err != nil {
+					return nil, err
+				}
+				result.productsUpdated[parsedPath.Product] = true
 			}
 		}
 	}
@@ -231,6 +236,7 @@ func (r *Repository) Update(update Update) ([]string, error) {
 		}
 		result.metadata[path] = m
 		result.changed[parsedPath.Product][path] = config
+		result.productsUpdated[parsedPath.Product] = true
 	}
 
 	// 4.a: Store the new targets.signed.custom.opaque_client_state
@@ -256,8 +262,8 @@ func (r *Repository) Update(update Update) ([]string, error) {
 	}
 
 	changedProducts := make([]string, 0)
-	for product, configs := range result.changed {
-		if len(configs) > 0 {
+	for product, updated := range result.productsUpdated {
+		if updated {
 			changedProducts = append(changedProducts, product)
 		}
 	}
@@ -348,9 +354,10 @@ func (r *Repository) CurrentState() (RepositoryState, error) {
 // An updateResult allows the client to apply the update as a transaction
 // after validating all required preconditions
 type updateResult struct {
-	removed  []string
-	metadata map[string]Metadata
-	changed  map[string]map[string]interface{}
+	removed         []string
+	metadata        map[string]Metadata
+	changed         map[string]map[string]interface{}
+	productsUpdated map[string]bool
 }
 
 func newUpdateResult() updateResult {
@@ -361,9 +368,10 @@ func newUpdateResult() updateResult {
 	}
 
 	return updateResult{
-		removed:  make([]string, 0),
-		metadata: make(map[string]Metadata),
-		changed:  changed,
+		removed:         make([]string, 0),
+		metadata:        make(map[string]Metadata),
+		changed:         changed,
+		productsUpdated: map[string]bool{},
 	}
 }
 

--- a/pkg/remoteconfig/state/repository_test.go
+++ b/pkg/remoteconfig/state/repository_test.go
@@ -210,6 +210,66 @@ func TestUpdateNewConfig(t *testing.T) {
 	assertHashesEqual(t, hashes, cached.Hashes)
 }
 
+func TestUpdateEmpty(t *testing.T) {
+	ta := newTestArtifacts()
+
+	file := newCWSDDFile()
+	path, _, data := addCWSDDFile("test", 1, file, ta.targets)
+	b := signTargets(ta.key, ta.targets)
+
+	update := Update{
+		TUFRoots:      make([][]byte, 0),
+		TUFTargets:    b,
+		TargetFiles:   map[string][]byte{path: data},
+		ClientConfigs: []string{path},
+	}
+	_, err := ta.repository.Update(update)
+	assert.Nil(t, err)
+	_, err = ta.unverifiedRepository.Update(update)
+	assert.Nil(t, err)
+
+	// We test this exact update in another test, so we'll just carry on here.
+
+	ta.targets.Version = 2
+	b = signTargets(ta.key, ta.targets)
+	emptyUpdate := Update{
+		TUFRoots:      make([][]byte, 0),
+		TUFTargets:    b,
+		TargetFiles:   make(map[string][]byte),
+		ClientConfigs: []string{path},
+	}
+	r := ta.repository
+	updatedProducts, err := r.Update(emptyUpdate)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(updatedProducts))
+	assert.Equal(t, 0, len(r.GetConfigs(ProductAPMSampling)))
+	assert.Equal(t, 1, len(r.GetConfigs(ProductCWSDD)))
+
+	state, err := r.CurrentState()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(state.Configs))
+	assert.Equal(t, 1, len(state.CachedFiles))
+	assert.EqualValues(t, 2, state.TargetsVersion)
+	assert.EqualValues(t, 1, state.RootsVersion)
+	assert.Equal(t, testOpaqueBackendStateContents, state.OpaqueBackendState)
+
+	// Do the same with the unverified repository, it should be functionally identical
+	r = ta.unverifiedRepository
+	updatedProducts, err = r.Update(emptyUpdate)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(updatedProducts))
+	assert.Equal(t, 0, len(r.GetConfigs(ProductAPMSampling)))
+	assert.Equal(t, 1, len(r.GetConfigs(ProductCWSDD)))
+
+	state, err = r.CurrentState()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(state.Configs))
+	assert.Equal(t, 1, len(state.CachedFiles))
+	assert.EqualValues(t, 2, state.TargetsVersion)
+	assert.EqualValues(t, 1, state.RootsVersion)
+	assert.Equal(t, testOpaqueBackendStateContents, state.OpaqueBackendState)
+}
+
 func TestUpdateNewConfigThenRemove(t *testing.T) {
 	ta := newTestArtifacts()
 

--- a/pkg/remoteconfig/state/repository_test.go
+++ b/pkg/remoteconfig/state/repository_test.go
@@ -245,7 +245,7 @@ func TestUpdateNewConfigThenRemove(t *testing.T) {
 	r := ta.repository
 	updatedProducts, err := r.Update(removalUpdate)
 	assert.Nil(t, err)
-	assert.Equal(t, 0, len(updatedProducts))
+	assert.Equal(t, 1, len(updatedProducts))
 	assert.Equal(t, 0, len(r.GetConfigs(ProductAPMSampling)))
 	assert.Equal(t, 0, len(r.GetConfigs(ProductCWSDD)))
 
@@ -261,7 +261,7 @@ func TestUpdateNewConfigThenRemove(t *testing.T) {
 	r = ta.unverifiedRepository
 	updatedProducts, err = r.Update(removalUpdate)
 	assert.Nil(t, err)
-	assert.Equal(t, 0, len(updatedProducts))
+	assert.Equal(t, 1, len(updatedProducts))
 	assert.Equal(t, 0, len(r.GetConfigs(ProductAPMSampling)))
 	assert.Equal(t, 0, len(r.GetConfigs(ProductCWSDD)))
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

When the main RC client in the agent received an update from the backend to delete a config, there were 2 bugs:
* If `config delete` was the only update, there were no state update, we just ignored it
* Else, if `config delete` was the only update of a product, the state was updated, but the RC client listeners were not called with the update

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
