### PR TITLE
Adding metadata runner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -196,6 +196,7 @@
 /comp/core @DataDog/agent-shared-components
 /comp/dogstatsd @DataDog/agent-metrics-logs
 /comp/forwarder @DataDog/agent-shared-components
+/comp/metadata @DataDog/agent-shared-components
 /comp/process @DataDog/processes
 /comp/remote-config @DataDog/remote-config
 /comp/systray @DataDog/windows-agent

--- a/comp/README.md
+++ b/comp/README.md
@@ -63,6 +63,17 @@ Package forwarder implements the "forwarder" bundle
 
 Package defaultForwarder implements a component to send payloads to the backend
 
+## [comp/metadata](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/metadata) (Component Bundle)
+
+*Datadog Team*: agent-shared-components
+
+Package metadata implements the "metadata" bundle, providing services and support for all the metadata payload sent
+by the Agent.
+
+### [comp/metadata/runner](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/metadata/runner)
+
+Package runner implements a component to generate metadata payload at the right interval.
+
 ## [comp/process](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/process) (Component Bundle)
 
 *Datadog Team*: processes

--- a/comp/metadata/bundle.go
+++ b/comp/metadata/bundle.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package metadata implements the "metadata" bundle, providing services and support for all the metadata payload sent
+// by the Agent.
+package metadata
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: agent-shared-components
+
+// Bundle defines the fx options for this bundle.
+var Bundle = fxutil.Bundle()
+
+// MockBundle defines the mock fx options for this bundle.
+var MockBundle = fxutil.Bundle()

--- a/comp/metadata/bundle_test.go
+++ b/comp/metadata/bundle_test.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+)
+
+func TestBundleDependencies(t *testing.T) {
+	require.NoError(t, fx.ValidateApp(Bundle))
+}
+
+func TestMockBundleDependencies(t *testing.T) {
+	require.NoError(t, fx.ValidateApp(MockBundle))
+}

--- a/comp/metadata/runner/component.go
+++ b/comp/metadata/runner/component.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package runner implements a component to generate metadata payload at the right interval.
+package runner
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"go.uber.org/fx"
+)
+
+// team: agent-shared-components
+
+// Component is the component type.
+type Component interface{}
+
+// Module defines the fx options for this component.
+var Module = fxutil.Component(
+	fx.Provide(newRunner),
+)
+
+// The runner component doesn't provides a mock since other component don't use it directly.

--- a/comp/metadata/runner/runner.go
+++ b/comp/metadata/runner/runner.go
@@ -1,0 +1,129 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package runner
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"go.uber.org/fx"
+)
+
+type MetadataProvider func(context.Context) time.Duration
+
+type runner struct {
+	log       log.Component
+	config    config.Component
+	providers []MetadataProvider
+
+	wg       sync.WaitGroup
+	stopChan chan struct{}
+}
+
+type dependencies struct {
+	fx.In
+
+	Log       log.Component
+	Config    config.Component
+	Providers []MetadataProvider `group:"metadata_provider"`
+}
+
+// Provider represents the callback from a metada provider. This is returned by 'NewProvider' helper.
+type Provider struct {
+	fx.Out
+
+	Callback MetadataProvider `group:"metadata_provider"`
+}
+
+// NewProvider registers a new metadata provider by adding a callback to the runner.
+func NewProvider(callback MetadataProvider) Provider {
+	return Provider{
+		Callback: callback,
+	}
+}
+
+// createRunner instantiates a runner object
+func createRunner(deps dependencies) *runner {
+	return &runner{
+		log:       deps.Log,
+		config:    deps.Config,
+		providers: deps.Providers,
+		stopChan:  make(chan struct{}),
+	}
+}
+
+func newRunner(lc fx.Lifecycle, deps dependencies) Component {
+	r := createRunner(deps)
+
+	// We rely on FX to start and stop the metadata runner
+	lc.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			return r.start()
+		},
+		OnStop: func(ctx context.Context) error {
+			return r.stop()
+		},
+	})
+	return r
+}
+
+// handleProvider runs a provider at regular interval until the runner is stopped
+func (r *runner) handleProvider(p MetadataProvider) {
+	r.log.Debugf("Starting runner for MetadataProvider %v", p)
+	r.wg.Add(1)
+
+	intervalChan := make(chan time.Duration)
+	var interval time.Duration
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		r.log.Debugf("stopping runner for MetadataProvider %s", p)
+		r.wg.Done()
+	}()
+
+	for {
+		go func(intervalChan chan time.Duration) {
+			intervalChan <- p(ctx)
+		}(intervalChan)
+
+		select {
+		case interval = <-intervalChan:
+		case <-r.stopChan:
+			cancel()
+			return
+		}
+
+		select {
+		case <-time.After(interval):
+		case <-r.stopChan:
+			cancel()
+			return
+		}
+	}
+}
+
+// start is called by FX when the application starts. Lifecycle hooks are blocking and called sequencially. We should
+// not block here.
+func (r *runner) start() error {
+	r.log.Debugf("Starting metadata runner with %d providers", len(r.providers))
+	for _, p := range r.providers {
+		go r.handleProvider(p)
+	}
+	return nil
+}
+
+// stop is called by FX when the application stops. Lifecycle hooks are blocking and called sequencially. We should
+// not block here.
+func (r *runner) stop() error {
+	r.log.Debugf("Stopping metadata runner")
+	close(r.stopChan)
+	r.wg.Wait()
+	return nil
+}

--- a/comp/metadata/runner/runner_test.go
+++ b/comp/metadata/runner/runner_test.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package runner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+)
+
+func TestHandleProvider(t *testing.T) {
+	called := make(chan struct{})
+	provider := func(context.Context) time.Duration {
+		called <- struct{}{}
+		return 1 * time.Minute // Long timeout to block
+	}
+
+	r := createRunner(
+		fxutil.Test[dependencies](
+			t,
+			log.MockModule,
+			config.MockModule,
+			fx.Supply(NewProvider(provider)),
+		))
+
+	r.start()
+
+	// either called receive a value or the test will fail as a timeout
+	<-called
+
+	assert.NoError(t, r.stop())
+}
+
+func TestRunnerCreation(t *testing.T) {
+	called := make(chan struct{})
+	callback := func(context.Context) time.Duration {
+		called <- struct{}{}
+		return 1 * time.Minute // Long timeout to block
+	}
+
+	lc := fxtest.NewLifecycle(t)
+	fxutil.Test[Component](
+		t,
+		fx.Supply(lc),
+		log.MockModule,
+		config.MockModule,
+		Module,
+		// Supplying our provider by using the helper function
+		fx.Supply(NewProvider(callback)),
+	)
+
+	ctx := context.Background()
+	lc.Start(ctx)
+
+	// either called receive a value or the test will fail as a timeout
+	<-called
+
+	assert.NoError(t, lc.Stop(ctx))
+}


### PR DESCRIPTION
### What does this PR do?

Adding the metadata runner
    
This is the first for migrating metadata to component. In future PR/commits we will move each payload one at a time.
### Describe how to test/QA your changes

Nothing to test, the runner is not used anywhere right now.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
