### PR TITLE
Remove Oracle from Heroku

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/activity.go
+++ b/pkg/collector/corechecks/oracle-dbm/activity.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build oracle
+
 package oracle
 
 import (

--- a/pkg/collector/corechecks/oracle-dbm/activity_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/activity_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build oracle
+//go:build oracle_test
 
 package oracle
 

--- a/pkg/collector/corechecks/oracle-dbm/common/constants.go
+++ b/pkg/collector/corechecks/oracle-dbm/common/constants.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build oracle
+
 package common
 
 // IntegrationName is the name of the integration.

--- a/pkg/collector/corechecks/oracle-dbm/common/utils.go
+++ b/pkg/collector/corechecks/oracle-dbm/common/utils.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build oracle
+
 package common
 
 import (

--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build oracle
+
 package config
 
 import (

--- a/pkg/collector/corechecks/oracle-dbm/doc.go
+++ b/pkg/collector/corechecks/oracle-dbm/doc.go
@@ -3,13 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build oracle
-
-package config
-
-// MetricConfig holds the config for a metric.
-type MetricConfig struct {
-	Query   string `yaml:"query"`
-	Columns string `yaml:"columns"`
-	// Tags    string `yaml:"tags"`
-}
+/*
+Package systemd provides core checks for oracle
+*/
+package oracle

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build oracle
+
 package oracle
 
 import (

--- a/pkg/collector/corechecks/oracle-dbm/oracle_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build oracle
+//go:build oracle_test
 
 package oracle
 

--- a/pkg/collector/corechecks/oracle-dbm/processes.go
+++ b/pkg/collector/corechecks/oracle-dbm/processes.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build oracle
+
 package oracle
 
 import (

--- a/pkg/collector/corechecks/oracle-dbm/shared_memory.go
+++ b/pkg/collector/corechecks/oracle-dbm/shared_memory.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build oracle
+
 package oracle
 
 import (

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build oracle
+
 package oracle
 
 import (

--- a/pkg/collector/corechecks/oracle-dbm/statements_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build oracle
+//go:build oracle_test
 
 package oracle
 

--- a/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
+++ b/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build oracle
+
 package oracle
 
 import (

--- a/pkg/collector/corechecks/oracle-dbm/tablespaces.go
+++ b/pkg/collector/corechecks/oracle-dbm/tablespaces.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build oracle
+
 package oracle
 
 import (

--- a/releasenotes/notes/remove-oracle-from-heroku-3cbdf52b46175348.yaml
+++ b/releasenotes/notes/remove-oracle-from-heroku-3cbdf52b46175348.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Remove Oracle from the Heroku build.

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -32,6 +32,7 @@ ALL_TAGS = {
     "linux_bpf",
     "netcgo",  # Force the use of the CGO resolver. This will also have the effect of making the binary non-static
     "npm",
+    "oracle",
     "orchestrator",
     "otlp",
     "podman",
@@ -62,6 +63,7 @@ AGENT_TAGS = {
     "kubeapiserver",
     "kubelet",
     "netcgo",
+    "oracle",
     "orchestrator",
     "otlp",
     "podman",
@@ -84,6 +86,7 @@ AGENT_HEROKU_TAGS = AGENT_TAGS.difference(
         "jetson",
         "kubeapiserver",
         "kubelet",
+        "oracle",
         "orchestrator",
         "podman",
         "systemd",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Remove Oracle check from the Heroku build.

### Motivation

Reduce the size of the Heroku build.

### Additional Notes

Tested with invoke agent.build  --flavor heroku on MacOS M1.

Sizes before and after the change:

```
ls -l ./bin/agent/agent
-rwxr-xr-x 1 nenad.noveljic staff 96934176 Jul  3 15:30 ./bin/agent/agent
-rwxr-xr-x 1 nenad.noveljic staff 88032544 Jul  3 15:38 ./bin/agent/agent
```
On Ubuntu - package name `datadog-heroku-agent_7.46.0~heroku~w~oracle-1_amd64.deb` and `datadog-heroku-agent_7.46.0~oracle~wo~heroku~test~3-1_amd64.deb`:

```
-rwxr-xr-x 1 dd-agent dd-agent 77420672 Jun 27 15:41 /opt/datadog-agent/bin/agent/agent
-rwxr-xr-x 1 dd-agent dd-agent 69968224 Jul  3 15:03 /opt/datadog-agent/bin/agent/agent
```

### Describe how to test/QA your changes

1. Install Heroku build and verify that the agent size is less than 70M.
2. Verify that Oracle DBM is still working on the following platforms: Ubuntu, RHEL, Windows and Docker.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
