### PR TITLE
[CWS] use path_id for mount resolution

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/filesystem.h
+++ b/pkg/security/ebpf/c/include/helpers/filesystem.h
@@ -39,6 +39,10 @@ static __attribute__((always_inline)) u32 get_path_id(u32 mount_id, int invalida
     return id;
 }
 
+static __attribute__((always_inline)) void update_path_id(struct path_key_t *path_key, int invalidate) {
+    path_key->path_id = get_path_id(path_key->mount_id, invalidate);
+}
+
 static __attribute__((always_inline)) void inc_mount_ref(u32 mount_id) {
     u32 key = mount_id;
     struct mount_ref_t zero = {};

--- a/pkg/security/ebpf/c/include/structs/filesystem.h
+++ b/pkg/security/ebpf/c/include/structs/filesystem.h
@@ -15,12 +15,10 @@ struct mount_ref_t {
 };
 
 struct mount_fields_t {
-    unsigned long parent_inode;
-    unsigned long root_inode;
+    struct path_key_t parent_key;
+    struct path_key_t root_key;
     dev_t device;
     u32 mount_id;
-    u32 parent_mount_id;
-    u32 root_mount_id;
     u32 bind_src_mount_id;
     u32 padding;
     char fstype[FSTYPE_LEN];

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -592,7 +592,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 
 		// TODO: this should be moved in the resolver itself in order to handle the fallbacks
 		if event.Mount.GetFSType() == "nsfs" {
-			nsid := uint32(event.Mount.RootInode)
+			nsid := uint32(event.Mount.RootPathKey.Inode)
 			mountPath, err := p.resolvers.MountResolver.ResolveMountPath(event.Mount.MountID, event.PIDContext.Pid, event.ContainerContext.ID)
 			if err != nil {
 				seclog.Debugf("failed to get mount path: %v", err)
@@ -611,7 +611,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		// we can skip this error as this is for the umount only and there is no impact on the filepath resolution
 		mount, _ := p.resolvers.MountResolver.ResolveMount(event.Umount.MountID, event.PIDContext.Pid, event.ContainerContext.ID)
 		if mount != nil && mount.GetFSType() == "nsfs" {
-			nsid := uint32(mount.RootInode)
+			nsid := uint32(mount.RootPathKey.Inode)
 			if namespace := p.resolvers.NamespaceResolver.ResolveNetworkNamespace(nsid); namespace != nil {
 				p.FlushNetworkNamespace(namespace)
 			}

--- a/pkg/security/resolvers/mount/resolver_test.go
+++ b/pkg/security/resolvers/mount/resolver_test.go
@@ -45,12 +45,11 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
-								MountID:       27,
-								Device:        1,
-								ParentInode:   0,
-								RootMountID:   0,
-								RootInode:     0,
-								ParentMountID: 1,
+								MountID: 27,
+								Device:  1,
+								ParentPathKey: model.PathKey{
+									MountID: 1,
+								},
 								FSType:        "ext4",
 								MountPointStr: "/",
 								RootStr:       "",
@@ -75,12 +74,11 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
-								MountID:       27,
-								Device:        1,
-								ParentInode:   0,
-								RootMountID:   0,
-								RootInode:     0,
-								ParentMountID: 1,
+								MountID: 27,
+								Device:  1,
+								ParentPathKey: model.PathKey{
+									MountID: 1,
+								},
 								FSType:        "ext4",
 								MountPointStr: "/",
 								RootStr:       "",
@@ -105,12 +103,11 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
-								MountID:       127,
-								Device:        52,
-								ParentInode:   0,
-								RootMountID:   0,
-								RootInode:     0,
-								ParentMountID: 27,
+								MountID: 127,
+								Device:  52,
+								ParentPathKey: model.PathKey{
+									MountID: 27,
+								},
 								FSType:        "overlay",
 								MountPointStr: "/var/lib/docker/overlay2/f44b5a1fe134f57a31da79fa2e76ea09f8659a34edfa0fa2c3b4f52adbd91963/merged",
 								RootStr:       "",
@@ -165,12 +162,11 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
-								MountID:       27,
-								Device:        1,
-								ParentInode:   0,
-								RootMountID:   0,
-								RootInode:     0,
-								ParentMountID: 1,
+								MountID: 27,
+								Device:  1,
+								ParentPathKey: model.PathKey{
+									MountID: 1,
+								},
 								FSType:        "ext4",
 								MountPointStr: "/",
 								RootStr:       "",
@@ -181,12 +177,11 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
-								MountID:       22,
-								Device:        21,
-								ParentInode:   0,
-								RootMountID:   0,
-								RootInode:     0,
-								ParentMountID: 27,
+								MountID: 22,
+								Device:  21,
+								ParentPathKey: model.PathKey{
+									MountID: 27,
+								},
 								FSType:        "sysfs",
 								MountPointStr: "/sys",
 								RootStr:       "",
@@ -197,12 +192,11 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
-								MountID:       31,
-								Device:        26,
-								ParentInode:   0,
-								RootMountID:   0,
-								RootInode:     0,
-								ParentMountID: 22,
+								MountID: 31,
+								Device:  26,
+								ParentPathKey: model.PathKey{
+									MountID: 22,
+								},
 								FSType:        "tmpfs",
 								MountPointStr: "/fs/cgroup",
 								RootStr:       "",
@@ -267,12 +261,11 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
-								MountID:       27,
-								Device:        1,
-								ParentInode:   0,
-								RootMountID:   0,
-								RootInode:     0,
-								ParentMountID: 1,
+								MountID: 27,
+								Device:  1,
+								ParentPathKey: model.PathKey{
+									MountID: 1,
+								},
 								FSType:        "ext4",
 								MountPointStr: "/",
 								RootStr:       "",
@@ -283,12 +276,11 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
-								MountID:       176,
-								Device:        52,
-								ParentInode:   0,
-								RootMountID:   0,
-								RootInode:     0,
-								ParentMountID: 27,
+								MountID: 176,
+								Device:  52,
+								ParentPathKey: model.PathKey{
+									MountID: 27,
+								},
 								FSType:        "overlay",
 								MountPointStr: "/var/lib/docker/overlay2/f44b5a1fe134f57a31da79fa2e76ea09f8659a34edfa0fa2c3b4f52adbd91963/merged",
 								RootStr:       "",
@@ -299,12 +291,11 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
-								MountID:       638,
-								Device:        52,
-								ParentInode:   0,
-								RootMountID:   0,
-								RootInode:     0,
-								ParentMountID: 635,
+								MountID: 638,
+								Device:  52,
+								ParentPathKey: model.PathKey{
+									MountID: 635,
+								},
 								FSType:        "bind",
 								MountPointStr: "/",
 								RootStr:       "",
@@ -315,12 +306,11 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
-								MountID:       639,
-								Device:        54,
-								ParentInode:   0,
-								RootMountID:   0,
-								RootInode:     0,
-								ParentMountID: 638,
+								MountID: 639,
+								Device:  54,
+								ParentPathKey: model.PathKey{
+									MountID: 638,
+								},
 								FSType:        "proc",
 								MountPointStr: "proc",
 								RootStr:       "",
@@ -375,8 +365,10 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
-								MountID:       32,
-								ParentMountID: 638,
+								MountID: 32,
+								ParentPathKey: model.PathKey{
+									MountID: 638,
+								},
 								MountPointStr: "/",
 							},
 						},
@@ -385,8 +377,10 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
-								MountID:       41,
-								ParentMountID: 32,
+								MountID: 41,
+								ParentPathKey: model.PathKey{
+									MountID: 32,
+								},
 								MountPointStr: "/tmp",
 							},
 						},
@@ -395,8 +389,10 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
-								MountID:       42,
-								ParentMountID: 41,
+								MountID: 42,
+								ParentPathKey: model.PathKey{
+									MountID: 41,
+								},
 								MountPointStr: "/tmp",
 							},
 						},
@@ -469,18 +465,24 @@ func TestMountGetParentPath(t *testing.T) {
 				MountPointStr: "/",
 			},
 			2: {
-				MountID:       2,
-				ParentMountID: 1,
+				MountID: 2,
+				ParentPathKey: model.PathKey{
+					MountID: 1,
+				},
 				MountPointStr: "/a",
 			},
 			3: {
-				MountID:       3,
-				ParentMountID: 2,
+				MountID: 3,
+				ParentPathKey: model.PathKey{
+					MountID: 2,
+				},
 				MountPointStr: "/b",
 			},
 			4: {
-				MountID:       4,
-				ParentMountID: 3,
+				MountID: 4,
+				ParentPathKey: model.PathKey{
+					MountID: 3,
+				},
 				MountPointStr: "/c",
 			},
 		},
@@ -499,18 +501,24 @@ func TestMountLoop(t *testing.T) {
 				MountPointStr: "/",
 			},
 			2: {
-				MountID:       2,
-				ParentMountID: 4,
+				MountID: 2,
+				ParentPathKey: model.PathKey{
+					MountID: 4,
+				},
 				MountPointStr: "/a",
 			},
 			3: {
-				MountID:       3,
-				ParentMountID: 2,
+				MountID: 3,
+				ParentPathKey: model.PathKey{
+					MountID: 2,
+				},
 				MountPointStr: "/b",
 			},
 			4: {
-				MountID:       4,
-				ParentMountID: 3,
+				MountID: 4,
+				ParentPathKey: model.PathKey{
+					MountID: 3,
+				},
 				MountPointStr: "/c",
 			},
 		},
@@ -533,8 +541,10 @@ func BenchmarkGetParentPath(b *testing.B) {
 
 	for i := uint32(1); i != 100; i++ {
 		mr.mounts[i+1] = &model.Mount{
-			MountID:       i + 1,
-			ParentMountID: i,
+			MountID: i + 1,
+			ParentPathKey: model.PathKey{
+				MountID: i,
+			},
 			MountPointStr: fmt.Sprintf("/%d", i+1),
 		}
 	}

--- a/pkg/security/resolvers/path/resolver.go
+++ b/pkg/security/resolvers/path/resolver.go
@@ -117,9 +117,8 @@ func (r *Resolver) ResolveFileFieldsPath(e *model.FileFields, pidCtx *model.PIDC
 // SetMountRoot set the mount point information
 func (r *Resolver) SetMountRoot(ev *model.Event, e *model.Mount) error {
 	var err error
-	pathKey := model.PathKey{MountID: e.RootMountID, Inode: e.RootInode, PathID: 0}
 
-	e.RootStr, err = r.dentryResolver.Resolve(pathKey, true)
+	e.RootStr, err = r.dentryResolver.Resolve(e.RootPathKey, true)
 	if err != nil {
 		return &ErrPathResolutionNotCritical{Err: err}
 	}
@@ -139,9 +138,8 @@ func (r *Resolver) ResolveMountRoot(ev *model.Event, e *model.Mount) (string, er
 // SetMountPoint set the mount point information
 func (r *Resolver) SetMountPoint(ev *model.Event, e *model.Mount) error {
 	var err error
-	pathKey := model.PathKey{MountID: e.ParentMountID, Inode: e.ParentInode, PathID: 0}
 
-	e.MountPointStr, err = r.dentryResolver.Resolve(pathKey, true)
+	e.MountPointStr, err = r.dentryResolver.Resolve(e.ParentPathKey, true)
 	if err != nil {
 		return &ErrPathResolutionNotCritical{Err: err}
 	}

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -796,17 +796,15 @@ type ArgsEnvsEvent struct {
 
 // Mount represents a mountpoint (used by MountEvent and UnshareMountNSEvent)
 type Mount struct {
-	MountID        uint32 `field:"-"`
-	Device         uint32 `field:"-"`
-	ParentMountID  uint32 `field:"-"`
-	ParentInode    uint64 `field:"-"`
-	RootMountID    uint32 `field:"-"`
-	RootInode      uint64 `field:"-"`
-	BindSrcMountID uint32 `field:"-"`
-	FSType         string `field:"fs_type"` // SECLDoc[fs_type] Definition:`Type of the mounted file system`
-	MountPointStr  string `field:"-"`
-	RootStr        string `field:"-"`
-	Path           string `field:"-"`
+	MountID        uint32  `field:"-"`
+	Device         uint32  `field:"-"`
+	ParentPathKey  PathKey `field:"-"`
+	RootPathKey    PathKey `field:"-"`
+	BindSrcMountID uint32  `field:"-"`
+	FSType         string  `field:"fs_type"` // SECLDoc[fs_type] Definition:`Type of the mounted file system`
+	MountPointStr  string  `field:"-"`
+	RootStr        string  `field:"-"`
+	Path           string  `field:"-"`
 }
 
 // MountEvent represents a mount event

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -397,27 +397,34 @@ func (e *MkdirEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (m *Mount) UnmarshalBinary(data []byte) (int, error) {
-	if len(data) < 56 {
+	if len(data) < 64 {
 		return 0, ErrNotEnoughData
 	}
 
-	m.ParentInode = ByteOrder.Uint64(data[0:8])
-	m.RootInode = ByteOrder.Uint64(data[8:16])
-	m.Device = ByteOrder.Uint32(data[16:20])
-	m.MountID = ByteOrder.Uint32(data[20:24])
-	m.ParentMountID = ByteOrder.Uint32(data[24:28])
-	m.RootMountID = ByteOrder.Uint32(data[28:32])
-	m.BindSrcMountID = ByteOrder.Uint32(data[32:36])
+	n, err := m.ParentPathKey.UnmarshalBinary(data)
+	if err != nil {
+		return 0, err
+	}
+	data = data[n:]
+
+	n, err = m.RootPathKey.UnmarshalBinary(data)
+	if err != nil {
+		return 0, err
+	}
+	data = data[n:]
+
+	m.Device = ByteOrder.Uint32(data[0:4])
+	m.MountID = ByteOrder.Uint32(data[4:8])
+	m.BindSrcMountID = ByteOrder.Uint32(data[8:12])
 
 	// +4 for padding
 
-	var err error
-	m.FSType, err = UnmarshalString(data[40:56], 16)
+	m.FSType, err = UnmarshalString(data[16:], 16)
 	if err != nil {
 		return 0, err
 	}
 
-	return 56, nil
+	return 64, nil
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself

--- a/pkg/security/serializers/serializers.go
+++ b/pkg/security/serializers/serializers.go
@@ -1034,16 +1034,16 @@ func newMountEventSerializer(e *model.Event, resolvers *resolvers.Resolvers) *Mo
 	mountSerializer := &MountEventSerializer{
 		MountPoint: &FileSerializer{
 			Path:    dst,
-			MountID: &e.Mount.ParentMountID,
-			Inode:   &e.Mount.ParentInode,
+			MountID: &e.Mount.ParentPathKey.MountID,
+			Inode:   &e.Mount.ParentPathKey.Inode,
 		},
 		Root: &FileSerializer{
 			Path:    src,
-			MountID: &e.Mount.RootMountID,
-			Inode:   &e.Mount.RootInode,
+			MountID: &e.Mount.RootPathKey.MountID,
+			Inode:   &e.Mount.RootPathKey.Inode,
 		},
 		MountID:         e.Mount.MountID,
-		ParentMountID:   e.Mount.ParentMountID,
+		ParentMountID:   e.Mount.ParentPathKey.MountID,
 		BindSrcMountID:  e.Mount.BindSrcMountID,
 		Device:          e.Mount.Device,
 		FSType:          e.Mount.GetFSType(),

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -339,7 +339,7 @@ func TestMountSnapshot(t *testing.T) {
 			return
 		}
 		assert.Equal(t, uint32(mntInfo.ID), mount.MountID, "snapshot and model mount ID mismatch")
-		assert.Equal(t, uint32(mntInfo.Parent), mount.ParentMountID, "snapshot and model parent mount ID mismatch")
+		assert.Equal(t, uint32(mntInfo.Parent), mount.ParentPathKey.MountID, "snapshot and model parent mount ID mismatch")
 		assert.Equal(t, uint32(unix.Mkdev(uint32(mntInfo.Major), uint32(mntInfo.Minor))), mount.Device, "snapshot and model device mismatch")
 		assert.Equal(t, mntInfo.FSType, mount.FSType, "snapshot and model fstype mismatch")
 		assert.Equal(t, mntInfo.Root, mount.RootStr, "snapshot and model root mismatch")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
