### PR TITLE
[USM] shared library telemetry

### DIFF
--- a/pkg/network/usm/shared_libraries.go
+++ b/pkg/network/usm/shared_libraries.go
@@ -200,7 +200,6 @@ func (r *soRegistration) unregisterPath(pathID pathIdentifier, soreg *soRegistry
 			// We cannot handle the failure, and thus we should continue.
 			log.Warnf("error while unregistering %s : %s", pathID.String(), err)
 			soreg.libUnregisterErrors.Add(1)
-			return true
 		}
 	} else {
 		soreg.libUnregisterNoCB.Add(1)

--- a/pkg/network/usm/shared_libraries.go
+++ b/pkg/network/usm/shared_libraries.go
@@ -27,6 +27,7 @@ import (
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -110,6 +111,9 @@ type soWatcher struct {
 	loadEvents     *ddebpf.PerfHandler
 	processMonitor *monitor.ProcessMonitor
 	registry       *soRegistry
+
+	libHits    *telemetry.Metric
+	libMatches *telemetry.Metric
 }
 
 type pathIdentifierSet = map[pathIdentifier]struct{}
@@ -121,9 +125,24 @@ type soRegistry struct {
 
 	// if we can't register a uprobe we don't try more than once
 	blocklistByID pathIdentifierSet
+
+	libRegistered               *telemetry.Metric
+	libAlreadyRegistered        *telemetry.Metric
+	libBlocked                  *telemetry.Metric
+	libUnregistered             *telemetry.Metric
+	libUnregisterNoCB           *telemetry.Metric
+	libUnregisterErrors         *telemetry.Metric
+	libUnregisterPathIDNotFound *telemetry.Metric
 }
 
 func newSOWatcher(perfHandler *ddebpf.PerfHandler, rules ...soRule) *soWatcher {
+	metricGroup := telemetry.NewMetricGroup(
+		"usm.shared_libraries",
+		telemetry.OptStatsd,
+		telemetry.OptExpvar,
+		telemetry.OptMonotonic,
+		telemetry.OptPayloadTelemetry,
+	)
 	return &soWatcher{
 		wg:             sync.WaitGroup{},
 		done:           make(chan struct{}),
@@ -135,7 +154,18 @@ func newSOWatcher(perfHandler *ddebpf.PerfHandler, rules ...soRule) *soWatcher {
 			byID:          make(map[pathIdentifier]*soRegistration),
 			byPID:         make(map[uint32]pathIdentifierSet),
 			blocklistByID: make(pathIdentifierSet),
+
+			libRegistered:               metricGroup.NewMetric("registered"),
+			libAlreadyRegistered:        metricGroup.NewMetric("already_registered"),
+			libBlocked:                  metricGroup.NewMetric("blocked"),
+			libUnregistered:             metricGroup.NewMetric("unregistered"),
+			libUnregisterNoCB:           metricGroup.NewMetric("unregister_no_callback"),
+			libUnregisterErrors:         metricGroup.NewMetric("unregister_errors"),
+			libUnregisterPathIDNotFound: metricGroup.NewMetric("unregister_pathid_not_found"),
 		},
+
+		libHits:    metricGroup.NewMetric("hits"),
+		libMatches: metricGroup.NewMetric("matches"),
 	}
 }
 
@@ -145,23 +175,29 @@ type soRegistration struct {
 }
 
 // unregister return true if there are no more reference to this registration
-func (r *soRegistration) unregisterPath(pathID pathIdentifier) bool {
+func (r *soRegistration) unregisterPath(pathID pathIdentifier, soreg *soRegistry) bool {
 	currentUniqueProcessesCount := r.uniqueProcessesCount.Dec()
 	if currentUniqueProcessesCount > 0 {
 		return false
 	}
 	if currentUniqueProcessesCount < 0 {
 		log.Errorf("unregistered %+v too much (current counter %v)", pathID, currentUniqueProcessesCount)
+		soreg.libUnregisterErrors.Add(1)
 		return true
 	}
+
 	// currentUniqueProcessesCount is 0, thus we should unregister.
 	if r.unregisterCB != nil {
 		if err := r.unregisterCB(pathID); err != nil {
 			// Even if we fail here, we have to return true, as best effort methodology.
 			// We cannot handle the failure, and thus we should continue.
 			log.Warnf("error while unregistering %s : %s", pathID.String(), err)
+			soreg.libUnregisterErrors.Add(1)
 		}
+	} else {
+		soreg.libUnregisterNoCB.Add(1)
 	}
+	soreg.libUnregistered.Add(1)
 	return true
 }
 
@@ -269,6 +305,7 @@ func (w *soWatcher) Start() {
 					continue
 				}
 
+				w.libHits.Add(1)
 				path := toBytes(&lib)
 				libPath := string(path)
 				procPid := fmt.Sprintf("%s/%d", w.procRoot, lib.Pid)
@@ -281,6 +318,7 @@ func (w *soWatcher) Start() {
 
 				for _, r := range w.rules {
 					if r.re.Match(path) {
+						w.libMatches.Add(1)
 						w.registry.register(root, libPath, lib.Pid, r)
 						break
 					}
@@ -298,7 +336,7 @@ func (w *soWatcher) Start() {
 // This function should be called in the termination, and after we're stopping all other goroutines.
 func (r *soRegistry) cleanup() {
 	for pathID, reg := range r.byID {
-		reg.unregisterPath(pathID)
+		reg.unregisterPath(pathID, r)
 	}
 }
 
@@ -321,9 +359,10 @@ func (r *soRegistry) unregister(pid int) {
 	for pathID := range paths {
 		reg, found := r.byID[pathID]
 		if !found {
+			r.libUnregisterPathIDNotFound.Add(1)
 			continue
 		}
-		if reg.unregisterPath(pathID) {
+		if reg.unregisterPath(pathID, r) {
 			// we need to clean up our entries as there are no more processes using this ELF
 			delete(r.byID, pathID)
 		}
@@ -348,6 +387,7 @@ func (r *soRegistry) register(root, libPath string, pid uint32, rule soRule) {
 	r.m.Lock()
 	defer r.m.Unlock()
 	if _, found := r.blocklistByID[pathID]; found {
+		r.libBlocked.Add(1)
 		return
 	}
 
@@ -360,6 +400,7 @@ func (r *soRegistry) register(root, libPath string, pid uint32, rule soRule) {
 			}
 			r.byPID[pid][pathID] = struct{}{}
 		}
+		r.libAlreadyRegistered.Add(1)
 		return
 	}
 
@@ -374,6 +415,7 @@ func (r *soRegistry) register(root, libPath string, pid uint32, rule soRule) {
 		// save sentinel value, so we don't attempt to re-register shared
 		// libraries that are problematic for some reason
 		r.blocklistByID[pathID] = struct{}{}
+		r.libBlocked.Add(1)
 		return
 	}
 
@@ -384,4 +426,5 @@ func (r *soRegistry) register(root, libPath string, pid uint32, rule soRule) {
 	}
 	r.byPID[pid][pathID] = struct{}{}
 	log.Debugf("registering library %s path %s by pid %d", pathID.String(), hostLibPath, pid)
+	r.libRegistered.Add(1)
 }

--- a/pkg/network/usm/shared_libraries.go
+++ b/pkg/network/usm/shared_libraries.go
@@ -190,6 +190,7 @@ type soRegistration struct {
 	uniqueProcessesCount atomic.Int32
 	unregisterCB         func(pathIdentifier) error
 
+	// we sharing the telemetry from soRegistry
 	telemetry *soRegistryTelemetry
 }
 

--- a/pkg/network/usm/shared_libraries.go
+++ b/pkg/network/usm/shared_libraries.go
@@ -190,7 +190,7 @@ type soRegistration struct {
 	uniqueProcessesCount atomic.Int32
 	unregisterCB         func(pathIdentifier) error
 
-	// we sharing the telemetry from soRegistry
+	// we are sharing the telemetry from soRegistry
 	telemetry *soRegistryTelemetry
 }
 

--- a/pkg/network/usm/shared_libraries.go
+++ b/pkg/network/usm/shared_libraries.go
@@ -147,8 +147,6 @@ type soRegistry struct {
 func newSOWatcher(perfHandler *ddebpf.PerfHandler, rules ...soRule) *soWatcher {
 	metricGroup := telemetry.NewMetricGroup(
 		"usm.shared_libraries",
-		telemetry.OptStatsd,
-		telemetry.OptExpvar,
 		telemetry.OptMonotonic,
 		telemetry.OptPayloadTelemetry,
 	)

--- a/pkg/network/usm/shared_libraries_test.go
+++ b/pkg/network/usm/shared_libraries_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
 	errtelemetry "github.com/DataDog/datadog-agent/pkg/network/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
 )
@@ -87,6 +88,7 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetection() {
 		},
 	)
 	watcher.Start()
+	t.Cleanup(watcher.Stop)
 	launchProcessMonitor(t)
 
 	// create files
@@ -111,6 +113,20 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetection() {
 		// Checking path1 still exists, and path2 not.
 		return checkPathIDDoesNotExist(watcher, fooPathID1) && checkPIDNotAssociatedWithPathID(watcher, fooPathID1, uint32(command1.Process.Pid))
 	}, time.Second*10, time.Second, "")
+
+	tel := telemetry.ReportPayloadTelemetry("1")
+	telEqual := func(t *testing.T, expected int64, m string) {
+		require.Equal(t, expected, tel[m], m)
+	}
+	require.GreaterOrEqual(t, tel["usm.shared_libraries.hits"], tel["usm.shared_libraries.matches"], "usm.shared_libraries.hits")
+	telEqual(t, 0, "usm.shared_libraries.already_registered")
+	telEqual(t, 0, "usm.shared_libraries.blocked")
+	telEqual(t, 1, "usm.shared_libraries.matches")
+	telEqual(t, 1, "usm.shared_libraries.registered")
+	telEqual(t, 0, "usm.shared_libraries.unregister_errors")
+	telEqual(t, 1, "usm.shared_libraries.unregister_no_callback")
+	telEqual(t, 0, "usm.shared_libraries.unregister_pathid_not_found")
+	telEqual(t, 1, "usm.shared_libraries.unregistered")
 }
 
 func (s *SharedLibrarySuite) TestSharedLibraryDetectionWithPIDandRootNameSpace() {
@@ -153,6 +169,7 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetectionWithPIDandRootNameSpace()
 		},
 	)
 	watcher.Start()
+	t.Cleanup(watcher.Stop)
 	launchProcessMonitor(t)
 
 	time.Sleep(10 * time.Millisecond)
@@ -172,6 +189,20 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetectionWithPIDandRootNameSpace()
 	// must fail on the host
 	_, err = os.Stat(libpath)
 	require.Error(t, err)
+
+	tel := telemetry.ReportPayloadTelemetry("1")
+	telEqual := func(t *testing.T, expected int64, m string) {
+		require.Equal(t, expected, tel[m], m)
+	}
+	require.GreaterOrEqual(t, tel["usm.shared_libraries.hits"], tel["usm.shared_libraries.matches"], "usm.shared_libraries.hits")
+	telEqual(t, 0, "usm.shared_libraries.already_registered")
+	telEqual(t, 0, "usm.shared_libraries.blocked")
+	telEqual(t, 1, "usm.shared_libraries.matches")
+	telEqual(t, 1, "usm.shared_libraries.registered")
+	telEqual(t, 0, "usm.shared_libraries.unregister_errors")
+	telEqual(t, 1, "usm.shared_libraries.unregister_no_callback")
+	telEqual(t, 0, "usm.shared_libraries.unregister_pathid_not_found")
+	telEqual(t, 1, "usm.shared_libraries.unregistered")
 }
 
 func (s *SharedLibrarySuite) TestSameInodeRegression() {
@@ -199,6 +230,7 @@ func (s *SharedLibrarySuite) TestSameInodeRegression() {
 		},
 	)
 	watcher.Start()
+	t.Cleanup(watcher.Stop)
 	launchProcessMonitor(t)
 
 	clientBin := buildSOWatcherClientBin(t)
@@ -226,6 +258,20 @@ func (s *SharedLibrarySuite) TestSameInodeRegression() {
 			checkPIDNotAssociatedWithPathID(watcher, fooPathID1, uint32(command1.Process.Pid)) &&
 			checkPIDNotAssociatedWithPathID(watcher, fooPathID2, uint32(command1.Process.Pid))
 	}, time.Second*10, time.Second, "")
+
+	tel := telemetry.ReportPayloadTelemetry("1")
+	telEqual := func(t *testing.T, expected int64, m string) {
+		require.Equal(t, expected, tel[m], m)
+	}
+	require.GreaterOrEqual(t, tel["usm.shared_libraries.hits"], tel["usm.shared_libraries.matches"], "usm.shared_libraries.hits")
+	telEqual(t, 1, "usm.shared_libraries.already_registered")
+	telEqual(t, 0, "usm.shared_libraries.blocked")
+	telEqual(t, 2, "usm.shared_libraries.matches") // command1 access to 2 files
+	telEqual(t, 1, "usm.shared_libraries.registered")
+	telEqual(t, 0, "usm.shared_libraries.unregister_errors")
+	telEqual(t, 1, "usm.shared_libraries.unregister_no_callback")
+	telEqual(t, 0, "usm.shared_libraries.unregister_pathid_not_found")
+	telEqual(t, 1, "usm.shared_libraries.unregistered")
 }
 
 func (s *SharedLibrarySuite) TestSoWatcherLeaks() {
@@ -251,6 +297,7 @@ func (s *SharedLibrarySuite) TestSoWatcherLeaks() {
 		},
 	)
 	watcher.Start()
+	t.Cleanup(watcher.Stop)
 	launchProcessMonitor(t)
 
 	// create files
@@ -308,6 +355,20 @@ func (s *SharedLibrarySuite) TestSoWatcherLeaks() {
 	}, time.Second*10, time.Second, "")
 
 	checkWatcherStateIsClean(t, watcher)
+
+	tel := telemetry.ReportPayloadTelemetry("1")
+	telEqual := func(t *testing.T, expected int64, m string) {
+		require.Equal(t, expected, tel[m], m)
+	}
+	require.GreaterOrEqual(t, tel["usm.shared_libraries.hits"], tel["usm.shared_libraries.matches"], "usm.shared_libraries.hits")
+	telEqual(t, 1, "usm.shared_libraries.already_registered")
+	telEqual(t, 0, "usm.shared_libraries.blocked")
+	telEqual(t, 3, "usm.shared_libraries.matches") // command1 access to 2 files, command2 access to 1 file
+	telEqual(t, 2, "usm.shared_libraries.registered")
+	telEqual(t, 0, "usm.shared_libraries.unregister_errors")
+	telEqual(t, 0, "usm.shared_libraries.unregister_no_callback")
+	telEqual(t, 0, "usm.shared_libraries.unregister_pathid_not_found")
+	telEqual(t, 2, "usm.shared_libraries.unregistered")
 }
 
 func (s *SharedLibrarySuite) TestSoWatcherProcessAlreadyHoldingReferences() {
@@ -344,6 +405,7 @@ func (s *SharedLibrarySuite) TestSoWatcherProcessAlreadyHoldingReferences() {
 	registerProcessTerminationUponCleanup(t, command1)
 	time.Sleep(time.Second)
 	watcher.Start()
+	t.Cleanup(watcher.Stop)
 	launchProcessMonitor(t)
 
 	require.Eventuallyf(t, func() bool {
@@ -378,6 +440,20 @@ func (s *SharedLibrarySuite) TestSoWatcherProcessAlreadyHoldingReferences() {
 	}, time.Second*10, time.Second, "")
 
 	checkWatcherStateIsClean(t, watcher)
+
+	tel := telemetry.ReportPayloadTelemetry("1")
+	telEqual := func(t *testing.T, expected int64, m string) {
+		require.Equal(t, expected, tel[m], m)
+	}
+	require.GreaterOrEqual(t, tel["usm.shared_libraries.hits"], tel["usm.shared_libraries.matches"], "usm.shared_libraries.hits")
+	telEqual(t, 1, "usm.shared_libraries.already_registered")
+	telEqual(t, 0, "usm.shared_libraries.blocked")
+	telEqual(t, 3, "usm.shared_libraries.matches") // command1 access to 2 files, command2 access to 1 file
+	telEqual(t, 2, "usm.shared_libraries.registered")
+	telEqual(t, 0, "usm.shared_libraries.unregister_errors")
+	telEqual(t, 0, "usm.shared_libraries.unregister_no_callback")
+	telEqual(t, 0, "usm.shared_libraries.unregister_pathid_not_found")
+	telEqual(t, 2, "usm.shared_libraries.unregistered")
 }
 
 func buildSOWatcherClientBin(t *testing.T) string {


### PR DESCRIPTION
### What does this PR do?

Add telemertry of our shared library module

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
