### PR TITLE
Add information about defaulted limit and use it in process-agent

### DIFF
--- a/pkg/process/util/containers.go
+++ b/pkg/process/util/containers.go
@@ -195,11 +195,15 @@ func computeContainerStats(hostCPUCount float64, inStats *metrics.ContainerStats
 		outPreviousStats.UserCPU = statValue(inStats.CPU.User, -1)
 		outPreviousStats.SystemCPU = statValue(inStats.CPU.System, -1)
 
-		outStats.CpuLimit = float32(statValue(inStats.CPU.Limit, 0))
 		outStats.TotalPct = float32(cpuRatePctValue(outPreviousStats.TotalCPU, previousStats.TotalCPU, hostCPUCount, inStats.Timestamp, previousStats.ContainerStatsTimestamp))
 		outStats.UserPct = float32(cpuRatePctValue(outPreviousStats.UserCPU, previousStats.UserCPU, hostCPUCount, inStats.Timestamp, previousStats.ContainerStatsTimestamp))
 		outStats.SystemPct = float32(cpuRatePctValue(outPreviousStats.SystemCPU, previousStats.SystemCPU, hostCPUCount, inStats.Timestamp, previousStats.ContainerStatsTimestamp))
 		outStats.CpuUsageNs = float32(cpuRateValue(outPreviousStats.TotalCPU, previousStats.TotalCPU, inStats.Timestamp, previousStats.ContainerStatsTimestamp))
+
+		// We only emit limit if it was not defaulted
+		if !inStats.CPU.DefaultedLimit {
+			outStats.CpuLimit = float32(statValue(inStats.CPU.Limit, 0))
+		}
 	}
 
 	if inStats.Memory != nil {

--- a/pkg/process/util/containers_test.go
+++ b/pkg/process/util/containers_test.go
@@ -170,6 +170,7 @@ func TestGetContainers(t *testing.T) {
 
 	// cID5 garden container full stats (replacing Linux WorkingSet with CommitBytes)
 	cID5Metrics := mock.GetFullSampleContainerEntry()
+	cID5Metrics.ContainerStats.CPU.DefaultedLimit = true
 	cID5Metrics.ContainerStats.Timestamp = testTime
 	cID5Metrics.NetworkStats.Timestamp = testTime
 	cID5Metrics.ContainerStats.PID.PIDs = []int{6, 7}
@@ -398,7 +399,7 @@ func TestGetContainers(t *testing.T) {
 		{
 			Type:         "garden",
 			Id:           "cID5",
-			CpuLimit:     50,
+			CpuLimit:     0,
 			MemoryLimit:  42000,
 			State:        process.ContainerState_running,
 			Created:      testTime.Unix(),
@@ -607,7 +608,7 @@ func TestGetContainers(t *testing.T) {
 		{
 			Type:         "garden",
 			Id:           "cID5",
-			CpuLimit:     50,
+			CpuLimit:     0,
 			MemoryLimit:  42000,
 			State:        process.ContainerState_running,
 			Created:      testTime.Unix(),

--- a/pkg/util/containers/metrics/containerd/collector_linux.go
+++ b/pkg/util/containers/metrics/containerd/collector_linux.go
@@ -58,6 +58,7 @@ func fillStatsFromSpec(outContainerStats *provider.ContainerStats, spec *oci.Spe
 	// Always reporting a limit allows to compute CPU % accurately.
 	if outContainerStats.CPU.Limit == nil {
 		outContainerStats.CPU.Limit = pointer.Ptr(100 * float64(system.HostCPUCount()))
+		outContainerStats.CPU.DefaultedLimit = true
 	}
 }
 

--- a/pkg/util/containers/metrics/containerd/collector_linux_test.go
+++ b/pkg/util/containers/metrics/containerd/collector_linux_test.go
@@ -443,7 +443,8 @@ func Test_fillStatsFromSpec(t *testing.T) {
 			},
 			expected: &provider.ContainerStats{
 				CPU: &provider.ContainerCPUStats{
-					Limit: pointer.Ptr(100 * float64(system.HostCPUCount())),
+					Limit:          pointer.Ptr(100 * float64(system.HostCPUCount())),
+					DefaultedLimit: true,
 				},
 			},
 		},

--- a/pkg/util/containers/metrics/containerd/collector_windows.go
+++ b/pkg/util/containers/metrics/containerd/collector_windows.go
@@ -119,5 +119,6 @@ func fillStatsFromSpec(outContainerStats *provider.ContainerStats, spec *oci.Spe
 	// Always reporting a limit allows to compute CPU % accurately.
 	if outContainerStats.CPU != nil && outContainerStats.CPU.Limit == nil {
 		outContainerStats.CPU.Limit = pointer.Ptr(100 * float64(system.HostCPUCount()))
+		outContainerStats.CPU.DefaultedLimit = true
 	}
 }

--- a/pkg/util/containers/metrics/containerd/collector_windows_test.go
+++ b/pkg/util/containers/metrics/containerd/collector_windows_test.go
@@ -233,7 +233,8 @@ func Test_fillStatsFromSpec(t *testing.T) {
 			},
 			expected: &provider.ContainerStats{
 				CPU: &provider.ContainerCPUStats{
-					Limit: pointer.Ptr(100 * float64(system.HostCPUCount())),
+					Limit:          pointer.Ptr(100 * float64(system.HostCPUCount())),
+					DefaultedLimit: true,
 				},
 				Memory: &provider.ContainerMemStats{
 					Limit: pointer.Ptr(500.0),

--- a/pkg/util/containers/metrics/docker/collector_linux.go
+++ b/pkg/util/containers/metrics/docker/collector_linux.go
@@ -156,6 +156,7 @@ func computeCPULimit(containerStats *provider.ContainerStats, spec *types.Contai
 		// If no limit is available, setting the limit to number of CPUs.
 		// Always reporting a limit allows to compute CPU % accurately.
 		cpuLimit = 100 * float64(systemutils.HostCPUCount())
+		containerStats.CPU.DefaultedLimit = true
 	}
 
 	containerStats.CPU.Limit = &cpuLimit

--- a/pkg/util/containers/metrics/docker/collector_windows.go
+++ b/pkg/util/containers/metrics/docker/collector_windows.go
@@ -77,6 +77,7 @@ func computeCPULimit(containerStats *provider.ContainerStats, spec *types.Contai
 		// If no limit is available, setting the limit to number of CPUs.
 		// Always reporting a limit allows to compute CPU % accurately.
 		cpuLimit = 100 * float64(system.HostCPUCount())
+		containerStats.CPU.DefaultedLimit = true
 	}
 
 	containerStats.CPU.Limit = &cpuLimit

--- a/pkg/util/containers/metrics/provider/types.go
+++ b/pkg/util/containers/metrics/provider/types.go
@@ -37,10 +37,11 @@ type ContainerMemStats struct {
 // ContainerCPUStats stores CPU stats.
 type ContainerCPUStats struct {
 	// Common fields
-	Total  *float64
-	System *float64
-	User   *float64
-	Limit  *float64 // Percentage 0-100*numCPU
+	Total          *float64
+	System         *float64
+	User           *float64
+	Limit          *float64 // Percentage 0-100*numCPU
+	DefaultedLimit bool     // If Limit != nil, indicated if limit was explicit from container or defaulted to # of host CPUs
 
 	// Linux-only fields
 	Shares           *float64

--- a/pkg/util/containers/metrics/system/collector_linux.go
+++ b/pkg/util/containers/metrics/system/collector_linux.go
@@ -257,13 +257,14 @@ func buildCPUStats(cgs *cgroups.CPUStats, parentCPUStatsRetriever func(parentCPU
 	convertFieldAndUnit(cgs.PSISome.Total, &cs.PartialStallTime, float64(time.Microsecond))
 
 	// Compute complex fields
-	cs.Limit = computeCPULimitPct(cgs, parentCPUStatsRetriever)
+	cs.Limit, cs.DefaultedLimit = computeCPULimitPct(cgs, parentCPUStatsRetriever)
 
 	return cs
 }
 
-func computeCPULimitPct(cgs *cgroups.CPUStats, parentCPUStatsRetriever func(parentCPUStats *cgroups.CPUStats) error) *float64 {
+func computeCPULimitPct(cgs *cgroups.CPUStats, parentCPUStatsRetriever func(parentCPUStats *cgroups.CPUStats) error) (*float64, bool) {
 	limitPct := computeCgroupCPULimitPct(cgs)
+	defaulted := false
 
 	// Check parent cgroup as it's used on ECS
 	if limitPct == nil {
@@ -277,9 +278,10 @@ func computeCPULimitPct(cgs *cgroups.CPUStats, parentCPUStatsRetriever func(pare
 	// Always reporting a limit allows to compute CPU % accurately.
 	if limitPct == nil {
 		limitPct = pointer.Ptr(float64(systemutils.HostCPUCount() * 100))
+		defaulted = true
 	}
 
-	return limitPct
+	return limitPct, defaulted
 }
 
 func computeCgroupCPULimitPct(cgs *cgroups.CPUStats) *float64 {

--- a/pkg/util/containers/metrics/system/collector_linux_test.go
+++ b/pkg/util/containers/metrics/system/collector_linux_test.go
@@ -235,7 +235,8 @@ func TestBuildContainerMetrics(t *testing.T) {
 			},
 			wantStats: &provider.ContainerStats{
 				CPU: &provider.ContainerCPUStats{
-					Limit: pointer.Ptr(float64(utilsystem.HostCPUCount()) * 100),
+					Limit:          pointer.Ptr(float64(utilsystem.HostCPUCount()) * 100),
+					DefaultedLimit: true,
 				},
 				PID:    &provider.ContainerPIDStats{},
 				Memory: &provider.ContainerMemStats{},


### PR DESCRIPTION
### What does this PR do?

Add information about whether a CPU limit was defaulted or not.
Use it in the `process-agent` to avoid sending defaulted limits as it makes the backend believes that it was an explicit limit producing an inaccurate display.

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Agent and a container without limit. Hovering the CPU Usage % in the Live Container View should say `% of host CPU` instead of `% of container limit`.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
