### PR TITLE
[corechecks/snmp] Add symbol level metric_type for table metrics

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_metric.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_metric.go
@@ -27,6 +27,8 @@ type SymbolConfig struct {
 	ScaleFactor      float64 `yaml:"scale_factor"`
 	Format           string  `yaml:"format"`
 	ConstantValueOne bool    `yaml:"constant_value_one"`
+
+	ForcedType string `yaml:"forced_type"`
 }
 
 // MetricTagConfig holds metric tag info

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_metric.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_metric.go
@@ -28,7 +28,7 @@ type SymbolConfig struct {
 	Format           string  `yaml:"format"`
 	ConstantValueOne bool    `yaml:"constant_value_one"`
 
-	ForcedType string `yaml:"forced_type"`
+	MetricType string `yaml:"metric_type"`
 }
 
 // MetricTagConfig holds metric tag info

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich.go
@@ -75,7 +75,7 @@ func ValidateEnrichMetrics(metrics []MetricsConfig) []string {
 				errors = append(errors, validateEnrichSymbol(&metricConfig.Symbols[j], ColumnSymbol)...)
 			}
 			if len(metricConfig.MetricTags) == 0 {
-				errors = append(errors, fmt.Sprintf("column symbols %v doesn't have a 'metric_tags' section, all its metrics will use the same tags; "+
+				errors = append(errors, fmt.Sprintf("column symbols doesn't have a 'metric_tags' section (%v), all its metrics will use the same tags; "+
 					"if the table has multiple rows, only one row will be submitted; "+
 					"please add at least one discriminating metric tag (such as a row index) "+
 					"to ensure metrics of all rows are submitted", metricConfig.Symbols))

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich.go
@@ -157,6 +157,9 @@ func validateEnrichSymbol(symbol *SymbolConfig, symbolContext SymbolContext) []s
 	if symbolContext != ColumnSymbol && symbol.ConstantValueOne {
 		errors = append(errors, fmt.Sprintf("`constant_value_one` cannot be used outside of tables"))
 	}
+	if symbolContext != ColumnSymbol && symbol.ForcedType != "" {
+		errors = append(errors, fmt.Sprintf("`forced_type` cannot be used outside table symbols and metrics root"))
+	}
 	return errors
 }
 func validateEnrichMetricTag(metricTag *MetricTagConfig) []string {

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich.go
@@ -75,7 +75,7 @@ func ValidateEnrichMetrics(metrics []MetricsConfig) []string {
 				errors = append(errors, validateEnrichSymbol(&metricConfig.Symbols[j], ColumnSymbol)...)
 			}
 			if len(metricConfig.MetricTags) == 0 {
-				errors = append(errors, fmt.Sprintf("column symbols doesn't have a 'metric_tags' section (%v), all its metrics will use the same tags; "+
+				errors = append(errors, fmt.Sprintf("column symbols doesn't have a 'metric_tags' section (%+v), all its metrics will use the same tags; "+
 					"if the table has multiple rows, only one row will be submitted; "+
 					"please add at least one discriminating metric tag (such as a row index) "+
 					"to ensure metrics of all rows are submitted", metricConfig.Symbols))

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich.go
@@ -157,7 +157,7 @@ func validateEnrichSymbol(symbol *SymbolConfig, symbolContext SymbolContext) []s
 	if symbolContext != ColumnSymbol && symbol.ConstantValueOne {
 		errors = append(errors, fmt.Sprintf("`constant_value_one` cannot be used outside of tables"))
 	}
-	if symbolContext != ColumnSymbol && symbol.ForcedType != "" {
+	if symbolContext != ColumnSymbol && symbol.MetricType != "" {
 		errors = append(errors, fmt.Sprintf("`forced_type` cannot be used outside table symbols and metrics root"))
 	}
 	return errors

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich_test.go
@@ -442,6 +442,45 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 			},
 		},
 		{
+			name: "forced_type usage in column symbol",
+			metrics: []MetricsConfig{
+				{
+					Symbols: []SymbolConfig{
+						{
+							Name:       "abc",
+							OID:        "1.2.3",
+							ForcedType: "monotonic_count",
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Column: SymbolConfig{
+								Name: "abc",
+								OID:  "1.2.3",
+							},
+							Tag: "hello",
+						},
+					},
+				},
+			},
+			expectedErrors: []string{},
+		},
+		{
+			name: "forced_type usage in scalar symbol",
+			metrics: []MetricsConfig{
+				{
+					Symbol: SymbolConfig{
+						Name:       "abc",
+						OID:        "1.2.3",
+						ForcedType: "monotonic_count",
+					},
+				},
+			},
+			expectedErrors: []string{
+				"`forced_type` cannot be used outside table symbols and metrics root",
+			},
+		},
+		{
 			name: "mapping used without tag should raise a warning",
 			metrics: []MetricsConfig{
 				{

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich_test.go
@@ -449,7 +449,7 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 						{
 							Name:       "abc",
 							OID:        "1.2.3",
-							ForcedType: "monotonic_count",
+							MetricType: "monotonic_count",
 						},
 					},
 					MetricTags: MetricTagConfigList{
@@ -472,7 +472,7 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 					Symbol: SymbolConfig{
 						Name:       "abc",
 						OID:        "1.2.3",
-						ForcedType: "monotonic_count",
+						MetricType: "monotonic_count",
 					},
 				},
 			},
@@ -495,7 +495,7 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 							Column: SymbolConfig{
 								Name:       "abc",
 								OID:        "1.2.3",
-								ForcedType: "monotonic_count",
+								MetricType: "monotonic_count",
 							},
 							Tag: "hello",
 						},

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich_test.go
@@ -481,6 +481,32 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 			},
 		},
 		{
+			name: "forced_type usage in metric_tags",
+			metrics: []MetricsConfig{
+				{
+					Symbols: []SymbolConfig{
+						{
+							Name: "abc",
+							OID:  "1.2.3",
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Column: SymbolConfig{
+								Name:       "abc",
+								OID:        "1.2.3",
+								ForcedType: "monotonic_count",
+							},
+							Tag: "hello",
+						},
+					},
+				},
+			},
+			expectedErrors: []string{
+				"`forced_type` cannot be used outside table symbols and metrics root",
+			},
+		},
+		{
 			name: "mapping used without tag should raise a warning",
 			metrics: []MetricsConfig{
 				{

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich_test.go
@@ -169,7 +169,7 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 				},
 			},
 			expectedErrors: []string{
-				"column symbols [{1.2 abc  <nil>   <nil> 0  false}] doesn't have a 'metric_tags' section",
+				"column symbols doesn't have a 'metric_tags' section",
 			},
 		},
 		{

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
@@ -171,6 +171,9 @@ func (ms *MetricSender) reportColumnMetrics(metricConfig checkconfig.MetricsConf
 func (ms *MetricSender) sendMetric(metricSample MetricSample) {
 	metricFullName := "snmp." + metricSample.symbol.Name
 	forcedType := metricSample.forcedType
+	if metricSample.symbol.ForcedType != "" {
+		forcedType = metricSample.symbol.ForcedType
+	}
 	if forcedType == "" {
 		if metricSample.value.SubmissionType != "" {
 			forcedType = metricSample.value.SubmissionType

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
@@ -171,8 +171,8 @@ func (ms *MetricSender) reportColumnMetrics(metricConfig checkconfig.MetricsConf
 func (ms *MetricSender) sendMetric(metricSample MetricSample) {
 	metricFullName := "snmp." + metricSample.symbol.Name
 	forcedType := metricSample.forcedType
-	if metricSample.symbol.ForcedType != "" {
-		forcedType = metricSample.symbol.ForcedType
+	if metricSample.symbol.MetricType != "" {
+		forcedType = metricSample.symbol.MetricType
 	}
 	if forcedType == "" {
 		if metricSample.value.SubmissionType != "" {

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
@@ -195,6 +195,18 @@ func TestSendMetric(t *testing.T) {
 			},
 		},
 		{
+			caseName:           "Forced monotonic_count via symbol config",
+			symbol:             checkconfig.SymbolConfig{Name: "my.metric", ForcedType: "monotonic_count"},
+			value:              valuestore.ResultValue{SubmissionType: "counter", Value: float64(10)},
+			tags:               []string{},
+			metricConfig:       checkconfig.MetricsConfig{},
+			expectedMethod:     "MonotonicCount",
+			expectedMetricName: "snmp.my.metric",
+			expectedValue:      float64(10),
+			expectedTags:       []string{},
+			expectedSubMetrics: 1,
+		},
+		{
 			caseName: "Error converting value",
 			symbol:   checkconfig.SymbolConfig{Name: "metric"},
 			value:    valuestore.ResultValue{Value: valuestore.ResultValue{}},

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
@@ -196,7 +196,7 @@ func TestSendMetric(t *testing.T) {
 		},
 		{
 			caseName:           "Forced monotonic_count via symbol config",
-			symbol:             checkconfig.SymbolConfig{Name: "my.metric", ForcedType: "monotonic_count"},
+			symbol:             checkconfig.SymbolConfig{Name: "my.metric", MetricType: "monotonic_count"},
 			value:              valuestore.ResultValue{SubmissionType: "counter", Value: float64(10)},
 			tags:               []string{},
 			metricConfig:       checkconfig.MetricsConfig{},

--- a/releasenotes/notes/add_snmp_symbol_forced_type-ffc92909484115c4.yaml
+++ b/releasenotes/notes/add_snmp_symbol_forced_type-ffc92909484115c4.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    [corechecks/snmp] Add symbol level ``forced_type`` for table metrics.
+    [corechecks/snmp] Add symbol level ``metric_type`` for table metrics.

--- a/releasenotes/notes/add_snmp_symbol_forced_type-ffc92909484115c4.yaml
+++ b/releasenotes/notes/add_snmp_symbol_forced_type-ffc92909484115c4.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    [corechecks/snmp] Add symbol level ``forced_type`` for table metrics.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[corechecks/snmp] Symbol level forced_type

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

NDM-704



Issue:

Currently, forced_type is at root of metrics elements in profiles.

This is leading to duplication of metric_tags section when we want metrics from the same table e.g. ifTable but some metrics 

Example of duplicated metric_tags 

```
 metrics:
  - MIB: IF-MIB
  table:
    OID: 1.3.6.1.2.1.2.2
    name: ifTable
  forced_type: monotonic_count_and_rate
  symbols:
  - OID: 1.3.6.1.2.1.2.2.1.14
    name: ifInErrors
  - OID: 1.3.6.1.2.1.2.2.1.13
    name: ifInDiscards
  metric_tags:
  - column:
      OID: 1.3.6.1.2.1.31.1.1.1.1
      name: ifName
    table: ifXTable
    tag: interface
    
  
- MIB: IF-MIB
  table:
    OID: 1.3.6.1.2.1.2.2
    name: ifTable
  symbols:
  - OID: 1.3.6.1.2.1.2.2.1.7
    name: ifAdminStatus
  metric_tags:
  - column:
      OID: 1.3.6.1.2.1.31.1.1.1.1
      name: ifName
    table: ifXTable
    tag: interface
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
