### PR TITLE
External Metrics batch error handling

### DIFF
--- a/pkg/clusteragent/externalmetrics/metrics_retriever.go
+++ b/pkg/clusteragent/externalmetrics/metrics_retriever.go
@@ -18,11 +18,13 @@ import (
 )
 
 const (
-	invalidMetricErrorMessage         string = "%v, query was: %s, will retry after %s."
-	invalidMetricOutdatedErrorMessage string = "Query returned outdated result, check MaxAge setting, query: %s"
-	invalidMetricNotFoundErrorMessage string = "Unexpected error, query data not found in result, query: %s"
-	invalidMetricGlobalErrorMessage   string = "Global error (all queries, batch size %d) from backend, invalid syntax in query? Check Cluster Agent leader logs for details. Will retry after %s."
-	metricRetrieverStoreID            string = "mr"
+	invalidMetricErrorMessage                  string = "%v, query was: %s"
+	invalidMetricErrorWithRetriesMessage       string = "%v, query was: %s, will retry after %s."
+	invalidMetricOutdatedErrorMessage          string = "Query returned outdated result, check MaxAge setting, query: %s"
+	invalidMetricNotFoundErrorMessage          string = "Unexpected error, query data not found in result, query: %s"
+	invalidMetricGlobalErrorMessage            string = "Global error (all queries) from backend, invalid syntax in query? Check Cluster Agent leader logs for details"
+	invalidMetricGlobalErrorWithRetriesMessage string = "Global error (all queries, batch size %d) from backend, invalid syntax in query? Check Cluster Agent leader logs for details. Will retry after %s."
+	metricRetrieverStoreID                     string = "mr"
 )
 
 // Backoff range for number of retries R:
@@ -32,21 +34,23 @@ var backoffPolicy backoff.Policy = backoff.NewPolicy(2, 30, 1800, 2, false)
 
 // MetricsRetriever is responsible for querying and storing external metrics
 type MetricsRetriever struct {
-	refreshPeriod int64
-	metricsMaxAge int64
-	processor     autoscalers.ProcessorInterface
-	store         *DatadogMetricsInternalStore
-	isLeader      func() bool
+	refreshPeriod             int64
+	metricsMaxAge             int64
+	splitBatchBackoffOnErrors bool
+	processor                 autoscalers.ProcessorInterface
+	store                     *DatadogMetricsInternalStore
+	isLeader                  func() bool
 }
 
 // NewMetricsRetriever returns a new MetricsRetriever
-func NewMetricsRetriever(refreshPeriod, metricsMaxAge int64, processor autoscalers.ProcessorInterface, isLeader func() bool, store *DatadogMetricsInternalStore) (*MetricsRetriever, error) {
+func NewMetricsRetriever(refreshPeriod, metricsMaxAge int64, processor autoscalers.ProcessorInterface, isLeader func() bool, store *DatadogMetricsInternalStore, splitBatchBackoffOnErrors bool) (*MetricsRetriever, error) {
 	return &MetricsRetriever{
-		refreshPeriod: refreshPeriod,
-		metricsMaxAge: metricsMaxAge,
-		processor:     processor,
-		store:         store,
-		isLeader:      isLeader,
+		refreshPeriod:             refreshPeriod,
+		metricsMaxAge:             metricsMaxAge,
+		processor:                 processor,
+		store:                     store,
+		isLeader:                  isLeader,
+		splitBatchBackoffOnErrors: splitBatchBackoffOnErrors,
 	}, nil
 }
 
@@ -68,30 +72,37 @@ func (mr *MetricsRetriever) Run(stopCh <-chan struct{}) {
 }
 
 func (mr *MetricsRetriever) retrieveMetricsValues() {
-	// We only update active DatadogMetrics
-	// We split metrics in two slices, those with errors and those without.
-	// Query first slice one by one, other as batch.
-	// TODO: consider implementing one-pass splitting in the store
-	datadogMetrics := mr.store.GetFiltered(func(datadogMetric model.DatadogMetricInternal) bool {
-		return datadogMetric.Active && datadogMetric.Error == nil
-	})
 
-	// Do all errors warrant separate query? probably no, but we run them separately because:
-	// Backoff should be applied to each metrics separately.
-	// Only way to differentiate error from a global error is via comparing error strings.
-	datadogMetricsErr := mr.store.GetFiltered(func(datadogMetric model.DatadogMetricInternal) bool {
-		return datadogMetric.Active && datadogMetric.Error != nil
-	})
+	if mr.splitBatchBackoffOnErrors {
+		// We only update active DatadogMetrics
+		// We split metrics in two slices, those with errors and those without.
+		// Query first slice one by one, other as batch.
+		// TODO: consider implementing one-pass splitting in the store
+		datadogMetrics := mr.store.GetFiltered(func(datadogMetric model.DatadogMetricInternal) bool {
+			return datadogMetric.Active && datadogMetric.Error == nil
+		})
 
-	// First split then query because store state is shared and query mutates it
-	mr.retrieveMetricsValuesSlice(datadogMetrics)
+		// Do all errors warrant separate query? probably no, but we run them separately because:
+		// Backoff should be applied to each metrics separately.
+		// Only way to differentiate error from a global error is via comparing error strings.
+		datadogMetricsErr := mr.store.GetFiltered(func(datadogMetric model.DatadogMetricInternal) bool {
+			return datadogMetric.Active && datadogMetric.Error != nil
+		})
 
-	// Now test each metric query separately respecting its backoff retry duration elapse value.
-	for _, metrics := range datadogMetricsErr {
-		if time.Now().After(metrics.RetryAfter) {
-			singleton := []model.DatadogMetricInternal{metrics}
-			mr.retrieveMetricsValuesSlice(singleton)
+		// First split then query because store state is shared and query mutates it
+		mr.retrieveMetricsValuesSlice(datadogMetrics)
+
+		// Now test each metric query separately respecting its backoff retry duration elapse value.
+		for _, metrics := range datadogMetricsErr {
+			if time.Now().After(metrics.RetryAfter) {
+				singleton := []model.DatadogMetricInternal{metrics}
+				mr.retrieveMetricsValuesSlice(singleton)
+			}
 		}
+	} else {
+		// We only update active DatadogMetrics
+		datadogMetrics := mr.store.GetFiltered(func(datadogMetric model.DatadogMetricInternal) bool { return datadogMetric.Active })
+		mr.retrieveMetricsValuesSlice(datadogMetrics)
 	}
 }
 
@@ -132,9 +143,14 @@ func (mr *MetricsRetriever) retrieveMetricsValuesSlice(datadogMetrics []model.Da
 		query := datadogMetric.Query()
 		timeWindow := MaybeAdjustTimeWindowForQuery(datadogMetric.GetTimeWindow())
 		results := resultsByTimeWindow[timeWindow]
+
 		if queryResult, found := results[query]; found {
+			log.Debugf("QueryResult from DD for %q: %v", query, queryResult)
+
 			if queryResult.Valid {
-				datadogMetricFromStore.Retries = 0
+				if mr.splitBatchBackoffOnErrors {
+					datadogMetricFromStore.Retries = 0
+				}
 				datadogMetricFromStore.Value = queryResult.Value
 				datadogMetricFromStore.DataTime = time.Unix(queryResult.Timestamp, 0).UTC()
 
@@ -153,14 +169,23 @@ func (mr *MetricsRetriever) retrieveMetricsValuesSlice(datadogMetrics []model.Da
 				}
 			} else {
 				datadogMetricFromStore.Valid = false
-				incrementRetries(datadogMetricFromStore)
-				datadogMetricFromStore.Error = fmt.Errorf(invalidMetricErrorMessage, queryResult.Error, query, datadogMetricFromStore.RetryAfter.Format(time.RFC3339))
+				if mr.splitBatchBackoffOnErrors {
+					incrementRetries(datadogMetricFromStore)
+					datadogMetricFromStore.Error = fmt.Errorf(invalidMetricErrorWithRetriesMessage,
+						queryResult.Error, query, datadogMetricFromStore.RetryAfter.Format(time.RFC3339))
+				} else {
+					datadogMetricFromStore.Error = fmt.Errorf(invalidMetricErrorMessage, queryResult.Error, query)
+				}
 			}
 		} else {
 			datadogMetricFromStore.Valid = false
 			if globalError {
-				incrementRetries(datadogMetricFromStore)
-				datadogMetricFromStore.Error = fmt.Errorf(invalidMetricGlobalErrorMessage, len(datadogMetrics), datadogMetricFromStore.RetryAfter.Format(time.RFC3339))
+				if mr.splitBatchBackoffOnErrors {
+					incrementRetries(datadogMetricFromStore)
+					datadogMetricFromStore.Error = fmt.Errorf(invalidMetricGlobalErrorWithRetriesMessage, len(datadogMetrics), datadogMetricFromStore.RetryAfter.Format(time.RFC3339))
+				} else {
+					datadogMetricFromStore.Error = fmt.Errorf(invalidMetricGlobalErrorMessage)
+				}
 			} else {
 				// This should never happen as `QueryExternalMetric` is filling all missing series
 				// if no global error.

--- a/pkg/clusteragent/externalmetrics/metrics_retriever.go
+++ b/pkg/clusteragent/externalmetrics/metrics_retriever.go
@@ -71,11 +71,14 @@ func (mr *MetricsRetriever) retrieveMetricsValues() {
 	// We only update active DatadogMetrics
 	// We split metrics in two slices, those with errors and those without.
 	// Query first slice one by one, other as batch.
+	// TODO: consider implementing one-pass splitting in the store
 	datadogMetrics := mr.store.GetFiltered(func(datadogMetric model.DatadogMetricInternal) bool {
 		return datadogMetric.Active && datadogMetric.Error == nil
 	})
 
-	// Do all errors warrant separate query?
+	// Do all errors warrant separate query? probably no, but we run them separately because:
+	// Backoff should be applied to each metrics separately.
+	// Only way to differentiate error from a global error is via comparing error strings.
 	datadogMetricsErr := mr.store.GetFiltered(func(datadogMetric model.DatadogMetricInternal) bool {
 		return datadogMetric.Active && datadogMetric.Error != nil
 	})

--- a/pkg/clusteragent/externalmetrics/metrics_retriever.go
+++ b/pkg/clusteragent/externalmetrics/metrics_retriever.go
@@ -82,6 +82,8 @@ func (mr *MetricsRetriever) retrieveMetricsValues() {
 
 	// First split then query because store state is shared and query mutates it
 	mr.retrieveMetricsValuesSlice(datadogMetrics)
+	
+	// Now test each metric query separately respecting its backoff retry duration elapse value. 
 	for _, metrics := range datadogMetricsErr {
 
 		shouldBackoff := shouldBackoff(&metrics, &backoffPolicy)

--- a/pkg/clusteragent/externalmetrics/metrics_retriever_backoff_test.go
+++ b/pkg/clusteragent/externalmetrics/metrics_retriever_backoff_test.go
@@ -1,0 +1,1313 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package externalmetrics
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/externalmetrics/model"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/autoscalers"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockedProcessorWithBackoff struct {
+	points          map[string]autoscalers.Point
+	err             []error
+	errIndex        int
+	extQueryCounter int64
+	queryCapture    [][]string
+}
+
+func (p *mockedProcessorWithBackoff) UpdateExternalMetrics(emList map[string]custommetrics.ExternalMetricValue) map[string]custommetrics.ExternalMetricValue {
+	return nil
+}
+
+func (p *mockedProcessorWithBackoff) QueryExternalMetric(queries []string, timeWindow time.Duration) (map[string]autoscalers.Point, error) {
+	p.extQueryCounter++
+	// Sort for slice comparison
+	sort.Sort(sort.StringSlice(queries))
+	p.queryCapture = append(p.queryCapture, queries)
+	// Sort slices by first element, slices should be disjoint
+	sort.Slice(p.queryCapture, func(i, j int) bool {
+		return p.queryCapture[i][0] < p.queryCapture[j][0]
+	})
+
+	if p.errIndex == len(p.err)-1 {
+		return p.points, p.err[p.errIndex]
+	} else {
+		p.errIndex++
+		return p.points, p.err[p.errIndex]
+	}
+}
+
+func (p *mockedProcessorWithBackoff) ProcessEMList(emList []custommetrics.ExternalMetricValue) map[string]custommetrics.ExternalMetricValue {
+	return nil
+}
+
+type metricsFixtureWithBackoff struct {
+	desc            string
+	maxAge          int64
+	storeContent    []ddmWithQuery
+	queryResults    map[string]autoscalers.Point
+	queryError      []error
+	expected        []ddmWithQuery
+	extQueryCount   int64
+	extQueryBatches [][]string
+}
+
+func (f *metricsFixtureWithBackoff) runWithBackoff(t *testing.T, testTime time.Time) {
+	t.Helper()
+
+	// Create and fill store
+	store := NewDatadogMetricsInternalStore()
+	for _, datadogMetric := range f.storeContent {
+		datadogMetric.ddm.SetQueries(datadogMetric.query)
+		store.Set(datadogMetric.ddm.ID, datadogMetric.ddm, "utest")
+	}
+
+	// Create MetricsRetriever
+	mockedProcessor := mockedProcessorWithBackoff{
+		points:          f.queryResults,
+		err:             f.queryError,
+		errIndex:        0,
+		extQueryCounter: 0,
+	}
+	metricsRetriever, err := NewMetricsRetriever(0, f.maxAge, &mockedProcessor, getIsLeaderFunction(true), &store, true)
+	assert.Nil(t, err)
+	metricsRetriever.retrieveMetricsValues()
+
+	for _, expectedDatadogMetric := range f.expected {
+		expectedDatadogMetric.ddm.SetQueries(expectedDatadogMetric.query)
+		datadogMetric := store.Get(expectedDatadogMetric.ddm.ID)
+
+		// Update time will be set to a value (as metricsRetriever uses time.Now()) that should be > testTime
+		// Thus, aligning updateTime to have a working comparison
+		if datadogMetric != nil && datadogMetric.Active {
+			assert.Condition(t, func() bool { return datadogMetric.UpdateTime.After(expectedDatadogMetric.ddm.UpdateTime) })
+
+			alignedTime := time.Now().UTC()
+			expectedDatadogMetric.ddm.UpdateTime = alignedTime
+			datadogMetric.UpdateTime = alignedTime
+
+			// These will contain random element if Retries > 0
+			if expectedDatadogMetric.ddm.Retries > 0 {
+				expectedDatadogMetric.ddm.RetryAfter = datadogMetric.RetryAfter
+				// Align errors and verify prefix is expected
+				expectedDatadogMetric.ddm.Error = datadogMetric.Error
+				assert.True(t, strings.HasPrefix(datadogMetric.Error.Error(), expectedDatadogMetric.ddm.Error.Error()))
+			}
+		}
+
+		assert.Equal(t, &expectedDatadogMetric.ddm, datadogMetric)
+		assert.Equal(t, f.extQueryCount, mockedProcessor.extQueryCounter)
+
+		// Skip this assert, when not set, i.e. test doesn't verify actual queries
+		if len(f.extQueryBatches) > 0 {
+			assert.Equal(t, f.extQueryBatches, mockedProcessor.queryCapture)
+		}
+	}
+}
+
+func (f *metricsFixtureWithBackoff) runQueryOnly(t *testing.T) {
+	t.Helper()
+
+	// Create and fill store
+	store := NewDatadogMetricsInternalStore()
+	for _, datadogMetric := range f.storeContent {
+		datadogMetric.ddm.SetQueries(datadogMetric.query)
+		store.Set(datadogMetric.ddm.ID, datadogMetric.ddm, "utest")
+	}
+
+	// Create MetricsRetriever
+	mockedProcessor := mockedProcessorWithBackoff{
+		points:          f.queryResults,
+		err:             f.queryError,
+		errIndex:        0,
+		extQueryCounter: 0,
+	}
+	metricsRetriever, err := NewMetricsRetriever(0, f.maxAge, &mockedProcessor, getIsLeaderFunction(true), &store, true)
+	assert.Nil(t, err)
+	metricsRetriever.retrieveMetricsValues()
+	assert.Equal(t, f.extQueryCount, mockedProcessor.extQueryCounter)
+	assert.Equal(t, f.extQueryBatches, mockedProcessor.queryCapture)
+}
+
+func TestRetrieveMetricsBasicWithBackoff(t *testing.T) {
+	// At the end we'll check that update time has been updated, giving 10s to run the tests
+	// We truncate down to the second as that's the granularity we have from backend
+	defaultTestTime := time.Now().Add(time.Duration(-1) * time.Second).UTC().Truncate(time.Second)
+	defaultPreviousUpdateTime := time.Now().Add(time.Duration(-11) * time.Second).UTC().Truncate(time.Second)
+
+	fixtures := []metricsFixtureWithBackoff{
+		{
+			maxAge:        30,
+			desc:          "Test nominal case - no errors while retrieving metric values",
+			extQueryCount: 1,
+			storeContent: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    true,
+						Error:    nil,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   true,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    nil,
+					},
+					query: "query-metric1",
+				},
+			},
+			queryResults: map[string]autoscalers.Point{
+				"query-metric0": {
+					Value:     10.0,
+					Timestamp: defaultTestTime.Unix(),
+					Valid:     true,
+				},
+				"query-metric1": {
+					Value:     11.0,
+					Timestamp: defaultTestTime.Unix(),
+					Valid:     true,
+				},
+			},
+			queryError: []error{nil},
+			expected: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						Value:    10.0,
+						DataTime: defaultTestTime,
+						Valid:    true,
+						Error:    nil,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   true,
+						Value:    11.0,
+						DataTime: defaultTestTime,
+						Valid:    true,
+						Error:    nil,
+					},
+					query: "query-metric1",
+				},
+			},
+		},
+	}
+
+	for i, fixture := range fixtures {
+		t.Run(fmt.Sprintf("#%d %s", i, fixture.desc), func(t *testing.T) {
+			fixture.runWithBackoff(t, defaultTestTime)
+		})
+	}
+}
+
+func TestRetrieveMetricsErrorCasesWithBackoff(t *testing.T) {
+	// At the end we'll check that update time has been updated, giving 10s to run the tests
+	// We truncate down to the second as that's the granularity we have from backend
+	defaultTestTime := time.Now().Add(time.Duration(-1) * time.Second).UTC().Truncate(time.Second)
+	defaultPreviousUpdateTime := time.Now().Add(time.Duration(-11) * time.Second).UTC().Truncate(time.Second)
+
+	fixtures := []metricsFixtureWithBackoff{
+		{
+			maxAge:        5,
+			desc:          "Test expired data from backend, don't set Retries",
+			extQueryCount: 1,
+			storeContent: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    true,
+						Error:    nil,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   true,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    nil,
+					},
+					query: "query-metric1",
+				},
+			},
+			queryResults: map[string]autoscalers.Point{
+				"query-metric0": {
+					Value:     10.0,
+					Timestamp: defaultTestTime.Unix(),
+					Valid:     true,
+				},
+				"query-metric1": {
+					Value:     11.0,
+					Timestamp: defaultPreviousUpdateTime.Unix(),
+					Valid:     true,
+				},
+			},
+			queryError: []error{nil},
+			expected: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						Value:    10.0,
+						DataTime: defaultTestTime,
+						Valid:    true,
+						Error:    nil,
+						Retries:  0,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   true,
+						Value:    11.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    fmt.Errorf(invalidMetricOutdatedErrorMessage, "query-metric1"),
+						Retries:  0,
+					},
+					query: "query-metric1",
+				},
+			},
+		},
+		{
+			maxAge:        15,
+			desc:          "Test expired data from backend defining per-metric maxAge (overrides global maxAge), don't set Retries",
+			extQueryCount: 1,
+			storeContent: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    true,
+						Error:    nil,
+						MaxAge:   20 * time.Second,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   true,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    nil,
+						MaxAge:   5 * time.Second,
+					},
+					query: "query-metric1",
+				},
+			},
+			queryResults: map[string]autoscalers.Point{
+				"query-metric0": {
+					Value:     10.0,
+					Timestamp: defaultTestTime.Unix(),
+					Valid:     true,
+				},
+				"query-metric1": {
+					Value:     11.0,
+					Timestamp: defaultPreviousUpdateTime.Unix(),
+					Valid:     true,
+				},
+			},
+			queryError: []error{nil},
+			expected: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						Value:    10.0,
+						DataTime: defaultTestTime,
+						Valid:    true,
+						Error:    nil,
+						MaxAge:   20 * time.Second,
+						Retries:  0,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   true,
+						Value:    11.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    fmt.Errorf(invalidMetricOutdatedErrorMessage, "query-metric1"),
+						MaxAge:   5 * time.Second,
+						Retries:  0,
+					},
+					query: "query-metric1",
+				},
+			},
+		},
+		{
+			maxAge:        30,
+			desc:          "Test backend error (single metric), set Retries (single metrics)",
+			extQueryCount: 1,
+			storeContent: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						Value:    8.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    true,
+						Error:    nil,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   true,
+						Value:    11.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    true,
+						Error:    nil,
+					},
+					query: "query-metric1",
+				},
+			},
+			queryResults: map[string]autoscalers.Point{
+				"query-metric0": {
+					Value:     10.0,
+					Timestamp: defaultTestTime.Unix(),
+					Valid:     true,
+				},
+				"query-metric1": {
+					Value:     0,
+					Timestamp: defaultPreviousUpdateTime.Unix(),
+					Valid:     false,
+					Error:     errors.New("some err"),
+				},
+			},
+			queryError: []error{nil},
+			expected: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						Value:    10.0,
+						DataTime: defaultTestTime,
+						Valid:    true,
+						Error:    nil,
+						Retries:  0,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   true,
+						Value:    11.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    fmt.Errorf(invalidMetricErrorWithRetriesMessage, errors.New("some err"), "query-metric1", ""),
+						Retries:  1,
+					},
+					query: "query-metric1",
+				},
+			},
+		},
+		{
+			maxAge:        30,
+			desc:          "Test global error from backend, set Retries (all)",
+			extQueryCount: 1,
+			storeContent: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						Value:    1.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    true,
+						Error:    nil,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   true,
+						Value:    2.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    nil,
+					},
+					query: "query-metric1",
+				},
+			},
+			queryResults: map[string]autoscalers.Point{},
+			queryError:   []error{fmt.Errorf("Backend error 500")},
+			expected: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						Value:    1.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    fmt.Errorf(invalidMetricGlobalErrorWithRetriesMessage, 2, ""),
+						Retries:  1,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   true,
+						Value:    2.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    fmt.Errorf(invalidMetricGlobalErrorWithRetriesMessage, 2, ""),
+						Retries:  1,
+					},
+					query: "query-metric1",
+				},
+			},
+		},
+		{
+			maxAge:        30,
+			desc:          "Test missing query response from backend, don't set Retries",
+			extQueryCount: 1,
+			storeContent: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						Value:    1.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    true,
+						Error:    nil,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   true,
+						Value:    2.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    nil,
+					},
+					query: "query-metric1",
+				},
+			},
+			queryResults: map[string]autoscalers.Point{
+				"query-metric0": {
+					Value:     10.0,
+					Timestamp: defaultTestTime.Unix(),
+					Valid:     true,
+				},
+			},
+			queryError: []error{fmt.Errorf("Backend error 500")},
+			expected: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						Value:    10.0,
+						DataTime: defaultTestTime,
+						Valid:    true,
+						Error:    nil,
+						Retries:  0,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   true,
+						Value:    2.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    fmt.Errorf(invalidMetricNotFoundErrorMessage, "query-metric1"),
+						Retries:  0,
+					},
+					query: "query-metric1",
+				},
+			},
+		},
+	}
+
+	for i, fixture := range fixtures {
+		t.Run(fmt.Sprintf("#%d %s", i, fixture.desc), func(t *testing.T) {
+			// if fixture.desc == "Test global error from backend, set Retries (all)" {
+			fixture.runWithBackoff(t, defaultTestTime)
+			// }
+		})
+	}
+}
+
+func TestRetrieveMetricsNotActiveWithBackoff(t *testing.T) {
+	// At the end we'll check that update time has been updated, giving 10s to run the tests
+	// We truncate down to the second as that's the granularity we have from backend
+	defaultTestTime := time.Now().Add(time.Duration(-1) * time.Second).UTC().Truncate(time.Second)
+	defaultPreviousUpdateTime := time.Now().Add(time.Duration(-11) * time.Second).UTC().Truncate(time.Second)
+
+	fixtures := []metricsFixtureWithBackoff{
+		{
+			maxAge:        30,
+			desc:          "Test some metrics are not active",
+			extQueryCount: 1,
+			storeContent: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    true,
+						Error:    nil,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   false,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    nil,
+					},
+					query: "query-metric1",
+				},
+			},
+			queryResults: map[string]autoscalers.Point{
+				"query-metric0": {
+					Value:     10.0,
+					Timestamp: defaultTestTime.Unix(),
+					Valid:     true,
+				},
+				"query-metric1": {
+					Value:     11.0,
+					Timestamp: defaultTestTime.Unix(),
+					Valid:     true,
+				},
+			},
+			queryError: []error{nil},
+			expected: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						Value:    10.0,
+						DataTime: defaultTestTime,
+						Valid:    true,
+						Error:    nil,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   false,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    nil,
+					},
+					query: "query-metric1",
+				},
+			},
+		},
+		{
+			maxAge:        30,
+			desc:          "Test no active metrics",
+			extQueryCount: 0,
+			storeContent: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   false,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    true,
+						Error:    nil,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   false,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    nil,
+					},
+					query: "query-metric1",
+				},
+			},
+			queryResults: map[string]autoscalers.Point{
+				"query-metric0": {
+					Value:     10.0,
+					Timestamp: defaultTestTime.Unix(),
+					Valid:     true,
+				},
+				"query-metric1": {
+					Value:     11.0,
+					Timestamp: defaultTestTime.Unix(),
+					Valid:     true,
+				},
+			},
+			queryError: []error{nil},
+			expected: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   false,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    true,
+						Error:    nil,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   false,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    nil,
+					},
+					query: "query-metric1",
+				},
+			},
+		},
+	}
+
+	for i, fixture := range fixtures {
+		t.Run(fmt.Sprintf("#%d %s", i, fixture.desc), func(t *testing.T) {
+			fixture.runWithBackoff(t, defaultTestTime)
+		})
+	}
+}
+
+func TestGetUniqueQueriesByTimeWindowWithBackoff(t *testing.T) {
+	metrics := []model.DatadogMetricInternal{
+		NewDatadogMetricForTests("1", "system.cpu", time.Minute*1, time.Hour*2),
+		NewDatadogMetricForTests("2", "system.cpu", time.Minute*1, time.Hour*2),
+		NewDatadogMetricForTests("3", "system.mem", time.Minute*1, time.Hour*2),
+		NewDatadogMetricForTests("4", "system.mem", time.Minute*1, time.Minute*2),
+		NewDatadogMetricForTests("5", "system.mem", time.Minute*1, time.Minute*1),
+		NewDatadogMetricForTests("6", "system.network", time.Minute*1, time.Minute*1),
+		NewDatadogMetricForTests("7", "system.disk", time.Minute*1, 0),
+	}
+	metricsByTimeWindow := getBatchedQueriesByTimeWindow(metrics)
+	expected := map[time.Duration][]string{
+		// These have a longer than default time window
+		time.Hour * 2: {"system.cpu", "system.mem"},
+		// These do not.
+		autoscalers.GetDefaultTimeWindow(): {"system.mem", "system.network", "system.disk"},
+	}
+
+	assert.Equal(t, expected, metricsByTimeWindow)
+}
+
+func TestRetrieveMetricsBatchErrorCasesWithBackoff(t *testing.T) {
+	// At the end we'll check that update time has been updated, giving 10s to run the tests
+	// We truncate down to the second as that's the granularity we have from backend
+	defaultTestTime := time.Now().Add(time.Duration(-1) * time.Second).UTC().Truncate(time.Second)
+	defaultPreviousUpdateTime := time.Now().Add(time.Duration(-11) * time.Second).UTC().Truncate(time.Second)
+
+	fixtures := []metricsFixtureWithBackoff{
+		{
+			maxAge:        30,
+			desc:          "Test split batch, error recovers; reset Retries",
+			extQueryCount: 2,
+			extQueryBatches: [][]string{
+				{"query-metric0"},
+				{"query-metric1"},
+			},
+			storeContent: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						Value:    1.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    true,
+						Error:    nil,
+						Retries:  0,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   true,
+						Value:    2.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    fmt.Errorf("Backend error 400"),
+						Retries:  1,
+					},
+					query: "query-metric1",
+				},
+			},
+			queryResults: map[string]autoscalers.Point{
+				"query-metric0": {
+					Value:     10.0,
+					Timestamp: defaultTestTime.Unix(),
+					Valid:     true,
+				},
+				"query-metric1": {
+					Value:     20.0,
+					Timestamp: defaultTestTime.Unix(),
+					Valid:     true,
+					Error:     nil,
+				},
+			},
+			queryError: []error{nil},
+			expected: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						Value:    10.0,
+						DataTime: defaultTestTime,
+						Valid:    true,
+						Error:    nil,
+						Retries:  0,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   true,
+						Value:    20.0,
+						DataTime: defaultTestTime,
+						Valid:    true,
+						Error:    nil,
+						Retries:  0,
+					},
+					query: "query-metric1",
+				},
+			},
+		},
+		{
+			maxAge:        30,
+			desc:          "Test split batch, error persists; increase Retries",
+			extQueryCount: 2,
+			extQueryBatches: [][]string{
+				{"query-metric0"},
+				{"query-metric1"},
+			},
+
+			storeContent: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						Value:    1.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    true,
+						Error:    nil,
+						Retries:  0,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   true,
+						Value:    2.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    fmt.Errorf("Backend error 400"),
+						Retries:  1,
+					},
+					query: "query-metric1",
+				},
+			},
+			queryResults: map[string]autoscalers.Point{
+				"query-metric0": {
+					Value:     10.0,
+					Timestamp: defaultTestTime.Unix(),
+					Valid:     true,
+				},
+				"query-metric1": {
+					Value:     20.0,
+					Timestamp: defaultPreviousUpdateTime.Unix(),
+					Valid:     false,
+					Error:     errors.New("some err"),
+				},
+			},
+			queryError: []error{nil},
+			expected: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						Value:    10.0,
+						DataTime: defaultTestTime,
+						Valid:    true,
+						Error:    nil,
+						Retries:  0,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   true,
+						Value:    2.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    errors.New("some err, query was: query-metric1"),
+						Retries:  2,
+					},
+					query: "query-metric1",
+				},
+			},
+		},
+		{
+			maxAge:        30,
+			desc:          "Test 3 batches one with good, two for error metrics; increase Retries",
+			extQueryCount: 3,
+			extQueryBatches: [][]string{
+				{"query-metric0"},
+				{"query-metric1"},
+				{"query-metric2"},
+			},
+			storeContent: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						Value:    1.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    true,
+						Error:    nil,
+						Retries:  0,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   true,
+						Value:    2.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    fmt.Errorf("Backend error 500"),
+						Retries:  1,
+					},
+					query: "query-metric1",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric2",
+						Active:   true,
+						Value:    3.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    fmt.Errorf("Backend error 500"),
+						Retries:  1,
+					},
+					query: "query-metric2",
+				},
+			},
+			queryResults: map[string]autoscalers.Point{
+				"query-metric0": {
+					Value:     10.0,
+					Timestamp: defaultTestTime.Unix(),
+					Valid:     true,
+				},
+				"query-metric1": {
+					Value:     20.0,
+					Timestamp: defaultPreviousUpdateTime.Unix(),
+					Valid:     false,
+					Error:     errors.New("some err"),
+				},
+				"query-metric2": {
+					Value:     30.0,
+					Timestamp: defaultPreviousUpdateTime.Unix(),
+					Valid:     false,
+					Error:     errors.New("some other err"),
+				},
+			},
+			queryError: []error{nil, fmt.Errorf("Backend error 500")},
+			expected: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						Value:    10.0,
+						DataTime: defaultTestTime,
+						Valid:    true,
+						Error:    nil,
+						Retries:  0,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   true,
+						Value:    2.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    errors.New("some err, query was: query-metric1"),
+						Retries:  2,
+					},
+					query: "query-metric1",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric2",
+						Active:   true,
+						Value:    3.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    errors.New("some other err, query was: query-metric2"),
+						Retries:  2,
+					},
+					query: "query-metric2",
+				},
+			},
+		},
+		{
+			maxAge:        30,
+			desc:          "Test 2 batches, one with error, other with two good metrics; increase Retries",
+			extQueryCount: 2,
+			extQueryBatches: [][]string{
+				{"query-metric0", "query-metric2"},
+				{"query-metric1"},
+			},
+			storeContent: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						Value:    1.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    true,
+						Error:    nil,
+						Retries:  0,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   true,
+						Value:    2.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    fmt.Errorf("Backend error 500"),
+						Retries:  1,
+					},
+					query: "query-metric1",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric2",
+						Active:   true,
+						Value:    3.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    true,
+						Error:    nil,
+						Retries:  0,
+					},
+					query: "query-metric2",
+				},
+			},
+			queryResults: map[string]autoscalers.Point{
+				"query-metric0": {
+					Value:     10.0,
+					Timestamp: defaultTestTime.Unix(),
+					Valid:     true,
+				},
+				"query-metric1": {
+					Value:     20.0,
+					Timestamp: defaultPreviousUpdateTime.Unix(),
+					Valid:     false,
+					Error:     errors.New("some err"),
+				},
+				"query-metric2": {
+					Value:     30.0,
+					Timestamp: defaultTestTime.Unix(),
+					Valid:     true,
+					Error:     nil,
+				},
+			},
+			queryError: []error{fmt.Errorf("Backend error 500")},
+			expected: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric0",
+						Active:   true,
+						Value:    10.0,
+						DataTime: defaultTestTime,
+						Valid:    true,
+						Error:    nil,
+						Retries:  0,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric1",
+						Active:   true,
+						Value:    2.0,
+						DataTime: defaultPreviousUpdateTime,
+						Valid:    false,
+						Error:    errors.New("some err, query was: query-metric1"),
+						Retries:  2,
+					},
+					query: "query-metric1",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:       "metric2",
+						Active:   true,
+						Value:    30.0,
+						DataTime: defaultTestTime,
+						Valid:    true,
+						Error:    nil,
+						Retries:  0,
+					},
+					query: "query-metric2",
+				},
+			},
+		},
+	}
+
+	for i, fixture := range fixtures {
+		t.Run(fmt.Sprintf("#%d %s", i, fixture.desc), func(t *testing.T) {
+			fixture.runWithBackoff(t, defaultTestTime)
+		})
+	}
+}
+
+func TestRetryIncTimingWithBackoff(t *testing.T) {
+	// Current backoff policy in metrics retriever: backoff.NewPolicy(2, 30, 1800, 2, false)
+	// when retries > 5,  backoff capped at 1800sec
+	// when retries <= 5, backoff random(2^(retries-1) * 30, 2^retries * 30)
+
+	tests := []struct {
+		Name                 string
+		CurrentRetries       int
+		NewRetries           int
+		RetryAfterMinFromNow int
+		RetryAfterMaxFromNow int
+	}{
+		{
+			Name:                 "0->1",
+			CurrentRetries:       0,
+			NewRetries:           1,
+			RetryAfterMinFromNow: 30,
+			RetryAfterMaxFromNow: 60,
+		},
+		{
+			Name:                 "1->2",
+			CurrentRetries:       1,
+			NewRetries:           2,
+			RetryAfterMinFromNow: 60,
+			RetryAfterMaxFromNow: 120,
+		},
+		{
+			Name:                 "5->6",
+			CurrentRetries:       5,
+			NewRetries:           6,
+			RetryAfterMinFromNow: 1799,
+			RetryAfterMaxFromNow: 1801,
+		},
+		{
+			Name:                 "10->11",
+			CurrentRetries:       10,
+			NewRetries:           11,
+			RetryAfterMinFromNow: 1799,
+			RetryAfterMaxFromNow: 1801,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			ddMetricsInternal := model.DatadogMetricInternal{
+				Retries: tt.CurrentRetries,
+			}
+			retryTimeMin := time.Now().Add(time.Duration(tt.RetryAfterMinFromNow) * time.Second)
+			retryTimeMax := time.Now().Add(time.Duration(tt.RetryAfterMaxFromNow) * time.Second)
+			incrementRetries(&ddMetricsInternal)
+			assert.Equal(t, tt.NewRetries, ddMetricsInternal.Retries)
+			assert.True(t, ddMetricsInternal.RetryAfter.After(retryTimeMin))
+			assert.True(t, ddMetricsInternal.RetryAfter.Before(retryTimeMax))
+		})
+	}
+}
+
+func TestBatchSplittingWithBackoff(t *testing.T) {
+
+	// In this case we only care about how many queries batch queries are made
+	// to verify the backoff logic. Backoff timing is tested in the previous test
+
+	fixtures := []metricsFixtureWithBackoff{
+		{
+			desc:          "Test mixed queries with backoffs, query one with expired backoff; backoff one; query valid",
+			extQueryCount: 3,
+			extQueryBatches: [][]string{
+				{"query-metric0"},
+				{"query-metric2"},
+				{"query-metric3"},
+			},
+			storeContent: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:      "metric0",
+						Active:  true,
+						Error:   nil,
+						Retries: 0, // no error, no backoff: +1 query
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric1",
+						Active:     true,
+						Error:      errors.New("some err"),
+						RetryAfter: time.Now().Add(time.Duration(5) * time.Second),
+						Retries:    1, // backoff not expired: no change
+					},
+					query: "query-metric1",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric2",
+						Active:     true,
+						Error:      errors.New("some err"),
+						RetryAfter: time.Now().Add(time.Duration(-5) * time.Second),
+						Retries:    1, // backoff expired: +1 query
+					},
+					query: "query-metric2",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric3",
+						Active:     true,
+						Error:      errors.New("some err"),
+						RetryAfter: time.Now().Add(time.Duration(-5) * time.Second),
+						Retries:    2, // backoff expired: +1 query
+					},
+					query: "query-metric3",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric4",
+						Active:     true,
+						Error:      errors.New("some err"),
+						RetryAfter: time.Now().Add(time.Duration(5) * time.Second),
+						Retries:    2, // backoff not expired: no change
+					},
+					query: "query-metric4",
+				},
+			},
+			queryResults: map[string]autoscalers.Point{
+				"query-metric0": {},
+				"query-metric1": {},
+				"query-metric2": {},
+				"query-metric3": {},
+				"query-metric4": {},
+			},
+			queryError: []error{nil},
+		},
+		{
+			desc:          "Test mix with multiple valid metrics, invalid with and without backoff",
+			extQueryCount: 2,
+			extQueryBatches: [][]string{
+				{"query-metric0", "query-metric1", "query-metric2"},
+				{"query-metric3"},
+			},
+			storeContent: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:      "metric0",
+						Active:  true,
+						Error:   nil,
+						Retries: 0, // no error, no backoff: +1 query for valid queries
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:      "metric1",
+						Active:  true,
+						Error:   nil,
+						Retries: 0, // no error, no backoff, same query as metric0
+					},
+					query: "query-metric1",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:      "metric2",
+						Active:  true,
+						Error:   nil,
+						Retries: 0, // no error, no backoff, same query as metric0
+					},
+					query: "query-metric2",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric3",
+						Active:     true,
+						Error:      errors.New("some err"),
+						RetryAfter: time.Now().Add(time.Duration(-5) * time.Second),
+						Retries:    2, // backoff expired: +1 query
+					},
+					query: "query-metric3",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric4",
+						Active:     true,
+						Error:      errors.New("some err"),
+						RetryAfter: time.Now().Add(time.Duration(5) * time.Second),
+						Retries:    2, // backoff not expired: no change
+					},
+					query: "query-metric4",
+				},
+			},
+			queryResults: map[string]autoscalers.Point{
+				"query-metric0": {},
+				"query-metric1": {},
+				"query-metric2": {},
+				"query-metric3": {},
+				"query-metric4": {},
+			},
+			queryError: []error{nil},
+		},
+	}
+
+	for i, fixture := range fixtures {
+		t.Run(fmt.Sprintf("#%d %s", i, fixture.desc), func(t *testing.T) {
+			fixture.runQueryOnly(t)
+		})
+	}
+}

--- a/pkg/clusteragent/externalmetrics/model/datadogmetricinternal.go
+++ b/pkg/clusteragent/externalmetrics/model/datadogmetricinternal.go
@@ -158,6 +158,8 @@ func (d *DatadogMetricInternal) UpdateFrom(current datadoghq.DatadogMetric) {
 		d.resolveQuery(currentSpec.Query)
 	}
 
+	// Changing one of these fields may get `DatadogMetric` out of error state. To get query attempted
+	// right away we reset retry count and backoff.
 	if d.query != currentSpec.Query ||
 		d.MaxAge != currentSpec.MaxAge.Duration ||
 		d.TimeWindow != currentSpec.TimeWindow.Duration {

--- a/pkg/clusteragent/externalmetrics/model/datadogmetricinternal.go
+++ b/pkg/clusteragent/externalmetrics/model/datadogmetricinternal.go
@@ -48,6 +48,7 @@ type DatadogMetricInternal struct {
 	MaxAge               time.Duration
 	TimeWindow           time.Duration
 	Retries              int
+	RetryAfter           time.Time
 }
 
 // NewDatadogMetricInternal returns a `DatadogMetricInternal` object from a `DatadogMetric` CRD Object
@@ -156,6 +157,14 @@ func (d *DatadogMetricInternal) UpdateFrom(current datadoghq.DatadogMetric) {
 	if d.shouldResolveQuery(currentSpec) {
 		d.resolveQuery(currentSpec.Query)
 	}
+
+	if d.query != currentSpec.Query ||
+		d.MaxAge != currentSpec.MaxAge.Duration ||
+		d.TimeWindow != currentSpec.TimeWindow.Duration {
+		d.Retries = 0
+		d.RetryAfter = time.Time{}
+	}
+
 	d.query = currentSpec.Query
 	d.MaxAge = currentSpec.MaxAge.Duration
 	d.TimeWindow = currentSpec.TimeWindow.Duration

--- a/pkg/clusteragent/externalmetrics/model/datadogmetricinternal.go
+++ b/pkg/clusteragent/externalmetrics/model/datadogmetricinternal.go
@@ -47,6 +47,7 @@ type DatadogMetricInternal struct {
 	Error                error
 	MaxAge               time.Duration
 	TimeWindow           time.Duration
+	Retries              int
 }
 
 // NewDatadogMetricInternal returns a `DatadogMetricInternal` object from a `DatadogMetric` CRD Object
@@ -63,6 +64,7 @@ func NewDatadogMetricInternal(id string, datadogMetric datadoghq.DatadogMetric) 
 		AutoscalerReferences: datadogMetric.Status.AutoscalerReferences,
 		MaxAge:               datadogMetric.Spec.MaxAge.Duration,
 		TimeWindow:           datadogMetric.Spec.TimeWindow.Duration,
+		Retries:              0,
 	}
 
 	if len(datadogMetric.Spec.ExternalMetricName) > 0 {

--- a/pkg/clusteragent/externalmetrics/provider.go
+++ b/pkg/clusteragent/externalmetrics/provider.go
@@ -58,7 +58,7 @@ func NewDatadogMetricProvider(ctx context.Context, apiCl *apiserver.APIClient) (
 
 	refreshPeriod := config.Datadog.GetInt64("external_metrics_provider.refresh_period")
 	retrieverMetricsMaxAge := int64(math.Max(config.Datadog.GetFloat64("external_metrics_provider.max_age"), float64(3*rollup)))
-	splitBatchBackoffOnErrors := config.Datadog.GetBool("external_metrics_provider.split_batches_and_backoff")
+	splitBatchBackoffOnErrors := config.Datadog.GetBool("external_metrics_provider.split_batches_with_backoff")
 	autogenNamespace := common.GetResourcesNamespace()
 	autogenEnabled := config.Datadog.GetBool("external_metrics_provider.enable_datadogmetric_autogen")
 

--- a/pkg/clusteragent/externalmetrics/provider.go
+++ b/pkg/clusteragent/externalmetrics/provider.go
@@ -58,6 +58,7 @@ func NewDatadogMetricProvider(ctx context.Context, apiCl *apiserver.APIClient) (
 
 	refreshPeriod := config.Datadog.GetInt64("external_metrics_provider.refresh_period")
 	retrieverMetricsMaxAge := int64(math.Max(config.Datadog.GetFloat64("external_metrics_provider.max_age"), float64(3*rollup)))
+	splitBatchBackoffOnErrors := config.Datadog.GetBool("external_metrics_provider.split_batch_backoff_on_errors")
 	autogenNamespace := common.GetResourcesNamespace()
 	autogenEnabled := config.Datadog.GetBool("external_metrics_provider.enable_datadogmetric_autogen")
 
@@ -73,7 +74,7 @@ func NewDatadogMetricProvider(ctx context.Context, apiCl *apiserver.APIClient) (
 		return nil, fmt.Errorf("Unable to create DatadogMetricProvider as DatadogClient failed with: %v", err)
 	}
 
-	metricsRetriever, err := NewMetricsRetriever(refreshPeriod, retrieverMetricsMaxAge, autoscalers.NewProcessor(datadogClient), le.IsLeader, &provider.store)
+	metricsRetriever, err := NewMetricsRetriever(refreshPeriod, retrieverMetricsMaxAge, autoscalers.NewProcessor(datadogClient), le.IsLeader, &provider.store, splitBatchBackoffOnErrors)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to create DatadogMetricProvider as MetricsRetriever failed with: %v", err)
 	}

--- a/pkg/clusteragent/externalmetrics/provider.go
+++ b/pkg/clusteragent/externalmetrics/provider.go
@@ -58,7 +58,7 @@ func NewDatadogMetricProvider(ctx context.Context, apiCl *apiserver.APIClient) (
 
 	refreshPeriod := config.Datadog.GetInt64("external_metrics_provider.refresh_period")
 	retrieverMetricsMaxAge := int64(math.Max(config.Datadog.GetFloat64("external_metrics_provider.max_age"), float64(3*rollup)))
-	splitBatchBackoffOnErrors := config.Datadog.GetBool("external_metrics_provider.split_batch_backoff_on_errors")
+	splitBatchBackoffOnErrors := config.Datadog.GetBool("external_metrics_provider.split_batches_and_backoff")
 	autogenNamespace := common.GetResourcesNamespace()
 	autogenEnabled := config.Datadog.GetBool("external_metrics_provider.enable_datadogmetric_autogen")
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1003,7 +1003,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("external_metrics_provider.config", map[string]string{})        // list of options that can be used to configure the external metrics server
 	config.BindEnvAndSetDefault("external_metrics_provider.local_copy_refresh_rate", 30)        // value in seconds
 	config.BindEnvAndSetDefault("external_metrics_provider.chunk_size", 35)                     // Maximum number of queries to batch when querying Datadog.
-	config.BindEnvAndSetDefault("external_metrics_provider.split_batches_and_backoff", false)   // Splits batches and runs queries with errors individually with an expnential backoff
+	config.BindEnvAndSetDefault("external_metrics_provider.split_batches_and_backoff", false)   // Splits batches and runs queries with errors individually with an exponential backoff
 	AddOverrideFunc(sanitizeExternalMetricsProviderChunkSize)
 	// Cluster check Autodiscovery
 	config.BindEnvAndSetDefault("cluster_checks.enabled", false)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1003,6 +1003,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("external_metrics_provider.config", map[string]string{})        // list of options that can be used to configure the external metrics server
 	config.BindEnvAndSetDefault("external_metrics_provider.local_copy_refresh_rate", 30)        // value in seconds
 	config.BindEnvAndSetDefault("external_metrics_provider.chunk_size", 35)                     // Maximum number of queries to batch when querying Datadog.
+	config.BindEnvAndSetDefault("external_metrics_provider.split_batches_and_backoff", false)   // Splits batches and runs queries with errors individually with an expnential backoff
 	AddOverrideFunc(sanitizeExternalMetricsProviderChunkSize)
 	// Cluster check Autodiscovery
 	config.BindEnvAndSetDefault("cluster_checks.enabled", false)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1003,7 +1003,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("external_metrics_provider.config", map[string]string{})        // list of options that can be used to configure the external metrics server
 	config.BindEnvAndSetDefault("external_metrics_provider.local_copy_refresh_rate", 30)        // value in seconds
 	config.BindEnvAndSetDefault("external_metrics_provider.chunk_size", 35)                     // Maximum number of queries to batch when querying Datadog.
-	config.BindEnvAndSetDefault("external_metrics_provider.split_batches_and_backoff", false)   // Splits batches and runs queries with errors individually with an exponential backoff
+	config.BindEnvAndSetDefault("external_metrics_provider.split_batches_with_backoff", false)  // Splits batches and runs queries with errors individually with an exponential backoff
 	AddOverrideFunc(sanitizeExternalMetricsProviderChunkSize)
 	// Cluster check Autodiscovery
 	config.BindEnvAndSetDefault("cluster_checks.enabled", false)

--- a/releasenotes/notes/em-batch-error-handling-caee30e96391cfcf.yaml
+++ b/releasenotes/notes/em-batch-error-handling-caee30e96391cfcf.yaml
@@ -9,5 +9,5 @@
 enhancements:
   - |
     Improve error handling in External Metrics query logic by running
-    queries with errors individually with retry and backoff and batching
+    queries with errors individually with retry and backoff, and batching
     only queries without errors.

--- a/releasenotes/notes/em-batch-error-handling-caee30e96391cfcf.yaml
+++ b/releasenotes/notes/em-batch-error-handling-caee30e96391cfcf.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Improve error handling in External Metrics query logic by running
+    queries with errors individually with retry and backoff and batching
+    only queries without errors.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Current query batching logic for External Metrics leads to whole batch failures when a single query is invalid. This leads to recurring full batch failures until query is fixed. This can also lead to a noisy neighbor problem on shared clusters.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Current PR makes changes to the batching logic:
* Batch splitting - before processing the batch, it's examined and split into one batch consisting of all queries without errors, and single-query batches for those `DatadogMetrics` objects marked with Error.
* Backoff for queries with errors - queries which failed on a pervious attempt leading to `DatadogMetrics` error state, won't be retried at the same cadence as successful queries. Logic will backoff retry exponentially up to max 30min.

Example to illustrate above:
1. We have 4 `DatadogMetrics` in a batch. On a first attempt whole batch fails with 'global' error causing all four to be marked with error. We set retry count and backoff time on each.
2. On a next iteration for each of the four `DatadogMetrics` in the batch, we check if backoff time has passed. If it did, we retry each separately, otherwise we skip. 
3. Assume 2 succeeded, 2 failed again when retried.
4. Batch of 4 now is split into three batches - one with two successful queries, and one for each failed queries.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
Increased API usage - change will increase API burst rate, since in the worst case we will go from 1 API call per 35 queries to 35 API calls for 'global' errors. Backoff/jitter would make this average ~18. Alternative would be testing queries when they are created/edited. That change would be more complex and wouldn't address issues when valid queries start erroring.

Non-persistent backoff - DCA restart or leader change will lead to starting retry accounting from scratch. Having persistence would involve additional effort which doesn't seem justified due to added complexity and fact that DCA restarts are not frequent (every <=3 minutes - time it take to reach max backoff of 1800sec).

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

I followed below steps and [HPA tutorial](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/) using GKE cluster:
* Two namespaces, `ns1`, `ns2`, installed identical HPA and `DatadogMetrics` in each. In `ns2` put a broken query (`mix:..`, vs `max:..).
```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogMetric
metadata:
  name: cpu-broken
  namespace: ns2
spec:
  externalMetricName: ddm_mix_cpu
  query: mix:container.cpu.usage{kube_namespace:ns2}.rollup(1)
---
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: php-autoscaler
  namespace: ns2
spec:
  minReplicas: 1
  maxReplicas: 3
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: php-apache
  metrics:
  - type: External
    external:
      metric:
        name: datadogmetric@ns2:cpu-broken
      target:
        type: Value
        value: 10
```
* Installed default DCA version using Operator and observed both queries breaking.
```yaml
  features:
    externalMetricsServer:
      enabled: true
      useDatadogMetrics: true
  override:
    clusterAgent:
      image:
        name:
```
* Installed fixed image and observed one `ns1` metric recovering, `ns2` remaining broken. Observe backoff time increase and retry delays; error message containing retry time.
* Fixed `ns2` metric and it recovered too.
* Break `ns2` query again - metrics break, `ns1` is valid.
* Install default DCA image. Both metrics break.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
