### PR TITLE
Move modcache before extraction in windows runner

### DIFF
--- a/.gitlab/binary_build/windows.yml
+++ b/.gitlab/binary_build/windows.yml
@@ -3,7 +3,7 @@
 build_windows_container_entrypoint:
   rules:
   stage: binary_build
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:windows-docker", "windowsversion:1809_test"]
   needs: ["lint_windows-x64", "tests_windows-x64"]
   variables:
     ARCH: "x64"

--- a/.gitlab/choco_build.yml
+++ b/.gitlab/choco_build.yml
@@ -7,7 +7,7 @@ windows_choco_offline_7_x64:
   rules:
     !reference [.on_a7_manual]
   stage: choco_build
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:windows-docker", "windowsversion:1809_test"]
   needs: ["windows_msi_and_bosh_zip_x64-a7"]
   variables:
     ARCH: "x64"
@@ -29,7 +29,7 @@ windows_choco_online_7_x64:
   rules:
     !reference [.on_deploy_stable_or_rc_tag_on_beta_repo_branch_a7]
   stage: choco_build
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:windows-docker", "windowsversion:1809_test"]
   needs: ["deploy_staging_windows_tags-7"]
   variables:
     ARCH: "x64"

--- a/.gitlab/choco_deploy.yml
+++ b/.gitlab/choco_deploy.yml
@@ -6,7 +6,7 @@ publish_choco_7_x64:
   rules:
     !reference [.on_deploy_stable_or_rc_tag_on_beta_repo_branch_a7_manual_on_stable]
   stage: choco_deploy
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:windows-docker", "windowsversion:1809_test"]
   needs: ["windows_choco_online_7_x64"]
   variables:
     ARCH: "x64"

--- a/.gitlab/container_build/docker_windows_agent6.yml
+++ b/.gitlab/container_build/docker_windows_agent6.yml
@@ -3,7 +3,7 @@
 docker_build_agent6_windows1809_core:
   extends:
     - .docker_build_agent6_windows_servercore_common
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:windows-docker", "windowsversion:1809_test"]
   variables:
     VARIANT: 1809
     TAG_SUFFIX: -6

--- a/.gitlab/container_build/docker_windows_agent7.yml
+++ b/.gitlab/container_build/docker_windows_agent7.yml
@@ -2,7 +2,7 @@
 docker_build_agent7_windows1809:
   extends:
     - .docker_build_agent7_windows_common
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:windows-docker", "windowsversion:1809_test"]
   variables:
     VARIANT: 1809
     TAG_SUFFIX: -7
@@ -11,7 +11,7 @@ docker_build_agent7_windows1809:
 docker_build_agent7_windows1809_jmx:
   extends:
     - .docker_build_agent7_windows_common
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:windows-docker", "windowsversion:1809_test"]
   variables:
     VARIANT: 1809
     TAG_SUFFIX: -7-jmx
@@ -39,7 +39,7 @@ docker_build_agent7_windows2022:
 docker_build_agent7_windows1809_core:
   extends:
     - .docker_build_agent7_windows_servercore_common
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:windows-docker", "windowsversion:1809_test"]
   variables:
     VARIANT: 1809
     TAG_SUFFIX: -7
@@ -48,7 +48,7 @@ docker_build_agent7_windows1809_core:
 docker_build_agent7_windows1809_core_jmx:
   extends:
     - .docker_build_agent7_windows_servercore_common
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:windows-docker", "windowsversion:1809_test"]
   variables:
     VARIANT: 1809
     TAG_SUFFIX: -7-jmx

--- a/.gitlab/deploy_7/winget.yml
+++ b/.gitlab/deploy_7/winget.yml
@@ -7,7 +7,7 @@ publish_winget_7_x64:
   rules:
     !reference [.on_deploy_stable_or_beta_repo_branch_a7_manual]
   stage: deploy7
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:windows-docker", "windowsversion:1809_test"]
   variables:
     ARCH: "x64"
   before_script:

--- a/.gitlab/deps_build.yml
+++ b/.gitlab/deps_build.yml
@@ -87,7 +87,7 @@ build_clang_arm64:
 
 build_vcpkg_deps:
   stage: deps_build
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:windows-docker", "windowsversion:1809_test"]
   variables:
     ARCH: "x64"
   before_script:

--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -1,7 +1,7 @@
 ---
 .windows_msi_base:
   stage: package_build
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:windows-docker", "windowsversion:1809_test"]
   needs: ["go_mod_tidy_check", "go_deps", "build_vcpkg_deps"]
   script:
     - $ErrorActionPreference = 'Stop'
@@ -83,7 +83,7 @@ windows_zip_agent_binaries_x64-a7:
   rules:
     !reference [.on_a7]
   stage: package_build
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:windows-docker", "windowsversion:1809_test"]
   needs: ["go_mod_tidy_check", "go_deps", "build_vcpkg_deps"]
   variables:
     ARCH: "x64"

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -50,7 +50,7 @@
 .tests_windows_sysprobe:
   stage: source_test
   needs: ["go_deps"]
-  tags: [ "runner:windows-docker", "windowsversion:1809" ]
+  tags: [ "runner:windows-docker", "windowsversion:1809_test" ]
   script:
     - $ErrorActionPreference = "Stop"
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'

--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -2,7 +2,7 @@
 .tests_windows_base:
   stage: source_test
   needs: ["go_deps", "go_tools_deps", "build_vcpkg_deps"]
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:windows-docker", "windowsversion:1809_test"]
   before_script:
     - $vcpkgBlobSaSUrl = (aws ssm get-parameter --region us-east-1 --name ci.datadog-agent-buildimages.vcpkg_blob_sas_url --with-decryption --query "Parameter.Value" --out text)
   script:
@@ -39,7 +39,7 @@
 .lint_windows_base:
   stage: source_test
   needs: ["go_deps", "go_tools_deps"]
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:windows-docker", "windowsversion:1809_test"]
   script:
     - $ErrorActionPreference = "Stop"
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'

--- a/tasks/winbuildscripts/extract-modcache.bat
+++ b/tasks/winbuildscripts/extract-modcache.bat
@@ -1,9 +1,18 @@
 if exist c:\mnt\modcache.tar.gz (
-    @echo Extracting modcache
-    Powershell -C "7z x c:\mnt\modcache.tar.gz -oc:\mnt"
-    Powershell -C "7z x c:\mnt\modcache.tar -oc:\modcache"
-    del /f c:\mnt\modcache.tar.gz
-    del /f c:\mnt\modcache.tar
+    @echo Extracting modcache in dedicated repository
+    if not exist c:\cache (
+        mkdir "c:\cache"
+    )
+    move "c:\mnt\modcache.tar.gz" "c:\cache\modcache.tar.gz"
+    if errorlevel 1 (
+        @echo Failed to move modcache
+    ) else (
+        @echo Successfully moved modcache
+    )
+    Powershell -C "7z x c:\cache\modcache.tar.gz -oc:\cache"
+    Powershell -C "7z x c:\cache\modcache.tar -oc:\modcache"
+    del /f c:\cache\modcache.tar.gz
+    del /f c:\cache\modcache.tar
     @echo Modcache extracted
 ) else (
     @echo modcache.tar.gz not found, dependencies will be downloaded

--- a/tasks/winbuildscripts/extract-tools-modcache.bat
+++ b/tasks/winbuildscripts/extract-tools-modcache.bat
@@ -1,13 +1,22 @@
 if exist c:\mnt\modcache_tools.tar.gz (
-    @echo Extracting modcache_tools
-    Powershell -C "7z x c:\mnt\modcache_tools.tar.gz -oc:\mnt"
+    @echo Extracting modcache_tools in a dedicated repository
+    if not exist c:\cache (
+        mkdir "c:\cache"
+    )
+    move "c:\mnt\modcache.tar.gz" "c:\cache\modcache.tar.gz"
+    if errorlevel 1 (
+        @echo Failed to move modcache
+    ) else (
+        @echo Successfully moved modcache
+    )
+    Powershell -C "7z x c:\cache\modcache_tools.tar.gz -oc:\cache"
     REM Use -aoa to allow overwriting existing files
     REM This shouldn't have any negative impact: since modules are
     REM stored per version and hash, files that get replaced will
     REM get replaced by the same files
-    Powershell -C "7z x c:\mnt\modcache_tools.tar -oc:\modcache -aoa"
-    del /f c:\mnt\modcache_tools.tar.gz
-    del /f c:\mnt\modcache_tools.tar
+    Powershell -C "7z x c:\cache\modcache_tools.tar -oc:\modcache -aoa"
+    del /f c:\cache\modcache_tools.tar.gz
+    del /f c:\cache\modcache_tools.tar
     @echo modcache_tools extracted
 ) else (
     @echo modcache_tools.tar.gz not found, tooling dependencies will be downloaded


### PR DESCRIPTION
Try to prevent conflict access to the shared repository

### What does this PR do?
Move modcache out of the shared repository (CI_PROJECT_DIR) to prevent errors in Windows gitlab runners

### Motivation
Windows runners stability

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
