### PR TITLE
[usm][npm] Use LRU map type for `connection_protocol` when available

### DIFF
--- a/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
+++ b/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
@@ -7,6 +7,9 @@
 
 // Maps a connection tuple to its classified protocol. Used to reduce redundant
 // classification procedures on the same connection
+// Note that LRU maps were introduced in Kernel 4.10, but protocol
+// classification is supported by >= 4.7. For kernel releases within this range
+// we replace the LRU map by a regular HashMap during eBPF program load time.
 BPF_LRU_MAP(connection_protocol, conn_tuple_t, protocol_stack_t, 0)
 
 static __always_inline protocol_stack_t* get_protocol_stack(conn_tuple_t *skb_tup) {

--- a/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
+++ b/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
@@ -7,7 +7,7 @@
 
 // Maps a connection tuple to its classified protocol. Used to reduce redundant
 // classification procedures on the same connection
-BPF_HASH_MAP(connection_protocol, conn_tuple_t, protocol_stack_t, 0)
+BPF_LRU_MAP(connection_protocol, conn_tuple_t, protocol_stack_t, 0)
 
 static __always_inline protocol_stack_t* get_protocol_stack(conn_tuple_t *skb_tup) {
     conn_tuple_t normalized_tup = *skb_tup;


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Use LRU map type for the `connection_protocol` map.

### Motivation

During the 7.46 QA process we have determined that this particular map is leaking in certain workloads. This is a long standing bug and predates the current release, but it has been affecting the USM data accuracy since the recent refactoring introduced by https://github.com/DataDog/datadog-agent/pull/16167

The current PR should be regarded as workaround while we investigate the underlying root cause that is being responsible for filling up the map. Here we replace it by a LRU map type which should prevent USM data accuracy to drop when the map reaches capacity.

Also note that while we are aware of the CPU contention that can be caused during LRU evictions we believe that impact should be negligible in this case since the leak rate is relatively slow and therefore we don't expect that eviction rate to be that high (we have observed something around <10 entries/s leaking in a busy node). We obviously plan to test this thoroughly to ensure no regressions are introduced.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
