### PR TITLE
Added nightly/manual CI jobs for running macrobenchmarks on the Trace agent

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,6 +41,7 @@ include:
   - /.gitlab/kitchen_common/testing.yml
   - /.gitlab/docker_common/publish_job_templates.yml
   - /.gitlab/benchmarks/benchmarks.yml
+  - /.gitlab/benchmarks/macrobenchmarks.yml
 
 default:
   retry:

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -3,7 +3,7 @@ variables:
 
 .benchmarks:
   stage: benchmarks
-  tags: ["runner:apm-k8s-same-cpu"]
+  tags: ["team:apm-k8s-tweaked-metal-datadog-agent", "specific:true"]
   timeout: 1h
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -32,16 +32,119 @@ variables:
   # benchmarks get changed to run on every PR)
   allow_failure: true
 
-trace-agent-endpoint-v04-macrobenchmarks:
+trace-agent-v04-4cpus-avg_load-fixed_sps-macrobenchmarks:
   extends: .benchmarks
   variables:
-    DD_BENCHMARKS_CONFIGURATION: trace-agent-endpoint-v04
-    DD_RELENV_CONFIGURATION: $DD_BENCHMARKS_CONFIGURATION
+    TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v04
+    TRACE_AGENT_CPUS: 4
+    DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-avg_load-fixed_sps
+    BENCHMARK_TARGETS: "avg_load.*sps"
 
-trace-agent-endpoint-v05-macrobenchmarks:
+trace-agent-v04-4cpus-avg_load-fixed_mbps-macrobenchmarks:
   extends: .benchmarks
   variables:
-    DD_BENCHMARKS_CONFIGURATION: trace-agent-endpoint-v05
-    DD_RELENV_CONFIGURATION: $DD_BENCHMARKS_CONFIGURATION
+    TRACE_AGENT_VERSION: main
+    TRACE_AGENT_ENDPOINT: v04
+    TRACE_AGENT_CPUS: 4
+    DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-avg_load-fixed_mbps
+    BENCHMARK_TARGETS: "avg_load.*Mbps"
+
+trace-agent-v04-4cpus-high_load-fixed_sps-macrobenchmarks:
+  extends: .benchmarks
+  when: manual
+  variables:
+    TRACE_AGENT_VERSION: main
+    TRACE_AGENT_ENDPOINT: v04
+    TRACE_AGENT_CPUS: 4
+    DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-high_load-fixed_sps
+    BENCHMARK_TARGETS: "high_load.*sps"
+
+trace-agent-v04-4cpus-high_load-fixed_mbps-macrobenchmarks:
+  extends: .benchmarks
+  when: manual
+  variables:
+    TRACE_AGENT_VERSION: main
+    TRACE_AGENT_ENDPOINT: v04
+    TRACE_AGENT_CPUS: 4
+    DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-high_load-fixed_mbps
+    BENCHMARK_TARGETS: "high_load.*Mbps"
+
+trace-agent-v04-4cpus-stress_load-fixed_sps-macrobenchmarks:
+  extends: .benchmarks
+  when: manual
+  variables:
+    TRACE_AGENT_VERSION: main
+    TRACE_AGENT_ENDPOINT: v04
+    TRACE_AGENT_CPUS: 4
+    DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-stress_load-fixed_sps
+    BENCHMARK_TARGETS: "stress_load.*sps"
+
+trace-agent-v04-4cpus-stress_load-fixed_mbps-macrobenchmarks:
+  extends: .benchmarks
+  when: manual
+  variables:
+    TRACE_AGENT_VERSION: main
+    TRACE_AGENT_ENDPOINT: v04
+    TRACE_AGENT_CPUS: 4
+    DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-stress_load-fixed_mbps
+    BENCHMARK_TARGETS: "stress_load.*Mbps"
+  
+trace-agent-v05-4cpus-avg_load-fixed_sps-macrobenchmarks:
+  extends: .benchmarks
+  variables:
+    TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v05
+    TRACE_AGENT_CPUS: 4
+    DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-avg_load-fixed_sps
+    BENCHMARK_TARGETS: "avg_load.*sps"
+
+trace-agent-v05-4cpus-avg_load-fixed_mbps-macrobenchmarks:
+  extends: .benchmarks
+  variables:
+    TRACE_AGENT_VERSION: main
+    TRACE_AGENT_ENDPOINT: v05
+    TRACE_AGENT_CPUS: 4
+    DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-avg_load-fixed_mbps
+    BENCHMARK_TARGETS: "avg_load.*Mbps"
+
+trace-agent-v05-4cpus-high_load-fixed_sps-macrobenchmarks:
+  extends: .benchmarks
+  when: manual
+  variables:
+    TRACE_AGENT_VERSION: main
+    TRACE_AGENT_ENDPOINT: v05
+    TRACE_AGENT_CPUS: 4
+    DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-high_load-fixed_sps
+    BENCHMARK_TARGETS: "high_load.*sps"
+
+trace-agent-v05-4cpus-high_load-fixed_mbps-macrobenchmarks:
+  extends: .benchmarks
+  when: manual
+  variables:
+    TRACE_AGENT_VERSION: main
+    TRACE_AGENT_ENDPOINT: v05
+    TRACE_AGENT_CPUS: 4
+    DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-high_load-fixed_mbps
+    BENCHMARK_TARGETS: "high_load.*Mbps"
+
+trace-agent-v05-4cpus-stress_load-fixed_sps-macrobenchmarks:
+  extends: .benchmarks
+  when: manual
+  variables:
+    TRACE_AGENT_VERSION: main
+    TRACE_AGENT_ENDPOINT: v05
+    TRACE_AGENT_CPUS: 4
+    DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-stress_load-fixed_sps
+    BENCHMARK_TARGETS: "stress_load.*sps"
+
+trace-agent-v05-4cpus-stress_load-fixed_mbps-macrobenchmarks:
+  extends: .benchmarks
+  when: manual
+  variables:
+    TRACE_AGENT_VERSION: main
+    TRACE_AGENT_ENDPOINT: v05
+    TRACE_AGENT_CPUS: 4
+    DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-stress_load-fixed_mbps
+    BENCHMARK_TARGETS: "stress_load.*Mbps"
+ 

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -1,0 +1,47 @@
+variables:
+  BENCHMARKS_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:trace-agent
+
+.benchmarks:
+  stage: benchmarks
+  tags: ["runner:apm-k8s-same-cpu"]
+  timeout: 1h
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: always
+    - when: manual
+  # If you have a problem with Gitlab cache, see Troubleshooting section in Benchmarking Platform docs
+  image: $BENCHMARKS_CI_IMAGE
+  script:
+    - export ARTIFACTS_DIR="$(pwd)/reports" && (mkdir "${ARTIFACTS_DIR}" || :)
+    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.dd_api_key --with-decryption --query "Parameter.Value" --out text)
+    - git clone --branch trace-agent https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform /platform && cd /platform
+    - ./steps/capture-hardware-software-info.sh
+    - ./steps/run-benchmarks.sh
+    - "./steps/upload-results-to-s3.sh || :"
+  artifacts:
+    name: "reports"
+    paths:
+      - reports/
+    expire_in: 3 months
+  variables:
+    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true" # Important tweak for stability of benchmarks
+    K6_RUN_ID_PREFIX: ci
+    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: datadog-agent
+  # Workaround: Currently we're not running the benchmarks on every PR, but GitHub still shows them as pending.
+  # By marking the benchmarks as allow_failure, this should go away. (This workaround should be removed once the
+  # benchmarks get changed to run on every PR)
+  allow_failure: true
+
+trace-agent-endpoint-v04-macrobenchmarks:
+  extends: .benchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: trace-agent-endpoint-v04
+    DD_RELENV_CONFIGURATION: $DD_BENCHMARKS_CONFIGURATION
+    TRACE_AGENT_ENDPOINT: v04
+
+trace-agent-endpoint-v05-macrobenchmarks:
+  extends: .benchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: trace-agent-endpoint-v05
+    DD_RELENV_CONFIGURATION: $DD_BENCHMARKS_CONFIGURATION
+    TRACE_AGENT_ENDPOINT: v05

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -1,7 +1,7 @@
 variables:
   BENCHMARKS_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:trace-agent
 
-.benchmarks:
+.trace_agent_benchmarks:
   stage: benchmarks
   tags: ["team:apm-k8s-tweaked-metal-datadog-agent", "specific:true"]
   timeout: 1h
@@ -33,7 +33,7 @@ variables:
   allow_failure: true
 
 trace-agent-v04-4cpus-avg_load-fixed_sps-macrobenchmarks:
-  extends: .benchmarks
+  extends: .trace_agent_benchmarks
   variables:
     TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v04
@@ -42,7 +42,7 @@ trace-agent-v04-4cpus-avg_load-fixed_sps-macrobenchmarks:
     BENCHMARK_TARGETS: "avg_load.*sps"
 
 trace-agent-v04-4cpus-avg_load-fixed_mbps-macrobenchmarks:
-  extends: .benchmarks
+  extends: .trace_agent_benchmarks
   variables:
     TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v04
@@ -51,7 +51,7 @@ trace-agent-v04-4cpus-avg_load-fixed_mbps-macrobenchmarks:
     BENCHMARK_TARGETS: "avg_load.*Mbps"
 
 trace-agent-v04-4cpus-high_load-fixed_sps-macrobenchmarks:
-  extends: .benchmarks
+  extends: .trace_agent_benchmarks
   when: manual
   variables:
     TRACE_AGENT_VERSION: main
@@ -61,7 +61,7 @@ trace-agent-v04-4cpus-high_load-fixed_sps-macrobenchmarks:
     BENCHMARK_TARGETS: "high_load.*sps"
 
 trace-agent-v04-4cpus-high_load-fixed_mbps-macrobenchmarks:
-  extends: .benchmarks
+  extends: .trace_agent_benchmarks
   when: manual
   variables:
     TRACE_AGENT_VERSION: main
@@ -71,7 +71,7 @@ trace-agent-v04-4cpus-high_load-fixed_mbps-macrobenchmarks:
     BENCHMARK_TARGETS: "high_load.*Mbps"
 
 trace-agent-v04-4cpus-stress_load-fixed_sps-macrobenchmarks:
-  extends: .benchmarks
+  extends: .trace_agent_benchmarks
   when: manual
   variables:
     TRACE_AGENT_VERSION: main
@@ -81,7 +81,7 @@ trace-agent-v04-4cpus-stress_load-fixed_sps-macrobenchmarks:
     BENCHMARK_TARGETS: "stress_load.*sps"
 
 trace-agent-v04-4cpus-stress_load-fixed_mbps-macrobenchmarks:
-  extends: .benchmarks
+  extends: .trace_agent_benchmarks
   when: manual
   variables:
     TRACE_AGENT_VERSION: main
@@ -91,7 +91,7 @@ trace-agent-v04-4cpus-stress_load-fixed_mbps-macrobenchmarks:
     BENCHMARK_TARGETS: "stress_load.*Mbps"
   
 trace-agent-v05-4cpus-avg_load-fixed_sps-macrobenchmarks:
-  extends: .benchmarks
+  extends: .trace_agent_benchmarks
   variables:
     TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v05
@@ -100,7 +100,7 @@ trace-agent-v05-4cpus-avg_load-fixed_sps-macrobenchmarks:
     BENCHMARK_TARGETS: "avg_load.*sps"
 
 trace-agent-v05-4cpus-avg_load-fixed_mbps-macrobenchmarks:
-  extends: .benchmarks
+  extends: .trace_agent_benchmarks
   variables:
     TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v05
@@ -109,7 +109,7 @@ trace-agent-v05-4cpus-avg_load-fixed_mbps-macrobenchmarks:
     BENCHMARK_TARGETS: "avg_load.*Mbps"
 
 trace-agent-v05-4cpus-high_load-fixed_sps-macrobenchmarks:
-  extends: .benchmarks
+  extends: .trace_agent_benchmarks
   when: manual
   variables:
     TRACE_AGENT_VERSION: main
@@ -119,7 +119,7 @@ trace-agent-v05-4cpus-high_load-fixed_sps-macrobenchmarks:
     BENCHMARK_TARGETS: "high_load.*sps"
 
 trace-agent-v05-4cpus-high_load-fixed_mbps-macrobenchmarks:
-  extends: .benchmarks
+  extends: .trace_agent_benchmarks
   when: manual
   variables:
     TRACE_AGENT_VERSION: main
@@ -129,7 +129,7 @@ trace-agent-v05-4cpus-high_load-fixed_mbps-macrobenchmarks:
     BENCHMARK_TARGETS: "high_load.*Mbps"
 
 trace-agent-v05-4cpus-stress_load-fixed_sps-macrobenchmarks:
-  extends: .benchmarks
+  extends: .trace_agent_benchmarks
   when: manual
   variables:
     TRACE_AGENT_VERSION: main
@@ -139,7 +139,7 @@ trace-agent-v05-4cpus-stress_load-fixed_sps-macrobenchmarks:
     BENCHMARK_TARGETS: "stress_load.*sps"
 
 trace-agent-v05-4cpus-stress_load-fixed_mbps-macrobenchmarks:
-  extends: .benchmarks
+  extends: .trace_agent_benchmarks
   when: manual
   variables:
     TRACE_AGENT_VERSION: main


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR sets up nightly/manual CI jobs for running macrobenchmarks on the Trace agent.
* The benchmarks are described and explained in [DataDog/benchmarking-platform@trace-agent](https://github.com/DataDog/benchmarking-platform/tree/trace-agent).
* Currently, the following suites are set to be run on a nightly basis: 
    * `trace-agent-v04-4cpus-avg_load-fixed_sps-macrobenchmarks`
    * `trace-agent-v04-4cpus-avg_load-fixed_mbps-macrobenchmarks`
    * `trace-agent-v05-4cpus-avg_load-fixed_sps-macrobenchmarks`
    * `trace-agent-v05-4cpus-avg_load-fixed_mbps-macrobenchmarks`
* `high_load` and `stress_load` scenarios were set to be run manually, because they are not stable enough as a macrobenchmark needs to be.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
* Related Jira issue: [Add Macrobenchmarks for the Trace Agent](https://datadoghq.atlassian.net/browse/AIT-7388)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
