### PR TITLE
Upgrade Python 3 to 3.8.17

### DIFF
--- a/omnibus/config/software/pip3.rb
+++ b/omnibus/config/software/pip3.rb
@@ -1,15 +1,15 @@
 name "pip3"
 
 # The version of pip used must be at least equal to the one bundled with the Python version we use
-# Python 3.8.16 bundles pip 22.0.4
-default_version "22.3.1"
+# Python 3.8.17 bundles pip 23.0.1
+default_version "23.0.1"
 
 skip_transitive_dependency_licensing true
 
 dependency "python3"
 
 source :url => "https://github.com/pypa/pip/archive/#{version}.tar.gz",
-       :sha256 => "8d9f7cd8ad0d6f0c70e71704fd3f0f6538d70930454f1f21bbc2f8e94f6964ee",
+       :sha256 => "8544443b6810cf1e41306f44218449524d579f4f801b6b16e46f7cabe64de155",
        :extract => :seven_zip
 
 relative_path "pip-#{version}"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -1,7 +1,7 @@
 name "python3"
 
 if ohai["platform"] != "windows"
-  default_version "3.8.16"
+  default_version "3.8.17"
 
   dependency "libxcrypt"
   dependency "libffi"
@@ -15,7 +15,7 @@ if ohai["platform"] != "windows"
   dependency "libyaml"
 
   source :url => "https://python.org/ftp/python/#{version}/Python-#{version}.tgz",
-         :sha256 => "71ca9d935637ed2feb59e90a368361dc91eca472a90acb1d344a2e8178ccaf10"
+         :sha256 => "def428fa6cf61b66bcde72e3d9f7d07d33b2e4226f04f9d6fce8384c055113ae"
 
   relative_path "Python-#{version}"
 
@@ -68,19 +68,19 @@ if ohai["platform"] != "windows"
   end
 
 else
-  default_version "3.8.16-dc2e87f"
+  default_version "3.8.17-e0a363f"
   dependency "vc_redist_14"
 
   if windows_arch_i386?
     dependency "vc_ucrt_redist"
 
     source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x86.zip",
-            :sha256 => "A0D0451685DA1D1EA343F43A42BFB9843EE198BCFC6B51239A77EF1DDF5CE26E".downcase
+            :sha256 => "A72C0D9CBF5235F28811A339723D1D05CE4FA95578153DEDA851119F2E099433".downcase
   else
 
     # note that startring with 3.7.3 on Windows, the zip should be created without the built-in pip
     source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x64.zip",
-         :sha256 => "D3BACF66A264913CC1CD194B6875167FCCD91FE1B2D4FFAA314731D656A3FE3C".downcase
+         :sha256 => "27D3B4AB04929F42119318309BD4F08CDAC6D89B3A3BE4290A27CB8CB4556212".downcase
 
   end
   vcrt140_root = "#{Omnibus::Config.source_dir()}/vc_redist_140/expanded"

--- a/releasenotes/notes/update-python-to-3-8-17-344d67959f6a2735.yaml
+++ b/releasenotes/notes/update-python-to-3-8-17-344d67959f6a2735.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+security:
+  - |
+    Upgraded embedded Python3 to 3.8.17; addressed CVE-2023-24329.


### PR DESCRIPTION

### What does this PR do?

This PR upgrades the version of Python 3 to [3.8.17](https://www.python.org/downloads/release/python-3817/). This also bumps the version of PIP3 to `23.0.1`.

### Motivation

This was done due to a fix for CVE-2023-24329. The OpenSSL CVEs were already addressed in #17680.

### Additional Notes

This not needed in `main` as that now uses Python 3.9.

### Possible Drawbacks / Trade-offs

None.

### Describe how to test/QA your changes

* Run an Agent with Python 3 (either Agent 6 configured with py3 or an Agent 7)
* Execute agent status and validate Python version
* Validate the Python integrations are working properly

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
