### PR TITLE
collect_gce_tags set to false

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -768,7 +768,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("ecs_metadata_timeout", 500) // value in milliseconds
 
 	// GCE
-	config.BindEnvAndSetDefault("collect_gce_tags", true)
+	config.BindEnvAndSetDefault("collect_gce_tags", false)
 	config.BindEnvAndSetDefault("exclude_gce_tags", []string{
 		"kube-env", "kubelet-config", "containerd-configure-sh", "startup-script", "shutdown-script",
 		"configure-sh", "sshKeys", "ssh-keys", "user-data", "cli-cert", "ipsec-cert", "ssl-cert", "google-container-manifest",

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -408,11 +408,11 @@ api_key:
 #
 # ec2_prefer_imdsv2: false
 
-## @param collect_gce_tags - boolean - optional - default: true
-## @env DD_COLLECT_GCE_TAGS - boolean - optional - default: true
+## @param collect_gce_tags - boolean - optional - default: false
+## @env DD_COLLECT_GCE_TAGS - boolean - optional - default: false
 ## Collect Google Cloud Engine metadata as host tags
 #
-# collect_gce_tags: true
+# collect_gce_tags: false
 
 ## @param exclude_gce_tags - list of strings - optional - default: ["kube-env", "kubelet-config", "containerd-configure-sh", "startup-script", "shutdown-script", "configure-sh", "sshKeys", "ssh-keys", "user-data", "cli-cert", "ipsec-cert", "ssl-cert", "google-container-manifest", "bosh_settings"]
 ## @env DD_EXCLUDE_GCE_TAGS - space separated list of strings - optional - default: kube-env kubelet-config containerd-configure-sh startup-script shutdown-script configure-sh sshKeys ssh-keys user-data cli-cert ipsec-cert ssl-cert google-container-manifest bosh_settings


### PR DESCRIPTION
### What does this PR do?
A change to set collect_gce_tags false.

### Motivation
Non-GCP environments will have periodic WARN logs due to collect_gce_tags defaulting to true.
We have issued a correction due to the impact of this on the log.

### Possible Drawbacks / Trade-offs
When using GCP, the procedure to set it up needs to be modified.

### Describe how to test/QA your changes

### Reviewer's Checklist
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.