### PR TITLE
[Windows][Installer] Remove non-tracked files during uninstall

### DIFF
--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
@@ -664,7 +664,7 @@ namespace Datadog.CustomActions.Native
                 return false;
             }
 
-            throw new Exception("unexpected error while looking account name");
+            throw new Exception("unexpected error while looking account name", new Win32Exception((int)err));
         }
 
         public bool GetComputerName(COMPUTER_NAME_FORMAT format, out string name)

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
@@ -202,8 +202,7 @@ namespace WixSetup.Datadog
                     Return.check,
                     When.After,
                     new Step(WriteConfig.Id),
-                    // Only on first install otherwise we risk ruining the existing install
-                    Conditions.FirstInstall
+                    Conditions.FirstInstall | Conditions.Upgrading | Conditions.Maintenance
                 )
                 {
                     Execute = Execute.rollback,

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -312,7 +312,10 @@ namespace WixSetup.Datadog
                     new DirFiles($@"{InstallerSource}\LICENSE"),
                     new DirFiles($@"{InstallerSource}\*.json"),
                     new DirFiles($@"{InstallerSource}\*.txt"),
-                    new CompressedDir(this, "embedded3", $@"{InstallerSource}\embedded3")
+                    new CompressedDir(this, "embedded3", $@"{InstallerSource}\embedded3"),
+                    // Recursively delete/backup all files/folders in PROJECTLOCATION, they will be restored
+                    // on rollback. By default WindowsInstller only removes the files it tracks, and embedded3 isn't tracked
+                    new RemoveFolderEx { On=InstallEvent.uninstall, Property="PROJECTLOCATION"}
                 );
             if (_agentPython.IncludePython2)
             {

--- a/tools/windows/DatadogAgentInstaller/WixSetup/WixUtilExtensions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/WixUtilExtensions.cs
@@ -1,0 +1,41 @@
+using System.Xml.Linq;
+using WixSharp;
+
+namespace WixSetup
+{
+    public enum InstallEvent
+    {
+        install,
+        uninstall,
+        both
+    }
+
+    /// <summary>
+    /// WixSharp integration for util:RemoveFolderEx extension
+    /// https://wixtoolset.org/docs/v3/xsd/util/removefolderex/
+    /// https://www.hass.de/content/wix-how-use-removefolderex-your-xml-scripts
+    /// </summary>
+    public class RemoveFolderEx : WixEntity, IGenericEntity
+    {
+        [Xml] public InstallEvent? On;
+
+        [Xml] public string Property;
+
+        [Xml]
+        public new string Id
+        {
+            get => base.Id;
+            set => base.Id = value;
+        }
+
+        public void Process(ProcessingContext context)
+        {
+            // ensure WixUtilExtension.dll is included
+            context.Project.Include(WixExtension.Util);
+            XElement element = this.ToXElement((WixExtension.Util.ToXName("RemoveFolderEx")));
+            context.XParent
+                .FindFirst("Component")
+                .Add(element);
+        }
+    }
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds  `RemoveFolderEx("PROJECTLOCATION")`[[docs]](https://wixtoolset.org/docs/v3/xsd/util/removefolderex/) that the OG installer used to cleanup non-tracked files during uninstall. They are backed up and restored during rollback.

`CleanupOnRollback` runs during install/ugprade/change/repair so that the uninstall-rollback has a clean environment to rollback into.

Always recursively delete `embedded3` before extracting

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

non-tracked directories like `embedded3` were being merged during upgrade and rollback.

https://datadoghq.atlassian.net/browse/WA-358


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Upgrade with `WIXFAILWHENDEFFERED=1` from OG to NG. Ensure there are no extra files/dirs in the `embedded3` directory tree and that it contains the files from the original install.

Upgrade from 7.45 NG to latest NG. Ensure there are no extra files/dirs in the `embedded3` directory tree.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
