### PR TITLE
fix conntrackerTelemetry.unregistersTotal

### DIFF
--- a/pkg/network/netlink/conntracker.go
+++ b/pkg/network/netlink/conntracker.go
@@ -293,7 +293,7 @@ func (ctr *realConntracker) run() error {
 func (ctr *realConntracker) compact() {
 	var removed int64
 	defer func() {
-		conntrackerTelemetry.unregistersTotal.Inc()
+		conntrackerTelemetry.unregistersTotal.Add(float64(removed))
 		log.Debugf("removed %d orphans", removed)
 	}()
 


### PR DESCRIPTION
### What does this PR do?

Fix a regression on orphans conntracker unregister counter

### Motivation

Bug introduced [PR](https://github.com/DataDog/datadog-agent/pull/15249)

https://github.com/DataDog/datadog-agent/pull/15249/files#diff-6126a80d06a0c69dd11c6bc3fdc2e1d3c770e66edbf2877af88b279a17851c36L317-L323

[Conntrack Registers / Unregisters (smoothed)](https://ddstaging.datadoghq.com/s/c894ecec5/x53-hgm-acf)
![slack-imgs](https://github.com/DataDog/datadog-agent/assets/334425/5397fcaa-dad7-4534-9ac6-7dfd011bf51b)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
