### PR TITLE
Revert "[usm] Improve `incompleteBuffer`"

### DIFF
--- a/pkg/network/protocols/http/telemetry.go
+++ b/pkg/network/protocols/http/telemetry.go
@@ -24,10 +24,6 @@ type Telemetry struct {
 	rejected     *libtelemetry.Metric // this happens when an user-defined reject-filter matches a request
 	malformed    *libtelemetry.Metric // this happens when the request doesn't have the expected format
 	aggregations *libtelemetry.Metric
-
-	newIncomplete    *libtelemetry.Metric
-	totalIncomplete  *libtelemetry.Metric
-	joinedIncomplete *libtelemetry.Metric
 }
 
 func NewTelemetry() (*Telemetry, error) {
@@ -45,11 +41,6 @@ func NewTelemetry() (*Telemetry, error) {
 		hits4XX:      metricGroup.NewMetric("hits4xx"),
 		hits5XX:      metricGroup.NewMetric("hits5xx"),
 		aggregations: metricGroup.NewMetric("aggregations"),
-
-		// metrics from `incompleteBuffer`
-		newIncomplete:    metricGroup.NewMetric("new_incomplete"),
-		totalIncomplete:  metricGroup.NewMetric("total_incomplete"),
-		joinedIncomplete: metricGroup.NewMetric("joined_incomplete"),
 
 		// these metrics are also exported as statsd metrics
 		totalHits: metricGroup.NewMetric("total_hits", libtelemetry.OptStatsd),
@@ -92,14 +83,11 @@ func (t *Telemetry) Log() {
 	rejected := t.rejected.Delta()
 	malformed := t.malformed.Delta()
 	aggregations := t.aggregations.Delta()
-	newIncomplete := t.newIncomplete.Delta()
-	joinedIncomplete := t.joinedIncomplete.Delta()
-	totalIncomplete := t.totalIncomplete.Delta()
 	elapsed := now - t.LastCheck.Load()
 	t.LastCheck.Store(now)
 
 	log.Debugf(
-		"http stats summary: requests_processed=%d(%.2f/s) requests_dropped=%d(%.2f/s) requests_rejected=%d(%.2f/s) requests_malformed=%d(%.2f/s) incomplete_parts=%d(%.2f/s) incomplete_parts_joined=%d(%.2f/s) incomplete_parts_accumulated=%d aggregations=%d",
+		"http stats summary: requests_processed=%d(%.2f/s) requests_dropped=%d(%.2f/s) requests_rejected=%d(%.2f/s) requests_malformed=%d(%.2f/s) aggregations=%d",
 		totalRequests,
 		float64(totalRequests)/float64(elapsed),
 		dropped,
@@ -108,11 +96,6 @@ func (t *Telemetry) Log() {
 		float64(rejected)/float64(elapsed),
 		malformed,
 		float64(malformed)/float64(elapsed),
-		newIncomplete,
-		float64(newIncomplete)/float64(elapsed),
-		joinedIncomplete,
-		float64(joinedIncomplete)/float64(elapsed),
-		totalIncomplete,
 		aggregations,
 	)
 }

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -264,9 +264,8 @@ func (m *Monitor) GetHTTPStats() map[http.Key]*http.RequestStats {
 		return nil
 	}
 
-	defer m.httpTelemetry.Log()
-
 	m.httpConsumer.Sync()
+	m.httpTelemetry.Log()
 	return m.httpStatkeeper.GetAndResetAllStats()
 }
 
@@ -277,9 +276,8 @@ func (m *Monitor) GetHTTP2Stats() map[http.Key]*http.RequestStats {
 		return nil
 	}
 
-	defer m.http2Telemetry.Log()
-
 	m.http2Consumer.Sync()
+	m.http2Telemetry.Log()
 	return m.http2Statkeeper.GetAndResetAllStats()
 }
 
@@ -289,9 +287,8 @@ func (m *Monitor) GetKafkaStats() map[kafka.Key]*kafka.RequestStat {
 		return nil
 	}
 
-	defer m.kafkaTelemetry.Log()
-
 	m.kafkaConsumer.Sync()
+	m.kafkaTelemetry.Log()
 	return m.kafkaStatkeeper.GetAndResetAllStats()
 }
 


### PR DESCRIPTION
Reverts DataDog/datadog-agent#17164

This has cause a regression in data accuracy so we'll be reverting the change for 7.46.0 and fixing the underlying issue in the next release