### PR TITLE
Retry functional tests

### DIFF
--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -247,7 +247,7 @@ kernel_matrix_testing_run_tests_arm64:
     matrix:
       - TAG: ["focal", "jammy"]
 
-kernel_matrix_testing_cleanup:
+.kernel_matrix_testing_cleanup:
   stage: kernel_matrix_testing
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:7c39524b
   needs: ["kernel_matrix_testing_setup_env", "kernel_matrix_testing_run_tests_x64", "kernel_matrix_testing_run_tests_arm64"]
@@ -259,3 +259,13 @@ kernel_matrix_testing_cleanup:
     - INSTANCE_IDS=$(aws ec2 describe-instances --filters "Name=tag:team,Values=ebpf-platform" "Name=tag:pipeline-id,Values=$CI_PIPELINE_ID" "Name=tag:managed-by,Values=pulumi" "Name=private-ip-address,Values=$INSTANCE_IPS" --output text --query 'Reservations[*].Instances[*].InstanceId' | tr '\n' ' ')
     - echo $INSTANCE_IDS
     - aws ec2 terminate-instances --instance-ids $INSTANCE_IDS
+
+kernel_matrix_testing_cleanup_on_failure:
+  extends:
+    - .kernel_matrix_testing_cleanup
+  when: on_failure
+
+kernel_matrix_testing_cleanup_on_success:
+  extends:
+    - .kernel_matrix_testing_cleanup
+  when: on_success

--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -248,7 +248,7 @@ kernel_matrix_testing_run_tests_arm64:
     matrix:
       - TAG: ["focal", "jammy"]
 
-.kernel_matrix_testing_cleanup:
+kernel_matrix_testing_cleanup:
   stage: kernel_matrix_testing
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:7c39524b
   needs: ["kernel_matrix_testing_setup_env", "kernel_matrix_testing_run_tests_x64", "kernel_matrix_testing_run_tests_arm64"]
@@ -260,13 +260,4 @@ kernel_matrix_testing_run_tests_arm64:
     - INSTANCE_IDS=$(aws ec2 describe-instances --filters "Name=tag:team,Values=ebpf-platform" "Name=tag:pipeline-id,Values=$CI_PIPELINE_ID" "Name=tag:managed-by,Values=pulumi" "Name=private-ip-address,Values=$INSTANCE_IPS" --output text --query 'Reservations[*].Instances[*].InstanceId' | tr '\n' ' ')
     - echo $INSTANCE_IDS
     - aws ec2 terminate-instances --instance-ids $INSTANCE_IDS
-
-kernel_matrix_testing_cleanup_on_failure:
-  extends:
-    - .kernel_matrix_testing_cleanup
-  when: on_failure
-
-kernel_matrix_testing_cleanup_on_success:
-  extends:
-    - .kernel_matrix_testing_cleanup
-  when: on_success
+  when: always

--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -208,6 +208,7 @@ kernel_matrix_testing_upload_deps:
   tags: ["arch:amd64"]
   variables:
     AWS_EC2_SSH_KEY_FILE: $CI_PROJECT_DIR/ssh_key
+    RETRY: 2
   before_script:
     - !reference [.kernel_matrix_testing_new_profile]
   script:
@@ -222,7 +223,7 @@ kernel_matrix_testing_upload_deps:
     - MICRO_VM_IP=$(cat $CI_PROJECT_DIR/stack.outputs | grep $ARCH-$TAG | cut -d ' ' -f 2)
     - MICRO_VM_NAME=$(cat $CI_PROJECT_DIR/stack.outputs | grep $ARCH.$TAG | cut -d ' ' -f 1)
     # ssh into each micro-vm and run initialization script. This script will also run the tests.
-    - ssh -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP "ssh -o StrictHostKeyChecking=no -i /home/kernel-version-testing/ddvm_rsa root@${MICRO_VM_IP} 'bash /root/fetch_dependencies.sh ${ARCH} && /micro-vm-init.sh ${GO_VERSION}'"
+    - ssh -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP "ssh -o StrictHostKeyChecking=no -i /home/kernel-version-testing/ddvm_rsa root@${MICRO_VM_IP} 'bash /root/fetch_dependencies.sh ${ARCH} && /micro-vm-init.sh ${GO_VERSION} ${RETRY}'"
     - ssh -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP "scp -o StrictHostKeyChecking=no -i /home/kernel-version-testing/ddvm_rsa root@${MICRO_VM_IP}:/junit-*.tar.gz /home/ubuntu/"
     - ssh -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP "scp -o StrictHostKeyChecking=no -i /home/kernel-version-testing/ddvm_rsa root@${MICRO_VM_IP}:/testjson-*.tar.gz /home/ubuntu/"
     - scp -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP:/home/ubuntu/testjson-*.tar.gz $DD_AGENT_TESTING_DIR/

--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -223,11 +223,11 @@ kernel_matrix_testing_upload_deps:
     - MICRO_VM_NAME=$(cat $CI_PROJECT_DIR/stack.outputs | grep $ARCH.$TAG | cut -d ' ' -f 1)
     # ssh into each micro-vm and run initialization script. This script will also run the tests.
     - ssh -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP "ssh -o StrictHostKeyChecking=no -i /home/kernel-version-testing/ddvm_rsa root@${MICRO_VM_IP} 'bash /root/fetch_dependencies.sh ${ARCH} && /micro-vm-init.sh ${GO_VERSION}'"
-    - ssh -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP "scp -o StrictHostKeyChecking=no -i /home/kernel-version-testing/ddvm_rsa root@${MICRO_VM_IP}:/junit-${MICRO_VM_IP}.tar.gz /home/ubuntu/junit-${MICRO_VM_IP}.tar.gz"
-    - ssh -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP "scp -o StrictHostKeyChecking=no -i /home/kernel-version-testing/ddvm_rsa root@${MICRO_VM_IP}:/testjson-${MICRO_VM_IP}.tar.gz /home/ubuntu/testjson-${MICRO_VM_IP}.tar.gz"
-    - scp -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP:/home/ubuntu/testjson-$MICRO_VM_IP.tar.gz $DD_AGENT_TESTING_DIR/kernel-matrix-testing-testjson-$MICRO_VM_NAME.tar.gz
-    - scp -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP:/home/ubuntu/junit-$MICRO_VM_IP.tar.gz $DD_AGENT_TESTING_DIR/kernel-matrix-testing-junit-$MICRO_VM_NAME.tar.gz
-    - ssh -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP "ssh -o StrictHostKeyChecking=no -i /home/kernel-version-testing/ddvm_rsa root@${MICRO_VM_IP} '/test-json-review /testjson/out.json'"
+    - ssh -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP "scp -o StrictHostKeyChecking=no -i /home/kernel-version-testing/ddvm_rsa root@${MICRO_VM_IP}:/junit-*.tar.gz /home/ubuntu/"
+    - ssh -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP "scp -o StrictHostKeyChecking=no -i /home/kernel-version-testing/ddvm_rsa root@${MICRO_VM_IP}:/testjson-*.tar.gz /home/ubuntu/"
+    - scp -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP:/home/ubuntu/testjson-*.tar.gz $DD_AGENT_TESTING_DIR/
+    - scp -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP:/home/ubuntu/junit-*.tar.gz $DD_AGENT_TESTING_DIR/
+    - ssh -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP "ssh -o StrictHostKeyChecking=no -i /home/kernel-version-testing/ddvm_rsa root@${MICRO_VM_IP} '/test-json-review'"
 
 kernel_matrix_testing_run_tests_x64:
   extends:

--- a/test/new-e2e/system-probe/test-json-review/main.go
+++ b/test/new-e2e/system-probe/test-json-review/main.go
@@ -76,6 +76,8 @@ func main() {
 		}
 	}
 
+	// We want to make sure the exit code is correctly set to
+	// failed here, so that the CI job also fails.
 	os.Exit(1)
 }
 

--- a/test/new-e2e/system-probe/test-json-review/main.go
+++ b/test/new-e2e/system-probe/test-json-review/main.go
@@ -28,9 +28,9 @@ func init() {
 }
 
 func printHeader(str string) {
-	greenString := color.New(color.FgGreen, color.Bold).Add(color.Underline)
+	magentaString := color.New(color.FgMagenta, color.Bold).Add(color.Underline)
 	fmt.Println()
-	greenString.Println(str)
+	magentaString.Println(str)
 }
 
 func main() {

--- a/test/new-e2e/system-probe/test-json-review/main.go
+++ b/test/new-e2e/system-probe/test-json-review/main.go
@@ -21,7 +21,7 @@ import (
 	"github.com/fatih/color"
 )
 
-var CIVisibility = filepath.Join("/", "ci-visibility")
+const CIVisibility = "/ci-visibility"
 
 func init() {
 	color.NoColor = false
@@ -71,7 +71,7 @@ func main() {
 		if len(failedTests) > 0 {
 			fmt.Fprintf(os.Stderr, color.RedString(failedTests))
 		} else {
-			fmt.Fprintf(os.Stderr, color.GreenString(fmt.Sprintf("All tests cleared in attempt %d", i+1)))
+			fmt.Println(color.GreenString(fmt.Sprintf("All tests cleared in attempt %d", i+1)))
 			return
 		}
 	}

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -285,10 +285,10 @@ func parseTestConfiguration() *TestConfig {
 	excludeLs := []string{}
 
 	if *packagesPtr != "" {
-		packagesLs := strings.Split(*packagesPtr, ",")
+		packagesLs = strings.Split(*packagesPtr, ",")
 	}
 	if *excludePackagesPtr != "" {
-		excludeLs := strings.Split(*excludePackagesPtr, ",")
+		excludeLs = strings.Split(*excludePackagesPtr, ",")
 	}
 
 	return &TestConfig{

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -28,7 +28,7 @@ func init() {
 
 type TestConfig struct {
 	retry           int
-	packages        []string
+	includePackages []string
 	excludePackages []string
 }
 
@@ -203,8 +203,8 @@ func testPass(testConfig *TestConfig, attempt int) (bool, error) {
 				}
 			}
 		}
-		if len(testConfig.packages) != 0 {
-			for _, p := range testConfig.packages {
+		if len(testConfig.includePackages) != 0 {
+			for _, p := range testConfig.includePackages {
 				if dir == p {
 					return true
 				}
@@ -278,7 +278,7 @@ func main() {
 
 func parseTestConfiguration() *TestConfig {
 	retryPtr := flag.Int("retry", 2, "number of times to retry testing pass")
-	packagesPtr := flag.String("packages", "", "Comma seperated list of packages to test")
+	packagesPtr := flag.String("include-packages", "", "Comma seperated list of packages to test")
 	excludePackagesPtr := flag.String("exclude-packages", "", "Comma seperated list of packages to exclude")
 
 	flag.Parse()
@@ -295,7 +295,7 @@ func parseTestConfiguration() *TestConfig {
 
 	return &TestConfig{
 		retry:           *retryPtr,
-		packages:        packagesLs,
+		includePackages: packagesLs,
 		excludePackages: excludeLs,
 	}
 }

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -300,6 +300,7 @@ func parseTestConfiguration() *TestConfig {
 
 func printHeader(str string) {
 	greenString := color.New(color.FgGreen, color.Bold).Add(color.Underline)
+	fmt.Println()
 	greenString.Println(str)
 }
 

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -193,7 +193,7 @@ func testPass(testConfig *TestConfig, attempt int) (bool, error) {
 	var retry bool
 
 	matches, err := glob(TestDirRoot, Testsuite, func(path string) bool {
-		dir := filepath.Dir(path)
+		dir := strings.TrimLeft(strings.TrimPrefix(filepath.Dir(path), TestDirRoot), "/")
 		if len(testConfig.excludePackages) != 0 {
 			for _, p := range testConfig.excludePackages {
 				if dir == p {
@@ -281,8 +281,15 @@ func parseTestConfiguration() *TestConfig {
 
 	flag.Parse()
 
-	packagesLs := strings.Split(*packagesPtr, ",")
-	excludeLs := strings.Split(*excludePackagesPtr, ",")
+	packagesLs := []string{}
+	excludeLs := []string{}
+
+	if *packagesPtr != "" {
+		packagesLs := strings.Split(*packagesPtr, ",")
+	}
+	if *excludePackagesPtr != "" {
+		excludeLs := strings.Split(*excludePackagesPtr, ",")
+	}
 
 	return &TestConfig{
 		retry:           *retryPtr,
@@ -292,7 +299,7 @@ func parseTestConfiguration() *TestConfig {
 }
 
 func printHeader(str string) {
-	greenString := color.New(FgGreen, color.Bold).Add(color.Underline)
+	greenString := color.New(color.FgGreen, color.Bold).Add(color.Underline)
 	greenString.Println(str)
 }
 

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -299,9 +299,9 @@ func parseTestConfiguration() *TestConfig {
 }
 
 func printHeader(str string) {
-	greenString := color.New(color.FgGreen, color.Bold).Add(color.Underline)
+	magentaString := color.New(color.FgMagenta, color.Bold).Add(color.Underline)
 	fmt.Println()
-	greenString.Println(str)
+	magentaString.Println(str)
 }
 
 func run() error {

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -276,7 +276,7 @@ func main() {
 	}
 }
 
-func parseTestConfiguration() *TestConfig {
+func buildTestConfiguration() *TestConfig {
 	retryPtr := flag.Int("retry", 2, "number of times to retry testing pass")
 	packagesPtr := flag.String("include-packages", "", "Comma seperated list of packages to test")
 	excludePackagesPtr := flag.String("exclude-packages", "", "Comma seperated list of packages to exclude")
@@ -310,7 +310,7 @@ func run() error {
 	var err error
 	var uname unix.Utsname
 
-	testConfig := parseTestConfiguration()
+	testConfig := buildTestConfiguration()
 
 	if err := unix.Uname(&uname); err != nil {
 		return fmt.Errorf("error calling uname: %w", err)

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -195,8 +195,6 @@ func testPass(testConfig *TestConfig, attempt int) (bool, error) {
 
 	matches, err := glob(TestDirRoot, Testsuite, func(path string) bool {
 		dir, _ := filepath.Rel(TestDirRoot, filepath.Dir(path))
-		fmt.Printf("dir: %s\n", dir)
-
 		for _, p := range testConfig.excludePackages {
 			if dir == p {
 				return false

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -37,11 +37,13 @@ const (
 	TestDirRoot = "/opt/system-probe-tests"
 	GoTestSum   = "/go/bin/gotestsum"
 
-	CIVisibility = "ci-visibility"
-	XMLDir       = "junit-%d"
-	JSONDir      = "pkgjson-%d"
-	JSONOutDir   = "testjson-%d"
+	// The directroy format is <name>-<attempt>*
+	XMLDir     = "junit-%d"
+	JSONDir    = "pkgjson-%d"
+	JSONOutDir = "testjson-%d"
 )
+
+var CIVisibility = filepath.Join("/", "ci-visibility")
 
 var BaseEnv = map[string]interface{}{
 	"DD_SYSTEM_PROBE_BPF_DIR":  filepath.Join(TestDirRoot, "pkg/ebpf/bytecode/build"),
@@ -167,7 +169,7 @@ func concatenateJsons(indir, outdir string) error {
 }
 
 func getCIVisibilityDir(dir string, attempt int) string {
-	return filepath.Join("/", CIVisibility, fmt.Sprintf(dir, attempt))
+	return filepath.Join(CIVisibility, fmt.Sprintf(dir, attempt))
 }
 
 func buildCIVisibilityDirs(attempt int) error {

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -328,7 +328,7 @@ func run() error {
 	}
 
 	for i := 1; i <= testConfig.retry; i++ {
-		printHeader(fmt.Sprintf("Test pass attempt %d", i))
+		printHeader(fmt.Sprintf("Test attempt %d", i))
 		retry, err := testPass(testConfig, i)
 		if !retry || err != nil {
 			break

--- a/test/new-e2e/system-probe/test/micro-vm-init.sh
+++ b/test/new-e2e/system-probe/test/micro-vm-init.sh
@@ -3,6 +3,7 @@
 set -eo xtrace
 
 GOVERSION=$1
+RETRY_COUNT=$2
 KITCHEN_DOCKERS=/kitchen-docker
 
 # Add provisioning steps here !
@@ -20,7 +21,7 @@ IP=$(ip route get 8.8.8.8 | grep -Po '(?<=(src ))(\S+)')
 rm -rf ci-visibility
 
 CODE=0
-/test-runner -retry 2 || CODE=$?
+/test-runner -retry $RETRY_COUNT || CODE=$?
 
 find /ci-visibility -maxdepth 1 -type d -name testjson-* -exec tar czvf {}-$IP.tar.gz {} \;
 find /ci-visibility -maxdepth 1 -type d -name junit-* -exec tar czvf {}-$IP.tar.gz {} \;

--- a/test/new-e2e/system-probe/test/micro-vm-init.sh
+++ b/test/new-e2e/system-probe/test/micro-vm-init.sh
@@ -17,13 +17,12 @@ find $KITCHEN_DOCKERS -maxdepth 1 -type f -exec docker load -i {} \;
 
 # Start tests
 IP=$(ip route get 8.8.8.8 | grep -Po '(?<=(src ))(\S+)')
-rm -f "/testjson-$IP.tar.gz"
-rm -f "/junit-$IP.tar.gz"
+rm -rf ci-visibility
 
 CODE=0
-/test-runner || CODE=$?
+/test-runner -retry 2 || CODE=$?
 
-tar czvf "/testjson-$IP.tar.gz" /testjson
-tar czvf "/junit-$IP.tar.gz" /junit
+find /ci-visibility -maxdepth 1 -type d -name testjson-* -exec tar czvf {}-$IP.tar.gz {} \;
+find /ci-visibility -maxdepth 1 -type d -name junit-* -exec tar czvf {}-$IP.tar.gz {} \;
 
 exit $CODE

--- a/test/new-e2e/system-probe/test/micro-vm-init.sh
+++ b/test/new-e2e/system-probe/test/micro-vm-init.sh
@@ -18,7 +18,7 @@ find $KITCHEN_DOCKERS -maxdepth 1 -type f -exec docker load -i {} \;
 
 # Start tests
 IP=$(ip route get 8.8.8.8 | grep -Po '(?<=(src ))(\S+)')
-rm -rf ci-visibility
+rm -rf /ci-visibility
 
 CODE=0
 /test-runner -retry $RETRY_COUNT || CODE=$?


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR provides the ability for the user to specify the number of times to retry the functional tests in the kernel-matrix-testing system.
It also allows the user to specify which packages to test.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
