### PR TITLE
[apm] fix service peer service normalization

### DIFF
--- a/pkg/trace/traceutil/fuzz_test.go
+++ b/pkg/trace/traceutil/fuzz_test.go
@@ -12,16 +12,22 @@ import (
 	"unicode/utf8"
 )
 
+var normalizationSeedCorpus = []string{
+	"key:val",
+	"Data🐨dog🐶 繋がっ⛰てて",
+	"Test Conversion Of Weird !@#$%^&**() Characters",
+	"test\x99\x8faaa",
+	"A00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 000000000000",
+}
+
 func FuzzNormalizeTag(f *testing.F) {
-	seedCorpus := []string{
-		"key:val",
-		"Data🐨dog🐶 繋がっ⛰てて",
-		"Test Conversion Of Weird !@#$%^&**() Characters",
-		"test\x99\x8faaa",
-		"A00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 000000000000",
-	}
 	normalize := func(in, _ string) (string, error) { return NormalizeTag(in), nil }
-	fuzzNormalization(f, seedCorpus, maxTagLength, normalize)
+	fuzzNormalization(f, normalizationSeedCorpus, maxTagLength, normalize)
+}
+
+func FuzzNormalizeTagValue(f *testing.F) {
+	normalize := func(in, _ string) (string, error) { return NormalizeTagValue(in), nil }
+	fuzzNormalization(f, normalizationSeedCorpus, maxTagLength, normalize)
 }
 
 func FuzzNormalizeName(f *testing.F) {
@@ -34,13 +40,22 @@ func FuzzNormalizeName(f *testing.F) {
 	fuzzNormalization(f, seedCorpus, MaxNameLen, normalize)
 }
 
+var svcNormalizationSeedCorpus = []string{
+	"good",
+	"bad$",
+	"Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.",
+	"127.0.0.1",
+	":4500",
+	"120.site.platform.com-db.replica1",
+}
+
 func FuzzNormalizeService(f *testing.F) {
-	seedCorpus := []string{
-		"good",
-		"bad$",
-		"Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.",
-	}
-	fuzzNormalization(f, seedCorpus, MaxServiceLen, NormalizeService)
+	fuzzNormalization(f, svcNormalizationSeedCorpus, MaxServiceLen, NormalizeService)
+}
+
+func FuzzNormalizePeerService(f *testing.F) {
+	normalize := func(in, _ string) (string, error) { return NormalizePeerService(in) }
+	fuzzNormalization(f, svcNormalizationSeedCorpus, MaxServiceLen, normalize)
 }
 
 func fuzzNormalization(f *testing.F, seedCorpus []string, maxLen int, normalize func(in, lang string) (string, error)) {

--- a/pkg/trace/traceutil/normalize.go
+++ b/pkg/trace/traceutil/normalize.go
@@ -115,20 +115,21 @@ func fallbackService(lang string) string {
 
 const maxTagLength = 200
 
-// NormalizeTag applies some normalization to ensure the full tag_key:tag_value matches the backend requirements.
+// NormalizeTag applies some normalization to ensure the full tag_key:tag_value string matches the backend requirements.
 func NormalizeTag(v string) string {
 	return normalize(v, true)
 }
 
-// NormalizeTagValue applies some normalization to ensure the tag values match the backend requirements.
+// NormalizeTagValue applies some normalization to ensure the tag value matches the backend requirements.
+// It should be used for cases where we have just the tag_value as the input (instead of tag_key:tag_value).
 func NormalizeTagValue(v string) string {
 	return normalize(v, false)
 }
 
-func normalize(v string, checkValidStartChar bool) string {
+func normalize(v string, allowDigitStartChar bool) string {
 	// Fast path: Check if the tag is valid and only contains ASCII characters,
 	// if yes return it as-is right away. For most use-cases this reduces CPU usage.
-	if isNormalizedASCIITag(v, checkValidStartChar) {
+	if isNormalizedASCIITag(v, allowDigitStartChar) {
 		return v
 	}
 	// the algorithm works by creating a set of cuts marking start and end offsets in v
@@ -180,9 +181,9 @@ func normalize(v string, checkValidStartChar bool) string {
 		switch {
 		case unicode.IsLetter(r):
 			chars++
-		// If it's not a unicode letter, and it's the first char, and we're checking the validity of the start char,
+		// If it's not a unicode letter, and it's the first char, and digits are allowed for the start char,
 		// we should goto end because the remaining cases are not valid for a start char.
-		case checkValidStartChar && chars == 0:
+		case allowDigitStartChar && chars == 0:
 			trim = i + jump
 			goto end
 		case unicode.IsDigit(r) || r == '.' || r == '/' || r == '-':

--- a/pkg/trace/traceutil/normalize.go
+++ b/pkg/trace/traceutil/normalize.go
@@ -318,7 +318,7 @@ func isNormalizedASCIITag(tag string, checkValidStartChar bool) bool {
 	}
 	i := 0
 	if checkValidStartChar {
-		if !isValidASCIITagStartChar(tag[0]) {
+		if !isValidASCIIStartChar(tag[0]) {
 			return false
 		}
 		i++
@@ -342,10 +342,10 @@ func isNormalizedASCIITag(tag string, checkValidStartChar bool) bool {
 	return true
 }
 
-func isValidASCIITagStartChar(c byte) bool {
+func isValidASCIIStartChar(c byte) bool {
 	return ('a' <= c && c <= 'z') || c == ':'
 }
 
 func isValidASCIITagChar(c byte) bool {
-	return isValidASCIITagStartChar(c) || ('0' <= c && c <= '9') || c == '.' || c == '/' || c == '-'
+	return isValidASCIIStartChar(c) || ('0' <= c && c <= '9') || c == '.' || c == '/' || c == '-'
 }

--- a/releasenotes/notes/fix-service-and-peer-service-normalization-d459b8a4c28ae2e4.yaml
+++ b/releasenotes/notes/fix-service-and-peer-service-normalization-d459b8a4c28ae2e4.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    [apm] fix an issue for service and peer.service normalization where names starting with a digit are incorrectly considered as invalid


### PR DESCRIPTION
### What does this PR do?

Addresses a bug where service and peer.service normalization will strip out IP addresses and otherwise legitimate names that start with a digit value.

### Motivation

If a `service` or `peer.service` comes through with an IP address as the value, it will be normalized to an empty string.

### Additional Notes

None.

### Possible Drawbacks / Trade-offs

The performance of `NormalizeTag` has become worse on a relative basis, but on an absolute basis it's a matter of 1-10ns. No changes in allocations. The following `benchstat` is based on 100 trials for the old and new versions of the func.

```
                          │   old.txt   │                new.txt                │
                          │   sec/op    │   sec/op     vs base                  │
NormalizeTag/ok-10          6.525n ± 0%   7.146n ± 0%  +9.52% (p=0.000 n=100)
NormalizeTag/trim-10        71.65n ± 0%   78.50n ± 0%  +9.57% (p=0.000 n=100)
NormalizeTag/trim-both-10   118.5n ± 0%   127.0n ± 0%  +7.17% (p=0.000 n=100)
NormalizeTag/plenty-10      114.6n ± 0%   122.7n ± 0%  +7.07% (p=0.000 n=100)
NormalizeTag/more-10        182.8n ± 0%   193.0n ± 0%  +5.58% (p=0.000 n=59+53)
geomean                     65.00n        70.05n       +7.77%

                          │   old.txt    │                new.txt                 │
                          │     B/op     │    B/op     vs base                    │
NormalizeTag/ok-10          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=100)   ¹
NormalizeTag/trim-10        32.00 ± 0%     32.00 ± 0%       ~ (p=1.000 n=100)   ¹
NormalizeTag/trim-both-10   64.00 ± 0%     64.00 ± 0%       ~ (p=1.000 n=100)   ¹
NormalizeTag/plenty-10      64.00 ± 0%     64.00 ± 0%       ~ (p=1.000 n=100)   ¹
NormalizeTag/more-10        128.0 ± 0%     128.0 ± 0%       ~ (p=1.000 n=59+53) ¹
geomean                                ²               +0.00%                   ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                          │   old.txt    │                new.txt                 │
                          │  allocs/op   │ allocs/op   vs base                    │
NormalizeTag/ok-10          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=100)   ¹
NormalizeTag/trim-10        2.000 ± 0%     2.000 ± 0%       ~ (p=1.000 n=100)   ¹
NormalizeTag/trim-both-10   3.000 ± 0%     3.000 ± 0%       ~ (p=1.000 n=100)   ¹
NormalizeTag/plenty-10      3.000 ± 0%     3.000 ± 0%       ~ (p=1.000 n=100)   ¹
NormalizeTag/more-10        4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=59+53) ¹
geomean                                ²               +0.00%                   ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

The performance of the new `NormalizeTagValue` appears to be in line with the performance of `NormalizeTag`, except slightly slower for the trim cases:
```
BenchmarkNormalizeTagValue/ok-10 	       156753241	       7.460 ns/op	       0 B/op	       0 allocs/op
BenchmarkNormalizeTagValue/trim-10         	11464036	       103.6 ns/op	      64 B/op	       3 allocs/op
BenchmarkNormalizeTagValue/trim-both-10    	 7841328	       152.6 ns/op	     128 B/op	       4 allocs/op
BenchmarkNormalizeTagValue/plenty-10       	 9747152	       122.8 ns/op	      64 B/op	       3 allocs/op
BenchmarkNormalizeTagValue/more-10         	 6213727	       193.3 ns/op	     128 B/op	       4 allocs/op

# New case for NormalizeTagValue
BenchmarkNormalizeTagValue/digit-10        	124552738	         9.666 ns/op	       0 B/op	       0 allocs/op
```

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
