### PR TITLE
Persist in-flight transactions at shutdown

### DIFF
--- a/comp/forwarder/defaultforwarder/domain_forwarder.go
+++ b/comp/forwarder/defaultforwarder/domain_forwarder.go
@@ -245,6 +245,13 @@ func (f *domainForwarder) Stop(purgeHighPrio bool) {
 	close(f.highPrio)
 	close(f.lowPrio)
 	close(f.requeuedTransaction)
+
+	for len(f.requeuedTransaction) > 0 {
+		t := <-f.requeuedTransaction
+		f.requeueTransaction(t)
+	}
+	f.retryQueue.FlushToDisk()
+
 	f.log.Info("domainForwarder stopped")
 	f.internalState = Stopped
 }

--- a/comp/forwarder/defaultforwarder/domain_forwarder.go
+++ b/comp/forwarder/defaultforwarder/domain_forwarder.go
@@ -249,7 +249,9 @@ func (f *domainForwarder) Stop(purgeHighPrio bool) {
 	for t := range f.requeuedTransaction {
 		f.requeueTransaction(t)
 	}
-	f.retryQueue.FlushToDisk()
+	if err := f.retryQueue.FlushToDisk(); err != nil {
+		f.log.Errorf("Error when flushing the retry queue to disk: %v", err)
+	}
 
 	f.log.Info("domainForwarder stopped")
 	f.internalState = Stopped

--- a/comp/forwarder/defaultforwarder/domain_forwarder.go
+++ b/comp/forwarder/defaultforwarder/domain_forwarder.go
@@ -246,8 +246,7 @@ func (f *domainForwarder) Stop(purgeHighPrio bool) {
 	close(f.lowPrio)
 	close(f.requeuedTransaction)
 
-	for len(f.requeuedTransaction) > 0 {
-		t := <-f.requeuedTransaction
+	for t := range f.requeuedTransaction {
 		f.requeueTransaction(t)
 	}
 	f.retryQueue.FlushToDisk()

--- a/comp/forwarder/defaultforwarder/domain_forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/domain_forwarder_test.go
@@ -79,15 +79,9 @@ func TestDomainForwarderStop(t *testing.T) {
 	forwarder.Stop(false) // this should be a noop
 	forwarder.Start()
 	assert.Equal(t, Started, forwarder.State())
-
-	// Add a transaction which should be flushed to retry queue on stop
-	tr := transaction.NewHTTPTransaction()
-	forwarder.requeuedTransaction <- tr
-	requireLenForwarderRetryQueue(t, forwarder, 0)
-
 	forwarder.Stop(false)
 	assert.Len(t, forwarder.workers, 0)
-	requireLenForwarderRetryQueue(t, forwarder, 1)
+	requireLenForwarderRetryQueue(t, forwarder, 0)
 	assert.Equal(t, Stopped, forwarder.State())
 }
 

--- a/comp/forwarder/defaultforwarder/domain_forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/domain_forwarder_test.go
@@ -79,9 +79,15 @@ func TestDomainForwarderStop(t *testing.T) {
 	forwarder.Stop(false) // this should be a noop
 	forwarder.Start()
 	assert.Equal(t, Started, forwarder.State())
+
+	// Add a transaction which should be flushed to retry queue on stop
+	tr := transaction.NewHTTPTransaction()
+	forwarder.requeuedTransaction <- tr
+	requireLenForwarderRetryQueue(t, forwarder, 0)
+
 	forwarder.Stop(false)
 	assert.Len(t, forwarder.workers, 0)
-	requireLenForwarderRetryQueue(t, forwarder, 0)
+	requireLenForwarderRetryQueue(t, forwarder, 1)
 	assert.Equal(t, Stopped, forwarder.State())
 }
 

--- a/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue.go
@@ -212,14 +212,14 @@ func (tc *TransactionRetryQueue) GetDiskSpaceUsed() int64 {
 // on capacity still apply, and the same rules are followed as during normal operation in terms
 // of which transactions are dropped and which are persisted.
 func (tc *TransactionRetryQueue) FlushToDisk() error {
-    if tc.optionalStorage == nil {
-        return nil
-    }
-    tc.mutex.RLock()
-    defer tc.mutex.RUnlock()
+	if tc.optionalStorage == nil {
+		return nil
+	}
+	tc.mutex.RLock()
+	defer tc.mutex.RUnlock()
 
-    transactions := tc.extractTransactionsFromMemory(tc.GetMaxMemSizeInBytes())
-    return tc.optionalStorage.Store(transactions)
+	transactions := tc.extractTransactionsFromMemory(tc.GetMaxMemSizeInBytes())
+	return tc.optionalStorage.Store(transactions)
 }
 
 func (tc *TransactionRetryQueue) extractTransactionsForDisk(payloadSize int) [][]transaction.Transaction {

--- a/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue.go
@@ -212,14 +212,14 @@ func (tc *TransactionRetryQueue) GetDiskSpaceUsed() int64 {
 // on capacity still apply, and the same rules are followed as during normal operation in terms
 // of which transactions are dropped and which are persisted.
 func (tc *TransactionRetryQueue) FlushToDisk() error {
-	if tc.optionalStorage != nil {
-		tc.mutex.RLock()
-		defer tc.mutex.RUnlock()
+    if tc.optionalStorage == nil {
+        return nil
+    }
+    tc.mutex.RLock()
+    defer tc.mutex.RUnlock()
 
-		transactions := tc.extractTransactionsFromMemory(tc.GetMaxMemSizeInBytes())
-		return tc.optionalStorage.Store(transactions)
-	}
-	return nil
+    transactions := tc.extractTransactionsFromMemory(tc.GetMaxMemSizeInBytes())
+    return tc.optionalStorage.Store(transactions)
 }
 
 func (tc *TransactionRetryQueue) extractTransactionsForDisk(payloadSize int) [][]transaction.Transaction {

--- a/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue.go
@@ -208,6 +208,17 @@ func (tc *TransactionRetryQueue) GetDiskSpaceUsed() int64 {
 	return 0
 }
 
+// FlushToDisk is called on shutdown and persists all transactions to disk
+func (tc *TransactionRetryQueue) FlushToDisk() {
+	if tc.optionalStorage != nil {
+		tc.mutex.RLock()
+		defer tc.mutex.RUnlock()
+
+		transactions := tc.extractTransactionsFromMemory(tc.GetMaxMemSizeInBytes())
+		tc.optionalStorage.Store(transactions)
+	}
+}
+
 func (tc *TransactionRetryQueue) extractTransactionsForDisk(payloadSize int) [][]transaction.Transaction {
 	sizeInBytesToFlush := int(float64(tc.maxMemSizeInBytes) * tc.flushToStorageRatio)
 	var payloadsGroupToFlush [][]transaction.Transaction

--- a/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue.go
@@ -208,7 +208,9 @@ func (tc *TransactionRetryQueue) GetDiskSpaceUsed() int64 {
 	return 0
 }
 
-// FlushToDisk is called on shutdown and persists all transactions to disk
+// FlushToDisk is called on shutdown and persists all transactions to disk. The normal limits
+// on capacity still apply, and the same rules are followed as during normal operation in terms
+// of which transactions are dropped and which are persisted.
 func (tc *TransactionRetryQueue) FlushToDisk() {
 	if tc.optionalStorage != nil {
 		tc.mutex.RLock()

--- a/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/transaction_retry_queue.go
@@ -211,14 +211,15 @@ func (tc *TransactionRetryQueue) GetDiskSpaceUsed() int64 {
 // FlushToDisk is called on shutdown and persists all transactions to disk. The normal limits
 // on capacity still apply, and the same rules are followed as during normal operation in terms
 // of which transactions are dropped and which are persisted.
-func (tc *TransactionRetryQueue) FlushToDisk() {
+func (tc *TransactionRetryQueue) FlushToDisk() error {
 	if tc.optionalStorage != nil {
 		tc.mutex.RLock()
 		defer tc.mutex.RUnlock()
 
 		transactions := tc.extractTransactionsFromMemory(tc.GetMaxMemSizeInBytes())
-		tc.optionalStorage.Store(transactions)
+		return tc.optionalStorage.Store(transactions)
 	}
+	return nil
 }
 
 func (tc *TransactionRetryQueue) extractTransactionsForDisk(payloadSize int) [][]transaction.Transaction {

--- a/comp/forwarder/defaultforwarder/worker.go
+++ b/comp/forwarder/defaultforwarder/worker.go
@@ -150,14 +150,6 @@ func (w *Worker) ScheduleConnectionReset() {
 // callProcess will process a transaction and cancel it if we need to stop the
 // worker.
 func (w *Worker) callProcess(t transaction.Transaction) error {
-	requeue := func() {
-		select {
-		case w.RequeueChan <- t:
-		default:
-			w.log.Errorf("dropping transaction because the retry goroutine is too busy to handle another one")
-		}
-	}
-
 	// poll for connection reset events first
 	select {
 	case <-w.resetConnectionChan:
@@ -179,7 +171,7 @@ func (w *Worker) callProcess(t transaction.Transaction) error {
 	case <-w.stopChan:
 		// cancel current Transaction if we need to stop the worker
 		cancel()
-		requeue()
+		w.requeue(t)
 		<-done // We still need to wait for the process func to return
 		return fmt.Errorf("Worker was requested to stop")
 	}
@@ -188,26 +180,26 @@ func (w *Worker) callProcess(t transaction.Transaction) error {
 }
 
 func (w *Worker) process(ctx context.Context, t transaction.Transaction) {
-	requeue := func() {
-		select {
-		case w.RequeueChan <- t:
-		default:
-			w.log.Errorf("dropping transaction because the retry goroutine is too busy to handle another one")
-		}
-	}
-
 	// Run the endpoint through our blockedEndpoints circuit breaker
 	target := t.GetTarget()
 	if w.blockedList.isBlock(target) {
-		requeue()
+		w.requeue(t)
 		w.log.Errorf("Too many errors for endpoint '%s': retrying later", target)
 	} else if err := t.Process(ctx, w.config, w.log, w.Client); err != nil {
 		w.blockedList.close(target)
-		requeue()
+		w.requeue(t)
 		w.log.Errorf("Error while processing transaction: %v", err)
 	} else {
 		w.pointSuccessfullySent.OnPointSuccessfullySent(t.GetPointCount())
 		w.blockedList.recover(target)
+	}
+}
+
+func (w *Worker) requeue(t transaction.Transaction) {
+	select {
+	case w.RequeueChan <- t:
+	default:
+		w.log.Errorf("dropping transaction because the retry goroutine is too busy to handle another one")
 	}
 }
 

--- a/releasenotes/notes/persist-retry-queue-at-shutdown-29fe6ba3b61b3a33.yaml
+++ b/releasenotes/notes/persist-retry-queue-at-shutdown-29fe6ba3b61b3a33.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Flush in-flight requests and pending retries to disk at shutdown when disk-based buffering of metrics is enabled
+    (i.e. when `forwarder_storage_max_size_in_bytes` is set).

--- a/releasenotes/notes/persist-retry-queue-at-shutdown-29fe6ba3b61b3a33.yaml
+++ b/releasenotes/notes/persist-retry-queue-at-shutdown-29fe6ba3b61b3a33.yaml
@@ -9,4 +9,4 @@
 features:
   - |
     Flush in-flight requests and pending retries to disk at shutdown when disk-based buffering of metrics is enabled
-    (i.e. when `forwarder_storage_max_size_in_bytes` is set).
+    (for example, when `forwarder_storage_max_size_in_bytes` is set).


### PR DESCRIPTION
### What does this PR do?

This PR adds a step to agent shutdown that writes all in-flight transactions to the on-disk retry queue if one is configured.

### Motivation

When intake is down or unreachable for some period of time, the agent accumulated transactions in-memory to be tried again later. This is the purpose of the transaction retry queue. The queue is primarily in-memory, with an optional spillover to disk that can be configured.

Before this change, any transactions that had not made it to the disk portion of the queue via spillover would be lost when the agent is restarted. Since the default size of the in-memory portion of the queue is 15MB, this could represent a significant gap in customer metrics that would be unrecoverable after the restart.

After this change, both the in-memory portion of the retry queue and any in-flight requests that are cancelled will be flushed to disk at the time the agent is shut down. This allows it to recover all of that data and continue retrying the transactions when it comes back up. The end result is that customers are less likely to lose large chunks of data during an outage by restarting their agent instances.

### Additional Notes

There are likely more thorough changes we could make to how the agent persists failed transactions, but most would require significantly larger changes that we're making here. The hope is that this covers the vast majority of cases without the risk of a larger change.

### Possible Drawbacks / Trade-offs

The agent always immediately cancels any in-flight requests at shutdown, which means that we always requeue those requests at shutdown now. This potentially means that we are writing to disk nearly every time that the agent is shutdown, where before we would only write to disk at the time that the in-memory queue filled up. If this is considered undesirable or too risky a change, we can simply not requeue in-flight requests at shutdown. The rest of the PR would not need to change in that case.

### Describe how to test/QA your changes

1. Set `forwarder_storage_max_size_in_bytes` to a reasonably high value to enable disk persistence
2. Set `dd_url` to either an instance of `fakeintake` or a proxy fronting real intake that you can take down as needed
3. Start the agent and see that data is flowing normally
4. Shutdown your intake and see that the agents requests are failing
5. Wait enough time for a meaningful gap in metrics to form (e.g. 2 minutes or more)
6. Restart the agent
7. Bring your intake back up
8. See that the gap is filled in as the agent retries requests from before it was shutdown

If you're using `fakeintake`, there is some sample code [here](https://github.com/lukesteensen/fake-intake-reader) that will monitor what has been sent and show the current largest gap in metrics points. If using the app, you can probably just look visually.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
