### PR TITLE
[SNMP] Update extract_value to support non-string types

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/valuestore/value.go
+++ b/pkg/collector/corechecks/snmp/internal/valuestore/value.go
@@ -42,21 +42,17 @@ func (sv ResultValue) ToString() (string, error) {
 
 // ExtractStringValue extract value using a regex
 func (sv ResultValue) ExtractStringValue(extractValuePattern *regexp.Regexp) (ResultValue, error) {
-	switch sv.Value.(type) {
-	case string, []byte:
-		srcValue := bytesOrStringToString(sv.Value)
-		matches := extractValuePattern.FindStringSubmatch(srcValue)
-		if matches == nil {
-			return ResultValue{}, fmt.Errorf("extract value extractValuePattern does not match (extractValuePattern=%v, srcValue=%v)", extractValuePattern, srcValue)
-		}
-		if len(matches) < 2 {
-			return ResultValue{}, fmt.Errorf("extract value pattern des not contain any matching group (extractValuePattern=%v, srcValue=%v)", extractValuePattern, srcValue)
-		}
-		matchedValue := matches[1] // use first matching group
-		return ResultValue{SubmissionType: sv.SubmissionType, Value: matchedValue}, nil
-	default:
-		return sv, nil
+	// Cast unknown type to a string
+	srcValue := fmt.Sprintf("%v", sv.Value)
+	matches := extractValuePattern.FindStringSubmatch(srcValue)
+	if matches == nil {
+		return ResultValue{}, fmt.Errorf("extract value extractValuePattern does not match (extractValuePattern=%v, srcValue=%v)", extractValuePattern, srcValue)
 	}
+	if len(matches) < 2 {
+		return ResultValue{}, fmt.Errorf("extract value pattern des not contain any matching group (extractValuePattern=%v, srcValue=%v)", extractValuePattern, srcValue)
+	}
+	matchedValue := matches[1] // use first matching group
+	return ResultValue{SubmissionType: sv.SubmissionType, Value: matchedValue}, nil
 }
 
 func bytesOrStringToString(value interface{}) string {

--- a/releasenotes/notes/snmp_add_non_string_support_for_extract_value-6cdcb595eaab20bb.yaml
+++ b/releasenotes/notes/snmp_add_non_string_support_for_extract_value-6cdcb595eaab20bb.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add support for using extract_value on non-strings (aka integers and floats) in SNMP Profiles


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds support in SNMP Profiles for the `extract_value` option to be used on number fields.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
We are currently working on an SNMP Profile, specifically adding a metric for temperature, and the vendor for the device deviated from industry standard and used millidegrees instead of degrees. We are trying to use `extract_value` to round the number to degrees, and it works on the Python loader, but does not work on Core.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
This is already how it works with the Python loader for the agent, this just brings parity with Core.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
If folks are already using `extract_value` on number fields, it currently does nothing. So, upgrading to a version with this fix will cause a change for them.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Added Unit tests for String, Integer, and Float values

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [X] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [X] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [X] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [X] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [X] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [X] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
