### PR TITLE
[process-agent] Extend WorkloadMetaExtractor to expose NSPid and creation time and not update cache if there's no process creation/deletion

### DIFF
--- a/pkg/process/metadata/workloadmeta/extractor_test.go
+++ b/pkg/process/metadata/workloadmeta/extractor_test.go
@@ -21,11 +21,13 @@ const (
 	Pid1 = 1000
 	Pid2 = 1001
 	Pid3 = 1002
+	Pid4 = 1003
 )
 
 func testProc(pid int32, cmdline []string) *procutil.Process {
 	return &procutil.Process{
 		Pid:     pid,
+		NsPid:   1,
 		Cmdline: cmdline,
 		Stats:   &procutil.Stats{CreateTime: time.Now().Unix()},
 	}
@@ -38,6 +40,7 @@ func TestExtractor(t *testing.T) {
 		proc1 = testProc(Pid1, []string{"java", "mydatabase.jar"})
 		proc2 = testProc(Pid2, []string{"python", "myprogram.py"})
 		proc3 = testProc(Pid3, []string{"corrina", "--at-her-best"})
+		proc4 = testProc(Pid4, []string{"python", "test.py"})
 	)
 
 	// Assert that first run generates creation events for all processes
@@ -51,12 +54,16 @@ func TestExtractor(t *testing.T) {
 	assert.Equal(t, int32(1), cacheVersion)
 	assert.Equal(t, map[string]*ProcessEntity{
 		hashProcess(Pid1, proc1.Stats.CreateTime): {
-			pid:      proc1.Pid,
-			language: &languagemodels.Language{Name: languagemodels.Java},
+			Pid:          proc1.Pid,
+			NsPid:        proc1.NsPid,
+			CreationTime: proc1.Stats.CreateTime,
+			Language:     &languagemodels.Language{Name: languagemodels.Java},
 		},
 		hashProcess(Pid2, proc2.Stats.CreateTime): {
-			pid:      proc2.Pid,
-			language: &languagemodels.Language{Name: languagemodels.Python},
+			Pid:          proc2.Pid,
+			NsPid:        proc2.NsPid,
+			CreationTime: proc2.Stats.CreateTime,
+			Language:     &languagemodels.Language{Name: languagemodels.Python},
 		},
 	}, procs)
 
@@ -66,41 +73,74 @@ func TestExtractor(t *testing.T) {
 	// Events are generated through map range which doesn't have a deterministic order
 	assert.ElementsMatch(t, []*ProcessEntity{
 		{
-			pid:      proc1.Pid,
-			language: &languagemodels.Language{Name: languagemodels.Java},
+			Pid:          proc1.Pid,
+			NsPid:        proc1.NsPid,
+			CreationTime: proc1.Stats.CreateTime,
+			Language:     &languagemodels.Language{Name: languagemodels.Java},
 		},
 		{
-			pid:      proc2.Pid,
-			language: &languagemodels.Language{Name: languagemodels.Python},
+			Pid:          proc2.Pid,
+			NsPid:        proc2.NsPid,
+			CreationTime: proc2.Stats.CreateTime,
+			Language:     &languagemodels.Language{Name: languagemodels.Python},
 		},
 	}, diff.creation)
 	assert.ElementsMatch(t, []*ProcessEntity{}, diff.deletion)
 
-	// Assert that duplicates generate an empty diff
+	// Assert that if no process is created or terminated, the cache is not updated nor a diff generated
 	extractor.Extract(map[int32]*procutil.Process{
 		Pid1: proc1,
 		Pid2: proc2,
 	})
 
 	procs, cacheVersion = extractor.GetAllProcessEntities()
-	assert.Equal(t, int32(2), cacheVersion)
+	assert.Equal(t, int32(1), cacheVersion) // cache version doesn't change
 	assert.Equal(t, map[string]*ProcessEntity{
 		hashProcess(Pid1, proc1.Stats.CreateTime): {
-			pid:      proc1.Pid,
-			language: &languagemodels.Language{Name: languagemodels.Java},
+			Pid:          proc1.Pid,
+			NsPid:        proc1.NsPid,
+			CreationTime: proc1.Stats.CreateTime,
+			Language:     &languagemodels.Language{Name: languagemodels.Java},
 		},
 		hashProcess(Pid2, proc2.Stats.CreateTime): {
-			pid:      proc2.Pid,
-			language: &languagemodels.Language{Name: languagemodels.Python},
+			Pid:          proc2.Pid,
+			NsPid:        proc2.NsPid,
+			CreationTime: proc2.Stats.CreateTime,
+			Language:     &languagemodels.Language{Name: languagemodels.Python},
+		},
+	}, procs)
+
+	assert.Len(t, extractor.ProcessCacheDiff(), 0)
+
+	// Process deletion generates a cache update and diff event
+	extractor.Extract(map[int32]*procutil.Process{
+		Pid2: proc2,
+	})
+
+	procs, cacheVersion = extractor.GetAllProcessEntities()
+	assert.Equal(t, int32(2), cacheVersion)
+	assert.Equal(t, map[string]*ProcessEntity{
+		hashProcess(Pid2, proc2.Stats.CreateTime): {
+			Pid:          proc2.Pid,
+			NsPid:        proc2.NsPid,
+			CreationTime: proc2.Stats.CreateTime,
+			Language:     &languagemodels.Language{Name: languagemodels.Python},
 		},
 	}, procs)
 
 	diff = <-extractor.ProcessCacheDiff()
 	assert.Equal(t, int32(2), diff.cacheVersion)
 	assert.ElementsMatch(t, []*ProcessEntity{}, diff.creation)
-	assert.ElementsMatch(t, []*ProcessEntity{}, diff.deletion)
+	assert.ElementsMatch(t, []*ProcessEntity{
+		{
+			Pid:          Pid1,
+			NsPid:        proc1.NsPid,
+			CreationTime: proc1.Stats.CreateTime,
+			Language:     &languagemodels.Language{Name: languagemodels.Java},
+		},
+	}, diff.deletion)
 
-	// Assert that old events are evicted from the cache and generate diff with deletion
+	// Process creation generates a cache update and diff event
 	extractor.Extract(map[int32]*procutil.Process{
 		Pid2: proc2,
 		Pid3: proc3,
@@ -110,12 +150,16 @@ func TestExtractor(t *testing.T) {
 	assert.Equal(t, int32(3), cacheVersion)
 	assert.Equal(t, map[string]*ProcessEntity{
 		hashProcess(Pid2, proc2.Stats.CreateTime): {
-			pid:      proc2.Pid,
-			language: &languagemodels.Language{Name: languagemodels.Python},
+			Pid:          proc2.Pid,
+			NsPid:        proc2.NsPid,
+			CreationTime: proc2.Stats.CreateTime,
+			Language:     &languagemodels.Language{Name: languagemodels.Python},
 		},
 		hashProcess(Pid3, proc3.Stats.CreateTime): {
-			pid:      proc3.Pid,
-			language: &languagemodels.Language{Name: languagemodels.Unknown},
+			Pid:          proc3.Pid,
+			NsPid:        proc3.NsPid,
+			CreationTime: proc3.Stats.CreateTime,
+			Language:     &languagemodels.Language{Name: languagemodels.Unknown},
 		},
 	}, procs)
 
@@ -123,14 +167,53 @@ func TestExtractor(t *testing.T) {
 	assert.Equal(t, int32(3), diff.cacheVersion)
 	assert.ElementsMatch(t, []*ProcessEntity{
 		{
-			pid:      Pid3,
-			language: &languagemodels.Language{Name: languagemodels.Unknown},
+			Pid:          Pid3,
+			NsPid:        proc3.NsPid,
+			CreationTime: proc3.Stats.CreateTime,
+			Language:     &languagemodels.Language{Name: languagemodels.Unknown},
+		},
+	}, diff.creation)
+	assert.ElementsMatch(t, []*ProcessEntity{}, diff.deletion)
+
+	// Process creation and deletion generate a cache update and diff event
+	extractor.Extract(map[int32]*procutil.Process{
+		Pid3: proc3,
+		Pid4: proc4,
+	})
+
+	procs, cacheVersion = extractor.GetAllProcessEntities()
+	assert.Equal(t, int32(4), cacheVersion)
+	assert.Equal(t, map[string]*ProcessEntity{
+		hashProcess(Pid3, proc3.Stats.CreateTime): {
+			Pid:          proc3.Pid,
+			NsPid:        proc3.NsPid,
+			CreationTime: proc3.Stats.CreateTime,
+			Language:     &languagemodels.Language{Name: languagemodels.Unknown},
+		},
+		hashProcess(Pid4, proc4.Stats.CreateTime): {
+			Pid:          proc4.Pid,
+			NsPid:        proc4.NsPid,
+			CreationTime: proc4.Stats.CreateTime,
+			Language:     &languagemodels.Language{Name: languagemodels.Python},
+		},
+	}, procs)
+
+	diff = <-extractor.ProcessCacheDiff()
+	assert.Equal(t, int32(4), diff.cacheVersion)
+	assert.ElementsMatch(t, []*ProcessEntity{
+		{
+			Pid:          Pid4,
+			NsPid:        proc4.NsPid,
+			CreationTime: proc4.Stats.CreateTime,
+			Language:     &languagemodels.Language{Name: languagemodels.Python},
 		},
 	}, diff.creation)
 	assert.ElementsMatch(t, []*ProcessEntity{
 		{
-			pid:      Pid1,
-			language: &languagemodels.Language{Name: languagemodels.Java},
+			Pid:          Pid2,
+			NsPid:        proc2.NsPid,
+			CreationTime: proc2.Stats.CreateTime,
+			Language:     &languagemodels.Language{Name: languagemodels.Python},
 		},
 	}, diff.deletion)
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds the following changes to the `WorkdloadMetaExtractor`:
* expose processes' NSPid and creation time
* do not update the internal cache nor generate a diff event when there's no process creation or deletion

### Motivation

We'd like to expose processes's NSPid and creation time in the workloadmeta running in the core agent. We'd also want to avoid unnecessary traffic between process-agent and core-agent if there's no process being created or deleted.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Enable the language detection feature in the process-agent and core-agent using the following settings in `datadog.yaml` file:

```yaml
process_config:
  process_collection: {enabled: true}
  language_detection: {enabled: true}

workloadmeta:
  remote_process_collector: {enabled: true}
```

Start the process-agent and core-agent. Run the following command against the core agent binary:
```
./agent workload-list
```

And make sure that processes are shown with their:
* pid
* namespaced pid
* creation time
* language (when available, e.g. for a python process)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
