### PR TITLE
Add a curl config file and use it in e2e tests

### DIFF
--- a/.curlrc
+++ b/.curlrc
@@ -1,0 +1,7 @@
+--continue-at -
+--include
+--location
+--retry 5
+--retry-delay 60
+--retry-max-time 1800
+--silent

--- a/tasks/docker_tasks.py
+++ b/tasks/docker_tasks.py
@@ -107,7 +107,7 @@ COPY test.bin /test.bin
 def delete(ctx, org, image, tag, token):
     print(f"Deleting {org}/{image}:{tag}")
     ctx.run(
-        f"curl 'https://hub.docker.com/v2/repositories/{org}/{image}/tags/{tag}/' -X DELETE -H 'Authorization: JWT {token}' &>/dev/null"
+        f"curl --config ./.curlrc 'https://hub.docker.com/v2/repositories/{org}/{image}/tags/{tag}/' -X DELETE -H 'Authorization: JWT {token}' &>/dev/null"
     )
 
 

--- a/test/e2e/argo-workflows/templates/fake-datadog.yaml
+++ b/test/e2e/argo-workflows/templates/fake-datadog.yaml
@@ -137,7 +137,7 @@ spec:
           set -euo pipefail
           set -x
 
-          until timeout 2 curl  --max-time 1 --fail http://fake-datadog.{{inputs.parameters.namespace}}.svc.cluster.local/_/reset -XPOST; do
+          until timeout 2 curl --max-time 1 --fail http://fake-datadog.{{inputs.parameters.namespace}}.svc.cluster.local/_/reset -XPOST; do
             sleep 3
           done
 

--- a/test/e2e/scripts/run-instance/10-setup-kind.sh
+++ b/test/e2e/scripts/run-instance/10-setup-kind.sh
@@ -13,7 +13,7 @@ case $(uname -m) in
 esac
 
 download_and_install_kubectl() {
-    curl --retry 5 --fail --retry-all-errors -LO "https://dl.k8s.io/release/$(curl --retry 5 --fail --retry-all-errors -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$arch/kubectl"
+    curl --fail --retry-all-errors -O "https://dl.k8s.io/release/$(curl --fail --retry-all-errors https://dl.k8s.io/release/stable.txt)/bin/linux/$arch/kubectl"
     sudo install kubectl /usr/local/bin/kubectl
 }
 
@@ -32,7 +32,7 @@ if [[ ! -f ./kubectl ]]; then
     download_and_install_kubectl
 else
     # else, download the SHA256 of the wanted version
-    curl --retry 5 --fail --retry-all-errors -LO "https://dl.k8s.io/release/$(curl --retry 5 --fail --retry-all-errors -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$arch/kubectl.sha256"
+    curl --fail --retry-all-errors -O "https://dl.k8s.io/release/$(curl --fail --retry-all-errors https://dl.k8s.io/release/stable.txt)/bin/linux/$arch/kubectl.sha256"
     # And if it differs, force the download again
     if ! echo "$(<kubectl.sha256)  kubectl" | sha256sum --check ; then
         echo "SHA256 of kubectl differs, downloading it again"
@@ -40,7 +40,7 @@ else
     fi
 fi
 
-curl -Lo ./kind "https://kind.sigs.k8s.io/dl/$(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/kubernetes-sigs/kind/releases | jq -r '.[0].tag_name')/kind-linux-$arch"
+curl -o ./kind "https://kind.sigs.k8s.io/dl/$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/kubernetes-sigs/kind/releases | jq -r '.[0].tag_name')/kind-linux-$arch"
 sudo install kind /usr/local/bin/kind
 
 

--- a/test/e2e/scripts/run-instance/20-argo-download.sh
+++ b/test/e2e/scripts/run-instance/20-argo-download.sh
@@ -20,7 +20,7 @@ esac
 
 # if argo is not here, or if the SHA doesnt match, (re)download it
 if [[ ! -f ./argo.gz ]] || ! sha256sum -c "argo.$arch.sha256sum" ; then
-    curl -Lf "https://github.com/argoproj/argo-workflows/releases/download/v3.4.3/argo-linux-$arch.gz" -o argo.gz
+    curl -f "https://github.com/argoproj/argo-workflows/releases/download/v3.4.3/argo-linux-$arch.gz" -o argo.gz
     # before gunziping it, check its SHA
     if ! sha256sum -c "argo.$arch.sha256sum"; then
         echo "SHA256 of argo.gz differs, exiting."

--- a/test/e2e/scripts/run-instance/23-argo-get.sh
+++ b/test/e2e/scripts/run-instance/23-argo-get.sh
@@ -49,7 +49,7 @@ if [[ $EXIT_CODE != 0 ]]; then
 fi
 
 TIME_LEFT=$(systemctl status terminate.timer | awk '$1 == "Trigger:" {print gensub(/ *Trigger: (.*)/, "\\1", 1)}')
-LOCAL_IP=$(curl -s http://169.254.169.254/2020-10-27/meta-data/local-ipv4)
+LOCAL_IP=$(curl http://169.254.169.254/2020-10-27/meta-data/local-ipv4)
 BEGIN_TS=$(./argo list -o json | jq -r '.[] | .metadata.creationTimestamp' | while read -r ts; do date -d "$ts" +%s; done | sort -n | head -n 1)
 
 printf "\033[1mThe Argo UI will remain available at \033[1;34mhttps://%s\033[0m until \033[1;33m%s\033[0m.\n" "$LOCAL_IP" "$TIME_LEFT"

--- a/test/e2e/scripts/run-instance/24-argo-to-ci-setup.sh
+++ b/test/e2e/scripts/run-instance/24-argo-to-ci-setup.sh
@@ -5,4 +5,4 @@ cd "$(dirname "$0")"
 
 docker build -t argo-to-junit-helper:local ./argo-to-junit
 
-sudo curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" && sudo chmod +x /usr/local/bin/datadog-ci
+sudo curl --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" && sudo chmod +x /usr/local/bin/datadog-ci

--- a/test/e2e/scripts/setup-instance/00-entrypoint-dev.sh
+++ b/test/e2e/scripts/setup-instance/00-entrypoint-dev.sh
@@ -18,7 +18,10 @@ fi
 
 set -e
 
-cd "$(dirname "$0")"
+dir_path=$(cd "$(dirname "$0")" && pwd)
+# Configuration file for curl is at root of the git repository
+export CURL_HOME="$(dirname $(dirname $(dirname $(dirname "$dir_path"))))"
+cd "$dir_path"
 
 git clean -fdx .
 

--- a/test/e2e/scripts/setup-instance/00-entrypoint-gitlab.sh
+++ b/test/e2e/scripts/setup-instance/00-entrypoint-gitlab.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 printf '=%.0s' {0..79} ; echo
 set -x
 
-cd "$(dirname "$0")"
+dir_path=$(cd "$(dirname "$0")" && pwd)
+# Configuration file for curl is at root of the git repository
+export CURL_HOME="$(dirname $(dirname $(dirname $(dirname "$dir_path"))))"
+cd "$dir_path"
 
 git clean -fdx .
 
@@ -54,7 +57,7 @@ echo "using ARGO_WORKFLOW=${ARGO_WORKFLOW}"
 echo "${DATADOG_AGENT_IMAGE} is hosted on a docker registry, checking if it's available"
 IMAGE_REPOSITORY=${DATADOG_AGENT_IMAGE%:*}
 IMAGE_TAG=${DATADOG_AGENT_IMAGE#*:}
-if ! curl -Lfs --head "https://hub.docker.com/v2/repositories/${IMAGE_REPOSITORY}/tags/${IMAGE_TAG}" > /dev/null ; then
+if ! curl -f --head "https://hub.docker.com/v2/repositories/${IMAGE_REPOSITORY}/tags/${IMAGE_TAG}" > /dev/null ; then
         echo "The DATADOG_AGENT_IMAGE=${DATADOG_AGENT_IMAGE} is not available on DockerHub"
         exit 2
 fi
@@ -62,7 +65,7 @@ fi
 echo "${DATADOG_CLUSTER_AGENT_IMAGE} is hosted on a docker registry, checking if it's available"
 IMAGE_REPOSITORY=${DATADOG_CLUSTER_AGENT_IMAGE%:*}
 IMAGE_TAG=${DATADOG_CLUSTER_AGENT_IMAGE#*:}
-if ! curl -Lfs --head "https://hub.docker.com/v2/repositories/${IMAGE_REPOSITORY}/tags/${IMAGE_TAG}" > /dev/null ; then
+if ! curl -f --head "https://hub.docker.com/v2/repositories/${IMAGE_REPOSITORY}/tags/${IMAGE_TAG}" > /dev/null ; then
         echo "The DATADOG_CLUSTER_AGENT_IMAGE=${DATADOG_CLUSTER_AGENT_IMAGE} is not available on DockerHub"
         exit 2
 fi

--- a/test/e2e/scripts/setup-instance/00-entrypoint-local.sh
+++ b/test/e2e/scripts/setup-instance/00-entrypoint-local.sh
@@ -2,7 +2,10 @@
 
 printf '=%.0s' {0..79} ; echo
 set -ex
-cd "$(dirname "$0")"
+dir_path=$(cd "$(dirname "$0")" && pwd)
+# Configuration file for curl is at root of the git repository
+export CURL_HOME="$(dirname $(dirname $(dirname $(dirname "$dir_path"))))"
+cd "$dir_path"
 
 ../run-instance/10-setup-kind.sh
 ../run-instance/11-setup-kind-cluster.sh

--- a/test/e2e/scripts/setup-instance/01-ignition.sh
+++ b/test/e2e/scripts/setup-instance/01-ignition.sh
@@ -19,9 +19,9 @@ case "$(uname)" in
     Darwin) butane="butane-$arch-apple-darwin";;
 esac
 
-curl -O     "https://fedoraproject.org/fedora.gpg"
-curl -LOC - "https://github.com/coreos/butane/releases/download/v0.16.0/${butane}"
-curl -LO    "https://github.com/coreos/butane/releases/download/v0.16.0/${butane}.asc"
+curl -O "https://fedoraproject.org/fedora.gpg"
+curl -O "https://github.com/coreos/butane/releases/download/v0.16.0/${butane}"
+curl -O "https://github.com/coreos/butane/releases/download/v0.16.0/${butane}.asc"
 
 gpgv --keyring ./fedora.gpg "${butane}.asc" "$butane"
 chmod +x "$butane"

--- a/test/e2e/scripts/setup-instance/02-ec2.sh
+++ b/test/e2e/scripts/setup-instance/02-ec2.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 printf '=%.0s' {0..79} ; echo
 set -x
 
-cd "$(dirname "$0")"
+dir_path=$(cd "$(dirname "$0")" && pwd)
+# Configuration file for curl is at root of the git repository
+export CURL_HOME="$(dirname $(dirname $(dirname $(dirname "$dir_path"))))"
+cd "$dir_path"
 
 COMMIT_ID=$(git rev-parse --verify HEAD)
 export COMMIT_ID

--- a/test/e2e/scripts/setup-instance/04-send-dd-event.sh
+++ b/test/e2e/scripts/setup-instance/04-send-dd-event.sh
@@ -13,7 +13,7 @@ if [[ -n ${CI_JOB_URL+x} ]] && [[ -n ${DD_API_KEY+x} ]]; then
     fi
 
     oldstate=$(shopt -po xtrace ||:); set +x  # Do not log credentials
-    curl -s -X POST "https://api.datadoghq.com/api/v1/events?api_key=${DD_API_KEY}" \
+    curl -X POST "https://api.datadoghq.com/api/v1/events?api_key=${DD_API_KEY}" \
          -H "Content-Type: application/json" \
          -d @- <<EOF
 {


### PR DESCRIPTION
### What does this PR do?
Add a central curl config to ease management of retries in curl configuration

### Motivation
Reduce effort with a central configuration and improve robustness with automatic retries on dependencies

### Additional Notes
### Possible Drawbacks / Trade-offs
### Describe how to test/QA your changes
TBD

### Reviewer's Checklist
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
