### PR TITLE
[new-e2e] use standard-verbose format when verbose is True

### DIFF
--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -21,6 +21,7 @@ from .test import test_flavor
         'tags': 'Build tags to use',
         'targets': 'Target packages (same as inv test)',
         'configparams': 'Set overrides for ConfigMap parameters (same as -c option in test-infra-definitions)',
+        'verbose': 'Verbose output: log all tests as they are run (same as gotest -v) [default: True]',
     },
 )
 def run(ctx, profile="", tags=[], targets=[], configparams=[], verbose=True, cache=False, junit_tar=""):  # noqa: B006
@@ -52,7 +53,12 @@ def run(ctx, profile="", tags=[], targets=[], configparams=[], verbose=True, cac
     if parsedParams:
         envVars["E2E_STACK_PARAMS"] = json.dumps(parsedParams)
 
-    cmd = 'gotestsum --format pkgname --packages="{packages}" -- {verbose} -mod={go_mod} -vet=off -timeout {timeout} -tags {go_build_tags} {nocache}'
+    gotestsum_format = "standard-verbose" if verbose else "pkgname"
+
+    cmd = f'gotestsum --format {gotestsum_format} '
+    cmd += (
+        '--packages="{packages}" -- {verbose} -mod={go_mod} -vet=off -timeout {timeout} -tags {go_build_tags} {nocache}'
+    )
     args = {
         "go_mod": "mod",
         "timeout": "4h",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Use `standard-verbose` format in gotestsum call with new-e2e test invoke task on `verbose=True`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

e2e tests execution is longer than unit tests, when running locally developers expect to have frequent feedback to ensure there is no blocked task.


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

| standard-verbose | pkgname |
|--------|--------|
| ![image](https://github.com/DataDog/datadog-agent/assets/45568537/93884d50-f8b0-44b9-9a90-45050b7a1b06) | ![image](https://github.com/DataDog/datadog-agent/assets/45568537/06f78e89-cad0-4dab-8bf3-c79fedeeb8ee) |

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

This option would be used by the CI too, not sure this would break something.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
