### PR TITLE
Chocolatey: Replace `iwr` with `System.Net.WebRequest`

### DIFF
--- a/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
@@ -61,15 +61,19 @@ Invoke-WebRequest -Uri "https://raw.githubusercontent.com/DataDog/datadog-agent/
 
 Write-Host "Generating Chocolatey $installMethod package version $agentVersion in $outputDirectory"
 
+Write-Host ("Downloading {0}" -f $url)
 $statusCode = -1
 try {
-    $statusCode = (iwr $url).StatusCode
+    $req = [System.Net.WebRequest]::Create($url)
+    $rep = $req.GetResponse()
+    $statusCode = $rep.StatusCode
 }
 catch [System.Net.WebException] {
     if ($_.Exception.Status -eq "ProtocolError") {
         $statusCode = [int]$_.Exception.Response.StatusCode
     }
 }
+Write-Host $statusCode
 
 if ($statusCode -ne 200) {
     Write-Warning "Package $($url) doesn't exists yet, make sure it exists before publishing the Chocolatey package !"
@@ -83,6 +87,9 @@ if ($installMethod -eq "online") {
     # Set the $url in the install script
     (Get-Content $installScript).replace('$__url_from_ci__', '"' +  $url  + '"') | Set-Content $installScript
 }
+
+Write-Host "Generated nupsec file:"
+Write-Host (Get-Content $installScript | Out-String)
 
 choco pack --out=$outputDirectory $nuspecFile package_version=$agentVersion release_notes=$releaseNotes copyright=$copyright
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR replaces `iwr` with `System.Net.WebRequest` and also prints out the content of the NuSpec file for troubleshooting purposes.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Chocolatey jobs should succeed.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
`Invoke-WebRequest` without the `-UseBasicParsing` flag uses the Internet Explorer COM API to parse the result, which fails inside a container. Passing `-UseBasicParsing` is  a solution but `iwr` is ultimately based on `System.Net.WebRequest`, so this PR bypasses all the higher-logic for `iwr` since we are only interested in the status code.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
For 7.46.0 RC.4, check that the Chocolatey job succeeds.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
