### PR TITLE
Save modcache in container and not shared folder

### DIFF
--- a/.gitlab/deps_fetch.yml
+++ b/.gitlab/deps_fetch.yml
@@ -4,12 +4,12 @@
 # to reuse them in further jobs that need them.
 
 .retrieve_linux_go_deps:
-  - mkdir -p $GOPATH/pkg/mod && tar xzf modcache.tar.gz -C $GOPATH/pkg/mod
-  - rm -f modcache.tar.gz
+  - mkdir -p "${GOPATH}/pkg/mod" && tar xzf "modcache_${CI_PIPELINE_ID}.tar.gz" -C "${GOPATH}/pkg/mod"
+  - rm -f "modcache_${CI_PIPELINE_ID}.tar.gz"
 
 .retrieve_linux_go_tools_deps:
-  - mkdir -p $GOPATH/pkg/mod && tar xzf modcache_tools.tar.gz -C $GOPATH/pkg/mod
-  - rm -f modcache_tools.tar.gz
+  - mkdir -p "${GOPATH}/pkg/mod" && tar xzf "modcache_tools_${CI_PIPELINE_ID}.tar.gz" -C "${GOPATH}/pkg/mod"
+  - rm -f "modcache_tools_${CI_PIPELINE_ID}.tar.gz"
 
 go_deps:
   stage: deps_fetch
@@ -19,11 +19,11 @@ go_deps:
   script:
     - source /root/.bashrc
     - inv -e deps --verbose
-    - cd $GOPATH/pkg/mod/ && tar czf $CI_PROJECT_DIR/modcache.tar.gz .
+    - cd "${GOPATH}/pkg/mod/" && tar czf "${CI_PROJECT_DIR}/modcache_${CI_PIPELINE_ID}.tar.gz" .
   artifacts:
     expire_in: 1 day
     paths:
-      - $CI_PROJECT_DIR/modcache.tar.gz
+      - "${CI_PROJECT_DIR}/modcache_$CI_PIPELINE_ID.tar.gz"
   retry: 1
 
 go_tools_deps:
@@ -34,9 +34,9 @@ go_tools_deps:
   script:
     - source /root/.bashrc
     - inv -e download-tools
-    - cd $GOPATH/pkg/mod/ && tar czf $CI_PROJECT_DIR/modcache_tools.tar.gz .
+    - cd "${GOPATH}/pkg/mod/" && tar czf "${CI_PROJECT_DIR}/modcache_tools_${CI_PIPELINE_ID}.tar.gz" .
   artifacts:
     expire_in: 1 day
     paths:
-      - $CI_PROJECT_DIR/modcache_tools.tar.gz
+      - "${CI_PROJECT_DIR}/modcache_tools_${CI_PIPELINE_ID}.tar.gz"
   retry: 1

--- a/tasks/winbuildscripts/extract-modcache.bat
+++ b/tasks/winbuildscripts/extract-modcache.bat
@@ -1,10 +1,10 @@
-if exist c:\mnt\modcache.tar.gz (
+if exist c:\mnt\modcache_%CI_PIPELINE_ID%.tar.gz (
     @echo Extracting modcache
-    Powershell -C "7z x c:\mnt\modcache.tar.gz -oc:\mnt"
-    Powershell -C "7z x c:\mnt\modcache.tar -oc:\modcache"
-    del /f c:\mnt\modcache.tar.gz
-    del /f c:\mnt\modcache.tar
+    Powershell -C "7z x c:\mnt\modcache_%CI_PIPELINE_ID%.tar.gz -oc:\mnt"
+    Powershell -C "7z x c:\mnt\modcache_%CI_PIPELINE_ID%.tar -oc:\modcache"
+    del /f c:\mnt\modcache_%CI_PIPELINE_ID%.tar.gz
+    del /f c:\mnt\modcache_%CI_PIPELINE_ID%.tar
     @echo Modcache extracted
 ) else (
-    @echo modcache.tar.gz not found, dependencies will be downloaded
+    @echo modcache_%CI_PIPELINE_ID%.tar.gz not found, dependencies will be downloaded
 )

--- a/tasks/winbuildscripts/extract-tools-modcache.bat
+++ b/tasks/winbuildscripts/extract-tools-modcache.bat
@@ -1,14 +1,14 @@
-if exist c:\mnt\modcache_tools.tar.gz (
+if exist c:\mnt\modcache_tools_%CI_PIPELINE_ID%.tar.gz (
     @echo Extracting modcache_tools
-    Powershell -C "7z x c:\mnt\modcache_tools.tar.gz -oc:\mnt"
+    Powershell -C "7z x c:\mnt\modcache_tools_%CI_PIPELINE_ID%.tar.gz -oc:\mnt"
     REM Use -aoa to allow overwriting existing files
     REM This shouldn't have any negative impact: since modules are
     REM stored per version and hash, files that get replaced will
     REM get replaced by the same files
-    Powershell -C "7z x c:\mnt\modcache_tools.tar -oc:\modcache -aoa"
-    del /f c:\mnt\modcache_tools.tar.gz
-    del /f c:\mnt\modcache_tools.tar
+    Powershell -C "7z x c:\mnt\modcache_tools_%CI_PIPELINE_ID%.tar -oc:\modcache -aoa"
+    del /f c:\mnt\modcache_tools_%CI_PIPELINE_ID%.tar.gz
+    del /f c:\mnt\modcache_tools_%CI_PIPELINE_ID%.tar
     @echo modcache_tools extracted
 ) else (
-    @echo modcache_tools.tar.gz not found, tooling dependencies will be downloaded
+    @echo modcache_tools_%CI_PIPELINE_ID%.tar.gz not found, tooling dependencies will be downloaded
 )


### PR DESCRIPTION
### What does this PR do?
Change the modcache repository to be "pipeline specific" to prevent conflict in I/O on this file when an executor is not properly released by GitLab. It occurs especially with WindowsRunners where the job cancellation is not well caught by executors.

### Motivation
Decrease failures in windows-related jobs

### Additional Notes
A suggestion was to handle the modcache.tar file out of the shared folder. I suggest here to have "pipeline specific" modcache which could be more secure.

### Possible Drawbacks / Trade-offs
This workaround does not solve the behaviour of the executors on windows runnners. This is still under investigation on CI Reliability team

### Describe how to test/QA your changes
TBD

### Reviewer's Checklist
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
