### PR TITLE
[CWS] module tester: fix kernel lost accounting

### DIFF
--- a/pkg/security/probe/eventstream/monitor.go
+++ b/pkg/security/probe/eventstream/monitor.go
@@ -243,8 +243,8 @@ func (pbm *EventStreamMonitor) GetKernelLostCount(perfMap string, cpu int, evtTy
 			for kernelEvtType := range pbm.kernelStats[perfMap][cpuID] {
 				var shouldCount bool
 
-				for evtType := range evtTypes {
-					if evtType == kernelEvtType || evtType == model.MaxAllEventType {
+				for _, evtType := range evtTypes {
+					if evtType == model.EventType(kernelEvtType) || evtType == model.MaxKernelEventType {
 						shouldCount = true
 						break
 					}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -1149,7 +1149,7 @@ func GetStatusMetrics(probe *sprobe.Probe) string {
 	}
 
 	status := map[string]interface{}{
-		"kernel-lost": eventStreamMonitor.GetKernelLostCount("events", model.MaxAllEventType),
+		"kernel-lost": eventStreamMonitor.GetKernelLostCount("events", -1, model.MaxKernelEventType),
 		"per-events":  map[string]interface{}{},
 	}
 

--- a/pkg/security/tests/stress_test.go
+++ b/pkg/security/tests/stress_test.go
@@ -54,7 +54,7 @@ func stressOpen(t *testing.T, rule *rules.RuleDefinition, pathname string, size 
 
 	eventStreamMonitor := test.probe.GetMonitor().GetEventStreamMonitor()
 	eventStreamMonitor.GetAndResetLostCount("events", -1)
-	eventStreamMonitor.GetKernelLostCount("events", -1)
+	eventStreamMonitor.GetKernelLostCount("events", -1, model.MaxKernelEventType)
 
 	fnc := func() error {
 		f, err := os.Create(testFile)
@@ -94,7 +94,7 @@ func stressOpen(t *testing.T, rule *rules.RuleDefinition, pathname string, size 
 	}
 
 	report.AddMetric("lost", float64(eventStreamMonitor.GetLostCount("events", -1)), "lost")
-	report.AddMetric("kernel_lost", float64(eventStreamMonitor.GetKernelLostCount("events", -1)), "kernel lost")
+	report.AddMetric("kernel_lost", float64(eventStreamMonitor.GetKernelLostCount("events", -1, model.MaxKernelEventType)), "kernel lost")
 	report.AddMetric("events", float64(events), "events")
 	report.AddMetric("events/sec", float64(events)/report.Duration.Seconds(), "event/s")
 
@@ -196,7 +196,7 @@ func stressExec(t *testing.T, rule *rules.RuleDefinition, pathname string, execu
 
 	eventStreamMonitor := test.probe.GetMonitor().GetEventStreamMonitor()
 	eventStreamMonitor.GetAndResetLostCount("events", -1)
-	eventStreamMonitor.GetKernelLostCount("events", -1)
+	eventStreamMonitor.GetKernelLostCount("events", -1, model.MaxKernelEventType)
 
 	fnc := func() error {
 		cmd := exec.Command(executable, testFile)
@@ -232,7 +232,7 @@ func stressExec(t *testing.T, rule *rules.RuleDefinition, pathname string, execu
 	time.Sleep(2 * time.Second)
 
 	report.AddMetric("lost", float64(eventStreamMonitor.GetLostCount("events", -1)), "lost")
-	report.AddMetric("kernel_lost", float64(eventStreamMonitor.GetKernelLostCount("events", -1)), "kernel lost")
+	report.AddMetric("kernel_lost", float64(eventStreamMonitor.GetKernelLostCount("events", -1, model.MaxKernelEventType)), "kernel lost")
 	report.AddMetric("events", float64(events), "events")
 	report.AddMetric("events/sec", float64(events)/report.Duration.Seconds(), "event/s")
 	report.AddMetric("kevents", float64(kevents), "kevents")


### PR DESCRIPTION
PR #17730 broke total kernel event loss accounting. This PR fixes this.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
