### PR TITLE
[USM] tests RunDockerServer/RunHostServer log pid

### DIFF
--- a/pkg/network/protocols/testutil/serverutils.go
+++ b/pkg/network/protocols/testutil/serverutils.go
@@ -52,7 +52,7 @@ func RunDockerServer(t testing.TB, serverName, dockerPath string, env []string, 
 		case <-ctx.Done():
 			if err := ctx.Err(); err != nil {
 				patternScanner.PrintLogs(t)
-				return fmt.Errorf("failed to start %s server: %s", serverName, err)
+				return fmt.Errorf("failed to start %s pid %d server: %s", serverName, cmd.Process.Pid, err)
 			}
 		case <-patternScanner.DoneChan:
 			t.Logf("%s server pid (docker) %d is ready", serverName, cmd.Process.Pid)
@@ -60,7 +60,7 @@ func RunDockerServer(t testing.TB, serverName, dockerPath string, env []string, 
 		case <-time.After(timeout):
 			patternScanner.PrintLogs(t)
 			// please don't use t.Fatalf() here as we could test if it failed later
-			return fmt.Errorf("failed to start %s server: timed out after %s", serverName, timeout.String())
+			return fmt.Errorf("failed to start %s server pid %d: timed out after %s", serverName, cmd.Process.Pid, timeout.String())
 		}
 	}
 }
@@ -97,17 +97,17 @@ func RunHostServer(t *testing.T, command []string, env []string, serverStartRege
 		case <-ctx.Done():
 			if err := ctx.Err(); err != nil {
 				patternScanner.PrintLogs(t)
-				t.Errorf("failed to start %s server: %s", serverName, err)
+				t.Errorf("failed to start %s pid %d server: %s", serverName, cmd.Process.Pid, err)
 			}
 			return false
 		case <-patternScanner.DoneChan:
-			t.Logf("%s host server is ready", serverName)
+			t.Logf("%s host server pid %d is ready", serverName, cmd.Process.Pid)
 			patternScanner.PrintLogs(t)
 			return true
 		case <-time.After(time.Second * 60):
 			patternScanner.PrintLogs(t)
 			// please don't use t.Fatalf() here as we could test if it failed later
-			t.Errorf("failed to start %s host server", serverName)
+			t.Errorf("failed to start %s host server pid %d", serverName, cmd.Process.Pid)
 			return false
 		}
 	}


### PR DESCRIPTION

### What does this PR do?

Log info, pid for CI troubeshooting

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
