### PR TITLE
[omnibus] Set rpmlog verbosity to RPMLOG_ERR in OpenSCAP

### DIFF
--- a/omnibus/config/patches/openscap/rpm-verbosity-err.patch
+++ b/omnibus/config/patches/openscap/rpm-verbosity-err.patch
@@ -1,0 +1,40 @@
+--- a/src/OVAL/probes/unix/linux/rpminfo_probe.c
++++ b/src/OVAL/probes/unix/linux/rpminfo_probe.c
+@@ -286,6 +286,7 @@ void *rpminfo_probe_init(void)
+ {
+ #ifdef RPM46_FOUND
+ 	rpmlogSetCallback(rpmErrorCb, NULL);
++	rpmSetVerbosity(RPMLOG_ERR);
+ #endif
+ 	struct rpm_probe_global *g_rpm = malloc(sizeof(struct rpm_probe_global));
+ 	if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
+--- a/src/OVAL/probes/unix/linux/rpmverify_probe.c
++++ b/src/OVAL/probes/unix/linux/rpmverify_probe.c
+@@ -229,6 +229,7 @@ void *rpmverify_probe_init(void)
+ {
+ #ifdef RPM46_FOUND
+ 	rpmlogSetCallback(rpmErrorCb, NULL);
++	rpmSetVerbosity(RPMLOG_ERR);
+ #endif
+         if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
+                 dD("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
+--- a/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
++++ b/src/OVAL/probes/unix/linux/rpmverifyfile_probe.c
+@@ -348,6 +348,7 @@ void *rpmverifyfile_probe_init(void)
+ {
+ #ifdef RPM46_FOUND
+ 	rpmlogSetCallback(rpmErrorCb, NULL);
++	rpmSetVerbosity(RPMLOG_ERR);
+ #endif
+ 	if (rpmReadConfigFiles ((const char *)NULL, (const char *)NULL) != 0) {
+ 		dD("rpmReadConfigFiles failed: %u, %s.", errno, strerror (errno));
+--- a/src/OVAL/probes/unix/linux/rpmverifypackage_probe.c
++++ b/src/OVAL/probes/unix/linux/rpmverifypackage_probe.c
+@@ -338,6 +338,7 @@ void *rpmverifypackage_probe_init(void)
+ 
+ #ifdef RPM46_FOUND
+ 	rpmlogSetCallback(rpmErrorCb, NULL);
++	rpmSetVerbosity(RPMLOG_ERR);
+ #endif
+ 
+ 	if (CHROOT_IS_SET()) {

--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -46,6 +46,7 @@ build do
   patch source: "dpkginfo-init.patch", env: env # fix memory leak of pkgcache in dpkginfo probe
   patch source: "fsdev-ignore-host.patch", env: env # ignore /host directory in fsdev probe
   patch source: "systemd-dbus-address.patch", env: env # fix dbus address in systemd probe
+  patch source: "rpm-verbosity-err.patch", env: env # decrease rpmlog verbosity level to ERR
 
   patch source: "oscap-io.patch", env: env # add new oscap-io tool
 


### PR DESCRIPTION
### What does this PR do?

This change sets rpmlog verbosity to RPMLOG_ERR in OpenSCAP's RPM probe.

This should prevent the RPM library from printing the following warnings, which appear when opening the RPM database with the Berkeley DB compatibility mode:

```
warning: Found bdb_ro Packages database while attempting sqlite backend: using bdb_ro backend.
warning: could not open /var/lib/rpm/Filetriggername: No such file or directory
warning: could not open /var/lib/rpm/Transfiletriggername: No such file or directory
warning: could not open /var/lib/rpm/Recommendname: No such file or directory
warning: could not open /var/lib/rpm/Suggestname: No such file or directory
warning: could not open /var/lib/rpm/Supplementname: No such file or directory
warning: could not open /var/lib/rpm/Enhancename: No such file or directory
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
