### PR TITLE
fix(cluster-check): update node busyness score

### DIFF
--- a/cmd/agent/subcommands/run/internal/clcrunnerapi/v1/clcrunner.go
+++ b/cmd/agent/subcommands/run/internal/clcrunnerapi/v1/clcrunner.go
@@ -37,7 +37,7 @@ func SetupHandlers(r *mux.Router) {
 // getCLCRunnerStats retrieves Cluster Level Check runners stats
 func getCLCRunnerStats(w http.ResponseWriter, r *http.Request) {
 	log.Info("Got a request for the runner stats. Making stats.")
-	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set("Content-Type", "application/json")
 	stats, err := status.GetExpvarRunnerStats()
 	if err != nil {
 		log.Errorf("Error getting exp var stats: %v", err)

--- a/pkg/clusteragent/clusterchecks/helpers.go
+++ b/pkg/clusteragent/clusterchecks/helpers.go
@@ -16,8 +16,10 @@ import (
 )
 
 var (
-	checkExecutionTimeWeight float64 = 0
-	checkMetricSamplesWeight float64 = 1
+	checkExecutionTimeWeight   float64 = 0
+	checkMetricSamplesWeight   float64 = 1
+	checkHistogramBucketWeight float64 = 1
+	checkEventsWeight          float64 = 0.2
 )
 
 // makeConfigArray flattens a map of configs into a slice. Creating a new slice
@@ -55,7 +57,10 @@ func busynessFunc(s types.CLCRunnerStats) int {
 		// The check is failing, its weight is 0
 		return 0
 	}
-	return int(checkExecutionTimeWeight*float64(s.AverageExecutionTime) + checkMetricSamplesWeight*float64(s.MetricSamples))
+	return int(checkExecutionTimeWeight*float64(s.AverageExecutionTime) +
+		checkMetricSamplesWeight*float64(s.MetricSamples) +
+		checkHistogramBucketWeight*float64(s.HistogramBuckets) +
+		checkEventsWeight*float64(s.Events))
 }
 
 // orderedKeys sorts the keys of a map and return them in a slice

--- a/pkg/clusteragent/clusterchecks/helpers_test.go
+++ b/pkg/clusteragent/clusterchecks/helpers_test.go
@@ -91,6 +91,57 @@ func Test_calculateBusyness(t *testing.T) {
 			},
 			want: 200,
 		},
+		{
+			name: "with histogrambuckets case",
+			stats: types.CLCRunnersStats{
+				"cluster check": types.CLCRunnerStats{
+					AverageExecutionTime: 100,
+					MetricSamples:        100,
+					HistogramBuckets:     100,
+					IsClusterCheck:       true,
+				},
+				"node check": types.CLCRunnerStats{
+					AverageExecutionTime: 100,
+					MetricSamples:        100,
+					HistogramBuckets:     100,
+					IsClusterCheck:       false,
+				},
+				"failed check": types.CLCRunnerStats{
+					AverageExecutionTime: 100,
+					MetricSamples:        100,
+					HistogramBuckets:     100,
+					LastExecFailed:       true,
+				},
+			},
+			want: 400,
+		},
+		{
+			name: "with events case",
+			stats: types.CLCRunnersStats{
+				"cluster check": types.CLCRunnerStats{
+					AverageExecutionTime: 100,
+					MetricSamples:        100,
+					HistogramBuckets:     100,
+					Events:               100,
+					IsClusterCheck:       true,
+				},
+				"node check": types.CLCRunnerStats{
+					AverageExecutionTime: 100,
+					MetricSamples:        100,
+					HistogramBuckets:     100,
+					Events:               100,
+					IsClusterCheck:       false,
+				},
+				"failed check": types.CLCRunnerStats{
+					AverageExecutionTime: 100,
+					MetricSamples:        100,
+					HistogramBuckets:     100,
+					Events:               100,
+					LastExecFailed:       true,
+				},
+			},
+			want: 440,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/clusteragent/clusterchecks/types/types.go
+++ b/pkg/clusteragent/clusterchecks/types/types.go
@@ -84,6 +84,8 @@ type CLCRunnersStats map[string]CLCRunnerStats
 type CLCRunnerStats struct {
 	AverageExecutionTime int  `json:"AverageExecutionTime"`
 	MetricSamples        int  `json:"MetricSamples"`
+	HistogramBuckets     int  `json:"HistogramBuckets"`
+	Events               int  `json:"Events"`
 	IsClusterCheck       bool `json:"IsClusterCheck"`
 	LastExecFailed       bool `json:"LastExecFailed"`
 }

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -19,13 +19,15 @@ func Test_convertExpvarRunnerStats(t *testing.T) {
 	}{
 		{
 			name:      "no error present",
-			inputJSON: []byte(`{"Checks": {"foo": {"id1": {"AverageExecutionTime": 42, "MetricSamples": 100, "LastError": ""}}}}`),
+			inputJSON: []byte(`{"Checks": {"foo": {"id1": {"AverageExecutionTime": 42, "MetricSamples": 100, "HistogramBuckets": 50, "Events": 200, "LastError": ""}}}}`),
 			want: CLCChecks{
 				Checks: map[string]map[string]CLCStats{
 					"foo": {
 						"id1": {
 							AverageExecutionTime: 42,
 							MetricSamples:        100,
+							HistogramBuckets:     50,
+							Events:               200,
 							LastExecFailed:       false,
 						},
 					},
@@ -35,13 +37,15 @@ func Test_convertExpvarRunnerStats(t *testing.T) {
 		},
 		{
 			name:      "error present",
-			inputJSON: []byte(`{"Checks": {"foo": {"id1": {"AverageExecutionTime": 42, "MetricSamples": 100, "LastError": "this is an error"}}}}`),
+			inputJSON: []byte(`{"Checks": {"foo": {"id1": {"AverageExecutionTime": 42, "MetricSamples": 100, "HistogramBuckets": 50, "Events": 200, "LastError": "this is an error"}}}}`),
 			want: CLCChecks{
 				Checks: map[string]map[string]CLCStats{
 					"foo": {
 						"id1": {
 							AverageExecutionTime: 42,
 							MetricSamples:        100,
+							HistogramBuckets:     50,
+							Events:               200,
 							LastExecFailed:       true,
 						},
 					},

--- a/pkg/status/types.go
+++ b/pkg/status/types.go
@@ -20,6 +20,8 @@ type CLCChecks struct {
 type CLCStats struct {
 	AverageExecutionTime int  `json:"AverageExecutionTime"`
 	MetricSamples        int  `json:"MetricSamples"`
+	HistogramBuckets     int  `json:"HistogramBuckets"`
+	Events               int  `json:"Events"`
 	LastExecFailed       bool `json:"LastExecFailed"`
 }
 
@@ -31,6 +33,8 @@ func (d *CLCStats) UnmarshalJSON(data []byte) error {
 	}
 	d.AverageExecutionTime = int(stats.AverageExecutionTime)
 	d.MetricSamples = int(stats.MetricSamples)
+	d.HistogramBuckets = int(stats.HistogramBuckets)
+	d.Events = int(stats.Events)
 	if stats.LastError != "" {
 		d.LastExecFailed = true
 	} else {

--- a/releasenotes-dca/notes/clc-busyness-score-logic-update-0d1d1b3f8cef927f.yaml
+++ b/releasenotes-dca/notes/clc-busyness-score-logic-update-0d1d1b3f8cef927f.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Expose to cluster-agent HistogramBuckets and Events check stats.
+    It should help the cluster-agent to define a better cluster-checks
+    dispatching.


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Expose to "cluster-agent" `HistogramBuckets` and `Events` check stats.
The cluster-checks instances and Node busyness score will reflect better the real check resources (CPU/Memory) usage.

It should help the cluster-agent to define a better cluster-checks dispatching.

### Motivation

Currently if a cluster-check only emit Histogram or Events, the cluster-check instance is seen by the cluster-agent as
not consuming any resource (busyness score). It makes the cluster-check dispatching wrong.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Deploy the Cluster-Agent with Cluster-Check-Runner enable.
Deploy an application that expose an Openmetrics check returning only histogram data. For that you can use the the "metrics" filter parameter to only select histogram metrics.

The cluster-agent metrics `datadog.cluster_agent.cluster_checks.busyness` should not be 0.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
