### PR TITLE
Remove the erratic designation from trace-agent RD experiments

### DIFF
--- a/test/regression/cases/trace_agent_json/experiment.yaml
+++ b/test/regression/cases/trace_agent_json/experiment.yaml
@@ -1,2 +1,2 @@
 optimization_goal: ingress_throughput
-erratic: true # See https://datadoghq.atlassian.net/browse/SMP-606
+erratic: false

--- a/test/regression/cases/trace_agent_msgpack/experiment.yaml
+++ b/test/regression/cases/trace_agent_msgpack/experiment.yaml
@@ -1,2 +1,2 @@
 optimization_goal: ingress_throughput
-erratic: true # See https://datadoghq.atlassian.net/browse/SMP-606
+erratic: false


### PR DESCRIPTION
### What does this PR do?

This commit removes the erratic flag from the two trace-agent Regression Detector experiments, see #17693 for details. This reverts #17688.

## Related Issues 

REF SMP-606
REF SMP-330
