### PR TITLE
[RCM-1040] Support log level change in sysprobe

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -51,6 +51,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed/jmx"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
 	remoteconfig "github.com/DataDog/datadog-agent/pkg/config/remote/service"
 	"github.com/DataDog/datadog-agent/pkg/logs"
 	"github.com/DataDog/datadog-agent/pkg/metadata"
@@ -400,8 +401,8 @@ func startAgent(
 			log.Errorf("Failed to start config management service: %s", err)
 		}
 
-		if err := rcclient.Listen(); err != nil {
-			pkglog.Errorf("Failed to start the AGENT_TASK RC client: %s", err)
+		if err := rcclient.Listen("core-agent", []data.Product{data.ProductAgentTask, data.ProductAgentConfig}); err != nil {
+			pkglog.Errorf("Failed to start the RC client component: %s", err)
 		}
 	}
 

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -29,7 +29,9 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
+	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
 	"github.com/DataDog/datadog-agent/pkg/config/settings"
 	"github.com/DataDog/datadog-agent/pkg/pidfile"
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
@@ -69,6 +71,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(log.LogForDaemon("SYS-PROBE", "log_file", common.DefaultLogFile)),
 				config.Module,
 				sysprobeconfig.Module,
+				rcclient.Module,
 				// use system-probe config instead of agent config for logging
 				fx.Provide(func(lc fx.Lifecycle, params log.Params, sysprobeconfig sysprobeconfig.Component) (log.Component, error) {
 					return log.NewLogger(lc, params, sysprobeconfig)
@@ -82,7 +85,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 }
 
 // run starts the main loop.
-func run(log log.Component, config config.Component, sysprobeconfig sysprobeconfig.Component, cliParams *cliParams) error {
+func run(log log.Component, config config.Component, sysprobeconfig sysprobeconfig.Component, rcclient rcclient.Component, cliParams *cliParams) error {
 	defer func() {
 		stopSystemProbe(cliParams)
 	}()
@@ -123,7 +126,7 @@ func run(log log.Component, config config.Component, sysprobeconfig sysprobeconf
 		}
 	}()
 
-	if err := startSystemProbe(cliParams, log, sysprobeconfig); err != nil {
+	if err := startSystemProbe(cliParams, log, sysprobeconfig, rcclient); err != nil {
 		if err == ErrNotEnabled {
 			// A sleep is necessary to ensure that supervisor registers this process as "STARTED"
 			// If the exit is "too quick", we enter a BACKOFF->FATAL loop even though this is an expected exit
@@ -157,7 +160,7 @@ func StartSystemProbeWithDefaults() error {
 }
 
 // startSystemProbe Initializes the system-probe process
-func startSystemProbe(cliParams *cliParams, log log.Component, sysprobeconfig sysprobeconfig.Component) error {
+func startSystemProbe(cliParams *cliParams, log log.Component, sysprobeconfig sysprobeconfig.Component, rcclient rcclient.Component) error {
 	var err error
 	var ctx context.Context
 	ctx, common.MainCtxCancel = context.WithCancel(context.Background())
@@ -192,6 +195,13 @@ func startSystemProbe(cliParams *cliParams, log log.Component, sysprobeconfig sy
 	}
 
 	setupInternalProfiling(sysprobeconfig, configPrefix, log)
+
+	if ddconfig.Datadog.GetBool("remote_configuration.enabled") {
+		err = rcclient.Listen("system-probe", []data.Product{data.ProductAgentConfig})
+		if err != nil {
+			return log.Criticalf("unable to start remote configuration client: %s", err)
+		}
+	}
 
 	if cliParams.pidfilePath != "" {
 		if err := pidfile.WritePID(cliParams.pidfilePath); err != nil {

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -143,13 +143,14 @@ func run(log log.Component, config config.Component, sysprobeconfig sysprobeconf
 func StartSystemProbeWithDefaults() error {
 	// run startSystemProbe in an app, so that the log and config components get initialized
 	return fxutil.OneShot(
-		func(log log.Component, config config.Component, sysprobeconfig sysprobeconfig.Component) error {
-			return startSystemProbe(&cliParams{GlobalParams: &command.GlobalParams{}}, log, sysprobeconfig)
+		func(log log.Component, config config.Component, sysprobeconfig sysprobeconfig.Component, rcclient rcclient.Component) error {
+			return startSystemProbe(&cliParams{GlobalParams: &command.GlobalParams{}}, log, sysprobeconfig, rcclient)
 		},
 		// no config file path specification in this situation
 		fx.Supply(config.NewAgentParamsWithoutSecrets("", config.WithConfigMissingOK(true))),
 		fx.Supply(sysprobeconfig.NewParams(sysprobeconfig.WithSysProbeConfFilePath(""), sysprobeconfig.WithConfigLoadSecrets(true))),
 		fx.Supply(log.LogForDaemon("SYS-PROBE", "log_file", common.DefaultLogFile)),
+		rcclient.Module,
 		config.Module,
 		sysprobeconfig.Module,
 		// use system-probe config instead of agent config for logging

--- a/comp/remote-config/rcclient/component.go
+++ b/comp/remote-config/rcclient/component.go
@@ -6,6 +6,7 @@
 package rcclient
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"go.uber.org/fx"
 )
@@ -17,7 +18,7 @@ type Component interface {
 	// TODO: (components) Start the remote config client to listen to AGENT_TASK configurations
 	// Once the remote config client is refactored and can push updates directly to the listeners,
 	// we can remove this.
-	Listen() error
+	Listen(clientName string, products []data.Product) error
 }
 
 // Module defines the fx options for this component.

--- a/comp/remote-config/rcclient/rcclient.go
+++ b/comp/remote-config/rcclient/rcclient.go
@@ -69,12 +69,9 @@ func newRemoteConfigClient(deps dependencies) (Component, error) {
 }
 
 // Listen start the remote config client to listen to AGENT_TASK configurations
-func (rc rcClient) Listen() error {
+func (rc rcClient) Listen(clientName string, products []data.Product) error {
 	c, err := remote.NewUnverifiedGRPCClient(
-		"core-agent", version.AgentVersion, []data.Product{
-			data.ProductAgentTask,
-			data.ProductAgentConfig,
-		}, 1*time.Second,
+		clientName, version.AgentVersion, products, 1*time.Second,
 	)
 	if err != nil {
 		return err
@@ -83,8 +80,18 @@ func (rc rcClient) Listen() error {
 	rc.client = c
 	rc.taskProcessed = map[string]bool{}
 
-	rc.client.Subscribe(state.ProductAgentTask, rc.agentTaskUpdateCallback)
-	rc.client.Subscribe(state.ProductAgentConfig, rc.agentConfigUpdateCallback)
+	for _, product := range products {
+		switch product {
+		case state.ProductAgentTask:
+			rc.client.Subscribe(state.ProductAgentTask, rc.agentTaskUpdateCallback)
+			break
+		case state.ProductAgentConfig:
+			rc.client.Subscribe(state.ProductAgentConfig, rc.agentConfigUpdateCallback)
+			break
+		default:
+			pkglog.Infof("remote config client %s started unsupported product: %s", clientName, product)
+		}
+	}
 
 	rc.client.Start()
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Run a remote-config client requesting `AGENT_CONFIG` in the system-probe, so the log level can be dynamically changed with RC

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

* If RC is disabled (remote_configuration.enabled: false), check the RC client is indeed not started and nothing changes
* If RC is enabled
    * Request a debug log flare from the UI
    * Check that the log level of the trace agent switch to debug automatically
    * Wait a few minutes
    * Check that the log level switch back to the previous level automatically

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
