### PR TITLE
[USM] add missing map dumps

### DIFF
--- a/pkg/network/protocols/http/http_types.go
+++ b/pkg/network/protocols/http/http_types.go
@@ -14,7 +14,7 @@ package http
 */
 import "C"
 
-type httpConnTuple = C.conn_tuple_t
+type HttpConnTuple = C.conn_tuple_t
 type SslSock C.ssl_sock_t
 type SslReadArgs C.ssl_read_args_t
 

--- a/pkg/network/protocols/http/http_types_linux.go
+++ b/pkg/network/protocols/http/http_types_linux.go
@@ -3,7 +3,7 @@
 
 package http
 
-type httpConnTuple = struct {
+type HttpConnTuple = struct {
 	Saddr_h  uint64
 	Saddr_l  uint64
 	Daddr_h  uint64
@@ -15,7 +15,7 @@ type httpConnTuple = struct {
 	Metadata uint32
 }
 type SslSock struct {
-	Tup       httpConnTuple
+	Tup       HttpConnTuple
 	Fd        uint32
 	Pad_cgo_0 [4]byte
 }
@@ -25,7 +25,7 @@ type SslReadArgs struct {
 }
 
 type EbpfHttpTx struct {
-	Tup                  httpConnTuple
+	Tup                  HttpConnTuple
 	Request_started      uint64
 	Request_method       uint8
 	Response_status_code uint16

--- a/pkg/network/usm/dump.go
+++ b/pkg/network/usm/dump.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/davecgh/go-spew/spew"
 
-	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
 )
 
@@ -28,15 +27,6 @@ func (e *ebpfProgram) dumpMapsHandler(manager *manager.Manager, mapName string, 
 		iter := currentMap.Iterate()
 		var key uintptr // C.void *
 		var value http.SslSock
-		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
-			output.WriteString(spew.Sdump(key, value))
-		}
-
-	case protocols.ProtocolDispatcherProgramsMap: // maps/protocols_progs (BPF_MAP_TYPE_PROG_ARRAY), key C.__u32, value C.__u32
-		output.WriteString("Map: '" + mapName + "', key: 'C.__u32', value: 'C.__u32'\n")
-		iter := currentMap.Iterate()
-		var key uint32
-		var value uint32
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -81,15 +71,6 @@ func (e *ebpfProgram) dumpMapsHandler(manager *manager.Manager, mapName string, 
 		output.WriteString("Map: '" + mapName + "', key: 'C.conn_tuple_t', value: 'C.__u32'\n")
 		iter := currentMap.Iterate()
 		var key http.HttpConnTuple
-		var value uint32
-		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
-			output.WriteString(spew.Sdump(key, value))
-		}
-
-	case protocolDispatcherClassificationPrograms: // maps/dispatcher_classification_progs (BPF_MAP_TYPE_PROG_ARRAY), key C.__u32, value C.__u32
-		output.WriteString("Map: '" + mapName + "', key: 'C.__u32', value: 'C.__u32'\n")
-		iter := currentMap.Iterate()
-		var key uint32
 		var value uint32
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds a missing map dump to the debug endpoint. The missing map is `maps/connection_states`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- Start system-probe.
- For each map added, run the following:
```
sudo curl --unix /opt/datadog-agent/run/sysprobe.sock http://unix/network_tracer/debug/ebpf_maps?maps=connection_states
```
Replace `<mapName>` by the name of the map you want to check. Beware that the newlines might be printed as `\n` in the output. You should see some output similar to this (here taking `connection_states` as an example):
```
Map: 'connection_states', key: '', value: '' \n(struct { Saddr_h uint64; Saddr_l uint64; Daddr_h uint64; Daddr_l uint64; Sport uint16; Dport uint16; Netns uint32; Pid uint32; Metadata uint32 }) {\n Saddr_h: (uint64) 0,\n Saddr_l: (uint64) 1077400330,\n Daddr_h: (uint64) 0,\n Daddr_l: (uint64) 37212938,\n Sport: (uint16) 22,\n Dport: (uint16) 53830,\n Netns: (uint32) 0,\n Pid: (uint32) 0,\n Metadata: (uint32) 1\n}\n(uint32) 2524529433\n(struct { Saddr_h uint64; Saddr_l uint64; Daddr_h uint64; Daddr_l uint64; Sport uint16; Dport uint16; Netns uint32; Pid uint32; Metadata uint32 }) {\n Saddr_h: (uint64) 0,\n Saddr_l: (uint64) 37212938,\n Daddr_h: (uint64) 0,\n Daddr_l: (uint64) 1077400330,\n Sport: (uint16) 53830,\n Dport: (uint16) 22,\n Netns: (uint32) 0,\n Pid: (uint32) 0,\n Metadata: (uint32) 1\n}\n(uint32) 2125272448\n(struct { Saddr_h uint64; Saddr_l uint64; Daddr_h uint64; Daddr_l uint64; Sport uint16; Dport uint16; Netns uint32; Pid uint32; Metadata uint32 }) {\n Saddr_h: (uint64) 0,\n Saddr_l: (uint64) 4272553641,\n Daddr_h: (uint64) 0,\n Daddr_l: (uint64) 1077400330,\n Sport: (uint16) 80,\n Dport: (uint16) 59148,\n Netns: (uint32) 0,\n Pid: (uint32) 0,\n Metadata: (uint32) 1\n}\n(uint32) 276044319\n"
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
