### PR TITLE
[ASC-582] Fix local flare with non-default expvar_port

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -39,11 +39,6 @@ import (
 )
 
 var (
-	pprofURL = fmt.Sprintf("http://127.0.0.1:%s/debug/pprof/goroutine?debug=2",
-		config.Datadog.GetString("expvar_port"))
-	telemetryURL = fmt.Sprintf("http://127.0.0.1:%s/telemetry",
-		config.Datadog.GetString("expvar_port"))
-
 	// Match .yaml and .yml to ship configuration files in the flare.
 	cnfFileExtRx = regexp.MustCompile(`(?i)\.ya?ml`)
 )
@@ -86,6 +81,9 @@ func CompleteFlare(fb flarehelpers.FlareBuilder) error {
 		fb.AddFileFromFunc(filepath.Join("expvar", "system-probe"), getSystemProbeStats)
 	}
 
+	pprofURL := fmt.Sprintf("http://127.0.0.1:%s/debug/pprof/goroutine?debug=2",
+		config.Datadog.GetString("expvar_port"))
+
 	fb.AddFileFromFunc("process_agent_runtime_config_dump.yaml", getProcessAgentFullConfig)
 	fb.AddFileFromFunc("runtime_config_dump.yaml", func() ([]byte, error) { return yaml.Marshal(config.Datadog.AllSettings()) })
 	fb.AddFileFromFunc("system_probe_runtime_config_dump.yaml", func() ([]byte, error) { return yaml.Marshal(config.SystemProbe.AllSettings()) })
@@ -109,6 +107,8 @@ func CompleteFlare(fb flarehelpers.FlareBuilder) error {
 	getWindowsData(fb)
 
 	if config.Datadog.GetBool("telemetry.enabled") {
+		telemetryURL := fmt.Sprintf("http://127.0.0.1:%s/telemetry",
+			config.Datadog.GetString("expvar_port"))
 		fb.AddFileFromFunc("telemetry.log", func() ([]byte, error) { return getHTTPCallContent(telemetryURL) })
 	}
 

--- a/releasenotes/notes/flare-local-with-non-default-expvar_port-4cf1514f9580137a.yaml
+++ b/releasenotes/notes/flare-local-with-non-default-expvar_port-4cf1514f9580137a.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix building a local flare to use the expvar_port from the config instead of the default port. 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Move the `pprofURL` and `telemetryURL` inside functions instead of global variables.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The values of the URLs were computed before the config was loaded, which means that it always used the default value for `expvar_port`.
This was visible when building a "local" flare while using a non-default `expvar_port`, the command would try to use the default port and display the following error:
``` 
error: error collecting data for 'go-routine-dump.log': Get "http://127.0.0.1:5000/debug/pprof/goroutine?debug=2": dial tcp 127.0.0.1:5000: connect: connection refused
error: error collecting data for 'telemetry.log': Get "http://127.0.0.1:5000/telemetry": dial tcp 127.0.0.1:5000: connect: connection refused
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Use a non-default `expvar_port` (eg. 5050) and enable telemetry (`telemetry.enabled: true`), then run `datadog-agent flare -l`.
The errors mentioned above shouldn't occur.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
