### PR TITLE
Double Agent replicate counts

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -18,7 +18,7 @@ single-machine-performance-regression_detector:
     LADING_VERSION: 0.14.0
     TOTAL_SAMPLES: 600
     WARMUP_SECONDS: 45
-    REPLICAS: 10
+    REPLICAS: 20
     CPUS: 7
     MEMORY: "30g"
   # At present we require two artifacts to exist for the 'baseline' and the


### PR DESCRIPTION
### What does this PR do?

We intend to automatically expand the number of replicates if a possible wobble is detected. In order to approach the goal of doing this automatically we first need to validate that consistently running this number of replicates is

1. feasible and 
1. we draw more clear results by this doubling. 
 
There is work required on our side to adjust the statistics, so in some sense this PR is a change that will lead to a change that will lead to a change.

## Related Issues

REF SMP-599
REF SMP-333

