### PR TITLE
e2e: Add Agent command arguments

### DIFF
--- a/test/new-e2e/test-infra-definition/agent_test.go
+++ b/test/new-e2e/test-infra-definition/agent_test.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package testinfradefinition
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/utils/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/utils/e2e/client"
+	"github.com/stretchr/testify/assert"
+)
+
+type agentSuite struct {
+	e2e.Suite[e2e.AgentEnv]
+}
+
+func TestAgentSuite(t *testing.T) {
+	e2e.Run(t, &agentSuite{}, e2e.AgentStackDef(nil))
+}
+
+func (v *agentSuite) TestAgentCommandNoArg() {
+	version := v.Env().Agent.Version()
+
+	match, err := regexp.MatchString("^Agent .* - Commit: .* - Serialization version: .* - Go version: .*$", strings.TrimSuffix(version, "\n"))
+	assert.NoError(v.T(), err)
+	assert.True(v.T(), match)
+}
+
+func (v *agentSuite) TestAgentCommandWithArg() {
+	err := v.Env().Agent.WaitForReady()
+	assert.NoError(v.T(), err)
+
+	status := v.Env().Agent.Status(client.WithArgs("-h"))
+	assert.Contains(v.T(), status.Content, "Use \"datadog-agent status [command] --help\" for more information about a command.")
+}

--- a/test/new-e2e/utils/e2e/client/agent.go
+++ b/test/new-e2e/utils/e2e/client/agent.go
@@ -51,6 +51,14 @@ func (agent *Agent) GetCommand(parameters string) string {
 
 func (agent *Agent) Config() string {
 	return agent.vmClient.Execute(agent.GetCommand("config"))
+ }
+
+func (agent *Agent) executeCommand(command string, commandArgs ...AgentArgsOption) string {
+	args, err := newAgentArgs(commandArgs...)
+	if err != nil {
+		return ""
+	}
+	return agent.vmClient.Execute(agent.GetCommand(command) + " " + args.Args)
 }
 
 type Status struct {

--- a/test/new-e2e/utils/e2e/client/agent.go
+++ b/test/new-e2e/utils/e2e/client/agent.go
@@ -46,10 +46,7 @@ func (agent *Agent) GetCommand(parameters string) string {
 }
 
 func (agent *Agent) executeCommand(command string, commandArgs ...AgentArgsOption) string {
-	args, err := newAgentArgs(commandArgs...)
-	if err != nil {
-		return ""
-	}
+	args := newAgentArgs(commandArgs...)
 	return agent.vmClient.Execute(agent.GetCommand(command) + " " + args.Args)
 }
 

--- a/test/new-e2e/utils/e2e/client/agent.go
+++ b/test/new-e2e/utils/e2e/client/agent.go
@@ -41,17 +41,9 @@ func (agent *Agent) initService(t *testing.T, data *agent.ClientData) error {
 	return err
 }
 
-func (agent *Agent) Version() string {
-	return agent.vmClient.Execute(agent.GetCommand("version"))
-}
-
 func (agent *Agent) GetCommand(parameters string) string {
 	return agent.os.GetRunAgentCmd(parameters)
 }
-
-func (agent *Agent) Config() string {
-	return agent.vmClient.Execute(agent.GetCommand("config"))
- }
 
 func (agent *Agent) executeCommand(command string, commandArgs ...AgentArgsOption) string {
 	args, err := newAgentArgs(commandArgs...)
@@ -59,6 +51,14 @@ func (agent *Agent) executeCommand(command string, commandArgs ...AgentArgsOptio
 		return ""
 	}
 	return agent.vmClient.Execute(agent.GetCommand(command) + " " + args.Args)
+}
+
+func (agent *Agent) Version(commandArgs ...AgentArgsOption) string {
+	return agent.executeCommand("version", commandArgs...)
+}
+
+func (agent *Agent) Config(commandArgs ...AgentArgsOption) string {
+	return agent.executeCommand("config", commandArgs...)
 }
 
 type Status struct {
@@ -74,8 +74,8 @@ func (s *Status) isReady() (bool, error) {
 	return regexp.MatchString("={15}\nAgent \\(v7\\.\\d{2}\\..*\n={15}", s.Content)
 }
 
-func (agent *Agent) Status() *Status {
-	return newStatus(agent.vmClient.Execute(agent.GetCommand("status")))
+func (agent *Agent) Status(commandArgs ...AgentArgsOption) *Status {
+	return newStatus(agent.executeCommand("status", commandArgs...))
 }
 
 // IsReady runs status command and returns true if the agent is ready.

--- a/test/new-e2e/utils/e2e/client/agent_args.go
+++ b/test/new-e2e/utils/e2e/client/agent_args.go
@@ -5,25 +5,25 @@
 
 package client
 
-import "github.com/DataDog/test-infra-definitions/common"
-
 // agentArgs contains the arguments for the Agent commands.
 // Its value is populated using the functional options pattern.
 type agentArgs struct {
 	Args string
 }
 
-type AgentArgsOption = func(*agentArgs) error
+type AgentArgsOption = func(*agentArgs)
 
 // WithArgs sets the Agent arguments
 func WithArgs(args string) AgentArgsOption {
-	return func(a *agentArgs) error {
+	return func(a *agentArgs) {
 		a.Args = args
-		return nil
 	}
 }
 
-func newAgentArgs(commandArgs ...AgentArgsOption) (*agentArgs, error) {
+func newAgentArgs(commandArgs ...AgentArgsOption) *agentArgs {
 	args := &agentArgs{}
-	return common.ApplyOption(args, commandArgs)
+	for _, argsFunc := range commandArgs {
+		argsFunc(args)
+	}
+	return args
 }

--- a/test/new-e2e/utils/e2e/client/agent_args.go
+++ b/test/new-e2e/utils/e2e/client/agent_args.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package client
+
+import "github.com/DataDog/test-infra-definitions/common"
+
+// agentArgs contains the arguments for the Agent commands.
+// Its value is populated using the functional options pattern.
+type agentArgs struct {
+	Args string
+}
+
+type AgentArgsOption = func(*agentArgs) error
+
+// WithArgs sets the Agent arguments
+func WithArgs(args string) AgentArgsOption {
+	return func(a *agentArgs) error {
+		a.Args = args
+		return nil
+	}
+}
+
+func newAgentArgs(commandArgs ...AgentArgsOption) (*agentArgs, error) {
+	args := &agentArgs{}
+	return common.ApplyOption(args, commandArgs)
+}

--- a/test/new-e2e/utils/e2e/client/vm_client.go
+++ b/test/new-e2e/utils/e2e/client/vm_client.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/utils/clients"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -43,6 +44,7 @@ func (vmClient *vmClient) ExecuteWithError(command string) (string, error) {
 
 // Execute executes a command and returns its output.
 func (vmClient *vmClient) Execute(command string) string {
-	output, _ := vmClient.ExecuteWithError(command)
+	output, err := vmClient.ExecuteWithError(command)
+	require.NoError(vmClient.t, err)
 	return output
 }

--- a/test/new-e2e/utils/e2e/client/vm_client.go
+++ b/test/new-e2e/utils/e2e/client/vm_client.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/utils/clients"
 	"github.com/DataDog/test-infra-definitions/common/utils"
-	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -44,7 +43,6 @@ func (vmClient *vmClient) ExecuteWithError(command string) (string, error) {
 
 // Execute execute a command and asserts there is no error.
 func (vmClient *vmClient) Execute(command string) string {
-	output, err := vmClient.ExecuteWithError(command)
-	require.NoError(vmClient.t, err)
+	output, _ := vmClient.ExecuteWithError(command)
 	return output
 }

--- a/test/new-e2e/utils/e2e/client/vm_client.go
+++ b/test/new-e2e/utils/e2e/client/vm_client.go
@@ -41,7 +41,7 @@ func (vmClient *vmClient) ExecuteWithError(command string) (string, error) {
 	return output, nil
 }
 
-// Execute execute a command and asserts there is no error.
+// Execute executes a command and returns its output.
 func (vmClient *vmClient) Execute(command string) string {
 	output, _ := vmClient.ExecuteWithError(command)
 	return output


### PR DESCRIPTION

### What does this PR do?

Adds a way to give arguments to Agent commands. It also removes `require.NoError` which was making tests panicking when the Agent was not ready / returns error code.

### Motivation

Be able to test more cases

### Additional Notes

- Since e2e is for internal / devs usage I did not do any argument sanitizing (since `Execute` is available, I don't think it matters)

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
