### PR TITLE
http2: remove packed enum values (#17586)

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -42,7 +42,7 @@ typedef enum {
     kMethod = 2,
     kPath = 4,
     kStatus = 9,
-} __attribute__ ((packed)) static_table_key_t;
+} static_table_key_t;
 
 typedef enum {
     kGET = 2,
@@ -56,7 +56,7 @@ typedef enum {
     k400 = 12,
     k404 = 13,
     k500 = 14,
-} __attribute__ ((packed)) static_table_value_t;
+} static_table_value_t;
 
 typedef struct {
     static_table_key_t key;
@@ -84,7 +84,7 @@ typedef struct {
     __u64 request_started;
 
     __u16 response_status_code;
-    __u8 request_method;
+    __u32 request_method;
     __u8 path_size;
     bool request_end_of_stream;
 

--- a/pkg/network/protocols/http/http2_types_linux.go
+++ b/pkg/network/protocols/http/http2_types_linux.go
@@ -19,15 +19,15 @@ type EbpfHttp2Tx struct {
 	Response_last_seen    uint64
 	Request_started       uint64
 	Response_status_code  uint16
-	Request_method        uint8
+	Request_method        uint32
 	Path_size             uint8
 	Request_end_of_stream bool
-	Pad_cgo_0             [3]byte
+	Pad_cgo_0             [6]byte
 	Request_path          [30]uint8
 	Pad_cgo_1             [2]byte
 }
 
-type StaticTableEnumKey = uint8
+type StaticTableEnumKey = uint32
 
 const (
 	MethodKey StaticTableEnumKey = 0x2
@@ -35,7 +35,7 @@ const (
 	StatusKey StaticTableEnumKey = 0x9
 )
 
-type StaticTableEnumValue = uint8
+type StaticTableEnumValue = uint32
 
 const (
 	GetValue       StaticTableEnumValue = 0x2
@@ -52,6 +52,6 @@ const (
 )
 
 type StaticTableValue = struct {
-	Key   uint8
-	Value uint8
+	Key   uint32
+	Value uint32
 }

--- a/pkg/network/protocols/http/model_http2_linux.go
+++ b/pkg/network/protocols/http/model_http2_linux.go
@@ -107,7 +107,7 @@ func (tx *EbpfHttp2Tx) RequestStarted() uint64 {
 }
 
 func (tx *EbpfHttp2Tx) SetRequestMethod(m Method) {
-	tx.Request_method = uint8(m)
+	tx.Request_method = uint32(m)
 }
 
 func (tx *EbpfHttp2Tx) StaticTags() uint64 {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR fixes a loading issue due to a kernel bug with packed enums, that are used in our HTTP2 monitoring. The bug was introduced in kernel 4.18 and fixed in 4.19.114, 5.4.29, 5.5.14 and 5.6.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

The bug can be reproduced by running grpc tests on a 5.4 kernel, without the fix:
`inv -e system-probe.test --skip-linters -p ./pkg/network/protocols/grpc`
One should see errors such as:
```
Error: could not instantiate http monitor: error initializing http ebpf program: verifier error loading eBPF programs: map http2_static_table: load BTF: load btf: invalid argument: [8] STRUCT (anon) size=2 vlen=2: key type_id=6 bits_offset=0 Member exceeds struct_size (34 line(s) omitted)
```
After the fix, the tests should pass.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
