### PR TITLE
[RCM] Add proxy error for remote-config

### DIFF
--- a/pkg/config/remote/api/http.go
+++ b/pkg/config/remote/api/http.go
@@ -32,6 +32,12 @@ var (
 	// ErrUnauthorized is the error that will be logged for the customer to see in case of a 401. We make it as
 	// descriptive as possible (while not leaking data) to make RC onboarding easier
 	ErrUnauthorized = fmt.Errorf("unauthorized. Please make sure your API key is valid and has the Remote Config scope")
+	// ErrProxy is the error that will be logged if we suspect that there is a wrong proxy setup for remote-config.
+	// It is displayed for any 4XX status code except 401
+	ErrProxy = fmt.Errorf(
+		"4XX status code. This might be related to the proxy settings. " +
+			"Please make sure the agent can reach Remote Configuration with the proxy setup",
+	)
 )
 
 // API is the interface to implement for a configuration fetcher
@@ -115,6 +121,10 @@ func (c *HTTPClient) Fetch(ctx context.Context, request *pbgo.LatestConfigsReque
 		return nil, ErrUnauthorized
 	}
 
+	if resp.StatusCode >= 400 && resp.StatusCode <= 499 {
+		return nil, fmt.Errorf("%w: %d", ErrProxy, resp.StatusCode)
+	}
+
 	// Any other error will have a generic message
 	if resp.StatusCode != 200 {
 		body, err = io.ReadAll(resp.Body)
@@ -162,6 +172,10 @@ func (c *HTTPClient) FetchOrgData(ctx context.Context) (*pbgo.OrgDataResponse, e
 	// to fix this as the error is pretty common
 	if resp.StatusCode == 401 {
 		return nil, ErrUnauthorized
+	}
+
+	if resp.StatusCode >= 400 && resp.StatusCode <= 499 {
+		return nil, fmt.Errorf("%w: %d", ErrProxy, resp.StatusCode)
 	}
 
 	// Any other error will have a generic message


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

With RC enabled by default, the agent can receive expected non-401 4XX errors. If the proxy between the agent and the backend is not setup for `config.datadoghq.com`, the agent can receive such error codes.

See https://docs.datadoghq.com/agent/guide/network/?tab=agentv6v7

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
