### PR TITLE
Improvements for metrics blocklist

### DIFF
--- a/comp/dogstatsd/server/blocklist.go
+++ b/comp/dogstatsd/server/blocklist.go
@@ -6,6 +6,7 @@
 package server
 
 import (
+	"sort"
 	"strings"
 )
 
@@ -15,6 +16,26 @@ type blocklist struct {
 }
 
 func newBlocklist(data []string, matchPrefix bool) blocklist {
+	sort.Strings(data)
+
+	if matchPrefix && len(data) > 0 {
+		// Make sure that elements identify unique prefixes.
+		i := 0
+		for j := 1; j < len(data); j++ {
+			if strings.HasPrefix(data[j], data[i]) {
+				continue
+			}
+			i++
+			data[i] = data[j]
+		}
+
+		data = data[:i+1]
+	}
+
+	// Invariants for data:
+	// For all i, j such that i < j, data[i] < data[j].
+	// for all i, j such that i != j, !HasPrefix(data[i], data[j]).
+
 	return blocklist{
 		data:        data,
 		matchPrefix: matchPrefix,
@@ -22,18 +43,30 @@ func newBlocklist(data []string, matchPrefix bool) blocklist {
 }
 
 func (b *blocklist) test(name string) bool {
-	if b.matchPrefix {
-		for _, item := range b.data {
-			if strings.HasPrefix(name, item) {
-				return true
-			}
-		}
-	} else {
-		for _, item := range b.data {
-			if name == item {
-				return true
-			}
-		}
+	if len(b.data) == 0 {
+		return false
+	}
+
+	i := sort.SearchStrings(b.data, name)
+
+	// SearchStrings returns an index such that either:
+	// - data[i] == name
+	// - data[i-1] < name (if i > 0) && data[i] > name (if i < len(b.data))
+	//
+	// If for some j, data[j] is a prefix of name, then:
+	//
+	// - j < i, because any prefix of a string is less than string itself,
+	//
+	// - if j < i - 1, then strings in range [j+1, i-1] would have
+	// data[j] as a prefix, which is impossible by construction of
+	// data.
+	//
+	// Thus j must be i - 1.
+	if b.matchPrefix && i > 0 && strings.HasPrefix(name, b.data[i-1]) {
+		return true
+	}
+	if i < len(b.data) {
+		return name == b.data[i]
 	}
 
 	return false

--- a/comp/dogstatsd/server/blocklist.go
+++ b/comp/dogstatsd/server/blocklist.go
@@ -16,6 +16,7 @@ type blocklist struct {
 }
 
 func newBlocklist(data []string, matchPrefix bool) blocklist {
+	data = append([]string{}, data...)
 	sort.Strings(data)
 
 	if matchPrefix && len(data) > 0 {

--- a/comp/dogstatsd/server/blocklist.go
+++ b/comp/dogstatsd/server/blocklist.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package server
+
+import (
+	"strings"
+)
+
+type blocklist struct {
+	data        []string
+	matchPrefix bool
+}
+
+func newBlocklist(data []string, matchPrefix bool) blocklist {
+	return blocklist{
+		data:        data,
+		matchPrefix: matchPrefix,
+	}
+}
+
+func (b *blocklist) test(name string) bool {
+	if b.matchPrefix {
+		for _, item := range b.data {
+			if strings.HasPrefix(name, item) {
+				return true
+			}
+		}
+	} else {
+		for _, item := range b.data {
+			if name == item {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/comp/dogstatsd/server/blocklist_test.go
+++ b/comp/dogstatsd/server/blocklist_test.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package server
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewBlocklist(t *testing.T) {
+	check := func(data []string) []string {
+		b := newBlocklist(data, true)
+		return b.data
+	}
+
+	assert.Equal(t, []string{}, check([]string{}))
+	assert.Equal(t, []string{"a"}, check([]string{"a"}))
+	assert.Equal(t, []string{"a"}, check([]string{"a", "aa"}))
+	assert.Equal(t, []string{"a", "b"}, check([]string{"a", "aa", "b", "bb"}))
+	assert.Equal(t, []string{"a", "b"}, check([]string{"a", "b", "bb"}))
+}
+
+func TestIsMetricBlocklisted(t *testing.T) {
+	cases := []struct {
+		result      bool
+		name        string
+		blocklist   []string
+		matchPrefix bool
+	}{
+		{false, "some", []string{}, false},
+		{false, "some", []string{}, true},
+		{false, "foo", []string{"bar", "baz"}, false},
+		{false, "foo", []string{"bar", "baz"}, true},
+		{false, "bar", []string{"foo", "baz"}, false},
+		{false, "bar", []string{"foo", "baz"}, true},
+		{true, "baz", []string{"foo", "baz"}, false},
+		{true, "baz", []string{"foo", "baz"}, true},
+		{false, "foobar", []string{"foo", "baz"}, false},
+		{true, "foobar", []string{"foo", "baz"}, true},
+	}
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%v-%v-%v", c.name, c.blocklist, c.matchPrefix),
+			func(t *testing.T) {
+				b := newBlocklist(c.blocklist, c.matchPrefix)
+				assert.Equal(t, c.result, b.test(c.name))
+			})
+	}
+}

--- a/comp/dogstatsd/server/enrich.go
+++ b/comp/dogstatsd/server/enrich.go
@@ -27,7 +27,7 @@ var (
 type enrichConfig struct {
 	metricPrefix              string
 	metricPrefixBlacklist     []string
-	metricBlocklist           []string
+	metricBlocklist           blocklist
 	defaultHostname           string
 	entityIDPrecedenceEnabled bool
 	serverlessMode            bool
@@ -141,15 +141,7 @@ func isExcluded(metricName, namespace string, excludedNamespaces []string) bool 
 			}
 		}
 	}
-	return false
-}
 
-func isMetricBlocklisted(metricName string, metricBlocklist []string) bool {
-	for _, item := range metricBlocklist {
-		if metricName == item {
-			return true
-		}
-	}
 	return false
 }
 
@@ -169,7 +161,7 @@ func enrichMetricSample(dest []metrics.MetricSample, ddSample dogstatsdMetricSam
 		metricName = conf.metricPrefix + metricName
 	}
 
-	if len(conf.metricBlocklist) > 0 && isMetricBlocklisted(metricName, conf.metricBlocklist) {
+	if conf.metricBlocklist.test(metricName) {
 		return []metrics.MetricSample{}
 	}
 

--- a/comp/dogstatsd/server/enrich_bench_test.go
+++ b/comp/dogstatsd/server/enrich_bench_test.go
@@ -61,7 +61,7 @@ func BenchmarkMetricsExclusion(b *testing.B) {
 	}
 
 	for i := 1; i <= 512; i *= 2 {
-		conf.metricBlocklist = list[:i]
+		conf.metricBlocklist = newBlocklist(list[:i], false)
 		b.Run(fmt.Sprintf("%d-exact", i),
 			func(b *testing.B) {
 				for i := 0; i < b.N; i++ {

--- a/comp/dogstatsd/server/enrich_bench_test.go
+++ b/comp/dogstatsd/server/enrich_bench_test.go
@@ -8,6 +8,8 @@ package server
 import (
 	"fmt"
 	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
 func buildTags(tagCount int) []string {
@@ -35,5 +37,36 @@ func BenchmarkExtractTagsMetadata(b *testing.B) {
 				tags, _, _, _, _ = extractTagsMetadata(baseTags, "", []byte{}, conf)
 			}
 		})
+	}
+}
+
+func BenchmarkMetricsExclusion(b *testing.B) {
+	conf := enrichConfig{}
+
+	sample := dogstatsdMetricSample{
+		name: "datadog.agent.testing.metric.does_not_match",
+	}
+
+	out := make([]metrics.MetricSample, 0, 10)
+
+	b.Run("none", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			enrichMetricSample(out, sample, "", conf)
+		}
+	})
+
+	list := []string{}
+	for i := 0; i < 512; i++ {
+		list = append(list, fmt.Sprintf("datadog.agent.testing.metric.with_long_name.%d", i))
+	}
+
+	for i := 1; i <= 512; i *= 2 {
+		conf.metricBlocklist = list[:i]
+		b.Run(fmt.Sprintf("%d-exact", i),
+			func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					enrichMetricSample(out, sample, "", conf)
+				}
+			})
 	}
 }

--- a/comp/dogstatsd/server/enrich_test.go
+++ b/comp/dogstatsd/server/enrich_test.go
@@ -949,10 +949,10 @@ func TestMetricBlocklistShouldBlock(t *testing.T) {
 
 	message := []byte("custom.metric.a:21|ms")
 	conf := enrichConfig{
-		metricBlocklist: []string{
+		metricBlocklist: newBlocklist([]string{
 			"custom.metric.a",
 			"custom.metric.b",
-		},
+		}, false),
 		defaultHostname: "default",
 	}
 
@@ -968,7 +968,6 @@ func TestMetricBlocklistShouldBlock(t *testing.T) {
 
 func TestServerlessModeShouldSetEmptyHostname(t *testing.T) {
 	conf := enrichConfig{
-		metricBlocklist: []string{},
 		serverlessMode:  true,
 		defaultHostname: "default",
 	}
@@ -988,10 +987,10 @@ func TestServerlessModeShouldSetEmptyHostname(t *testing.T) {
 func TestMetricBlocklistShouldNotBlock(t *testing.T) {
 	message := []byte("custom.metric.a:21|ms")
 	conf := enrichConfig{
-		metricBlocklist: []string{
+		metricBlocklist: newBlocklist([]string{
 			"custom.metric.b",
 			"custom.metric.c",
-		},
+		}, false),
 		defaultHostname: "default",
 	}
 	cfg := fxutil.Test[config.Component](t, config.MockModule)

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -212,7 +212,10 @@ func newServerCompat(cfg config.ConfigReader, log logComponent.Component, captur
 	}
 
 	metricPrefixBlacklist := cfg.GetStringSlice("statsd_metric_namespace_blacklist")
-	metricBlocklist := cfg.GetStringSlice("statsd_metric_blocklist")
+	metricBlocklist := newBlocklist(
+		cfg.GetStringSlice("statsd_metric_blocklist"),
+		cfg.GetBool("statsd_metric_blocklist_match_prefix"),
+	)
 
 	defaultHostname, err := hostname.Get(context.TODO())
 	if err != nil {

--- a/comp/dogstatsd/server/server_bench_test.go
+++ b/comp/dogstatsd/server/server_bench_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
+
 package server
 
 import (

--- a/comp/dogstatsd/server/server_test.go
+++ b/comp/dogstatsd/server/server_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
+
 package server
 
 import (

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -584,6 +584,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("statsd_metric_namespace", "")
 	config.BindEnvAndSetDefault("statsd_metric_namespace_blacklist", StandardStatsdPrefixes)
 	config.BindEnvAndSetDefault("statsd_metric_blocklist", []string{})
+	config.BindEnvAndSetDefault("statsd_metric_blocklist_match_prefix", false)
+
 	// Autoconfig
 	config.BindEnvAndSetDefault("autoconf_template_dir", "/datadog/check_configs")
 	config.BindEnvAndSetDefault("autoconf_config_files_poll", false)


### PR DESCRIPTION
### What does this PR do?

Add option to exclude metrics based on a prefix instead of a full match. To keep performance reasonable for lager lists, use binary search instead of linear scan to check the blocklist.

### Motivation

Improve control over which metrics are accepted by the agent.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Run the agent with 
```
DD_STATSD_METRIC_BLOCKLIST='foo'
DD_DOGSTATSD_SOCKET='/tmp/dsd.sock'
DD_LOG_LEVEL=debug
DD_LOG_PAYLOADS=true
```

Check that `foobar` and `bar` are flushed:
```
echo -e 'foo:1|c\nfoobar:1|c\nbar:1|c' | nc -uUw0 /tmp/dsd.sock
```

Restart the agent with `DD_STATSD_METRIC_BLOCKLIST_MATCH_PREFIX=true` added.

Check that only `bar` is sent to the backend:
```
echo -e 'foo:1|c\nfoobar:1|c\nbar:1|c' | nc -uUw0 /tmp/dsd.sock
```


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
