### PR TITLE
[CWS][SEC-9104] ignore dd agent containers from telemetry

### DIFF
--- a/cmd/security-agent/subcommands/runtime/command.go
+++ b/cmd/security-agent/subcommands/runtime/command.go
@@ -661,11 +661,12 @@ func StartRuntimeSecurity(log log.Component, config config.Component, hostname s
 		return nil, nil
 	}
 
-	logProfiledWorkloads := config.GetBool("runtime_security_config.log_profiled_workloads")
-
 	// start/stop order is important, agent need to be stopped first and started after all the others
 	// components
-	agent, err := secagent.NewRuntimeSecurityAgent(hostname, logProfiledWorkloads)
+	agent, err := secagent.NewRuntimeSecurityAgent(hostname, secagent.RSAOptions{
+		LogProfiledWorkloads:    config.GetBool("runtime_security_config.log_profiled_workloads"),
+		IgnoreDDAgentContainers: config.GetBool("runtime_security_config.telemetry.ignore_dd_agent_containers"),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to create a runtime security agent instance: %w", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1187,6 +1187,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.socket", "/opt/datadog-agent/run/runtime-security.sock")
 	config.BindEnvAndSetDefault("runtime_security_config.run_path", defaultRunPath)
 	config.BindEnvAndSetDefault("runtime_security_config.log_profiled_workloads", false)
+	config.BindEnvAndSetDefault("runtime_security_config.telemetry.ignore_dd_agent_containers", true)
 	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.endpoints.")
 	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.activity_dump.remote_storage.endpoints.")
 

--- a/pkg/security/agent/agent.go
+++ b/pkg/security/agent/agent.go
@@ -44,14 +44,19 @@ type RuntimeSecurityAgent struct {
 	storage *dump.ActivityDumpStorageManager
 }
 
+type RSAOptions struct {
+	LogProfiledWorkloads    bool
+	IgnoreDDAgentContainers bool
+}
+
 // NewRuntimeSecurityAgent instantiates a new RuntimeSecurityAgent
-func NewRuntimeSecurityAgent(hostname string, logProfiledWorkloads bool) (*RuntimeSecurityAgent, error) {
+func NewRuntimeSecurityAgent(hostname string, opts RSAOptions) (*RuntimeSecurityAgent, error) {
 	client, err := NewRuntimeSecurityClient()
 	if err != nil {
 		return nil, err
 	}
 
-	telemetry, err := newTelemetry(logProfiledWorkloads)
+	telemetry, err := newTelemetry(opts.LogProfiledWorkloads, opts.IgnoreDDAgentContainers)
 	if err != nil {
 		return nil, errors.New("failed to initialize the telemetry reporter")
 	}

--- a/pkg/security/agent/telemetry.go
+++ b/pkg/security/agent/telemetry.go
@@ -25,7 +25,7 @@ type telemetry struct {
 	logProfiledWorkloads  bool
 }
 
-func newTelemetry(logProfiledWorkloads bool) (*telemetry, error) {
+func newTelemetry(logProfiledWorkloads, ignoreDDAgentContainers bool) (*telemetry, error) {
 	runtimeSecurityClient, err := NewRuntimeSecurityClient()
 	if err != nil {
 		return nil, err
@@ -35,6 +35,7 @@ func newTelemetry(logProfiledWorkloads bool) (*telemetry, error) {
 	if err != nil {
 		return nil, err
 	}
+	containersTelemetry.IgnoreDDAgent = ignoreDDAgentContainers
 
 	return &telemetry{
 		containers:            containersTelemetry,

--- a/pkg/security/common/telemetry.go
+++ b/pkg/security/common/telemetry.go
@@ -49,7 +49,7 @@ func (c *ContainersTelemetry) ReportContainers(metricName string) {
 			if value == "yes" || value == "true" {
 				continue
 			}
-			log.Infof("ignoring container: name=%s id=%s image_id=%s", container.Name, container.ID, container.Image.ID)
+			log.Debugf("ignoring container: name=%s id=%s image_id=%s", container.Name, container.ID, container.Image.ID)
 		}
 
 		c.Sender.Gauge(metricName, 1.0, "", []string{"container_id:" + container.ID})

--- a/pkg/security/common/telemetry.go
+++ b/pkg/security/common/telemetry.go
@@ -47,9 +47,9 @@ func (c *ContainersTelemetry) ReportContainers(metricName string) {
 			value := container.EnvVars["DOCKER_DD_AGENT"]
 			value = strings.ToLower(value)
 			if value == "yes" || value == "true" {
+				log.Debugf("ignoring container: name=%s id=%s image_id=%s", container.Name, container.ID, container.Image.ID)
 				continue
 			}
-			log.Debugf("ignoring container: name=%s id=%s image_id=%s", container.Name, container.ID, container.Image.ID)
 		}
 
 		c.Sender.Gauge(metricName, 1.0, "", []string{"container_id:" + container.ID})

--- a/pkg/security/common/telemetry.go
+++ b/pkg/security/common/telemetry.go
@@ -6,7 +6,10 @@
 package common
 
 import (
+	"strings"
+
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
@@ -14,6 +17,7 @@ import (
 type ContainersTelemetry struct {
 	Sender        aggregator.Sender
 	MetadataStore workloadmeta.Store
+	IgnoreDDAgent bool
 }
 
 // NewContainersTelemetry returns a new ContainersTelemetry based on default/global objects
@@ -39,6 +43,15 @@ func (c *ContainersTelemetry) ReportContainers(metricName string) {
 	containers := c.ListRunningContainers()
 
 	for _, container := range containers {
+		if c.IgnoreDDAgent {
+			value := container.EnvVars["DOCKER_DD_AGENT"]
+			value = strings.ToLower(value)
+			if value == "yes" || value == "true" {
+				continue
+			}
+			log.Infof("ignoring container: name=%s id=%s image_id=%s", container.Name, container.ID, container.Image.ID)
+		}
+
 		c.Sender.Gauge(metricName, 1.0, "", []string{"container_id:" + container.ID})
 	}
 

--- a/pkg/util/containers/env_vars_filter.go
+++ b/pkg/util/containers/env_vars_filter.go
@@ -27,6 +27,7 @@ var (
 		"MESOS_TASK_ID",
 		"ECS_CONTAINER_METADATA_URI",
 		"ECS_CONTAINER_METADATA_URI_V4",
+		"DOCKER_DD_AGENT", // included to be able detect agent containers
 		// Included to ease unit tests withtout requiring a mock
 		"TEST_ENV",
 	}

--- a/pkg/util/containers/env_vars_filter.go
+++ b/pkg/util/containers/env_vars_filter.go
@@ -27,7 +27,7 @@ var (
 		"MESOS_TASK_ID",
 		"ECS_CONTAINER_METADATA_URI",
 		"ECS_CONTAINER_METADATA_URI_V4",
-		"DOCKER_DD_AGENT", // included to be able detect agent containers
+		"DOCKER_DD_AGENT", // included to be able to detect agent containers
 		// Included to ease unit tests withtout requiring a mock
 		"TEST_ENV",
 	}


### PR DESCRIPTION
### What does this PR do?

The security agent reports the amount of containers monitored for both the CWS and CSPM products. This PR allows to configure the CWS part to ignore datadog agent containers from this reporting. This is configurable but default to true.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
