### PR TITLE
[CWS] support kernel with usernamespaces arguments for security functions

### DIFF
--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -144,10 +144,6 @@ unsigned long __attribute__((always_inline)) get_dentry_ino(struct dentry *dentr
     return get_inode_ino(get_dentry_inode(dentry));
 }
 
-void __attribute__((always_inline)) write_dentry_inode(struct dentry *dentry, struct inode **d_inode) {
-    bpf_probe_read(d_inode, sizeof(d_inode), &dentry->d_inode);
-}
-
 struct dentry* __attribute__((always_inline)) get_file_dentry(struct file *file) {
     struct dentry *file_dentry;
     bpf_probe_read(&file_dentry, sizeof(file_dentry), &file->f_path.dentry);

--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -30,6 +30,12 @@ dev_t __attribute__((always_inline)) get_dentry_dev(struct dentry *dentry) {
     return dev;
 }
 
+u64 __attribute__((always_inline)) has_usernamespace_first_arg(void) {
+    u64 flag;
+    LOAD_CONSTANT("has_usernamespace_first_arg", flag);
+    return flag;
+}
+
 u32 __attribute__((always_inline)) get_mount_offset_of_mount_id(void) {
     u64 offset;
     LOAD_CONSTANT("mount_id_offset", offset);

--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -14,10 +14,6 @@ unsigned long __attribute__((always_inline)) get_inode_ino(struct inode *inode) 
     return ino;
 }
 
-void __attribute__((always_inline)) write_inode_ino(struct inode *inode, u64 *ino) {
-    bpf_probe_read(ino, sizeof(inode), &inode->i_ino);
-}
-
 dev_t __attribute__((always_inline)) get_inode_dev(struct inode *inode) {
     dev_t dev;
     struct super_block *sb;

--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -30,7 +30,7 @@ dev_t __attribute__((always_inline)) get_dentry_dev(struct dentry *dentry) {
     return dev;
 }
 
-u64 __attribute__((always_inline)) has_usernamespace_first_arg(void) {
+u64 __attribute__((always_inline)) security_have_usernamespace_first_arg(void) {
     u64 flag;
     LOAD_CONSTANT("has_usernamespace_first_arg", flag);
     return flag;

--- a/pkg/security/ebpf/c/include/hooks/setattr.h
+++ b/pkg/security/ebpf/c/include/hooks/setattr.h
@@ -17,7 +17,7 @@ int kprobe_security_inode_setattr(struct pt_regs *ctx) {
 
     struct dentry *dentry;
     struct iattr *iattr;
-    if (has_usernamespace_first_arg()) {
+    if (security_have_usernamespace_first_arg()) {
         dentry = (struct dentry *)PT_REGS_PARM2(ctx);
         iattr = (struct iattr *)PT_REGS_PARM3(ctx);
     } else {

--- a/pkg/security/ebpf/c/include/hooks/setattr.h
+++ b/pkg/security/ebpf/c/include/hooks/setattr.h
@@ -14,10 +14,10 @@ int kprobe_security_inode_setattr(struct pt_regs *ctx) {
         return 0;
     }
 
-    struct dentry *dentry = (struct dentry *)PT_REGS_PARM1(ctx);
+    struct dentry *dentry = (struct dentry *)PT_REGS_PARM2(ctx);
     fill_file_metadata(dentry, &syscall->setattr.file.metadata);
 
-    struct iattr *iattr = (struct iattr *)PT_REGS_PARM2(ctx);
+    struct iattr *iattr = (struct iattr *)PT_REGS_PARM3(ctx);
     if (iattr != NULL) {
         int valid;
         bpf_probe_read(&valid, sizeof(valid), &iattr->ia_valid);

--- a/pkg/security/ebpf/c/include/hooks/setattr.h
+++ b/pkg/security/ebpf/c/include/hooks/setattr.h
@@ -15,14 +15,18 @@ int kprobe_security_inode_setattr(struct pt_regs *ctx) {
         return 0;
     }
 
+    u64 param1 = PT_REGS_PARM1(ctx);
+    u64 param2 = PT_REGS_PARM2(ctx);
+    u64 param3 = PT_REGS_PARM3(ctx);
+
     struct dentry *dentry;
     struct iattr *iattr;
     if (security_have_usernamespace_first_arg()) {
-        dentry = (struct dentry *)PT_REGS_PARM2(ctx);
-        iattr = (struct iattr *)PT_REGS_PARM3(ctx);
+        dentry = (struct dentry *)param2;
+        iattr = (struct iattr *)param3;
     } else {
-        dentry = (struct dentry *)PT_REGS_PARM1(ctx);
-        iattr = (struct iattr *)PT_REGS_PARM2(ctx);
+        dentry = (struct dentry *)param1;
+        iattr = (struct iattr *)param2;
     }
 
     fill_file_metadata(dentry, &syscall->setattr.file.metadata);

--- a/pkg/security/ebpf/c/include/hooks/setattr.h
+++ b/pkg/security/ebpf/c/include/hooks/setattr.h
@@ -2,6 +2,7 @@
 #define _HOOKS_SETATTR_H_
 
 #include "constants/syscall_macro.h"
+#include "constants/offsets/filesystem.h"
 #include "helpers/approvers.h"
 #include "helpers/events_predicates.h"
 #include "helpers/filesystem.h"
@@ -14,10 +15,18 @@ int kprobe_security_inode_setattr(struct pt_regs *ctx) {
         return 0;
     }
 
-    struct dentry *dentry = (struct dentry *)PT_REGS_PARM2(ctx);
+    struct dentry *dentry;
+    struct iattr *iattr;
+    if (has_usernamespace_first_arg()) {
+        dentry = (struct dentry *)PT_REGS_PARM2(ctx);
+        iattr = (struct iattr *)PT_REGS_PARM3(ctx);
+    } else {
+        dentry = (struct dentry *)PT_REGS_PARM1(ctx);
+        iattr = (struct iattr *)PT_REGS_PARM2(ctx);
+    }
+
     fill_file_metadata(dentry, &syscall->setattr.file.metadata);
 
-    struct iattr *iattr = (struct iattr *)PT_REGS_PARM3(ctx);
     if (iattr != NULL) {
         int valid;
         bpf_probe_read(&valid, sizeof(valid), &iattr->ia_valid);

--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -87,6 +87,8 @@ var (
 	Kernel5_18 = kernel.VersionCode(5, 18, 0)
 	// Kernel5_19 is the KernelVersion representation of kernel version 5.19
 	Kernel5_19 = kernel.VersionCode(5, 19, 0)
+	// Kernel6_0 is the KernelVersion representation of kernel version 6.0
+	Kernel6_0 = kernel.VersionCode(6, 0, 0)
 )
 
 // Version defines a kernel version helper

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -1540,6 +1540,10 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 			Value: getDoForkInput(p.kernelVersion),
 		},
 		manager.ConstantEditor{
+			Name:  "has_usernamespace_first_arg",
+			Value: getHasUsernamespaceFirstArg(p.kernelVersion),
+		},
+		manager.ConstantEditor{
 			Name:  "mount_id_offset",
 			Value: mount.GetMountIDOffset(p.kernelVersion),
 		},
@@ -1723,6 +1727,13 @@ func getDoForkInput(kernelVersion *kernel.Version) uint64 {
 		return doForkStructInput
 	}
 	return doForkListInput
+}
+
+func getHasUsernamespaceFirstArg(kernelVersion *kernel.Version) uint64 {
+	if kernelVersion.Code != 0 && kernelVersion.Code >= kernel.Kernel6_0 {
+		return 1
+	}
+	return 0
 }
 
 // isBPFSendSignalHelperAvailable returns true if the bpf_send_signal helper is available in the current kernel


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds support for kernel with user namespace pointer as first argument to some security hook functions. This provides support for kernel 6.0 and higher. Introduced by https://github.com/torvalds/linux/commit/0e363cf3fa598c69340794da068d4d9cbc869322
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
