### PR TITLE
Change MacOS install script

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -75,16 +75,17 @@ function find_latest_patch_version_for() {
 }
 
 function prepare_dmg_file() {
-    $sudo_cmd rm -f $dmg_file
-    $sudo_cmd touch $dmg_file
-    $sudo_cmd chmod 600 $dmg_file
+    dmg_file_to_prepare=$1
+    $sudo_cmd rm -f "$dmg_file_to_prepare"
+    $sudo_cmd touch "$dmg_file_to_prepare"
+    $sudo_cmd chmod 600 "$dmg_file_to_prepare"
 
-    file_owner=$(stat -c %u $dmg_file)
-    file_permission=$(stat -c %a $dmg_file)
-    file_size=$(stat -c %s $dmg_file)
-    if [ "$file_owner" -ne 0 ] || [ "$file_permission" -ne 600 ] || [ "$file_size" -ne 0 ]; then
-    echo -e "\033[31mFailed to prepare datadog-agent dmg file\033[0m\n"
-    exit 1;
+    file_owner=$(stat -c %u "$dmg_file_to_prepare")
+    file_permission=$(stat -c %a "$dmg_file_to_prepare")
+    file_size=$(stat -c %s "$dmg_file_to_prepare")
+    if [[ "$file_owner" -ne 0 ]] || [[ "$file_permission" -ne 600 ]] || [[ "$file_size" -ne 0 ]]; then
+        echo -e "\033[31mFailed to prepare datadog-agent dmg file\033[0m\n"
+        exit 1;
     fi
 }
 
@@ -341,7 +342,7 @@ function plist_modify_user_group() {
 
 # # Install the agent
 printf "\033[34m\n* Downloading datadog-agent\n\033[0m"
-prepare_dmg_file
+prepare_dmg_file $dmg_file
 if ! $sudo_cmd curl --fail --progress-bar "$dmg_url" --output $dmg_file; then
     printf "\033[31mCouldn't download the installer for macOS Agent version ${dmg_version}.\033[0m\n"
     exit 1;

--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -74,6 +74,20 @@ function find_latest_patch_version_for() {
     echo "$latest_patch"
 }
 
+function prepare_dmg_file() {
+    $sudo_cmd rm -f $dmg_file
+    $sudo_cmd touch $dmg_file
+    $sudo_cmd chmod 600 $dmg_file
+
+    file_owner=$(stat -c %u $dmg_file)
+    file_permission=$(stat -c %a $dmg_file)
+    file_size=$(stat -c %s $dmg_file)
+    if [ "$file_owner" -ne 0 ] || [ "$file_permission" -ne 600 ] || [ "$file_size" -ne 0 ]; then
+    echo -e "\033[31mFailed to prepare datadog-agent dmg file\033[0m\n"
+    exit 1;
+    fi
+}
+
 systemdaemon_install=false
 systemdaemon_user_group=
 if [ -n "$DD_SYSTEMDAEMON_INSTALL" ]; then
@@ -327,8 +341,8 @@ function plist_modify_user_group() {
 
 # # Install the agent
 printf "\033[34m\n* Downloading datadog-agent\n\033[0m"
-rm -f $dmg_file
-if ! curl --fail --progress-bar "$dmg_url" > $dmg_file; then
+prepare_dmg_file
+if ! $sudo_cmd curl --fail --progress-bar "$dmg_url" --output $dmg_file; then
     printf "\033[31mCouldn't download the installer for macOS Agent version ${dmg_version}.\033[0m\n"
     exit 1;
 fi


### PR DESCRIPTION
### What does this PR do?
Changes MacOS install script


### Motivation
### Additional Notes
### Possible Drawbacks / Trade-offs
### Describe how to test/QA your changes
- Run the MacOS install script on a MacOS laptop and check that the installation works.
### Reviewer's Checklist
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
