### PR TITLE
Add USM metrics to agent telemetry

### DIFF
--- a/pkg/network/protocols/http/incomplete_stats_test.go
+++ b/pkg/network/protocols/http/incomplete_stats_test.go
@@ -20,7 +20,7 @@ import (
 func TestOrphanEntries(t *testing.T) {
 	t.Run("orphan entries can be joined even after flushing", func(t *testing.T) {
 		now := time.Now()
-		tel := NewTelemetry()
+		tel := NewTelemetry("http")
 		buffer := newIncompleteBuffer(config.New(), tel)
 		request := &EbpfTx{
 			Request_fragment: requestFragment([]byte("GET /foo/bar")),
@@ -49,7 +49,7 @@ func TestOrphanEntries(t *testing.T) {
 	})
 
 	t.Run("orphan entries are not kept indefinitely", func(t *testing.T) {
-		tel := NewTelemetry()
+		tel := NewTelemetry("http")
 		buffer := newIncompleteBuffer(config.New(), tel)
 		now := time.Now()
 		buffer.minAgeNano = (30 * time.Second).Nanoseconds()

--- a/pkg/network/protocols/http/protocol.go
+++ b/pkg/network/protocols/http/protocol.go
@@ -70,7 +70,7 @@ func newHttpProtocol(cfg *config.Config) (protocols.Protocol, error) {
 		return nil, fmt.Errorf("http feature not available on pre %s kernels", MinimumKernelVersion.String())
 	}
 
-	telemetry := NewTelemetry()
+	telemetry := NewTelemetry("http")
 
 	return &protocol{
 		cfg:       cfg,

--- a/pkg/network/protocols/http/statkeeper_test.go
+++ b/pkg/network/protocols/http/statkeeper_test.go
@@ -13,17 +13,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	libtelemetry "github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestProcessHTTPTransactions(t *testing.T) {
 	cfg := config.New()
 	cfg.MaxHTTPStatsBuffered = 1000
-	tel := NewTelemetry()
+	tel := NewTelemetry("http")
 	sk := NewStatkeeper(cfg, tel)
 
 	srcString := "1.1.1.1"
@@ -69,7 +70,7 @@ func TestProcessHTTPTransactions(t *testing.T) {
 
 func BenchmarkProcessSameConn(b *testing.B) {
 	cfg := &config.Config{MaxHTTPStatsBuffered: 1000}
-	tel := NewTelemetry()
+	tel := NewTelemetry("http")
 	sk := NewStatkeeper(cfg, tel)
 	tx := generateIPv4HTTPTransaction(
 		util.AddressFromString("1.1.1.1"),
@@ -103,7 +104,7 @@ func TestPathProcessing(t *testing.T) {
 		c := cfg
 		c.HTTPReplaceRules = rules
 
-		tel := NewTelemetry()
+		tel := NewTelemetry("http")
 		return NewStatkeeper(c, tel)
 	}
 
@@ -195,7 +196,7 @@ func TestHTTPCorrectness(t *testing.T) {
 		cfg := config.New()
 		cfg.MaxHTTPStatsBuffered = 1000
 		libtelemetry.Clear()
-		tel := NewTelemetry()
+		tel := NewTelemetry("http")
 		sk := NewStatkeeper(cfg, tel)
 		tx := generateIPv4HTTPTransaction(
 			util.AddressFromString("1.1.1.1"),
@@ -219,7 +220,7 @@ func TestHTTPCorrectness(t *testing.T) {
 		cfg := config.New()
 		cfg.MaxHTTPStatsBuffered = 1000
 		libtelemetry.Clear()
-		tel := NewTelemetry()
+		tel := NewTelemetry("http")
 		sk := NewStatkeeper(cfg, tel)
 		tx := generateIPv4HTTPTransaction(
 			util.AddressFromString("1.1.1.1"),
@@ -244,7 +245,7 @@ func TestHTTPCorrectness(t *testing.T) {
 		cfg := config.New()
 		cfg.MaxHTTPStatsBuffered = 1000
 		libtelemetry.Clear()
-		tel := NewTelemetry()
+		tel := NewTelemetry("http")
 		sk := NewStatkeeper(cfg, tel)
 		tx := generateIPv4HTTPTransaction(
 			util.AddressFromString("1.1.1.1"),

--- a/pkg/network/protocols/kafka/kafka_statkeeper.go
+++ b/pkg/network/protocols/kafka/kafka_statkeeper.go
@@ -46,6 +46,7 @@ func (statKeeper *KafkaStatKeeper) Process(tx *EbpfKafkaTx) {
 	requestStats, ok := statKeeper.stats[key]
 	if !ok {
 		if len(statKeeper.stats) >= statKeeper.maxEntries {
+			telem.dropped.Inc()
 			statKeeper.telemetry.dropped.Add(1)
 			return
 		}

--- a/pkg/network/protocols/kafka/telemetry.go
+++ b/pkg/network/protocols/kafka/telemetry.go
@@ -13,8 +13,16 @@ import (
 	"go.uber.org/atomic"
 
 	libtelemetry "github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
+	pkgtelemetry "github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+var telem = struct {
+	hits, dropped pkgtelemetry.Counter
+}{
+	pkgtelemetry.NewCounter("usm__kafka", "hits", []string{}, ""),
+	pkgtelemetry.NewCounter("usm__kafka", "dropped", []string{}, ""),
+}
 
 type Telemetry struct {
 	then *atomic.Int64
@@ -42,6 +50,7 @@ func NewTelemetry() *Telemetry {
 }
 
 func (t *Telemetry) Count(_ *EbpfKafkaTx) {
+	telem.hits.Inc()
 	t.totalHits.Add(1)
 }
 

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -17,6 +17,8 @@ import (
 	"github.com/cilium/ebpf"
 	"go.uber.org/atomic"
 
+	manager "github.com/DataDog/ebpf-manager"
+
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	filterpkg "github.com/DataDog/datadog-agent/pkg/network/filter"
@@ -28,7 +30,6 @@ import (
 	errtelemetry "github.com/DataDog/datadog-agent/pkg/network/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	manager "github.com/DataDog/ebpf-manager"
 )
 
 type monitorState = string
@@ -143,7 +144,7 @@ func NewMonitor(c *config.Config, connectionProtocolMap, sockFD *ebpf.Map, bpfTe
 	var http2Statkeeper *http.StatKeeper
 	var http2Telemetry *http.Telemetry
 	if c.EnableHTTP2Monitoring {
-		http2Telemetry = http.NewTelemetry()
+		http2Telemetry = http.NewTelemetry("http2")
 
 		// for now the max HTTP2 entries would be taken from the maxHTTPEntries.
 		http2Statkeeper = http.NewStatkeeper(c, http2Telemetry)

--- a/pkg/network/usm/monitor_windows.go
+++ b/pkg/network/usm/monitor_windows.go
@@ -48,7 +48,7 @@ func NewWindowsMonitor(c *config.Config, dh driver.Handle) (Monitor, error) {
 	hei.SetMaxRequestBytes(uint64(c.HTTPMaxRequestFragment))
 	hei.SetCapturedProtocols(c.EnableHTTPMonitoring, c.EnableHTTPSMonitoring)
 
-	telemetry := http.NewTelemetry()
+	telemetry := http.NewTelemetry("http")
 
 	return &WindowsMonitor{
 		di:         di,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adds agent telemetry that mirrors the metrics USM was already collecting for expvar.

### Motivation

Conversion to agent telemetry internally.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
