### PR TITLE
[CWS][SEC-8451] Fix part of the exec-exec issue in Activity Trees

### DIFF
--- a/pkg/security/security_profile/activity_tree/activity_tree_test.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_test.go
@@ -8,8 +8,11 @@
 package activity_tree
 
 import (
+	"fmt"
+	"math"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -64,4 +67,936 @@ func TestInsertFileEvent(t *testing.T) {
 	debugOutput := strings.TrimSpace(builder.String())
 
 	assert.Equal(t, expectedDebugOuput, debugOutput)
+}
+
+func TestActivityTree_Insert(t *testing.T) {
+	for _, tt := range activityTreeInsertTestCases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.tree.Insert(tt.inputEvent, Runtime)
+			if tt.wantErr != nil {
+				if !tt.wantErr(t, err, fmt.Sprintf("unexpected error: %v", err)) {
+					return
+				}
+			} else if err != nil {
+				t.Fatalf("an err was returned but none was expected: %v", err)
+				return
+			}
+
+			var builder strings.Builder
+			tt.tree.Debug(&builder)
+			inputResult := strings.TrimSpace(builder.String())
+
+			builder.Reset()
+			tt.wantTree.Debug(&builder)
+			wantedResult := strings.TrimSpace(builder.String())
+
+			assert.Equalf(t, wantedResult, inputResult, "the generated tree didn't match the expected output")
+		})
+	}
+}
+
+// activityTreeInsertTestValidator is a mock validator to test the activity tree insert feature
+type activityTreeInsertTestValidator struct{}
+
+func (a activityTreeInsertTestValidator) MatchesSelector(entry *model.ProcessCacheEntry) bool {
+	return entry.ContainerID == "123"
+}
+
+func (a activityTreeInsertTestValidator) IsEventTypeValid(evtType model.EventType) bool {
+	return true
+}
+
+func (a activityTreeInsertTestValidator) NewProcessNodeCallback(p *ProcessNode) {}
+
+// newExecTestEventWithAncestors returns a new exec test event with a process cache entry populated with the input list.
+// A final `systemd` node is appended.
+func newExecTestEventWithAncestors(lineage []model.Process) *model.Event {
+	// build the list of ancestors
+	ancestor := new(model.ProcessCacheEntry)
+	lineageDup := make([]model.Process, len(lineage))
+	copy(lineageDup, lineage)
+
+	// reverse lineageDup
+	for i, j := 0, len(lineageDup)-1; i < j; i, j = i+1, j-1 {
+		lineageDup[i], lineageDup[j] = lineageDup[j], lineageDup[i]
+	}
+
+	cursor := ancestor
+	for _, p := range lineageDup[1:] {
+		cursor.Process = p
+		cursor.Ancestor = new(model.ProcessCacheEntry)
+		cursor = cursor.Ancestor
+	}
+
+	// append systemd
+	cursor.Process = model.Process{
+		PIDContext: model.PIDContext{
+			Pid: 1,
+		},
+		FileEvent: model.FileEvent{
+			PathnameStr: "/bin/systemd",
+			FileFields: model.FileFields{
+				PathKey: model.PathKey{
+					Inode: math.MaxUint64,
+				},
+			},
+		},
+	}
+
+	evt := &model.Event{
+		Type:             uint32(model.ExecEventType),
+		FieldHandlers:    &model.DefaultFieldHandlers{},
+		ContainerContext: &model.ContainerContext{},
+		ProcessContext:   &model.ProcessContext{},
+		Exec: model.ExecEvent{
+			Process: &model.Process{},
+		},
+		ProcessCacheEntry: &model.ProcessCacheEntry{
+			ProcessContext: model.ProcessContext{
+				Process:  lineageDup[0],
+				Ancestor: ancestor,
+			},
+		},
+	}
+	return evt
+}
+
+var activityTreeInsertTestCases = []struct {
+	name         string
+	tree         *ActivityTree
+	inputEvent   *model.Event
+	wantNewEntry bool
+	wantErr      assert.ErrorAssertionFunc
+	wantTree     *ActivityTree
+}{
+	// exec/1
+	// ---------------
+	//
+	//     empty tree          +          systemd                 ==>>              /bin/bash
+	//                                       |- /bin/bash                               |
+	//                                       |- /bin/ls                              /bin/ls
+	{
+		name: "exec/1",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 1,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+			},
+		}),
+		wantNewEntry: true,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/ls",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// exec/2
+	// ---------------
+	//
+	//      /bin/bash          +          systemd                 ==>>              /bin/bash
+	//                                       |- /bin/bash                               |
+	//                                       |- /bin/ls                              /bin/ls
+	{
+		name: "exec/2",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 1,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+			},
+		}),
+		wantNewEntry: true,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/ls",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// exec/3
+	// ---------------
+	//
+	//      /bin/bash          +          systemd                 ==>>              /bin/bash ------------
+	//          |                            |- /bin/bash                               |                |
+	//      /bin/webserver                   |- /bin/ls                           /bin/webserver      /bin/ls
+	//          |                                                                       |
+	//       /bin/ls                                                                 /bin/ls
+	{
+		name: "exec/3",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/ls",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 1,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+			},
+		}),
+		wantNewEntry: true,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/ls",
+										},
+									},
+								},
+							},
+						},
+						{
+							Process: model.Process{
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/ls",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// exec/4
+	// ---------------
+	//
+	//      /bin/bash          +          systemd                 ==>>              /bin/bash
+	//          |                            |- /bin/bash                               |
+	//      /bin/webserver                   |- /bin/ls                            /bin/webserver
+	//          | (exec)                                                                | (exec)
+	//       /bin/ls                                                                 /bin/ls
+	{
+		name: "exec/4",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+								ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/ls",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 1,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+			},
+		}),
+		wantNewEntry: false,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+								ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/ls",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// exec/5
+	// ---------------
+	//
+	//      /bin/webserver         +          systemd             ==>>           /bin/webserver
+	//          | (exec)                       |- /bin/ls                              | (exec)
+	//       /bin/ls                                                                 /bin/ls
+	{
+		name: "exec/5",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+						ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/webserver",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/ls",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+			},
+		}),
+		wantNewEntry: false,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+						ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/webserver",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/ls",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// exec/6
+	// ---------------
+	//
+	//      /bin/bash          +          systemd                 ==>>               /bin/bash
+	//          |                            |- /bin/bash                               |
+	//      /bin/webserver1                  |- /bin/ls                           /bin/webserver1
+	//          | (exec)                                                                | (exec)
+	//     /bin/webserver2----------                                              /bin/webserver2
+	//          | (exec)           |                                                    | (exec)
+	//     /bin/webserver3      /bin/id                                           /bin/webserver3
+	//          | (exec)                                                                | (exec)
+	//     /bin/webserver4                                                        /bin/webserver4
+	//          | (exec)                                                                | (exec)
+	//       /bin/ls---------------                                                  /bin/ls--------------
+	//          |                 |                                                     |                |
+	//       /bin/wc           /bin/id                                               /bin/wc          /bin/id
+	{
+		name: "exec/6",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+								ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver1",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/webserver2",
+										},
+									},
+									Children: []*ProcessNode{
+										{
+											Process: model.Process{
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/id",
+												},
+											},
+										},
+										{
+											Process: model.Process{
+												ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+												ExitTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/webserver3",
+												},
+											},
+											Children: []*ProcessNode{
+												{
+													Process: model.Process{
+														ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+														ExitTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+														FileEvent: model.FileEvent{
+															PathnameStr: "/bin/webserver4",
+														},
+													},
+													Children: []*ProcessNode{
+														{
+															Process: model.Process{
+																ExecTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+																FileEvent: model.FileEvent{
+																	PathnameStr: "/bin/ls",
+																},
+															},
+															Children: []*ProcessNode{
+																{
+																	Process: model.Process{
+																		FileEvent: model.FileEvent{
+																			PathnameStr: "/bin/id",
+																		},
+																	},
+																},
+																{
+																	Process: model.Process{
+																		FileEvent: model.FileEvent{
+																			PathnameStr: "/bin/wc",
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 1,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+			},
+		}),
+		wantNewEntry: false,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+								ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver1",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/webserver2",
+										},
+									},
+									Children: []*ProcessNode{
+										{
+											Process: model.Process{
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/id",
+												},
+											},
+										},
+										{
+											Process: model.Process{
+												ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+												ExitTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/webserver3",
+												},
+											},
+											Children: []*ProcessNode{
+												{
+													Process: model.Process{
+														ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+														ExitTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+														FileEvent: model.FileEvent{
+															PathnameStr: "/bin/webserver4",
+														},
+													},
+													Children: []*ProcessNode{
+														{
+															Process: model.Process{
+																ExecTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+																FileEvent: model.FileEvent{
+																	PathnameStr: "/bin/ls",
+																},
+															},
+															Children: []*ProcessNode{
+																{
+																	Process: model.Process{
+																		FileEvent: model.FileEvent{
+																			PathnameStr: "/bin/id",
+																		},
+																	},
+																},
+																{
+																	Process: model.Process{
+																		FileEvent: model.FileEvent{
+																			PathnameStr: "/bin/wc",
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// exec/7
+	// ---------------
+	//
+	//      /bin/webserver1              +           systemd           ==>        /bin/webserver1
+	//          | (exec)                              |- /bin/ls                        | (exec)
+	//     /bin/webserver2----------                                              /bin/webserver2---------
+	//          | (exec)           |                                                    | (exec)         |
+	//     /bin/webserver3      /bin/id                                           /bin/webserver3     /bin/id
+	//          | (exec)                                                                | (exec)
+	//     /bin/webserver4                                                        /bin/webserver4
+	//          | (exec)                                                                | (exec)
+	//       /bin/ls---------------                                                  /bin/ls--------------
+	//          |                 |                                                     |                |
+	//       /bin/wc           /bin/id                                               /bin/wc          /bin/id
+	{
+		name: "exec/7",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+						ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/webserver1",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver2",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/id",
+										},
+									},
+								},
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										ExitTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/webserver3",
+										},
+									},
+									Children: []*ProcessNode{
+										{
+											Process: model.Process{
+												ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+												ExitTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/webserver4",
+												},
+											},
+											Children: []*ProcessNode{
+												{
+													Process: model.Process{
+														ExecTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+														FileEvent: model.FileEvent{
+															PathnameStr: "/bin/ls",
+														},
+													},
+													Children: []*ProcessNode{
+														{
+															Process: model.Process{
+																FileEvent: model.FileEvent{
+																	PathnameStr: "/bin/id",
+																},
+															},
+														},
+														{
+															Process: model.Process{
+																FileEvent: model.FileEvent{
+																	PathnameStr: "/bin/wc",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+			},
+		}),
+		wantNewEntry: false,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+						ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/webserver1",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver2",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/id",
+										},
+									},
+								},
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										ExitTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/webserver3",
+										},
+									},
+									Children: []*ProcessNode{
+										{
+											Process: model.Process{
+												ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+												ExitTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/webserver4",
+												},
+											},
+											Children: []*ProcessNode{
+												{
+													Process: model.Process{
+														ExecTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+														FileEvent: model.FileEvent{
+															PathnameStr: "/bin/ls",
+														},
+													},
+													Children: []*ProcessNode{
+														{
+															Process: model.Process{
+																FileEvent: model.FileEvent{
+																	PathnameStr: "/bin/id",
+																},
+															},
+														},
+														{
+															Process: model.Process{
+																FileEvent: model.FileEvent{
+																	PathnameStr: "/bin/wc",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR fixes part of the `exec-exec` issue in Activity Trees. The goal of this PR is to handle the case where an execution event was missed at runtime (but not in the activity tree), and thus, we're trying to match an incomplete process tree with a profile. This PR allows skipping the evaluation of intermediary `exec-exec` nodes in a profile (see the tests).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Improve our Anomaly Detection feature.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
