### PR TITLE
Allow collecting logs by file path with a logs integration config yaml +`ad_identifiers`

### DIFF
--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -190,7 +190,7 @@ func (s *Scheduler) toSources(config integration.Config) ([]*sourcesPkg.LogSourc
 		if service != nil {
 			// a config defined in a container label or a pod annotation does not always contain a type,
 			// override it here to ensure that the config won't be dropped at validation.
-			if cfg.Type == logsConfig.FileType && (config.Provider == names.Kubernetes || config.Provider == names.Container || config.Provider == names.KubeContainer) {
+			if cfg.Type == logsConfig.FileType && (config.Provider == names.Kubernetes || config.Provider == names.Container || config.Provider == names.KubeContainer || config.Provider == logsConfig.FileType) {
 				// cfg.Type is not overwritten as tailing a file from a Docker or Kubernetes AD configuration
 				// is explicitly supported (other combinations may be supported later)
 				cfg.Identifier = service.Identifier

--- a/releasenotes/notes/allow-ad-identifiers-in-file-configs-655f8f0b59f75d35.yaml
+++ b/releasenotes/notes/allow-ad-identifiers-in-file-configs-655f8f0b59f75d35.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Allow ``ad_identifiers`` to be used in file based logs integration configs 
+    in order to collect logs from disk.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[Today we allow users to annotate their pods with log file collection configurations](https://docs.datadoghq.com/containers/kubernetes/log/?tab=operator#examples---log-collection-from-file-configured-in-an-annotation) in order to instruct the agent to collect logs from disk (usually a volume mounted within the agent container).  

However this only worked when using a pod annotation, if you were include a configmap with a file based log collection config, the agent would not respect the `ad_identifiers`, and as a result not attempt to tail the file. You could omit `ad_identifiers` and collect the file, but then you lose autodiscovery. 

This change unifies the behavior between a file based configmap config and a pod annotation. 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

In a k8s cluster (minikube works), deploy the agent helm chart. 

in `values.yaml` change the `confd` [section](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L501) and add a config like:


```yaml
  confd:
    "bash.yaml": |-
      ad_identifiers:
        - bash
      logs:
        - type: file
          path: /tmp/foo/test.log
          source: bash-test
          service: bash-test
```

- Deploy a pod named `bash` that writes logs to `/tmp/test.log`
```yaml
  - command:
    - bash
    - -c
    - i=0; while true; do echo "HELLO $i at" $(date) >> /tmp/foo/test.log; i=$((i+1)); sleep 1; done

```

Mount the host path `/tmp/foo` in both the bash container and the agent container ([our docs have an example](https://docs.datadoghq.com/containers/kubernetes/log/?tab=operator#examples---log-collection-from-file-configured-in-an-annotation))

run `agent status` and you should see something like
```
  bash
  ----
    - Type: file
      Identifier: 385cefc7b2fc301ef57d86e335d408e3fc1f441ea4765956794ea11328d65704
      Path: /tmp/test.log
      Service: bash-test
      Source: bash-test
```


<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
