### PR TITLE
usm: Replace kprobes with tracepoints

### DIFF
--- a/pkg/network/ebpf/c/prebuilt/usm.c
+++ b/pkg/network/ebpf/c/prebuilt/usm.c
@@ -6,16 +6,15 @@
 #include "offsets.h"
 
 #include "protocols/classification/dispatcher-helpers.h"
-#include "protocols/http/http.h"
 #include "protocols/http/buffer.h"
+#include "protocols/http/http.h"
 #include "protocols/http2/decoding.h"
-#include "protocols/tls/https.h"
-#include "protocols/tls/tags-types.h"
+#include "protocols/kafka/kafka-parsing.h"
 #include "protocols/tls/java/erpc_dispatcher.h"
 #include "protocols/tls/java/erpc_handlers.h"
-#include "protocols/kafka/kafka-parsing.h"
-
-#define SO_SUFFIX_SIZE 3
+#include "protocols/tls/https.h"
+#include "protocols/tls/sowatcher.h"
+#include "protocols/tls/tags-types.h"
 
 SEC("socket/protocol_dispatcher")
 int socket__protocol_dispatcher(struct __sk_buff *skb) {
@@ -507,104 +506,6 @@ int uprobe__gnutls_deinit(struct pt_regs *ctx) {
     gnutls_goodbye(ssl_session);
     http_batch_flush(ctx);
     return 0;
-}
-
-static __always_inline int fill_path_safe(lib_path_t *path, char *path_argument) {
-#pragma unroll
-    for (int i = 0; i < LIB_PATH_MAX_SIZE; i++) {
-        bpf_probe_read_user(&path->buf[i], 1, &path_argument[i]);
-        if (path->buf[i] == 0) {
-            path->len = i;
-            break;
-        }
-    }
-    return 0;
-}
-
-static __always_inline int do_sys_open_helper_enter(struct pt_regs* ctx) {
-    char *path_argument = (char *)PT_REGS_PARM2(ctx);
-    lib_path_t path = {0};
-    if (bpf_probe_read_user_with_telemetry(path.buf, sizeof(path.buf), path_argument) >= 0) {
-// Find the null character and clean up the garbage following it
-#pragma unroll
-        for (int i = 0; i < LIB_PATH_MAX_SIZE; i++) {
-            if (path.len) {
-                path.buf[i] = 0;
-            } else if (path.buf[i] == 0) {
-                path.len = i;
-            }
-        }
-    } else {
-        fill_path_safe(&path, path_argument);
-    }
-
-    // Bail out if the path size is larger than our buffer
-    if (!path.len) {
-        return 0;
-    }
-
-    u64 pid_tgid = bpf_get_current_pid_tgid();
-    path.pid = pid_tgid >> 32;
-    bpf_map_update_with_telemetry(open_at_args, &pid_tgid, &path, BPF_ANY);
-    return 0;
-}
-
-SEC("kprobe/do_sys_open")
-int kprobe__do_sys_open(struct pt_regs* ctx) {
-    return do_sys_open_helper_enter(ctx);
-}
-
-SEC("kprobe/do_sys_openat2")
-int kprobe__do_sys_openat2(struct pt_regs* ctx) {
-    return do_sys_open_helper_enter(ctx);
-}
-
-static __always_inline int do_sys_open_helper_exit(struct pt_regs* ctx) {
-    u64 pid_tgid = bpf_get_current_pid_tgid();
-
-    // If file couldn't be opened, bail out
-    if ((long)PT_REGS_RC(ctx) < 0) {
-        goto cleanup;
-    }
-
-    lib_path_t *path = bpf_map_lookup_elem(&open_at_args, &pid_tgid);
-    if (path == NULL) {
-        return 0;
-    }
-
-    // Detect whether the file being opened is a shared library
-    bool is_shared_library = false;
-#pragma unroll
-    for (int i = 0; i < LIB_PATH_MAX_SIZE - SO_SUFFIX_SIZE; i++) {
-        if (path->buf[i] == '.' && path->buf[i+1] == 's' && path->buf[i+2] == 'o') {
-            is_shared_library = true;
-            break;
-        }
-    }
-
-    if (!is_shared_library) {
-        goto cleanup;
-    }
-
-    // Copy map value into eBPF stack
-    lib_path_t lib_path;
-    bpf_memcpy(&lib_path, path, sizeof(lib_path));
-
-    u32 cpu = bpf_get_smp_processor_id();
-    bpf_perf_event_output_with_telemetry(ctx, &shared_libraries, cpu, &lib_path, sizeof(lib_path));
-cleanup:
-    bpf_map_delete_elem(&open_at_args, &pid_tgid);
-    return 0;
-}
-
-SEC("kretprobe/do_sys_open")
-int kretprobe__do_sys_open(struct pt_regs* ctx) {
-    return do_sys_open_helper_exit(ctx);
-}
-
-SEC("kretprobe/do_sys_openat2")
-int kretprobe__do_sys_openat2(struct pt_regs* ctx) {
-    return do_sys_open_helper_exit(ctx);
 }
 
 SEC("kprobe/do_vfs_ioctl")

--- a/pkg/network/ebpf/c/protocols/http/maps.h
+++ b/pkg/network/ebpf/c/protocols/http/maps.h
@@ -6,6 +6,7 @@
 
 #include "protocols/http/types.h"
 #include "protocols/tls/go-tls-types.h"
+#include "protocols/tls/sowatcher-types.h"
 
 /* This map is used to keep track of in-flight HTTP transactions for each TCP connection */
 BPF_LRU_MAP(http_in_flight, conn_tuple_t, http_transaction_t, 0)

--- a/pkg/network/ebpf/c/protocols/http/types.h
+++ b/pkg/network/ebpf/c/protocols/http/types.h
@@ -83,12 +83,4 @@ typedef struct {
     __u32 fd;
 } ssl_sock_t;
 
-#define LIB_PATH_MAX_SIZE 120
-
-typedef struct {
-    __u32 pid;
-    __u32 len;
-    char buf[LIB_PATH_MAX_SIZE];
-} lib_path_t;
-
 #endif

--- a/pkg/network/ebpf/c/protocols/tls/sowatcher-types.h
+++ b/pkg/network/ebpf/c/protocols/tls/sowatcher-types.h
@@ -1,0 +1,34 @@
+#ifndef __SOWATCHER_TYPES_H
+#define __SOWATCHER_TYPES_H
+
+#include "ktypes.h"
+
+#define SO_SUFFIX_SIZE 3
+#define LIB_PATH_MAX_SIZE 120
+
+typedef struct {
+    __u32 pid;
+    __u32 len;
+    char buf[LIB_PATH_MAX_SIZE];
+} lib_path_t;
+
+typedef struct {
+    unsigned short common_type;
+    unsigned char common_flags;
+    unsigned char common_preempt_count;
+    int common_pid;
+    long syscall_nr;
+} trace_common;
+
+typedef struct {
+    trace_common unsued;
+    int dfd;
+    char* filename;
+} enter_sys_openat_ctx;
+
+typedef struct {
+    trace_common unsued;
+    long ret;
+} exit_sys_openat_ctx;
+
+#endif

--- a/pkg/network/ebpf/c/protocols/tls/sowatcher-types.h
+++ b/pkg/network/ebpf/c/protocols/tls/sowatcher-types.h
@@ -17,19 +17,26 @@ typedef struct {
     unsigned char common_flags;
     unsigned char common_preempt_count;
     int common_pid;
-    long syscall_nr;
-} trace_common;
+    long __syscall_nr;
+
+    int dfd;
+    const char* filename;
+    int flags;
+    int mode;
+} enter_sys_openat_ctx;
 
 typedef struct {
     unsigned short common_type;
     unsigned char common_flags;
     unsigned char common_preempt_count;
     int common_pid;
-    int __syscall_nr;
+    long __syscall_nr;
 
     int dfd;
-    char* filename;
-} enter_sys_openat_ctx;
+    const char* filename;
+    void *how;
+    size_t usize;
+} enter_sys_openat2_ctx;
 
 typedef struct {
     unsigned short common_type;

--- a/pkg/network/ebpf/c/protocols/tls/sowatcher-types.h
+++ b/pkg/network/ebpf/c/protocols/tls/sowatcher-types.h
@@ -21,13 +21,23 @@ typedef struct {
 } trace_common;
 
 typedef struct {
-    trace_common unsued;
+    unsigned short common_type;
+    unsigned char common_flags;
+    unsigned char common_preempt_count;
+    int common_pid;
+    int __syscall_nr;
+
     int dfd;
     char* filename;
 } enter_sys_openat_ctx;
 
 typedef struct {
-    trace_common unsued;
+    unsigned short common_type;
+    unsigned char common_flags;
+    unsigned char common_preempt_count;
+    int common_pid;
+    int __syscall_nr;
+
     long ret;
 } exit_sys_openat_ctx;
 

--- a/pkg/network/ebpf/c/protocols/tls/sowatcher.h
+++ b/pkg/network/ebpf/c/protocols/tls/sowatcher.h
@@ -1,0 +1,102 @@
+#ifndef __SOWATCHER_H
+#define __SOWATCHER_H
+
+#include "protocols/tls/sowatcher-types.h"
+
+static __always_inline void fill_path_safe(lib_path_t *path, char *path_argument) {
+#pragma unroll
+    for (int i = 0; i < LIB_PATH_MAX_SIZE; i++) {
+        bpf_probe_read_user(&path->buf[i], 1, &path_argument[i]);
+        if (path->buf[i] == 0) {
+            path->len = i;
+            break;
+        }
+    }
+}
+
+static __always_inline void do_sys_open_helper_enter(enter_sys_openat_ctx* args) {
+    lib_path_t path = {0};
+    if (bpf_probe_read_user_with_telemetry(path.buf, sizeof(path.buf), args->filename) >= 0) {
+// Find the null character and clean up the garbage following it
+#pragma unroll
+        for (int i = 0; i < LIB_PATH_MAX_SIZE; i++) {
+            if (path.len) {
+                path.buf[i] = 0;
+            } else if (path.buf[i] == 0) {
+                path.len = i;
+            }
+        }
+    } else {
+        fill_path_safe(&path, args->filename);
+    }
+
+    // Bail out if the path size is larger than our buffer
+    if (!path.len) {
+        return;
+    }
+
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    path.pid = pid_tgid >> 32;
+    bpf_map_update_with_telemetry(open_at_args, &pid_tgid, &path, BPF_ANY);
+    return;
+}
+
+static __always_inline void do_sys_open_helper_exit(exit_sys_openat_ctx *args) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+
+    // If file couldn't be opened, bail out
+    if (args->ret < 0) {
+        goto cleanup;
+    }
+
+    lib_path_t *path = bpf_map_lookup_elem(&open_at_args, &pid_tgid);
+    if (path == NULL) {
+        return;
+    }
+
+    // Detect whether the file being opened is a shared library
+    bool is_shared_library = false;
+#pragma unroll
+    for (int i = 0; i < LIB_PATH_MAX_SIZE - SO_SUFFIX_SIZE; i++) {
+        if (path->buf[i] == '.' && path->buf[i + 1] == 's' && path->buf[i + 2] == 'o') {
+            is_shared_library = true;
+            break;
+        }
+    }
+
+    if (!is_shared_library) {
+        goto cleanup;
+    }
+
+    u32 cpu = bpf_get_smp_processor_id();
+    bpf_perf_event_output_with_telemetry((void*)args, &shared_libraries, cpu, path, sizeof(lib_path_t));
+cleanup:
+    bpf_map_delete_elem(&open_at_args, &pid_tgid);
+    return;
+}
+
+SEC("tracepoint/syscalls/sys_enter_openat")
+int tracepoint__syscalls__sys_enter_openat(enter_sys_openat_ctx* args) {
+    do_sys_open_helper_enter(args);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_exit_openat")
+int tracepoint__syscalls__sys_exit_openat(exit_sys_openat_ctx *args) {
+    do_sys_open_helper_exit(args);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_openat2")
+int tracepoint__syscalls__sys_enter_openat2(enter_sys_openat_ctx* args) {
+    do_sys_open_helper_enter(args);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_exit_openat2")
+int tracepoint__syscalls__sys_exit_openat2(exit_sys_openat_ctx *args) {
+    do_sys_open_helper_exit(args);
+    return 0;
+}
+
+#endif

--- a/pkg/network/ebpf/c/runtime/usm.c
+++ b/pkg/network/ebpf/c/runtime/usm.c
@@ -13,20 +13,19 @@
 #include "port_range.h"
 
 #include "protocols/classification/dispatcher-helpers.h"
-#include "protocols/http/http.h"
 #include "protocols/http/buffer.h"
+#include "protocols/http/http.h"
 #include "protocols/http2/decoding.h"
-#include "protocols/tls/https.h"
+#include "protocols/kafka/kafka-parsing.h"
+#include "protocols/tls/java/erpc_dispatcher.h"
+#include "protocols/tls/java/erpc_handlers.h"
 #include "protocols/tls/go-tls-types.h"
 #include "protocols/tls/go-tls-goid.h"
 #include "protocols/tls/go-tls-location.h"
 #include "protocols/tls/go-tls-conn.h"
+#include "protocols/tls/https.h"
+#include "protocols/tls/sowatcher.h"
 #include "protocols/tls/tags-types.h"
-#include "protocols/tls/java/erpc_dispatcher.h"
-#include "protocols/tls/java/erpc_handlers.h"
-#include "protocols/kafka/kafka-parsing.h"
-
-#define SO_SUFFIX_SIZE 3
 
 // The entrypoint for all packets classification & decoding in universal service monitoring.
 SEC("socket/protocol_dispatcher")
@@ -520,104 +519,6 @@ int uprobe__gnutls_deinit(struct pt_regs *ctx) {
     gnutls_goodbye(ssl_session);
     http_batch_flush(ctx);
     return 0;
-}
-
-static __always_inline int fill_path_safe(lib_path_t *path, char *path_argument) {
-#pragma unroll
-    for (int i = 0; i < LIB_PATH_MAX_SIZE; i++) {
-        bpf_probe_read_user(&path->buf[i], 1, &path_argument[i]);
-        if (path->buf[i] == 0) {
-            path->len = i;
-            break;
-        }
-    }
-    return 0;
-}
-
-static __always_inline int do_sys_open_helper_enter(struct pt_regs *ctx) {
-    char *path_argument = (char *)PT_REGS_PARM2(ctx);
-    lib_path_t path = { 0 };
-    if (bpf_probe_read_user_with_telemetry(path.buf, sizeof(path.buf), path_argument) >= 0) {
-// Find the null character and clean up the garbage following it
-#pragma unroll
-        for (int i = 0; i < LIB_PATH_MAX_SIZE; i++) {
-            if (path.len) {
-                path.buf[i] = 0;
-            } else if (path.buf[i] == 0) {
-                path.len = i;
-            }
-        }
-    } else {
-        fill_path_safe(&path, path_argument);
-    }
-
-    // Bail out if the path size is larger than our buffer
-    if (!path.len) {
-        return 0;
-    }
-
-    u64 pid_tgid = bpf_get_current_pid_tgid();
-    path.pid = pid_tgid >> 32;
-    bpf_map_update_with_telemetry(open_at_args, &pid_tgid, &path, BPF_ANY);
-    return 0;
-}
-
-SEC("kprobe/do_sys_open")
-int kprobe__do_sys_open(struct pt_regs *ctx) {
-    return do_sys_open_helper_enter(ctx);
-}
-
-SEC("kprobe/do_sys_openat2")
-int kprobe__do_sys_openat2(struct pt_regs *ctx) {
-    return do_sys_open_helper_enter(ctx);
-}
-
-static __always_inline int do_sys_open_helper_exit(struct pt_regs *ctx) {
-    u64 pid_tgid = bpf_get_current_pid_tgid();
-
-    // If file couldn't be opened, bail out
-    if ((long)PT_REGS_RC(ctx) < 0) {
-        goto cleanup;
-    }
-
-    lib_path_t *path = bpf_map_lookup_elem(&open_at_args, &pid_tgid);
-    if (path == NULL) {
-        return 0;
-    }
-
-    // Detect whether the file being opened is a shared library
-    bool is_shared_library = false;
-#pragma unroll
-    for (int i = 0; i < LIB_PATH_MAX_SIZE - SO_SUFFIX_SIZE; i++) {
-        if (path->buf[i] == '.' && path->buf[i + 1] == 's' && path->buf[i + 2] == 'o') {
-            is_shared_library = true;
-            break;
-        }
-    }
-
-    if (!is_shared_library) {
-        goto cleanup;
-    }
-
-    // Copy map value into eBPF stack
-    lib_path_t lib_path;
-    bpf_memcpy(&lib_path, path, sizeof(lib_path));
-
-    u32 cpu = bpf_get_smp_processor_id();
-    bpf_perf_event_output_with_telemetry(ctx, &shared_libraries, cpu, &lib_path, sizeof(lib_path));
-cleanup:
-    bpf_map_delete_elem(&open_at_args, &pid_tgid);
-    return 0;
-}
-
-SEC("kretprobe/do_sys_open")
-int kretprobe__do_sys_open(struct pt_regs *ctx) {
-    return do_sys_open_helper_exit(ctx);
-}
-
-SEC("kretprobe/do_sys_openat2")
-int kretprobe__do_sys_openat2(struct pt_regs *ctx) {
-    return do_sys_open_helper_exit(ctx);
 }
 
 // GO TLS PROBES

--- a/pkg/network/protocols/http/http_types.go
+++ b/pkg/network/protocols/http/http_types.go
@@ -9,6 +9,7 @@ package http
 
 /*
 #include "../../ebpf/c/protocols/tls/tags-types.h"
+#include "../../ebpf/c/protocols/tls/sowatcher-types.h"
 #include "../../ebpf/c/protocols/http/types.h"
 #include "../../ebpf/c/protocols/classification/defs.h"
 */

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -9,6 +9,7 @@ package usm
 
 import (
 	"debug/elf"
+	"fmt"
 	"os"
 	"regexp"
 	"strings"
@@ -195,13 +196,14 @@ var gnuTLSProbes = []manager.ProbesSelector{
 const (
 	sslSockByCtxMap        = "ssl_sock_by_ctx"
 	sharedLibrariesPerfMap = "shared_libraries"
+
+	// probe used for streaming shared library events
+	openatSysCall  = "openat"
+	openat2SysCall = "openat2"
 )
 
-// probe used for streaming shared library events
 var (
-	kprobeKretprobePrefix = []string{"kprobe", "kretprobe"}
-	doSysOpen             = "do_sys_open"
-	doSysOpenAt2          = "do_sys_openat2"
+	traceTypes = []string{"enter", "exit"}
 )
 
 type sslProgram struct {
@@ -467,10 +469,10 @@ func (*sslProgram) GetAllUndefinedProbes() []manager.ProbeIdentificationPair {
 		}
 	}
 
-	for _, hook := range []string{doSysOpen, doSysOpenAt2} {
-		for _, kprobe := range kprobeKretprobePrefix {
+	for _, hook := range []string{openatSysCall, openat2SysCall} {
+		for _, traceType := range traceTypes {
 			probeList = append(probeList, manager.ProbeIdentificationPair{
-				EBPFFuncName: kprobe + "__" + hook,
+				EBPFFuncName: fmt.Sprintf("tracepoint__syscalls__sys_%s_%s", traceType, hook),
 			})
 		}
 	}
@@ -479,7 +481,7 @@ func (*sslProgram) GetAllUndefinedProbes() []manager.ProbeIdentificationPair {
 }
 
 func sysOpenAt2Supported() bool {
-	missing, err := ddebpf.VerifyKernelFuncs(doSysOpenAt2)
+	missing, err := ddebpf.VerifyKernelFuncs("do_sys_openat2")
 	if err == nil && len(missing) == 0 {
 		return true
 	}
@@ -492,19 +494,20 @@ func sysOpenAt2Supported() bool {
 	return kversion >= kernel.VersionCode(5, 6, 0)
 }
 
-// getSysOpenHooksIdentifiers returns the kprobe and kretprobe for the chosen kernel function to hook, to get notification
-// about file opening. Before kernel 5.6 we use do_sys_open, otherwise we use do_sys_openat2.
+// getSysOpenHooksIdentifiers returns the enter and exit tracepoints for openat and openat2 (if supported).
 func getSysOpenHooksIdentifiers() []manager.ProbeIdentificationPair {
-	probeSysOpen := doSysOpen
+	openatProbes := []string{openatSysCall}
 	if sysOpenAt2Supported() {
-		probeSysOpen = doSysOpenAt2
+		openatProbes = append(openatProbes, openat2SysCall)
 	}
 
-	res := make([]manager.ProbeIdentificationPair, len(kprobeKretprobePrefix))
-	for i, kprobe := range kprobeKretprobePrefix {
-		res[i] = manager.ProbeIdentificationPair{
-			EBPFFuncName: kprobe + "__" + probeSysOpen,
-			UID:          probeUID,
+	res := make([]manager.ProbeIdentificationPair, 0, len(traceTypes)*len(openatProbes))
+	for _, probe := range openatProbes {
+		for _, traceType := range traceTypes {
+			res = append(res, manager.ProbeIdentificationPair{
+				EBPFFuncName: fmt.Sprintf("tracepoint__syscalls__sys_%s_%s", traceType, probe),
+				UID:          probeUID,
+			})
 		}
 	}
 

--- a/pkg/network/usm/shared_libraries_test.go
+++ b/pkg/network/usm/shared_libraries_test.go
@@ -613,7 +613,7 @@ func initEBPFProgram(t *testing.T) *ddebpf.PerfHandler {
 
 	if !includeOpenat2 {
 		exclude = append(exclude, getTracepointFuncName(enterTracepoint, openat2SysCall),
-			getTracepointFuncName(exitTracepoint, openat2SysCall),
+			getTracepointFuncName(exitTracepoint, openat2SysCall))
 	}
 
 	for _, sslProbeList := range [][]manager.ProbesSelector{openSSLProbes, cryptoProbes, gnuTLSProbes} {

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -339,6 +339,7 @@ def ninja_cgo_type_files(nw, windows):
             "pkg/network/protocols/http/http_types.go": [
                 "pkg/network/ebpf/c/tracer/tracer.h",
                 "pkg/network/ebpf/c/protocols/tls/tags-types.h",
+                "pkg/network/ebpf/c/protocols/tls/sowatcher-types.h",
                 "pkg/network/ebpf/c/protocols/http/types.h",
                 "pkg/network/ebpf/c/protocols/classification/defs.h",
             ],


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Converts SOWatcher kprobes into tracepoints.
Unifies prebuilt and runtime compilation functions, as they were the same.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Using tracepoints is encouraged as the ABI is stable and change less over the years, furthermore, unlike kprobes, tracepoints does not suffer from misses.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
