### PR TITLE
Upgrade gotest.tools to v3

### DIFF
--- a/cmd/serverless-init/cloudservice/service_test.go
+++ b/cmd/serverless-init/cloudservice/service_test.go
@@ -8,7 +8,7 @@ package cloudservice
 import (
 	"testing"
 
-	"gotest.tools/assert"
+	"gotest.tools/v3/assert"
 )
 
 func TestGetCloudServiceType(t *testing.T) {

--- a/cmd/serverless-init/metric/metric_test.go
+++ b/cmd/serverless-init/metric/metric_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"gotest.tools/assert"
+	"gotest.tools/v3/assert"
 )
 
 func TestAdd(t *testing.T) {

--- a/cmd/system-probe/utils/limiter_test.go
+++ b/cmd/system-probe/utils/limiter_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"gotest.tools/assert"
+	"gotest.tools/v3/assert"
 )
 
 func TestWithConcurrencyLimit(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -226,7 +226,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	gopkg.in/zorkian/go-datadog-api.v2 v2.30.0
-	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.25.5
 	k8s.io/apiextensions-apiserver v0.25.5
 	k8s.io/apimachinery v0.25.5
@@ -574,6 +573,7 @@ require (
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/kr/pretty v0.3.1
 	github.com/sijms/go-ora/v2 v2.7.6
+	gotest.tools/v3 v3.3.0
 )
 
 require (
@@ -590,7 +590,6 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20220613132600-b0d781184e0d // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gotest.tools/v3 v3.3.0 // indirect
 	honnef.co/go/tools v0.3.2 // indirect
 	inet.af/netaddr v0.0.0-20220617031823-097006376321 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2721,7 +2721,6 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/zorkian/go-datadog-api.v2 v2.30.0 h1:umQdVO0Ytx+kYadhuJNjFtDgIsIEBnKrOTvNuu8ClKI=
 gopkg.in/zorkian/go-datadog-api.v2 v2.30.0/go.mod h1:kx0CSMRpzEZfx/nFH62GLU4stZjparh/BRpM89t4XCQ=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=

--- a/pkg/logs/internal/launchers/journald/launcher_test.go
+++ b/pkg/logs/internal/launchers/journald/launcher_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/launchers"
@@ -20,7 +22,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/coreos/go-systemd/sdjournal"
-	"gotest.tools/assert"
 )
 
 type MockJournal struct{}

--- a/pkg/logs/schedulers/cca/scheduler_test.go
+++ b/pkg/logs/schedulers/cca/scheduler_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gotest.tools/assert"
+	"gotest.tools/v3/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	coreConfig "github.com/DataDog/datadog-agent/pkg/config"

--- a/pkg/network/protocols/events/batch_offsets_test.go
+++ b/pkg/network/protocols/events/batch_offsets_test.go
@@ -10,7 +10,7 @@ package events
 import (
 	"testing"
 
-	"gotest.tools/assert"
+	"gotest.tools/v3/assert"
 )
 
 func TestOffsets(t *testing.T) {

--- a/pkg/security/security_profile/profile/manager_test.go
+++ b/pkg/security/security_profile/profile/manager_test.go
@@ -15,7 +15,7 @@ import (
 	"unsafe"
 
 	"go.uber.org/atomic"
-	"gotest.tools/assert"
+	"gotest.tools/v3/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"

--- a/pkg/serverless/daemon/utils_test.go
+++ b/pkg/serverless/daemon/utils_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"gotest.tools/assert"
+	"gotest.tools/v3/assert"
 )
 
 func TestWaitWithTimeoutTimesOut(t *testing.T) {

--- a/pkg/serverless/proc/proc_test.go
+++ b/pkg/serverless/proc/proc_test.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 	"testing"
 
-	"gotest.tools/assert"
+	"gotest.tools/v3/assert"
 )
 
 func TestGetPidListInvalid(t *testing.T) {

--- a/pkg/util/filesystem/permission_nowindows_test.go
+++ b/pkg/util/filesystem/permission_nowindows_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gotest.tools/assert"
+	"gotest.tools/v3/assert"
 )
 
 func TestRemoveAccessToOtherUsers(t *testing.T) {

--- a/pkg/workloadmeta/store_test.go
+++ b/pkg/workloadmeta/store_test.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"testing"
 
-	"gotest.tools/assert"
+	"gotest.tools/v3/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/errors"
 )


### PR DESCRIPTION
### What does this PR do?

Fix all references to package `gotest.tools/assert` to use instead `gotest.tools/v3/assert`. This allows to move to the maintained branch of that module and drop references to a module with a Go-modules-incompatible version ([`v2.2.0+incompatible`](https://pkg.go.dev/gotest.tools@v2.2.0+incompatible)).

### Motivation

Dependency cleanup.

### Possible Drawbacks / Trade-offs

None.

### Describe how to test/QA your changes

Note that I wasn't able to run all modified tests because some are behind build tags which are not compatible with my development environment (macOS).

CI should be able catch mistakes.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
