### PR TITLE
[SBOM] Add new `export_size` metric to track the size of the archive copied by the sbom collection

### DIFF
--- a/pkg/sbom/telemetry/telemetry.go
+++ b/pkg/sbom/telemetry/telemetry.go
@@ -38,9 +38,19 @@ var (
 	SBOMGenerationDuration = telemetry.NewHistogramWithOpts(
 		subsystem,
 		"generation_duration",
-		[]string{"source", "type"},
+		[]string{"source", "scan_type"},
 		"SBOM generation duration (in seconds)",
 		[]float64{10, 30, 60, 120, 180, 240, 300, 360, 420, 480, 540, 600},
+		commonOpts,
+	)
+
+	// SBOMExportSize is the size of the archive written on disk
+	SBOMExportSize = telemetry.NewHistogramWithOpts(
+		subsystem,
+		"export_size",
+		[]string{"source", "scan_ref"},
+		"Size of the archive written on disk",
+		[]float64{10_000_000, 50_000_000, 100_000_000, 200_000_000, 400_000_000, 600_000_000, 800_000_000, 1_000_000_000, 1_500_000_000},
 		commonOpts,
 	)
 

--- a/pkg/util/trivy/containerd.go
+++ b/pkg/util/trivy/containerd.go
@@ -33,6 +33,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
+const CONTAINERD_COLLECTOR = "containerd"
+
 // Code ported from https://github.com/aquasecurity/trivy/blob/2206e008ea6e5f4e5c1aa7bc8fc77dae7041de6a/pkg/fanal/image/daemon/containerd.go
 type familiarNamed string
 
@@ -92,7 +94,7 @@ func convertContainerdImage(ctx context.Context, client *containerd.Client, imgM
 
 	return &image{
 		name:    img.Name(),
-		opener:  imageOpener(ctx, ref.String(), f, imageWriter(client, img)),
+		opener:  imageOpener(ctx, CONTAINERD_COLLECTOR, ref.String(), f, imageWriter(client, img)),
 		inspect: insp,
 		history: history,
 	}, cleanup, nil

--- a/pkg/util/trivy/docker.go
+++ b/pkg/util/trivy/docker.go
@@ -18,6 +18,8 @@ import (
 	"golang.org/x/xerrors"
 )
 
+const DOCKER_COLLECTOR = "docker"
+
 // Custom code based on https://github.com/aquasecurity/trivy/blob/2206e008ea6e5f4e5c1aa7bc8fc77dae7041de6a/pkg/fanal/image/daemon/docker.go `DockerImage`
 func convertDockerImage(ctx context.Context, client client.ImageAPIClient, imgMeta *workloadmeta.ContainerImageMetadata) (types.Image, func(), error) {
 	cleanup := func() {}
@@ -51,7 +53,7 @@ func convertDockerImage(ctx context.Context, client client.ImageAPIClient, imgMe
 	}
 
 	return &image{
-		opener:  imageOpener(ctx, imageID, f, client.ImageSave),
+		opener:  imageOpener(ctx, DOCKER_COLLECTOR, imageID, f, client.ImageSave),
 		inspect: inspect,
 		history: configHistory(history),
 	}, cleanup, nil

--- a/pkg/util/trivy/image.go
+++ b/pkg/util/trivy/image.go
@@ -44,11 +44,11 @@ func imageOpener(ctx context.Context, collector, ref string, f *os.File, imageSa
 		defer rc.Close()
 
 		written, err := io.Copy(f, rc)
-
 		if err != nil {
 			return nil, xerrors.Errorf("failed to copy the image: %w", err)
 		}
 		defer f.Close()
+
 		telemetry.SBOMExportSize.Observe(float64(written), collector, ref)
 
 		img, err := tarball.ImageFromPath(f.Name(), nil)

--- a/pkg/util/trivy/image.go
+++ b/pkg/util/trivy/image.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/sbom/telemetry"
 	fimage "github.com/aquasecurity/trivy/pkg/fanal/image"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -33,7 +34,7 @@ type opener func() (v1.Image, error)
 
 type imageSave func(context.Context, []string) (io.ReadCloser, error)
 
-func imageOpener(ctx context.Context, ref string, f *os.File, imageSave imageSave) opener {
+func imageOpener(ctx context.Context, collector, ref string, f *os.File, imageSave imageSave) opener {
 	return func() (v1.Image, error) {
 		// Store the tarball in local filesystem and return a new reader into the bytes each time we need to access something.
 		rc, err := imageSave(ctx, []string{ref})
@@ -42,10 +43,13 @@ func imageOpener(ctx context.Context, ref string, f *os.File, imageSave imageSav
 		}
 		defer rc.Close()
 
-		if _, err = io.Copy(f, rc); err != nil {
+		written, err := io.Copy(f, rc)
+
+		if err != nil {
 			return nil, xerrors.Errorf("failed to copy the image: %w", err)
 		}
 		defer f.Close()
+		telemetry.SBOMExportSize.Observe(float64(written), collector, ref)
 
 		img, err := tarball.ImageFromPath(f.Name(), nil)
 		if err != nil {


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR adds a new metric `datadog.agent.sbom_export_size` to track the size of the archive copied by the sbom collection.
Renames tag `type` to `scan_type` to avoid conflicts.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
More visibility when a large copy occurs.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
`ref` tag is a high cardinality tag. Perhaps it can be removed.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Deploy the agent with SBOM check enabled and telemetry enabled:
```
  env:
    - name: DD_TELEMETRY_ENABLED
      value: "true"
    - name: DD_SBOM_CONTAINER_IMAGE_ENABLED
      value: "true"
    - name: DD_CONTAINER_IMAGE_COLLECTION_SBOM_ENABLED
      value: "true"
```
Make sure this metric is sent.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
