### PR TITLE
config/apm: fix parsing DD_APM_FEATURES

### DIFF
--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -235,7 +235,7 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 		if c.HasFeature("big_resource") {
 			c.MaxResourceLen = 15_000
 		}
-		log.Debug("Found APM feature flags: %v", c.Features)
+		log.Infof("Found APM feature flags: %s", feats)
 	}
 
 	if k := "apm_config.ignore_resources"; coreconfig.Datadog.IsSet(k) {

--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -114,7 +114,21 @@ func setupAPM(config Config) {
 	config.BindEnv("apm_config.obfuscation.credit_cards.luhn", "DD_APM_OBFUSCATION_CREDIT_CARDS_LUHN")
 	config.BindEnvAndSetDefault("apm_config.debug.port", 5012, "DD_APM_DEBUG_PORT")
 	config.BindEnv("apm_config.features", "DD_APM_FEATURES")
-	config.SetEnvKeyTransformer("apm_config.features", parseKVList("apm_config.features"))
+	config.SetEnvKeyTransformer("apm_config.features", func(s string) interface{} {
+		// Either commas or spaces can be used as separators.
+		// Comma takes precedence as it was the only supported separator in the past.
+		// Mixing separators is not supported.
+		var res []string
+		if strings.ContainsRune(s, ',') {
+			res = strings.Split(s, ",")
+		} else {
+			res = strings.Split(s, " ")
+		}
+		for i, v := range res {
+			res[i] = strings.TrimSpace(v)
+		}
+		return res
+	})
 
 	config.SetEnvKeyTransformer("apm_config.ignore_resources", func(in string) interface{} {
 		r, err := splitCSVString(in, ',')

--- a/releasenotes/notes/apm-features-fix-c1c0adac4f3f4edf.yaml
+++ b/releasenotes/notes/apm-features-fix-c1c0adac4f3f4edf.yaml
@@ -11,4 +11,4 @@ fixes:
     APM: Fix a bug introduced in Agent versions 7.44 and 6.44 that
     changed the expected strings separator from comma to space when
     multiple features are defined in DD_APM_FEATURES.
-    Now either separator can be used (e.g DD_APM_FEATURES="feat1,feat2" or DD_APM_FEATURES="feat1 feat2").
+    Now either separator can be used (for example, DD_APM_FEATURES="feat1,feat2" or DD_APM_FEATURES="feat1 feat2").

--- a/releasenotes/notes/apm-features-fix-c1c0adac4f3f4edf.yaml
+++ b/releasenotes/notes/apm-features-fix-c1c0adac4f3f4edf.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fixed a bug introduced in Agent versions 7.44 and 6.44 that
+    changed the expected strings separator from comma to space when
+    multiple features are defined in DD_APM_FEATURES.
+    Now either separator can be used (e.g DD_APM_FEATURES="feat1,feat2" or DD_APM_FEATURES="feat1 feat2").

--- a/releasenotes/notes/apm-features-fix-c1c0adac4f3f4edf.yaml
+++ b/releasenotes/notes/apm-features-fix-c1c0adac4f3f4edf.yaml
@@ -8,7 +8,7 @@
 ---
 fixes:
   - |
-    APM: Fixed a bug introduced in Agent versions 7.44 and 6.44 that
+    APM: Fix a bug introduced in Agent versions 7.44 and 6.44 that
     changed the expected strings separator from comma to space when
     multiple features are defined in DD_APM_FEATURES.
     Now either separator can be used (e.g DD_APM_FEATURES="feat1,feat2" or DD_APM_FEATURES="feat1 feat2").


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Support either `,` or ` ` as separator when parsing the value of `DD_APM_FEATURES`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fix a regression introduced in https://github.com/DataDog/datadog-agent/pull/15904 which changed the separator from comma to space. This was a breaking change.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

From 7.44 to 7.46 using a space as separator was suggested ad a workaround, this PR ensures we don't break compatibility again. We now support either space or comma.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Covered by unit tests
- For manual QA you can run the agent with `DD_APM_FEATURES="error_rare_sample_tracer_drop,enable_cid_stats"` and then with `DD_APM_FEATURES="error_rare_sample_tracer_drop enable_cid_stats"`. In both cases you have to see the info log `Found APM feature flags: [error_rare_sample_tracer_drop enable_cid_stats]` 

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
