### PR TITLE
[process-agent] Set larger limits for max batch settings

### DIFF
--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -41,7 +41,7 @@ const (
 	// DefaultProcessMaxMessageBytes is the default max for size of a message containing processes or container data. Note: Only change if the defaults are causing issues.
 	DefaultProcessMaxMessageBytes = 1000000
 
-	// ProcessMaxMessageBytesLimit is the maximum allowed value for the max size of a message containing processes or container data.
+	// ProcessMaxMessageBytesLimit is the maximum allowed value for the maximum size of a message containing processes or container data.
 	ProcessMaxMessageBytesLimit = 4000000
 
 	// DefaultProcessExpVarPort is the default port used by the process-agent expvar server

--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -42,7 +42,7 @@ const (
 	DefaultProcessMaxMessageBytes = 1000000
 
 	// ProcessMaxMessageBytesLimit is the maximum allowed value for the max size of a message containing processes or container data.
-	ProcessMaxMessageBytesLimit = 10000000
+	ProcessMaxMessageBytesLimit = 4000000
 
 	// DefaultProcessExpVarPort is the default port used by the process-agent expvar server
 	DefaultProcessExpVarPort = 6062

--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -35,8 +35,14 @@ const (
 	// DefaultProcessMaxPerMessage is the default maximum number of processes, or containers per message. Note: Only change if the defaults are causing issues.
 	DefaultProcessMaxPerMessage = 100
 
+	// ProcessMaxPerMessageLimit is the maximum allowed value for maximum number of processes, or containers per message.
+	ProcessMaxPerMessageLimit = 10000
+
 	// DefaultProcessMaxMessageBytes is the default max for size of a message containing processes or container data. Note: Only change if the defaults are causing issues.
 	DefaultProcessMaxMessageBytes = 1000000
+
+	// ProcessMaxMessageBytesLimit is the maximum allowed value for the max size of a message containing processes or container data.
+	ProcessMaxMessageBytesLimit = 10000000
 
 	// DefaultProcessExpVarPort is the default port used by the process-agent expvar server
 	DefaultProcessExpVarPort = 6062

--- a/pkg/process/checks/config.go
+++ b/pkg/process/checks/config.go
@@ -16,7 +16,7 @@ var getMaxBatchSize = func(config ddconfig.ConfigReader) int {
 }
 
 func ensureValidMaxBatchSize(batchSize int) int {
-	if batchSize <= 0 || batchSize > ddconfig.DefaultProcessMaxPerMessage {
+	if batchSize <= 0 || batchSize > ddconfig.ProcessMaxPerMessageLimit {
 		log.Warnf("Invalid max item count per message (%d), using default value of %d", batchSize, ddconfig.DefaultProcessMaxPerMessage)
 		return ddconfig.DefaultProcessMaxPerMessage
 	}
@@ -29,7 +29,7 @@ var getMaxBatchBytes = func(config ddconfig.ConfigReader) int {
 }
 
 func ensureValidMaxBatchBytes(batchBytes int) int {
-	if batchBytes <= 0 || batchBytes > ddconfig.DefaultProcessMaxMessageBytes {
+	if batchBytes <= 0 || batchBytes > ddconfig.ProcessMaxMessageBytesLimit {
 		log.Warnf("Invalid max byte size per message (%d), using default value of %d", batchBytes, ddconfig.DefaultProcessMaxMessageBytes)
 		return ddconfig.DefaultProcessMaxMessageBytes
 	}

--- a/pkg/process/checks/config_test.go
+++ b/pkg/process/checks/config_test.go
@@ -21,23 +21,28 @@ func TestEnsureValidMaxBatchSize(t *testing.T) {
 		expectedMaxBatchSize int
 	}{
 		{
-			name:                 "valid batch count",
+			name:                 "valid smaller batch count",
 			maxPerMessage:        50,
 			expectedMaxBatchSize: 50,
 		},
 		{
-			name:                 "negative batch count",
+			name:                 "valid larger batch count",
+			maxPerMessage:        200,
+			expectedMaxBatchSize: 200,
+		},
+		{
+			name:                 "invalid negative batch count",
 			maxPerMessage:        -1,
 			expectedMaxBatchSize: ddconfig.DefaultProcessMaxPerMessage,
 		},
 		{
-			name:                 "0 max batch size",
+			name:                 "invalid 0 max batch size",
 			maxPerMessage:        0,
 			expectedMaxBatchSize: ddconfig.DefaultProcessMaxPerMessage,
 		},
 		{
-			name:                 "big max batch size",
-			maxPerMessage:        2000,
+			name:                 "invalid big max batch size",
+			maxPerMessage:        20000,
 			expectedMaxBatchSize: ddconfig.DefaultProcessMaxPerMessage,
 		},
 	}
@@ -57,23 +62,28 @@ func TestEnsureValidMaxBatchBytes(t *testing.T) {
 		expectedMaxBatchBytes int
 	}{
 		{
-			name:                  "valid batch size",
+			name:                  "valid smaller batch size",
 			maxMessageBytes:       100000,
 			expectedMaxBatchBytes: 100000,
 		},
 		{
-			name:                  "negative batch size",
+			name:                  "valid larger batch size",
+			maxMessageBytes:       5000000,
+			expectedMaxBatchBytes: 5000000,
+		},
+		{
+			name:                  "invalid negative batch size",
 			maxMessageBytes:       -1,
 			expectedMaxBatchBytes: ddconfig.DefaultProcessMaxMessageBytes,
 		},
 		{
-			name:                  "0 max batch size",
+			name:                  "invalid 0 max batch size",
 			maxMessageBytes:       0,
 			expectedMaxBatchBytes: ddconfig.DefaultProcessMaxMessageBytes,
 		},
 		{
-			name:                  "big max batch size",
-			maxMessageBytes:       2000000,
+			name:                  "invalid big max batch size",
+			maxMessageBytes:       20000000,
 			expectedMaxBatchBytes: ddconfig.DefaultProcessMaxMessageBytes,
 		},
 	}

--- a/pkg/process/checks/config_test.go
+++ b/pkg/process/checks/config_test.go
@@ -68,8 +68,8 @@ func TestEnsureValidMaxBatchBytes(t *testing.T) {
 		},
 		{
 			name:                  "valid larger batch size",
-			maxMessageBytes:       5000000,
-			expectedMaxBatchBytes: 5000000,
+			maxMessageBytes:       2000000,
+			expectedMaxBatchBytes: 2000000,
 		},
 		{
 			name:                  "invalid negative batch size",

--- a/releasenotes/notes/proc-batch-size-844ecfed36a30c47.yaml
+++ b/releasenotes/notes/proc-batch-size-844ecfed36a30c47.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes an issue where `process_config.max_per_message` and `process_config.max_message_bytes`
+    were ignored when set larger than the default values.

--- a/releasenotes/notes/proc-batch-size-844ecfed36a30c47.yaml
+++ b/releasenotes/notes/proc-batch-size-844ecfed36a30c47.yaml
@@ -9,4 +9,5 @@
 fixes:
   - |
     Fixes an issue where `process_config.max_per_message` and `process_config.max_message_bytes`
-    were ignored when set larger than the default values.
+    were ignored when set larger than the default values, and increases the limit on accepted values for these 
+    variables.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adds a larger maximum allowable value for `process_config.max_per_message` and `process_config.max_message_bytes`.

### Motivation

Discovered during customer debugging that we could not increase the batch size for processes payloads.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

* Set up a host with hundreds of processes
* With the default setting and with `trace` level logging, check the value of the log line `Created %d process messages` ([src](https://github.com/DataDog/datadog-agent/blob/67531f2f64e93482cadfd547bc57b3f573f3c401/pkg/process/checks/process.go#L368))
* Increase the setting
* Verify that fewer messages are being created

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
