### PR TITLE
Inject DD_DOGSTATSD_URL in /config admission controller

### DIFF
--- a/pkg/clusteragent/admission/mutate/config_test.go
+++ b/pkg/clusteragent/admission/mutate/config_test.go
@@ -135,6 +135,7 @@ func TestInjectSocket(t *testing.T) {
 	err := injectConfig(pod, "", nil)
 	assert.Nil(t, err)
 	assert.Contains(t, pod.Spec.Containers[0].Env, fakeEnvWithValue("DD_TRACE_AGENT_URL", "unix:///var/run/datadog/apm.socket"))
+	assert.Contains(t, pod.Spec.Containers[0].Env, fakeEnvWithValue("DD_DOGSTATSD_URL", "unix:///var/run/datadog/dsd.socket"))
 	assert.Equal(t, pod.Spec.Containers[0].VolumeMounts[0].MountPath, "/var/run/datadog")
 	assert.Equal(t, pod.Spec.Containers[0].VolumeMounts[0].Name, "datadog")
 	assert.Equal(t, pod.Spec.Containers[0].VolumeMounts[0].ReadOnly, true)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1037,6 +1037,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("admission_controller.inject_config.local_service_name", "datadog")
 	config.BindEnvAndSetDefault("admission_controller.inject_config.socket_path", "/var/run/datadog")
 	config.BindEnvAndSetDefault("admission_controller.inject_config.trace_agent_socket", "unix:///var/run/datadog/apm.socket")
+	config.BindEnvAndSetDefault("admission_controller.inject_config.dogstatsd_socket", "unix:///var/run/datadog/dsd.socket")
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.enabled", true)
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.endpoint", "/injecttags")
 	config.BindEnvAndSetDefault("admission_controller.pod_owners_cache_validity", 10) // in minutes

--- a/releasenotes-dca/notes/admission-controller-dsd-bf4585681102204f.yaml
+++ b/releasenotes-dca/notes/admission-controller-dsd-bf4585681102204f.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    The Cluster Agent Admission Controller now injects DD_DOGSTATSD_URL when used in `socket` mode (default), allowing Dogstatsd clients to work without configuration.
+    The Cluster Agent Admission Controller now injects DD_DOGSTATSD_URL when used in `socket` mode (default), allowing DogStatsD clients to work without configuration.

--- a/releasenotes-dca/notes/admission-controller-dsd-bf4585681102204f.yaml
+++ b/releasenotes-dca/notes/admission-controller-dsd-bf4585681102204f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    The Cluster Agent Admission Controller now injects DD_DOGSTATSD_URL when used in `socket` mode (default), allowing Dogstatsd clients to work without configuration.


### PR DESCRIPTION
### What does this PR do?

Inject DD_DOGSTATSD_URL in /config admission controller

### Motivation

Fixes missing Dogstatsd configuration when Admission Controller is used in `socket` mode (which is now default).
Fixes #14638.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Agent and Cluster Agent in Kubernetes with Helm chart.
Deploy any application with `admission.datadoghq.com/enabled=true` label, observe that `DD_DOGSTATSD_URL` is injected correctly in the target app, alongside socket volume/volumeMount.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
