### PR TITLE
[Gohai][ASC-569] Implement memory metadata collection using sysctl syscall on Darwin

### DIFF
--- a/pkg/gohai/memory/memory_darwin.go
+++ b/pkg/gohai/memory/memory_darwin.go
@@ -7,44 +7,40 @@ package memory
 
 import (
 	"fmt"
-	"os/exec"
-	"regexp"
-	"strconv"
-	"strings"
+	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/gohai/utils"
+	"golang.org/x/sys/unix"
 )
 
 func getTotalBytes() (uint64, error) {
-	out, err := exec.Command("sysctl", "-n", "hw.memsize").Output()
-	if err != nil {
-		return 0, fmt.Errorf("sysctl: %w", err)
-	}
-
-	v := strings.Trim(string(out), "\n")
-	mem, e := strconv.ParseUint(v, 10, 64)
-	if e != nil {
-		return 0, fmt.Errorf("could not parse memory size: %w", e)
-	}
-
-	return mem, nil // mem is in bytes
+	return unix.SysctlUint64("hw.memsize")
 }
 
 func getTotalSwapKb() (uint64, error) {
-	out, err := exec.Command("sysctl", "-n", "vm.swapusage").Output()
-	if err != nil {
-		return 0, fmt.Errorf("sysctl: %w", err)
+	// see struct xsw_usage defined in sys/sysctl.h
+	type xswUsage struct {
+		xsuTotal     uint64
+		xsuAvail     uint64
+		xsuUsed      uint64
+		xsuPagesize  uint32
+		xsuEncrypted bool
 	}
 
-	swap := regexp.MustCompile("total = ").Split(string(out), 2)[1]
-	v := strings.Split(swap, " ")[0]
-	idx := strings.IndexAny(v, ",.") // depending on the locale either a comma or dot is used
-	swapTotal, err := strconv.ParseUint(v[0:idx], 10, 64)
+	// sysctl returns an xsw_usage struct, so we use the raw variant
+	// and then cast the result
+	value, err := unix.SysctlRaw("vm.swapusage")
 	if err != nil {
-		return 0, fmt.Errorf("could not parse swap size: %w", err)
+		return 0, err
 	}
 
-	return swapTotal * 1024, nil // swapTotal is in mb
+	xswSize := unsafe.Sizeof(xswUsage{})
+	if uintptr(len(value)) != xswSize {
+		return 0, fmt.Errorf("sysctl should return %d bytes but returned %d", xswSize, len(value))
+	}
+
+	xsw := (*xswUsage)(unsafe.Pointer(&value[0]))
+	return xsw.xsuTotal / 1024, nil // swapTotal is in bytes
 }
 
 func (info *Info) fillMemoryInfo() {

--- a/pkg/gohai/memory/memory_darwin.go
+++ b/pkg/gohai/memory/memory_darwin.go
@@ -40,7 +40,7 @@ func getTotalSwapKb() (uint64, error) {
 	}
 
 	xsw := (*xswUsage)(unsafe.Pointer(&value[0]))
-	return xsw.xsuTotal / 1024, nil // swapTotal is in bytes
+	return xsw.xsuTotal / 1024, nil // xsuTotal is in bytes
 }
 
 func (info *Info) fillMemoryInfo() {

--- a/releasenotes/notes/gohai-darwin-memory-native-4307a8ca1cf7781d.yaml
+++ b/releasenotes/notes/gohai-darwin-memory-native-4307a8ca1cf7781d.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Memory metadata is now collected without running the `sysctl` binary on Darwin.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Implement memory metadata collection using the `sysctl` syscall instead of executing the `sysctl` binary.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Eventually remove all shell-outs in Gohai to have a native and more reliable way to collect data.
No parsing / cleaning of the output, just get the plain value directly.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The value should be exactly the same for the total memory, and a little more precise for the swap if it is not a round number of MB (before we read a value in MB and converted it to KB, now we have a value in bytes and convert it to KB). 

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Check that the values for the memory package are the same on Darwin.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
