### PR TITLE
[corechecks/snmp] Allow extending default profile with same name

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/profile_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/profile_test.go
@@ -241,6 +241,7 @@ func Test_loadProfiles(t *testing.T) {
 			inputProfileConfigMap: profileConfigMap{
 				"f5-big-ip": {
 					DefinitionFile: filepath.Join(string(filepath.Separator), "does", "not", "exist"),
+					isUserProfile:  true,
 				},
 			},
 			expectedProfileDefMap: profileConfigMap{},
@@ -253,6 +254,7 @@ func Test_loadProfiles(t *testing.T) {
 			inputProfileConfigMap: profileConfigMap{
 				"f5-big-ip": {
 					DefinitionFile: profileWithInvalidExtends,
+					isUserProfile:  true,
 				},
 			},
 			expectedProfileDefMap: profileConfigMap{},
@@ -463,12 +465,13 @@ func Test_loadDefaultProfiles_withUserProfiles(t *testing.T) {
 	defaultProfiles, err := loadDefaultProfiles()
 	assert.Nil(t, err)
 
-	assert.Len(t, defaultProfiles, 3)
+	assert.Len(t, defaultProfiles, 4)
 	assert.NotNil(t, defaultProfiles)
 
 	p1 := defaultProfiles["p1"].Definition // user p1 overrides datadog p1
 	p2 := defaultProfiles["p2"].Definition // datadog p2
 	p3 := defaultProfiles["p3"].Definition // user p3
+	p4 := defaultProfiles["p4"].Definition // user p3
 
 	assert.Equal(t, "p1_user", p1.Device.Vendor) // overrides datadog p1 profile
 	assert.NotNil(t, getMetricFromProfile(p1, "p1_metric_override"))
@@ -478,6 +481,10 @@ func Test_loadDefaultProfiles_withUserProfiles(t *testing.T) {
 
 	assert.Equal(t, "p3_user", p3.Device.Vendor)
 	assert.NotNil(t, getMetricFromProfile(p3, "p3_metric"))
+
+	assert.Equal(t, "p4_user", p4.Device.Vendor)
+	assert.NotNil(t, getMetricFromProfile(p4, "p4_user_metric"))
+	assert.NotNil(t, getMetricFromProfile(p4, "p4_default_metric"))
 }
 
 func Test_loadDefaultProfiles_invalidDir(t *testing.T) {

--- a/pkg/collector/corechecks/snmp/internal/test/user_profiles.d/snmp.d/default_profiles/p4.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/user_profiles.d/snmp.d/default_profiles/p4.yaml
@@ -1,0 +1,14 @@
+# Profile for F5 BIG-IP devices
+#
+extends:
+  - _base.yaml
+
+device:
+  vendor: "p4_default"
+
+sysobjectid: 1.2.5.*
+
+metrics:
+  - symbol:
+      OID: 1.2.3.5
+      name: p4_default_metric

--- a/pkg/collector/corechecks/snmp/internal/test/user_profiles.d/snmp.d/profiles/p4.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/user_profiles.d/snmp.d/profiles/p4.yaml
@@ -1,0 +1,14 @@
+# Profile for F5 BIG-IP devices
+#
+extends:
+  - p4.yaml
+
+device:
+  vendor: "p4_user"
+
+sysobjectid: 1.2.5.*
+
+metrics:
+  - symbol:
+      OID: 1.2.3.5
+      name: p4_user_metric


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[corechecks/snmp] Allow extending default profile with same name

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This will help users to extend a default profiles instead of having to overwrite it (by copying the content of the default profile).

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
