### PR TITLE
[CWS][SEC-8451] Rebase activity tree on insertion of new exec-exec nodes

### DIFF
--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -243,7 +243,7 @@ func (at *ActivityTree) insert(event *model.Event, dryRun bool, generationType N
 		return false, fmt.Errorf("invalid event: %s", err)
 	}
 
-	node, newProcessNode, err := at.CreateProcessNode(event.ProcessCacheEntry, generationType, dryRun)
+	node, newProcessNode, err := at.CreateProcessNode(event.ProcessCacheEntry, nil, generationType, dryRun)
 	if err != nil {
 		return false, err
 	}
@@ -344,7 +344,7 @@ func GetNextAncestorBinaryOrArgv0(entry *model.ProcessContext) *model.ProcessCac
 
 // CreateProcessNode finds or a create a new process activity node in the activity dump if the entry
 // matches the activity dump selector.
-func (at *ActivityTree) CreateProcessNode(entry *model.ProcessCacheEntry, generationType NodeGenerationType, dryRun bool) (node *ProcessNode, newProcessNode bool, err error) {
+func (at *ActivityTree) CreateProcessNode(entry *model.ProcessCacheEntry, branch []*model.ProcessCacheEntry, generationType NodeGenerationType, dryRun bool) (node *ProcessNode, newProcessNode bool, err error) {
 	if entry == nil {
 		return nil, false, nil
 	}
@@ -369,9 +369,11 @@ func (at *ActivityTree) CreateProcessNode(entry *model.ProcessCacheEntry, genera
 		}
 	}()
 
+	branch = append([]*model.ProcessCacheEntry{entry}, branch...)
+
 	// find or create a ProcessActivityNode for the parent of the input ProcessCacheEntry. If the parent is a fork entry,
 	// jump immediately to the next ancestor.
-	parentNode, newProcessNode, err := at.CreateProcessNode(GetNextAncestorBinaryOrArgv0(&entry.ProcessContext), Snapshot, dryRun)
+	parentNode, newProcessNode, err := at.CreateProcessNode(GetNextAncestorBinaryOrArgv0(&entry.ProcessContext), branch, Snapshot, dryRun)
 	if err != nil || (newProcessNode && dryRun) {
 		// Explanation of (newProcessNode && dryRun): when dryRun is on, we can return as soon as we
 		// see something new in the tree. Although `newProcessNode` and `err` seem to be tied (i.e. newProcessNode is
@@ -390,15 +392,8 @@ func (at *ActivityTree) CreateProcessNode(entry *model.ProcessCacheEntry, genera
 		}
 
 		// go through the root nodes and check if one of them matches the input ProcessCacheEntry:
-		for _, root := range at.ProcessNodes {
-			if root.Matches(&entry.Process, at.differentiateArgs) {
-				return root, false, nil
-			}
-
-			// has root exec into one of its own children ?
-			if execChild := at.recursiveFindExecChild(root, entry); execChild != nil {
-				return execChild, false, nil
-			}
+		if branchRoot, newChildNode := at.findBranchInChildrenNodes(&at.ProcessNodes, branch, dryRun, generationType); branchRoot != nil {
+			return branchRoot, newChildNode, nil
 		}
 
 		// we're about to add a root process node, make sure this root node passes the root node sanitizer
@@ -418,18 +413,12 @@ func (at *ActivityTree) CreateProcessNode(entry *model.ProcessCacheEntry, genera
 		// if parentNode wasn't nil, then (at least) the parent is part of the activity dump. This means that we need
 		// to add the current entry no matter if it matches the selector or not. Go through the root children of the
 		// parent node and check if one of them matches the input ProcessCacheEntry.
-		for _, child := range parentNode.Children {
-			if child.Matches(&entry.Process, at.differentiateArgs) {
-				return child, false, nil
-			}
-
-			// has child exec into one of its own children ?
-			if execChild := at.recursiveFindExecChild(child, entry); execChild != nil {
-				return execChild, false, nil
-			}
+		branchRoot, newChildNode := at.findBranchInChildrenNodes(&parentNode.Children, branch, dryRun, generationType)
+		if branchRoot != nil {
+			return branchRoot, newChildNode || newProcessNode, nil
 		}
 
-		// if none of them matched, create a new ProcessActivityNode for the input processCacheEntry
+		// we haven't found anything, create a new ProcessActivityNode for the input processCacheEntry
 		if !dryRun {
 			node = NewProcessNode(entry, generationType)
 			// insert in the list of children
@@ -448,7 +437,92 @@ func (at *ActivityTree) CreateProcessNode(entry *model.ProcessCacheEntry, genera
 	return node, true, nil
 }
 
-func (at *ActivityTree) recursiveFindExecChild(child *ProcessNode, entry *model.ProcessCacheEntry) *ProcessNode {
+// findBranchInChildrenNodes looks for the provided branch in the list of children. Returns the node that matches the
+// first node of the branch and true if a new entry was inserted.
+func (at *ActivityTree) findBranchInChildrenNodes(tree *[]*ProcessNode, branch []*model.ProcessCacheEntry, dryRun bool, generationType NodeGenerationType) (*ProcessNode, bool) {
+	for i, branchCursor := range branch {
+
+		// look for eventExecChild in the tree
+		treeNodeToRebase, treeNodeToRebaseIndex := at.findProcessCacheEntryInChildrenNodes(tree, branchCursor)
+
+		// if found, append the input process sequence and rebase the tree
+		if treeNodeToRebase != nil {
+			// if this is the first iteration, we've just identified a direct match without looking for execs, return now
+			if i == 0 {
+				return treeNodeToRebase, false
+			}
+
+			// we're about to rebase part of the tree, exit early if this is a dry run
+			if dryRun {
+				return nil, true
+			}
+
+			// here is the current state of the tree:
+			//   parentNode (owner of tree) -> treeNodeToRebase -> [...] -> an existing node that matched children[i]
+			// here is what we want:
+			//   parentNode (owner of tree) -> children[0] -> children[i-1] -> treeNodeToRebase
+
+			// start by appending the entry
+			newNodesRoot := NewProcessNode(branch[0], generationType)
+			*tree = append(*tree, newNodesRoot)
+			at.Stats.ProcessNodes++
+			at.Stats.addedCount[model.ExecEventType][generationType].Inc()
+
+			// now add the children
+			childrenCursor := newNodesRoot
+			for _, eventExecChildTmp := range branch[1:i] {
+				n := NewProcessNode(eventExecChildTmp, generationType)
+				childrenCursor.Children = append(childrenCursor.Children, n)
+				at.Stats.ProcessNodes++
+				at.Stats.addedCount[model.ExecEventType][generationType].Inc()
+
+				childrenCursor = n
+			}
+
+			// attach the head of  to the last newly inserted child
+			childrenCursor.Children = append(childrenCursor.Children, (*tree)[treeNodeToRebaseIndex])
+			// rebase the tree, break the link between parent and treeNodeToRebase
+			*tree = append((*tree)[0:treeNodeToRebaseIndex], (*tree)[treeNodeToRebaseIndex+1:]...)
+
+			// now that the tree is ready, call the validator on the first node
+			at.validator.NewProcessNodeCallback(newNodesRoot)
+
+			// we need to return the node that matched `entry`
+			return newNodesRoot, true
+		} else {
+			// We didn't find the current entry anywhere, has it execed into something else ? (i.e. are we missing something
+			// in the profile ?)
+			if i+1 < len(branch) {
+				if !branchCursor.ExitTime.IsZero() && branch[i+1].ExecTime.Equal(branchCursor.ExitTime) {
+					continue
+				}
+			}
+
+			// if we're here, we've either reached the end of the list of children, or the next child wasn't
+			// directly exec-ed
+			break
+		}
+	}
+	return nil, false
+}
+
+// findProcessCacheEntryInChildrenNodes looks for the provided entry in the list of process nodes, returns the node (if
+// found) and the index of the top level child that lead to the node (if found) and its index (or -1 if not found).
+func (at *ActivityTree) findProcessCacheEntryInChildrenNodes(tree *[]*ProcessNode, entry *model.ProcessCacheEntry) (*ProcessNode, int) {
+	for i, child := range *tree {
+		if child.Matches(&entry.Process, at.differentiateArgs) {
+			return child, i
+		}
+
+		// has root exec into one of its own children ?
+		if execChild := at.recursiveFindEntryInChildNode(child, entry); execChild != nil {
+			return execChild, i
+		}
+	}
+	return nil, -1
+}
+
+func (at *ActivityTree) recursiveFindEntryInChildNode(child *ProcessNode, entry *model.ProcessCacheEntry) *ProcessNode {
 	// execedChild will be used if we don't find the node we're looking for and we detected that the parent process
 	// execed into one of its child without forking
 	var execedChild *ProcessNode
@@ -471,7 +545,7 @@ func (at *ActivityTree) recursiveFindExecChild(child *ProcessNode, entry *model.
 	}
 
 	// look recursively for its children
-	return at.recursiveFindExecChild(execedChild, entry)
+	return at.recursiveFindEntryInChildNode(execedChild, entry)
 }
 
 func (at *ActivityTree) FindMatchingRootNodes(arg0 string) []*ProcessNode {

--- a/pkg/security/security_profile/activity_tree/activity_tree_test.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_test.go
@@ -72,7 +72,7 @@ func TestInsertFileEvent(t *testing.T) {
 func TestActivityTree_Insert(t *testing.T) {
 	for _, tt := range activityTreeInsertTestCases {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := tt.tree.Insert(tt.inputEvent, Runtime)
+			newEntry, err := tt.tree.Insert(tt.inputEvent, Runtime)
 			if tt.wantErr != nil {
 				if !tt.wantErr(t, err, fmt.Sprintf("unexpected error: %v", err)) {
 					return
@@ -91,6 +91,7 @@ func TestActivityTree_Insert(t *testing.T) {
 			wantedResult := strings.TrimSpace(builder.String())
 
 			assert.Equalf(t, wantedResult, inputResult, "the generated tree didn't match the expected output")
+			assert.Equalf(t, tt.wantNewEntry, newEntry, "invalid newEntry output")
 		})
 	}
 }
@@ -590,9 +591,9 @@ var activityTreeInsertTestCases = []struct {
 	//          |                            |- /bin/bash                               |
 	//      /bin/webserver1                  |- /bin/ls                           /bin/webserver1
 	//          | (exec)                                                                | (exec)
-	//     /bin/webserver2----------                                              /bin/webserver2
-	//          | (exec)           |                                                    | (exec)
-	//     /bin/webserver3      /bin/id                                           /bin/webserver3
+	//     /bin/webserver2----------                                              /bin/webserver2---------
+	//          | (exec)           |                                                    | (exec)         |
+	//     /bin/webserver3      /bin/id                                           /bin/webserver3      /bin/id
 	//          | (exec)                                                                | (exec)
 	//     /bin/webserver4                                                        /bin/webserver4
 	//          | (exec)                                                                | (exec)
@@ -983,6 +984,1525 @@ var activityTreeInsertTestCases = []struct {
 															Process: model.Process{
 																FileEvent: model.FileEvent{
 																	PathnameStr: "/bin/wc",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// exec/8
+	// ---------------
+	//
+	//      /bin/bash          +          systemd                              ==>>              /bin/bash
+	//          |                            |- /bin/bash                                             |
+	//      /bin/ls                          |- /bin/webserver -> /bin/ls                       /bin/webserver
+	//                                                                                                | (exec)
+	//                                                                                             /bin/ls
+	{
+		name: "exec/8",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/ls",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 1,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/webserver",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+				ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 3,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+			},
+		}),
+		wantNewEntry: true,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+								ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/ls",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// exec/9
+	// ---------------
+	//
+	//      /bin/webserver      +          systemd                              ==>>              /bin/bash
+	//          |                            |- /bin/bash -> /bin/webserver                           | (exec)
+	//      /bin/ls                          |- /bin/ls                                         /bin/webserver
+	//                                                                                                |
+	//                                                                                             /bin/ls
+	{
+		name: "exec/9",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/webserver",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/ls",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 1,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+				ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/webserver",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 3,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+			},
+		}),
+		wantNewEntry: true,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						ExitTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/ls",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// exec/10
+	// ---------------
+	//
+	//      /bin/webserver      +          systemd                                              ==>>              /bin/bash
+	//          |                            |- /bin/bash -> /bin/webserver -> /bin/apache                           | (exec)
+	//      /bin/ls                          |- /bin/ls                                                         /bin/webserver------------
+	//                                                                                                               | (exec)            |
+	//                                                                                                          /bin/apache           /bin/ls
+	//                                                                                                               |
+	//                                                                                                            /bin/ls
+	{
+		name: "exec/10",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/webserver",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/ls",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 1,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+				ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/webserver",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+				ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/apache",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 3,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 4,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+			},
+		}),
+		wantNewEntry: true,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/ls",
+										},
+									},
+								},
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/apache",
+										},
+									},
+									Children: []*ProcessNode{
+										{
+											Process: model.Process{
+												ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/ls",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// exec/11
+	// ---------------
+	//
+	//      /bin/apache         +          systemd                                              ==>>              /bin/bash
+	//          |                            |- /bin/bash -> /bin/webserver -> /bin/apache                           | (exec)
+	//      /bin/ls                          |- /bin/ls                                                         /bin/webserver
+	//                                                                                                               | (exec)
+	//                                                                                                          /bin/apache
+	//                                                                                                               |
+	//                                                                                                            /bin/ls
+	{
+		name: "exec/11",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/apache",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/ls",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 1,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+				ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/webserver",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+				ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/apache",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 3,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 4,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+			},
+		}),
+		wantNewEntry: true,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/apache",
+										},
+									},
+									Children: []*ProcessNode{
+										{
+											Process: model.Process{
+												ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/ls",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// exec/12
+	// ---------------
+	//
+	//      /bin/apache         +          systemd                                              ==>>              /bin/bash
+	//          |                            |- /bin/bash -> /bin/webserver -> /bin/apache                           | (exec)
+	//       /bin/ls                         |- /bin/wc -> /bin/id -> /bin/ls                                   /bin/webserver
+	//          |                            |- /bin/date                                                            | (exec)
+	//       /bin/date                       |- /bin/passwd -> /bin/bpftool -> /bin/du                           /bin/apache
+	//          |                                                                                                     |
+	//       /bin/du                                                                                               /bin/wc
+	//                                                                                                               | (exec)
+	//                                                                                                            /bin/id
+	//                                                                                                               | (exec)
+	//                                                                                                            /bin/ls
+	//                                                                                                               |
+	//                                                                                                            /bin/date
+	//                                                                                                               |
+	//                                                                                                           /bin/passwd
+	//                                                                                                               | (exec)
+	//                                                                                                           /bin/bpftool
+	//                                                                                                               | (exec)
+	//                                                                                                           /bin/du
+	{
+		name: "exec/12",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/apache",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/ls",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/date",
+										},
+									},
+									Children: []*ProcessNode{
+										{
+											Process: model.Process{
+												ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/du",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 1,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+				ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/webserver",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+				ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/apache",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 3,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/wc",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 4,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+				ExitTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/id",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 5,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+				ExitTime: time.Date(2023, 06, 26, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 6,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 26, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/date",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 7,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 27, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/passwd",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 8,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 28, 1, 2, 3, 4, time.UTC),
+				ExitTime: time.Date(2023, 06, 29, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bpftool",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 9,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 29, 1, 2, 3, 4, time.UTC),
+				ExitTime: time.Date(2023, 06, 30, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/du",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 10,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 30, 1, 2, 3, 4, time.UTC),
+			},
+		}),
+		wantNewEntry: true,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/apache",
+										},
+									},
+									Children: []*ProcessNode{
+										{
+											Process: model.Process{
+												ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+												ExitTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/wc",
+												},
+											},
+											Children: []*ProcessNode{
+												{
+													Process: model.Process{
+														ExecTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+														ExitTime: time.Date(2023, 06, 26, 1, 2, 3, 4, time.UTC),
+														FileEvent: model.FileEvent{
+															PathnameStr: "/bin/id",
+														},
+													},
+													Children: []*ProcessNode{
+														{
+															Process: model.Process{
+																ExecTime: time.Date(2023, 06, 26, 1, 2, 3, 4, time.UTC),
+																FileEvent: model.FileEvent{
+																	PathnameStr: "/bin/ls",
+																},
+															},
+															Children: []*ProcessNode{
+																{
+																	Process: model.Process{
+																		ExecTime: time.Date(2023, 06, 27, 1, 2, 3, 4, time.UTC),
+																		FileEvent: model.FileEvent{
+																			PathnameStr: "/bin/date",
+																		},
+																	},
+																	Children: []*ProcessNode{
+																		{
+																			Process: model.Process{
+																				ExecTime: time.Date(2023, 06, 28, 1, 2, 3, 4, time.UTC),
+																				ExitTime: time.Date(2023, 06, 29, 1, 2, 3, 4, time.UTC),
+																				FileEvent: model.FileEvent{
+																					PathnameStr: "/bin/passwd",
+																				},
+																			},
+																			Children: []*ProcessNode{
+																				{
+																					Process: model.Process{
+																						ExecTime: time.Date(2023, 06, 29, 1, 2, 3, 4, time.UTC),
+																						ExitTime: time.Date(2023, 06, 30, 1, 2, 3, 4, time.UTC),
+																						FileEvent: model.FileEvent{
+																							PathnameStr: "/bin/bpftool",
+																						},
+																					},
+																					Children: []*ProcessNode{
+																						{
+																							Process: model.Process{
+																								ExecTime: time.Date(2023, 06, 30, 1, 2, 3, 4, time.UTC),
+																								FileEvent: model.FileEvent{
+																									PathnameStr: "/bin/du",
+																								},
+																							},
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// exec/13
+	// ---------------
+	//
+	//      /bin/webserver      +          systemd                              ==>>              /bin/bash
+	//          |                            |- /bin/bash -> /bin/webserver                           | (exec)
+	//      /bin/ls                          |- /bin/wc                                         /bin/webserver
+	//          | (exec)                                                                              |
+	//       /bin/wc                                                                               /bin/ls
+	//                                                                                                | (exec)
+	//                                                                                             /bin/wc
+	{
+		name: "exec/13",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/webserver",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/ls",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/wc",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 1,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+				ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/webserver",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 3,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+			},
+		}),
+		wantNewEntry: true,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						ExitTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+										ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/ls",
+										},
+									},
+									Children: []*ProcessNode{
+										{
+											Process: model.Process{
+												ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/wc",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// exec/14
+	// ---------------
+	//
+	//      /bin/webserver      +          systemd                                     ==>>              /bin/bash
+	//          | (exec)                     |- /bin/bash -> /bin/apache                                    | (exec)
+	//      /bin/apache                      |- /bin/ls                                               /bin/webserver
+	//          |                                                                                           | (exec)
+	//       /bin/wc                                                                                     /bin/apache------
+	//                                                                                                      |            |
+	//                                                                                                   /bin/wc       /bin/ls
+	{
+		name: "exec/14",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/webserver",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/apache",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/wc",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 1,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+				ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/apache",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 3,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+			},
+		}),
+		wantNewEntry: true,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						ExitTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+								ExitTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/apache",
+										},
+									},
+									Children: []*ProcessNode{
+										{
+											Process: model.Process{
+												ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/wc",
+												},
+											},
+										},
+										{
+											Process: model.Process{
+												ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/ls",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// exec/15
+	// ---------------
+	//
+	//      /bin/webserver      +          systemd                                             ==>>              /bin/bash
+	//          | (exec)                     |- /bin/bash -> /bin/du -> /bin/apache                                 | (exec)
+	//      /bin/date                        |- /bin/ls                                                          /bin/du
+	//          | (exec)                                                                                            | (exec)
+	//      /bin/apache                                                                                       /bin/webserver
+	//          |                                                                                                   | (exec)
+	//       /bin/wc                                                                                            /bin/date
+	//                                                                                                              | (exec)
+	//                                                                                                          /bin/apache------
+	//                                                                                                              |            |
+	//                                                                                                          /bin/wc       /bin/ls
+	{
+		name: "exec/15",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/webserver",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/date",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/apache",
+										},
+									},
+									Children: []*ProcessNode{
+										{
+											Process: model.Process{
+												ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/wc",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 1,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+				ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/du",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+				ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/apache",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 3,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 4,
+						},
+					},
+				},
+				ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+			},
+		}),
+		wantNewEntry: true,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						ExitTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+								ExitTime: time.Date(2023, 06, 21, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/du",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 21, 1, 2, 3, 4, time.UTC),
+										ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/webserver",
+										},
+									},
+									Children: []*ProcessNode{
+										{
+											Process: model.Process{
+												ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+												ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/date",
+												},
+											},
+											Children: []*ProcessNode{
+												{
+													Process: model.Process{
+														ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+														FileEvent: model.FileEvent{
+															PathnameStr: "/bin/apache",
+														},
+													},
+													Children: []*ProcessNode{
+														{
+															Process: model.Process{
+																ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+																FileEvent: model.FileEvent{
+																	PathnameStr: "/bin/wc",
+																},
+															},
+														},
+														{
+															Process: model.Process{
+																ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+																FileEvent: model.FileEvent{
+																	PathnameStr: "/bin/ls",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// exec/16
+	// ---------------
+	//
+	//      /bin/bash          +          systemd                 ==>>               /bin/bash
+	//          |                            |- /bin/bash                               |
+	//      /bin/webserver1                  |- /bin/webserver3                   /bin/webserver1
+	//          | (exec)                     |- /bin/ls                                 | (exec)
+	//     /bin/webserver2----------         |- /bin/date                         /bin/webserver2---------
+	//          | (exec)           |                                                    | (exec)         |
+	//     /bin/webserver3      /bin/id                                           /bin/webserver3      /bin/id
+	//          |                                                                       |
+	//     /bin/webserver4                                                        /bin/webserver4
+	//          | (exec)                                                                | (exec)
+	//       /bin/ls---------------                                                  /bin/ls----------------------------
+	//          |                 |                                                     |                |             |
+	//       /bin/wc           /bin/id                                               /bin/wc          /bin/id       /bin/date
+	{
+		name: "exec/16",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+								ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver1",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/webserver2",
+										},
+									},
+									Children: []*ProcessNode{
+										{
+											Process: model.Process{
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/id",
+												},
+											},
+										},
+										{
+											Process: model.Process{
+												ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/webserver3",
+												},
+											},
+											Children: []*ProcessNode{
+												{
+													Process: model.Process{
+														ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+														ExitTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+														FileEvent: model.FileEvent{
+															PathnameStr: "/bin/webserver4",
+														},
+													},
+													Children: []*ProcessNode{
+														{
+															Process: model.Process{
+																ExecTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+																FileEvent: model.FileEvent{
+																	PathnameStr: "/bin/ls",
+																},
+															},
+															Children: []*ProcessNode{
+																{
+																	Process: model.Process{
+																		FileEvent: model.FileEvent{
+																			PathnameStr: "/bin/id",
+																		},
+																	},
+																},
+																{
+																	Process: model.Process{
+																		FileEvent: model.FileEvent{
+																			PathnameStr: "/bin/wc",
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 1,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/webserver3",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 3,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/date",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 4,
+						},
+					},
+				},
+			},
+		}),
+		wantNewEntry: true,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+								ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver1",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/webserver2",
+										},
+									},
+									Children: []*ProcessNode{
+										{
+											Process: model.Process{
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/id",
+												},
+											},
+										},
+										{
+											Process: model.Process{
+												ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/webserver3",
+												},
+											},
+											Children: []*ProcessNode{
+												{
+													Process: model.Process{
+														ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+														ExitTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+														FileEvent: model.FileEvent{
+															PathnameStr: "/bin/webserver4",
+														},
+													},
+													Children: []*ProcessNode{
+														{
+															Process: model.Process{
+																ExecTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+																FileEvent: model.FileEvent{
+																	PathnameStr: "/bin/ls",
+																},
+															},
+															Children: []*ProcessNode{
+																{
+																	Process: model.Process{
+																		FileEvent: model.FileEvent{
+																			PathnameStr: "/bin/id",
+																		},
+																	},
+																},
+																{
+																	Process: model.Process{
+																		FileEvent: model.FileEvent{
+																			PathnameStr: "/bin/wc",
+																		},
+																	},
+																},
+																{
+																	Process: model.Process{
+																		FileEvent: model.FileEvent{
+																			PathnameStr: "/bin/date",
+																		},
+																	},
 																},
 															},
 														},

--- a/pkg/security/security_profile/activity_tree/activity_tree_test.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_test.go
@@ -69,10 +69,10 @@ func TestInsertFileEvent(t *testing.T) {
 	assert.Equal(t, expectedDebugOuput, debugOutput)
 }
 
-func TestActivityTree_Insert(t *testing.T) {
-	for _, tt := range activityTreeInsertTestCases {
+func TestActivityTree_InsertExecEvent(t *testing.T) {
+	for _, tt := range activityTreeInsertExecEventTestCases {
 		t.Run(tt.name, func(t *testing.T) {
-			newEntry, err := tt.tree.Insert(tt.inputEvent, Runtime)
+			node, newEntry, err := tt.tree.CreateProcessNode(tt.inputEvent.ProcessCacheEntry, nil, Runtime, false)
 			if tt.wantErr != nil {
 				if !tt.wantErr(t, err, fmt.Sprintf("unexpected error: %v", err)) {
 					return
@@ -92,6 +92,7 @@ func TestActivityTree_Insert(t *testing.T) {
 
 			assert.Equalf(t, wantedResult, inputResult, "the generated tree didn't match the expected output")
 			assert.Equalf(t, tt.wantNewEntry, newEntry, "invalid newEntry output")
+			assert.Equalf(t, tt.wantNode.Process.FileEvent.PathnameStr, node.Process.FileEvent.PathnameStr, "the returned ProcessNode is invalid")
 		})
 	}
 }
@@ -162,13 +163,14 @@ func newExecTestEventWithAncestors(lineage []model.Process) *model.Event {
 	return evt
 }
 
-var activityTreeInsertTestCases = []struct {
+var activityTreeInsertExecEventTestCases = []struct {
 	name         string
 	tree         *ActivityTree
 	inputEvent   *model.Event
 	wantNewEntry bool
 	wantErr      assert.ErrorAssertionFunc
 	wantTree     *ActivityTree
+	wantNode     *ProcessNode
 }{
 	// exec/1
 	// ---------------
@@ -206,6 +208,13 @@ var activityTreeInsertTestCases = []struct {
 				},
 			},
 		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+				},
+			},
+		},
 		wantNewEntry: true,
 		wantTree: &ActivityTree{
 			ProcessNodes: []*ProcessNode{
@@ -274,6 +283,13 @@ var activityTreeInsertTestCases = []struct {
 				},
 			},
 		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+				},
+			},
+		},
 		wantNewEntry: true,
 		wantTree: &ActivityTree{
 			ProcessNodes: []*ProcessNode{
@@ -365,6 +381,13 @@ var activityTreeInsertTestCases = []struct {
 				},
 			},
 		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+				},
+			},
+		},
 		wantNewEntry: true,
 		wantTree: &ActivityTree{
 			ProcessNodes: []*ProcessNode{
@@ -476,6 +499,13 @@ var activityTreeInsertTestCases = []struct {
 				},
 			},
 		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+				},
+			},
+		},
 		wantNewEntry: false,
 		wantTree: &ActivityTree{
 			ProcessNodes: []*ProcessNode{
@@ -558,6 +588,13 @@ var activityTreeInsertTestCases = []struct {
 				},
 			},
 		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+				},
+			},
+		},
 		wantNewEntry: false,
 		wantTree: &ActivityTree{
 			ProcessNodes: []*ProcessNode{
@@ -717,6 +754,13 @@ var activityTreeInsertTestCases = []struct {
 				},
 			},
 		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+				},
+			},
+		},
 		wantNewEntry: false,
 		wantTree: &ActivityTree{
 			ProcessNodes: []*ProcessNode{
@@ -919,6 +963,13 @@ var activityTreeInsertTestCases = []struct {
 				},
 			},
 		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+				},
+			},
+		},
 		wantNewEntry: false,
 		wantTree: &ActivityTree{
 			ProcessNodes: []*ProcessNode{
@@ -1073,6 +1124,13 @@ var activityTreeInsertTestCases = []struct {
 				ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 			},
 		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+				},
+			},
+		},
 		wantNewEntry: true,
 		wantTree: &ActivityTree{
 			ProcessNodes: []*ProcessNode{
@@ -1182,6 +1240,13 @@ var activityTreeInsertTestCases = []struct {
 				ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
 			},
 		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+				},
+			},
+		},
 		wantNewEntry: true,
 		wantTree: &ActivityTree{
 			ProcessNodes: []*ProcessNode{
@@ -1306,6 +1371,13 @@ var activityTreeInsertTestCases = []struct {
 				ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
 			},
 		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+				},
+			},
+		},
 		wantNewEntry: true,
 		wantTree: &ActivityTree{
 			ProcessNodes: []*ProcessNode{
@@ -1449,6 +1521,13 @@ var activityTreeInsertTestCases = []struct {
 				ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
 			},
 		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+				},
+			},
+		},
 		wantNewEntry: true,
 		wantTree: &ActivityTree{
 			ProcessNodes: []*ProcessNode{
@@ -1692,6 +1771,13 @@ var activityTreeInsertTestCases = []struct {
 				ExecTime: time.Date(2023, 06, 30, 1, 2, 3, 4, time.UTC),
 			},
 		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/du",
+				},
+			},
+		},
 		wantNewEntry: true,
 		wantTree: &ActivityTree{
 			ProcessNodes: []*ProcessNode{
@@ -1889,6 +1975,13 @@ var activityTreeInsertTestCases = []struct {
 				ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
 			},
 		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+				},
+			},
+		},
 		wantNewEntry: true,
 		wantTree: &ActivityTree{
 			ProcessNodes: []*ProcessNode{
@@ -2022,6 +2115,13 @@ var activityTreeInsertTestCases = []struct {
 				ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
 			},
 		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+				},
+			},
+		},
 		wantNewEntry: true,
 		wantTree: &ActivityTree{
 			ProcessNodes: []*ProcessNode{
@@ -2191,6 +2291,13 @@ var activityTreeInsertTestCases = []struct {
 				ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
 			},
 		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+				},
+			},
+		},
 		wantNewEntry: true,
 		wantTree: &ActivityTree{
 			ProcessNodes: []*ProcessNode{
@@ -2422,6 +2529,13 @@ var activityTreeInsertTestCases = []struct {
 				},
 			},
 		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/date",
+				},
+			},
+		},
 		wantNewEntry: true,
 		wantTree: &ActivityTree{
 			ProcessNodes: []*ProcessNode{

--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -633,7 +633,7 @@ func (adm *ActivityDumpManager) SearchTracedProcessCacheEntryCallback(ad *Activi
 		}
 
 		for _, parent = range ancestors {
-			_, _, err := ad.ActivityTree.CreateProcessNode(parent, activity_tree.Snapshot, false)
+			_, _, err := ad.ActivityTree.CreateProcessNode(parent, nil, activity_tree.Snapshot, false)
 			if err != nil {
 				// if one of the parents wasn't inserted, leave now
 				break


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR introduces the ability to rebase an activity tree when a new intermediary `exec-exec` node is inserted in an Activity Tree. One layer of recursion was also removed. For example:

```
//      /bin/bash          +          systemd                              ==>>              /bin/bash
//          |                            |- /bin/bash                                             |
//      /bin/ls                          |- /bin/webserver -> /bin/ls                       /bin/webserver
//                                                                                                | (exec)
//                                                                                             /bin/ls
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This is necessary to improve the reliability of our generated Security Snapshots and Security Profiles. This is the second "fix" for the exec-exec issue.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
