### PR TITLE
Fix:  TestRetryDelayNotElapsed flakiness

### DIFF
--- a/pkg/util/retry/retrier_test.go
+++ b/pkg/util/retry/retrier_test.go
@@ -200,9 +200,9 @@ func TestRetryDelayNotElapsed(t *testing.T) {
 	err = mocked.TriggerRetry()
 	assert.True(t, IsErrWillRetry(err))
 
-	// Testing the NextRetry value is within 1ms
+	// Testing the NextRetry value is within 15ms
 	expectedNext := time.Now().Add(retryDelay - 100*time.Millisecond)
-	assert.WithinDuration(t, expectedNext, mocked.NextRetry(), time.Millisecond)
+	assert.WithinDuration(t, expectedNext, mocked.NextRetry(), 15*time.Millisecond)
 
 	// Second call should skip
 


### PR DESCRIPTION
### What does this PR do?

Fix TestRetryDelayNotElapsed flakiness

### Motivation

the previous implementation was to agressive with only 1ms delay allowed.

previous error

```
Failed

=== RUN   TestRetryDelayNotElapsed
    retrier_test.go:205: 
        	Error Trace:	C:/dev/go/src/github.com/DataDog/datadog-agent/pkg/util/retry/retrier_test.go:205
        	Error:      	Max difference between 2023-06-20 14:08:08.4304759 +0000 UTC m=+1199.958214701 and 2023-06-20 14:08:08.4231039 +0000 UTC m=+1199.950842701 allowed is 1ms, but difference was 7.372ms
        	Test:       	TestRetryDelayNotElapsed
--- FAIL: TestRetryDelayNotElapsed (0.08s)
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

NA, this change is only an unit-test change

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
