### PR TITLE
[CWS] convert more hooks to fentry

### DIFF
--- a/pkg/security/ebpf/c/include/constants/fentry_macro.h
+++ b/pkg/security/ebpf/c/include/constants/fentry_macro.h
@@ -5,13 +5,15 @@
 
 #define HOOK_ENTRY(func_name) SEC("fentry/" func_name)
 typedef unsigned long long ctx_t;
-#define CTX_PARM1(ctx) (void *)(ctx[0])
+#define CTX_PARM1(ctx) (u64)(ctx[0])
+#define CTX_PARM2(ctx) (u64)(ctx[1])
 
 #else
 
 #define HOOK_ENTRY(func_name) SEC("kprobe/" func_name)
 typedef struct pt_regs ctx_t;
 #define CTX_PARM1(ctx) PT_REGS_PARM1(ctx)
+#define CTX_PARM2(ctx) PT_REGS_PARM2(ctx)
 
 #endif
 

--- a/pkg/security/ebpf/c/include/constants/fentry_macro.h
+++ b/pkg/security/ebpf/c/include/constants/fentry_macro.h
@@ -7,6 +7,7 @@
 typedef unsigned long long ctx_t;
 #define CTX_PARM1(ctx) (u64)(ctx[0])
 #define CTX_PARM2(ctx) (u64)(ctx[1])
+#define CTX_PARM3(ctx) (u64)(ctx[2])
 
 #else
 
@@ -14,6 +15,7 @@ typedef unsigned long long ctx_t;
 typedef struct pt_regs ctx_t;
 #define CTX_PARM1(ctx) PT_REGS_PARM1(ctx)
 #define CTX_PARM2(ctx) PT_REGS_PARM2(ctx)
+#define CTX_PARM3(ctx) PT_REGS_PARM3(ctx)
 
 #endif
 

--- a/pkg/security/ebpf/c/include/helpers/filesystem.h
+++ b/pkg/security/ebpf/c/include/helpers/filesystem.h
@@ -50,7 +50,7 @@ static __attribute__((always_inline)) void inc_mount_ref(u32 mount_id) {
     }
 }
 
-static __attribute__((always_inline)) void dec_mount_ref(struct pt_regs *ctx, u32 mount_id) {
+static __attribute__((always_inline)) void dec_mount_ref(ctx_t *ctx, u32 mount_id) {
     u32 key = mount_id;
     struct mount_ref_t *ref = bpf_map_lookup_elem(&mount_ref, &key);
     if (ref) {

--- a/pkg/security/ebpf/c/include/hooks/bpf.h
+++ b/pkg/security/ebpf/c/include/hooks/bpf.h
@@ -3,6 +3,7 @@
 
 #include "constants/offsets/bpf.h"
 #include "constants/syscall_macro.h"
+#include "constants/fentry_macro.h"
 #include "helpers/bpf.h"
 #include "helpers/discarders.h"
 #include "helpers/process.h"
@@ -91,14 +92,14 @@ SYSCALL_KRETPROBE(bpf) {
     return sys_bpf_ret(ctx, (int)PT_REGS_RC(ctx));
 }
 
-SEC("kprobe/security_bpf_map")
-int kprobe_security_bpf_map(struct pt_regs *ctx) {
+HOOK_ENTRY("security_bpf_map")
+int hook_security_bpf_map(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_BPF);
     if (!syscall) {
         return 0;
     }
 
-    struct bpf_map *map = (struct bpf_map *)PT_REGS_PARM1(ctx);
+    struct bpf_map *map = (struct bpf_map *)CTX_PARM1(ctx);
 
     // collect relevant map metadata
     struct bpf_map_t m = {};
@@ -114,14 +115,14 @@ int kprobe_security_bpf_map(struct pt_regs *ctx) {
     return 0;
 }
 
-SEC("kprobe/security_bpf_prog")
-int kprobe_security_bpf_prog(struct pt_regs *ctx) {
+HOOK_ENTRY("security_bpf_prog")
+int hook_security_bpf_prog(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_BPF);
     if (!syscall) {
         return 0;
     }
 
-    struct bpf_prog *prog = (struct bpf_prog *)PT_REGS_PARM1(ctx);
+    struct bpf_prog *prog = (struct bpf_prog *)CTX_PARM1(ctx);
     struct bpf_prog_aux *prog_aux = 0;
     bpf_probe_read(&prog_aux, sizeof(prog_aux), (void *)prog + get_bpf_prog_aux_offset());
 
@@ -148,8 +149,8 @@ int kprobe_security_bpf_prog(struct pt_regs *ctx) {
     return 0;
 }
 
-SEC("kprobe/check_helper_call")
-int kprobe_check_helper_call(struct pt_regs *ctx) {
+HOOK_ENTRY("check_helper_call")
+int hook_check_helper_call(ctx_t *ctx) {
     int func_id = 0;
     struct syscall_cache_t *syscall = peek_syscall(EVENT_BPF);
     if (!syscall) {
@@ -158,9 +159,9 @@ int kprobe_check_helper_call(struct pt_regs *ctx) {
 
     u64 input = get_check_helper_call_input();
     if (input == CHECK_HELPER_CALL_FUNC_ID) {
-        func_id = (int)PT_REGS_PARM2(ctx);
+        func_id = (int)CTX_PARM2(ctx);
     } else if (input == CHECK_HELPER_CALL_INSN) {
-        struct bpf_insn *insn = (struct bpf_insn *)PT_REGS_PARM2(ctx);
+        struct bpf_insn *insn = (struct bpf_insn *)CTX_PARM2(ctx);
         bpf_probe_read(&func_id, sizeof(func_id), &insn->imm);
     }
 

--- a/pkg/security/ebpf/c/include/hooks/commit_creds.h
+++ b/pkg/security/ebpf/c/include/hooks/commit_creds.h
@@ -266,11 +266,11 @@ struct cred_ids {
     kernel_cap_t cap_ambient;
 };
 
-SEC("kprobe/commit_creds")
-int kprobe_commit_creds(struct pt_regs *ctx) {
+HOOK_ENTRY("commit_creds")
+int hook_commit_creds(ctx_t *ctx) {
     u64 creds_uid_offset;
     LOAD_CONSTANT("creds_uid_offset", creds_uid_offset);
-    struct cred_ids *credentials = (struct cred_ids *)(PT_REGS_PARM1(ctx) + creds_uid_offset);
+    struct cred_ids *credentials = (struct cred_ids *)(CTX_PARM1(ctx) + creds_uid_offset);
     struct pid_cache_t new_pid_entry = {};
 
     // update pid_cache entry for the current process

--- a/pkg/security/ebpf/c/include/hooks/dentry_resolver.h
+++ b/pkg/security/ebpf/c/include/hooks/dentry_resolver.h
@@ -113,6 +113,7 @@ int __attribute__((always_inline)) resolve_dentry_tail_call(void *ctx, struct de
         bpf_tail_call_compat(ctx, callbacks_map, syscall->resolver.callback);                                          \
     }                                                                                                                  \
 
+// fentry blocked by: tail call
 SEC("kprobe/dentry_resolver_kern")
 int kprobe_dentry_resolver_kern(struct pt_regs *ctx) {
     dentry_resolver_kern(ctx, &dentry_resolver_kprobe_progs, &dentry_resolver_kprobe_callbacks, DR_KPROBE_DENTRY_RESOLVER_KERN_KEY);
@@ -125,6 +126,7 @@ int tracepoint_dentry_resolver_kern(void *ctx) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/dentry_resolver_erpc_write_user")
 int kprobe_dentry_resolver_erpc_write_user(struct pt_regs *ctx) {
     u32 key = 0;
@@ -199,6 +201,7 @@ exit:
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/dentry_resolver_erpc_mmap")
 int kprobe_dentry_resolver_erpc_mmap(struct pt_regs *ctx) {
     u32 key = 0;
@@ -280,6 +283,7 @@ exit:
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/dentry_resolver_segment_erpc_write_user")
 int kprobe_dentry_resolver_segment_erpc_write_user(struct pt_regs *ctx) {
     u32 key = 0;
@@ -326,6 +330,7 @@ exit:
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/dentry_resolver_segment_erpc_mmap")
 int kprobe_dentry_resolver_segment_erpc_mmap(struct pt_regs *ctx) {
     u32 key = 0;
@@ -379,6 +384,7 @@ exit:
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/dentry_resolver_parent_erpc_write_user")
 int kprobe_dentry_resolver_parent_erpc_write_user(struct pt_regs *ctx) {
     u32 key = 0;
@@ -419,6 +425,7 @@ exit:
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/dentry_resolver_parent_erpc_mmap")
 int kprobe_dentry_resolver_parent_erpc_mmap(struct pt_regs *ctx) {
     u32 key = 0;
@@ -465,6 +472,7 @@ exit:
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/dentry_resolver_ad_filter")
 int kprobe_dentry_resolver_ad_filter(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_ANY);

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -329,6 +329,7 @@ int hook_security_bprm_check(ctx_t *ctx) {
     return fill_exec_context();
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/get_envs_offset")
 int kprobe_get_envs_offset(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_current_or_impersonated_exec_syscall();
@@ -446,6 +447,7 @@ void __attribute__((always_inline)) parse_args_envs(struct pt_regs *ctx, struct 
     }
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/parse_args_envs_split")
 int kprobe_parse_args_envs_split(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_current_or_impersonated_exec_syscall();
@@ -475,6 +477,7 @@ int kprobe_parse_args_envs_split(struct pt_regs *ctx) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/parse_args_envs")
 int kprobe_parse_args_envs(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_current_or_impersonated_exec_syscall();
@@ -530,12 +533,14 @@ int __attribute__((always_inline)) fetch_interpreter(struct pt_regs *ctx, struct
     return handle_interpreted_exec_event(ctx, syscall, interpreter);
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/setup_new_exec")
 int kprobe_setup_new_exec_interp(struct pt_regs *ctx) {
     struct linux_binprm *bprm = (struct linux_binprm *) PT_REGS_PARM1(ctx);
     return fetch_interpreter(ctx, bprm);
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/setup_new_exec")
 int kprobe_setup_new_exec_args_envs(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_current_or_impersonated_exec_syscall();
@@ -576,6 +581,7 @@ int kprobe_setup_new_exec_args_envs(struct pt_regs *ctx) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/setup_arg_pages")
 int kprobe_setup_arg_pages(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_current_or_impersonated_exec_syscall();

--- a/pkg/security/ebpf/c/include/hooks/filename.h
+++ b/pkg/security/ebpf/c/include/hooks/filename.h
@@ -2,9 +2,10 @@
 #define _HOOKS_FILENAME_H_
 
 #include "helpers/syscalls.h"
+#include "constants/fentry_macro.h"
 
-SEC("kprobe/filename_create")
-int kprobe_filename_create(struct pt_regs *ctx) {
+HOOK_ENTRY("filename_create")
+int hook_filename_create(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_ANY);
     if (!syscall) {
         return 0;
@@ -12,10 +13,10 @@ int kprobe_filename_create(struct pt_regs *ctx) {
 
     switch (syscall->type) {
         case EVENT_MKDIR:
-            syscall->mkdir.path = (struct path *)PT_REGS_PARM3(ctx);
+            syscall->mkdir.path = (struct path *)CTX_PARM3(ctx);
             break;
        case EVENT_LINK:
-            syscall->link.target_path = (struct path *)PT_REGS_PARM3(ctx);
+            syscall->link.target_path = (struct path *)CTX_PARM3(ctx);
             break;
     }
     return 0;

--- a/pkg/security/ebpf/c/include/hooks/ioctl.h
+++ b/pkg/security/ebpf/c/include/hooks/ioctl.h
@@ -3,6 +3,7 @@
 
 #include "helpers/erpc.h"
 
+// fentry blocked by: tail call
 SEC("kprobe/do_vfs_ioctl")
 int kprobe_do_vfs_ioctl(struct pt_regs *ctx) {
     if (is_erpc_request(ctx)) {

--- a/pkg/security/ebpf/c/include/hooks/iouring.h
+++ b/pkg/security/ebpf/c/include/hooks/iouring.h
@@ -18,16 +18,16 @@ int kretprobe_io_ring_ctx_alloc(struct pt_regs *ctx) {
     return 0;
 }
 
-SEC("kprobe/io_allocate_scq_urings")
-int kprobe_io_allocate_scq_urings(struct pt_regs *ctx) {
-    void *ioctx = (void *)PT_REGS_PARM1(ctx);
+HOOK_ENTRY("io_allocate_scq_urings")
+int hook_io_allocate_scq_urings(ctx_t *ctx) {
+    void *ioctx = (void *)CTX_PARM1(ctx);
     cache_ioctx_pid_tgid(ioctx);
     return 0;
 }
 
-SEC("kprobe/io_sq_offload_start")
-int kprobe_io_sq_offload_start(struct pt_regs *ctx) {
-    void *ioctx = (void *)PT_REGS_PARM1(ctx);
+HOOK_ENTRY("io_sq_offload_start")
+int hook_io_sq_offload_start(ctx_t *ctx) {
+    void *ioctx = (void *)CTX_PARM1(ctx);
     cache_ioctx_pid_tgid(ioctx);
     return 0;
 }

--- a/pkg/security/ebpf/c/include/hooks/iouring.h
+++ b/pkg/security/ebpf/c/include/hooks/iouring.h
@@ -25,11 +25,13 @@ int hook_io_allocate_scq_urings(ctx_t *ctx) {
     return 0;
 }
 
+#ifndef USE_FENTRY
 HOOK_ENTRY("io_sq_offload_start")
 int hook_io_sq_offload_start(ctx_t *ctx) {
     void *ioctx = (void *)CTX_PARM1(ctx);
     cache_ioctx_pid_tgid(ioctx);
     return 0;
 }
+#endif
 
 #endif

--- a/pkg/security/ebpf/c/include/hooks/link.h
+++ b/pkg/security/ebpf/c/include/hooks/link.h
@@ -32,8 +32,8 @@ SYSCALL_KPROBE0(linkat) {
     return trace__sys_link(SYNC_SYSCALL);
 }
 
-SEC("kprobe/do_linkat")
-int kprobe_do_linkat(struct pt_regs *ctx) {
+HOOK_ENTRY("do_linkat")
+int hook_do_linkat(ctx_t *ctx) {
     struct syscall_cache_t* syscall = peek_syscall(EVENT_LINK);
     if (!syscall) {
         return trace__sys_link(ASYNC_SYSCALL);

--- a/pkg/security/ebpf/c/include/hooks/link.h
+++ b/pkg/security/ebpf/c/include/hooks/link.h
@@ -41,6 +41,7 @@ int hook_do_linkat(ctx_t *ctx) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/vfs_link")
 int kprobe_vfs_link(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_LINK);
@@ -95,6 +96,7 @@ int kprobe_vfs_link(struct pt_regs *ctx) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/dr_link_src_callback")
 int __attribute__((always_inline)) kprobe_dr_link_src_callback(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_LINK);
@@ -196,6 +198,7 @@ int __attribute__((always_inline)) dr_link_dst_callback(void *ctx, int retval) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/dr_link_dst_callback")
 int __attribute__((always_inline)) kprobe_dr_link_dst_callback(struct pt_regs *ctx) {
     int ret = PT_REGS_RC(ctx);

--- a/pkg/security/ebpf/c/include/hooks/mkdir.h
+++ b/pkg/security/ebpf/c/include/hooks/mkdir.h
@@ -37,8 +37,8 @@ SYSCALL_KPROBE3(mkdirat, int, dirfd, const char*, filename, umode_t, mode)
     return trace__sys_mkdir(SYNC_SYSCALL, mode);
 }
 
-SEC("kprobe/vfs_mkdir")
-int kprobe_vfs_mkdir(struct pt_regs *ctx) {
+HOOK_ENTRY("vfs_mkdir")
+int hook_vfs_mkdir(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_MKDIR);
     if (!syscall) {
         return 0;
@@ -48,12 +48,12 @@ int kprobe_vfs_mkdir(struct pt_regs *ctx) {
         return 0;
     }
 
-    syscall->mkdir.dentry = (struct dentry *) PT_REGS_PARM2(ctx);
+    syscall->mkdir.dentry = (struct dentry *) CTX_PARM2(ctx);
     // change the register based on the value of vfs_mkdir_dentry_position
     if (get_vfs_mkdir_dentry_position() == VFS_ARG_POSITION3) {
         // prevent the verifier from whining
         bpf_probe_read(&syscall->mkdir.dentry, sizeof(syscall->mkdir.dentry), &syscall->mkdir.dentry);
-        syscall->mkdir.dentry = (struct dentry *) PT_REGS_PARM3(ctx);
+        syscall->mkdir.dentry = (struct dentry *) CTX_PARM3(ctx);
     }
 
     syscall->mkdir.file.path_key.mount_id = get_path_mount_id(syscall->mkdir.path);
@@ -92,11 +92,11 @@ int __attribute__((always_inline)) sys_mkdir_ret(void *ctx, int retval, int dr_t
     return 0;
 }
 
-SEC("kprobe/do_mkdirat")
-int kprobe_do_mkdirat(struct pt_regs *ctx) {
+HOOK_ENTRY("do_mkdirat")
+int kprobe_do_mkdirat(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_MKDIR);
     if (!syscall) {
-        umode_t mode = (umode_t)PT_REGS_PARM3(ctx);
+        umode_t mode = (umode_t)CTX_PARM3(ctx);
         return trace__sys_mkdir(ASYNC_SYSCALL, mode);
     }
     return 0;

--- a/pkg/security/ebpf/c/include/hooks/mkdir.h
+++ b/pkg/security/ebpf/c/include/hooks/mkdir.h
@@ -158,6 +158,7 @@ int __attribute__((always_inline)) dr_mkdir_callback(void *ctx, int retval) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/dr_mkdir_callback")
 int __attribute__((always_inline)) kprobe_dr_mkdir_callback(struct pt_regs *ctx) {
     int retval = PT_REGS_RC(ctx);

--- a/pkg/security/ebpf/c/include/hooks/module.h
+++ b/pkg/security/ebpf/c/include/hooks/module.h
@@ -50,6 +50,7 @@ int __attribute__((always_inline)) trace_kernel_file(struct pt_regs *ctx, struct
     return 0;
 }
 
+// fentry blocked by: parse args special bug
 SEC("kprobe/parse_args")
 int kprobe_parse_args(struct pt_regs *ctx){
     char *args = (char *) PT_REGS_PARM2(ctx);
@@ -64,12 +65,14 @@ int kprobe_parse_args(struct pt_regs *ctx){
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/security_kernel_module_from_file")
 int kprobe_security_kernel_module_from_file(struct pt_regs *ctx) {
     struct file *f = (struct file *)PT_REGS_PARM1(ctx);
     return trace_kernel_file(ctx, f);
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/security_kernel_read_file")
 int kprobe_security_kernel_read_file(struct pt_regs *ctx) {
     struct file *f = (struct file *)PT_REGS_PARM1(ctx);

--- a/pkg/security/ebpf/c/include/hooks/module.h
+++ b/pkg/security/ebpf/c/include/hooks/module.h
@@ -86,15 +86,15 @@ int __attribute__((always_inline)) trace_module(struct module *mod) {
     return 0;
 }
 
-SEC("kprobe/do_init_module")
-int kprobe_do_init_module(struct pt_regs *ctx) {
-    struct module *mod = (struct module *)PT_REGS_PARM1(ctx);
+HOOK_ENTRY("do_init_module")
+int hook_do_init_module(ctx_t *ctx) {
+    struct module *mod = (struct module *)CTX_PARM1(ctx);
     return trace_module(mod);
 }
 
-SEC("kprobe/module_put")
-int kprobe_module_put(struct pt_regs *ctx) {
-    struct module *mod = (struct module *)PT_REGS_PARM1(ctx);
+HOOK_ENTRY("module_put")
+int hook_module_put(ctx_t *ctx) {
+    struct module *mod = (struct module *)CTX_PARM1(ctx);
     return trace_module(mod);
 }
 
@@ -109,7 +109,7 @@ int __attribute__((always_inline)) trace_init_module_ret(void *ctx, int retval, 
         .file = syscall->init_module.file,
         .loaded_from_memory = syscall->init_module.loaded_from_memory,
     };
-    
+
     bpf_probe_read_str(&event.args, sizeof(event.args), &syscall->init_module.args);
     event.args_truncated = syscall->init_module.args_truncated;
 

--- a/pkg/security/ebpf/c/include/hooks/mount.h
+++ b/pkg/security/ebpf/c/include/hooks/mount.h
@@ -141,6 +141,7 @@ SYSCALL_KPROBE1(unshare, unsigned long, flags) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/attach_mnt")
 int kprobe_attach_mnt(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_UNSHARE_MNTNS);
@@ -157,6 +158,7 @@ int kprobe_attach_mnt(struct pt_regs *ctx) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/__attach_mnt")
 int kprobe___attach_mnt(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_UNSHARE_MNTNS);
@@ -179,6 +181,7 @@ int kprobe___attach_mnt(struct pt_regs *ctx) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/mnt_set_mountpoint")
 int kprobe_mnt_set_mountpoint(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_UNSHARE_MNTNS);
@@ -202,6 +205,7 @@ int kprobe_mnt_set_mountpoint(struct pt_regs *ctx) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/dr_unshare_mntns_stage_one_callback")
 int __attribute__((always_inline)) kprobe_dr_unshare_mntns_stage_one_callback(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_UNSHARE_MNTNS);
@@ -225,6 +229,7 @@ int __attribute__((always_inline)) kprobe_dr_unshare_mntns_stage_one_callback(st
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/dr_unshare_mntns_stage_two_callback")
 int __attribute__((always_inline)) kprobe_dr_unshare_mntns_stage_two_callback(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_UNSHARE_MNTNS);
@@ -252,6 +257,7 @@ int __attribute__((always_inline)) kprobe_dr_unshare_mntns_stage_two_callback(st
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/clone_mnt")
 int kprobe_clone_mnt(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_MOUNT);
@@ -280,6 +286,7 @@ int kprobe_clone_mnt(struct pt_regs *ctx) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/attach_recursive_mnt")
 int kprobe_attach_recursive_mnt(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_MOUNT);
@@ -311,6 +318,7 @@ int kprobe_attach_recursive_mnt(struct pt_regs *ctx) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/propagate_mnt")
 int kprobe_propagate_mnt(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_MOUNT);
@@ -414,6 +422,7 @@ int __attribute__((always_inline)) dr_mount_callback(void *ctx, int retval) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/dr_mount_callback")
 int __attribute__((always_inline)) kprobe_dr_mount_callback(struct pt_regs *ctx) {
     int ret = PT_REGS_RC(ctx);

--- a/pkg/security/ebpf/c/include/hooks/mprotect.h
+++ b/pkg/security/ebpf/c/include/hooks/mprotect.h
@@ -20,8 +20,8 @@ SYSCALL_KPROBE0(mprotect) {
     return 0;
 }
 
-SEC("kprobe/security_file_mprotect")
-int kprobe_security_file_mprotect(struct pt_regs *ctx) {
+HOOK_ENTRY("security_file_mprotect")
+int hook_security_file_mprotect(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_MPROTECT);
     if (!syscall) {
         return 0;
@@ -31,11 +31,11 @@ int kprobe_security_file_mprotect(struct pt_regs *ctx) {
     LOAD_CONSTANT("vm_area_struct_flags_offset", flags_offset);
 
     // Retrieve vma information
-    struct vm_area_struct *vma = (struct vm_area_struct *)PT_REGS_PARM1(ctx);
+    struct vm_area_struct *vma = (struct vm_area_struct *)CTX_PARM1(ctx);
     bpf_probe_read(&syscall->mprotect.vm_protection, sizeof(syscall->mprotect.vm_protection), (char*)vma + flags_offset);
     bpf_probe_read(&syscall->mprotect.vm_start, sizeof(syscall->mprotect.vm_start), &vma->vm_start);
     bpf_probe_read(&syscall->mprotect.vm_end, sizeof(syscall->mprotect.vm_end), &vma->vm_end);
-    syscall->mprotect.req_protection = (u64)PT_REGS_PARM2(ctx);
+    syscall->mprotect.req_protection = (u64)CTX_PARM2(ctx);
     return 0;
 }
 

--- a/pkg/security/ebpf/c/include/hooks/namespaces.h
+++ b/pkg/security/ebpf/c/include/hooks/namespaces.h
@@ -4,9 +4,9 @@
 #include "constants/offsets/netns.h"
 #include "maps.h"
 
-SEC("kprobe/switch_task_namespaces")
-int kprobe_switch_task_namespaces(struct pt_regs *ctx) {
-    struct nsproxy *new_ns = (struct nsproxy *)PT_REGS_PARM2(ctx);
+HOOK_ENTRY("switch_task_namespaces")
+int hook_switch_task_namespaces(ctx_t *ctx) {
+    struct nsproxy *new_ns = (struct nsproxy *)CTX_PARM2(ctx);
     if (new_ns == NULL) {
         return 0;
     }

--- a/pkg/security/ebpf/c/include/hooks/network/bind.h
+++ b/pkg/security/ebpf/c/include/hooks/network/bind.h
@@ -64,10 +64,10 @@ SYSCALL_KRETPROBE(bind) {
     return sys_bind_ret(ctx, retval);
 }
 
-SEC("kprobe/security_socket_bind")
-int kprobe_security_socket_bind(struct pt_regs *ctx) {
-    struct socket *sk = (struct socket *)PT_REGS_PARM1(ctx);
-    struct sockaddr *address = (struct sockaddr *)PT_REGS_PARM2(ctx);
+HOOK_ENTRY("security_socket_bind")
+int hook_security_socket_bind(ctx_t *ctx) {
+    struct socket *sk = (struct socket *)CTX_PARM1(ctx);
+    struct sockaddr *address = (struct sockaddr *)CTX_PARM2(ctx);
     struct pid_route_t key = {};
     u16 family = 0;
 

--- a/pkg/security/ebpf/c/include/hooks/offset_guesser.h
+++ b/pkg/security/ebpf/c/include/hooks/offset_guesser.h
@@ -2,10 +2,11 @@
 #define _HOOKS_OFFSET_GUESSER_H_
 
 #include "constants/macros.h"
+#include "constants/fentry_macro.h"
 
-SEC("kprobe/get_pid_task")
-int kprobe_get_pid_task_numbers(struct pt_regs *ctx) {
-    struct pid *pid = (struct pid *) PT_REGS_PARM1(ctx);
+HOOK_ENTRY("get_pid_task")
+int hook_get_pid_task_numbers(ctx_t *ctx) {
+    struct pid *pid = (struct pid *) CTX_PARM1(ctx);
     if (!pid) {
         return 0;
     }
@@ -39,9 +40,9 @@ int kprobe_get_pid_task_numbers(struct pt_regs *ctx) {
     return 0;
 }
 
-SEC("kprobe/get_pid_task")
-int kprobe_get_pid_task_offset(struct pt_regs *ctx) {
-    u64 expected_pid_ptr = (u64)PT_REGS_PARM1(ctx);
+HOOK_ENTRY("get_pid_task")
+int hook_get_pid_task_offset(ctx_t *ctx) {
+    u64 expected_pid_ptr = (u64)CTX_PARM1(ctx);
     if (!expected_pid_ptr) {
         return 0;
     }

--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -115,7 +115,7 @@ int hook_vfs_truncate(ctx_t *ctx) {
 }
 
 HOOK_ENTRY("vfs_open")
-int kprobe_vfs_open(struct pt_regs *ctx) {
+int kprobe_vfs_open(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_OPEN);
     if (!syscall) {
         return 0;
@@ -129,15 +129,15 @@ int kprobe_vfs_open(struct pt_regs *ctx) {
     return handle_open_event(syscall, file, path, inode);
 }
 
-HOOK_ENTRY("do_dentry_open")
-int hook_do_dentry_open(ctx_t *ctx) {
+SEC("kprobe/do_dentry_open")
+int kprobe_do_dentry_open(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_EXEC);
     if (!syscall) {
         return 0;
     }
 
-    struct file *file = (struct file *)CTX_PARM1(ctx);
-    struct inode *inode = (struct inode *)CTX_PARM2(ctx);
+    struct file *file = (struct file *)PT_REGS_PARM1(ctx);
+    struct inode *inode = (struct inode *)PT_REGS_PARM2(ctx);
 
     return handle_exec_event(ctx, syscall, file, &file->f_path, inode);
 }

--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -298,6 +298,7 @@ int __attribute__((always_inline)) dr_open_callback(void *ctx, int retval) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/dr_open_callback")
 int __attribute__((always_inline)) kprobe_dr_open_callback(struct pt_regs *ctx) {
     int retval = PT_REGS_RC(ctx);

--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -2,6 +2,7 @@
 #define _HOOKS_OPEN_H_
 
 #include "constants/syscall_macro.h"
+#include "constants/fentry_macro.h"
 #include "helpers/approvers.h"
 #include "helpers/discarders.h"
 #include "helpers/filesystem.h"
@@ -87,8 +88,8 @@ int __attribute__((always_inline)) handle_open_event(struct syscall_cache_t *sys
     return 0;
 }
 
-SEC("kprobe/vfs_truncate")
-int kprobe_vfs_truncate(struct pt_regs *ctx) {
+HOOK_ENTRY("vfs_truncate")
+int hook_vfs_truncate(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_OPEN);
     if (!syscall) {
         return 0;
@@ -98,7 +99,7 @@ int kprobe_vfs_truncate(struct pt_regs *ctx) {
         return 0;
     }
 
-    struct path *path = (struct path *)PT_REGS_PARM1(ctx);
+    struct path *path = (struct path *)CTX_PARM1(ctx);
     struct dentry *dentry = get_path_dentry(path);
 
     syscall->open.dentry = dentry;
@@ -113,36 +114,36 @@ int kprobe_vfs_truncate(struct pt_regs *ctx) {
     return 0;
 }
 
-SEC("kprobe/vfs_open")
+HOOK_ENTRY("vfs_open")
 int kprobe_vfs_open(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_OPEN);
     if (!syscall) {
         return 0;
     }
 
-    struct path *path = (struct path *)PT_REGS_PARM1(ctx);
-    struct file *file = (struct file *)PT_REGS_PARM2(ctx);
+    struct path *path = (struct path *)CTX_PARM1(ctx);
+    struct file *file = (struct file *)CTX_PARM2(ctx);
     struct dentry *dentry = get_path_dentry(path);
     struct inode *inode = get_dentry_inode(dentry);
 
     return handle_open_event(syscall, file, path, inode);
 }
 
-SEC("kprobe/do_dentry_open")
-int kprobe_do_dentry_open(struct pt_regs *ctx) {
+HOOK_ENTRY("do_dentry_open")
+int hook_do_dentry_open(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_EXEC);
     if (!syscall) {
         return 0;
     }
 
-    struct file *file = (struct file *)PT_REGS_PARM1(ctx);
-    struct inode *inode = (struct inode *)PT_REGS_PARM2(ctx);
+    struct file *file = (struct file *)CTX_PARM1(ctx);
+    struct inode *inode = (struct inode *)CTX_PARM2(ctx);
 
     return handle_exec_event(ctx, syscall, file, &file->f_path, inode);
 }
 
-int __attribute__((always_inline)) trace_io_openat(struct pt_regs *ctx) {
-    void *raw_req = (void *)PT_REGS_PARM1(ctx);
+int __attribute__((always_inline)) trace_io_openat(ctx_t *ctx) {
+    void *raw_req = (void *)CTX_PARM1(ctx);
 
     struct io_open req;
     if (bpf_probe_read(&req, sizeof(req), raw_req)) {
@@ -162,13 +163,13 @@ int __attribute__((always_inline)) trace_io_openat(struct pt_regs *ctx) {
     return 0;
 }
 
-SEC("kprobe/io_openat")
-int kprobe_io_openat(struct pt_regs *ctx) {
+HOOK_ENTRY("io_openat")
+int hook_io_openat(ctx_t *ctx) {
     return trace_io_openat(ctx);
 }
 
-SEC("kprobe/io_openat2")
-int kprobe_io_openat2(struct pt_regs *ctx) {
+HOOK_ENTRY("io_openat2")
+int hook_io_openat2(ctx_t *ctx) {
     return trace_io_openat(ctx);
 }
 
@@ -244,9 +245,9 @@ int kretprobe_io_openat2(struct pt_regs *ctx) {
     return sys_open_ret(ctx, retval, DR_KPROBE);
 }
 
-SEC("kprobe/filp_close")
-int kprobe_filp_close(struct pt_regs *ctx) {
-    struct file *file = (struct file *) PT_REGS_PARM1(ctx);
+HOOK_ENTRY("filp_close")
+int hook_filp_close(ctx_t *ctx) {
+    struct file *file = (struct file *) CTX_PARM1(ctx);
     u32 mount_id = get_file_mount_id(file);
     if (mount_id) {
         dec_mount_ref(ctx, mount_id);

--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -129,6 +129,7 @@ int hook_vfs_open(ctx_t *ctx) {
     return handle_open_event(syscall, file, path, inode);
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/do_dentry_open")
 int kprobe_do_dentry_open(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_EXEC);

--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -115,7 +115,7 @@ int hook_vfs_truncate(ctx_t *ctx) {
 }
 
 HOOK_ENTRY("vfs_open")
-int kprobe_vfs_open(ctx_t *ctx) {
+int hook_vfs_open(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_OPEN);
     if (!syscall) {
         return 0;

--- a/pkg/security/ebpf/c/include/hooks/pipe.h
+++ b/pkg/security/ebpf/c/include/hooks/pipe.h
@@ -8,9 +8,9 @@
 DECLARE_EQUAL_TO(pipefs);
 
 /* hook here to grab and cache the pipefs mount id */
-SEC("kprobe/mntget")
-int kprobe_mntget(struct pt_regs* ctx) {
-    struct vfsmount* vfsm = (struct vfsmount*)PT_REGS_PARM1(ctx);
+HOOK_ENTRY("mntget")
+int hook_mntget(ctx_t *ctx) {
+    struct vfsmount* vfsm = (struct vfsmount*)CTX_PARM1(ctx);
 
     // check if we already have the pipefs mount id
     if (get_pipefs_mount_id()) {

--- a/pkg/security/ebpf/c/include/hooks/procfs.h
+++ b/pkg/security/ebpf/c/include/hooks/procfs.h
@@ -8,8 +8,8 @@
 #include "helpers/utils.h"
 
 // used during the snapshot thus this kprobe will present only at the snapshot
-SEC("kprobe/security_inode_getattr")
-int kprobe_security_inode_getattr(struct pt_regs *ctx) {
+HOOK_ENTRY("security_inode_getattr")
+int hook_security_inode_getattr(ctx_t *ctx) {
     if (!is_runtime_request()) {
         return 0;
     }
@@ -20,12 +20,12 @@ int kprobe_security_inode_getattr(struct pt_regs *ctx) {
     u64 getattr2 = get_getattr2();
 
     if (getattr2) {
-        struct vfsmount *mnt = (struct vfsmount *)PT_REGS_PARM1(ctx);
+        struct vfsmount *mnt = (struct vfsmount *)CTX_PARM1(ctx);
         mount_id = get_vfsmount_mount_id(mnt);
 
-        dentry = (struct dentry *)PT_REGS_PARM2(ctx);
+        dentry = (struct dentry *)CTX_PARM2(ctx);
     } else {
-        struct path *path = (struct path *)PT_REGS_PARM1(ctx);
+        struct path *path = (struct path *)CTX_PARM1(ctx);
         mount_id = get_path_mount_id(path);
 
         dentry = get_path_dentry(path);

--- a/pkg/security/ebpf/c/include/hooks/procfs.h
+++ b/pkg/security/ebpf/c/include/hooks/procfs.h
@@ -54,8 +54,8 @@ int kprobe_security_inode_getattr(struct pt_regs *ctx) {
 
 #ifndef DO_NOT_USE_TC
 
-SEC("kprobe/path_get")
-int kprobe_path_get(struct pt_regs *ctx) {
+HOOK_ENTRY("path_get")
+int hook_path_get(ctx_t *ctx) {
     if (!is_runtime_request()) {
         return 0;
     }
@@ -67,7 +67,7 @@ int kprobe_path_get(struct pt_regs *ctx) {
         return 0;
     }
 
-    struct path *p = (struct path *)PT_REGS_PARM1(ctx);
+    struct path *p = (struct path *)CTX_PARM1(ctx);
     struct file *sock_file = (void *)p - offsetof(struct file, f_path);
     struct pid_route_t route = {};
 
@@ -112,13 +112,13 @@ int kprobe_path_get(struct pt_regs *ctx) {
     return 0;
 }
 
-SEC("kprobe/proc_fd_link")
-int kprobe_proc_fd_link(struct pt_regs *ctx) {
+HOOK_ENTRY("proc_fd_link")
+int hook_proc_fd_link(ctx_t *ctx) {
     if (!is_runtime_request()) {
         return 0;
     }
 
-    struct dentry *d = (struct dentry *)PT_REGS_PARM1(ctx);
+    struct dentry *d = (struct dentry *)CTX_PARM1(ctx);
     struct dentry *d_parent = NULL;
     struct basename_t basename = {};
 

--- a/pkg/security/ebpf/c/include/hooks/ptrace.h
+++ b/pkg/security/ebpf/c/include/hooks/ptrace.h
@@ -24,14 +24,14 @@ SYSCALL_KPROBE3(ptrace, u32, request, pid_t, pid, void *, addr) {
     return 0;
 }
 
-SEC("kprobe/ptrace_check_attach")
-int kprobe_ptrace_check_attach(struct pt_regs *ctx) {
+HOOK_ENTRY("ptrace_check_attach")
+int hook_ptrace_check_attach(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_PTRACE);
     if (!syscall) {
         return 0;
     }
 
-    struct task_struct *child = (struct task_struct *)PT_REGS_PARM1(ctx);
+    struct task_struct *child = (struct task_struct *)CTX_PARM1(ctx);
     if (!child) {
         return 0;
     }

--- a/pkg/security/ebpf/c/include/hooks/rename.h
+++ b/pkg/security/ebpf/c/include/hooks/rename.h
@@ -30,8 +30,8 @@ SYSCALL_KPROBE0(renameat2) {
     return trace__sys_rename(SYNC_SYSCALL);
 }
 
-SEC("kprobe/do_renameat2")
-int kprobe_do_renameat2(struct pt_regs *ctx) {
+HOOK_ENTRY("do_renameat2")
+int hook_do_renameat2(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_RENAME);
     if (!syscall) {
         return trace__sys_rename(ASYNC_SYSCALL);
@@ -39,6 +39,7 @@ int kprobe_do_renameat2(struct pt_regs *ctx) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/vfs_rename")
 int kprobe_vfs_rename(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_RENAME);

--- a/pkg/security/ebpf/c/include/hooks/rename.h
+++ b/pkg/security/ebpf/c/include/hooks/rename.h
@@ -209,6 +209,7 @@ int __attribute__((always_inline)) dr_rename_callback(void *ctx, int retval) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/dr_rename_callback")
 int __attribute__((always_inline)) kprobe_dr_rename_callback(struct pt_regs *ctx) {
     int ret = PT_REGS_RC(ctx);

--- a/pkg/security/ebpf/c/include/hooks/rmdir.h
+++ b/pkg/security/ebpf/c/include/hooks/rmdir.h
@@ -33,6 +33,7 @@ int kprobe_do_rmdir(struct pt_regs *ctx) {
 }
 
 // security_inode_rmdir is shared between rmdir and unlink syscalls
+// fentry blocked by: tail call
 SEC("kprobe/security_inode_rmdir")
 int kprobe_security_inode_rmdir(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(rmdir_predicate);
@@ -104,6 +105,7 @@ int kprobe_security_inode_rmdir(struct pt_regs *ctx) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/dr_security_inode_rmdir_callback")
 int __attribute__((always_inline)) kprobe_dr_security_inode_rmdir_callback(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(rmdir_predicate);

--- a/pkg/security/ebpf/c/include/hooks/rmdir.h
+++ b/pkg/security/ebpf/c/include/hooks/rmdir.h
@@ -23,8 +23,8 @@ SYSCALL_KPROBE0(rmdir) {
     return trace__sys_rmdir(SYNC_SYSCALL, 0);
 }
 
-SEC("kprobe/do_rmdir")
-int kprobe_do_rmdir(struct pt_regs *ctx) {
+HOOK_ENTRY("do_rmdir")
+int hook_do_rmdir(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(rmdir_predicate);
     if (!syscall) {
         return trace__sys_rmdir(ASYNC_SYSCALL, 0);

--- a/pkg/security/ebpf/c/include/hooks/selinux.h
+++ b/pkg/security/ebpf/c/include/hooks/selinux.h
@@ -99,6 +99,7 @@ int __attribute__((always_inline)) dr_selinux_callback(void *ctx, int retval) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/dr_selinux_callback")
 int __attribute__((always_inline)) kprobe_dr_selinux_callback(struct pt_regs *ctx) {
     int retval = PT_REGS_RC(ctx);

--- a/pkg/security/ebpf/c/include/hooks/setattr.h
+++ b/pkg/security/ebpf/c/include/hooks/setattr.h
@@ -8,6 +8,7 @@
 #include "helpers/filesystem.h"
 #include "helpers/syscalls.h"
 
+// fentry blocked by: tail call
 SEC("kprobe/security_inode_setattr")
 int kprobe_security_inode_setattr(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(security_inode_predicate);
@@ -89,6 +90,7 @@ int kprobe_security_inode_setattr(struct pt_regs *ctx) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/dr_setattr_callback")
 int __attribute__((always_inline)) kprobe_dr_setattr_callback(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(security_inode_predicate);

--- a/pkg/security/ebpf/c/include/hooks/setxattr.h
+++ b/pkg/security/ebpf/c/include/hooks/setxattr.h
@@ -101,6 +101,7 @@ int __attribute__((always_inline)) trace__vfs_setxattr(struct pt_regs *ctx, u64 
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/dr_setxattr_callback")
 int __attribute__((always_inline)) kprobe_dr_setxattr_callback(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(xattr_predicate);
@@ -116,11 +117,13 @@ int __attribute__((always_inline)) kprobe_dr_setxattr_callback(struct pt_regs *c
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/vfs_setxattr")
 int kprobe_vfs_setxattr(struct pt_regs *ctx) {
     return trace__vfs_setxattr(ctx, EVENT_SETXATTR);
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/vfs_removexattr")
 int kprobe_vfs_removexattr(struct pt_regs *ctx) {
     return trace__vfs_setxattr(ctx, EVENT_REMOVEXATTR);

--- a/pkg/security/ebpf/c/include/hooks/signal.h
+++ b/pkg/security/ebpf/c/include/hooks/signal.h
@@ -28,14 +28,14 @@ SYSCALL_KPROBE2(kill, int, pid, int, type) {
     return 0;
 }
 
-SEC("kprobe/kill_pid_info")
-int kprobe_kill_pid_info(struct pt_regs *ctx) {
+HOOK_ENTRY("kill_pid_info")
+int hook_kill_pid_info(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_SIGNAL);
     if (!syscall || syscall->signal.pid) {
         return 0;
     }
 
-    struct pid *pid = (struct pid *)PT_REGS_PARM3(ctx);
+    struct pid *pid = (struct pid *)CTX_PARM3(ctx);
     if (!pid) {
         return 0;
     }

--- a/pkg/security/ebpf/c/include/hooks/splice.h
+++ b/pkg/security/ebpf/c/include/hooks/splice.h
@@ -22,8 +22,8 @@ SYSCALL_KPROBE0(splice) {
     return 0;
 }
 
-SEC("kprobe/get_pipe_info")
-int kprobe_get_pipe_info(struct pt_regs *ctx) {
+HOOK_ENTRY("get_pipe_info")
+int hook_get_pipe_info(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_SPLICE);
     if (!syscall) {
         return 0;
@@ -31,7 +31,7 @@ int kprobe_get_pipe_info(struct pt_regs *ctx) {
 
     // resolve the "in" file path
     if (!syscall->splice.file_found) {
-        struct file *f = (struct file*) PT_REGS_PARM1(ctx);
+        struct file *f = (struct file*) CTX_PARM1(ctx);
         syscall->splice.dentry = get_file_dentry(f);
         set_file_inode(syscall->splice.dentry, &syscall->splice.file, 0);
         syscall->splice.file.path_key.mount_id = get_file_mount_id(f);

--- a/pkg/security/ebpf/c/include/hooks/umount.h
+++ b/pkg/security/ebpf/c/include/hooks/umount.h
@@ -10,12 +10,12 @@ SYSCALL_KPROBE0(umount) {
     return 0;
 }
 
-SEC("kprobe/security_sb_umount")
-int kprobe_security_sb_umount(struct pt_regs *ctx) {
+HOOK_ENTRY("security_sb_umount")
+int hook_security_sb_umount(ctx_t *ctx) {
     struct syscall_cache_t syscall = {
         .type = EVENT_UMOUNT,
         .umount = {
-            .vfs = (struct vfsmount *)PT_REGS_PARM1(ctx),
+            .vfs = (struct vfsmount *)CTX_PARM1(ctx),
         }
     };
 

--- a/pkg/security/ebpf/c/include/hooks/unlink.h
+++ b/pkg/security/ebpf/c/include/hooks/unlink.h
@@ -31,8 +31,8 @@ SYSCALL_KPROBE3(unlinkat, int, dirfd, const char*, filename, int, flags) {
     return trace__sys_unlink(SYNC_SYSCALL, flags);
 }
 
-SEC("kprobe/do_unlinkat")
-int kprobe_do_unlinkat(struct pt_regs *ctx) {
+HOOK_ENTRY("do_unlinkat")
+int hook_do_unlinkat(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_UNLINK);
     if (!syscall) {
         return trace__sys_unlink(ASYNC_SYSCALL, 0);

--- a/pkg/security/ebpf/c/include/hooks/unlink.h
+++ b/pkg/security/ebpf/c/include/hooks/unlink.h
@@ -40,6 +40,7 @@ int hook_do_unlinkat(ctx_t *ctx) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/vfs_unlink")
 int kprobe_vfs_unlink(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_UNLINK);
@@ -84,6 +85,7 @@ int kprobe_vfs_unlink(struct pt_regs *ctx) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kprobe/dr_unlink_callback")
 int __attribute__((always_inline)) kprobe_dr_unlink_callback(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_UNLINK);

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -67,7 +67,7 @@ func AllProbes(fentry bool) []*manager.Probe {
 	allProbes = append(allProbes, getOpenProbes()...)
 	allProbes = append(allProbes, getRenameProbes()...)
 	allProbes = append(allProbes, getRmdirProbe()...)
-	allProbes = append(allProbes, sharedProbes...)
+	allProbes = append(allProbes, getSharedProbes(fentry)...)
 	allProbes = append(allProbes, getIouringProbes(fentry)...)
 	allProbes = append(allProbes, getUnlinkProbes()...)
 	allProbes = append(allProbes, getXattrProbes()...)

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -68,7 +68,7 @@ func AllProbes(fentry bool) []*manager.Probe {
 	allProbes = append(allProbes, getRenameProbes()...)
 	allProbes = append(allProbes, getRmdirProbe()...)
 	allProbes = append(allProbes, sharedProbes...)
-	allProbes = append(allProbes, iouringProbes...)
+	allProbes = append(allProbes, getIouringProbes(fentry)...)
 	allProbes = append(allProbes, getUnlinkProbes()...)
 	allProbes = append(allProbes, getXattrProbes()...)
 	allProbes = append(allProbes, getIoctlProbes()...)

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -98,7 +98,7 @@ func AllProbes(fentry bool) []*manager.Probe {
 		&manager.Probe{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe_security_inode_getattr",
+				EBPFFuncName: "hook_security_inode_getattr",
 			},
 		},
 	)

--- a/pkg/security/ebpf/probes/bind.go
+++ b/pkg/security/ebpf/probes/bind.go
@@ -23,7 +23,7 @@ func getBindProbes() []*manager.Probe {
 	bindProbes = append(bindProbes, &manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_security_socket_bind",
+			EBPFFuncName: "hook_security_socket_bind",
 		},
 	})
 

--- a/pkg/security/ebpf/probes/bpf.go
+++ b/pkg/security/ebpf/probes/bpf.go
@@ -14,19 +14,19 @@ var bpfProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_security_bpf_map",
+			EBPFFuncName: "hook_security_bpf_map",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_security_bpf_prog",
+			EBPFFuncName: "hook_security_bpf_prog",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_check_helper_call",
+			EBPFFuncName: "hook_check_helper_call",
 		},
 		MatchFuncName: "check_helper_call",
 	},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -228,7 +228,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "unlink", EntryAndExit)},
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_linkat"}},
+				kprobeOrFentry("do_linkat", fentry),
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_do_linkat"}},
 			}},
 
@@ -297,7 +297,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 		// List of probes required to capture mkdir events
 		"mkdir": {
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_mkdir"}},
+				kprobeOrFentry("vfs_mkdir", fentry),
 				kprobeOrFentry("filename_create", fentry),
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "mkdir", EntryAndExit)},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -65,9 +65,11 @@ var SyscallMonitorSelectors = []manager.ProbesSelector{
 }
 
 // SnapshotSelectors selectors required during the snapshot
-var SnapshotSelectors = []manager.ProbesSelector{
-	// required to stat /proc/.../exe
-	&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_inode_getattr"}},
+func SnapshotSelectors(fentry bool) []manager.ProbesSelector {
+	return []manager.ProbesSelector{
+		// required to stat /proc/.../exe
+		kprobeOrFentry("security_inode_getattr", fentry),
+	}
 }
 
 var selectorsPerEventTypeStore map[eval.EventType][]manager.ProbesSelector
@@ -200,7 +202,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "renameat", EntryAndExit)},
 			&manager.BestEffort{Selectors: append(
 				[]manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_renameat2"}},
+					kprobeOrFentry("do_renameat2", fentry),
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_do_renameat2"}}},
 				ExpandSyscallProbesSelector(SecurityAgentUID, "renameat2", EntryAndExit)...)},
 
@@ -368,7 +370,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 		"ptrace": {
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "ptrace", EntryAndExit)},
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_ptrace_check_attach"}},
+				kprobeOrFentry("ptrace_check_attach", fentry),
 			}},
 		},
 

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -412,7 +412,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 		"signal": {
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_check_kill_permission"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_kill_pid_info"}},
+				kprobeOrFentry("kill_pid_info", fentry),
 			}},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "kill", Entry)},
 		},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -99,7 +99,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_open"}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_dentry_open"}},
 				kprobeOrFentry("commit_creds", fentry),
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_switch_task_namespaces"}},
+				kprobeOrFentry("switch_task_namespaces", fentry),
 				kprobeOrFentry("do_coredump", fentry),
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -355,9 +355,9 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 		// List of probes required to capture bpf events
 		"bpf": {
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_bpf_map"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_bpf_prog"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_check_helper_call"}},
+				kprobeOrFentry("security_bpf_map", fentry),
+				kprobeOrFentry("security_bpf_prog", fentry),
+				kprobeOrFentry("check_helper_call", fentry),
 			}},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "bpf", EntryAndExit)},
 		},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -194,7 +194,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			// Rename probes
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_rename"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write"}},
+				kprobeOrFentry("mnt_want_write", fentry),
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "rename", EntryAndExit)},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "renameat", EntryAndExit)},
@@ -206,7 +206,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 
 			// unlink rmdir probes
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write"}},
+				kprobeOrFentry("mnt_want_write", fentry),
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "unlinkat", EntryAndExit)},
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
@@ -271,7 +271,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 		// List of probes required to capture chmod events
 		"chmod": {
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write"}},
+				kprobeOrFentry("mnt_want_write", fentry),
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chmod", EntryAndExit)},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchmod", EntryAndExit)},
@@ -281,11 +281,11 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 		// List of probes required to capture chown events
 		"chown": {
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write"}},
+				kprobeOrFentry("mnt_want_write", fentry),
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write_file"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write_file_path"}},
+				kprobeOrFentry("mnt_want_write_file", fentry),
+				kprobeOrFentry("mnt_want_write_file_path", fentry, withSkipIfFentry(true)),
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chown", EntryAndExit)},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chown16", EntryAndExit)},
@@ -313,11 +313,11 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 		"removexattr": {
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_removexattr"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write"}},
+				kprobeOrFentry("mnt_want_write", fentry),
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write_file"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write_file_path"}},
+				kprobeOrFentry("mnt_want_write_file", fentry),
+				kprobeOrFentry("mnt_want_write_file_path", fentry, withSkipIfFentry(true)),
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "removexattr", EntryAndExit)},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fremovexattr", EntryAndExit)},
@@ -328,11 +328,11 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 		"setxattr": {
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_setxattr"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write"}},
+				kprobeOrFentry("mnt_want_write", fentry),
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write_file"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write_file_path"}},
+				kprobeOrFentry("mnt_want_write_file", fentry),
+				kprobeOrFentry("mnt_want_write_file_path", fentry, withSkipIfFentry(true)),
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setxattr", EntryAndExit)},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fsetxattr", EntryAndExit)},
@@ -342,7 +342,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 		// List of probes required to capture utimes events
 		"utimes": {
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mnt_want_write"}},
+				kprobeOrFentry("mnt_want_write", fentry),
 			}},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utime", EntryAndExit, true)},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utime32", EntryAndExit)},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -240,7 +240,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			// Link
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_link"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_filename_create"}},
+				kprobeOrFentry("filename_create", fentry),
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "link", EntryAndExit)},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "linkat", EntryAndExit)},
@@ -298,7 +298,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 		"mkdir": {
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_mkdir"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_filename_create"}},
+				kprobeOrFentry("filename_create", fentry),
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "mkdir", EntryAndExit)},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "mkdirat", EntryAndExit)},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -103,8 +103,8 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				kprobeOrFentry("do_coredump", fentry),
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_cgroup_procs_write"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_cgroup1_procs_write"}},
+				kprobeOrFentry("cgroup_procs_write", fentry),
+				kprobeOrFentry("cgroup1_procs_write", fentry),
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
 				kprobeOrFentry("_do_fork", fentry, withSkipIfFentry(true)),
@@ -112,8 +112,8 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				kprobeOrFentry("kernel_clone", fentry),
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_cgroup_tasks_write"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_cgroup1_tasks_write"}},
+				kprobeOrFentry("cgroup_tasks_write", fentry, withSkipIfFentry(true)),
+				kprobeOrFentry("cgroup1_tasks_write", fentry, withSkipIfFentry(true)),
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "execve", Entry)},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "execveat", Entry)},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -96,7 +96,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				kprobeOrFentry("exit_itimers", fentry),
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_open"}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_dentry_open"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_commit_creds"}},
+				kprobeOrFentry("commit_creds", fentry),
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_switch_task_namespaces"}},
 				kprobeOrFentry("do_coredump", fentry),
 			}},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -97,7 +97,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				kprobeOrFentry("mprotect_fixup", fentry),
 				kprobeOrFentry("exit_itimers", fentry),
 				kprobeOrFentry("vfs_open", fentry),
-				kprobeOrFentry("do_dentry_open", fentry),
+				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_dentry_open"}},
 				kprobeOrFentry("commit_creds", fentry),
 				kprobeOrFentry("switch_task_namespaces", fentry),
 				kprobeOrFentry("do_coredump", fentry),

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -222,7 +222,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "rmdir", EntryAndExit)},
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_rmdir"}},
+				kprobeOrFentry("do_rmdir", fentry),
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_do_rmdir"}},
 			}},
 

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -394,8 +394,8 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_kernel_module_from_file"}},
 				}},
 				&manager.OneOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_init_module"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_module_put"}},
+					kprobeOrFentry("do_init_module", fentry),
+					kprobeOrFentry("module_put", fentry),
 				}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_parse_args"}},
 			}},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -30,31 +30,33 @@ var NetworkVethSelectors = []manager.ProbesSelector{
 }
 
 // NetworkSelectors is the list of probes that should be activated when the network is enabled
-var NetworkSelectors = []manager.ProbesSelector{
-	// flow classification probes
-	&manager.AllOf{Selectors: []manager.ProbesSelector{
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_socket_bind"}},
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_sk_classify_flow"}},
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_path_get"}},
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_proc_fd_link"}},
-	}},
-
-	// network device probes
-	&manager.AllOf{Selectors: []manager.ProbesSelector{
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_register_netdevice"}},
-		&manager.OneOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_dev_change_net_namespace"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe___dev_change_net_namespace"}},
+func NetworkSelectors(fentry bool) []manager.ProbesSelector {
+	return []manager.ProbesSelector{
+		// flow classification probes
+		&manager.AllOf{Selectors: []manager.ProbesSelector{
+			kprobeOrFentry("security_socket_bind", fentry),
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_sk_classify_flow"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_path_get"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_proc_fd_link"}},
 		}},
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_register_netdevice"}},
-	}},
-	&manager.BestEffort{Selectors: []manager.ProbesSelector{
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_dev_get_valid_name"}},
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_dev_new_index"}},
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_dev_new_index"}},
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe___dev_get_by_index"}},
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe___dev_get_by_name"}},
-	}},
+
+		// network device probes
+		&manager.AllOf{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_register_netdevice"}},
+			&manager.OneOf{Selectors: []manager.ProbesSelector{
+				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_dev_change_net_namespace"}},
+				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe___dev_change_net_namespace"}},
+			}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_register_netdevice"}},
+		}},
+		&manager.BestEffort{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_dev_get_valid_name"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_dev_new_index"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_dev_new_index"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe___dev_get_by_index"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe___dev_get_by_name"}},
+		}},
+	}
 }
 
 // SyscallMonitorSelectors is the list of probes that should be activated for the syscall monitor feature
@@ -177,7 +179,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_attach_recursive_mnt"}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_propagate_mnt"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_sb_umount"}},
+				kprobeOrFentry("security_sb_umount", fentry),
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_clone_mnt"}},
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "mount", EntryAndExit, true)},
@@ -397,7 +399,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 					kprobeOrFentry("do_init_module", fentry),
 					kprobeOrFentry("module_put", fentry),
 				}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_parse_args"}},
+				kprobeOrFentry("parse_args", fentry),
 			}},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "init_module", EntryAndExit)},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "finit_module", EntryAndExit)},
@@ -421,14 +423,14 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 		"splice": {
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "splice", EntryAndExit)},
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_get_pipe_info"}},
+				kprobeOrFentry("get_pipe_info", fentry),
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_get_pipe_info"}},
 			}}},
 
 		// List of probes required to capture bind events
 		"bind": {
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_socket_bind"}},
+				kprobeOrFentry("security_socket_bind", fentry),
 			}},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "bind", EntryAndExit)},
 		},
@@ -436,9 +438,9 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 		// List of probes required to capture DNS events
 		"dns": {
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
-				&manager.AllOf{Selectors: NetworkSelectors},
+				&manager.AllOf{Selectors: NetworkSelectors(fentry)},
 				&manager.AllOf{Selectors: NetworkVethSelectors},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_socket_bind"}},
+				kprobeOrFentry("security_socket_bind", fentry),
 			}},
 		},
 	}

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -170,7 +170,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "io_uring_create"}},
 				&manager.OneOf{Selectors: []manager.ProbesSelector{
 					kprobeOrFentry("io_allocate_scq_urings", fentry),
-					kprobeOrFentry("io_sq_offload_start", fentry),
+					kprobeOrFentry("io_sq_offload_start", fentry, withSkipIfFentry(true)),
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_io_ring_ctx_alloc"}},
 				}},
 			}},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -36,7 +36,7 @@ func NetworkSelectors(fentry bool) []manager.ProbesSelector {
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
 			kprobeOrFentry("security_socket_bind", fentry),
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_sk_classify_flow"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_path_get"}},
+			kprobeOrFentry("path_get", fentry),
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_proc_fd_link"}},
 		}},
 
@@ -265,7 +265,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			// pipes
 			// This is needed to skip FIM events relatives to pipes (avoiding abnormal path events)
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_mntget"}},
+				kprobeOrFentry("mntget", fentry),
 			}}},
 
 		// List of probes required to capture chmod events

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -210,7 +210,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "unlinkat", EntryAndExit)},
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_unlinkat"}},
+				kprobeOrFentry("do_unlinkat", fentry),
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_do_unlinkat"}},
 			}},
 

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -169,8 +169,8 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "io_uring_create"}},
 				&manager.OneOf{Selectors: []manager.ProbesSelector{
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_io_allocate_scq_urings"}},
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_io_sq_offload_start"}},
+					kprobeOrFentry("io_allocate_scq_urings", fentry),
+					kprobeOrFentry("io_sq_offload_start", fentry),
 					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_io_ring_ctx_alloc"}},
 				}},
 			}},
@@ -383,7 +383,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 		// List of probes required to capture mprotect events
 		"mprotect": {
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_file_mprotect"}},
+				kprobeOrFentry("security_file_mprotect", fentry),
 			}},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "mprotect", EntryAndExit)},
 		},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -399,7 +399,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 					kprobeOrFentry("do_init_module", fentry),
 					kprobeOrFentry("module_put", fentry),
 				}},
-				kprobeOrFentry("parse_args", fentry),
+				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_parse_args"}},
 			}},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "init_module", EntryAndExit)},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "finit_module", EntryAndExit)},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -37,7 +37,7 @@ func NetworkSelectors(fentry bool) []manager.ProbesSelector {
 			kprobeOrFentry("security_socket_bind", fentry),
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_sk_classify_flow"}},
 			kprobeOrFentry("path_get", fentry),
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_proc_fd_link"}},
+			kprobeOrFentry("proc_fd_link", fentry),
 		}},
 
 		// network device probes

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -96,8 +96,8 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_setup_arg_pages"}},
 				kprobeOrFentry("mprotect_fixup", fentry),
 				kprobeOrFentry("exit_itimers", fentry),
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_open"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_do_dentry_open"}},
+				kprobeOrFentry("vfs_open", fentry),
+				kprobeOrFentry("do_dentry_open", fentry),
 				kprobeOrFentry("commit_creds", fentry),
 				kprobeOrFentry("switch_task_namespaces", fentry),
 				kprobeOrFentry("do_coredump", fentry),
@@ -148,7 +148,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 
 			// Open probes
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_vfs_truncate"}},
+				kprobeOrFentry("vfs_truncate", fentry),
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "open", EntryAndExit, true)},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "creat", EntryAndExit)},
@@ -157,12 +157,12 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "openat2", EntryAndExit)},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "open_by_handle_at", EntryAndExit, true)},
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_io_openat"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_io_openat2"}},
+				kprobeOrFentry("io_openat", fentry),
+				kprobeOrFentry("io_openat2", fentry),
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_io_openat2"}},
 			}},
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_filp_close"}},
+				kprobeOrFentry("filp_close", fentry),
 			}},
 
 			// iouring

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -98,7 +98,7 @@ func getExecProbes(fentry bool) []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe_commit_creds",
+				EBPFFuncName: "hook_commit_creds",
 			},
 		},
 		{

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -104,7 +104,7 @@ func getExecProbes(fentry bool) []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe_switch_task_namespaces",
+				EBPFFuncName: "hook_switch_task_namespaces",
 			},
 		},
 		{

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -44,25 +44,13 @@ func getExecProbes(fentry bool) []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe_cgroup_procs_write",
+				EBPFFuncName: "hook_cgroup_procs_write",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe_cgroup1_procs_write",
-			},
-		},
-		{
-			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe_cgroup_tasks_write",
-			},
-		},
-		{
-			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe_cgroup1_tasks_write",
+				EBPFFuncName: "hook_cgroup1_procs_write",
 			},
 		},
 		{
@@ -133,6 +121,18 @@ func getExecProbes(fentry bool) []*manager.Probe {
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					UID:          SecurityAgentUID,
 					EBPFFuncName: "hook__do_fork",
+				},
+			},
+			{
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					UID:          SecurityAgentUID,
+					EBPFFuncName: "hook_cgroup_tasks_write",
+				},
+			},
+			{
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					UID:          SecurityAgentUID,
+					EBPFFuncName: "hook_cgroup1_tasks_write",
 				},
 			},
 		}...)

--- a/pkg/security/ebpf/probes/flow.go
+++ b/pkg/security/ebpf/probes/flow.go
@@ -38,7 +38,7 @@ var flowProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_proc_fd_link",
+			EBPFFuncName: "hook_proc_fd_link",
 		},
 	},
 }

--- a/pkg/security/ebpf/probes/flow.go
+++ b/pkg/security/ebpf/probes/flow.go
@@ -32,7 +32,7 @@ var flowProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_path_get",
+			EBPFFuncName: "hook_path_get",
 		},
 	},
 	{

--- a/pkg/security/ebpf/probes/iouring.go
+++ b/pkg/security/ebpf/probes/iouring.go
@@ -10,28 +10,35 @@ package probes
 import manager "github.com/DataDog/ebpf-manager"
 
 // iouringProbes is the list of probes that are used for iouring monitoring
-var iouringProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "io_uring_create"},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kretprobe_io_ring_ctx_alloc",
+func getIouringProbes(fentry bool) []*manager.Probe {
+	iouringProbes := []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "io_uring_create"},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_io_allocate_scq_urings",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kretprobe_io_ring_ctx_alloc",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_io_sq_offload_start",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_io_allocate_scq_urings",
+			},
 		},
-	},
+	}
+
+	if !fentry {
+		iouringProbes = append(iouringProbes, &manager.Probe{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_io_sq_offload_start",
+			},
+		})
+	}
+
+	return iouringProbes
 }

--- a/pkg/security/ebpf/probes/iouring.go
+++ b/pkg/security/ebpf/probes/iouring.go
@@ -25,13 +25,13 @@ var iouringProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_io_allocate_scq_urings",
+			EBPFFuncName: "hook_io_allocate_scq_urings",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_io_sq_offload_start",
+			EBPFFuncName: "hook_io_sq_offload_start",
 		},
 	},
 }

--- a/pkg/security/ebpf/probes/link.go
+++ b/pkg/security/ebpf/probes/link.go
@@ -20,7 +20,7 @@ var linkProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_do_linkat",
+			EBPFFuncName: "hook_do_linkat",
 		},
 	},
 	{

--- a/pkg/security/ebpf/probes/mkdir.go
+++ b/pkg/security/ebpf/probes/mkdir.go
@@ -14,7 +14,7 @@ var mkdirProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_vfs_mkdir",
+			EBPFFuncName: "hook_vfs_mkdir",
 		},
 	},
 	{

--- a/pkg/security/ebpf/probes/module.go
+++ b/pkg/security/ebpf/probes/module.go
@@ -26,13 +26,13 @@ var moduleProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_do_init_module",
+			EBPFFuncName: "hook_do_init_module",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_module_put",
+			EBPFFuncName: "hook_module_put",
 		},
 	},
 	{

--- a/pkg/security/ebpf/probes/mount.go
+++ b/pkg/security/ebpf/probes/mount.go
@@ -26,7 +26,7 @@ var mountProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_security_sb_umount",
+			EBPFFuncName: "hook_security_sb_umount",
 		},
 	},
 	{

--- a/pkg/security/ebpf/probes/mprotect.go
+++ b/pkg/security/ebpf/probes/mprotect.go
@@ -14,7 +14,7 @@ var mprotectProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_security_file_mprotect",
+			EBPFFuncName: "hook_security_file_mprotect",
 		},
 	},
 }

--- a/pkg/security/ebpf/probes/open.go
+++ b/pkg/security/ebpf/probes/open.go
@@ -26,7 +26,7 @@ var openProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_do_dentry_open",
+			EBPFFuncName: "kprobe_do_dentry_open",
 		},
 	},
 	{

--- a/pkg/security/ebpf/probes/open.go
+++ b/pkg/security/ebpf/probes/open.go
@@ -14,31 +14,31 @@ var openProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_vfs_truncate",
+			EBPFFuncName: "hook_vfs_truncate",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_vfs_open",
+			EBPFFuncName: "hook_vfs_open",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_do_dentry_open",
+			EBPFFuncName: "hook_do_dentry_open",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_io_openat",
+			EBPFFuncName: "hook_io_openat",
 		},
 	},
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_io_openat2",
+			EBPFFuncName: "hook_io_openat2",
 		},
 	},
 	{
@@ -50,7 +50,7 @@ var openProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_filp_close",
+			EBPFFuncName: "hook_filp_close",
 		},
 	},
 }

--- a/pkg/security/ebpf/probes/pipe.go
+++ b/pkg/security/ebpf/probes/pipe.go
@@ -14,7 +14,7 @@ var pipeProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_mntget",
+			EBPFFuncName: "hook_mntget",
 		},
 	},
 }

--- a/pkg/security/ebpf/probes/ptrace.go
+++ b/pkg/security/ebpf/probes/ptrace.go
@@ -22,8 +22,7 @@ func getPTraceProbes() []*manager.Probe {
 	ptraceProbes = append(ptraceProbes, &manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/ptrace_check_attach",
-			EBPFFuncName: "kprobe_ptrace_check_attach",
+			EBPFFuncName: "hook_ptrace_check_attach",
 		},
 	})
 	return ptraceProbes

--- a/pkg/security/ebpf/probes/rename.go
+++ b/pkg/security/ebpf/probes/rename.go
@@ -20,7 +20,7 @@ var renameProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_do_renameat2",
+			EBPFFuncName: "hook_do_renameat2",
 		},
 	},
 	{

--- a/pkg/security/ebpf/probes/rmdir.go
+++ b/pkg/security/ebpf/probes/rmdir.go
@@ -20,7 +20,7 @@ var rmdirProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_do_rmdir",
+			EBPFFuncName: "hook_do_rmdir",
 		},
 	},
 	{

--- a/pkg/security/ebpf/probes/shared.go
+++ b/pkg/security/ebpf/probes/shared.go
@@ -9,30 +9,37 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// sharedProbes is the list of probes that are shared across multiple events
-var sharedProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_filename_create",
+// getSharedProbes returns the list of probes that are shared across multiple events
+func getSharedProbes(fentry bool) []*manager.Probe {
+	probes := []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_filename_create",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_mnt_want_write",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_mnt_want_write",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_mnt_want_write_file",
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_mnt_want_write_file",
+			},
 		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_mnt_want_write_file_path",
-		},
-	},
+	}
+
+	if !fentry {
+		probes = append(probes, &manager.Probe{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_mnt_want_write_file_path",
+			},
+		})
+	}
+
+	return probes
 }

--- a/pkg/security/ebpf/probes/shared.go
+++ b/pkg/security/ebpf/probes/shared.go
@@ -14,7 +14,7 @@ var sharedProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_filename_create",
+			EBPFFuncName: "hook_filename_create",
 		},
 	},
 	{

--- a/pkg/security/ebpf/probes/shared.go
+++ b/pkg/security/ebpf/probes/shared.go
@@ -36,7 +36,7 @@ func getSharedProbes(fentry bool) []*manager.Probe {
 		probes = append(probes, &manager.Probe{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe_mnt_want_write_file_path",
+				EBPFFuncName: "hook_mnt_want_write_file_path",
 			},
 		})
 	}

--- a/pkg/security/ebpf/probes/signal.go
+++ b/pkg/security/ebpf/probes/signal.go
@@ -29,8 +29,7 @@ func getSignalProbes() []*manager.Probe {
 	signalProbes = append(signalProbes, &manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFSection:  "kprobe/kill_pid_info",
-			EBPFFuncName: "kprobe_kill_pid_info",
+			EBPFFuncName: "hook_kill_pid_info",
 		},
 	})
 	return signalProbes

--- a/pkg/security/ebpf/probes/splice.go
+++ b/pkg/security/ebpf/probes/splice.go
@@ -20,7 +20,7 @@ var spliceProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_get_pipe_info",
+			EBPFFuncName: "hook_get_pipe_info",
 		},
 	},
 }

--- a/pkg/security/ebpf/probes/unlink.go
+++ b/pkg/security/ebpf/probes/unlink.go
@@ -20,7 +20,7 @@ var unlinkProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_do_unlinkat",
+			EBPFFuncName: "hook_do_unlinkat",
 		},
 	},
 	{

--- a/pkg/security/probe/constantfetch/offset_guesser.go
+++ b/pkg/security/probe/constantfetch/offset_guesser.go
@@ -34,13 +34,13 @@ var (
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          offsetGuesserUID,
-				EBPFFuncName: "kprobe_get_pid_task_numbers",
+				EBPFFuncName: "hook_get_pid_task_numbers",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          offsetGuesserUID + "_a",
-				EBPFFuncName: "kprobe_get_pid_task_offset",
+				EBPFFuncName: "hook_get_pid_task_offset",
 			},
 		},
 	}

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -249,7 +249,7 @@ func (p *Probe) Init() error {
 		})
 	}
 
-	p.managerOptions.ActivatedProbes = append(p.managerOptions.ActivatedProbes, probes.SnapshotSelectors...)
+	p.managerOptions.ActivatedProbes = append(p.managerOptions.ActivatedProbes, probes.SnapshotSelectors(p.useFentry)...)
 
 	if err := p.Manager.InitWithOptions(bytecodeReader, p.managerOptions); err != nil {
 		return fmt.Errorf("failed to init manager: %w", err)


### PR DESCRIPTION
### What does this PR do?

This PR converts all kprobe hookpoints, that do not use tail calls and that are not hooks in modules, to the new fentry hook infrastructure.

With this PR ~15% of kprobe hookpoints are now fentry compatible.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
