### PR TITLE
[omnibus] Reset syschar in xccdf_session_result_reset in OpenSCAP

### DIFF
--- a/omnibus/config/patches/openscap/session_reset_syschar.patch
+++ b/omnibus/config/patches/openscap/session_reset_syschar.patch
@@ -1,0 +1,54 @@
+--- a/src/OVAL/oval_agent.c
++++ b/src/OVAL/oval_agent.c
+@@ -254,6 +254,10 @@ int oval_agent_reset_session(oval_agent_session_t * ag_sess) {
+ 	return 0;
+ }
+ 
++void oval_agent_reset_syschar(oval_agent_session_t * ag_sess) {
++	oval_syschar_model_reset(ag_sess->sys_model);
++}
++
+ int oval_agent_abort_session(oval_agent_session_t *ag_sess)
+ {
+ 	if (ag_sess == NULL) {
+--- a/src/OVAL/public/oval_agent_api.h
++++ b/src/OVAL/public/oval_agent_api.h
+@@ -96,6 +96,11 @@ OSCAP_API struct oval_result_definition * oval_agent_get_result_definition(oval_
+  */
+ OSCAP_API int oval_agent_reset_session(oval_agent_session_t * ag_sess);
+ 
++/**
++ * Clean system characteristics that were generated in this agent session
++ */
++OSCAP_API void oval_agent_reset_syschar(oval_agent_session_t * ag_sess);
++
+ /**
+  * Abort a running probe session
+  */
+--- a/src/XCCDF/xccdf_session.c
++++ b/src/XCCDF/xccdf_session.c
+@@ -362,6 +362,15 @@ void xccdf_session_free(struct xccdf_session *session)
+ 	free(session);
+ }
+ 
++static void _xccdf_session_reset_oval_agents_syschar(struct xccdf_session *session)
++{
++	if (session->oval.agents != NULL) {
++		for (int i=0; session->oval.agents[i]; i++) {
++			oval_agent_reset_syschar(session->oval.agents[i]);
++		}
++	}
++}
++
+ void xccdf_session_result_reset(struct xccdf_session *session)
+ {
+ 	if (session->xccdf.policy_model != NULL) {
+@@ -373,6 +382,8 @@ void xccdf_session_result_reset(struct xccdf_session *session)
+ 	session->rules = oscap_list_new();
+ 	oscap_list_free(session->skip_rules, (oscap_destruct_func) free);
+ 	session->skip_rules = oscap_list_new();
++
++	_xccdf_session_reset_oval_agents_syschar(session);
+ }
+ 
+ const char *xccdf_session_get_filename(const struct xccdf_session *session)

--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -41,6 +41,7 @@ build do
 
   patch source: "get_results_from_session.patch", env: env # add a function to retrieve results from session
   patch source: "session_result_reset.patch", env: env # add a function to reset results from session
+  patch source: "session_reset_syschar.patch", env: env # also reset system characteristics
   patch source: "010_perlpm_install_fix.patch", env: env # fix build of perl bindings
   patch source: "dpkginfo-cacheconfig.patch", env: env # work around incomplete pkgcache path
   patch source: "dpkginfo-init.patch", env: env # fix memory leak of pkgcache in dpkginfo probe


### PR DESCRIPTION
### What does this PR do?

This change resets system characteristics in the
xccdf_session_result_reset function.

This change should be applied after PR #17872.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
