### PR TITLE
Exposing system-probe global config values to agent metadata (inventories)

### DIFF
--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -111,7 +111,6 @@ const (
 	AgentSPRuntimeCompilationEnabled    AgentMetadataName = "system_probe_runtime_compilation_enabled"
 	AgentSPKernelHeadersDownloadEnabled AgentMetadataName = "system_probe_kernel_headers_download_enabled"
 	AgentSPPrebuiltFallbackEnabled      AgentMetadataName = "system_probe_prebuilt_fallback_enabled"
-	AgentSPBPFDebugEnabled              AgentMetadataName = "system_probe_bpf_debug_enabled"
 	AgentSPMaxConnectionPerMessage      AgentMetadataName = "system_probe_max_connections_per_message"
 
 	// Those are reserved fields for the agentMetadata payload.
@@ -455,10 +454,9 @@ func initializeConfig(cfg config.Config) {
 	// case like that, we should move otlp.IsEnabled to pkg/config/otlp
 
 	// SystemProbe module level configuration,
-	// doesn't include configuration for specific products running in SystemProbe (USM, NPM, CWS, etc...)
+	// configuration knobs for specific products running in SystemProbe (USM, NPM, CWS, etc...) are NOT included
 	SetAgentMetadata(AgentSPTCPQueueLengthEnabled, config.SystemProbe.GetBool("system_probe_config.enable_tcp_queue_length"))
 	SetAgentMetadata(AgentSPOOMKillEnabled, config.SystemProbe.GetBool("system_probe_config.enable_oom_kill"))
-	SetAgentMetadata(AgentSPBPFDebugEnabled, config.SystemProbe.GetBool("system_probe_config.bpf_debug"))
 	SetAgentMetadata(AgentSPCOREEnabled, config.SystemProbe.GetBool("system_probe_config.enable_co_re"))
 	SetAgentMetadata(AgentSPRuntimeCompilationEnabled, config.SystemProbe.GetBool("system_probe_config.enable_runtime_compiler"))
 	SetAgentMetadata(AgentSPKernelHeadersDownloadEnabled, config.SystemProbe.GetBool("system_probe_config.enable_kernel_header_download"))

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -103,6 +103,17 @@ const (
 	AgentAPMEnabled                     AgentMetadataName = "feature_apm_enabled"
 	AgentIMDSv2Enabled                  AgentMetadataName = "feature_imdsv2_enabled"
 
+	// System Probe general config values
+	AgentSPOOMKillEnabled               AgentMetadataName = "feature_oom_kill_enabled"
+	AgentSPTCPQueueLengthEnabled        AgentMetadataName = "feature_tcp_queue_length_enabled"
+	AgentSPTelemetryEnabled             AgentMetadataName = "system_probe_telemetry_enabled"
+	AgentSPCOREEnabled                  AgentMetadataName = "system_probe_core_enabled"
+	AgentSPRuntimeCompilationEnabled    AgentMetadataName = "system_probe_runtime_compilation_enabled"
+	AgentSPKernelHeadersDownloadEnabled AgentMetadataName = "system_probe_kernel_headers_download_enabled"
+	AgentSPPrebuiltFallbackEnabled      AgentMetadataName = "system_probe_prebuilt_fallback_enabled"
+	AgentSPBPFDebugEnabled              AgentMetadataName = "system_probe_bpf_debug_enabled"
+	AgentSPMaxConnectionPerMessage      AgentMetadataName = "system_probe_max_connections_per_message"
+
 	// Those are reserved fields for the agentMetadata payload.
 	agentProvidedConf AgentMetadataName = "provided_configuration"
 	agentFullConf     AgentMetadataName = "full_configuration"
@@ -442,4 +453,16 @@ func initializeConfig(cfg config.Config) {
 	// NOTE: until otlp config stabilizes, we set AgentOTLPEnabled in cmd/agent/app/run.go
 	// Also note we can't import OTLP here, as it would trigger an import loop - if we see another
 	// case like that, we should move otlp.IsEnabled to pkg/config/otlp
+
+	// SystemProbe module level configuration,
+	// doesn't include configuration for specific products running in SystemProbe (USM, NPM, CWS, etc...)
+	SetAgentMetadata(AgentSPTCPQueueLengthEnabled, config.SystemProbe.GetBool("system_probe_config.enable_tcp_queue_length"))
+	SetAgentMetadata(AgentSPOOMKillEnabled, config.SystemProbe.GetBool("system_probe_config.enable_oom_kill"))
+	SetAgentMetadata(AgentSPBPFDebugEnabled, config.SystemProbe.GetBool("system_probe_config.bpf_debug"))
+	SetAgentMetadata(AgentSPCOREEnabled, config.SystemProbe.GetBool("system_probe_config.enable_co_re"))
+	SetAgentMetadata(AgentSPRuntimeCompilationEnabled, config.SystemProbe.GetBool("system_probe_config.enable_runtime_compiler"))
+	SetAgentMetadata(AgentSPKernelHeadersDownloadEnabled, config.SystemProbe.GetBool("system_probe_config.enable_kernel_header_download"))
+	SetAgentMetadata(AgentSPPrebuiltFallbackEnabled, config.SystemProbe.GetBool("system_probe_config.allow_precompiled_fallback"))
+	SetAgentMetadata(AgentSPTelemetryEnabled, config.SystemProbe.GetBool("system_probe_config.telemetry_enabled"))
+	SetAgentMetadata(AgentSPMaxConnectionPerMessage, config.SystemProbe.GetInt("system_probe_config.max_conns_per_message"))
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
Exposing system-probe global config values to metadata agent (inventories)

Currently some basic configuration values from SystemProbe config namespace.
This should allows us to filter installed agents based on those config values in Datadog's [inventories](https://app.datadoghq.com/inventories/sql?viz=query) tab.

### Additional Notes
Jira [ticket](https://datadoghq.atlassian.net/browse/EBPF-216) 

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
