### PR TITLE
Annotates dogstatsd metric series with an origin

### DIFF
--- a/comp/dogstatsd/server/enrich_bench_test.go
+++ b/comp/dogstatsd/server/enrich_bench_test.go
@@ -34,7 +34,7 @@ func BenchmarkExtractTagsMetadata(b *testing.B) {
 			sb.ResetTimer()
 
 			for n := 0; n < sb.N; n++ {
-				tags, _, _, _, _ = extractTagsMetadata(baseTags, "", []byte{}, conf)
+				tags, _, _, _, _, _ = extractTagsMetadata(baseTags, "", []byte{}, conf)
 			}
 		})
 	}

--- a/comp/dogstatsd/server/enrich_test.go
+++ b/comp/dogstatsd/server/enrich_test.go
@@ -1069,13 +1069,14 @@ func TestEnrichTags(t *testing.T) {
 		conf          enrichConfig
 	}
 	tests := []struct {
-		name              string
-		args              args
-		wantedTags        []string
-		wantedHost        string
-		wantedOrigin      string
-		wantedK8sOrigin   string
-		wantedCardinality string
+		name               string
+		args               args
+		wantedTags         []string
+		wantedHost         string
+		wantedOrigin       string
+		wantedK8sOrigin    string
+		wantedCardinality  string
+		wantedMetricSource metrics.MetricSource
 	}{
 		{
 			name: "empty tags, host=foo",
@@ -1086,11 +1087,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: true,
 				},
 			},
-			wantedTags:        nil,
-			wantedHost:        "foo",
-			wantedOrigin:      "",
-			wantedK8sOrigin:   "",
-			wantedCardinality: "",
+			wantedTags:         nil,
+			wantedHost:         "foo",
+			wantedOrigin:       "",
+			wantedK8sOrigin:    "",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "",
 		},
 		{
 			name: "entityId not present, host=foo, should return origin tags",
@@ -1102,11 +1104,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: true,
 				},
 			},
-			wantedTags:        []string{"env:prod"},
-			wantedHost:        "foo",
-			wantedOrigin:      "originID",
-			wantedK8sOrigin:   "",
-			wantedCardinality: "",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "originID",
+			wantedK8sOrigin:    "",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "",
 		},
 		{
 			name: "entityId not present, host=foo, empty tags list, should return origin tags",
@@ -1118,11 +1121,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: true,
 				},
 			},
-			wantedTags:        nil,
-			wantedHost:        "foo",
-			wantedOrigin:      "originID",
-			wantedK8sOrigin:   "",
-			wantedCardinality: "",
+			wantedTags:         nil,
+			wantedHost:         "foo",
+			wantedOrigin:       "originID",
+			wantedK8sOrigin:    "",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "",
 		},
 		{
 			name: "entityId present, host=foo, should not return origin tags",
@@ -1134,11 +1138,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: true,
 				},
 			},
-			wantedTags:        []string{"env:prod"},
-			wantedHost:        "foo",
-			wantedOrigin:      "",
-			wantedK8sOrigin:   "kubernetes_pod_uid://my-id",
-			wantedCardinality: "",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "",
+			wantedK8sOrigin:    "kubernetes_pod_uid://my-id",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "",
 		},
 		{
 			name: "entityId=none present, host=foo, should not call the originFromUDSFunc()",
@@ -1150,11 +1155,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: true,
 				},
 			},
-			wantedTags:        []string{"env:prod"},
-			wantedHost:        "foo",
-			wantedOrigin:      "",
-			wantedK8sOrigin:   "",
-			wantedCardinality: "",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "",
+			wantedK8sOrigin:    "",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "",
 		},
 		{
 			name: "entityId=42 present entityIDPrecendenceEnabled=false, host=foo, should call the originFromUDSFunc()",
@@ -1166,11 +1172,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: false,
 				},
 			},
-			wantedTags:        []string{"env:prod"},
-			wantedHost:        "foo",
-			wantedOrigin:      "originID",
-			wantedK8sOrigin:   "kubernetes_pod_uid://42",
-			wantedCardinality: "",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "originID",
+			wantedK8sOrigin:    "kubernetes_pod_uid://42",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "",
 		},
 		{
 			name: "entityId=42 cardinality=high present entityIDPrecendenceEnabled=false, host=foo, should call the originFromUDSFunc()",
@@ -1182,11 +1189,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: false,
 				},
 			},
-			wantedTags:        []string{"env:prod"},
-			wantedHost:        "foo",
-			wantedOrigin:      "originID",
-			wantedK8sOrigin:   "kubernetes_pod_uid://42",
-			wantedCardinality: "high",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "originID",
+			wantedK8sOrigin:    "kubernetes_pod_uid://42",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "high",
 		},
 		{
 			name: "entityId=42 cardinality=orchestrator present entityIDPrecendenceEnabled=false, host=foo, should call the originFromUDSFunc()",
@@ -1198,11 +1206,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: false,
 				},
 			},
-			wantedTags:        []string{"env:prod"},
-			wantedHost:        "foo",
-			wantedOrigin:      "originID",
-			wantedK8sOrigin:   "kubernetes_pod_uid://42",
-			wantedCardinality: "orchestrator",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "originID",
+			wantedK8sOrigin:    "kubernetes_pod_uid://42",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "orchestrator",
 		},
 		{
 			name: "entityId=42 cardinality=low present entityIDPrecendenceEnabled=false, host=foo, should call the originFromUDSFunc()",
@@ -1214,11 +1223,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: false,
 				},
 			},
-			wantedTags:        []string{"env:prod"},
-			wantedHost:        "foo",
-			wantedOrigin:      "originID",
-			wantedK8sOrigin:   "kubernetes_pod_uid://42",
-			wantedCardinality: "low",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "originID",
+			wantedK8sOrigin:    "kubernetes_pod_uid://42",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "low",
 		},
 		{
 			name: "entityId=42 cardinality=unknown present entityIDPrecendenceEnabled=false, host=foo, should call the originFromUDSFunc()",
@@ -1230,11 +1240,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: false,
 				},
 			},
-			wantedTags:        []string{"env:prod"},
-			wantedHost:        "foo",
-			wantedOrigin:      "originID",
-			wantedK8sOrigin:   "kubernetes_pod_uid://42",
-			wantedCardinality: "unknown",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "originID",
+			wantedK8sOrigin:    "kubernetes_pod_uid://42",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "unknown",
 		},
 		{
 			name: "entityId=42 cardinality='' present entityIDPrecendenceEnabled=false, host=foo, should call the originFromUDSFunc()",
@@ -1246,11 +1257,12 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: false,
 				},
 			},
-			wantedTags:        []string{"env:prod"},
-			wantedHost:        "foo",
-			wantedOrigin:      "originID",
-			wantedK8sOrigin:   "kubernetes_pod_uid://42",
-			wantedCardinality: "",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "originID",
+			wantedK8sOrigin:    "kubernetes_pod_uid://42",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
+			wantedCardinality:  "",
 		},
 		{
 			name: "entity_id=pod-uid, originFromMsg=container-id, should consider entity_id",
@@ -1262,10 +1274,11 @@ func TestEnrichTags(t *testing.T) {
 					defaultHostname: "foo",
 				},
 			},
-			wantedTags:      []string{"env:prod"},
-			wantedHost:      "foo",
-			wantedOrigin:    "originID",
-			wantedK8sOrigin: "kubernetes_pod_uid://pod-uid",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "originID",
+			wantedK8sOrigin:    "kubernetes_pod_uid://pod-uid",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
 		},
 		{
 			name: "no entity_id, originFromMsg=container-id, should consider originFromMsg",
@@ -1277,10 +1290,11 @@ func TestEnrichTags(t *testing.T) {
 					defaultHostname: "foo",
 				},
 			},
-			wantedTags:      []string{"env:prod"},
-			wantedHost:      "foo",
-			wantedOrigin:    "originID",
-			wantedK8sOrigin: "container_id://container-id",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "originID",
+			wantedK8sOrigin:    "container_id://container-id",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
 		},
 
 		{
@@ -1294,15 +1308,16 @@ func TestEnrichTags(t *testing.T) {
 					originOptOutEnabled: true,
 				},
 			},
-			wantedTags:      []string{"env:prod"},
-			wantedHost:      "foo",
-			wantedOrigin:    "",
-			wantedK8sOrigin: "",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "foo",
+			wantedOrigin:       "",
+			wantedK8sOrigin:    "",
+			wantedMetricSource: metrics.MetricSourceDogstatsd,
 		},
 		{
 			name: "opt-out, entity id present, uds origin present",
 			args: args{
-				tags:          []string{"env:prod", "dd.internal.entity_id:pod-uid", "dd.internal.card:none", "host:"},
+				tags:          []string{"env:prod", "dd.internal.entity_id:pod-uid", "dd.internal.card:none", "host:", "jmx_domain:org.apache"},
 				originFromUDS: "originID",
 				originFromMsg: []byte("none"),
 				conf: enrichConfig{
@@ -1310,20 +1325,22 @@ func TestEnrichTags(t *testing.T) {
 					originOptOutEnabled: true,
 				},
 			},
-			wantedTags:      []string{"env:prod"},
-			wantedHost:      "",
-			wantedOrigin:    "",
-			wantedK8sOrigin: "",
+			wantedTags:         []string{"env:prod"},
+			wantedHost:         "",
+			wantedOrigin:       "",
+			wantedK8sOrigin:    "",
+			wantedMetricSource: metrics.MetricSourceJmxCustom,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tags, host, origin, k8sOrigin, cardinality := extractTagsMetadata(tt.args.tags, tt.args.originFromUDS, tt.args.originFromMsg, tt.args.conf)
+			tags, host, origin, k8sOrigin, cardinality, metricSource := extractTagsMetadata(tt.args.tags, tt.args.originFromUDS, tt.args.originFromMsg, tt.args.conf)
 			assert.Equal(t, tt.wantedTags, tags)
 			assert.Equal(t, tt.wantedHost, host)
 			assert.Equal(t, tt.wantedOrigin, origin)
 			assert.Equal(t, tt.wantedK8sOrigin, k8sOrigin)
 			assert.Equal(t, tt.wantedCardinality, cardinality)
+			assert.Equal(t, tt.wantedMetricSource, metricSource)
 		})
 
 		if !tt.args.conf.originOptOutEnabled {
@@ -1331,12 +1348,13 @@ func TestEnrichTags(t *testing.T) {
 			conf := tt.args.conf
 			conf.originOptOutEnabled = true
 			t.Run(tt.name, func(t *testing.T) {
-				tags, host, origin, k8sOrigin, cardinality := extractTagsMetadata(tt.args.tags, tt.args.originFromUDS, tt.args.originFromMsg, conf)
+				tags, host, origin, k8sOrigin, cardinality, metricSource := extractTagsMetadata(tt.args.tags, tt.args.originFromUDS, tt.args.originFromMsg, conf)
 				assert.Equal(t, tt.wantedTags, tags)
 				assert.Equal(t, tt.wantedHost, host)
 				assert.Equal(t, tt.wantedOrigin, origin)
 				assert.Equal(t, tt.wantedK8sOrigin, k8sOrigin)
 				assert.Equal(t, tt.wantedCardinality, cardinality)
+				assert.Equal(t, tt.wantedMetricSource, metricSource)
 			})
 		}
 	}

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -24,6 +24,7 @@ type Context struct {
 	taggerTags *tags.Entry
 	metricTags *tags.Entry
 	noIndex    bool
+	source     metrics.MetricSource
 }
 
 // Tags returns tags for the context.
@@ -87,6 +88,7 @@ func (cr *contextResolver) trackContext(metricSampleContext metrics.MetricSample
 			Host:       metricSampleContext.GetHost(),
 			mtype:      mtype,
 			noIndex:    metricSampleContext.IsNoIndex(),
+			source:     metricSampleContext.GetSource(),
 		}
 		cr.countsByMtype[mtype]++
 	}

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -273,6 +273,7 @@ func (s *mockSample) GetName() string                   { return s.name }
 func (s *mockSample) GetHost() string                   { return "noop" }
 func (s *mockSample) GetMetricType() metrics.MetricType { return metrics.GaugeType }
 func (s *mockSample) IsNoIndex() bool                   { return false }
+func (s *mockSample) GetSource() metrics.MetricSource   { return metrics.MetricSourceUnknown }
 func (s *mockSample) GetTags(tb, mb tagset.TagsAccumulator) {
 	tb.Append(s.taggerTags...)
 	mb.Append(s.metricTags...)

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -191,6 +191,7 @@ func (s *TimeSampler) dedupSerieBySerieSignature(
 			serie.Host = context.Host
 			serie.NoIndex = context.noIndex
 			serie.Interval = s.interval
+			serie.Source = context.source
 
 			serieBySignature[serieSignature] = serie
 		}

--- a/pkg/metrics/histogram_bucket.go
+++ b/pkg/metrics/histogram_bucket.go
@@ -18,6 +18,7 @@ type HistogramBucket struct {
 	Host            string
 	Timestamp       float64
 	FlushFirstValue bool
+	Source          MetricSource
 }
 
 // Implement the MetricSampleContext interface
@@ -48,4 +49,9 @@ func (m *HistogramBucket) GetMetricType() MetricType {
 // IsNoIndex returns if the metric must not be indexed.
 func (m *HistogramBucket) IsNoIndex() bool {
 	return false
+}
+
+// GetSource returns the currently set MetricSource
+func (m *HistogramBucket) GetSource() MetricSource {
+	return m.Source
 }

--- a/pkg/metrics/metric_sample.go
+++ b/pkg/metrics/metric_sample.go
@@ -79,6 +79,9 @@ type MetricSampleContext interface {
 
 	// IsNoIndex returns true if the metric must not be indexed.
 	IsNoIndex() bool
+
+	//GetMetricSource returns the metric source for this metric. This is used to define the Origin
+	GetSource() MetricSource
 }
 
 // MetricSample represents a raw metric sample
@@ -96,6 +99,7 @@ type MetricSample struct {
 	OriginFromClient string
 	Cardinality      string
 	NoIndex          bool
+	Source           MetricSource
 }
 
 // Implement the MetricSampleContext interface
@@ -133,4 +137,9 @@ func (m *MetricSample) Copy() *MetricSample {
 // IsNoIndex returns true if the metric must not be indexed.
 func (m *MetricSample) IsNoIndex() bool {
 	return m.NoIndex
+}
+
+// GetSource returns the currently set MetricSource
+func (m *MetricSample) GetSource() MetricSource {
+	return m.Source
 }

--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -6,7 +6,7 @@
 package metrics
 
 // MetricSource represents how this metric made it into the Agent
-type MetricSource int
+type MetricSource uint16
 
 // Enumeration of the currently supported MetricSources
 const (

--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -33,31 +33,3 @@ func (ms MetricSource) String() string {
 
 	}
 }
-
-func (ms MetricSource) OriginCategory() int32 {
-	// These constants map to specific fields in the 'OriginCategory' enum
-	switch ms {
-	case MetricSourceUnknown:
-		return 0
-	case MetricSourceDogstatsd:
-		return 10
-	case MetricSourceJmxCustom:
-		return 11
-	default:
-		return 0
-	}
-}
-
-func (ms MetricSource) OriginService() int32 {
-	// These constants map to specific fields in the 'OriginService' enum
-	switch ms {
-	case MetricSourceDogstatsd:
-		return 0
-	case MetricSourceJmxCustom:
-		return 9
-	case MetricSourceUnknown:
-		return 0
-	default:
-		return 0
-	}
-}

--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metrics
+
+// MetricSource represents how this metric made it into the Agent
+type MetricSource int
+
+// Enumeration of the currently supported MetricSources
+const (
+	MetricSourceUnknown MetricSource = iota
+
+	MetricSourceDogstatsd
+
+	// In the future, metrics from official JMX integrations will
+	// be properly categorized, but as things are today, ALL metrics
+	// from a JMX check will be marked as "custom", including official
+	// integrations
+	MetricSourceJmxCustom
+)
+
+// String returns a string representation of MetricSource
+func (ms MetricSource) String() string {
+	switch ms {
+	case MetricSourceDogstatsd:
+		return "dogstatsd"
+	case MetricSourceJmxCustom:
+		return "jmx-custom-check"
+	default:
+		return "<unknown>"
+
+	}
+}
+
+func (ms MetricSource) OriginCategory() int32 {
+	// These constants map to specific fields in the 'OriginCategory' enum
+	switch ms {
+	case MetricSourceUnknown:
+		return 0
+	case MetricSourceDogstatsd:
+		return 10
+	case MetricSourceJmxCustom:
+		return 11
+	default:
+		return 0
+	}
+}
+
+func (ms MetricSource) OriginService() int32 {
+	// These constants map to specific fields in the 'OriginService' enum
+	switch ms {
+	case MetricSourceDogstatsd:
+		return 0
+	case MetricSourceJmxCustom:
+		return 9
+	case MetricSourceUnknown:
+		return 0
+	default:
+		return 0
+	}
+}

--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -59,6 +59,7 @@ type Serie struct {
 	NameSuffix     string               `json:"-"`
 	NoIndex        bool                 `json:"-"` // This is only used by api V2
 	Resources      []Resource           `json:"-"` // This is only used by api V2
+	Source         MetricSource         `json:"-"` // This is only used by api V2
 }
 
 // SeriesAPIV2Enum returns the enumeration value for MetricPayload.MetricType in

--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -344,11 +344,11 @@ func (series *IterableSeries) MarshalSplitCompress(bufferContext *marshaler.Buff
 					if err != nil {
 						return err
 					}
-					err = ps.Int32(serieMetadataOriginOriginCategory, serie.Source.OriginCategory())
+					err = ps.Int32(serieMetadataOriginOriginCategory, MetricSourceToOriginCategory(serie.Source))
 					if err != nil {
 						return err
 					}
-					return ps.Int32(serieMetadataOriginOriginService, serie.Source.OriginService())
+					return ps.Int32(serieMetadataOriginOriginService, MetricSourceToOriginService(serie.Source))
 				})
 			})
 			if err != nil {

--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -142,8 +142,28 @@ func (series *IterableSeries) MarshalSplitCompress(bufferContext *marshaler.Buff
 	const pointValue = 1
 	const pointTimestamp = 2
 	const serieMetadataOrigin = 1
+	//         |------| 'Metadata' message
+	//                 |-----| 'origin' field index
 	const serieMetadataOriginMetricType = 3
+	//         |------| 'Metadata' message
+	//                 |----| 'origin' message
+	//                       |--------| 'metric_type' field index
 	const metryTypeNotIndexed = 9
+	//    |-----------------| 'metric_type_agent_hidden' field index
+
+	const serieMetadataOriginOriginProduct = 4
+	//                 |----|  'Origin' message
+	//                       |-----------| 'origin_product' field index
+	const serieMetadataOriginOriginCategory = 5
+	//                 |----|  'Origin' message
+	//                       |-----------| 'origin_category' field index
+	const serieMetadataOriginOriginService = 6
+	//                 |----|  'Origin' message
+	//                       |-----------| 'origin_service' field index
+	const serieMetadataOriginOriginProductAgentType = 10
+	//                 |----|  'Origin' message
+	//                       |-----------| 'OriginProduct' enum
+	//                                    |-------| 'Agent' enum value
 
 	// Prepare to write the next payload
 	startPayload := func() error {
@@ -312,12 +332,27 @@ func (series *IterableSeries) MarshalSplitCompress(bufferContext *marshaler.Buff
 				}
 			}
 
-			if serie.NoIndex {
-				return ps.Embedded(serieMetadata, func(ps *molecule.ProtoStream) error {
-					return ps.Embedded(serieMetadataOrigin, func(ps *molecule.ProtoStream) error {
-						return ps.Int32(serieMetadataOriginMetricType, metryTypeNotIndexed)
-					})
+			err = ps.Embedded(serieMetadata, func(ps *molecule.ProtoStream) error {
+				return ps.Embedded(serieMetadataOrigin, func(ps *molecule.ProtoStream) error {
+					if serie.NoIndex {
+						err = ps.Int32(serieMetadataOriginMetricType, metryTypeNotIndexed)
+						if err != nil {
+							return err
+						}
+					}
+					err = ps.Int32(serieMetadataOriginOriginProduct, serieMetadataOriginOriginProductAgentType)
+					if err != nil {
+						return err
+					}
+					err = ps.Int32(serieMetadataOriginOriginCategory, serie.Source.OriginCategory())
+					if err != nil {
+						return err
+					}
+					return ps.Int32(serieMetadataOriginOriginService, serie.Source.OriginService())
 				})
+			})
+			if err != nil {
+				return err
 			}
 			return nil
 		})

--- a/pkg/serializer/internal/metrics/origin_mapping.go
+++ b/pkg/serializer/internal/metrics/origin_mapping.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 package metrics
 
 import (

--- a/pkg/serializer/internal/metrics/origin_mapping.go
+++ b/pkg/serializer/internal/metrics/origin_mapping.go
@@ -1,0 +1,34 @@
+package metrics
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+func MetricSourceToOriginCategory(ms metrics.MetricSource) int32 {
+	// These constants map to specific fields in the 'OriginCategory' enum in origin.proto
+	switch ms {
+	case metrics.MetricSourceUnknown:
+		return 0
+	case metrics.MetricSourceDogstatsd:
+		return 10
+	case metrics.MetricSourceJmxCustom:
+		return 11
+	default:
+		return 0
+	}
+}
+
+func MetricSourceToOriginService(ms metrics.MetricSource) int32 {
+	// These constants map to specific fields in the 'OriginService' enum in origin.proto
+	switch ms {
+	case metrics.MetricSourceDogstatsd:
+		return 0
+	case metrics.MetricSourceJmxCustom:
+		return 9
+	case metrics.MetricSourceUnknown:
+		return 0
+	default:
+		return 0
+	}
+
+}

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -307,6 +307,7 @@ func TestSendSeries(t *testing.T) {
 	matcher := createProtoscopeMatcher(`1: {
 		1: { 1: {"host"} }
 		5: 3
+		9: { 1: { 4: 10 }}
 	  }`)
 	f.On("SubmitSeries", matcher, protobufExtraHeadersWithCompression).Return(nil).Times(1)
 	config.Datadog.Set("use_v2_api.series", true) // default value, but just to be sure


### PR DESCRIPTION
### What does this PR do?
This adds some extra metadata to each metric series in the form of a `MetricSource`.

This change will support non-sketch dogstatsd series and annotate them as either dogstatsd or jmx-custom series.

### Motivation
Better metric tracking

### Additional Notes
There will be a few follow ups to this to support (in no particular order)
- core checks
- python checks
- jmx-based checks
- sketches

### Possible Drawbacks / Trade-offs
Benchmarks show no performance impact in terms of CPU or memory.
Care was taken here to ensure the `pkg/aggregator Context` struct remains in the `64` byte sizeclass.

### Describe how to test/QA your changes
- Start an instance of the `proxy-dumper` MITM agent proxy locally on port 8081 with the `--print-origins` flag. (Slack me if you need help finding this proxy)
- Run the agent and point `DD_URL` to `localhost:8081`
- Send some dogstatsd metrics `echo -n "sample.dogstatsd.gauge:1|g|#tagA:a-value" | nc -4u -w0 127.0.0.1 8125`
- Look through output of `proxy-dumper` for `sample.dogstatsd.gauge` and ensure these fields are set `OriginProduct="agent"  OriginCategory="dogstatsd_metrics"  OriginService="no_origin_service"`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
