### PR TITLE
[event monitor][CWS] reintroduce snapshot event playing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.48.0-rc.2
 	github.com/DataDog/datadog-go/v5 v5.3.0
 	github.com/DataDog/datadog-operator v1.1.0
-	github.com/DataDog/ebpf-manager v0.2.15
+	github.com/DataDog/ebpf-manager v0.2.16
 	github.com/DataDog/go-libddwaf v1.0.0
 	github.com/DataDog/go-tuf v1.0.2-0.5.2
 	github.com/DataDog/gopsutil v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,8 @@ github.com/DataDog/datadog-go/v5 v5.3.0 h1:2q2qjFOb3RwAZNU+ez27ZVDwErJv5/VpbBPpr
 github.com/DataDog/datadog-go/v5 v5.3.0/go.mod h1:XRDJk1pTc00gm+ZDiBKsjh7oOOtJfYfglVCmFb8C2+Q=
 github.com/DataDog/datadog-operator v1.1.0 h1:cSZqKarzM66GR0T1pPPZVopz4oPm3ltcRyqJ/h/6eJg=
 github.com/DataDog/datadog-operator v1.1.0/go.mod h1:3aWOjI4EaE1jYVN6llOXygA9nasy70GCa1XnTIWNoCY=
-github.com/DataDog/ebpf-manager v0.2.15 h1:l2xWDA/38xvhmTpu8vCnmM2zH50cbXeqIXUb7fPEWS4=
-github.com/DataDog/ebpf-manager v0.2.15/go.mod h1:pcPSCI1TxwCjWTg+n2/hRqt1NN9LdsufFFZYmi8CCJY=
+github.com/DataDog/ebpf-manager v0.2.16 h1:GYbSjuLsfau3BrHXCmXv/6b1U/zZt3npR0a8pTvz9eo=
+github.com/DataDog/ebpf-manager v0.2.16/go.mod h1:pcPSCI1TxwCjWTg+n2/hRqt1NN9LdsufFFZYmi8CCJY=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2 h1:uTE/QEU0oYtHnebKSMbxap7XMG5603WQxNP/UX63E7k=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2/go.mod h1:JgKVGTsjdTdtJjNyxRZjcs81/rng6LJ3XX/0D7Y12Gc=
 github.com/DataDog/glog v1.1.2-0.20230527101146-81a67cdbc7a1 h1:YpYdpEG3ohpETQTzz9u4bTvvJUzkRFwMyLrx/jtbU5g=

--- a/pkg/eventmonitor/eventmonitor.go
+++ b/pkg/eventmonitor/eventmonitor.go
@@ -150,6 +150,8 @@ func (m *EventMonitor) Start() error {
 			log.Errorf("unable to start %s event consumer: %v", em.ID(), err)
 		}
 	}
+	// Apply rules to the snapshotted data
+	m.Probe.PlaySnapshot()
 
 	if err := m.Probe.Start(); err != nil {
 		return err

--- a/pkg/eventmonitor/eventmonitor.go
+++ b/pkg/eventmonitor/eventmonitor.go
@@ -150,8 +150,6 @@ func (m *EventMonitor) Start() error {
 			log.Errorf("unable to start %s event consumer: %v", em.ID(), err)
 		}
 	}
-	// Apply rules to the snapshotted data
-	m.Probe.PlaySnapshot()
 
 	if err := m.Probe.Start(); err != nil {
 		return err

--- a/pkg/eventmonitor/eventmonitor.go
+++ b/pkg/eventmonitor/eventmonitor.go
@@ -144,15 +144,15 @@ func (m *EventMonitor) Start() error {
 		return err
 	}
 
-	if err := m.Probe.Start(); err != nil {
-		return err
-	}
-
 	// start event consumers
 	for _, em := range m.eventConsumers {
 		if err := em.Start(); err != nil {
 			log.Errorf("unable to start %s event consumer: %v", em.ID(), err)
 		}
+	}
+
+	if err := m.Probe.Start(); err != nil {
+		return err
 	}
 
 	m.wg.Add(1)

--- a/pkg/security/probe/eventstream/reorderer/perfmap.go
+++ b/pkg/security/probe/eventstream/reorderer/perfmap.go
@@ -71,7 +71,7 @@ func (m *OrderedPerfMap) Start(wg *sync.WaitGroup) error {
 	wg.Add(2)
 	go m.reordererMonitor.Start(wg)
 	go m.reOrderer.Start(wg)
-	return nil
+	return m.perfMap.Start()
 }
 
 // Pause the event stream.

--- a/pkg/security/probe/eventstream/ringbuffer/ringbuffer.go
+++ b/pkg/security/probe/eventstream/ringbuffer/ringbuffer.go
@@ -44,7 +44,7 @@ func (rb *RingBuffer) Init(mgr *manager.Manager, config *config.Config) error {
 
 // Start the event stream.
 func (rb *RingBuffer) Start(wg *sync.WaitGroup) error {
-	return nil
+	return rb.ringBuffer.Start()
 }
 
 // SetMonitor set the monitor

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -298,6 +298,8 @@ func (p *Probe) Setup() error {
 
 // Start processing events
 func (p *Probe) Start() error {
+	// Apply rules to the snapshotted data before starting the event stream
+	p.PlaySnapshot()
 	return p.eventStream.Start(&p.wg)
 }
 

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -296,9 +296,9 @@ func (p *Probe) Setup() error {
 	return nil
 }
 
-// Start processing events
+// Start plays the snapshot data and then start the event stream
 func (p *Probe) Start() error {
-	// Apply rules to the snapshotted data before starting the event stream
+	// Apply rules to the snapshotted data before starting the event stream to avoid concurrency issues
 	p.PlaySnapshot()
 	return p.eventStream.Start(&p.wg)
 }

--- a/pkg/security/tests/snapshot_replay_test.go
+++ b/pkg/security/tests/snapshot_replay_test.go
@@ -9,9 +9,10 @@ package tests
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"testing"
 )
 
 func TestSnapshotReplay(t *testing.T) {

--- a/pkg/security/tests/snapshot_replay_test.go
+++ b/pkg/security/tests/snapshot_replay_test.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build functionaltests
+
+package tests
+
+import (
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"testing"
+)
+
+func TestSnapshotReplay(t *testing.T) {
+	ruleDef := &rules.RuleDefinition{
+		ID:         "test_rule_snapshot_replay",
+		Expression: fmt.Sprintf(`exec.comm in ["testsuite"] `),
+	}
+
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{ruleDef}, testOpts{})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	t.Run("snapshot-replay", func(t *testing.T) {
+		// Check that the process is present in the process resolver's entrycache
+		test.WaitSignal(t, func() error {
+			go test.probe.PlaySnapshot()
+			return nil
+		}, func(event *model.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_rule_snapshot_replay")
+			test.validateExecSchema(t, event)
+		})
+	})
+
+}


### PR DESCRIPTION
This PR delays the startup of the event monitor eventstream to make it possible to match process data collected by the probe snapshot against CWS rules without any concurrency issue.

Currently, CWS rules are loaded upon starting the CWS consumer, which happens after the runtime security probe goroutine started processing events, hence matching snapshotted process data from another goroutine requires locking the runtime security probe's process data structures which isn't ideal.

To avoid requiring locking, this PR refactors the startup code of the event monitor module the following way:

- Setup the runtime security probe:
  - Start the eBPF manager (create eBPF maps and load eBPF programs)
  - Apply default kernel filters
  - Attach the probes for the default event types common to all consumers + the probe required to populate eBPF maps during the snapshot phase   
- Do the probe snapshot to populate the runtime security probe and eBPF maps process data
- Start the event monitor's consumers, the CWS consumer will load its policies, updating the activated probes and kernel filters in the process
- Start the runtime security probe: 
  - Play the snapshotted process data, potentially triggering CWS rules in the process
  - then start the event stream


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
