### PR TITLE
[CWS] block when deleting module in tests

### DIFF
--- a/pkg/security/tests/kernel_module_test.go
+++ b/pkg/security/tests/kernel_module_test.go
@@ -117,7 +117,7 @@ func TestLoadModule(t *testing.T) {
 	}
 
 	// make sure the xfs module isn't currently loaded
-	err := unix.DeleteModule(testModuleName, unix.O_NONBLOCK)
+	err := unix.DeleteModule(testModuleName, 0)
 	if err != nil {
 		t.Skipf("couldn't delete %s module: %v", testModuleName, err)
 	}
@@ -162,7 +162,7 @@ func TestLoadModule(t *testing.T) {
 				return fmt.Errorf("couldn't insert module: %w", err)
 			}
 
-			return unix.DeleteModule(testModuleName, unix.O_NONBLOCK)
+			return unix.DeleteModule(testModuleName, 0)
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "test_load_module_from_memory", r.ID, "invalid rule triggered")
 
@@ -190,7 +190,7 @@ func TestLoadModule(t *testing.T) {
 				return fmt.Errorf("couldn't insert module: %w", err)
 			}
 
-			return unix.DeleteModule(testModuleName, unix.O_NONBLOCK)
+			return unix.DeleteModule(testModuleName, 0)
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "test_load_module", r.ID, "invalid rule triggered")
 
@@ -199,7 +199,7 @@ func TestLoadModule(t *testing.T) {
 	})
 
 	t.Run("kworker", func(t *testing.T) {
-		_ = unix.DeleteModule("xt_LED", unix.O_NONBLOCK)
+		_ = unix.DeleteModule("xt_LED", 0)
 
 		cmd := exec.Command("modprobe", "xt_LED")
 		if err := cmd.Run(); err != nil {
@@ -209,11 +209,11 @@ func TestLoadModule(t *testing.T) {
 		defer func() {
 			cmd := exec.Command("iptables", "-D", "INPUT", "-p", "tcp", "--dport", "2222", "-j", "LED", "--led-trigger-id", "123")
 			_ = cmd.Run()
-			_ = unix.DeleteModule("xt_LED", unix.O_NONBLOCK)
+			_ = unix.DeleteModule("xt_LED", 0)
 		}()
 
 		test.WaitSignal(t, func() error {
-			_ = unix.DeleteModule("xt_LED", unix.O_NONBLOCK)
+			_ = unix.DeleteModule("xt_LED", 0)
 
 			cmd := exec.Command("iptables", "-A", "INPUT", "-p", "tcp", "--dport", "2222", "-j", "LED", "--led-trigger-id", "123")
 			if err := cmd.Run(); err != nil {
@@ -237,7 +237,7 @@ func TestLoadModule(t *testing.T) {
 			if err = unix.FinitModule(int(f.Fd()), "toto=2 toto=3", 0); err != nil {
 				return fmt.Errorf("couldn't insert module: %w", err)
 			}
-			return unix.DeleteModule(testModuleName, unix.O_NONBLOCK)
+			return unix.DeleteModule(testModuleName, 0)
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, strings.Contains("test_load_module_with_params, test_load_module_with_specific_param, test_load_module", r.ID), true, "invalid rule triggered")
 			assertFieldEqual(t, event, "load_module.args", "toto=2 toto=3")
@@ -258,7 +258,7 @@ func TestLoadModule(t *testing.T) {
 				return fmt.Errorf("couldn't insert module: %w", err)
 			}
 
-			return unix.DeleteModule(testModuleName, unix.O_NONBLOCK)
+			return unix.DeleteModule(testModuleName, 0)
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, strings.Contains("test_load_module_with_params, test_load_module_with_specific_param, test_load_module_from_memory", r.ID), true, "invalid rule triggered")
 			assertFieldEqual(t, event, "load_module.argv", []string{"toto=1"})
@@ -279,7 +279,7 @@ func TestLoadModule(t *testing.T) {
 				return fmt.Errorf("couldn't insert module: %w", err)
 			}
 
-			return unix.DeleteModule(testModuleName, unix.O_NONBLOCK)
+			return unix.DeleteModule(testModuleName, 0)
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, strings.Contains("test_load_module_with_params, test_load_module_with_specific_param, test_load_module_from_memory", r.ID), true, "invalid rule triggered")
 			assertFieldEqual(t, event, "load_module.argv", []string{"Lorem", "ipsum", "dolor", "sit", "amet,", "consectetur", "adipiscing", "elit.", "Duis", "in", "luctus", "quam.", "Nam", "purus", "risus,", "varius", "non", "massa", "bibendum,"})
@@ -308,7 +308,7 @@ func TestUnloadModule(t *testing.T) {
 	}
 
 	// make sure the xfs module isn't currently loaded
-	err := unix.DeleteModule(testModuleName, unix.O_NONBLOCK)
+	err := unix.DeleteModule(testModuleName, 0)
 	if err != nil {
 		t.Skipf("couldn't delete %s module: %v", testModuleName, err)
 	}
@@ -337,7 +337,7 @@ func TestUnloadModule(t *testing.T) {
 				return fmt.Errorf("couldn't insert module: %w", err)
 			}
 
-			return unix.DeleteModule(testModuleName, unix.O_NONBLOCK)
+			return unix.DeleteModule(testModuleName, 0)
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "test_unload_module", r.ID, "invalid rule triggered")
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR ensures linux modules are actually unloaded before running the following test. This should reduce the flakyness of `TestLoadModule/*` tests by a fair bit.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
