### PR TITLE
Revert "[usm] Improve `incompleteBuffer` (#17164)" (#17593)

### DIFF
--- a/pkg/network/protocols/http/telemetry.go
+++ b/pkg/network/protocols/http/telemetry.go
@@ -24,10 +24,6 @@ type Telemetry struct {
 	rejected     *libtelemetry.Metric // this happens when an user-defined reject-filter matches a request
 	malformed    *libtelemetry.Metric // this happens when the request doesn't have the expected format
 	aggregations *libtelemetry.Metric
-
-	newIncomplete    *libtelemetry.Metric
-	totalIncomplete  *libtelemetry.Metric
-	joinedIncomplete *libtelemetry.Metric
 }
 
 func NewTelemetry() (*Telemetry, error) {
@@ -45,11 +41,6 @@ func NewTelemetry() (*Telemetry, error) {
 		hits4XX:      metricGroup.NewMetric("hits4xx"),
 		hits5XX:      metricGroup.NewMetric("hits5xx"),
 		aggregations: metricGroup.NewMetric("aggregations"),
-
-		// metrics from `incompleteBuffer`
-		newIncomplete:    metricGroup.NewMetric("new_incomplete"),
-		totalIncomplete:  metricGroup.NewMetric("total_incomplete"),
-		joinedIncomplete: metricGroup.NewMetric("joined_incomplete"),
 
 		// these metrics are also exported as statsd metrics
 		totalHits: metricGroup.NewMetric("total_hits", libtelemetry.OptStatsd),
@@ -92,14 +83,11 @@ func (t *Telemetry) Log() {
 	rejected := t.rejected.Delta()
 	malformed := t.malformed.Delta()
 	aggregations := t.aggregations.Delta()
-	newIncomplete := t.newIncomplete.Delta()
-	joinedIncomplete := t.joinedIncomplete.Delta()
-	totalIncomplete := t.totalIncomplete.Delta()
 	elapsed := now - t.LastCheck.Load()
 	t.LastCheck.Store(now)
 
 	log.Debugf(
-		"http stats summary: requests_processed=%d(%.2f/s) requests_dropped=%d(%.2f/s) requests_rejected=%d(%.2f/s) requests_malformed=%d(%.2f/s) incomplete_parts=%d(%.2f/s) incomplete_parts_joined=%d(%.2f/s) incomplete_parts_accumulated=%d aggregations=%d",
+		"http stats summary: requests_processed=%d(%.2f/s) requests_dropped=%d(%.2f/s) requests_rejected=%d(%.2f/s) requests_malformed=%d(%.2f/s) aggregations=%d",
 		totalRequests,
 		float64(totalRequests)/float64(elapsed),
 		dropped,
@@ -108,11 +96,6 @@ func (t *Telemetry) Log() {
 		float64(rejected)/float64(elapsed),
 		malformed,
 		float64(malformed)/float64(elapsed),
-		newIncomplete,
-		float64(newIncomplete)/float64(elapsed),
-		joinedIncomplete,
-		float64(joinedIncomplete)/float64(elapsed),
-		totalIncomplete,
 		aggregations,
 	)
 }

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -264,9 +264,8 @@ func (m *Monitor) GetHTTPStats() map[http.Key]*http.RequestStats {
 		return nil
 	}
 
-	defer m.httpTelemetry.Log()
-
 	m.httpConsumer.Sync()
+	m.httpTelemetry.Log()
 	return m.httpStatkeeper.GetAndResetAllStats()
 }
 
@@ -277,9 +276,8 @@ func (m *Monitor) GetHTTP2Stats() map[http.Key]*http.RequestStats {
 		return nil
 	}
 
-	defer m.http2Telemetry.Log()
-
 	m.http2Consumer.Sync()
+	m.http2Telemetry.Log()
 	return m.http2Statkeeper.GetAndResetAllStats()
 }
 
@@ -289,9 +287,8 @@ func (m *Monitor) GetKafkaStats() map[kafka.Key]*kafka.RequestStat {
 		return nil
 	}
 
-	defer m.kafkaTelemetry.Log()
-
 	m.kafkaConsumer.Sync()
+	m.kafkaTelemetry.Log()
 	return m.kafkaStatkeeper.GetAndResetAllStats()
 }
 


### PR DESCRIPTION
This reverts commit a0481de26a4a68c1e6fb228294774e8916f37943.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Backport https://github.com/DataDog/datadog-agent/pull/17593
### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
