### PR TITLE
[CSPM] Add missing user/group metadata for k8sconfig

### DIFF
--- a/pkg/compliance/k8sconfig/loader.go
+++ b/pkg/compliance/k8sconfig/loader.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/compliance/utils"
 	"github.com/shirou/gopsutil/v3/process"
 	"gopkg.in/yaml.v3"
 )
@@ -144,8 +145,10 @@ func (l *loader) loadDirMeta(name string) *K8sDirMeta {
 		return nil
 	}
 	return &K8sDirMeta{
-		Path: name,
-		Mode: uint32(info.Mode()),
+		Path:  name,
+		User:  utils.GetFileUser(info),
+		Group: utils.GetFileGroup(info),
+		Mode:  uint32(info.Mode()),
 	}
 }
 
@@ -179,8 +182,11 @@ func (l *loader) loadConfigFileMeta(name string) *K8sConfigFileMeta {
 	default:
 		content = string(b)
 	}
+
 	return &K8sConfigFileMeta{
 		Path:    name,
+		User:    utils.GetFileUser(info),
+		Group:   utils.GetFileGroup(info),
 		Mode:    uint32(info.Mode()),
 		Content: content,
 	}
@@ -207,6 +213,8 @@ func (l *loader) loadAdmissionConfigFileMeta(name string) *K8sAdmissionConfigFil
 		result.Plugins = append(result.Plugins, added)
 	}
 	result.Path = name
+	result.User = utils.GetFileUser(info)
+	result.Group = utils.GetFileGroup(info)
 	result.Mode = uint32(info.Mode())
 	return &result
 }
@@ -222,6 +230,8 @@ func (l *loader) loadEncryptionProviderConfigFileMeta(name string) *K8sEncryptio
 		return nil
 	}
 	content.Path = name
+	content.User = utils.GetFileUser(info)
+	content.Group = utils.GetFileGroup(info)
 	content.Mode = uint32(info.Mode())
 	return &content
 }
@@ -232,8 +242,10 @@ func (l *loader) loadTokenFileMeta(name string) *K8sTokenFileMeta {
 		return nil
 	}
 	return &K8sTokenFileMeta{
-		Path: name,
-		Mode: uint32(info.Mode()),
+		Path:  name,
+		User:  utils.GetFileUser(info),
+		Group: utils.GetFileGroup(info),
+		Mode:  uint32(info.Mode()),
 	}
 }
 
@@ -244,6 +256,8 @@ func (l *loader) loadKeyFileMeta(name string) *K8sKeyFileMeta {
 	}
 	var meta K8sKeyFileMeta
 	meta.Path = name
+	meta.User = utils.GetFileUser(info)
+	meta.Group = utils.GetFileGroup(info)
 	meta.Mode = uint32(info.Mode())
 	return &meta
 }
@@ -256,6 +270,8 @@ func (l *loader) loadCertFileMeta(name string) *K8sCertFileMeta {
 	}
 	meta := l.extractCertData(certData)
 	meta.Path = name
+	meta.User = utils.GetFileUser(info)
+	meta.Group = utils.GetFileGroup(info)
 	meta.Mode = uint32(info.Mode())
 	return meta
 }
@@ -377,6 +393,8 @@ func (l *loader) loadKubeconfigMeta(name string) *K8sKubeconfigMeta {
 
 	return &K8sKubeconfigMeta{
 		Path:       name,
+		User:       utils.GetFileUser(info),
+		Group:      utils.GetFileGroup(info),
 		Mode:       uint32(info.Mode()),
 		Kubeconfig: content,
 	}

--- a/pkg/compliance/k8sconfig/types.go
+++ b/pkg/compliance/k8sconfig/types.go
@@ -38,19 +38,25 @@ type K8sManagedEnvConfig struct {
 }
 
 type K8sDirMeta struct {
-	Path string `json:"path"`
-	Mode uint32 `json:"mode"`
+	Path  string `json:"path"`
+	User  string `json:"user"`
+	Group string `json:"group"`
+	Mode  uint32 `json:"mode"`
 }
 
 type K8sConfigFileMeta struct {
 	Path    string      `json:"path"`
+	User    string      `json:"user"`
+	Group   string      `json:"group"`
 	Mode    uint32      `json:"mode"`
 	Content interface{} `json:"content"`
 }
 
 type K8sTokenFileMeta struct {
-	Path string `json:"path"`
-	Mode uint32 `json:"mode"`
+	Path  string `json:"path"`
+	User  string `json:"user"`
+	Group string `json:"group"`
+	Mode  uint32 `json:"mode"`
 }
 
 // https://github.com/kubernetes/kubernetes/blob/6356023cb42d681b7ad0e6d14d1652247d75b797/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go#L30
@@ -69,6 +75,8 @@ type (
 	}
 
 	K8sAdmissionConfigFileMeta struct {
+		User    string                          `json:"user,omitempty"`
+		Group   string                          `json:"group,omitempty"`
 		Path    string                          `json:"path,omitempty"`
 		Mode    uint32                          `json:"mode,omitempty"`
 		Plugins []*K8sAdmissionPluginConfigMeta `json:"plugins"`
@@ -77,17 +85,23 @@ type (
 
 type K8sKubeconfigMeta struct {
 	Path       string      `json:"path,omitempty"`
+	User       string      `json:"user,omitempty"`
+	Group      string      `json:"group,omitempty"`
 	Mode       uint32      `json:"mode,omitempty"`
 	Kubeconfig interface{} `json:"kubeconfig"`
 }
 
 type K8sKeyFileMeta struct {
-	Path string `json:"path,omitempty"`
-	Mode uint32 `json:"mode,omitempty"`
+	Path  string `json:"path,omitempty"`
+	User  string `json:"user,omitempty"`
+	Group string `json:"group,omitempty"`
+	Mode  uint32 `json:"mode,omitempty"`
 }
 
 type K8sCertFileMeta struct {
 	Path        string `json:"path,omitempty"`
+	User        string `json:"user,omitempty"`
+	Group       string `json:"group,omitempty"`
 	Mode        uint32 `json:"mode,omitempty"`
 	Certificate struct {
 		Fingerprint    string    `json:"fingerprint"`
@@ -191,6 +205,8 @@ type (
 type (
 	K8sEncryptionProviderConfigFileMeta struct {
 		Path      string `json:"path,omitempty"`
+		User      string `json:"user,omitempty"`
+		Group     string `json:"group,omitempty"`
 		Mode      uint32 `json:"mode,omitempty"`
 		Resources []struct {
 			Resources []string `yaml:"resources" json:"resources"`

--- a/pkg/compliance/resolver.go
+++ b/pkg/compliance/resolver.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance/metrics"
+	"github.com/DataDog/datadog-agent/pkg/compliance/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/jsonquery"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -317,8 +318,8 @@ func (r *defaultResolver) getFileMeta(path string) (*fileMeta, error) {
 		path:  path,
 		data:  data,
 		perms: perms,
-		user:  getFileUser(info),
-		group: getFileGroup(info),
+		user:  utils.GetFileUser(info),
+		group: utils.GetFileGroup(info),
 	}
 	r.filesCache = append(r.filesCache, *file)
 	if len(r.filesCache) > maxFilesCached {

--- a/pkg/compliance/utils/inputs_files.go
+++ b/pkg/compliance/utils/inputs_files.go
@@ -5,7 +5,7 @@
 
 //go:build !windows
 
-package compliance
+package utils
 
 import (
 	"os"
@@ -14,7 +14,7 @@ import (
 	"syscall"
 )
 
-func getFileUser(fi os.FileInfo) string {
+func GetFileUser(fi os.FileInfo) string {
 	if statt, ok := fi.Sys().(*syscall.Stat_t); ok {
 		u := strconv.Itoa(int(statt.Uid))
 		if user, err := user.LookupId(u); err == nil {
@@ -24,7 +24,7 @@ func getFileUser(fi os.FileInfo) string {
 	return ""
 }
 
-func getFileGroup(fi os.FileInfo) string {
+func GetFileGroup(fi os.FileInfo) string {
 	if statt, ok := fi.Sys().(*syscall.Stat_t); ok {
 		g := strconv.Itoa(int(statt.Gid))
 		if group, err := user.LookupGroupId(g); err == nil {

--- a/pkg/compliance/utils/inputs_files_nounix.go
+++ b/pkg/compliance/utils/inputs_files_nounix.go
@@ -5,14 +5,14 @@
 
 //go:build windows
 
-package compliance
+package utils
 
 import "os"
 
-func getFileUser(fi os.FileInfo) string {
+func GetFileUser(fi os.FileInfo) string {
 	return ""
 }
 
-func getFileGroup(fi os.FileInfo) string {
+func GetFileGroup(fi os.FileInfo) string {
 	return ""
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adds some missing stat informations about on file metadata when loading the k8sconfig. These metadata is required for some of our checks.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
