### PR TITLE
[Serverless] Require serverless specific milestones for serverless PRs.

### DIFF
--- a/tasks/test.py
+++ b/tasks/test.py
@@ -785,7 +785,20 @@ def lint_milestone(_):
 
         res = requests.get(f"https://api.github.com/repos/DataDog/datadog-agent/issues/{pr_id}")
         pr = res.json()
-        if pr.get("milestone"):
+        labels = pr.get("labels") or []
+        milestone = pr.get("milestone") or {}
+
+        # serverless team PRs must have serverless specific milestones
+        for label in labels:
+            if label.get("name") == "team/serverless":
+                title = milestone.get("title")
+                if not title or not title.startswith("lambda-extension-"):
+                    print(f"PR {pr_url} is assigned to 'team/serverless' and "
+                          "therefore requires a milestone that starts with "
+                          "'lambda-extension-'.")
+                    raise Exit(code=1)
+
+        if milestone:
             print(f"Milestone: {pr['milestone'].get('title', 'NO_TITLE')}")
             return
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Requires that any PRs by the serverless team are given a serverless specific milestone in the form `lambda-extension-x`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

On the serverless team, we do not always release off `main` when creating an AWS Lambda Extension release. Very often we’ll check out the tag from our last release, then cherry-pick any commits we want to go into the new release. 

The problem with this is we do not currently have a way to track which commits to include. We’ll usually write a message in our private team channel and then expect the team to respond to the message with commits they've each made since the last release. So, if you aren’t at work the day we release, your work won’t make it in. 

Instead, we’d like to add a `lambda-extension-x` milestone to our PRs so whoever is releasing can easily see what needs to go into the next release.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

I am giving this PR the `Triage` milestone so we can see exactly how a failure will look.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
