### PR TITLE
[omnibus] Copy SNMP default and user profiles folders

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -432,9 +432,12 @@ build do
         end
 
         # Copy SNMP profiles
-        profiles = "#{check_dir}/datadog_checks/#{check}/data/profiles"
-        if File.exist? profiles
-          copy profiles, "#{check_conf_dir}/"
+        profile_folders = ['profiles', 'user_profiles']
+        profile_folders.each do |profile_folder|
+            folder_path = "#{check_dir}/datadog_checks/#{check}/data/#{profile_folder}"
+            if File.exist? folder_path
+              copy folder_path, "#{check_conf_dir}/"
+            end
         end
 
         # pip < 21.2 replace underscores by dashes in package names per https://pip.pypa.io/en/stable/news/#v21-2

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -432,7 +432,7 @@ build do
         end
 
         # Copy SNMP profiles
-        profile_folders = ['profiles', 'user_profiles']
+        profile_folders = ['profiles', 'default_profiles']
         profile_folders.each do |profile_folder|
             folder_path = "#{check_dir}/datadog_checks/#{check}/data/#{profile_folder}"
             if File.exist? folder_path

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -437,9 +437,12 @@ build do
         end
 
         # Copy SNMP profiles
-        profiles = "#{check_dir}/datadog_checks/#{check}/data/profiles"
-        if File.exist? profiles
-          copy profiles, "#{check_conf_dir}/"
+        profile_folders = ['profiles', 'user_profiles']
+        profile_folders.each do |profile_folder|
+            folder_path = "#{check_dir}/datadog_checks/#{check}/data/#{profile_folder}"
+            if File.exist? folder_path
+              copy folder_path, "#{check_conf_dir}/"
+            end
         end
 
         # pip < 21.2 replace underscores by dashes in package names per https://pip.pypa.io/en/stable/news/#v21-2

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -437,7 +437,7 @@ build do
         end
 
         # Copy SNMP profiles
-        profile_folders = ['profiles', 'user_profiles']
+        profile_folders = ['profiles', 'default_profiles']
         profile_folders.each do |profile_folder|
             folder_path = "#{check_dir}/datadog_checks/#{check}/data/#{profile_folder}"
             if File.exist? folder_path


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Copy SNMP default and user profiles folders

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Copy both `profiles` and `user_profiles` folders needed for https://github.com/DataDog/datadog-agent/pull/17395]

Related integrations-core PR: https://github.com/DataDog/integrations-core/pull/14752

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
