### PR TITLE
[USM] sowatcher new kernel filter

### DIFF
--- a/pkg/network/ebpf/c/protocols/tls/sowatcher-types.h
+++ b/pkg/network/ebpf/c/protocols/tls/sowatcher-types.h
@@ -3,7 +3,7 @@
 
 #include "ktypes.h"
 
-#define LIB_SO_SUFFIX_SIZE 5
+#define LIB_SO_SUFFIX_SIZE 6
 #define LIB_PATH_MAX_SIZE 120
 
 typedef struct {

--- a/pkg/network/ebpf/c/protocols/tls/sowatcher-types.h
+++ b/pkg/network/ebpf/c/protocols/tls/sowatcher-types.h
@@ -3,7 +3,7 @@
 
 #include "ktypes.h"
 
-#define LIB_SO_SUFFIX_SIZE 6
+#define LIB_SO_SUFFIX_SIZE 5
 #define LIB_PATH_MAX_SIZE 120
 
 typedef struct {

--- a/pkg/network/ebpf/c/protocols/tls/sowatcher-types.h
+++ b/pkg/network/ebpf/c/protocols/tls/sowatcher-types.h
@@ -3,7 +3,7 @@
 
 #include "ktypes.h"
 
-#define LIB_SO_SUFFIX_SIZE 6
+#define LIB_SO_SUFFIX_SIZE 9
 #define LIB_PATH_MAX_SIZE 120
 
 typedef struct {

--- a/pkg/network/ebpf/c/protocols/tls/sowatcher-types.h
+++ b/pkg/network/ebpf/c/protocols/tls/sowatcher-types.h
@@ -3,7 +3,7 @@
 
 #include "ktypes.h"
 
-#define SO_SUFFIX_SIZE 3
+#define LIB_SO_SUFFIX_SIZE 6
 #define LIB_PATH_MAX_SIZE 120
 
 typedef struct {

--- a/pkg/network/ebpf/c/protocols/tls/sowatcher.h
+++ b/pkg/network/ebpf/c/protocols/tls/sowatcher.h
@@ -59,14 +59,18 @@ static __always_inline void do_sys_open_helper_exit(exit_sys_openat_ctx *args) {
 //    libssl.so -> libssl.so
 // libcrypto.so -> crypto.so
 // libgnutls.so -> gnutls.so
+//
+// The matching is done in 2 stages here, first we look if the filename finished by ".so" 6 chars forward
+// this will give us the index (where the loop) for the 2nd stage
+// 2nd stage will try to match the remaining
+// it's done this way to avoid unroll code generation complexity and some verifier don't allow that
     bool is_shared_library = false;
 #define match3chars(_base, _a,_b,_c) (path->buf[_base+i] == _a && path->buf[_base+i+1] == _b && path->buf[_base+i+2] == _c)
 #define match6chars(_base, _a,_b,_c,_d,_e,_f) (match3chars(_base,_a,_b,_c) && match3chars(_base+3,_d,_e,_f))
     int i = 0;
 #pragma unroll
     for (i = 0; i < LIB_PATH_MAX_SIZE - (LIB_SO_SUFFIX_SIZE); i++) {
-        if(
-            match3chars(6, '.','s','o')) {
+        if(match3chars(6, '.','s','o')) {
             is_shared_library = true;
             break;
         }

--- a/pkg/network/ebpf/c/protocols/tls/sowatcher.h
+++ b/pkg/network/ebpf/c/protocols/tls/sowatcher.h
@@ -54,11 +54,19 @@ static __always_inline void do_sys_open_helper_exit(exit_sys_openat_ctx *args) {
         return;
     }
 
-    // Detect whether the file being opened is a shared library
+// Check the last 6 characters of the following libraries to ensure the file is a relevant `.so`.
+// Libraries:
+//    libssl.so -> ssl.so
+// libcrypto.so -> pto.so
+// libgnutls.so -> tls.so
     bool is_shared_library = false;
+#define match3chars(_base, _a,_b,_c) (path->buf[_base+i] == _a && path->buf[_base+i+1] == _b && path->buf[_base+i+2] == _c)
 #pragma unroll
-    for (int i = 0; i < LIB_PATH_MAX_SIZE - SO_SUFFIX_SIZE; i++) {
-        if (path->buf[i] == '.' && path->buf[i + 1] == 's' && path->buf[i + 2] == 'o') {
+    for (int i = 0; i < LIB_PATH_MAX_SIZE - (LIB_SO_SUFFIX_SIZE); i++) {
+        if ((match3chars(0, 's','s','l') ||
+                match3chars(0, 'p','t','o') ||
+                match3chars(0, 't','l','s')) &&
+            match3chars(3, '.','s','o')) {
             is_shared_library = true;
             break;
         }

--- a/pkg/network/ebpf/c/protocols/tls/sowatcher.h
+++ b/pkg/network/ebpf/c/protocols/tls/sowatcher.h
@@ -59,21 +59,33 @@ static __always_inline void do_sys_open_helper_exit(exit_sys_openat_ctx *args) {
 //    libssl.so -> ssl.so
 // libcrypto.so -> pto.so
 // libgnutls.so -> tls.so
+
+
+    // TESTING
     bool is_shared_library = false;
 #define match2chars(_base, _a,_b) (path->buf[_base+i] == _a && path->buf[_base+i+1] == _b)
 #define match3chars(_base, _a,_b,_c) (path->buf[_base+i] == _a && path->buf[_base+i+1] == _b && path->buf[_base+i+2] == _c)
+#define match4chars(_base, _a,_b,_c,_d) (path->buf[_base+i] == _a && path->buf[_base+i+1] == _b && path->buf[_base+i+2] == _c && path->buf[_base+i+3] == _d)
+    // this would match regex [spt][stl][los]\.so
+    int i = 0;
 #pragma unroll
-    for (int i = 0; i < LIB_PATH_MAX_SIZE - (LIB_SO_SUFFIX_SIZE); i++) {
-        if ((match2chars(0, 's','l') ||
-                match2chars(0, 't','o') ||
-                match2chars(0, 'l','s')) &&
+    for (i = 0; i < LIB_PATH_MAX_SIZE - (LIB_SO_SUFFIX_SIZE); i++) {
+        if(
+            /*
+            ((path->buf[i] == 's') || (path->buf[i] == 'p') || (path->buf[i] == 't')) &&
+            ((path->buf[i+1] == 's') || (path->buf[i+1] == 't') || (path->buf[i+1] == 'l')) &&
+            ((path->buf[i+2] == 'l') || (path->buf[i+2] == 'o') || (path->buf[i+2] == 's')) &&
+            */
             match3chars(3, '.','s','o')) {
             is_shared_library = true;
             break;
         }
     }
-
     if (!is_shared_library) {
+        goto cleanup;
+    }
+
+    if (!match3chars(0, 's','s','l') && !match3chars(0, 'p','t','o') && !match3chars(0, 't','l','s')) {
         goto cleanup;
     }
 

--- a/pkg/network/ebpf/c/protocols/tls/sowatcher.h
+++ b/pkg/network/ebpf/c/protocols/tls/sowatcher.h
@@ -54,29 +54,19 @@ static __always_inline void do_sys_open_helper_exit(exit_sys_openat_ctx *args) {
         return;
     }
 
-// Check the last 6 characters of the following libraries to ensure the file is a relevant `.so`.
+// Check the last 9 characters of the following libraries to ensure the file is a relevant `.so`.
 // Libraries:
-//    libssl.so -> ssl.so
-// libcrypto.so -> pto.so
-// libgnutls.so -> tls.so
-
-
-    // TESTING
+//    libssl.so -> libssl.so
+// libcrypto.so -> crypto.so
+// libgnutls.so -> gnutls.so
     bool is_shared_library = false;
-#define match2chars(_base, _a,_b) (path->buf[_base+i] == _a && path->buf[_base+i+1] == _b)
 #define match3chars(_base, _a,_b,_c) (path->buf[_base+i] == _a && path->buf[_base+i+1] == _b && path->buf[_base+i+2] == _c)
-#define match4chars(_base, _a,_b,_c,_d) (path->buf[_base+i] == _a && path->buf[_base+i+1] == _b && path->buf[_base+i+2] == _c && path->buf[_base+i+3] == _d)
-    // this would match regex [spt][stl][los]\.so
+#define match6chars(_base, _a,_b,_c,_d,_e,_f) (match3chars(_base,_a,_b,_c) && match3chars(_base+3,_d,_e,_f))
     int i = 0;
 #pragma unroll
     for (i = 0; i < LIB_PATH_MAX_SIZE - (LIB_SO_SUFFIX_SIZE); i++) {
         if(
-            /*
-            ((path->buf[i] == 's') || (path->buf[i] == 'p') || (path->buf[i] == 't')) &&
-            ((path->buf[i+1] == 's') || (path->buf[i+1] == 't') || (path->buf[i+1] == 'l')) &&
-            ((path->buf[i+2] == 'l') || (path->buf[i+2] == 'o') || (path->buf[i+2] == 's')) &&
-            */
-            match3chars(3, '.','s','o')) {
+            match3chars(6, '.','s','o')) {
             is_shared_library = true;
             break;
         }
@@ -85,7 +75,7 @@ static __always_inline void do_sys_open_helper_exit(exit_sys_openat_ctx *args) {
         goto cleanup;
     }
 
-    if (!match3chars(0, 's','s','l') && !match3chars(0, 'p','t','o') && !match3chars(0, 't','l','s')) {
+    if (!match6chars(0, 'l','i','b','s','s','l') && !match6chars(0, 'c','r','y','p','t','o') && !match6chars(0, 'g','n','u','t','l','s')) {
         goto cleanup;
     }
 

--- a/pkg/network/ebpf/c/protocols/tls/sowatcher.h
+++ b/pkg/network/ebpf/c/protocols/tls/sowatcher.h
@@ -60,12 +60,13 @@ static __always_inline void do_sys_open_helper_exit(exit_sys_openat_ctx *args) {
 // libcrypto.so -> pto.so
 // libgnutls.so -> tls.so
     bool is_shared_library = false;
+#define match2chars(_base, _a,_b) (path->buf[_base+i] == _a && path->buf[_base+i+1] == _b)
 #define match3chars(_base, _a,_b,_c) (path->buf[_base+i] == _a && path->buf[_base+i+1] == _b && path->buf[_base+i+2] == _c)
 #pragma unroll
     for (int i = 0; i < LIB_PATH_MAX_SIZE - (LIB_SO_SUFFIX_SIZE); i++) {
-        if ((match3chars(0, 's','s','l') ||
-                match3chars(0, 'p','t','o') ||
-                match3chars(0, 't','l','s')) &&
+        if ((match2chars(0, 's','l') ||
+                match2chars(0, 't','o') ||
+                match2chars(0, 'l','s')) &&
             match3chars(3, '.','s','o')) {
             is_shared_library = true;
             break;

--- a/pkg/network/usm/shared_libraries_test.go
+++ b/pkg/network/usm/shared_libraries_test.go
@@ -66,7 +66,7 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetection() {
 	t := s.T()
 	perfHandler := initEBPFProgram(t)
 
-	fooPath1, fooPathID1 := createTempTestFile(t, "foo.so")
+	fooPath1, fooPathID1 := createTempTestFile(t, "foo-ssl.so")
 
 	var (
 		mux          sync.Mutex
@@ -82,7 +82,7 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetection() {
 
 	watcher := newSOWatcher(perfHandler,
 		soRule{
-			re:         regexp.MustCompile(`foo.so`),
+			re:         regexp.MustCompile(`foo-ssl.so`),
 			registerCB: callback,
 		},
 	)
@@ -125,7 +125,7 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetectionWithPIDandRootNameSpace()
 	err = os.MkdirAll(root, 0755)
 	require.NoError(t, err)
 
-	libpath := "/fooroot.so"
+	libpath := "/fooroot-pto.so"
 
 	err = exec.Command("cp", "/usr/bin/busybox", root+"/ash").Run()
 	require.NoError(t, err)
@@ -148,7 +148,7 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetectionWithPIDandRootNameSpace()
 
 	watcher := newSOWatcher(perfHandler,
 		soRule{
-			re:         regexp.MustCompile(`fooroot.so`),
+			re:         regexp.MustCompile(`fooroot-pto.so`),
 			registerCB: callback,
 		},
 	)
@@ -166,7 +166,7 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetectionWithPIDandRootNameSpace()
 
 	time.Sleep(10 * time.Millisecond)
 
-	// assert that soWatcher detected foo.so being opened and triggered the callback
+	// assert that soWatcher detected foo-ssl.so being opened and triggered the callback
 	require.Equal(t, libpath, pathDetected)
 
 	// must fail on the host
@@ -178,10 +178,10 @@ func (s *SharedLibrarySuite) TestSameInodeRegression() {
 	t := s.T()
 	perfHandler := initEBPFProgram(t)
 
-	fooPath1, fooPathID1 := createTempTestFile(t, "a-foo.so")
-	fooPath2 := filepath.Join(t.TempDir(), "b-foo.so")
+	fooPath1, fooPathID1 := createTempTestFile(t, "a-foo-ssl.so")
+	fooPath2 := filepath.Join(t.TempDir(), "b-foo-ssl.so")
 
-	// create a hard-link (a-foo.so and b-foo.so will share the same inode)
+	// create a hard-link (a-foo-ssl.so and b-foo-ssl.so will share the same inode)
 	require.NoError(t, os.Link(fooPath1, fooPath2))
 	fooPathID2, err := newPathIdentifier(fooPath2)
 	require.NoError(t, err)
@@ -194,7 +194,7 @@ func (s *SharedLibrarySuite) TestSameInodeRegression() {
 
 	watcher := newSOWatcher(perfHandler,
 		soRule{
-			re:         regexp.MustCompile(`foo.so`),
+			re:         regexp.MustCompile(`foo-ssl.so`),
 			registerCB: callback,
 		},
 	)
@@ -232,20 +232,20 @@ func (s *SharedLibrarySuite) TestSoWatcherLeaks() {
 	t := s.T()
 	perfHandler := initEBPFProgram(t)
 
-	fooPath1, fooPathID1 := createTempTestFile(t, "foo.so")
-	fooPath2, fooPathID2 := createTempTestFile(t, "foo2.so")
+	fooPath1, fooPathID1 := createTempTestFile(t, "foo-ssl.so")
+	fooPath2, fooPathID2 := createTempTestFile(t, "foo2-tls.so")
 
 	registerCB := func(id pathIdentifier, root string, path string) error { return nil }
 	unregisterCB := func(id pathIdentifier) error { return nil }
 
 	watcher := newSOWatcher(perfHandler,
 		soRule{
-			re:           regexp.MustCompile(`foo.so`),
+			re:           regexp.MustCompile(`foo-ssl.so`),
 			registerCB:   registerCB,
 			unregisterCB: unregisterCB,
 		},
 		soRule{
-			re:           regexp.MustCompile(`foo2.so`),
+			re:           regexp.MustCompile(`foo2-tls.so`),
 			registerCB:   registerCB,
 			unregisterCB: unregisterCB,
 		},
@@ -314,20 +314,20 @@ func (s *SharedLibrarySuite) TestSoWatcherProcessAlreadyHoldingReferences() {
 	t := s.T()
 	perfHandler := initEBPFProgram(t)
 
-	fooPath1, fooPathID1 := createTempTestFile(t, "foo.so")
-	fooPath2, fooPathID2 := createTempTestFile(t, "foo2.so")
+	fooPath1, fooPathID1 := createTempTestFile(t, "foo-ssl.so")
+	fooPath2, fooPathID2 := createTempTestFile(t, "foo2-tls.so")
 
 	registerCB := func(id pathIdentifier, root string, path string) error { return nil }
 	unregisterCB := func(id pathIdentifier) error { return nil }
 
 	watcher := newSOWatcher(perfHandler,
 		soRule{
-			re:           regexp.MustCompile(`foo.so`),
+			re:           regexp.MustCompile(`foo-ssl.so`),
 			registerCB:   registerCB,
 			unregisterCB: unregisterCB,
 		},
 		soRule{
-			re:           regexp.MustCompile(`foo2.so`),
+			re:           regexp.MustCompile(`foo2-tls.so`),
 			registerCB:   registerCB,
 			unregisterCB: unregisterCB,
 		},

--- a/pkg/network/usm/shared_libraries_test.go
+++ b/pkg/network/usm/shared_libraries_test.go
@@ -66,7 +66,7 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetection() {
 	t := s.T()
 	perfHandler := initEBPFProgram(t)
 
-	fooPath1, fooPathID1 := createTempTestFile(t, "foo-ssl.so")
+	fooPath1, fooPathID1 := createTempTestFile(t, "foo-libssl.so")
 
 	var (
 		mux          sync.Mutex
@@ -82,7 +82,7 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetection() {
 
 	watcher := newSOWatcher(perfHandler,
 		soRule{
-			re:         regexp.MustCompile(`foo-ssl.so`),
+			re:         regexp.MustCompile(`foo-libssl.so`),
 			registerCB: callback,
 		},
 	)
@@ -125,7 +125,7 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetectionWithPIDandRootNameSpace()
 	err = os.MkdirAll(root, 0755)
 	require.NoError(t, err)
 
-	libpath := "/fooroot-pto.so"
+	libpath := "/fooroot-crypto.so"
 
 	err = exec.Command("cp", "/usr/bin/busybox", root+"/ash").Run()
 	require.NoError(t, err)
@@ -148,7 +148,7 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetectionWithPIDandRootNameSpace()
 
 	watcher := newSOWatcher(perfHandler,
 		soRule{
-			re:         regexp.MustCompile(`fooroot-pto.so`),
+			re:         regexp.MustCompile(`fooroot-crypto.so`),
 			registerCB: callback,
 		},
 	)
@@ -166,7 +166,7 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetectionWithPIDandRootNameSpace()
 
 	time.Sleep(10 * time.Millisecond)
 
-	// assert that soWatcher detected foo-ssl.so being opened and triggered the callback
+	// assert that soWatcher detected foo-libssl.so being opened and triggered the callback
 	require.Equal(t, libpath, pathDetected)
 
 	// must fail on the host
@@ -178,10 +178,10 @@ func (s *SharedLibrarySuite) TestSameInodeRegression() {
 	t := s.T()
 	perfHandler := initEBPFProgram(t)
 
-	fooPath1, fooPathID1 := createTempTestFile(t, "a-foo-ssl.so")
-	fooPath2 := filepath.Join(t.TempDir(), "b-foo-ssl.so")
+	fooPath1, fooPathID1 := createTempTestFile(t, "a-foo-libssl.so")
+	fooPath2 := filepath.Join(t.TempDir(), "b-foo-libssl.so")
 
-	// create a hard-link (a-foo-ssl.so and b-foo-ssl.so will share the same inode)
+	// create a hard-link (a-foo-libssl.so and b-foo-libssl.so will share the same inode)
 	require.NoError(t, os.Link(fooPath1, fooPath2))
 	fooPathID2, err := newPathIdentifier(fooPath2)
 	require.NoError(t, err)
@@ -194,7 +194,7 @@ func (s *SharedLibrarySuite) TestSameInodeRegression() {
 
 	watcher := newSOWatcher(perfHandler,
 		soRule{
-			re:         regexp.MustCompile(`foo-ssl.so`),
+			re:         regexp.MustCompile(`foo-libssl.so`),
 			registerCB: callback,
 		},
 	)
@@ -232,20 +232,20 @@ func (s *SharedLibrarySuite) TestSoWatcherLeaks() {
 	t := s.T()
 	perfHandler := initEBPFProgram(t)
 
-	fooPath1, fooPathID1 := createTempTestFile(t, "foo-ssl.so")
-	fooPath2, fooPathID2 := createTempTestFile(t, "foo2-tls.so")
+	fooPath1, fooPathID1 := createTempTestFile(t, "foo-libssl.so")
+	fooPath2, fooPathID2 := createTempTestFile(t, "foo2-gnutls.so")
 
 	registerCB := func(id pathIdentifier, root string, path string) error { return nil }
 	unregisterCB := func(id pathIdentifier) error { return nil }
 
 	watcher := newSOWatcher(perfHandler,
 		soRule{
-			re:           regexp.MustCompile(`foo-ssl.so`),
+			re:           regexp.MustCompile(`foo-libssl.so`),
 			registerCB:   registerCB,
 			unregisterCB: unregisterCB,
 		},
 		soRule{
-			re:           regexp.MustCompile(`foo2-tls.so`),
+			re:           regexp.MustCompile(`foo2-gnutls.so`),
 			registerCB:   registerCB,
 			unregisterCB: unregisterCB,
 		},
@@ -314,20 +314,20 @@ func (s *SharedLibrarySuite) TestSoWatcherProcessAlreadyHoldingReferences() {
 	t := s.T()
 	perfHandler := initEBPFProgram(t)
 
-	fooPath1, fooPathID1 := createTempTestFile(t, "foo-ssl.so")
-	fooPath2, fooPathID2 := createTempTestFile(t, "foo2-tls.so")
+	fooPath1, fooPathID1 := createTempTestFile(t, "foo-libssl.so")
+	fooPath2, fooPathID2 := createTempTestFile(t, "foo2-gnutls.so")
 
 	registerCB := func(id pathIdentifier, root string, path string) error { return nil }
 	unregisterCB := func(id pathIdentifier) error { return nil }
 
 	watcher := newSOWatcher(perfHandler,
 		soRule{
-			re:           regexp.MustCompile(`foo-ssl.so`),
+			re:           regexp.MustCompile(`foo-libssl.so`),
 			registerCB:   registerCB,
 			unregisterCB: unregisterCB,
 		},
 		soRule{
-			re:           regexp.MustCompile(`foo2-tls.so`),
+			re:           regexp.MustCompile(`foo2-gnutls.so`),
 			registerCB:   registerCB,
 			unregisterCB: unregisterCB,
 		},


### PR DESCRIPTION
### What does this PR do?

Pre filter the library names in the kernel to avoid sending event to the userspace

### Motivation

As measured on oddish-b cluster
We would move from 15% true events to near 100% (for libssl.so libcrypto.so and libgnutls.so)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
