### PR TITLE
Add new config `secret_backend_env`

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -370,6 +370,7 @@ func InitConfig(config Config) {
 	// secrets backend
 	config.BindEnvAndSetDefault("secret_backend_command", "")
 	config.BindEnvAndSetDefault("secret_backend_arguments", []string{})
+	config.BindEnvAndSetDefault("secret_backend_env", []string{})
 	config.BindEnvAndSetDefault("secret_backend_output_max_size", secrets.SecretBackendOutputMaxSize)
 	config.BindEnvAndSetDefault("secret_backend_timeout", 30)
 	config.BindEnvAndSetDefault("secret_backend_command_allow_group_exec_perm", false)
@@ -1702,6 +1703,7 @@ func ResolveSecrets(config Config, origin string) error {
 	secrets.Init(
 		config.GetString("secret_backend_command"),
 		config.GetStringSlice("secret_backend_arguments"),
+		config.GetStringSlice("secret_backend_env"),
 		config.GetInt("secret_backend_timeout"),
 		config.GetInt("secret_backend_output_max_size"),
 		config.GetBool("secret_backend_command_allow_group_exec_perm"),

--- a/pkg/secrets/exec_nix.go
+++ b/pkg/secrets/exec_nix.go
@@ -13,6 +13,8 @@ import (
 )
 
 // commandContext sets up an exec.Cmd for running with a context
-func commandContext(ctx context.Context, name string, arg ...string) (*exec.Cmd, func(), error) {
-	return exec.CommandContext(ctx, name, arg...), func() {}, nil
+func commandContext(ctx context.Context, name string, env []string, arg ...string) (*exec.Cmd, func(), error) {
+	cmd := exec.CommandContext(ctx, name, arg...)
+	cmd.Env = append(cmd.Env, env...)
+	return cmd, func() {}, nil
 }

--- a/pkg/secrets/exec_windows.go
+++ b/pkg/secrets/exec_windows.go
@@ -22,8 +22,9 @@ import (
 const ddAgentServiceName = "datadogagent"
 
 // commandContext sets up an exec.Cmd for running with a context
-func commandContext(ctx context.Context, name string, arg ...string) (*exec.Cmd, func(), error) {
+func commandContext(ctx context.Context, name string, env []string, arg ...string) (*exec.Cmd, func(), error) {
 	cmd := exec.CommandContext(ctx, name, arg...)
+	cmd.Env = append(cmd.Env, env...)
 	done := func() {}
 	localSystem, err := getLocalSystemSID()
 	if err != nil {

--- a/pkg/secrets/fetch_secret.go
+++ b/pkg/secrets/fetch_secret.go
@@ -46,7 +46,7 @@ func execCommand(inputPayload string) ([]byte, error) {
 		time.Duration(secretBackendTimeout)*time.Second)
 	defer cancel()
 
-	cmd, done, err := commandContext(ctx, secretBackendCommand, secretBackendArguments...)
+	cmd, done, err := commandContext(ctx, secretBackendCommand, secretBackendEnv, secretBackendArguments...)
 	if err != nil {
 		return nil, err
 	}
@@ -74,11 +74,11 @@ func execCommand(inputPayload string) ([]byte, error) {
 	// buffer logs until it's initialized. This means the time of the log line will be the one after the package is
 	// initialized and not the creation time. This is an issue when troubleshooting a secret_backend_command in
 	// datadog.yaml.
-	log.Debugf("%s | calling secret_backend_command with payload: '%s'", time.Now().String(), inputPayload)
+	log.Debugf("%s | calling secret_backend_command with payload: %q, env: %q", time.Now().String(), inputPayload, secretBackendEnv)
 	start := time.Now()
 	err = cmd.Run()
 	elapsed := time.Since(start)
-	log.Debugf("%s | secret_backend_command '%s' completed in %s", time.Now().String(), secretBackendCommand, elapsed)
+	log.Debugf("%s | secret_backend_command %q completed in %s", time.Now().String(), secretBackendCommand, elapsed)
 
 	// We always log stderr to allow a secret_backend_command to logs info in the agent log file. This is useful to
 	// troubleshoot secret_backend_command in a containerized environment.

--- a/pkg/secrets/no_secrets.go
+++ b/pkg/secrets/no_secrets.go
@@ -18,7 +18,7 @@ import (
 var SecretBackendOutputMaxSize = 1024 * 1024
 
 // Init placeholder when compiled without the 'secrets' build tag
-func Init(command string, arguments []string, timeout int, maxSize int, groupExecPerm bool, removeTrailingLineBreak bool) {
+func Init(command string, arguments []string, env []string, timeout int, maxSize int, groupExecPerm bool, removeLinebreak bool) {
 }
 
 // Decrypt encrypted secrets are not available on windows

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -34,6 +34,7 @@ var (
 
 	secretBackendCommand               string
 	secretBackendArguments             []string
+	secretBackendEnv                   []string
 	secretBackendTimeout               = 5
 	secretBackendCommandAllowGroupExec bool
 	removeTrailingLinebreak            bool
@@ -83,9 +84,10 @@ func registerSecretOrigin(handle string, origin string, yamlPath []string) {
 // Init initializes the command and other options of the secrets package. Since
 // this package is used by the 'config' package to decrypt itself we can't
 // directly use it.
-func Init(command string, arguments []string, timeout int, maxSize int, groupExecPerm bool, removeLinebreak bool) {
+func Init(command string, arguments []string, env []string, timeout int, maxSize int, groupExecPerm bool, removeLinebreak bool) {
 	secretBackendCommand = command
 	secretBackendArguments = arguments
+	secretBackendEnv = env
 	secretBackendTimeout = timeout
 	SecretBackendOutputMaxSize = maxSize
 	secretBackendCommandAllowGroupExec = groupExecPerm

--- a/releasenotes/notes/add-secret_backend_command-94f88a917892287c.yaml
+++ b/releasenotes/notes/add-secret_backend_command-94f88a917892287c.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Add ``secret_backend_env`` to set environment variables for
+    ``secret_backend_command``.


### PR DESCRIPTION
### What does this PR do?

Add new config, `secret_backend_env` to set environment variables for `secret_backend_command`.

### Motivation

This PR make the [Secrets Management](https://docs.datadoghq.com/agent/guide/secrets-management/?tab=linux) more useful.
If we want to use an env var within the `secret_backend_command`, modifying a script or binary is the only way to do that.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1 ) Write the following shell script by `sudo -u dd-agent vim  /tmp/secret_backend_env.sh`.

```shell
#!/bin/bash
echo {\"key\": {\"value\": \"${KEY}\"}} > /tmp/test.log
echo {\"key\": {\"value\": \"${KEY}\"}}
```

2 ) Give the permission.

```bash
sudo chmod 700 /tmp/secret_backend_env.sh
```

3 ) Configure the [Agent main configuration file](https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6v7#agent-main-configuration-file)

```yaml
secret_backend_command: "/tmp/secret_backend_env.sh"
secret_backend_env: ["KEY=value"]
```

4 ) Configure `/etc/datadog-agent/conf.d/http_check.d/conf.yaml`

```yaml
init_config:
instances:
  - name: test
    url: https://example.com
    username: "ENC[key]"
    password: "ENC[key]"
```

5 ) Check logs and `/tmp/test.log`.

Confirmed that `${KEY}` in the `/tmp/secret_backend_env.sh` is replaced with the value of `KEY=value`.

```
2023-06-29 04:47:52 UTC | CORE | DEBUG | (pkg/secrets/fetch_secret.go:77 in execCommand) | 2023-06-29 04:47:52.39136784 +0000 UTC m=+0.531257303 | calling secret_backend_command with payload: "{\"secrets\":[\"key\",\"key\"],\"version\":\"1.0\"}", env: ["KEY=value"]
2023-06-29 04:47:52 UTC | CORE | DEBUG | (pkg/secrets/fetch_secret.go:81 in execCommand) | 2023-06-29 04:47:52.392782506 +0000 UTC m=+0.532671665 | secret_backend_command "/tmp/secret_backend_env.sh" completed in 1.344751ms
2023-06-29 04:47:52 UTC | CORE | DEBUG | (pkg/secrets/fetch_secret.go:104 in execCommand) | secret_backend_command stderr:
2023-06-29 04:47:52 UTC | CORE | DEBUG | (pkg/secrets/secrets.go:235 in func2) | Secret 'key' was retrieved from executable
2023-06-29 04:47:52 UTC | CORE | DEBUG | (pkg/secrets/secrets.go:235 in func2) | Secret 'key' was retrieved from executable
```

```bash
cat /tmp/test.log
{"key": {"value": "value"}}
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
