### PR TITLE
[CWS] fix overlayfs inode read on kernel 5.19 and higher

### DIFF
--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -215,10 +215,10 @@ int __attribute__((always_inline)) get_ovl_lower_ino(struct dentry *dentry) {
     bpf_probe_read(&d_inode, sizeof(d_inode), &dentry->d_inode);
 
     // escape from the embedded vfs_inode to reach ovl_inode
-    struct inode *lower;
-    bpf_probe_read(&lower, sizeof(lower), (char *)d_inode + get_sizeof_inode() + 8);
+    struct dentry *lower;
+    bpf_probe_read(&lower, sizeof(lower), (char *)d_inode + get_sizeof_inode() + 16);
 
-    return get_inode_ino(lower);
+    return get_dentry_ino(lower);
 }
 
 int __attribute__((always_inline)) get_ovl_upper_ino(struct dentry *dentry) {

--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -188,7 +188,7 @@ int __attribute__((always_inline)) get_sizeof_inode() {
 u64 __attribute__((always_inline)) get_ovl_path_in_inode() {
     u64 sizeof_inode;
     LOAD_CONSTANT("ovl_path_in_ovl_inode", sizeof_inode);
-	return 1;
+	return sizeof_inode;
 }
 
 int __attribute__((always_inline)) get_sb_magic_offset() {

--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -186,6 +186,8 @@ int __attribute__((always_inline)) get_sizeof_inode() {
 }
 
 u64 __attribute__((always_inline)) get_ovl_path_in_inode() {
+    u64 sizeof_inode;
+    LOAD_CONSTANT("ovl_path_in_ovl_inode", sizeof_inode);
 	return 1;
 }
 

--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -186,9 +186,9 @@ int __attribute__((always_inline)) get_sizeof_inode() {
 }
 
 u64 __attribute__((always_inline)) get_ovl_path_in_inode() {
-    u64 sizeof_inode;
-    LOAD_CONSTANT("ovl_path_in_ovl_inode", sizeof_inode);
-	return sizeof_inode;
+    u64 ovl_path_in_ovl_inode;
+    LOAD_CONSTANT("ovl_path_in_ovl_inode", ovl_path_in_ovl_inode);
+    return ovl_path_in_ovl_inode;
 }
 
 int __attribute__((always_inline)) get_sb_magic_offset() {

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -1544,6 +1544,10 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 			Value: getHasUsernamespaceFirstArg(p.kernelVersion),
 		},
 		manager.ConstantEditor{
+			Name:  "ovl_path_in_ovl_inode",
+			Value: getOvlPathInOvlInode(p.kernelVersion),
+		},
+		manager.ConstantEditor{
 			Name:  "mount_id_offset",
 			Value: mount.GetMountIDOffset(p.kernelVersion),
 		},
@@ -1733,6 +1737,14 @@ func getHasUsernamespaceFirstArg(kernelVersion *kernel.Version) uint64 {
 	if kernelVersion.Code != 0 && kernelVersion.Code >= kernel.Kernel6_0 {
 		return 1
 	}
+	return 0
+}
+
+func getOvlPathInOvlInode(kernelVersion *kernel.Version) uint64 {
+	if kernelVersion.Code != 0 && kernelVersion.Code >= kernel.Kernel5_19 {
+		return 1
+	}
+
 	return 0
 }
 

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -1757,8 +1757,6 @@ func getOvlPathInOvlInode(kernelVersion *kernel.Version) uint64 {
 		return 0
 	}
 
-	fmt.Println(check)
-
 	// VerifyKernelFuncs returns the missing functions
 	if _, ok := check[patchSentinel]; !ok {
 		return 1

--- a/pkg/security/tests/testdrive.go
+++ b/pkg/security/tests/testdrive.go
@@ -76,7 +76,8 @@ func newTestDriveWithMountPoint(tb testing.TB, fsType string, mountOpts []string
 		// }
 
 		mkfsCmd := exec.Command("/sbin/mkfs."+fsType, dev.Path())
-		if err := mkfsCmd.Run(); err != nil {
+		if out, err := mkfsCmd.CombinedOutput(); err != nil {
+			tb.Error(string(out))
 			_ = dev.Detach()
 			os.Remove(backingFile.Name())
 			os.RemoveAll(mountPoint)

--- a/pkg/security/tests/testdrive.go
+++ b/pkg/security/tests/testdrive.go
@@ -75,7 +75,20 @@ func newTestDriveWithMountPoint(tb testing.TB, fsType string, mountOpts []string
 		// 	mountOpts = append(mountOpts, "auto")
 		// }
 
+		var env []string
+		if fsType == "xfs" {
+			// starting with v5.19, mkfs.xfs does not accept filesystem of size < 300MB
+			// for more info see
+			// https://lore.kernel.org/all/164738662491.3191861.15611882856331908607.stgit@magnolia/
+			// https://patchwork.ozlabs.org/project/ltp/patch/20220817204015.31420-1-pvorel@suse.cz/#2950033
+			// so we re-use the undocumented escape path used in fstests
+			env = os.Environ()
+			env = append(env, "TEST_DIR=1", "TEST_DEV=1", "QA_CHECK_FS=1")
+		}
+
 		mkfsCmd := exec.Command("/sbin/mkfs."+fsType, dev.Path())
+		mkfsCmd.Env = env
+
 		if out, err := mkfsCmd.CombinedOutput(); err != nil {
 			tb.Error(string(out))
 			_ = dev.Detach()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This [kernel patch](https://github.com/torvalds/linux/commit/ffa5723c6d259b3191f851a50a98d0352b345b39) changed the way `ovl_inode` stores the upper and lower layer inodes.
This PR:
- fixes our handling of the new struct layout
- implements a detection based on kernel version, but also on the presence of a function from this patch (in order to support kernels were this was backported)
- fixes the way we create xfs volumes in the tests that was failing on >= 5.19

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
