### PR TITLE
[Gohai][ASC-568] Implement platform collection using uname syscall on unix

### DIFF
--- a/pkg/gohai/platform/platform_darwin.go
+++ b/pkg/gohai/platform/platform_darwin.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// getUnameProcessor returns the same value as `uname -p`
+// getUnameProcessor is similar to `uname -p`
 //
 // for Apple devices, uname does as follow to determine the value:
 // - if the architecture is arm or arm64, return "arm"

--- a/pkg/gohai/platform/platform_darwin.go
+++ b/pkg/gohai/platform/platform_darwin.go
@@ -8,6 +8,7 @@ package platform
 import (
 	"runtime"
 
+	"github.com/DataDog/datadog-agent/pkg/gohai/utils"
 	log "github.com/cihub/seelog"
 	"golang.org/x/sys/unix"
 )
@@ -53,14 +54,14 @@ func processIsTranslated() (bool, error) {
 }
 
 func updateArchInfo(archInfo map[string]string, uname *unix.Utsname) {
-	archInfo["kernel_name"] = string(uname.Sysname[:])
-	archInfo["hostname"] = string(uname.Nodename[:])
-	archInfo["kernel_release"] = string(uname.Release[:])
-	archInfo["machine"] = string(uname.Machine[:])
+	archInfo["kernel_name"] = utils.StringFromBytes(uname.Sysname[:])
+	archInfo["hostname"] = utils.StringFromBytes(uname.Nodename[:])
+	archInfo["kernel_release"] = utils.StringFromBytes(uname.Release[:])
+	archInfo["machine"] = utils.StringFromBytes(uname.Machine[:])
 	archInfo["processor"] = getUnameProcessor()
 	// for backward-compatibility reasons we just use the Sysname field
-	archInfo["os"] = string(uname.Sysname[:])
-	archInfo["kernel_version"] = string(uname.Version[:])
+	archInfo["os"] = utils.StringFromBytes(uname.Sysname[:])
+	archInfo["kernel_version"] = utils.StringFromBytes(uname.Version[:])
 
 	if isTranslated, err := processIsTranslated(); err == nil && isTranslated {
 		log.Debug("Running under Rosetta translator; overriding architecture values")

--- a/pkg/gohai/platform/platform_darwin.go
+++ b/pkg/gohai/platform/platform_darwin.go
@@ -6,13 +6,38 @@
 package platform
 
 import (
-	"strings"
+	"runtime"
 
 	log "github.com/cihub/seelog"
 	"golang.org/x/sys/unix"
 )
 
-var unameOptions = []string{"-s", "-n", "-r", "-m", "-p"}
+// getUnameProcessor returns the same value as `uname -p`
+//
+// for Apple devices, uname does as follow to determine the value:
+// - if the architecture is arm or arm64, return "arm"
+// - if the architecture is i386 or x86_64, return "i386"
+// - if the architecture is powerpc or powerpc64, return "powerpc"
+// - return "unknown"
+//
+// cf https://github.com/coreutils/coreutils/blob/master/src/uname.c
+func getUnameProcessor() string {
+	platforms := map[string]string{
+		"arm":     "arm",
+		"arm64":   "arm",
+		"amd64":   "i386",
+		"386":     "i386",
+		"ppc64":   "powerpc",
+		"ppc64le": "powerpc",
+	}
+
+	processor, ok := platforms[runtime.GOARCH]
+	if ok {
+		return processor
+	}
+
+	return "unknown"
+}
 
 // processIsTranslated detects if the process using gohai is running under the Rosetta 2 translator
 func processIsTranslated() (bool, error) {
@@ -27,13 +52,15 @@ func processIsTranslated() (bool, error) {
 	return false, err
 }
 
-func updateArchInfo(archInfo map[string]string, values []string) {
-	archInfo["kernel_name"] = values[0]
-	archInfo["hostname"] = values[1]
-	archInfo["kernel_release"] = values[2]
-	archInfo["machine"] = values[3]
-	archInfo["processor"] = strings.Trim(values[4], "\n")
-	archInfo["os"] = values[0]
+func updateArchInfo(archInfo map[string]string, uname *unix.Utsname) {
+	archInfo["kernel_name"] = string(uname.Sysname[:])
+	archInfo["hostname"] = string(uname.Nodename[:])
+	archInfo["kernel_release"] = string(uname.Release[:])
+	archInfo["machine"] = string(uname.Machine[:])
+	archInfo["processor"] = getUnameProcessor()
+	// for backward-compatibility reasons we just use the Sysname field
+	archInfo["os"] = string(uname.Sysname[:])
+	archInfo["kernel_version"] = string(uname.Version[:])
 
 	if isTranslated, err := processIsTranslated(); err == nil && isTranslated {
 		log.Debug("Running under Rosetta translator; overriding architecture values")

--- a/pkg/gohai/platform/platform_darwin_test.go
+++ b/pkg/gohai/platform/platform_darwin_test.go
@@ -5,29 +5,11 @@
 package platform
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
-
-func TestIsVendorAMD(t *testing.T) {
-	athlonSource := `processor   : 0
-vendor_id   : AuthenticAMD
-cpu family  : 15
-model       : 67
-model name  : Dual-Core AMD Opteron(tm) Processor 1218 HE`
-	reader := strings.NewReader(athlonSource)
-	require.True(t, isVendorAMD(reader))
-
-	notAthlonSource := `processor	: 0
-vendor_id	: GenuineIntel
-cpu family	: 6
-model		: 79
-model name	: Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz`
-	reader = strings.NewReader(notAthlonSource)
-	require.False(t, isVendorAMD(reader))
-}
 
 func TestUpdateArchInfo(t *testing.T) {
 	uname := &unix.Utsname{}
@@ -47,8 +29,8 @@ func TestUpdateArchInfo(t *testing.T) {
 		"hostname":       nodename,
 		"kernel_release": release,
 		"machine":        machine,
-		"processor":      machine,
-		"os":             machine,
+		"processor":      getUnameProcessor(),
+		"os":             sysname,
 		"kernel_version": version,
 	}
 

--- a/pkg/gohai/platform/platform_linux.go
+++ b/pkg/gohai/platform/platform_linux.go
@@ -25,7 +25,7 @@ func getOperatingSystem() string {
 }
 
 // isVendorAMD checks if the vendor is AMD.
-// The reader is expecetd be an io.Reader over /proc/cpuinfo
+// The reader is expected be an io.Reader over /proc/cpuinfo
 func isVendorAMD(reader io.Reader) bool {
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {

--- a/pkg/gohai/platform/platform_linux.go
+++ b/pkg/gohai/platform/platform_linux.go
@@ -15,21 +15,22 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// getUnameOS returns the same value as `uname -o`
+// getUnameOS is similar to `uname -o`
 //
 // uname uses preprocessor macros to determine the printable name of the operating system,
 // cf https://github.com/coreutils/gnulib/blob/master/m4/host-os.m4
 //
-// on every linux device it prints "GNU/Linux", probably because uname is from GNU coreutils,
+// on every Linux device it prints "GNU/Linux", probably because uname is from GNU coreutils,
 // so if you are using it your OS is considered to be GNU
 func getUnameOS() string {
-	// we might want to return different values depending on the actual OS (not all Linux are GNU)
-	// but for now it's good enough
+	// eventually we might want to return different values depending on the actual OS
+	// (not all Linux are GNU)
 	return "GNU/Linux"
 }
 
-// from the 80_fedora_sysinfo.patch uname patch
-func procIsAthlon(reader io.Reader) bool {
+// check if the vendor is AMD
+// reader should be an io.Reader over /proc/cpuinfo
+func isVendorAMD(reader io.Reader) bool {
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		text := scanner.Text()
@@ -43,18 +44,17 @@ func procIsAthlon(reader io.Reader) bool {
 	return false
 }
 
-// getUnameProcessor returns the same value as `uname -p`
+// getUnameProcessor is similar to `uname -p`
 //
-// note that each OS applies a set of patches on the base coreutils source, in particular the 80_fedora_sysinfo.patch
-// which makes uname work on Linux, so you have to look at the patched code, eg. for ubuntu jammy:
-// https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/coreutils/8.32-4.1ubuntu1/coreutils_8.32-4.1ubuntu1.debian.tar.xz
+// the version of uname commonly used on Linux handles specifically the edge case of athlon processors
+// on i686 devices
 func getUnameProcessor(machine string) string {
 	if machine == "i686" {
 		file, err := os.Open("/proc/cpuinfo")
 		if err == nil {
 			defer file.Close()
-			if procIsAthlon(file) {
-				machine = "athlon"
+			if isVendorAMD(file) {
+				return "athlon"
 			}
 		}
 	}
@@ -62,14 +62,12 @@ func getUnameProcessor(machine string) string {
 	return machine
 }
 
-// getUnameHardwarePlatform returns the same value as `uname -i`
+// getUnameHardwarePlatform is similar to `uname -i`
 //
-// note that each OS applies a set of patches on the base coreutils source, in particular the 80_fedora_sysinfo.patch
-// which makes uname work on Linux, so you have to look at the patched code, eg. for ubuntu jammy:
-// https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/coreutils/8.32-4.1ubuntu1/coreutils_8.32-4.1ubuntu1.debian.tar.xz
+// the version of uname commonly used on Linux returns 'i386' for all 'i*86' devices
 func getUnameHardwarePlatform(machine string) string {
 	if len(machine) == 4 && machine[0] == 'i' && machine[2] == '8' && machine[3] == '6' {
-		machine = "i386"
+		return "i386"
 	}
 	return machine
 }

--- a/pkg/gohai/platform/platform_linux.go
+++ b/pkg/gohai/platform/platform_linux.go
@@ -28,8 +28,8 @@ func getUnameOS() string {
 	return "GNU/Linux"
 }
 
-// check if the vendor is AMD
-// reader should be an io.Reader over /proc/cpuinfo
+// isVendorAMD checks if the vendor is AMD.
+// The reader is expecetd be an io.Reader over /proc/cpuinfo
 func isVendorAMD(reader io.Reader) bool {
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {

--- a/pkg/gohai/platform/platform_linux.go
+++ b/pkg/gohai/platform/platform_linux.go
@@ -7,10 +7,12 @@ package platform
 
 import (
 	"bufio"
-	"golang.org/x/sys/unix"
 	"io"
 	"os"
 	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/gohai/utils"
+	"golang.org/x/sys/unix"
 )
 
 // getUnameOS returns the same value as `uname -o`
@@ -73,13 +75,13 @@ func getUnameHardwarePlatform(machine string) string {
 }
 
 func updateArchInfo(archInfo map[string]string, uname *unix.Utsname) {
-	archInfo["kernel_name"] = string(uname.Sysname[:])
-	archInfo["hostname"] = string(uname.Nodename[:])
-	archInfo["kernel_release"] = string(uname.Release[:])
-	machine := string(uname.Machine[:])
+	archInfo["kernel_name"] = utils.StringFromBytes(uname.Sysname[:])
+	archInfo["hostname"] = utils.StringFromBytes(uname.Nodename[:])
+	archInfo["kernel_release"] = utils.StringFromBytes(uname.Release[:])
+	machine := utils.StringFromBytes(uname.Machine[:])
 	archInfo["machine"] = machine
 	archInfo["processor"] = getUnameProcessor(machine)
 	archInfo["hardware_platform"] = getUnameHardwarePlatform(machine)
 	archInfo["os"] = getUnameOS()
-	archInfo["kernel_version"] = string(uname.Version[:])
+	archInfo["kernel_version"] = utils.StringFromBytes(uname.Version[:])
 }

--- a/pkg/gohai/platform/platform_linux.go
+++ b/pkg/gohai/platform/platform_linux.go
@@ -5,16 +5,81 @@
 
 package platform
 
-import "strings"
+import (
+	"bufio"
+	"golang.org/x/sys/unix"
+	"io"
+	"os"
+	"strings"
+)
 
-var unameOptions = []string{"-s", "-n", "-r", "-m", "-p", "-i", "-o"}
+// getUnameOS returns the same value as `uname -o`
+//
+// uname uses preprocessor macros to determine the printable name of the operating system,
+// cf https://github.com/coreutils/gnulib/blob/master/m4/host-os.m4
+//
+// on every linux device it prints "GNU/Linux", probably because uname is from GNU coreutils,
+// so if you are using it your OS is considered to be GNU
+func getUnameOS() string {
+	// we might want to return different values depending on the actual OS (not all Linux are GNU)
+	// but for now it's good enough
+	return "GNU/Linux"
+}
 
-func updateArchInfo(archInfo map[string]string, values []string) {
-	archInfo["kernel_name"] = values[0]
-	archInfo["hostname"] = values[1]
-	archInfo["kernel_release"] = values[2]
-	archInfo["machine"] = values[3]
-	archInfo["processor"] = values[4]
-	archInfo["hardware_platform"] = values[5]
-	archInfo["os"] = strings.Trim(values[6], "\n")
+// from the 80_fedora_sysinfo.patch uname patch
+func procIsAthlon(reader io.Reader) bool {
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		text := scanner.Text()
+		if strings.HasPrefix(text, "vendor_id") {
+			if strings.Contains(text, "AuthenticAMD") {
+				return true
+			}
+			break
+		}
+	}
+	return false
+}
+
+// getUnameProcessor returns the same value as `uname -p`
+//
+// note that each OS applies a set of patches on the base coreutils source, in particular the 80_fedora_sysinfo.patch
+// which makes uname work on Linux, so you have to look at the patched code, eg. for ubuntu jammy:
+// https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/coreutils/8.32-4.1ubuntu1/coreutils_8.32-4.1ubuntu1.debian.tar.xz
+func getUnameProcessor(machine string) string {
+	if machine == "i686" {
+		file, err := os.Open("/proc/cpuinfo")
+		if err == nil {
+			defer file.Close()
+			if procIsAthlon(file) {
+				machine = "athlon"
+			}
+		}
+	}
+
+	return machine
+}
+
+// getUnameProcessor returns the same value as `uname -i`
+//
+// note that each OS applies a set of patches on the base coreutils source, in particular the 80_fedora_sysinfo.patch
+// which makes uname work on Linux, so you have to look at the patched code, eg. for ubuntu jammy:
+// https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/coreutils/8.32-4.1ubuntu1/coreutils_8.32-4.1ubuntu1.debian.tar.xz
+func getUnameHardwarePlatform(machine string) string {
+	if len(machine) == 4 && machine[0] == 'i' && machine[2] == '8' && machine[3] == '6' {
+		machine = "i386"
+	}
+	return machine
+}
+
+func updateArchInfo(archInfo map[string]string, uname *unix.Utsname) {
+	archInfo["kernel_name"] = string(uname.Sysname[:])
+	archInfo["hostname"] = string(uname.Nodename[:])
+	archInfo["kernel_release"] = string(uname.Release[:])
+	machine := string(uname.Machine[:])
+	archInfo["machine"] = machine
+	archInfo["processor"] = getUnameProcessor(machine)
+	archInfo["hardware_platform"] = getUnameHardwarePlatform(machine)
+	archInfo["os"] = getUnameOS()
+	archInfo["kernel_version"] = string(uname.Version[:])
 }

--- a/pkg/gohai/platform/platform_linux.go
+++ b/pkg/gohai/platform/platform_linux.go
@@ -62,7 +62,7 @@ func getUnameProcessor(machine string) string {
 	return machine
 }
 
-// getUnameProcessor returns the same value as `uname -i`
+// getUnameHardwarePlatform returns the same value as `uname -i`
 //
 // note that each OS applies a set of patches on the base coreutils source, in particular the 80_fedora_sysinfo.patch
 // which makes uname work on Linux, so you have to look at the patched code, eg. for ubuntu jammy:

--- a/pkg/gohai/platform/platform_linux_test.go
+++ b/pkg/gohai/platform/platform_linux_test.go
@@ -11,14 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProcIsAthlon(t *testing.T) {
+func TestIsVendorAMD(t *testing.T) {
 	athlonSource := `processor   : 0
 vendor_id   : AuthenticAMD
 cpu family  : 15
 model       : 67
 model name  : Dual-Core AMD Opteron(tm) Processor 1218 HE`
 	reader := strings.NewReader(athlonSource)
-	require.True(t, procIsAthlon(reader))
+	require.True(t, isVendorAMD(reader))
 
 	notAthlonSource := `processor	: 0
 vendor_id	: GenuineIntel
@@ -26,5 +26,5 @@ cpu family	: 6
 model		: 79
 model name	: Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz`
 	reader = strings.NewReader(notAthlonSource)
-	require.False(t, procIsAthlon(reader))
+	require.False(t, isVendorAMD(reader))
 }

--- a/pkg/gohai/platform/platform_linux_test.go
+++ b/pkg/gohai/platform/platform_linux_test.go
@@ -1,0 +1,30 @@
+// This file is licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2014-present Datadog, Inc.
+
+package platform
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcIsAthlon(t *testing.T) {
+	athlonSource := `processor   : 0
+vendor_id   : AuthenticAMD
+cpu family  : 15
+model       : 67
+model name  : Dual-Core AMD Opteron(tm) Processor 1218 HE`
+	reader := strings.NewReader(athlonSource)
+	require.True(t, procIsAthlon(reader))
+
+	notAthlonSource := `processor	: 0
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 79
+model name	: Intel(R) Xeon(R) CPU E5-2686 v4 @ 2.30GHz`
+	reader = strings.NewReader(notAthlonSource)
+	require.False(t, procIsAthlon(reader))
+}

--- a/pkg/gohai/platform/platform_linux_test.go
+++ b/pkg/gohai/platform/platform_linux_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 func TestIsVendorAMD(t *testing.T) {
@@ -43,13 +44,14 @@ func TestUpdateArchInfo(t *testing.T) {
 	copy(uname.Machine[:], []byte(machine))
 
 	expected := map[string]string{
-		"kernel_name":    sysname,
-		"hostname":       nodename,
-		"kernel_release": release,
-		"machine":        machine,
-		"processor":      machine,
-		"os":             machine,
-		"kernel_version": version,
+		"kernel_name":       sysname,
+		"hostname":          nodename,
+		"kernel_release":    release,
+		"machine":           machine,
+		"processor":         getProcessorType(machine),
+		"hardware_platform": getHardwarePlatform(machine),
+		"os":                getOperatingSystem(),
+		"kernel_version":    version,
 	}
 
 	archInfo := map[string]string{}

--- a/pkg/gohai/platform/platform_nix.go
+++ b/pkg/gohai/platform/platform_nix.go
@@ -9,28 +9,20 @@
 package platform
 
 import (
-	"os/exec"
-	"regexp"
-	"strings"
+	"golang.org/x/sys/unix"
 )
 
 // GetArchInfo returns basic host architecture information
-func GetArchInfo() (archInfo map[string]string, err error) {
-	archInfo = map[string]string{}
+func GetArchInfo() (map[string]string, error) {
+	archInfo := map[string]string{}
 
-	out, err := exec.Command("uname", unameOptions...).Output()
+	var uname unix.Utsname
+	err := unix.Uname(&uname)
 	if err != nil {
 		return nil, err
 	}
-	line := string(out)
-	values := regexp.MustCompile(" +").Split(line, 7)
-	updateArchInfo(archInfo, values)
 
-	out, err = exec.Command("uname", "-v").Output()
-	if err != nil {
-		return nil, err
-	}
-	archInfo["kernel_version"] = strings.Trim(string(out), "\n")
+	updateArchInfo(archInfo, &uname)
 
-	return
+	return archInfo, nil
 }

--- a/pkg/gohai/utils/helpers.go
+++ b/pkg/gohai/utils/helpers.go
@@ -1,0 +1,15 @@
+// This file is licensed under the MIT License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2014-present Datadog, Inc.
+
+package utils
+
+import "bytes"
+
+// StringFromBytes converts a null-terminated (C-style) string to a Go string
+//
+// The given slice must be null-terminated.
+func StringFromBytes(slice []byte) string {
+	length := bytes.IndexByte(slice, 0)
+	return string(slice[:length])
+}

--- a/pkg/gohai/utils/helpers.go
+++ b/pkg/gohai/utils/helpers.go
@@ -10,6 +10,11 @@ import "bytes"
 //
 // The given slice must be null-terminated.
 func StringFromBytes(slice []byte) string {
+	// using `string(slice)` will keep the null bytes in the resulting Go string, so we have to
+	// check for the position of the first null byte and troncate the slice
 	length := bytes.IndexByte(slice, 0)
+	if length == -1 {
+		length = len(slice)
+	}
 	return string(slice[:length])
 }

--- a/releasenotes/notes/gohai-unix-platform-native-ce7892d241f34307.yaml
+++ b/releasenotes/notes/gohai-unix-platform-native-ce7892d241f34307.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Platform metadata is now collected without running the `uname` binary on Linux and Darwin.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Implement platform metadata collection using the `uname` syscall instead of executing the `uname` binary.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Eventually remove all shell-outs in Gohai to have a native and more reliable way to collect data.
No parsing / cleaning of the output, just get the plain value directly.
We also have more control on the values we get, the `uname` binary is not an absolute source of truth and having our own implementation would allow to fix weird values (see 'OS' below for example). 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

5 out of the 8 values we get from the `uname` binary come directly from the `uname` syscall, and are thus trivial to retrieve.

The "processor" and "hardware_platform" are however non-portable (cf the man page of uname), they come from various syscall depending on the platform or default to "unknown". On Linux none of those syscalls are available and thus they are always "unknown".
To avoid that, most Linux distribution apply the `80_fedora_sysinfo.patch`, which re-uses the `machine` value.

The "os" value comes from macros and is very platform-dependent, but we can see [here](https://github.com/coreutils/gnulib/blob/master/m4/host-os.m4) that for every Linux it'll be "GNU/Linux". My guess is that since the `uname` binary is part of GNU, it assumes any device using it is also GNU. I kept this behavior here.

The source of the base GNU coreutil uname can be seen [here](https://github.com/coreutils/coreutils/blob/master/src/uname.c). 
The `80_fedora_sysinfo.patch` can be seen [here](https://github.com/DataDog/datadog-agent/files/11760381/80_fedora_sysinfo.patch).
The resulting code when the patch is applied to the 8.32 version of uname (used by ubuntu) can be seen [here](https://github.com/DataDog/datadog-agent/files/11760417/uname.txt).

I tested this code on the following OS/Arch:
- Mac OS X 13.04 arm64
- Debian 11 amd64 and arm64
- Ubuntu 22.04 amd64 and arm64
- Amazon Linux 2023 amd64 and arm64
- RHEL 9.2.0 amd64 and arm64
- Fedora 34 amd64 and arm64
- SLES 15 amd64 and arm64

All gave the exact same output as when using the `uname` binary, except for `Debian` which doesn't use the patch mentioned above (meaning we had "unknown" but now have an actual value, ie. "x86_64" or "aarch64").

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Compare the output of both versions of Gohai on various unix OS, at least one Darwin and one Linux.
Possibly also check with different architecture. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
