### PR TITLE
[omnibus] Upgrade version of Python to one that uses OpenSSL 1.1.1u on Windows

### DIFF
--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -68,19 +68,19 @@ if ohai["platform"] != "windows"
   end
 
 else
-  default_version "3.8.16-2609a9b"
+  default_version "3.8.16-dc2e87f"
   dependency "vc_redist_14"
 
   if windows_arch_i386?
     dependency "vc_ucrt_redist"
 
     source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x86.zip",
-            :sha256 => "07A1CD790D258AE925502E362701DED8B7362418766B89FE3CF53DB16D349A9C".downcase
+            :sha256 => "A0D0451685DA1D1EA343F43A42BFB9843EE198BCFC6B51239A77EF1DDF5CE26E".downcase
   else
 
     # note that startring with 3.7.3 on Windows, the zip should be created without the built-in pip
     source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x64.zip",
-         :sha256 => "E93C7A7290F422FDC09131B01DCE1F9FD94DC5273F26149FCDF8CC6B26454DE1".downcase
+         :sha256 => "D3BACF66A264913CC1CD194B6875167FCCD91FE1B2D4FFAA314731D656A3FE3C".downcase
 
   end
   vcrt140_root = "#{Omnibus::Config.source_dir()}/vc_redist_140/expanded"

--- a/releasenotes/notes/update-openssl-on-windows-to-1.1.1u-f901e37b3bf49efb.yaml
+++ b/releasenotes/notes/update-openssl-on-windows-to-1.1.1u-f901e37b3bf49efb.yaml
@@ -1,0 +1,4 @@
+---
+security:
+  - |
+    Updated the version of OpenSSL used by Python to `1.1.1u` on Windows


### PR DESCRIPTION
### What does this PR do?

Upgrades the version of OpenSSL being used to `1.1.1u`. Fixes CVE-2023-2650, CVE-2023-0466, CVE-2023-0465 and CVE-2023-0464.
See https://www.openssl.org/news/openssl-1.1.1-notes.html for more details.

Windows OpenSSL upgrade: [OpenSSL 1.1.1u](https://github.com/DataDog/cpython/pull/24).

### Motivation

The current version of OpenSSL being used (`1.1.1s` on Windows `1.1.1t` on Linux/macOS) has some reported CVEs that are mitigated by version `1.1.1u`.

### Describe how to test/QA your changes

* Run an Agent with Python 3 (either Agent 6 configured with py3 or an Agent 7)
* Execute agent status and validate Python version
* Validate the Python integrations are working properly


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
