### PR TITLE
[CSPM] Make sure we append the host:* tag in our logs

### DIFF
--- a/pkg/compliance/reporter.go
+++ b/pkg/compliance/reporter.go
@@ -6,7 +6,10 @@
 package compliance
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -19,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 )
@@ -31,7 +35,11 @@ type LogReporter struct {
 }
 
 // NewLogReporter instantiates a new log LogReporter
-func NewLogReporter(stopper startstop.Stopper, sourceName, sourceType, runPath string, endpoints *config.Endpoints, context *client.DestinationsContext) (*LogReporter, error) {
+func NewLogReporter(stopper startstop.Stopper, sourceName, sourceType, runPath string, endpoints *config.Endpoints, dstcontext *client.DestinationsContext) (*LogReporter, error) {
+	hostname, err := hostname.Get(context.Background())
+	if err != nil || hostname == "" {
+		hostname = "unknown"
+	}
 	health := health.RegisterLiveness(sourceType)
 
 	// setup the auditor
@@ -39,7 +47,7 @@ func NewLogReporter(stopper startstop.Stopper, sourceName, sourceType, runPath s
 	auditor.Start()
 
 	// setup the pipeline provider that provides pairs of processor and sender
-	pipelineProvider := pipeline.NewProvider(config.NumberOfPipelines, auditor, &diagnostic.NoopMessageReceiver{}, nil, endpoints, context)
+	pipelineProvider := pipeline.NewProvider(config.NumberOfPipelines, auditor, &diagnostic.NoopMessageReceiver{}, nil, endpoints, dstcontext)
 	pipelineProvider.Start()
 
 	stopper.Add(pipelineProvider)
@@ -54,7 +62,19 @@ func NewLogReporter(stopper startstop.Stopper, sourceName, sourceType, runPath s
 		},
 	)
 	logChan := pipelineProvider.NextPipelineChan()
-	tags := []string{common.QueryAccountIdTag()}
+
+	tags := []string{
+		common.QueryAccountIdTag(),
+		fmt.Sprintf("host:%s", hostname),
+	}
+
+	// merge tags from config
+	for _, tag := range coreconfig.GetConfiguredTags(coreconfig.Datadog, true) {
+		if strings.HasPrefix(tag, "host") {
+			continue
+		}
+		tags = append(tags, tag)
+	}
 
 	return &LogReporter{
 		logSource: logSource,


### PR DESCRIPTION
### What does this PR do?

`host:` tag was not properly setup in our log reporter. This PR makes sure the tag is properly setup and we also merge the globally configured tags into the mix.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
