### PR TITLE
[RCM-1040] Add log level support for security agent

### DIFF
--- a/comp/remote-config/rcclient/rcclient.go
+++ b/comp/remote-config/rcclient/rcclient.go
@@ -34,11 +34,10 @@ const (
 type RCAgentTaskListener func(taskType TaskType, task AgentTaskConfig) (bool, error)
 
 type rcClient struct {
-	client           *remote.Client
-	m                *sync.Mutex
-	taskProcessed    map[string]bool
-	fallbackLogLevel *string
-	latestLogLevel   *string
+	client        *remote.Client
+	m             *sync.Mutex
+	taskProcessed map[string]bool
+	configState   *remote.AgentConfigState
 
 	listeners []RCAgentTaskListener
 }
@@ -60,14 +59,11 @@ func newRemoteConfigClient(deps dependencies) (Component, error) {
 	rc := rcClient{
 		listeners: deps.Listeners,
 		m:         &sync.Mutex{},
-		// The string values can't be updated inside the component methods,
-		// so we need to use pointers
-		fallbackLogLevel: new(string),
-		latestLogLevel:   new(string),
-		client:           nil,
+		configState: &remote.AgentConfigState{
+			FallbackLogLevel: level.String(),
+		},
+		client: nil,
 	}
-
-	*rc.fallbackLogLevel = level.String()
 
 	return rc, nil
 }
@@ -103,22 +99,22 @@ func (rc rcClient) agentConfigUpdateCallback(updates map[string]state.RawConfig)
 
 	// TODO RCM-1064: implement priority between CLI and remote-config
 	// If there is no error, override the configs
-	if len(mergedConfig.LogLevel) > 0 && mergedConfig.LogLevel != *rc.latestLogLevel {
+	if len(mergedConfig.LogLevel) > 0 && mergedConfig.LogLevel != rc.configState.LatestLogLevel {
 		pkglog.Infof("Changing log level to %s through remote config", mergedConfig.LogLevel)
 		// Get the current log level
 		var newFallback seelog.LogLevel
 		newFallback, err = pkglog.GetLogLevel()
 		if err == nil {
-			*rc.fallbackLogLevel = newFallback.String()
+			rc.configState.FallbackLogLevel = newFallback.String()
 			err = settings.SetRuntimeSetting("log_level", mergedConfig.LogLevel)
-			*rc.latestLogLevel = mergedConfig.LogLevel
+			rc.configState.LatestLogLevel = mergedConfig.LogLevel
 		}
 	} else {
 		var currentLogLevel seelog.LogLevel
 		currentLogLevel, err = pkglog.GetLogLevel()
-		if err == nil && currentLogLevel.String() == *rc.latestLogLevel {
-			pkglog.Infof("Removing remote-config log level override, falling back to %s", *rc.fallbackLogLevel)
-			err = settings.SetRuntimeSetting("log_level", *rc.fallbackLogLevel)
+		if err == nil && currentLogLevel.String() == rc.configState.LatestLogLevel {
+			pkglog.Infof("Removing remote-config log level override, falling back to %s", rc.configState.FallbackLogLevel)
+			err = settings.SetRuntimeSetting("log_level", rc.configState.FallbackLogLevel)
 		}
 	}
 

--- a/pkg/config/remote/agent_config.go
+++ b/pkg/config/remote/agent_config.go
@@ -45,6 +45,12 @@ type agentConfigOrderData struct {
 	InternalOrder []string `json:"internal_order"`
 }
 
+// AgentConfigState contains the state of the config in case of fallback or override
+type AgentConfigState struct {
+	FallbackLogLevel string
+	LatestLogLevel   string
+}
+
 // parseConfigAgentConfig parses an agent task config
 func parseConfigAgentConfig(data []byte, metadata state.Metadata) (AgentConfig, error) {
 	var d agentConfigData


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Support changing log_level of the security agent through RC
See core-agent PR: https://github.com/DataDog/datadog-agent/pull/17615

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
