### PR TITLE
[corechecks/snmp] Add metric_type to metric root and deprecate forced_type

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_metric.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_metric.go
@@ -87,8 +87,10 @@ type MetricsConfig struct {
 	StaticTags []string            `yaml:"static_tags"`
 	MetricTags MetricTagConfigList `yaml:"metric_tags"`
 
-	ForcedType string              `yaml:"forced_type"`
-	Options    MetricsConfigOption `yaml:"options"`
+	ForcedType string `yaml:"forced_type"` // deprecated in favour of metric_type
+	MetricType string `yaml:"metric_type"`
+
+	Options MetricsConfigOption `yaml:"options"`
 }
 
 // GetSymbolTags returns symbol tags

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -49,7 +49,7 @@ metrics:
     OID: 1.3.6.1.4.1.318.1.1.1.11.1.1.0
     name: upsBasicStateOutputState
     scale_factor: 10
-  forced_type: flag_stream
+  metric_type: flag_stream
   options:
     placement: 5
     metric_suffix: ReplaceBattery
@@ -157,7 +157,7 @@ bulk_max_repetitions: 20
 			{symbolTag: "mytag1"},
 			{symbolTag: "mytag2"},
 		}},
-		{Symbol: SymbolConfig{OID: "1.3.6.1.4.1.318.1.1.1.11.1.1.0", Name: "upsBasicStateOutputState", ScaleFactor: 10}, ForcedType: "flag_stream", Options: MetricsConfigOption{Placement: 5, MetricSuffix: "ReplaceBattery"}},
+		{Symbol: SymbolConfig{OID: "1.3.6.1.4.1.318.1.1.1.11.1.1.0", Name: "upsBasicStateOutputState", ScaleFactor: 10}, MetricType: "flag_stream", Options: MetricsConfigOption{Placement: 5, MetricSuffix: "ReplaceBattery"}},
 		{
 			Symbols: []SymbolConfig{
 				// ifInErrors defined in instance config with a different set of metric tags from the one defined
@@ -307,7 +307,7 @@ profiles:
           tag: snmp_host
       metrics:
         - MIB: MY-PROFILE-MIB
-          forced_type: gauge
+          metric_type: gauge
           symbol:
             OID: 1.4.5
             name: myMetric
@@ -318,7 +318,7 @@ profiles:
 	assert.Equal(t, []string{"device_namespace:default", "snmp_device:1.2.3.4"}, config.GetStaticTags())
 	metrics := []MetricsConfig{
 		{Symbol: SymbolConfig{OID: "1.3.6.1.2.1.1.3.0", Name: "sysUpTimeInstance"}},
-		{Symbol: SymbolConfig{OID: "1.4.5", Name: "myMetric"}, ForcedType: "gauge"},
+		{Symbol: SymbolConfig{OID: "1.4.5", Name: "myMetric"}, MetricType: "gauge"},
 	}
 
 	metricsTags := []MetricTagConfig{

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich.go
@@ -85,6 +85,11 @@ func ValidateEnrichMetrics(metrics []MetricsConfig) []string {
 				errors = append(errors, validateEnrichMetricTag(metricTag)...)
 			}
 		}
+		// Setting forced_type value to metric_type value for backward compatibility
+		if metricConfig.MetricType == "" && metricConfig.ForcedType != "" {
+			metricConfig.MetricType = metricConfig.ForcedType
+		}
+		metricConfig.ForcedType = ""
 	}
 	return errors
 }
@@ -158,7 +163,7 @@ func validateEnrichSymbol(symbol *SymbolConfig, symbolContext SymbolContext) []s
 		errors = append(errors, fmt.Sprintf("`constant_value_one` cannot be used outside of tables"))
 	}
 	if symbolContext != ColumnSymbol && symbol.MetricType != "" {
-		errors = append(errors, fmt.Sprintf("`forced_type` cannot be used outside table symbols and metrics root"))
+		errors = append(errors, fmt.Sprintf("`metric_type` cannot be used outside table symbols and metrics root"))
 	}
 	return errors
 }

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich_test.go
@@ -442,7 +442,7 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 			},
 		},
 		{
-			name: "forced_type usage in column symbol",
+			name: "metric_type usage in column symbol",
 			metrics: []MetricsConfig{
 				{
 					Symbols: []SymbolConfig{
@@ -466,7 +466,7 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 			expectedErrors: []string{},
 		},
 		{
-			name: "forced_type usage in scalar symbol",
+			name: "metric_type usage in scalar symbol",
 			metrics: []MetricsConfig{
 				{
 					Symbol: SymbolConfig{
@@ -477,11 +477,11 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 				},
 			},
 			expectedErrors: []string{
-				"`forced_type` cannot be used outside table symbols and metrics root",
+				"`metric_type` cannot be used outside table symbols and metrics root",
 			},
 		},
 		{
-			name: "forced_type usage in metric_tags",
+			name: "metric_type usage in metric_tags",
 			metrics: []MetricsConfig{
 				{
 					Symbols: []SymbolConfig{
@@ -503,7 +503,50 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 				},
 			},
 			expectedErrors: []string{
-				"`forced_type` cannot be used outside table symbols and metrics root",
+				"`metric_type` cannot be used outside table symbols and metrics root",
+			},
+		},
+		{
+			name: "metric root forced_type converted to metric_type",
+			metrics: []MetricsConfig{
+				{
+					ForcedType: "monotonic_count",
+					Symbols: []SymbolConfig{
+						{
+							Name: "abc",
+							OID:  "1.2.3",
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Column: SymbolConfig{
+								Name: "abc",
+								OID:  "1.2.3",
+							},
+							Tag: "hello",
+						},
+					},
+				},
+			},
+			expectedMetrics: []MetricsConfig{
+				{
+					MetricType: "monotonic_count",
+					Symbols: []SymbolConfig{
+						{
+							Name: "abc",
+							OID:  "1.2.3",
+						},
+					},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Column: SymbolConfig{
+								Name: "abc",
+								OID:  "1.2.3",
+							},
+							Tag: "hello",
+						},
+					},
+				},
 			},
 		},
 		{

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/profile_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/profile_test.go
@@ -34,10 +34,10 @@ func getMetricFromProfile(p profileDefinition, metricName string) *MetricsConfig
 
 func fixtureProfileDefinitionMap() profileConfigMap {
 	metrics := []MetricsConfig{
-		{Symbol: SymbolConfig{OID: "1.3.6.1.4.1.3375.2.1.1.2.1.44.0", Name: "sysStatMemoryTotal", ScaleFactor: 2}, ForcedType: "gauge"},
+		{Symbol: SymbolConfig{OID: "1.3.6.1.4.1.3375.2.1.1.2.1.44.0", Name: "sysStatMemoryTotal", ScaleFactor: 2}, MetricType: "gauge"},
 		{Symbol: SymbolConfig{OID: "1.3.6.1.4.1.3375.2.1.1.2.1.44.999", Name: "oldSyntax"}},
 		{
-			ForcedType: "monotonic_count",
+			MetricType: "monotonic_count",
 			Symbols: []SymbolConfig{
 				{OID: "1.3.6.1.2.1.2.2.1.14", Name: "ifInErrors", ScaleFactor: 0.5},
 				{OID: "1.3.6.1.2.1.2.2.1.13", Name: "ifInDiscards"},
@@ -172,7 +172,7 @@ func fixtureProfileDefinitionMap() profileConfigMap {
 		"another_profile": profileConfig{
 			Definition: profileDefinition{
 				Metrics: []MetricsConfig{
-					{Symbol: SymbolConfig{OID: "1.3.6.1.2.1.1.999.0", Name: "someMetric"}, ForcedType: ""},
+					{Symbol: SymbolConfig{OID: "1.3.6.1.2.1.1.999.0", Name: "someMetric"}, MetricType: ""},
 				},
 				MetricTags: []MetricTagConfig{
 					{Tag: "snmp_host2", Column: SymbolConfig{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"}},
@@ -548,7 +548,7 @@ func Test_loadDefaultProfiles_validAndInvalidProfiles(t *testing.T) {
 func Test_mergeProfileDefinition(t *testing.T) {
 	okBaseDefinition := profileDefinition{
 		Metrics: []MetricsConfig{
-			{Symbol: SymbolConfig{OID: "1.1", Name: "metric1"}, ForcedType: "gauge"},
+			{Symbol: SymbolConfig{OID: "1.1", Name: "metric1"}, MetricType: "gauge"},
 		},
 		MetricTags: []MetricTagConfig{
 			{
@@ -596,7 +596,7 @@ func Test_mergeProfileDefinition(t *testing.T) {
 	emptyBaseDefinition := profileDefinition{}
 	okTargetDefinition := profileDefinition{
 		Metrics: []MetricsConfig{
-			{Symbol: SymbolConfig{OID: "1.2", Name: "metric2"}, ForcedType: "gauge"},
+			{Symbol: SymbolConfig{OID: "1.2", Name: "metric2"}, MetricType: "gauge"},
 		},
 		MetricTags: []MetricTagConfig{
 			{
@@ -649,8 +649,8 @@ func Test_mergeProfileDefinition(t *testing.T) {
 			targetDefinition: copyProfileDefinition(okTargetDefinition),
 			expectedDefinition: profileDefinition{
 				Metrics: []MetricsConfig{
-					{Symbol: SymbolConfig{OID: "1.2", Name: "metric2"}, ForcedType: "gauge"},
-					{Symbol: SymbolConfig{OID: "1.1", Name: "metric1"}, ForcedType: "gauge"},
+					{Symbol: SymbolConfig{OID: "1.2", Name: "metric2"}, MetricType: "gauge"},
+					{Symbol: SymbolConfig{OID: "1.1", Name: "metric1"}, MetricType: "gauge"},
 				},
 				MetricTags: []MetricTagConfig{
 					{
@@ -726,7 +726,7 @@ func Test_mergeProfileDefinition(t *testing.T) {
 			targetDefinition: copyProfileDefinition(okTargetDefinition),
 			expectedDefinition: profileDefinition{
 				Metrics: []MetricsConfig{
-					{Symbol: SymbolConfig{OID: "1.2", Name: "metric2"}, ForcedType: "gauge"},
+					{Symbol: SymbolConfig{OID: "1.2", Name: "metric2"}, MetricType: "gauge"},
 				},
 				MetricTags: []MetricTagConfig{
 					{
@@ -774,7 +774,7 @@ func Test_mergeProfileDefinition(t *testing.T) {
 			targetDefinition: copyProfileDefinition(emptyBaseDefinition),
 			expectedDefinition: profileDefinition{
 				Metrics: []MetricsConfig{
-					{Symbol: SymbolConfig{OID: "1.1", Name: "metric1"}, ForcedType: "gauge"},
+					{Symbol: SymbolConfig{OID: "1.1", Name: "metric1"}, MetricType: "gauge"},
 				},
 				MetricTags: []MetricTagConfig{
 					{

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -661,10 +661,10 @@ collect_topology: false
 
 	expectedMetrics := []checkconfig.MetricsConfig{
 		{Symbol: checkconfig.SymbolConfig{OID: "1.3.6.1.2.1.1.3.0", Name: "sysUpTimeInstance"}},
-		{Symbol: checkconfig.SymbolConfig{OID: "1.3.6.1.4.1.318.1.1.1.11.1.1.0", Name: "upsBasicStateOutputState"}, ForcedType: "flag_stream", Options: checkconfig.MetricsConfigOption{Placement: 1, MetricSuffix: "OnLine"}},
-		{Symbol: checkconfig.SymbolConfig{OID: "1.3.6.1.4.1.318.1.1.1.11.1.1.0", Name: "upsBasicStateOutputState"}, ForcedType: "flag_stream", Options: checkconfig.MetricsConfigOption{Placement: 2, MetricSuffix: "ReplaceBattery"}},
+		{Symbol: checkconfig.SymbolConfig{OID: "1.3.6.1.4.1.318.1.1.1.11.1.1.0", Name: "upsBasicStateOutputState"}, MetricType: "flag_stream", Options: checkconfig.MetricsConfigOption{Placement: 1, MetricSuffix: "OnLine"}},
+		{Symbol: checkconfig.SymbolConfig{OID: "1.3.6.1.4.1.318.1.1.1.11.1.1.0", Name: "upsBasicStateOutputState"}, MetricType: "flag_stream", Options: checkconfig.MetricsConfigOption{Placement: 2, MetricSuffix: "ReplaceBattery"}},
 		{
-			ForcedType: "monotonic_count",
+			MetricType: "monotonic_count",
 			Symbols: []checkconfig.SymbolConfig{
 				{OID: "1.3.6.1.2.1.2.2.1.14", Name: "ifInErrors", ScaleFactor: 0.5},
 				{OID: "1.3.6.1.2.1.2.2.1.13", Name: "ifInDiscards"},
@@ -676,7 +676,7 @@ collect_topology: false
 			},
 			StaticTags: []string{"table_static_tag:val"},
 		},
-		{Symbol: checkconfig.SymbolConfig{OID: "1.3.6.1.4.1.3375.2.1.1.2.1.44.0", Name: "sysStatMemoryTotal", ScaleFactor: 2}, ForcedType: "gauge"},
+		{Symbol: checkconfig.SymbolConfig{OID: "1.3.6.1.4.1.3375.2.1.1.2.1.44.0", Name: "sysStatMemoryTotal", ScaleFactor: 2}, MetricType: "gauge"},
 	}
 
 	expectedMetricTags := []checkconfig.MetricTagConfig{
@@ -1241,10 +1241,10 @@ community_string: public
 	expectedMetricsConfigs := []checkconfig.MetricsConfig{
 		{
 			Symbol:     checkconfig.SymbolConfig{OID: "1.3.6.1.4.1.3375.2.1.1.2.1.44.0", Name: "sysStatMemoryTotal", ScaleFactor: 2},
-			ForcedType: "gauge",
+			MetricType: "gauge",
 		},
 		{
-			ForcedType: "monotonic_count",
+			MetricType: "monotonic_count",
 			Symbols: []checkconfig.SymbolConfig{
 				{OID: "1.3.6.1.2.1.2.2.1.14", Name: "ifInErrors", ScaleFactor: 0.5},
 				{OID: "1.3.6.1.2.1.2.2.1.13", Name: "ifInDiscards"},

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
@@ -111,7 +111,7 @@ func (ms *MetricSender) reportScalarMetrics(metric checkconfig.MetricsConfig, va
 		value:      value,
 		tags:       scalarTags,
 		symbol:     metric.Symbol,
-		forcedType: metric.ForcedType,
+		forcedType: metric.MetricType,
 		options:    metric.Options,
 	}
 	ms.sendMetric(sample)
@@ -154,7 +154,7 @@ func (ms *MetricSender) reportColumnMetrics(metricConfig checkconfig.MetricsConf
 				value:      value,
 				tags:       rowTags,
 				symbol:     symbol,
-				forcedType: metricConfig.ForcedType,
+				forcedType: metricConfig.MetricType,
 				options:    metricConfig.Options,
 			}
 			ms.sendMetric(sample)

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
@@ -68,7 +68,7 @@ func TestSendMetric(t *testing.T) {
 			value:    valuestore.ResultValue{SubmissionType: "counter", Value: float64(10)},
 			tags:     []string{},
 			metricConfig: checkconfig.MetricsConfig{
-				ForcedType: "gauge",
+				MetricType: "gauge",
 			},
 			expectedMethod:     "Gauge",
 			expectedMetricName: "snmp.my.metric",
@@ -82,7 +82,7 @@ func TestSendMetric(t *testing.T) {
 			value:    valuestore.ResultValue{SubmissionType: "counter", Value: float64(10)},
 			tags:     []string{},
 			metricConfig: checkconfig.MetricsConfig{
-				ForcedType: "counter",
+				MetricType: "counter",
 			},
 			expectedMethod:     "Rate",
 			expectedMetricName: "snmp.my.metric",
@@ -96,7 +96,7 @@ func TestSendMetric(t *testing.T) {
 			value:    valuestore.ResultValue{SubmissionType: "counter", Value: float64(10)},
 			tags:     []string{},
 			metricConfig: checkconfig.MetricsConfig{
-				ForcedType: "monotonic_count",
+				MetricType: "monotonic_count",
 			},
 			expectedMethod:     "MonotonicCount",
 			expectedMetricName: "snmp.my.metric",
@@ -110,7 +110,7 @@ func TestSendMetric(t *testing.T) {
 			value:    valuestore.ResultValue{SubmissionType: "counter", Value: float64(10)},
 			tags:     []string{},
 			metricConfig: checkconfig.MetricsConfig{
-				ForcedType: "monotonic_count_and_rate",
+				MetricType: "monotonic_count_and_rate",
 			},
 			expectedMethod:     "MonotonicCount",
 			expectedMetricName: "snmp.my.metric",
@@ -124,7 +124,7 @@ func TestSendMetric(t *testing.T) {
 			value:    valuestore.ResultValue{SubmissionType: "counter", Value: float64(10)},
 			tags:     []string{},
 			metricConfig: checkconfig.MetricsConfig{
-				ForcedType: "monotonic_count_and_rate",
+				MetricType: "monotonic_count_and_rate",
 			},
 			expectedMethod:     "Rate",
 			expectedMetricName: "snmp.my.metric.rate",
@@ -138,7 +138,7 @@ func TestSendMetric(t *testing.T) {
 			value:    valuestore.ResultValue{Value: 0.5},
 			tags:     []string{},
 			metricConfig: checkconfig.MetricsConfig{
-				ForcedType: "percent",
+				MetricType: "percent",
 			},
 			expectedMethod:     "Rate",
 			expectedMetricName: "snmp.Rate.metric",
@@ -152,7 +152,7 @@ func TestSendMetric(t *testing.T) {
 			value:    valuestore.ResultValue{Value: "1010"},
 			tags:     []string{},
 			metricConfig: checkconfig.MetricsConfig{
-				ForcedType: "flag_stream",
+				MetricType: "flag_stream",
 				Options:    checkconfig.MetricsConfigOption{Placement: 1, MetricSuffix: "foo"},
 			},
 			expectedMethod:     "Gauge",
@@ -167,7 +167,7 @@ func TestSendMetric(t *testing.T) {
 			value:    valuestore.ResultValue{Value: "1010"},
 			tags:     []string{},
 			metricConfig: checkconfig.MetricsConfig{
-				ForcedType: "flag_stream",
+				MetricType: "flag_stream",
 				Options:    checkconfig.MetricsConfigOption{Placement: 2, MetricSuffix: "bar"},
 			},
 			expectedMethod:     "Gauge",
@@ -182,7 +182,7 @@ func TestSendMetric(t *testing.T) {
 			value:    valuestore.ResultValue{Value: "1010"},
 			tags:     []string{},
 			metricConfig: checkconfig.MetricsConfig{
-				ForcedType: "flag_stream",
+				MetricType: "flag_stream",
 				Options:    checkconfig.MetricsConfigOption{Placement: 10, MetricSuffix: "none"},
 			},
 			expectedMethod:     "",
@@ -212,7 +212,7 @@ func TestSendMetric(t *testing.T) {
 			value:    valuestore.ResultValue{Value: valuestore.ResultValue{}},
 			tags:     []string{},
 			metricConfig: checkconfig.MetricsConfig{
-				ForcedType: "flag_stream",
+				MetricType: "flag_stream",
 				Options:    checkconfig.MetricsConfigOption{Placement: 10, MetricSuffix: "ouch"},
 			},
 			expectedMethod:     "",
@@ -244,7 +244,7 @@ func TestSendMetric(t *testing.T) {
 			value:    valuestore.ResultValue{Value: "1"},
 			tags:     []string{},
 			metricConfig: checkconfig.MetricsConfig{
-				ForcedType: "invalidForceType",
+				MetricType: "invalidForceType",
 			},
 			expectedMethod:     "",
 			expectedMetricName: "",
@@ -300,7 +300,7 @@ func TestSendMetric(t *testing.T) {
 				value:      tt.value,
 				tags:       tt.tags,
 				symbol:     tt.symbol,
-				forcedType: tt.metricConfig.ForcedType,
+				forcedType: tt.metricConfig.MetricType,
 				options:    tt.metricConfig.Options,
 			}
 			metricSender.sendMetric(sample)

--- a/pkg/collector/corechecks/snmp/internal/test/conf.d/snmp.d/profiles/_generic-if.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/conf.d/snmp.d/profiles/_generic-if.yaml
@@ -43,7 +43,7 @@ metrics:
   table:
     OID: 1.3.6.1.2.1.2.2
     name: ifTable
-  forced_type: monotonic_count
+  metric_type: monotonic_count
   symbols:
   - OID: 1.3.6.1.2.1.2.2.1.14
     name: ifInErrors

--- a/pkg/collector/corechecks/snmp/internal/test/conf.d/snmp.d/profiles/f5-big-ip.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/conf.d/snmp.d/profiles/f5-big-ip.yaml
@@ -50,7 +50,7 @@ metadata:
 
 metrics:
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.1.44.0
       name: sysStatMemoryTotal

--- a/pkg/collector/corechecks/snmp/internal/test/detectmetr.d/snmp.d/profiles/_generic-if.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/detectmetr.d/snmp.d/profiles/_generic-if.yaml
@@ -43,7 +43,7 @@ metrics:
   table:
     OID: 1.3.6.1.2.1.2.2
     name: ifTable
-  forced_type: monotonic_count
+  metric_type: monotonic_count
   symbols:
   - OID: 1.3.6.1.2.1.2.2.1.14
     name: ifInErrors

--- a/pkg/collector/corechecks/snmp/internal/test/detectmetr.d/snmp.d/profiles/another_profile.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/detectmetr.d/snmp.d/profiles/another_profile.yaml
@@ -11,14 +11,14 @@ metrics:
   - symbol:
       OID: 1.3.6.1.4.1.318.1.1.1.11.1.1.0
       name: upsBasicStateOutputState
-    forced_type: flag_stream
+    metric_type: flag_stream
     options:
       placement: 1
       metric_suffix: OnLine
   - symbol:
       OID: 1.3.6.1.4.1.318.1.1.1.11.1.1.0
       name: upsBasicStateOutputState
-    forced_type: flag_stream
+    metric_type: flag_stream
     options:
       placement: 2
       metric_suffix: ReplaceBattery

--- a/pkg/collector/corechecks/snmp/internal/test/detectmetr.d/snmp.d/profiles/f5-big-ip.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/detectmetr.d/snmp.d/profiles/f5-big-ip.yaml
@@ -50,7 +50,7 @@ metadata:
 
 metrics:
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.1.44.0
       name: sysStatMemoryTotal

--- a/pkg/collector/corechecks/snmp/internal/test/invalid_cyclic.d/snmp.d/profiles/f5-big-ip.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/invalid_cyclic.d/snmp.d/profiles/f5-big-ip.yaml
@@ -11,7 +11,7 @@ sysobjectid: 1.3.6.1.4.1.3375.2.1.3.4.*
 
 metrics:
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.1.44.0
       name: sysStatMemoryTotal

--- a/pkg/collector/corechecks/snmp/internal/test/invalid_ext.d/snmp.d/profiles/f5-big-ip.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/invalid_ext.d/snmp.d/profiles/f5-big-ip.yaml
@@ -11,7 +11,7 @@ sysobjectid: 1.3.6.1.4.1.3375.2.1.3.4.*
 
 metrics:
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.1.44.0
       name: sysStatMemoryTotal

--- a/pkg/collector/corechecks/snmp/internal/test/metadata.d/snmp.d/profiles/_generic-if.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/metadata.d/snmp.d/profiles/_generic-if.yaml
@@ -43,7 +43,7 @@ metrics:
   table:
     OID: 1.3.6.1.2.1.2.2
     name: ifTable
-  forced_type: monotonic_count
+  metric_type: monotonic_count
   symbols:
   - OID: 1.3.6.1.2.1.2.2.1.14
     name: ifInErrors

--- a/pkg/collector/corechecks/snmp/internal/test/test_profiles/profile_with_invalid_extends.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/test_profiles/profile_with_invalid_extends.yaml
@@ -11,7 +11,7 @@ sysobjectid: 1.3.6.1.4.1.3375.2.1.3.4.*
 
 metrics:
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.1.44.0
       name: sysStatMemoryTotal

--- a/pkg/collector/corechecks/snmp/internal/test/test_profiles/validation_error.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/test_profiles/validation_error.yaml
@@ -25,7 +25,7 @@ metrics:
     table:
       OID: 1.3.6.1.2.1.2.2
       name: ifTable
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbols:
       - OID: 1.3.6.1.2.1.2.2.1.14
         name: ifInErrors

--- a/pkg/collector/corechecks/snmp/internal/test/valid_invalid.d/snmp.d/profiles/_generic-if.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/valid_invalid.d/snmp.d/profiles/_generic-if.yaml
@@ -8,7 +8,7 @@ metrics:
   table:
     OID: 1.3.6.1.2.1.2.2
     name: ifTable
-  forced_type: monotonic_count
+  metric_type: monotonic_count
   symbols:
   - OID: 1.3.6.1.2.1.2.2.1.14
     name: ifInErrors

--- a/pkg/collector/corechecks/snmp/internal/test/valid_invalid.d/snmp.d/profiles/f5-big-ip.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/valid_invalid.d/snmp.d/profiles/f5-big-ip.yaml
@@ -21,7 +21,7 @@ metric_tags:
 
 metrics:
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.1.44.0
       name: sysStatMemoryTotal

--- a/pkg/collector/corechecks/snmp/internal/test/valid_invalid.d/snmp.d/profiles/f5-invalid.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/valid_invalid.d/snmp.d/profiles/f5-invalid.yaml
@@ -12,5 +12,5 @@ sysobjectid: 1.3.6.1.4.1.3375.2.1.3.99.*
 
 metrics:
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol: sysStatMemoryTotal  # invalid

--- a/pkg/collector/corechecks/snmp/internal/valuestore/gosnmp_value.go
+++ b/pkg/collector/corechecks/snmp/internal/valuestore/gosnmp_value.go
@@ -103,7 +103,7 @@ func getSubmissionType(gosnmpType gosnmp.Asn1BER) string {
 	// Counter Types: From the snmp doc: The Counter32 type represents a non-negative integer which monotonically increases until it reaches a maximum
 	// value of 2^32-1 (4294967295 decimal), when it wraps around and starts increasing again from zero.
 	// We convert snmp counters by default to `rate` submission type, but sometimes `monotonic_count` might be more appropriate.
-	// To achieve that, we can use `forced_type: monotonic_count` or `forced_type: monotonic_count_and_rate`.
+	// To achieve that, we can use `metric_type: monotonic_count` or `metric_type: monotonic_count_and_rate`.
 	case gosnmp.Counter32, gosnmp.Counter64:
 		return "counter"
 	}

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -359,7 +359,7 @@ metrics:
 - table:
     OID: 1.3.6.1.2.1.2.2
     name: ifTable
-  forced_type: monotonic_count_and_rate
+  metric_type: monotonic_count_and_rate
   symbols:
   - OID: 1.3.6.1.2.1.31.1.1.1.6
     name: ifHCInOctets

--- a/releasenotes/notes/snmp_add_metric_type_to_metric_root-83130bb10c4918c6.yaml
+++ b/releasenotes/notes/snmp_add_metric_type_to_metric_root-83130bb10c4918c6.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    [corechecks/snmp] Add ``metric_type`` to metric root and deprecate ``forced_type``.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?


[corechecks/snmp] Add metric_type to metric root and deprecate forced_type

We keep supporting `forced_type` for backward compatibility.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
