### PR TITLE
AETT-171 Publish junit reports in GitLab and new-e2e junit ones to Datadog

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,7 @@ include:
   - /.gitlab/internal_image_deploy.yml
   - /.gitlab/trigger_release.yml
   - /.gitlab/e2e.yml
+  - /.gitlab/e2e_test_junit_upload.yml
   - /.gitlab/fakeintake.yml
   - /.gitlab/kitchen_cleanup.yml
   - /.gitlab/functional_test.yml
@@ -79,6 +80,7 @@ stages:
   - choco_deploy
   - internal_image_deploy
   - e2e
+  - e2e_test_junit_upload
   - kitchen_cleanup
   - functional_test
   - functional_test_cleanup

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -139,7 +139,14 @@ k8s-e2e-otlp-main:
     E2E_PRIVATE_KEY_PATH: /tmp/agent-qa-ssh-key
     E2E_KEY_PAIR_NAME: datadog-agent-ci
   script:
-    - inv -e new-e2e-tests.run --targets $TARGETS $CONFIGPARAMS
+    - inv -e new-e2e-tests.run --targets $TARGETS $CONFIGPARAMS --junit-tar "junit-${CI_JOB_NAME}.tgz"
+  artifacts:
+    expire_in: 2 weeks
+    when: always
+    paths:
+      - junit-*.tgz
+    reports:
+      junit: junit-*.tgz
 
 new-e2e-containers-dev:
   extends: .new_e2e_template

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -146,7 +146,7 @@ k8s-e2e-otlp-main:
     paths:
       - junit-*.tgz
     reports:
-      junit: junit/*.xml
+      junit: test/new-e2e/junit-*.xml
 
 new-e2e-containers-dev:
   extends: .new_e2e_template

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -139,7 +139,7 @@ k8s-e2e-otlp-main:
     E2E_PRIVATE_KEY_PATH: /tmp/agent-qa-ssh-key
     E2E_KEY_PAIR_NAME: datadog-agent-ci
   script:
-    - inv -e new-e2e-tests.run --targets $TARGETS $CONFIGPARAMS --junit-tar "junit-${CI_JOB_NAME}.tgz"
+    - inv -e new-e2e-tests.run --targets $TARGETS $CONFIGPARAMS --junit-tar "junit-${CI_JOB_NAME}.tgz" ${EXTRA_PARAMS}
   artifacts:
     expire_in: 2 weeks
     when: always
@@ -157,6 +157,12 @@ new-e2e-containers-dev:
   variables:
     TARGETS: ./containers
     CONFIGPARAMS: "-c ddagent:fullImagePath=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3 -c ddagent:clusterAgentFullImagePath=datadog/cluster-agent-dev:${CI_COMMIT_REF_SLUG}"
+  parallel:
+    matrix:
+      - EXTRA_PARAMS: --run TestKindSuite
+      - EXTRA_PARAMS: --run TestEKSSuite
+      - EXTRA_PARAMS: --run TestECSSuite
+      - EXTRA_PARAMS: --skip "Test(Kind|EKS|ECS)Suite"
 
 new-e2e-containers-main:
   extends: .new_e2e_template

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -140,9 +140,6 @@ k8s-e2e-otlp-main:
     E2E_KEY_PAIR_NAME: datadog-agent-ci
   script:
     - inv -e new-e2e-tests.run --targets $TARGETS $CONFIGPARAMS --junit-tar "junit-${CI_JOB_NAME}.tgz"
-  after_script:
-    - mkdir junit
-    - tar -xfC "junit-${CI_JOB_NAME}.tgz" junit
   artifacts:
     expire_in: 2 weeks
     when: always

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -140,13 +140,16 @@ k8s-e2e-otlp-main:
     E2E_KEY_PAIR_NAME: datadog-agent-ci
   script:
     - inv -e new-e2e-tests.run --targets $TARGETS $CONFIGPARAMS --junit-tar "junit-${CI_JOB_NAME}.tgz"
+  after_script:
+    - mkdir junit
+    - tar -xfC "junit-${CI_JOB_NAME}.tgz" junit
   artifacts:
     expire_in: 2 weeks
     when: always
     paths:
       - junit-*.tgz
     reports:
-      junit: junit-*.tgz
+      junit: junit/*.xml
 
 new-e2e-containers-dev:
   extends: .new_e2e_template

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -144,6 +144,8 @@ k8s-e2e-otlp-main:
     expire_in: 2 weeks
     when: always
     paths:
+      # This file will be consumed by the `e2e_test_junit_upload` job in next stage to push the report to datadog.
+      # If you create a new job from this template, do not forget to update the `dependencies` of the `e2e_test_junit_upload` job.
       - junit-*.tgz
     reports:
       junit: test/new-e2e/junit-*.xml
@@ -162,3 +164,7 @@ new-e2e-containers-main:
   variables:
     TARGETS: ./containers
     CONFIGPARAMS: "-c ddagent:fullImagePath=datadog/agent-dev:master-py3 -c ddagent:clusterAgentFullImagePath=datadog/cluster-agent-dev:master"
+
+#   ^    If you create a new job here that extends `.new_e2e_template`,
+#  /!\   do not forget to add it in the `dependencies` statement of the
+# /___\  `e2e_test_junit_upload` job in the `.gitlab/e2e_test_junit_upload.yml` file

--- a/.gitlab/e2e_test_junit_upload.yml
+++ b/.gitlab/e2e_test_junit_upload.yml
@@ -8,6 +8,8 @@ e2e_test_junit_upload:
   allow_failure: true
   variables:
     DD_ENV: ci
+  dependencies:
+    - new-e2e-containers-main
   script:
     - set +x
     - export DATADOG_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)

--- a/.gitlab/e2e_test_junit_upload.yml
+++ b/.gitlab/e2e_test_junit_upload.yml
@@ -1,4 +1,4 @@
-source_test_junit_upload:
+e2e_test_junit_upload:
   rules:
     !reference [.on_main]
   when: always

--- a/.gitlab/e2e_test_junit_upload.yml
+++ b/.gitlab/e2e_test_junit_upload.yml
@@ -9,6 +9,8 @@ e2e_test_junit_upload:
   variables:
     DD_ENV: ci
   dependencies:
+    # We need to exhaustively list all the `new-e2e-…` jobs that produce junit reports here
+    # to avoid downloading all the artifacts of all the jobs of all the previous stages.
     - new-e2e-containers-main
   script:
     - set +x

--- a/.gitlab/e2e_test_junit_upload.yml
+++ b/.gitlab/e2e_test_junit_upload.yml
@@ -1,0 +1,15 @@
+source_test_junit_upload:
+  rules:
+    !reference [.on_main]
+  when: always
+  stage: e2e_test_junit_upload
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/datadog-ci-uploader$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["runner:main"]
+  allow_failure: true
+  variables:
+    DD_ENV: ci
+  script:
+    - set +x
+    - export DATADOG_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
+    - set -x
+    - for f in junit-new-e2e-*.tgz; do inv -e junit-upload --tgz-path $f; done

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -28,7 +28,7 @@
       - test_output.json
       - junit-*.tgz
     reports:
-      junit: junit-*.xml
+      junit: "**/junit-out-*.xml"
 
 .linux_lint:
   stage: source_test

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -21,9 +21,6 @@
     - inv -e install-tools
     - inv -e invoke-unit-tests
     - inv -e test $FLAVORS --skip-linters --race --profile --rerun-fails=2 --python-runtimes "$PYTHON_RUNTIMES" --cpus 4 $EXTRA_OPTS --save-result-json test_output.json --junit-tar "junit-${CI_JOB_NAME}.tgz"
-  after_script:
-    - mkdir junit
-    - tar -xfC "junit-${CI_JOB_NAME}.tgz" junit
   artifacts:
     expire_in: 2 weeks
     when: always
@@ -31,7 +28,7 @@
       - test_output.json
       - junit-*.tgz
     reports:
-      junit: junit/*.xml
+      junit: junit-*.xml
 
 .linux_lint:
   stage: source_test

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -21,6 +21,9 @@
     - inv -e install-tools
     - inv -e invoke-unit-tests
     - inv -e test $FLAVORS --skip-linters --race --profile --rerun-fails=2 --python-runtimes "$PYTHON_RUNTIMES" --cpus 4 $EXTRA_OPTS --save-result-json test_output.json --junit-tar "junit-${CI_JOB_NAME}.tgz"
+  after_script:
+    - mkdir junit
+    - tar -xfC "junit-${CI_JOB_NAME}.tgz" junit
   artifacts:
     expire_in: 2 weeks
     when: always
@@ -28,7 +31,7 @@
       - test_output.json
       - junit-*.tgz
     reports:
-      junit: junit-*.tgz
+      junit: junit/*.xml
 
 .linux_lint:
   stage: source_test

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -27,6 +27,8 @@
     paths:
       - test_output.json
       - junit-*.tgz
+    reports:
+      junit: junit-*.tgz
 
 .linux_lint:
   stage: source_test

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -19,8 +19,6 @@ tests_macos:
     - inv -e github.trigger-macos-test --datadog-agent-ref "$CI_COMMIT_SHA" --python-runtimes "$PYTHON_RUNTIMES" --version-cache "$VERSION_CACHE_CONTENT"
   after_script:
     - inv -e junit-macos-repack --infile junit-tests_macos.tgz --outfile junit-tests_macos-repacked.tgz
-    - mkdir junit
-    - tar -xfC "junit-${CI_JOB_NAME}.tgz" junit
   artifacts:
     expire_in: 2 weeks
     when: always
@@ -28,4 +26,4 @@ tests_macos:
       - test_output.json
       - junit-*-repacked.tgz
     reports:
-      junit: junit/*.xml
+      junit: junit-*.xml

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -19,6 +19,8 @@ tests_macos:
     - inv -e github.trigger-macos-test --datadog-agent-ref "$CI_COMMIT_SHA" --python-runtimes "$PYTHON_RUNTIMES" --version-cache "$VERSION_CACHE_CONTENT"
   after_script:
     - inv -e junit-macos-repack --infile junit-tests_macos.tgz --outfile junit-tests_macos-repacked.tgz
+    - mkdir junit
+    - tar -xfC "junit-${CI_JOB_NAME}.tgz" junit
   artifacts:
     expire_in: 2 weeks
     when: always
@@ -26,4 +28,4 @@ tests_macos:
       - test_output.json
       - junit-*-repacked.tgz
     reports:
-      junit: junit-*-repacked.tgz
+      junit: junit/*.xml

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -25,3 +25,5 @@ tests_macos:
     paths:
       - test_output.json
       - junit-*-repacked.tgz
+    reports:
+      junit: junit-*-repacked.tgz

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -26,4 +26,4 @@ tests_macos:
       - test_output.json
       - junit-*-repacked.tgz
     reports:
-      junit: junit-*.xml
+      junit: "**/junit-out-*.xml"

--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -35,6 +35,8 @@
     paths:
       - test_output.json
       - junit-*.tgz
+    reports:
+      junit: junit-*.tgz
 
 .lint_windows_base:
   stage: source_test
@@ -44,14 +46,14 @@
     - $ErrorActionPreference = "Stop"
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
     - >
-      docker run --rm 
-      -m 8192M 
-      -v "$(Get-Location):c:\mnt" 
+      docker run --rm
+      -m 8192M
+      -v "$(Get-Location):c:\mnt"
       -e AWS_NETWORKING=true
       -e CI_PIPELINE_ID=${CI_PIPELINE_ID}
       -e CI_PROJECT_NAME=${CI_PROJECT_NAME}
-      -e PY_RUNTIMES="$PYTHON_RUNTIMES" 
-      -e GOMODCACHE="c:\modcache" 
+      -e PY_RUNTIMES="$PYTHON_RUNTIMES"
+      -e GOMODCACHE="c:\modcache"
       486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:$Env:DATADOG_AGENT_WINBUILDIMAGES c:\mnt\tasks\winbuildscripts\lint.bat
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
 

--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -35,8 +35,6 @@
     paths:
       - test_output.json
       - junit-*.tgz
-    reports:
-      junit: junit-*.tgz
 
 .lint_windows_base:
   stage: source_test

--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -36,7 +36,7 @@
       - test_output.json
       - junit-*.tgz
     reports:
-      junit: junit-*.xml
+      junit: "**/junit-out-*.xml"
 
 .lint_windows_base:
   stage: source_test

--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -35,6 +35,8 @@
     paths:
       - test_output.json
       - junit-*.tgz
+    reports:
+      junit: junit-*.xml
 
 .lint_windows_base:
   stage: source_test

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -34,8 +34,17 @@ from .utils import REPO_PATH, get_git_commit
     },
 )
 def run(
-    ctx, profile="", tags=[], targets=[], configparams=[], verbose=True, run="", skip="", cache=False, junit_tar=""
-):  # noqa: B006
+    ctx,
+    profile="",
+    tags=[],  # noqa: B006
+    targets=[],  # noqa: B006
+    configparams=[],  # noqa: B006
+    verbose=True,
+    run="",
+    skip="",
+    cache=False,
+    junit_tar="",
+):
     """
     Run E2E Tests based on test-infra-definitions infrastructure provisioning.
     """


### PR DESCRIPTION
### What does this PR do?

* Publish `junit` reports in GitLab.
* Publish the `new-e2e` results in Datadog.

### Motivation

This should hopefully give a structured view of the tests reports easier to read than a long log text stream.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Verify that the test results are visible in GitLab in this tab:
![image](https://github.com/DataDog/datadog-agent/assets/1437785/c1ecd943-bef0-4cfb-99b7-f599b9948288)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
