### PR TITLE
[backport] [no-aggregation] return the `MetricSampleBatch` to the pool only once done with it

### DIFF
--- a/comp/dogstatsd/server/batch.go
+++ b/comp/dogstatsd/server/batch.go
@@ -206,7 +206,6 @@ func (b *batcher) flushSamplesWithTs() {
 		tlmChannel.Observe(float64(t2.Sub(t1).Nanoseconds()), "late_metrics")
 
 		b.samplesWithTsCount = 0
-		b.metricSamplePool.PutBatch(b.samplesWithTs)
 		b.samplesWithTs = b.metricSamplePool.GetBatch()
 	}
 }

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -197,6 +197,7 @@ func initAgentDemultiplexer(sharedForwarder forwarder.Forwarder, options AgentDe
 		noAggSerializer = serializer.NewSerializer(sharedForwarder, orchestratorForwarder)
 		noAggWorker = newNoAggregationStreamWorker(
 			config.Datadog.GetInt("dogstatsd_no_aggregation_pipeline_batch_size"),
+			metricSamplePool,
 			noAggSerializer,
 			agg.flushAndSerializeInParallel,
 		)

--- a/releasenotes/notes/noagg-fix-pool-usage-9464ebcd9d33da37.yaml
+++ b/releasenotes/notes/noagg-fix-pool-usage-9464ebcd9d33da37.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a bug where the metric with timestamps pipeline could have wrongly
+    processed metrics without timestamps (when both pipelines were flooded),
+    potentially leading to inaccuracies. 


### PR DESCRIPTION
Backport of #17728 into `7.46.x`.

### Describe how to test/QA your changes

* Start an Agent with a **bad API key** (to not send the traffic)
* Then start the `statsd_normal.go` from this [gist](https://gist.github.com/remeh/a046e761f7cd7b40ab89c489484c1c41) in a loop: `while [ "1" = "1" ]; do go run statsd_normal.go; done`
* Then start the `statsd_noagg.go` from this [gist](https://gist.github.com/remeh/a046e761f7cd7b40ab89c489484c1c41) in a loop: `while [ "1" = "1" ]; do go run statsd_noagg.go; done`

Wait for a couple minutes and validate that no warning log message (`Discarding unsupported metric sample...`) are present.


* Restart the Agent with a **good api key** to send the traffic and use `log_payloads: true`
* Sends a normal metric and validate that it is sent properly
* Sends a metric with timestamp (`do echo -n 'foo:1|c|#tags|T1687203807' | socat -t 0 - UNIX-CLIENT:/path/to/your/statsd.sock`) and make sure it is sent properly.
### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [in progress] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
