### PR TITLE
Mark trace-agent Regression Detector experiments as erratic

### DIFF
--- a/test/regression/cases/trace_agent_json/experiment.yaml
+++ b/test/regression/cases/trace_agent_json/experiment.yaml
@@ -1,2 +1,2 @@
 optimization_goal: ingress_throughput
-erratic: false
+erratic: true # See https://datadoghq.atlassian.net/browse/SMP-606

--- a/test/regression/cases/trace_agent_msgpack/experiment.yaml
+++ b/test/regression/cases/trace_agent_msgpack/experiment.yaml
@@ -1,2 +1,2 @@
 optimization_goal: ingress_throughput
-erratic: false
+erratic: true # See https://datadoghq.atlassian.net/browse/SMP-606


### PR DESCRIPTION
### What does this PR do?

Now that we have #17449 in place any experiment that wobbles without cause -- see #17672 -- needs looked into. We believe we have a bug in our rig that's expressing in trace-agent experiments. To avoid dinging folks' PRs without cause and not deny us follow-up data we set these experiments as 'erratic', meaning they will still run but any detected "regression" will not be flagged.

### Additional Notes

We are actively pursuing this on our side. Much obliged to @hannahkm for the report.

## Related Issues

REF SMP-606
