### PR TITLE
[omnibus] Rename session_result_free to session_result_reset in OpenSCAP

### DIFF
--- a/omnibus/config/patches/openscap/oscap-io.patch
+++ b/omnibus/config/patches/openscap/oscap-io.patch
@@ -116,7 +116,7 @@
 +
 +	if (xccdf_session_evaluate(session) != 0) {
 +		fprintf(stderr, "error: xccdf_session_evaluate: %s\n", oscap_err_get_full_error());
-+		xccdf_session_result_free(session);
++		xccdf_session_result_reset(session);
 +		return 1;
 +	}
 +
@@ -163,7 +163,7 @@
 +		dprintf("rule %s returned failures or errors\n", rule);
 +	}
 +
-+	xccdf_session_result_free(session);
++	xccdf_session_result_reset(session);
 +
 +	return 0;
 +}

--- a/omnibus/config/patches/openscap/session_result_reset.patch
+++ b/omnibus/config/patches/openscap/session_result_reset.patch
@@ -5,11 +5,11 @@
  OSCAP_API void xccdf_session_free(struct xccdf_session *session);
  
 +/**
-+ * Free xccdf_session results.
++ * Reset xccdf_session results.
 + * @memberof xccdf_session
-+ * @param session to free results from.
++ * @param session to reset results from.
 + */
-+OSCAP_API void xccdf_session_result_free(struct xccdf_session *session);
++OSCAP_API void xccdf_session_result_reset(struct xccdf_session *session);
 +
  /**
   * Retrieves the filename the session was created with
@@ -20,7 +20,7 @@
  	free(session);
  }
  
-+void xccdf_session_result_free(struct xccdf_session *session)
++void xccdf_session_result_reset(struct xccdf_session *session)
 +{
 +	if (session->xccdf.policy_model != NULL) {
 +		oscap_list_free(session->xccdf.policy_model->policies, (oscap_destruct_func) xccdf_policy_free);

--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -40,7 +40,7 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   patch source: "get_results_from_session.patch", env: env # add a function to retrieve results from session
-  patch source: "session_result_free.patch", env: env # add a function to free results from session
+  patch source: "session_result_reset.patch", env: env # add a function to reset results from session
   patch source: "010_perlpm_install_fix.patch", env: env # fix build of perl bindings
   patch source: "dpkginfo-cacheconfig.patch", env: env # work around incomplete pkgcache path
   patch source: "dpkginfo-init.patch", env: env # fix memory leak of pkgcache in dpkginfo probe


### PR DESCRIPTION
### What does this PR do?

This changes renames the session_result_free function to session_result_reset, as suggested by the OpenSCAP maintainers.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
