### PR TITLE
[CSPM] Add certificates user/mode/group meta for certificates directory

### DIFF
--- a/pkg/compliance/k8sconfig/loader.go
+++ b/pkg/compliance/k8sconfig/loader.go
@@ -113,15 +113,15 @@ func (l *loader) load(ctx context.Context, loadProcesses procsLoader) (string, *
 	return resourceType, &node
 }
 
-func (l *loader) loadMeta(name string, loadContent bool) (os.FileInfo, []byte, bool) {
+func (l *loader) loadMeta(name string, loadContent bool) (string, os.FileInfo, []byte, bool) {
 	name = filepath.Join(l.hostroot, name)
 	info, err := os.Stat(name)
 	if err != nil {
 		l.pushError(err)
-		return nil, nil, false
+		return name, nil, nil, false
 	}
 	if loadContent && info.IsDir() {
-		return nil, nil, false
+		return name, nil, nil, false
 	}
 	var b []byte
 	const maxSize = 64 * 1024
@@ -136,11 +136,11 @@ func (l *loader) loadMeta(name string, loadContent bool) (os.FileInfo, []byte, b
 			}
 		}
 	}
-	return info, b, true
+	return name, info, b, true
 }
 
 func (l *loader) loadDirMeta(name string) *K8sDirMeta {
-	info, _, ok := l.loadMeta(name, false)
+	_, info, _, ok := l.loadMeta(name, false)
 	if !ok {
 		return nil
 	}
@@ -163,7 +163,7 @@ func (l *loader) loadServiceFileMeta(names []string) *K8sConfigFileMeta {
 }
 
 func (l *loader) loadConfigFileMeta(name string) *K8sConfigFileMeta {
-	info, b, ok := l.loadMeta(name, true)
+	_, info, b, ok := l.loadMeta(name, true)
 	if !ok {
 		return nil
 	}
@@ -193,7 +193,7 @@ func (l *loader) loadConfigFileMeta(name string) *K8sConfigFileMeta {
 }
 
 func (l *loader) loadAdmissionConfigFileMeta(name string) *K8sAdmissionConfigFileMeta {
-	info, b, ok := l.loadMeta(name, true)
+	_, info, b, ok := l.loadMeta(name, true)
 	if !ok {
 		return nil
 	}
@@ -220,7 +220,7 @@ func (l *loader) loadAdmissionConfigFileMeta(name string) *K8sAdmissionConfigFil
 }
 
 func (l *loader) loadEncryptionProviderConfigFileMeta(name string) *K8sEncryptionProviderConfigFileMeta {
-	info, b, ok := l.loadMeta(name, true)
+	_, info, b, ok := l.loadMeta(name, true)
 	if ok {
 		return nil
 	}
@@ -237,7 +237,7 @@ func (l *loader) loadEncryptionProviderConfigFileMeta(name string) *K8sEncryptio
 }
 
 func (l *loader) loadTokenFileMeta(name string) *K8sTokenFileMeta {
-	info, _, ok := l.loadMeta(name, false)
+	_, info, _, ok := l.loadMeta(name, false)
 	if ok {
 		return nil
 	}
@@ -250,7 +250,7 @@ func (l *loader) loadTokenFileMeta(name string) *K8sTokenFileMeta {
 }
 
 func (l *loader) loadKeyFileMeta(name string) *K8sKeyFileMeta {
-	info, _, ok := l.loadMeta(name, false)
+	_, info, _, ok := l.loadMeta(name, false)
 	if !ok {
 		return nil
 	}
@@ -264,7 +264,7 @@ func (l *loader) loadKeyFileMeta(name string) *K8sKeyFileMeta {
 
 // https://github.com/kubernetes/kubernetes/blob/ad18954259eae3db51bac2274ed4ca7304b923c4/cmd/kubeadm/test/kubeconfig/util.go#L77-L87
 func (l *loader) loadCertFileMeta(name string) *K8sCertFileMeta {
-	info, certData, ok := l.loadMeta(name, true)
+	name, info, certData, ok := l.loadMeta(name, true)
 	if !ok {
 		return nil
 	}
@@ -273,6 +273,12 @@ func (l *loader) loadCertFileMeta(name string) *K8sCertFileMeta {
 	meta.User = utils.GetFileUser(info)
 	meta.Group = utils.GetFileGroup(info)
 	meta.Mode = uint32(info.Mode())
+	dir := filepath.Dir(name)
+	if dirInfo, err := os.Stat(dir); err == nil {
+		meta.DirMode = uint32(dirInfo.Mode())
+		meta.DirUser = utils.GetFileUser(dirInfo)
+		meta.DirGroup = utils.GetFileGroup(dirInfo)
+	}
 	return meta
 }
 
@@ -315,7 +321,7 @@ func (l *loader) extractCertData(certData []byte) *K8sCertFileMeta {
 }
 
 func (l *loader) loadKubeconfigMeta(name string) *K8sKubeconfigMeta {
-	info, b, ok := l.loadMeta(name, true)
+	_, info, b, ok := l.loadMeta(name, true)
 	if !ok {
 		return nil
 	}

--- a/pkg/compliance/k8sconfig/types.go
+++ b/pkg/compliance/k8sconfig/types.go
@@ -103,6 +103,9 @@ type K8sCertFileMeta struct {
 	User        string `json:"user,omitempty"`
 	Group       string `json:"group,omitempty"`
 	Mode        uint32 `json:"mode,omitempty"`
+	DirUser     string `json:"dirUser,omitempty"`
+	DirGroup    string `json:"dirGroup,omitempty"`
+	DirMode     uint32 `json:"dirMode,omitempty"`
 	Certificate struct {
 		Fingerprint    string    `json:"fingerprint"`
 		SerialNumber   string    `json:"serialNumber,omitempty"`


### PR DESCRIPTION
### What does this PR do?

Add user/group/meta info of certificate file's directory.

### Motivation

Some of our checks require to check for user/meta/mode of the parent directory of the certificate files for Kubernetes checks.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
