### PR TITLE
[serverless] Add debug loging for Lambda trigger event unmarshalling

### DIFF
--- a/pkg/serverless/invocationlifecycle/constants.go
+++ b/pkg/serverless/invocationlifecycle/constants.go
@@ -24,4 +24,17 @@ const (
 
 	// SamplingPriorityHeader is the header containing the sampling priority for execution and/or inferred spans
 	SamplingPriorityHeader = "x-datadog-sampling-priority"
+
+	// Lambda function trigger span tag values
+	apiGateway              = "api-gateway"
+	applicationLoadBalancer = "application-load-balancer"
+	cloudwatchEvents        = "cloudwatch-events"
+	cloudwatchLogs          = "cloudwatch-logs"
+	dynamoDB                = "dynamodb"
+	eventBridge             = "eventbridge"
+	kinesis                 = "kinesis"
+	s3                      = "s3"
+	sns                     = "sns"
+	sqs                     = "sqs"
+	functionURL             = "lambda-function-url"
 )

--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -26,7 +26,7 @@ func (lp *LifecycleProcessor) initFromAPIGatewayEvent(event events.APIGatewayPro
 	}
 
 	lp.requestHandler.event = event
-	lp.addTag("function_trigger.event_source", "api-gateway")
+	lp.addTag("function_trigger.event_source", apiGateway)
 	lp.addTag("function_trigger.event_source_arn", trigger.ExtractAPIGatewayEventARN(event, region))
 	lp.addTags(trigger.GetTagsFromAPIGatewayEvent(event))
 }
@@ -37,7 +37,7 @@ func (lp *LifecycleProcessor) initFromAPIGatewayV2Event(event events.APIGatewayV
 	}
 
 	lp.requestHandler.event = event
-	lp.addTag("function_trigger.event_source", "api-gateway")
+	lp.addTag("function_trigger.event_source", apiGateway)
 	lp.addTag("function_trigger.event_source_arn", trigger.ExtractAPIGatewayV2EventARN(event, region))
 	lp.addTags(trigger.GetTagsFromAPIGatewayV2HTTPRequest(event))
 }
@@ -48,20 +48,20 @@ func (lp *LifecycleProcessor) initFromAPIGatewayWebsocketEvent(event events.APIG
 	}
 
 	lp.requestHandler.event = event
-	lp.addTag("function_trigger.event_source", "api-gateway")
+	lp.addTag("function_trigger.event_source", apiGateway)
 	lp.addTag("function_trigger.event_source_arn", trigger.ExtractAPIGatewayWebSocketEventARN(event, region))
 }
 
 func (lp *LifecycleProcessor) initFromALBEvent(event events.ALBTargetGroupRequest) {
 	lp.requestHandler.event = event
-	lp.addTag("function_trigger.event_source", "application-load-balancer")
+	lp.addTag("function_trigger.event_source", applicationLoadBalancer)
 	lp.addTag("function_trigger.event_source_arn", trigger.ExtractAlbEventARN(event))
 	lp.addTags(trigger.GetTagsFromALBTargetGroupRequest(event))
 }
 
 func (lp *LifecycleProcessor) initFromCloudWatchEvent(event events.CloudWatchEvent) {
 	lp.requestHandler.event = event
-	lp.addTag("function_trigger.event_source", "cloudwatch-events")
+	lp.addTag("function_trigger.event_source", cloudwatchEvents)
 	lp.addTag("function_trigger.event_source_arn", trigger.ExtractCloudwatchEventARN(event))
 }
 
@@ -73,7 +73,7 @@ func (lp *LifecycleProcessor) initFromCloudWatchLogsEvent(event events.Cloudwatc
 	}
 
 	lp.requestHandler.event = event
-	lp.addTag("function_trigger.event_source", "cloudwatch-logs")
+	lp.addTag("function_trigger.event_source", cloudwatchLogs)
 	lp.addTag("function_trigger.event_source_arn", arn)
 }
 
@@ -83,13 +83,13 @@ func (lp *LifecycleProcessor) initFromDynamoDBStreamEvent(event events.DynamoDBE
 	}
 
 	lp.requestHandler.event = event
-	lp.addTag("function_trigger.event_source", "dynamodb")
+	lp.addTag("function_trigger.event_source", dynamoDB)
 	lp.addTag("function_trigger.event_source_arn", trigger.ExtractDynamoDBStreamEventARN(event))
 }
 
 func (lp *LifecycleProcessor) initFromEventBridgeEvent(event inferredspan.EventBridgeEvent) {
 	lp.requestHandler.event = event
-	lp.addTag("function_trigger.event_source", "eventbridge")
+	lp.addTag("function_trigger.event_source", eventBridge)
 	lp.addTag("function_trigger.event_source_arn", event.Source)
 }
 
@@ -99,7 +99,7 @@ func (lp *LifecycleProcessor) initFromKinesisStreamEvent(event events.KinesisEve
 	}
 
 	lp.requestHandler.event = event
-	lp.addTag("function_trigger.event_source", "kinesis")
+	lp.addTag("function_trigger.event_source", kinesis)
 	lp.addTag("function_trigger.event_source_arn", trigger.ExtractKinesisStreamEventARN(event))
 }
 
@@ -109,7 +109,7 @@ func (lp *LifecycleProcessor) initFromS3Event(event events.S3Event) {
 	}
 
 	lp.requestHandler.event = event
-	lp.addTag("function_trigger.event_source", "s3")
+	lp.addTag("function_trigger.event_source", s3)
 	lp.addTag("function_trigger.event_source_arn", trigger.ExtractS3EventArn(event))
 }
 
@@ -119,7 +119,7 @@ func (lp *LifecycleProcessor) initFromSNSEvent(event events.SNSEvent) {
 	}
 
 	lp.requestHandler.event = event
-	lp.addTag("function_trigger.event_source", "sns")
+	lp.addTag("function_trigger.event_source", sns)
 	lp.addTag("function_trigger.event_source_arn", trigger.ExtractSNSEventArn(event))
 }
 
@@ -129,7 +129,7 @@ func (lp *LifecycleProcessor) initFromSQSEvent(event events.SQSEvent) {
 	}
 
 	lp.requestHandler.event = event
-	lp.addTag("function_trigger.event_source", "sqs")
+	lp.addTag("function_trigger.event_source", sqs)
 	lp.addTag("function_trigger.event_source_arn", trigger.ExtractSQSEventARN(event))
 
 	// test for SNS
@@ -164,7 +164,7 @@ func (lp *LifecycleProcessor) initFromSQSEvent(event events.SQSEvent) {
 
 func (lp *LifecycleProcessor) initFromLambdaFunctionURLEvent(event events.LambdaFunctionURLRequest, region string, accountID string, functionName string) {
 	lp.requestHandler.event = event
-	lp.addTag("function_trigger.event_source", "lambda-function-url")
+	lp.addTag("function_trigger.event_source", functionURL)
 	lp.addTag("function_trigger.event_source_arn", fmt.Sprintf("arn:aws:lambda:%v:%v:url:%v", region, accountID, functionName))
 	lp.addTags(trigger.GetTagsFromLambdaFunctionURLRequest(event))
 }

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -109,69 +109,95 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 	switch eventType {
 	case trigger.APIGatewayEvent:
 		var event events.APIGatewayProxyRequest
-		if err := json.Unmarshal(payloadBytes, &event); err == nil {
-			lp.initFromAPIGatewayEvent(event, region)
+		if err := json.Unmarshal(payloadBytes, &event); err != nil {
+			log.Debugf("Failed to unmarshal %s event: %s", apiGateway, err)
+			break
 		}
+		lp.initFromAPIGatewayEvent(event, region)
 	case trigger.APIGatewayV2Event:
 		var event events.APIGatewayV2HTTPRequest
-		if err := json.Unmarshal(payloadBytes, &event); err == nil {
-			lp.initFromAPIGatewayV2Event(event, region)
+		if err := json.Unmarshal(payloadBytes, &event); err != nil {
+			log.Debugf("Failed to unmarshal %s event: %s", apiGateway, err)
+			break
 		}
+		lp.initFromAPIGatewayV2Event(event, region)
 	case trigger.APIGatewayWebsocketEvent:
 		var event events.APIGatewayWebsocketProxyRequest
-		if err := json.Unmarshal(payloadBytes, &event); err == nil {
-			lp.initFromAPIGatewayWebsocketEvent(event, region)
+		if err := json.Unmarshal(payloadBytes, &event); err != nil {
+			log.Debugf("Failed to unmarshal %s event: %s", apiGateway, err)
+			break
 		}
+		lp.initFromAPIGatewayWebsocketEvent(event, region)
 	case trigger.ALBEvent:
 		var event events.ALBTargetGroupRequest
-		if err := json.Unmarshal(payloadBytes, &event); err == nil {
-			lp.initFromALBEvent(event)
+		if err := json.Unmarshal(payloadBytes, &event); err != nil {
+			log.Debugf("Failed to unmarshal %s event: %s", applicationLoadBalancer, err)
+			break
 		}
+		lp.initFromALBEvent(event)
 	case trigger.CloudWatchEvent:
 		var event events.CloudWatchEvent
-		if err := json.Unmarshal(payloadBytes, &event); err == nil {
-			lp.initFromCloudWatchEvent(event)
+		if err := json.Unmarshal(payloadBytes, &event); err != nil {
+			log.Debugf("Failed to unmarshal %s event: %s", cloudwatchEvents, err)
+			break
 		}
+		lp.initFromCloudWatchEvent(event)
 	case trigger.CloudWatchLogsEvent:
 		var event events.CloudwatchLogsEvent
-		if err := json.Unmarshal(payloadBytes, &event); err == nil && arnParseErr == nil {
-			lp.initFromCloudWatchLogsEvent(event, region, account)
+		if err := json.Unmarshal(payloadBytes, &event); err != nil && arnParseErr != nil {
+			log.Debugf("Failed to unmarshal %s event: %s", cloudwatchLogs, err)
+			break
 		}
+		lp.initFromCloudWatchLogsEvent(event, region, account)
 	case trigger.DynamoDBStreamEvent:
 		var event events.DynamoDBEvent
-		if err := json.Unmarshal(payloadBytes, &event); err == nil {
-			lp.initFromDynamoDBStreamEvent(event)
+		if err := json.Unmarshal(payloadBytes, &event); err != nil {
+			log.Debugf("Failed to unmarshal %s event: %s", dynamoDB, err)
+			break
 		}
+		lp.initFromDynamoDBStreamEvent(event)
 	case trigger.KinesisStreamEvent:
 		var event events.KinesisEvent
-		if err := json.Unmarshal(payloadBytes, &event); err == nil {
-			lp.initFromKinesisStreamEvent(event)
+		if err := json.Unmarshal(payloadBytes, &event); err != nil {
+			log.Debugf("Failed to unmarshal %s event: %s", kinesis, err)
+			break
 		}
+		lp.initFromKinesisStreamEvent(event)
 	case trigger.EventBridgeEvent:
 		var event inferredspan.EventBridgeEvent
-		if err := json.Unmarshal(payloadBytes, &event); err == nil {
-			lp.initFromEventBridgeEvent(event)
+		if err := json.Unmarshal(payloadBytes, &event); err != nil {
+			log.Debugf("Failed to unmarshal %s event: %s", eventBridge, err)
+			break
 		}
+		lp.initFromEventBridgeEvent(event)
 	case trigger.S3Event:
 		var event events.S3Event
-		if err := json.Unmarshal(payloadBytes, &event); err == nil {
-			lp.initFromS3Event(event)
+		if err := json.Unmarshal(payloadBytes, &event); err != nil {
+			log.Debugf("Failed to unmarshal %s event: %s", s3, err)
+			break
 		}
+		lp.initFromS3Event(event)
 	case trigger.SNSEvent:
 		var event events.SNSEvent
-		if err := json.Unmarshal(payloadBytes, &event); err == nil {
-			lp.initFromSNSEvent(event)
+		if err := json.Unmarshal(payloadBytes, &event); err != nil {
+			log.Debugf("Failed to unmarshal %s event: %s", sns, err)
+			break
 		}
+		lp.initFromSNSEvent(event)
 	case trigger.SQSEvent:
 		var event events.SQSEvent
-		if err := json.Unmarshal(payloadBytes, &event); err == nil {
-			lp.initFromSQSEvent(event)
+		if err := json.Unmarshal(payloadBytes, &event); err != nil {
+			log.Debugf("Failed to unmarshal %s event: %s", sqs, err)
+			break
 		}
+		lp.initFromSQSEvent(event)
 	case trigger.LambdaFunctionURLEvent:
 		var event events.LambdaFunctionURLRequest
-		if err := json.Unmarshal(payloadBytes, &event); err == nil && arnParseErr == nil {
-			lp.initFromLambdaFunctionURLEvent(event, region, account, resource)
+		if err := json.Unmarshal(payloadBytes, &event); err != nil && arnParseErr != nil {
+			log.Debugf("Failed to unmarshal %s event: %s", functionURL, err)
+			break
 		}
+		lp.initFromLambdaFunctionURLEvent(event, region, account, resource)
 	default:
 		log.Debug("Skipping adding trigger types and inferred spans as a non-supported payload was received.")
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds debug level logs when we fail to unmarshal a Lambda request payload into a Lambda event object.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Related to SLES-1042, where one of the fields in a Lambda event did not match the type expected by the aws-lambda-go package. We would silently fail to note any failures to unmarshal the event, which made debugging take longer than needed.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
More logs

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Tested manually with misconfigured payloads, so we would see debug logs such as:
```
2023-06-28 19:58:43 UTC \| DD_EXTENSION \| DEBUG \| Failed to unmarshal sqs event: json: cannot unmarshal object into Go struct field SQSMessageAttribute.Records.messageAttributes.binaryValue of type []uint8
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
