### PR TITLE
[CWS] remove `interface{}` and map of maps in invalid discarder check

### DIFF
--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -81,7 +81,7 @@ var (
 )
 
 var (
-	dentryInvalidDiscarder = []interface{}{""}
+	dentryInvalidDiscarder = []string{""}
 	eventZeroDiscarder     = &model.Event{
 		FieldHandlers:    &model.DefaultFieldHandlers{},
 		ContainerContext: &model.ContainerContext{},
@@ -89,7 +89,7 @@ var (
 )
 
 // InvalidDiscarders exposes list of values that are not discarders
-var InvalidDiscarders = map[eval.Field][]interface{}{
+var InvalidDiscarders = map[eval.Field][]string{
 	"open.file.path":               dentryInvalidDiscarder,
 	"unlink.file.path":             dentryInvalidDiscarder,
 	"chmod.file.path":              dentryInvalidDiscarder,
@@ -528,13 +528,13 @@ func isInvalidDiscarder(field eval.Field, value string) bool {
 }
 
 // rearrange invalid discarders for fast lookup
-func createInvalidDiscardersCache() map[eval.Field]map[interface{}]bool {
-	invalidDiscarders := make(map[eval.Field]map[interface{}]bool)
+func createInvalidDiscardersCache() map[eval.Field]map[string]bool {
+	invalidDiscarders := make(map[eval.Field]map[string]bool)
 
 	for field, values := range InvalidDiscarders {
 		ivalues := invalidDiscarders[field]
 		if ivalues == nil {
-			ivalues = make(map[interface{}]bool)
+			ivalues = make(map[string]bool)
 			invalidDiscarders[field] = ivalues
 		}
 		for _, value := range values {
@@ -700,7 +700,7 @@ func dumpDiscarders(resolver *dentry.Resolver, pidMap, inodeMap, statsFB, statsB
 	return dump, nil
 }
 
-var invalidDiscarders map[eval.Field]map[interface{}]bool
+var invalidDiscarders map[eval.Field]map[string]bool
 
 func init() {
 	invalidDiscarders = createInvalidDiscardersCache()

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -519,26 +519,22 @@ func filenameDiscarderWrapper(eventType model.EventType, getter inodeEventGetter
 
 // isInvalidDiscarder returns whether the given value is a valid discarder for the given field
 func isInvalidDiscarder(field eval.Field, value string) bool {
-	values, exists := invalidDiscarders[field]
-	if !exists {
-		return false
-	}
-
-	return values[value]
+	return invalidDiscarders[invalidDiscarderEntry{
+		field: field,
+		value: value,
+	}]
 }
 
 // rearrange invalid discarders for fast lookup
-func createInvalidDiscardersCache() map[eval.Field]map[string]bool {
-	invalidDiscarders := make(map[eval.Field]map[string]bool)
+func createInvalidDiscardersCache() map[invalidDiscarderEntry]bool {
+	invalidDiscarders := make(map[invalidDiscarderEntry]bool)
 
 	for field, values := range InvalidDiscarders {
-		ivalues := invalidDiscarders[field]
-		if ivalues == nil {
-			ivalues = make(map[string]bool)
-			invalidDiscarders[field] = ivalues
-		}
 		for _, value := range values {
-			ivalues[value] = true
+			invalidDiscarders[invalidDiscarderEntry{
+				field: field,
+				value: value,
+			}] = true
 		}
 	}
 
@@ -700,7 +696,12 @@ func dumpDiscarders(resolver *dentry.Resolver, pidMap, inodeMap, statsFB, statsB
 	return dump, nil
 }
 
-var invalidDiscarders map[eval.Field]map[string]bool
+type invalidDiscarderEntry struct {
+	field eval.Field
+	value string
+}
+
+var invalidDiscarders map[invalidDiscarderEntry]bool
 
 func init() {
 	invalidDiscarders = createInvalidDiscardersCache()

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -518,7 +518,7 @@ func filenameDiscarderWrapper(eventType model.EventType, getter inodeEventGetter
 }
 
 // isInvalidDiscarder returns whether the given value is a valid discarder for the given field
-func isInvalidDiscarder(field eval.Field, value interface{}) bool {
+func isInvalidDiscarder(field eval.Field, value string) bool {
 	values, exists := invalidDiscarders[field]
 	if !exists {
 		return false


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

For unknown reasons we only check for invalid discarders with string values, this PR replaces the `interface{}` with `string` to remove this useless indirection, and also removes the map of maps used in this same check.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
