### PR TITLE
[task] allow modules lint targets

### DIFF
--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -14,9 +14,19 @@ class GoModule:
     If True, a check will run to ensure this is true.
     """
 
-    def __init__(self, path, targets=None, condition=lambda: True, should_tag=True, importable=True, independent=False):
+    def __init__(
+        self,
+        path,
+        targets=None,
+        condition=lambda: True,
+        should_tag=True,
+        importable=True,
+        independent=False,
+        lint_targets=None,
+    ):
         self.path = path
         self.targets = targets if targets else ["."]
+        self.lint_targets = lint_targets if lint_targets else self.targets
         self.condition = condition
         self.should_tag = should_tag
         # HACK: Workaround for modules that can be tested, but not imported (eg. gohai), because
@@ -135,6 +145,7 @@ DEFAULT_MODULES = {
         independent=True,
         should_tag=False,
         targets=["./runner", "./utils/e2e/client"],
+        lint_targets=["."],
     ),
     "test/fakeintake": GoModule("test/fakeintake", independent=True, should_tag=False),
     "pkg/obfuscate": GoModule("pkg/obfuscate", independent=True),

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -284,11 +284,11 @@ def lint_flavor(
     Runs linters for given flavor, build tags, and modules.
     """
 
-    def command(module_results, module, module_result):
+    def command(module_results, module: GoModule, module_result):
         with ctx.cd(module.full_path()):
             lint_results = run_golangci_lint(
                 ctx,
-                targets=module.targets,
+                targets=module.lint_targets,
                 rtloader_root=rtloader_root,
                 build_tags=build_tags,
                 arch=arch,

--- a/test/new-e2e/containers/utils.go
+++ b/test/new-e2e/containers/utils.go
@@ -47,7 +47,17 @@ func assertTags(actualTags []string, expectedTags []*regexp.Regexp) error {
 		if len(expectedTags) > 0 {
 			errs = append(errs, fmt.Errorf("missing tags: %s", strings.Join(lo.Map(expectedTags, func(re *regexp.Regexp, _ int) string { return re.String() }), ", ")))
 		}
-		return errors.Join(errs...)
+		// replace with
+		// errors.Join(errs...)
+		// once migrated to go 1.20
+		errMsgs := make([]string, 0, 2)
+		for _, err := range errs {
+			if err == nil {
+				continue
+			}
+			errMsgs = append(errMsgs, err.Error())
+		}
+		return errors.New(strings.Join(errMsgs, "\n"))
 	}
 
 	return nil

--- a/test/new-e2e/examples/agentenv_logs_test.go
+++ b/test/new-e2e/examples/agentenv_logs_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/utils/e2e/client"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ecs"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2params"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2vm"
 	"github.com/cenkalti/backoff/v4"
@@ -38,7 +38,7 @@ func logsExampleStackDef(vmParams []ec2params.Option, agentParams ...agentparams
 				return nil, err
 			}
 
-			fakeintakeExporter, err := ecs.NewEcsFakeintake(vm.Infra)
+			fakeintakeExporter, err := aws.NewEcsFakeintake(vm.GetAwsEnvironment())
 			if err != nil {
 				return nil, err
 			}

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -100,8 +100,8 @@ func NewTestEnv(name, x86InstanceType, armInstanceType string, opts *SystemProbe
 	stackManager := infra.GetStackManager()
 
 	config := runner.ConfigMap{
-		"ddinfra:env":                    auto.ConfigValue{Value: opts.InfraEnv},
-		"ddinfra:aws/defaultKeyPairName": auto.ConfigValue{Value: opts.SSHKeyName},
+		runner.InfraEnvironmentVariables: auto.ConfigValue{Value: opts.InfraEnv},
+		runner.AWSKeyPairName:            auto.ConfigValue{Value: opts.SSHKeyName},
 		// Its fine to hardcode the password here, since the remote ec2 instances do not have
 		// any password on sudo. This secret configuration was introduced in the test-infra-definitions
 		// scenario for dev environments: https://github.com/DataDog/test-infra-definitions/pull/159

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -161,6 +161,9 @@ func NewTestEnv(name, x86InstanceType, armInstanceType string, opts *SystemProbe
 					},
 					OSCommand: osCommand,
 				})
+				if err != nil {
+					return fmt.Errorf("new runner: %w", err)
+				}
 
 				if opts.UploadDependencies {
 					// Copy dependencies to micro-vms. Directory '/opt/kernel-version-testing'

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !windows
+// +build !windows
+
 package main
 
 import (

--- a/test/new-e2e/utils/e2e/stack_definition.go
+++ b/test/new-e2e/utils/e2e/stack_definition.go
@@ -11,7 +11,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/components/vm"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ecs"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2params"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2vm"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -82,7 +82,7 @@ func AgentStackDef(vmParams []ec2params.Option, agentParameters ...agentparams.O
 				return nil, err
 			}
 
-			fakeintakeExporter, err := ecs.NewEcsFakeintake(vm.Infra)
+			fakeintakeExporter, err := aws.NewEcsFakeintake(vm.GetAwsEnvironment())
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add `lint_targets` to modules

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

With the introduction of e2e tests we have code in datadog-agent that should be covered by the linter and not by go test, as running those tests requires a specific image with pulumi support. E2E tests are go tests that create remote cloud instances, we want to filter them out from unit tests execution, while we still want to lint them.

To solve this, we add a linter_targets option in modules.py to override the deafult targets, that will be used specifically for unit tests and also for linters only when linter_targets is not defined

AP-2212

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
