### PR TITLE
[usm] Intern Kafka topic names

### DIFF
--- a/pkg/network/protocols/kafka/kafka_statkeeper.go
+++ b/pkg/network/protocols/kafka/kafka_statkeeper.go
@@ -18,6 +18,10 @@ type KafkaStatKeeper struct {
 	statsMutex sync.RWMutex
 	maxEntries int
 	telemetry  *Telemetry
+
+	// topicNames stores interned versions of the all topics currently stored in
+	// the `KafkaStatKeeper`
+	topicNames map[string]string
 }
 
 func NewKafkaStatkeeper(c *config.Config, telemetry *Telemetry) *KafkaStatKeeper {
@@ -25,6 +29,7 @@ func NewKafkaStatkeeper(c *config.Config, telemetry *Telemetry) *KafkaStatKeeper
 		stats:      make(map[Key]*RequestStat),
 		maxEntries: c.MaxKafkaStatsBuffered,
 		telemetry:  telemetry,
+		topicNames: make(map[string]string),
 	}
 }
 
@@ -32,7 +37,7 @@ func (statKeeper *KafkaStatKeeper) Process(tx *EbpfKafkaTx) {
 	key := Key{
 		RequestAPIKey:  tx.APIKey(),
 		RequestVersion: tx.APIVersion(),
-		TopicName:      tx.TopicName(),
+		TopicName:      statKeeper.extractTopicName(tx),
 		ConnectionKey:  tx.ConnTuple(),
 	}
 	statKeeper.statsMutex.Lock()
@@ -54,5 +59,21 @@ func (statKeeper *KafkaStatKeeper) GetAndResetAllStats() map[Key]*RequestStat {
 	defer statKeeper.statsMutex.RUnlock()
 	ret := statKeeper.stats // No deep copy needed since `statKeeper.stats` gets reset
 	statKeeper.stats = make(map[Key]*RequestStat)
+	statKeeper.topicNames = make(map[string]string)
 	return ret
+}
+
+func (statKeeper *KafkaStatKeeper) extractTopicName(tx *EbpfKafkaTx) string {
+	b := tx.Topic_name[:tx.Topic_name_size]
+
+	// the trick here is that the Go runtime doesn't allocate the string used in
+	// the map lookup, so if we have seen this topic name before, we don't
+	// perform any allocations
+	if v, ok := statKeeper.topicNames[string(b)]; ok {
+		return v
+	}
+
+	v := string(b)
+	statKeeper.topicNames[v] = v
+	return v
 }

--- a/pkg/network/protocols/kafka/kafka_statkeeper.go
+++ b/pkg/network/protocols/kafka/kafka_statkeeper.go
@@ -34,14 +34,15 @@ func NewKafkaStatkeeper(c *config.Config, telemetry *Telemetry) *KafkaStatKeeper
 }
 
 func (statKeeper *KafkaStatKeeper) Process(tx *EbpfKafkaTx) {
+	statKeeper.statsMutex.Lock()
+	defer statKeeper.statsMutex.Unlock()
+
 	key := Key{
 		RequestAPIKey:  tx.APIKey(),
 		RequestVersion: tx.APIVersion(),
 		TopicName:      statKeeper.extractTopicName(tx),
 		ConnectionKey:  tx.ConnTuple(),
 	}
-	statKeeper.statsMutex.Lock()
-	defer statKeeper.statsMutex.Unlock()
 	requestStats, ok := statKeeper.stats[key]
 	if !ok {
 		if len(statKeeper.stats) >= statKeeper.maxEntries {

--- a/pkg/network/protocols/kafka/kafka_statkeeper_test.go
+++ b/pkg/network/protocols/kafka/kafka_statkeeper_test.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package kafka
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/network/config"
+)
+
+func BenchmarkStatKeeperSameTX(b *testing.B) {
+	cfg := &config.Config{MaxKafkaStatsBuffered: 1000}
+	tel := NewTelemetry()
+	sk := NewKafkaStatkeeper(cfg, tel)
+
+	topicName := []byte("foobar")
+	topicNameSize := len(topicName)
+
+	tx := new(EbpfKafkaTx)
+	copy(tx.Topic_name[:], topicName)
+	tx.Topic_name_size = uint16(topicNameSize)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sk.Process(tx)
+	}
+}

--- a/pkg/network/protocols/kafka/model_linux.go
+++ b/pkg/network/protocols/kafka/model_linux.go
@@ -20,10 +20,6 @@ func (tx *EbpfKafkaTx) ConnTuple() types.ConnectionKey {
 	}
 }
 
-func (tx *EbpfKafkaTx) TopicName() string {
-	return string(tx.Topic_name[:tx.Topic_name_size])
-}
-
 func (tx *EbpfKafkaTx) APIKey() uint16 {
 	return tx.Request_api_key
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Intern Kafka topic names to avoid allocations in the hot loop of `KafkaStatKeeper.Process()`

### Motivation

This is based on the observation that we're repeatedly creating the same strings over and over again, which is accounting for over 40% of the total number of allocations in a kafka-heavy workload from one of our load test environments.

<img width="800" alt="Screenshot 2023-06-14 at 1 17 19 PM" src="https://github.com/DataDog/datadog-agent/assets/692520/9d596348-5acd-42e3-969a-6c4fd48bfbba">


### Additional Notes

```
goos: linux
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/network/protocols/kafka
                   │   old.txt   │               new.txt               │
                   │   sec/op    │   sec/op     vs base                │
StatKeeperSameTX-4   48.01n ± 0%   37.41n ± 0%  -22.08% (p=0.000 n=10)

                   │  old.txt   │               new.txt               │
                   │    B/op    │    B/op     vs base                 │
StatKeeperSameTX-4   8.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)

                   │  old.txt   │               new.txt               │
                   │ allocs/op  │ allocs/op   vs base                 │
StatKeeperSameTX-4   1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
