### PR TITLE
[RC] Avoid writing in nil map

### DIFF
--- a/pkg/clusteragent/admission/patch/patcher.go
+++ b/pkg/clusteragent/admission/patch/patcher.go
@@ -137,10 +137,15 @@ func disableConfig(deploy *corev1.Deployment, req PatchRequest) {
 		log.Debugf("Found pod label %q=%q in target %s. Setting it to false", common.EnabledLabelKey, val, req.K8sTarget)
 	}
 	deploy.Spec.Template.Labels[common.EnabledLabelKey] = "false"
+	if deploy.Spec.Template.Annotations == nil {
+		return
+	}
+
 	versionAnnotKey := fmt.Sprintf(common.LibVersionAnnotKeyFormat, req.LibConfig.Language)
 	delete(deploy.Spec.Template.Annotations, versionAnnotKey)
 	configAnnotKey := fmt.Sprintf(common.LibConfigV1AnnotKeyFormat, req.LibConfig.Language)
 	delete(deploy.Spec.Template.Annotations, configAnnotKey)
 	deploy.Spec.Template.Annotations[k8sutil.RcIDAnnotKey] = req.ID
 	deploy.Spec.Template.Annotations[k8sutil.RcRevisionAnnotKey] = fmt.Sprint(req.Revision)
+
 }

--- a/pkg/clusteragent/admission/patch/patcher.go
+++ b/pkg/clusteragent/admission/patch/patcher.go
@@ -138,7 +138,7 @@ func disableConfig(deploy *corev1.Deployment, req PatchRequest) {
 	}
 	deploy.Spec.Template.Labels[common.EnabledLabelKey] = "false"
 	if deploy.Spec.Template.Annotations == nil {
-		return
+		deploy.Spec.Template.Annotations = make(map[string]string)
 	}
 
 	versionAnnotKey := fmt.Sprintf(common.LibVersionAnnotKeyFormat, req.LibConfig.Language)

--- a/pkg/clusteragent/admission/patch/patcher.go
+++ b/pkg/clusteragent/admission/patch/patcher.go
@@ -147,5 +147,4 @@ func disableConfig(deploy *corev1.Deployment, req PatchRequest) {
 	delete(deploy.Spec.Template.Annotations, configAnnotKey)
 	deploy.Spec.Template.Annotations[k8sutil.RcIDAnnotKey] = req.ID
 	deploy.Spec.Template.Annotations[k8sutil.RcRevisionAnnotKey] = fmt.Sprint(req.Revision)
-
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Checks that the map is not nil before writing to it.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Avoid a panic when testing with remote instrumentation

```
2023-06-13 09:54:28 UTC | CLUSTER | INFO | (pkg/clusteragent/admission/patch/rc_provider.go:68 in process) | Got 2 updates from remote-config
panic: assignment to entry in nil map

goroutine 1172 [running]:
github.com/DataDog/datadog-agent/pkg/clusteragent/admission/patch.disableConfig(_, {{0x4001e6d540, 0x40}, 0x188afa029ee, {0x4001e734f8, 0x6}, {0x4001e73510, 0x7}, {{0x4001e73518, 0x6}, ...}, ...})
	/go/src/github.com/wgP5tecJ/0/DataDog/datadog-agent/pkg/clusteragent/admission/patch/patcher.go:145 +0x2ac
github.com/DataDog/datadog-agent/pkg/clusteragent/admission/patch.(*patcher).patchDeployment(_, {{0x4001e6d540, 0x40}, 0x188afa029ee, {0x4001e734f8, 0x6}, {0x4001e73510, 0x7}, {{0x4001e73518, 0x6}, ...}, ...})
	/go/src/github.com/wgP5tecJ/0/DataDog/datadog-agent/pkg/clusteragent/admission/patch/patcher.go:90 +0x658
github.com/DataDog/datadog-agent/pkg/clusteragent/admission/patch.(*patcher).start(0x4001843700, 0x4000bf4ea0)
	/go/src/github.com/wgP5tecJ/0/DataDog/datadog-agent/pkg/clusteragent/admission/patch/patcher.go:47 +0x108
created by github.com/DataDog/datadog-agent/pkg/clusteragent/admission/patch.StartControllers
	/go/src/github.com/wgP5tecJ/0/DataDog/datadog-agent/pkg/clusteragent/admission/patch/start.go:37 +0x208
```
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Enable remote instrumentation. Make the first config deploy fail (for example don't properly enable the org). Redeploy it properly and make sure it does not crash.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
