### PR TITLE
Lint test/new-e2e, fix duplicated build tags

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -37,7 +37,7 @@ def run_golangci_lint(ctx, targets, rtloader_root=None, build_tags=None, build="
     for target in targets:
         print(f"running golangci on {target}")
         concurrency_arg = "" if concurrency is None else f"--concurrency {concurrency}"
-        tags_arg = " ".join(tags)
+        tags_arg = " ".join(set(tags))
         result = ctx.run(
             f'golangci-lint run --timeout 20m0s {concurrency_arg} --build-tags "{tags_arg}" {target}/...',
             env=env,

--- a/test/new-e2e/system-probe/test-json-review/main.go
+++ b/test/new-e2e/system-probe/test-json-review/main.go
@@ -69,7 +69,7 @@ func main() {
 			log.Fatal(err)
 		}
 		if len(failedTests) > 0 {
-			fmt.Fprintf(os.Stderr, color.RedString(failedTests))
+			fmt.Fprint(os.Stderr, color.RedString(failedTests))
 		} else {
 			fmt.Println(color.GreenString(fmt.Sprintf("All tests cleared in attempt %d", i+1)))
 			return

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -37,7 +37,7 @@ const (
 	TestDirRoot = "/opt/system-probe-tests"
 	GoTestSum   = "/go/bin/gotestsum"
 
-	// The directroy format is <name>-<attempt>*
+	// The directory format is <name>-<attempt>*
 	XMLDir       = "junit-%d"
 	JSONDir      = "pkgjson-%d"
 	JSONOutDir   = "testjson-%d"
@@ -146,7 +146,7 @@ func concatenateJsons(indir, outdir string) error {
 		return fmt.Errorf("json glob: %s", err)
 	}
 
-	f, err := os.OpenFile(testJsonFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	f, err := os.OpenFile(testJsonFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o666)
 	if err != nil {
 		return fmt.Errorf("open %s: %s", testJsonFile, err)
 	}
@@ -182,7 +182,7 @@ func buildCIVisibilityDirs(attempt int) error {
 		if err := os.RemoveAll(d); err != nil {
 			return fmt.Errorf("failed to remove contents of %s: %w", d, err)
 		}
-		if err := os.MkdirAll(d, 0777); err != nil {
+		if err := os.MkdirAll(d, 0o777); err != nil {
 			return fmt.Errorf("failed to create directory %s", d)
 		}
 	}
@@ -275,8 +275,8 @@ func main() {
 
 func buildTestConfiguration() *TestConfig {
 	retryPtr := flag.Int("retry", 2, "number of times to retry testing pass")
-	packagesPtr := flag.String("include-packages", "", "Comma seperated list of packages to test")
-	excludePackagesPtr := flag.String("exclude-packages", "", "Comma seperated list of packages to exclude")
+	packagesPtr := flag.String("include-packages", "", "Comma separated list of packages to test")
+	excludePackagesPtr := flag.String("exclude-packages", "", "Comma separated list of packages to exclude")
 
 	flag.Parse()
 
@@ -321,7 +321,7 @@ func run() error {
 		return fmt.Errorf("failed to remove contents of %s: %w", CIVisibility, err)
 	}
 	if _, err := os.Stat(CIVisibility); errors.Is(err, fs.ErrNotExist) {
-		if err := os.MkdirAll(CIVisibility, 0777); err != nil {
+		if err := os.MkdirAll(CIVisibility, 0o777); err != nil {
 			return fmt.Errorf("failed to create directory %s", CIVisibility)
 		}
 	}

--- a/test/new-e2e/utils/infra/stack_manager.go
+++ b/test/new-e2e/utils/infra/stack_manager.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
 	"runtime"
 	"strings"
 	"sync"
@@ -35,7 +34,6 @@ const (
 )
 
 var (
-	workspaceFolder  = path.Join(os.TempDir(), e2eWorkspaceDirectory)
 	stackManager     *StackManager
 	initStackManager sync.Once
 )


### PR DESCRIPTION
### What does this PR do?

Lint test/new-e2e, fix duplicated build tags

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
