### PR TITLE
Remove problematic helper function feature probe

### DIFF
--- a/pkg/network/tracer/utils_linux.go
+++ b/pkg/network/tracer/utils_linux.go
@@ -8,13 +8,7 @@
 package tracer
 
 import (
-	"errors"
 	"fmt"
-	"strings"
-
-	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/asm"
-	"github.com/cilium/ebpf/features"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
@@ -56,28 +50,5 @@ func verifyOSVersion(kernelCode kernel.Version, platform string, exclusionList [
 	if platform == "ubuntu" && kernelCode >= kernel.VersionCode(4, 4, 114) && kernelCode <= kernel.VersionCode(4, 4, 127) {
 		return false, fmt.Errorf("Known bug for kernel %s on platform %s, see: \n- https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1763454", kernelCode, platform)
 	}
-
-	var requiredFuncs = []asm.BuiltinFunc{
-		asm.FnMapLookupElem,
-		asm.FnMapUpdateElem,
-		asm.FnMapDeleteElem,
-		asm.FnPerfEventOutput,
-		asm.FnPerfEventRead,
-	}
-	var missingFuncs []string
-	for _, rf := range requiredFuncs {
-		if err := features.HaveProgramHelper(ebpf.Kprobe, rf); err != nil {
-			if errors.Is(err, ebpf.ErrNotSupported) {
-				missingFuncs = append(missingFuncs, rf.String())
-			} else {
-				return false, fmt.Errorf("error checking for ebpf helper %s support: %w", rf.String(), err)
-			}
-		}
-	}
-	if len(missingFuncs) == 0 {
-		return true, nil
-	}
-	errMsg := fmt.Sprintf("Kernel unsupported (%s) - ", kernelCode)
-	errMsg += fmt.Sprintf("required functions missing: %s", strings.Join(missingFuncs, ", "))
-	return false, fmt.Errorf(errMsg)
+	return true, nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Removes feature testing for basic helpers in kprobes

### Motivation

The method of testing is causing errors on systems that otherwise run eBPF fine. Removing for now until we can do a full investigation and implement a proper fix.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
