### PR TITLE
[corecheck/snmp] Allow custom tags in interface_configs

### DIFF
--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -170,6 +170,10 @@ func TestExtraConfig(t *testing.T) {
 				MatchValue: "eth0",
 				InSpeed:    25,
 				OutSpeed:   10,
+				Tags: []string{
+					"customTag1",
+					"customTag2:value2",
+				},
 			}},
 		},
 	}
@@ -253,7 +257,7 @@ func TestExtraConfig(t *testing.T) {
 
 	info, err = svc.GetExtraConfig("interface_configs")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, `[{"match_field":"name","match_value":"eth0","in_speed":25,"out_speed":10}]`, info)
+	assert.Equal(t, `[{"match_field":"name","match_value":"eth0","in_speed":25,"out_speed":10,"tags":["customTag1","customTag2:value2"]}]`, info)
 
 	svc = SNMPService{
 		adIdentifier: "snmp",

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -60,15 +60,6 @@ var uptimeMetricConfig = MetricsConfig{Symbol: SymbolConfig{OID: "1.3.6.1.2.1.1.
 // DeviceDigest is the digest of a minimal config used for autodiscovery
 type DeviceDigest string
 
-// InterfaceConfig interface related configs (e.g. interface speed override)
-type InterfaceConfig struct {
-	MatchField string   `yaml:"match_field"` // e.g. name, index
-	MatchValue string   `yaml:"match_value"` // e.g. eth0 (name), 10 (index)
-	InSpeed    uint64   `yaml:"in_speed"`    // inbound speed override in bits per sec
-	OutSpeed   uint64   `yaml:"out_speed"`   // outbound speed override in bits per sec
-	Tags       []string `yaml:"tags"`        // tags
-}
-
 // InitConfig is used to deserialize integration init config
 type InitConfig struct {
 	Profiles                     profileConfigMap `yaml:"profiles"`

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -62,10 +62,11 @@ type DeviceDigest string
 
 // InterfaceConfig interface related configs (e.g. interface speed override)
 type InterfaceConfig struct {
-	MatchField string `yaml:"match_field"` // e.g. name, index
-	MatchValue string `yaml:"match_value"` // e.g. eth0 (name), 10 (index)
-	InSpeed    uint64 `yaml:"in_speed"`    // inbound speed override in bits per sec
-	OutSpeed   uint64 `yaml:"out_speed"`   // outbound speed override in bits per sec
+	MatchField string   `yaml:"match_field"` // e.g. name, index
+	MatchValue string   `yaml:"match_value"` // e.g. eth0 (name), 10 (index)
+	InSpeed    uint64   `yaml:"in_speed"`    // inbound speed override in bits per sec
+	OutSpeed   uint64   `yaml:"out_speed"`   // outbound speed override in bits per sec
+	Tags       []string `yaml:"tags"`        // tags
 }
 
 // InitConfig is used to deserialize integration init config

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -7,10 +7,11 @@ package checkconfig
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/snmp/snmpintegration"
 	"regexp"
 	"testing"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/snmp/snmpintegration"
 
 	"github.com/stretchr/testify/assert"
 
@@ -1565,6 +1566,9 @@ interface_configs:
     match_value: "eth0"
     in_speed: 25
     out_speed: 10
+    tags:
+      - "muted"
+      - "test1:value1"
 `),
 			// language=yaml
 			rawInitConfig: []byte(``),
@@ -1574,6 +1578,10 @@ interface_configs:
 					MatchValue: "eth0",
 					InSpeed:    25,
 					OutSpeed:   10,
+					Tags: []string{
+						"muted",
+						"test1:value1",
+					},
 				},
 			},
 		},
@@ -1582,7 +1590,7 @@ interface_configs:
 			// language=yaml
 			rawInstanceConfig: []byte(`
 ip_address: 1.2.3.4
-interface_configs: '[{"match_field":"name","match_value":"eth0","in_speed":25,"out_speed":10}]'
+interface_configs: '[{"match_field":"name","match_value":"eth0","in_speed":25,"out_speed":10, "tags":["test2:value2", "aTag"]}]'
 `),
 			// language=yaml
 			rawInitConfig: []byte(``),
@@ -1592,6 +1600,10 @@ interface_configs: '[{"match_field":"name","match_value":"eth0","in_speed":25,"o
 					MatchValue: "eth0",
 					InSpeed:    25,
 					OutSpeed:   10,
+					Tags: []string{
+						"test2:value2",
+						"aTag",
+					},
 				},
 			},
 		},

--- a/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage.go
@@ -71,6 +71,7 @@ func (ms *MetricSender) sendBandwidthUsageMetric(symbol checkconfig.SymbolConfig
 		case "ifHCOutOctets":
 			ifSpeed = interfaceConfig.OutSpeed
 		}
+		tags = append(tags, interfaceConfig.Tags...)
 	}
 	if ifSpeed == 0 {
 		ifHighSpeed, err := ms.getIfHighSpeed(fullIndex, values)
@@ -120,6 +121,7 @@ func (ms *MetricSender) sendIfSpeedMetrics(symbol checkconfig.SymbolConfig, full
 		log.Tracef("continue with empty interfaceConfig: %s", err)
 		interfaceConfig = snmpintegration.InterfaceConfig{}
 	}
+	tags = append(tags, interfaceConfig.Tags...)
 
 	ifHighSpeed, err := ms.getIfHighSpeed(fullIndex, values)
 	if err != nil {

--- a/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_bandwidth_usage_test.go
@@ -303,9 +303,12 @@ func Test_metricSender_sendBandwidthUsageMetric(t *testing.T) {
 				MatchValue: "eth0",
 				InSpeed:    160_000_000,
 				OutSpeed:   40_000_000,
+				Tags:       []string{"muted", "customIfTagKey:customIfTagValue"},
 			}},
 			tags: []string{
 				"interface:eth0",
+				"muted",
+				"customIfTagKey:customIfTagValue",
 			},
 			values: &valuestore.ResultValueStore{
 				ColumnValues: valuestore.ColumnResultValuesType{
@@ -348,9 +351,12 @@ func Test_metricSender_sendBandwidthUsageMetric(t *testing.T) {
 				MatchValue: "9",
 				InSpeed:    160_000_000,
 				OutSpeed:   40_000_000,
+				Tags:       []string{"muted", "customIfTagKey:customIfTagValue"},
 			}},
 			tags: []string{
 				"interface:eth0",
+				"muted",
+				"customIfTagKey:customIfTagValue",
 			},
 			values: &valuestore.ResultValueStore{
 				ColumnValues: valuestore.ColumnResultValuesType{
@@ -442,6 +448,33 @@ func Test_metricSender_sendIfSpeedMetrics(t *testing.T) {
 			expectedMetric: []Metric{
 				{"snmp.ifInSpeed", 160_000_000, []string{"interface:eth0", "speed_source:custom"}},
 				{"snmp.ifOutSpeed", 40_000_000, []string{"interface:eth0", "speed_source:custom"}},
+			},
+		},
+		{
+			name:      "InSpeed and OutSpeed Override with custom tags",
+			symbol:    checkconfig.SymbolConfig{OID: "1.3.6.1.2.1.31.1.1.1.6", Name: "ifHCInOctets"},
+			fullIndex: "9",
+			interfaceConfigs: []snmpintegration.InterfaceConfig{{
+				MatchField: "index",
+				MatchValue: "9",
+				InSpeed:    160_000_000,
+				OutSpeed:   40_000_000,
+				Tags:       []string{"muted", "customKey:customValue"},
+			}},
+			tags: []string{"interface:eth0"},
+			values: &valuestore.ResultValueStore{
+				ColumnValues: valuestore.ColumnResultValuesType{
+					// ifHighSpeed
+					"1.3.6.1.2.1.31.1.1.1.15": map[string]valuestore.ResultValue{
+						"9": {
+							Value: 80.0,
+						},
+					},
+				},
+			},
+			expectedMetric: []Metric{
+				{"snmp.ifInSpeed", 160_000_000, []string{"interface:eth0", "speed_source:custom", "muted", "customKey:customValue"}},
+				{"snmp.ifOutSpeed", 40_000_000, []string{"interface:eth0", "speed_source:custom", "muted", "customKey:customValue"}},
 			},
 		},
 		{

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -74,7 +74,7 @@ func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckCon
 		}
 		interfaceTags = append(interfaceTags, tags...)
 
-		// append custom user tags
+		// append user's custom interface tags
 		interfaceCfg, err := getInterfaceConfig(ms.interfaceConfigs, interfaceIndex, interfaceTags)
 		if err != nil {
 			log.Errorf("failed to tag interface status metric with user tags: %s", err.Error())

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -59,11 +59,12 @@ func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckCon
 	// Telemetry
 	for _, interfaceStatus := range interfaces {
 		status := string(computeInterfaceStatus(interfaceStatus.AdminStatus, interfaceStatus.OperStatus))
+		interfaceIndex := strconv.Itoa(int(interfaceStatus.Index))
 		interfaceTags := []string{
 			"status:" + status,
 			"admin_status:" + interfaceStatus.AdminStatus.AsString(),
 			"oper_status:" + interfaceStatus.OperStatus.AsString(),
-			"interface_index:" + strconv.Itoa(int(interfaceStatus.Index)),
+			"interface_index:" + interfaceIndex,
 		}
 		if interfaceStatus.Name != "" {
 			interfaceTags = append(interfaceTags, "interface:"+interfaceStatus.Name)
@@ -72,6 +73,14 @@ func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckCon
 			interfaceTags = append(interfaceTags, "interface_alias:"+interfaceStatus.Alias)
 		}
 		interfaceTags = append(interfaceTags, tags...)
+
+		// append custom user tags
+		interfaceCfg, err := getInterfaceConfig(ms.interfaceConfigs, interfaceIndex, interfaceTags)
+		if err != nil {
+			log.Errorf("failed to tag interface status metric with user tags: %s", err.Error())
+		}
+		interfaceTags = append(interfaceTags, interfaceCfg.Tags...)
+
 		ms.sender.Gauge(interfaceStatusMetric, 1, "", interfaceTags)
 	}
 }

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -77,7 +77,7 @@ func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckCon
 		// append user's custom interface tags
 		interfaceCfg, err := getInterfaceConfig(ms.interfaceConfigs, interfaceIndex, interfaceTags)
 		if err != nil {
-			log.Errorf("failed to tag interface status metric with user tags: %s", err.Error())
+			log.Tracef("unable to tag %s metric with interface_config data: %s", interfaceStatusMetric, err.Error())
 		}
 		interfaceTags = append(interfaceTags, interfaceCfg.Tags...)
 

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/DataDog/datadog-agent/pkg/snmp/snmpintegration"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
@@ -257,6 +258,16 @@ func Test_metricSender_reportNetworkDeviceMetadata_withInterfaces(t *testing.T) 
 	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	ms := &MetricSender{
 		sender: sender,
+		interfaceConfigs: []snmpintegration.InterfaceConfig{
+			{
+				MatchField: "index",
+				MatchValue: "2",
+				Tags: []string{
+					"muted",
+					"someKey:someValue",
+				},
+			},
+		},
 	}
 
 	config := &checkconfig.CheckConfig{
@@ -313,7 +324,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withInterfaces(t *testing.T) 
 	ms.ReportNetworkDeviceMetadata(config, storeWithIfName, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable)
 
 	ifTags1 := []string{"tag1", "tag2", "status:down", "interface:21", "interface_alias:ifAlias1", "interface_index:1", "oper_status:up", "admin_status:down"}
-	ifTags2 := []string{"tag1", "tag2", "status:off", "interface:22", "interface_index:2", "oper_status:down", "admin_status:down"}
+	ifTags2 := []string{"tag1", "tag2", "status:off", "interface:22", "interface_index:2", "oper_status:down", "admin_status:down", "muted", "someKey:someValue"}
 
 	sender.AssertMetric(t, "Gauge", interfaceStatusMetric, 1., "", ifTags1)
 	sender.AssertMetric(t, "Gauge", interfaceStatusMetric, 1., "", ifTags2)

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
@@ -141,7 +141,10 @@ func (ms *MetricSender) reportColumnMetrics(metricConfig checkconfig.MetricsConf
 				tmpTags = append(tmpTags, metricConfig.StaticTags...)
 				tmpTags = append(tmpTags, getTagsFromMetricTagConfigList(metricConfig.MetricTags, fullIndex, values)...)
 				if isInterfaceTableMetric(symbol.OID) {
-					interfaceCfg, _ := getInterfaceConfig(ms.interfaceConfigs, fullIndex, tmpTags)
+					interfaceCfg, err := getInterfaceConfig(ms.interfaceConfigs, fullIndex, tmpTags)
+					if err != nil {
+						log.Tracef("unable to tag snmp.%s metric with interface_config data: %s", symbol.Name, err.Error())
+					}
 					tmpTags = append(tmpTags, interfaceCfg.Tags...)
 				}
 				rowTagsCache[fullIndex] = tmpTags

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
@@ -140,6 +140,10 @@ func (ms *MetricSender) reportColumnMetrics(metricConfig checkconfig.MetricsConf
 				tmpTags := common.CopyStrings(tags)
 				tmpTags = append(tmpTags, metricConfig.StaticTags...)
 				tmpTags = append(tmpTags, getTagsFromMetricTagConfigList(metricConfig.MetricTags, fullIndex, values)...)
+				if isInterfaceTableMetric(symbol.OID) {
+					interfaceCfg, _ := getInterfaceConfig(ms.interfaceConfigs, fullIndex, tmpTags)
+					tmpTags = append(tmpTags, interfaceCfg.Tags...)
+				}
 				rowTagsCache[fullIndex] = tmpTags
 			}
 			rowTags := rowTagsCache[fullIndex]

--- a/pkg/collector/corechecks/snmp/internal/report/report_utils.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_utils.go
@@ -18,6 +18,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/valuestore"
 )
 
+const (
+	ifTablePrefix  = "1.3.6.1.2.1.2.2."
+	ifXTablePrefix = "1.3.6.1.2.1.31.1.1."
+)
+
 func getScalarValueFromSymbol(values *valuestore.ResultValueStore, symbol checkconfig.SymbolConfig) (valuestore.ResultValue, error) {
 	value, err := values.GetScalarValue(symbol.OID)
 	if err != nil {
@@ -202,5 +207,6 @@ func getConstantMetricValues(mtcl checkconfig.MetricTagConfigList, values *value
 // true if the prefix matches ifTable or ifXTable from
 // the IF-MIB
 func isInterfaceTableMetric(oid string) bool {
-	return strings.HasPrefix(oid, "1.3.6.1.2.1.2.2") || strings.HasPrefix(oid, "1.3.6.1.2.1.31.1.1")
+	oid = strings.TrimPrefix(oid, ".")
+	return strings.HasPrefix(oid, ifTablePrefix) || strings.HasPrefix(oid, ifXTablePrefix)
 }

--- a/pkg/collector/corechecks/snmp/internal/report/report_utils.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_utils.go
@@ -197,3 +197,10 @@ func getConstantMetricValues(mtcl checkconfig.MetricTagConfigList, values *value
 	}
 	return constantValues
 }
+
+// isInterfaceTableMetric takes in an OID and returns
+// true if the prefix matches ifTable or ifXTable from
+// the IF-MIB
+func isInterfaceTableMetric(oid string) bool {
+	return strings.HasPrefix(oid, "1.3.6.1.2.1.2.2") || strings.HasPrefix(oid, "1.3.6.1.2.1.31.1.1")
+}

--- a/pkg/collector/corechecks/snmp/internal/report/report_utils_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_utils_test.go
@@ -1106,3 +1106,64 @@ func Test_getContantMetricValues(t *testing.T) {
 		})
 	}
 }
+
+func Test_isInterfaceTableMetric(t *testing.T) {
+	tests := []struct {
+		name     string
+		oid      string
+		expected bool
+	}{
+		{
+			name:     "OID in ifTable with . prefix",
+			oid:      ".1.3.6.1.2.1.2.2.1.7", // ifAdminStatus
+			expected: true,
+		},
+		{
+			name:     "OID in ifXTable with . prefix",
+			oid:      ".1.3.6.1.2.1.31.1.1.1.10", // ifHCOutOctets
+			expected: true,
+		},
+		{
+			name:     "OID with similar prefix to ifTable with . prefix",
+			oid:      ".1.3.6.1.2.1.2.2222",
+			expected: false,
+		},
+		{
+			name:     "OID with similar prefix to ifTable",
+			oid:      "1.3.6.1.2.1.2.2222",
+			expected: false,
+		},
+		{
+			name:     "OID with similar prefix to ifXTable with . prefix",
+			oid:      ".1.3.6.1.2.1.31.1.1111",
+			expected: false,
+		},
+		{
+			name:     "OID with similar prefix to ifXTable",
+			oid:      "1.3.6.1.2.1.31.1.111",
+			expected: false,
+		},
+		{
+			name:     "OID in ifTable",
+			oid:      "1.3.6.1.2.1.2.2.1.8", // ifOperStatus
+			expected: true,
+		},
+		{
+			name:     "OID in ifXTable",
+			oid:      "1.3.6.1.2.1.31.1.1.1.9", // ifHCInBroadcastPkts
+			expected: true,
+		},
+		{
+			name:     "random OID",
+			oid:      "1.3.6.1.4.1.4.7.34.2345",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := isInterfaceTableMetric(tt.oid)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/pkg/snmp/snmpintegration/config.go
+++ b/pkg/snmp/snmpintegration/config.go
@@ -7,8 +7,9 @@ package snmpintegration
 
 // InterfaceConfig interface related configs (e.g. interface speed override)
 type InterfaceConfig struct {
-	MatchField string `mapstructure:"match_field" yaml:"match_field" json:"match_field"` // e.g. name, index
-	MatchValue string `mapstructure:"match_value" yaml:"match_value" json:"match_value"` // e.g. eth0 (name), 10 (index)
-	InSpeed    uint64 `mapstructure:"in_speed" yaml:"in_speed" json:"in_speed"`          // inbound speed override in bps
-	OutSpeed   uint64 `mapstructure:"out_speed" yaml:"out_speed" json:"out_speed"`       // outbound speed override in bps
+	MatchField string   `mapstructure:"match_field" yaml:"match_field" json:"match_field"` // e.g. name, index
+	MatchValue string   `mapstructure:"match_value" yaml:"match_value" json:"match_value"` // e.g. eth0 (name), 10 (index)
+	InSpeed    uint64   `mapstructure:"in_speed" yaml:"in_speed" json:"in_speed"`          // inbound speed override in bps
+	OutSpeed   uint64   `mapstructure:"out_speed" yaml:"out_speed" json:"out_speed"`       // outbound speed override in bps
+	Tags       []string `mapstructure:"tags" yaml:"tags" json:"tags"`                      // interface tags
 }

--- a/releasenotes/notes/snmp_add_tags_to_interface_configs-50283df5d3adabf7.yaml
+++ b/releasenotes/notes/snmp_add_tags_to_interface_configs-50283df5d3adabf7.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    [corechecks/snmp] Add ``tags`` to ``interface_configs`` to tag interface metrics
+


### PR DESCRIPTION
### What does this PR do?
Allows users to add custom tags to interfaces based on `interface_configs` similar to how custom interface speed is calculated today.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Customers want to selectively alert on interfaces and by tagging with something like `alerting:disabled` customers can create simple queries to accomplish this.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->


### Describe how to test/QA your changes
Ensure that custom tags are present for the following metrics but only on the IP/interface configured in both single instance and autodiscovery configuration:
```
snmp.interface.status
snmp.ifAdminStatus
snmp.ifOperStatus
snmp.ifInErrors
snmp.ifInErrors.rate
snmp.ifInDiscards
snmp.ifInDiscards.rate
snmp.ifOutErrors
snmp.ifOutErrors.rate
snmp.ifOutDiscards
snmp.ifOutDiscards.rate
snmp.ifSpeed
snmp.ifHCInUcastPkts
snmp.ifHCInMulticastPkts
snmp.ifHCInBroadcastPkts
snmp.ifHCOutUcastPkts
snmp.ifHCOutMulticastPkts
snmp.ifHCOutBroadcastPkts
snmp.ifHCInOctets
snmp.ifHCInOctets.rate
snmp.ifHCOutOctets
snmp.ifHCOutOctets.rate
snmp.ifHighSpeed
snmp.ifBandwidthInUsage.rate
snmp.ifInSpeed
snmp.ifOutSpeed
```

1) Single Instance Configuration
```yaml
init_config:
  loader: core  # use core check implementation of SNMP integration. recommended
  use_device_id_as_hostname: true  # recommended
instances:
  - ip_address: '127.0.0.1'
    port: 1161
    community_string: 'public'
    interface_configs:
      - match_field: index
        match_value: 1
        tags:
          - "thisIsACustomTag:thisIsItsValue"
```

2) Autodiscovery Configuration
```yaml
listeners:
  - name: snmp
snmp_listener:
  workers: 100  # number of workers used to discover devices concurrently
  discovery_interval: 3600  # interval between each autodiscovery in seconds
  loader: core  # use core check implementation of SNMP integration. recommended
  use_device_id_as_hostname: true  # recommended
  configs:
    - network_address: 127.0.0.0/24  # CIDR subnet (127.0.0.1-127.0.0.3)
      loader: core
      snmp_version: 2
      port: 1161
      community_string: public
      interface_configs:
        "127.0.0.1":
          - match_field: "name"
            match_value: "eth0"
            tags:
              - "alexMadeThisEasy:tyAlex"
              - "customTagAgain:wowItWorks"
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
