### PR TITLE
Minor fixes to system-probe

### DIFF
--- a/cmd/system-probe/api/restart.go
+++ b/cmd/system-probe/api/restart.go
@@ -19,7 +19,7 @@ func restartModuleHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	moduleName := config.ModuleName(vars["module-name"])
 
-	if moduleName == config.SecurityRuntimeModule {
+	if moduleName == config.EventMonitorModule {
 		w.WriteHeader(http.StatusOK)
 		return
 	}

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -31,7 +31,6 @@ const (
 	NetworkTracerModule          ModuleName = "network_tracer"
 	OOMKillProbeModule           ModuleName = "oom_kill_probe"
 	TCPQueueLengthTracerModule   ModuleName = "tcp_queue_length_tracer"
-	SecurityRuntimeModule        ModuleName = "security_runtime"
 	ProcessModule                ModuleName = "process"
 	EventMonitorModule           ModuleName = "event_monitor"
 	DynamicInstrumentationModule ModuleName = "dynamic_instrumentation"

--- a/pkg/network/netlink/conntracker_integration_test.go
+++ b/pkg/network/netlink/conntracker_integration_test.go
@@ -132,8 +132,10 @@ func testMessageDump(t *testing.T, f *os.File, serverIP, clientIP net.IP) {
 	defer udpServer.Close()
 
 	for i := 0; i < 100; i++ {
-		nettestutil.PingTCP(t, clientIP, natPort)
-		nettestutil.PingUDP(t, clientIP, nonNatPort)
+		tc := nettestutil.PingTCP(t, clientIP, natPort)
+		tc.Close()
+		uc := nettestutil.PingUDP(t, clientIP, nonNatPort)
+		uc.Close()
 	}
 
 	time.Sleep(time.Second)

--- a/pkg/network/testutil/ping.go
+++ b/pkg/network/testutil/ping.go
@@ -26,6 +26,7 @@ func PingTCP(tb testing.TB, ip net.IP, port int) net.Conn {
 
 	conn, err := net.DialTimeout(network, addr, time.Second)
 	require.NoError(tb, err)
+	tb.Cleanup(func() { conn.Close() })
 
 	_, err = conn.Write([]byte("ping"))
 	require.NoError(tb, err)
@@ -38,7 +39,7 @@ func PingTCP(tb testing.TB, ip net.IP, port int) net.Conn {
 
 // PingUDP connects to the provided IP address over UDP/UDPv6, sends the string "ping",
 // and returns the open connection for further use/inspection.
-func PingUDP(t *testing.T, ip net.IP, port int) net.Conn {
+func PingUDP(tb testing.TB, ip net.IP, port int) net.Conn {
 	network := "udp"
 	if isIpv6(ip) {
 		network = "udp6"
@@ -48,10 +49,11 @@ func PingUDP(t *testing.T, ip net.IP, port int) net.Conn {
 		Port: port,
 	}
 	conn, err := net.DialUDP(network, nil, addr)
-	require.NoError(t, err)
+	require.NoError(tb, err)
+	tb.Cleanup(func() { conn.Close() })
 
 	_, err = conn.Write([]byte("ping"))
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	return conn
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Fixes cleanup for PingTCP/PingUDP
- Removes outdated CWS module name

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
