### PR TITLE
[CWS] update fallback constants for recent kernels

### DIFF
--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -89,6 +89,8 @@ var (
 	Kernel5_19 = kernel.VersionCode(5, 19, 0)
 	// Kernel6_0 is the KernelVersion representation of kernel version 6.0
 	Kernel6_0 = kernel.VersionCode(6, 0, 0)
+	// Kernel6_1 is the KernelVersion representation of kernel version 6.1
+	Kernel6_1 = kernel.VersionCode(6, 1, 0)
 	// Kernel6_2 is the KernelVersion representation of kernel version 6.2
 	Kernel6_2 = kernel.VersionCode(6, 2, 0)
 )

--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -89,6 +89,8 @@ var (
 	Kernel5_19 = kernel.VersionCode(5, 19, 0)
 	// Kernel6_0 is the KernelVersion representation of kernel version 6.0
 	Kernel6_0 = kernel.VersionCode(6, 0, 0)
+	// Kernel6_2 is the KernelVersion representation of kernel version 6.2
+	Kernel6_2 = kernel.VersionCode(6, 2, 0)
 )
 
 // Version defines a kernel version helper

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -460,8 +460,10 @@ func getBpfProgAuxNameOffset(kv *kernel.Version) uint64 {
 		nameOffset = 528
 	case kv.IsInRangeCloseOpen(kernel.Kernel5_16, kernel.Kernel5_17):
 		nameOffset = 544
-	case kv.Code != 0 && kv.Code >= kernel.Kernel5_17:
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_17, kernel.Kernel6_1):
 		nameOffset = 528
+	case kv.Code != 0 && kv.Code >= kernel.Kernel6_1:
+		nameOffset = 912
 	}
 
 	return nameOffset

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -343,8 +343,10 @@ func getBpfMapNameOffset(kv *kernel.Version) uint64 {
 		nameOffset = 88
 	case kv.IsInRangeCloseOpen(kernel.Kernel5_16, kernel.Kernel5_19):
 		nameOffset = 96
-	case kv.Code >= kernel.Kernel5_19:
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_19, kernel.Kernel6_2):
 		nameOffset = 104
+	case kv.Code >= kernel.Kernel6_2:
+		nameOffset = 96
 	case kv.Code != 0 && kv.Code < kernel.Kernel4_15:
 		return ErrorSentinel
 	}

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -299,8 +299,10 @@ func getBpfMapIDOffset(kv *kernel.Version) uint64 {
 		return 52
 	case kv.IsInRangeCloseOpen(kernel.Kernel5_16, kernel.Kernel5_19):
 		return 60
-	case kv.Code >= kernel.Kernel5_19:
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_19, kernel.Kernel6_2):
 		return 68
+	case kv.Code >= kernel.Kernel6_2:
+		return 52
 	default:
 		return 48
 	}


### PR DESCRIPTION
### What does this PR do?

This PR updates the fallback constants on recent kernels. This should not be required since those kernels should really hit the CO-RE path and never the fallback. But it can still fixes some CI issues.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
