### PR TITLE
Adds basic developer docs around jmxfetch and jmx checks

### DIFF
--- a/docs/dev/checks/README.md
+++ b/docs/dev/checks/README.md
@@ -3,6 +3,10 @@
 For more informations about what a Custom check is and whether they are a good
 fit for your use case, please [refer to the official documentation][custom-checks].
 
+## JMX-based checks
+JMX-based checks are executed by a component of the Agent called `jmxfetch`.
+Refer to [./jmxfetch.md](./jmxfetch.md) for more.
+
 ## Configuration
 
 Every check has its own YAML configuration file. The file has one mandatory key,

--- a/docs/dev/checks/jmxfetch.md
+++ b/docs/dev/checks/jmxfetch.md
@@ -1,0 +1,27 @@
+# JMX Checks Development
+[JMXFetch](https://github.com/DataDog/jmxfetch/) is the component of the Agent which is responsible with collecting
+metrics from Java applications.
+
+These docs are intended to help you test changes to either JMXFetch or JMX-based
+integrations locally. Ie, you as a developer have made some changes to how JMXFetch
+works and you'd like to run JMXFetch via the Agent to validate your changes.
+
+## Custom Build of JMXFetch
+1. [Build JMXFetch](https://github.com/DataDog/jmxfetch/#building-from-source)
+2. Copy the resulting jar into `$GOPATH/src/github.com/DataDog/datadog-agent/dev/dist/jmx/jmxfetch.jar`
+3. Run `inv agent.run`
+4. Validate you see the JMXFetch section in `agent status`
+
+If you have a jmx-based integration configured to run, it should automatically
+be run in your local JMXFetch instance.
+
+## Custom JMX-based Check
+1. Run your JMX server listening on `localhost`
+    1. A testing JMX server can be found
+    [here](https://github.com/DataDog/jmxfetch/tree/master/tools/misbehaving-jmx-server)
+2. Add a check configuration that specifies how to connect to your JMX server
+    1. An example for the above test server can be found
+    [here](https://github.com/DataDog/jmxfetch/blob/master/tools/misbehaving-jmx-server/misbehaving-jmxfetch-conf.yaml)
+    2. This config should live in `dev/dist/conf.d/jmx-test-server.d/conf.yaml`
+3. Run `inv agent.run`
+4. Validate you see the check scheduled in `agent status`

--- a/docs/dev/checks/jmxfetch.md
+++ b/docs/dev/checks/jmxfetch.md
@@ -1,27 +1,26 @@
 # JMX Checks Development
-[JMXFetch](https://github.com/DataDog/jmxfetch/) is the component of the Agent which is responsible with collecting
-metrics from Java applications.
+[JMXFetch](https://github.com/DataDog/jmxfetch/) is the component of the Agent which is responsible for collecting metrics from Java applications.
 
 These docs are intended to help you test changes to either JMXFetch or JMX-based
-integrations locally. Ie, you as a developer have made some changes to how JMXFetch
+integrations locally. In other words, you've made changes to how JMXFetch
 works and you'd like to run JMXFetch via the Agent to validate your changes.
 
 ## Custom Build of JMXFetch
-1. [Build JMXFetch](https://github.com/DataDog/jmxfetch/#building-from-source)
-2. Copy the resulting jar into `$GOPATH/src/github.com/DataDog/datadog-agent/dev/dist/jmx/jmxfetch.jar`
-3. Run `inv agent.run`
-4. Validate you see the JMXFetch section in `agent status`
+1. [Build JMXFetch](https://github.com/DataDog/jmxfetch/#building-from-source).
+2. Copy the resulting jar into `$GOPATH/src/github.com/DataDog/datadog-agent/dev/dist/jmx/jmxfetch.jar`.
+3. Run `inv agent.run`.
+4. Validate that the JMXFetch section appears in `agent status`.
 
-If you have a jmx-based integration configured to run, it should automatically
+If you have a JMX-based integration configured to run, it should automatically
 be run in your local JMXFetch instance.
 
 ## Custom JMX-based Check
-1. Run your JMX server listening on `localhost`
+1. Run your JMX server listening on `localhost`.
     1. A testing JMX server can be found
-    [here](https://github.com/DataDog/jmxfetch/tree/master/tools/misbehaving-jmx-server)
+    [here](https://github.com/DataDog/jmxfetch/tree/master/tools/misbehaving-jmx-server).
 2. Add a check configuration that specifies how to connect to your JMX server
-    1. An example for the above test server can be found
-    [here](https://github.com/DataDog/jmxfetch/blob/master/tools/misbehaving-jmx-server/misbehaving-jmxfetch-conf.yaml)
-    2. This config should live in `dev/dist/conf.d/jmx-test-server.d/conf.yaml`
-3. Run `inv agent.run`
-4. Validate you see the check scheduled in `agent status`
+   - An example for the above test server can be found
+   [in the jmxfetch repo](https://github.com/DataDog/jmxfetch/blob/master/tools/misbehaving-jmx-server/misbehaving-jmxfetch-conf.yaml).
+   - This config should live in `dev/dist/conf.d/jmx-test-server.d/conf.yaml`.
+3. Run `inv agent.run`.
+4. Validate that the check appears as scheduled in `agent status`.


### PR DESCRIPTION

### What does this PR do?
Improves developer-facing documentation

### Motivation
Current check documentation is python-focused

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
