### PR TITLE
[CSPM] Update k8sconfig generated types to support k8s v1.27

### DIFF
--- a/pkg/compliance/k8sconfig/types_generated.go
+++ b/pkg/compliance/k8sconfig/types_generated.go
@@ -14,47 +14,47 @@ import (
 )
 
 type K8sKubeApiserverConfig struct {
-	AdmissionControlConfigFile      *K8sAdmissionConfigFileMeta          `json:"admission-control-config-file"`      // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	AllowPrivileged                 bool                                 `json:"allow-privileged"`                   // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	AnonymousAuth                   bool                                 `json:"anonymous-auth"`                     // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	AuditLogMaxage                  int                                  `json:"audit-log-maxage"`                   // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	AuditLogMaxbackup               int                                  `json:"audit-log-maxbackup"`                // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	AuditLogMaxsize                 int                                  `json:"audit-log-maxsize"`                  // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	AuditLogPath                    string                               `json:"audit-log-path"`                     // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	AuditPolicyFile                 *K8sConfigFileMeta                   `json:"audit-policy-file"`                  // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	AuthorizationMode               []string                             `json:"authorization-mode"`                 // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	BindAddress                     string                               `json:"bind-address"`                       // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	ClientCaFile                    *K8sCertFileMeta                     `json:"client-ca-file"`                     // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	DisableAdmissionPlugins         []string                             `json:"disable-admission-plugins"`          // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	EnableAdmissionPlugins          []string                             `json:"enable-admission-plugins"`           // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	EnableBootstrapTokenAuth        bool                                 `json:"enable-bootstrap-token-auth"`        // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	EncryptionProviderConfig        *K8sEncryptionProviderConfigFileMeta `json:"encryption-provider-config"`         // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	EtcdCafile                      *K8sCertFileMeta                     `json:"etcd-cafile"`                        // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	EtcdCertfile                    *K8sCertFileMeta                     `json:"etcd-certfile"`                      // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	EtcdKeyfile                     *K8sKeyFileMeta                      `json:"etcd-keyfile"`                       // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	FeatureGates                    string                               `json:"feature-gates"`                      // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	KubeletCertificateAuthority     *K8sCertFileMeta                     `json:"kubelet-certificate-authority"`      // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	KubeletClientCertificate        *K8sCertFileMeta                     `json:"kubelet-client-certificate"`         // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	KubeletClientKey                *K8sKeyFileMeta                      `json:"kubelet-client-key"`                 // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	Profiling                       bool                                 `json:"profiling"`                          // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	ProxyClientCertFile             *K8sCertFileMeta                     `json:"proxy-client-cert-file"`             // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	ProxyClientKeyFile              *K8sKeyFileMeta                      `json:"proxy-client-key-file"`              // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	RequestTimeout                  time.Duration                        `json:"request-timeout"`                    // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	RequestheaderAllowedNames       []string                             `json:"requestheader-allowed-names"`        // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	RequestheaderClientCaFile       *K8sCertFileMeta                     `json:"requestheader-client-ca-file"`       // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	RequestheaderExtraHeadersPrefix []string                             `json:"requestheader-extra-headers-prefix"` // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	RequestheaderGroupHeaders       []string                             `json:"requestheader-group-headers"`        // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	RequestheaderUsernameHeaders    []string                             `json:"requestheader-username-headers"`     // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	SecurePort                      int                                  `json:"secure-port"`                        // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	ServiceAccountIssuer            string                               `json:"service-account-issuer"`             // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	ServiceAccountKeyFile           *K8sKeyFileMeta                      `json:"service-account-key-file"`           // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	ServiceAccountLookup            bool                                 `json:"service-account-lookup"`             // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	ServiceAccountSigningKeyFile    *K8sKeyFileMeta                      `json:"service-account-signing-key-file"`   // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	ServiceClusterIpRange           string                               `json:"service-cluster-ip-range"`           // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	TlsCertFile                     *K8sCertFileMeta                     `json:"tls-cert-file"`                      // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	TlsCipherSuites                 []string                             `json:"tls-cipher-suites"`                  // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	TlsPrivateKeyFile               *K8sKeyFileMeta                      `json:"tls-private-key-file"`               // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	TokenAuthFile                   *K8sTokenFileMeta                    `json:"token-auth-file"`                    // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
+	AdmissionControlConfigFile      *K8sAdmissionConfigFileMeta          `json:"admission-control-config-file"`      // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	AllowPrivileged                 bool                                 `json:"allow-privileged"`                   // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	AnonymousAuth                   bool                                 `json:"anonymous-auth"`                     // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	AuditLogMaxage                  int                                  `json:"audit-log-maxage"`                   // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	AuditLogMaxbackup               int                                  `json:"audit-log-maxbackup"`                // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	AuditLogMaxsize                 int                                  `json:"audit-log-maxsize"`                  // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	AuditLogPath                    string                               `json:"audit-log-path"`                     // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	AuditPolicyFile                 *K8sConfigFileMeta                   `json:"audit-policy-file"`                  // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	AuthorizationMode               []string                             `json:"authorization-mode"`                 // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	BindAddress                     string                               `json:"bind-address"`                       // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	ClientCaFile                    *K8sCertFileMeta                     `json:"client-ca-file"`                     // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	DisableAdmissionPlugins         []string                             `json:"disable-admission-plugins"`          // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	EnableAdmissionPlugins          []string                             `json:"enable-admission-plugins"`           // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	EnableBootstrapTokenAuth        bool                                 `json:"enable-bootstrap-token-auth"`        // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	EncryptionProviderConfig        *K8sEncryptionProviderConfigFileMeta `json:"encryption-provider-config"`         // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	EtcdCafile                      *K8sCertFileMeta                     `json:"etcd-cafile"`                        // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	EtcdCertfile                    *K8sCertFileMeta                     `json:"etcd-certfile"`                      // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	EtcdKeyfile                     *K8sKeyFileMeta                      `json:"etcd-keyfile"`                       // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	FeatureGates                    string                               `json:"feature-gates"`                      // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	KubeletCertificateAuthority     *K8sCertFileMeta                     `json:"kubelet-certificate-authority"`      // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	KubeletClientCertificate        *K8sCertFileMeta                     `json:"kubelet-client-certificate"`         // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	KubeletClientKey                *K8sKeyFileMeta                      `json:"kubelet-client-key"`                 // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	Profiling                       bool                                 `json:"profiling"`                          // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	ProxyClientCertFile             *K8sCertFileMeta                     `json:"proxy-client-cert-file"`             // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	ProxyClientKeyFile              *K8sKeyFileMeta                      `json:"proxy-client-key-file"`              // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	RequestTimeout                  time.Duration                        `json:"request-timeout"`                    // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	RequestheaderAllowedNames       []string                             `json:"requestheader-allowed-names"`        // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	RequestheaderClientCaFile       *K8sCertFileMeta                     `json:"requestheader-client-ca-file"`       // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	RequestheaderExtraHeadersPrefix []string                             `json:"requestheader-extra-headers-prefix"` // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	RequestheaderGroupHeaders       []string                             `json:"requestheader-group-headers"`        // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	RequestheaderUsernameHeaders    []string                             `json:"requestheader-username-headers"`     // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	SecurePort                      int                                  `json:"secure-port"`                        // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	ServiceAccountIssuer            string                               `json:"service-account-issuer"`             // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	ServiceAccountKeyFile           *K8sKeyFileMeta                      `json:"service-account-key-file"`           // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	ServiceAccountLookup            bool                                 `json:"service-account-lookup"`             // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	ServiceAccountSigningKeyFile    *K8sKeyFileMeta                      `json:"service-account-signing-key-file"`   // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	ServiceClusterIpRange           string                               `json:"service-cluster-ip-range"`           // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	TlsCertFile                     *K8sCertFileMeta                     `json:"tls-cert-file"`                      // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	TlsCipherSuites                 []string                             `json:"tls-cipher-suites"`                  // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	TlsPrivateKeyFile               *K8sKeyFileMeta                      `json:"tls-private-key-file"`               // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	TokenAuthFile                   *K8sTokenFileMeta                    `json:"token-auth-file"`                    // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
 	SkippedFlags                    map[string]string                    `json:"skippedFlags,omitempty"`
 }
 
@@ -254,23 +254,23 @@ func (l *loader) newK8sKubeApiserverConfig(flags map[string]string) *K8sKubeApis
 }
 
 type K8sKubeSchedulerConfig struct {
-	AuthenticationKubeconfig        *K8sKubeconfigMeta `json:"authentication-kubeconfig"`          // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	AuthorizationKubeconfig         string             `json:"authorization-kubeconfig"`           // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	BindAddress                     string             `json:"bind-address"`                       // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	ClientCaFile                    *K8sCertFileMeta   `json:"client-ca-file"`                     // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	Config                          *K8sConfigFileMeta `json:"config"`                             // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	FeatureGates                    string             `json:"feature-gates"`                      // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	Kubeconfig                      *K8sKubeconfigMeta `json:"kubeconfig"`                         // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	Profiling                       bool               `json:"profiling"`                          // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	RequestheaderAllowedNames       []string           `json:"requestheader-allowed-names"`        // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	RequestheaderClientCaFile       *K8sCertFileMeta   `json:"requestheader-client-ca-file"`       // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	RequestheaderExtraHeadersPrefix []string           `json:"requestheader-extra-headers-prefix"` // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	RequestheaderGroupHeaders       []string           `json:"requestheader-group-headers"`        // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	RequestheaderUsernameHeaders    []string           `json:"requestheader-username-headers"`     // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	SecurePort                      int                `json:"secure-port"`                        // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	TlsCertFile                     *K8sCertFileMeta   `json:"tls-cert-file"`                      // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	TlsCipherSuites                 []string           `json:"tls-cipher-suites"`                  // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	TlsPrivateKeyFile               *K8sKeyFileMeta    `json:"tls-private-key-file"`               // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
+	AuthenticationKubeconfig        *K8sKubeconfigMeta `json:"authentication-kubeconfig"`          // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	AuthorizationKubeconfig         string             `json:"authorization-kubeconfig"`           // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	BindAddress                     string             `json:"bind-address"`                       // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	ClientCaFile                    *K8sCertFileMeta   `json:"client-ca-file"`                     // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	Config                          *K8sConfigFileMeta `json:"config"`                             // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	FeatureGates                    string             `json:"feature-gates"`                      // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	Kubeconfig                      *K8sKubeconfigMeta `json:"kubeconfig"`                         // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	Profiling                       bool               `json:"profiling"`                          // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	RequestheaderAllowedNames       []string           `json:"requestheader-allowed-names"`        // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	RequestheaderClientCaFile       *K8sCertFileMeta   `json:"requestheader-client-ca-file"`       // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	RequestheaderExtraHeadersPrefix []string           `json:"requestheader-extra-headers-prefix"` // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	RequestheaderGroupHeaders       []string           `json:"requestheader-group-headers"`        // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	RequestheaderUsernameHeaders    []string           `json:"requestheader-username-headers"`     // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	SecurePort                      int                `json:"secure-port"`                        // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	TlsCertFile                     *K8sCertFileMeta   `json:"tls-cert-file"`                      // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	TlsCipherSuites                 []string           `json:"tls-cipher-suites"`                  // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	TlsPrivateKeyFile               *K8sKeyFileMeta    `json:"tls-private-key-file"`               // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
 	SkippedFlags                    map[string]string  `json:"skippedFlags,omitempty"`
 }
 
@@ -366,29 +366,29 @@ func (l *loader) newK8sKubeSchedulerConfig(flags map[string]string) *K8sKubeSche
 }
 
 type K8sKubeControllerManagerConfig struct {
-	AuthenticationKubeconfig        *K8sKubeconfigMeta `json:"authentication-kubeconfig"`          // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	AuthorizationKubeconfig         string             `json:"authorization-kubeconfig"`           // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	BindAddress                     string             `json:"bind-address"`                       // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	ClientCaFile                    *K8sCertFileMeta   `json:"client-ca-file"`                     // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	ClusterSigningCertFile          *K8sCertFileMeta   `json:"cluster-signing-cert-file"`          // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	ClusterSigningKeyFile           *K8sKeyFileMeta    `json:"cluster-signing-key-file"`           // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	FeatureGates                    string             `json:"feature-gates"`                      // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	Kubeconfig                      *K8sKubeconfigMeta `json:"kubeconfig"`                         // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	Profiling                       bool               `json:"profiling"`                          // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	RequestheaderAllowedNames       []string           `json:"requestheader-allowed-names"`        // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	RequestheaderClientCaFile       *K8sCertFileMeta   `json:"requestheader-client-ca-file"`       // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	RequestheaderExtraHeadersPrefix []string           `json:"requestheader-extra-headers-prefix"` // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	RequestheaderGroupHeaders       []string           `json:"requestheader-group-headers"`        // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	RequestheaderUsernameHeaders    []string           `json:"requestheader-username-headers"`     // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	RootCaFile                      *K8sCertFileMeta   `json:"root-ca-file"`                       // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	SecurePort                      int                `json:"secure-port"`                        // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	ServiceAccountPrivateKeyFile    *K8sKeyFileMeta    `json:"service-account-private-key-file"`   // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	ServiceClusterIpRange           string             `json:"service-cluster-ip-range"`           // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	TerminatedPodGcThreshold        int                `json:"terminated-pod-gc-threshold"`        // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	TlsCertFile                     *K8sCertFileMeta   `json:"tls-cert-file"`                      // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	TlsCipherSuites                 []string           `json:"tls-cipher-suites"`                  // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	TlsPrivateKeyFile               *K8sKeyFileMeta    `json:"tls-private-key-file"`               // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	UseServiceAccountCredentials    bool               `json:"use-service-account-credentials"`    // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
+	AuthenticationKubeconfig        *K8sKubeconfigMeta `json:"authentication-kubeconfig"`          // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	AuthorizationKubeconfig         string             `json:"authorization-kubeconfig"`           // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	BindAddress                     string             `json:"bind-address"`                       // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	ClientCaFile                    *K8sCertFileMeta   `json:"client-ca-file"`                     // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	ClusterSigningCertFile          *K8sCertFileMeta   `json:"cluster-signing-cert-file"`          // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	ClusterSigningKeyFile           *K8sKeyFileMeta    `json:"cluster-signing-key-file"`           // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	FeatureGates                    string             `json:"feature-gates"`                      // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	Kubeconfig                      *K8sKubeconfigMeta `json:"kubeconfig"`                         // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	Profiling                       bool               `json:"profiling"`                          // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	RequestheaderAllowedNames       []string           `json:"requestheader-allowed-names"`        // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	RequestheaderClientCaFile       *K8sCertFileMeta   `json:"requestheader-client-ca-file"`       // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	RequestheaderExtraHeadersPrefix []string           `json:"requestheader-extra-headers-prefix"` // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	RequestheaderGroupHeaders       []string           `json:"requestheader-group-headers"`        // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	RequestheaderUsernameHeaders    []string           `json:"requestheader-username-headers"`     // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	RootCaFile                      *K8sCertFileMeta   `json:"root-ca-file"`                       // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	SecurePort                      int                `json:"secure-port"`                        // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	ServiceAccountPrivateKeyFile    *K8sKeyFileMeta    `json:"service-account-private-key-file"`   // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	ServiceClusterIpRange           string             `json:"service-cluster-ip-range"`           // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	TerminatedPodGcThreshold        int                `json:"terminated-pod-gc-threshold"`        // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	TlsCertFile                     *K8sCertFileMeta   `json:"tls-cert-file"`                      // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	TlsCipherSuites                 []string           `json:"tls-cipher-suites"`                  // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	TlsPrivateKeyFile               *K8sKeyFileMeta    `json:"tls-private-key-file"`               // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	UseServiceAccountCredentials    bool               `json:"use-service-account-credentials"`    // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
 	SkippedFlags                    map[string]string  `json:"skippedFlags,omitempty"`
 }
 
@@ -510,12 +510,12 @@ func (l *loader) newK8sKubeControllerManagerConfig(flags map[string]string) *K8s
 }
 
 type K8sKubeProxyConfig struct {
-	BindAddress      string             `json:"bind-address"`      // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	Config           *K8sConfigFileMeta `json:"config"`            // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	FeatureGates     string             `json:"feature-gates"`     // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	HostnameOverride string             `json:"hostname-override"` // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	Kubeconfig       *K8sKubeconfigMeta `json:"kubeconfig"`        // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	Profiling        bool               `json:"profiling"`         // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
+	BindAddress      string             `json:"bind-address"`      // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	Config           *K8sConfigFileMeta `json:"config"`            // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	FeatureGates     string             `json:"feature-gates"`     // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	HostnameOverride string             `json:"hostname-override"` // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	Kubeconfig       *K8sKubeconfigMeta `json:"kubeconfig"`        // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	Profiling        bool               `json:"profiling"`         // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
 	SkippedFlags     map[string]string  `json:"skippedFlags,omitempty"`
 }
 
@@ -557,29 +557,29 @@ func (l *loader) newK8sKubeProxyConfig(flags map[string]string) *K8sKubeProxyCon
 }
 
 type K8sKubeletConfig struct {
-	Address                        string             `json:"address"`                           // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	AnonymousAuth                  bool               `json:"anonymous-auth"`                    // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	AuthorizationMode              string             `json:"authorization-mode"`                // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	ClientCaFile                   *K8sCertFileMeta   `json:"client-ca-file"`                    // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	Config                         *K8sConfigFileMeta `json:"config"`                            // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	EventBurst                     int                `json:"event-burst"`                       // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	EventQps                       int                `json:"event-qps"`                         // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	FeatureGates                   string             `json:"feature-gates"`                     // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	HostnameOverride               string             `json:"hostname-override"`                 // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	ImageCredentialProviderBinDir  *K8sDirMeta        `json:"image-credential-provider-bin-dir"` // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	ImageCredentialProviderConfig  *K8sConfigFileMeta `json:"image-credential-provider-config"`  // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	Kubeconfig                     *K8sKubeconfigMeta `json:"kubeconfig"`                        // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	MakeIptablesUtilChains         bool               `json:"make-iptables-util-chains"`         // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	MaxPods                        int                `json:"max-pods"`                          // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	PodMaxPids                     int                `json:"pod-max-pids"`                      // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	ProtectKernelDefaults          bool               `json:"protect-kernel-defaults"`           // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	ReadOnlyPort                   int                `json:"read-only-port"`                    // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	RotateCertificates             bool               `json:"rotate-certificates"`               // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	RotateServerCertificates       bool               `json:"rotate-server-certificates"`        // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	StreamingConnectionIdleTimeout time.Duration      `json:"streaming-connection-idle-timeout"` // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	TlsCertFile                    *K8sCertFileMeta   `json:"tls-cert-file"`                     // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	TlsCipherSuites                []string           `json:"tls-cipher-suites"`                 // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
-	TlsPrivateKeyFile              *K8sKeyFileMeta    `json:"tls-private-key-file"`              // versions: v1.26.3, v1.25.8, v1.24.12, v1.23.17
+	Address                        string             `json:"address"`                           // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	AnonymousAuth                  bool               `json:"anonymous-auth"`                    // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	AuthorizationMode              string             `json:"authorization-mode"`                // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	ClientCaFile                   *K8sCertFileMeta   `json:"client-ca-file"`                    // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	Config                         *K8sConfigFileMeta `json:"config"`                            // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	EventBurst                     int                `json:"event-burst"`                       // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	EventQps                       int                `json:"event-qps"`                         // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	FeatureGates                   string             `json:"feature-gates"`                     // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	HostnameOverride               string             `json:"hostname-override"`                 // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	ImageCredentialProviderBinDir  *K8sDirMeta        `json:"image-credential-provider-bin-dir"` // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	ImageCredentialProviderConfig  *K8sConfigFileMeta `json:"image-credential-provider-config"`  // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	Kubeconfig                     *K8sKubeconfigMeta `json:"kubeconfig"`                        // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	MakeIptablesUtilChains         bool               `json:"make-iptables-util-chains"`         // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	MaxPods                        int                `json:"max-pods"`                          // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	PodMaxPids                     int                `json:"pod-max-pids"`                      // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	ProtectKernelDefaults          bool               `json:"protect-kernel-defaults"`           // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	ReadOnlyPort                   int                `json:"read-only-port"`                    // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	RotateCertificates             bool               `json:"rotate-certificates"`               // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	RotateServerCertificates       bool               `json:"rotate-server-certificates"`        // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	StreamingConnectionIdleTimeout time.Duration      `json:"streaming-connection-idle-timeout"` // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	TlsCertFile                    *K8sCertFileMeta   `json:"tls-cert-file"`                     // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	TlsCipherSuites                []string           `json:"tls-cipher-suites"`                 // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
+	TlsPrivateKeyFile              *K8sKeyFileMeta    `json:"tls-private-key-file"`              // versions: v1.27.3, v1.26.6, v1.25.11, v1.24.15, v1.23.17
 	SkippedFlags                   map[string]string  `json:"skippedFlags,omitempty"`
 }
 
@@ -618,13 +618,13 @@ func (l *loader) newK8sKubeletConfig(flags map[string]string) *K8sKubeletConfig 
 		delete(flags, "--event-burst")
 		res.EventBurst = l.parseInt(v)
 	} else {
-		res.EventBurst = l.parseInt("10")
+		res.EventBurst = l.parseInt("100")
 	}
 	if v, ok := flags["--event-qps"]; ok {
 		delete(flags, "--event-qps")
 		res.EventQps = l.parseInt(v)
 	} else {
-		res.EventQps = l.parseInt("5")
+		res.EventQps = l.parseInt("50")
 	}
 	if v, ok := flags["--feature-gates"]; ok {
 		delete(flags, "--feature-gates")

--- a/pkg/compliance/tools/k8s_types_generator.go
+++ b/pkg/compliance/tools/k8s_types_generator.go
@@ -35,9 +35,10 @@ var (
 
 	// https://kubernetes.io/releases/
 	k8sVersions = []string{
-		"v1.26.3",
-		"v1.25.8",
-		"v1.24.12",
+		"v1.27.3",
+		"v1.26.6",
+		"v1.25.11",
+		"v1.24.15",
 		"v1.23.17",
 	}
 

--- a/pkg/compliance/tools/k8s_types_generator.go
+++ b/pkg/compliance/tools/k8s_types_generator.go
@@ -6,8 +6,10 @@
 package main
 
 import (
+	"archive/tar"
 	"bufio"
 	"bytes"
+	"compress/gzip"
 	"fmt"
 	"io"
 	"log"
@@ -434,16 +436,47 @@ func printKomponentCode(komp *komponent) string {
 }
 
 func downloadEtcdAndExtractFlags(componentVersion string) *komponent {
-	componentName := "etcd"
+	const componentName = "etcd"
 	componentBin := path.Join(bindir, fmt.Sprintf("%s-%s", componentName, componentVersion))
+	componentTar := path.Join(bindir, fmt.Sprintf("%s-%s.tar.gz", componentName, componentVersion))
 	componentUrl := fmt.Sprintf("https://github.com/etcd-io/etcd/releases/download/%s/etcd-%s-linux-%s.tar.gz",
 		componentVersion, componentVersion, arch)
-
 	if _, err := os.Stat(componentBin); os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "downloading %s into %s", componentUrl, componentBin)
-		if err := download(componentUrl, componentBin); err != nil {
+		fmt.Fprintf(os.Stderr, "downloading %s into %s...", componentUrl, componentBin)
+		if err := download(componentUrl, componentTar); err != nil {
 			log.Fatal(err)
 		}
+		t, err := os.Open(componentTar)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer t.Close()
+		g, err := gzip.NewReader(t)
+		if err != nil {
+			log.Fatal(err)
+		}
+		r := tar.NewReader(g)
+		for true {
+			header, err := r.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				log.Fatal(err)
+			}
+			if header.Typeflag == tar.TypeReg && strings.HasSuffix(header.Name, "/etcd") {
+				outFile, err := os.Create(componentBin)
+				if err != nil {
+					log.Fatal(err)
+				}
+				if _, err := io.Copy(outFile, r); err != nil {
+					log.Fatal(err)
+				}
+				outFile.Close()
+			}
+
+		}
+		fmt.Fprintf(os.Stderr, "ok\n")
 	}
 
 	if err := os.Chmod(componentBin, 0770); err != nil {
@@ -478,10 +511,11 @@ func downloadKubeComponentAndExtractFlags(componentName, componentVersion string
 	componentUrl := fmt.Sprintf("https://dl.k8s.io/%s/bin/linux/%s/%s",
 		componentVersion, arch, componentName)
 	if _, err := os.Stat(componentBin); os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "downloading %s into %s", componentUrl, componentBin)
+		fmt.Fprintf(os.Stderr, "downloading %s into %s...", componentUrl, componentBin)
 		if err := download(componentUrl, componentBin); err != nil {
 			log.Fatal(err)
 		}
+		fmt.Fprintf(os.Stderr, "ok\n")
 	}
 
 	if err := os.Chmod(componentBin, 0770); err != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- add k8s v1.27 as target of our generated types for k8sconfig
- fix the type generator to properly extract the etcd binaries

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
