### PR TITLE
Update lading version, trace-agent stable throttle

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -15,7 +15,7 @@ single-machine-performance-regression_detector:
     when: always
   variables:
     SMP_VERSION: 0.7.3
-    LADING_VERSION: 0.14.0
+    LADING_VERSION: 0.15.3
     TOTAL_SAMPLES: 600
     WARMUP_SECONDS: 45
     REPLICAS: 20

--- a/test/regression/cases/trace_agent_json/lading/lading.yaml
+++ b/test/regression/cases/trace_agent_json/lading/lading.yaml
@@ -2,6 +2,7 @@ generator:
   - http:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
         59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      throttle: stable # See SMP-330
       headers: {}
       target_uri: "http://localhost:9091/"
       bytes_per_second: "256 Mb"

--- a/test/regression/cases/trace_agent_msgpack/lading/lading.yaml
+++ b/test/regression/cases/trace_agent_msgpack/lading/lading.yaml
@@ -2,6 +2,7 @@ generator:
   - http:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
         59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      throttle: stable # See SMP-330
       headers: {}
       target_uri: "http://localhost:9091/"
       bytes_per_second: "256 Mb"


### PR DESCRIPTION
### What does this PR do?

This commit updates the Agent CI's lading version to the latest release and marks the throttle for trace-agent experiments to 'stable'. By default lading uses a 'predictive' throttle, meaning we will examine the target's ingest rate and push load to the capacity of the target. However, we do not participate in back-off signals from the trace-agent yet -- see SMP-330 -- so the predictive throttle is wide-open. We believe that SMP-606 -- see #17688 -- is due at least in part to this mis-throttle.

## Related Issues

REF SMP-330
REF SMP-606
