### PR TITLE
Retry only failed tests

### DIFF
--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -218,10 +218,10 @@ kernel_matrix_testing_upload_deps_arm64:
     - MICRO_VM_NAME=$(cat $CI_PROJECT_DIR/stack.outputs | grep $ARCH-$TAG | cut -d ' ' -f 1)
     # ssh into each micro-vm and run initialization script. This script will also run the tests.
     - ssh -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP "ssh -o StrictHostKeyChecking=no -i /home/kernel-version-testing/ddvm_rsa root@${MICRO_VM_IP} 'bash /root/fetch_dependencies.sh ${ARCH} && /micro-vm-init.sh ${GO_VERSION} ${RETRY}'"
-    - ssh -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP "scp -o StrictHostKeyChecking=no -i /home/kernel-version-testing/ddvm_rsa root@${MICRO_VM_IP}:/ci-visibility/junit-*.tar.gz /home/ubuntu/"
-    - ssh -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP "scp -o StrictHostKeyChecking=no -i /home/kernel-version-testing/ddvm_rsa root@${MICRO_VM_IP}:/ci-visibility/testjson-*.tar.gz /home/ubuntu/"
-    - scp -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP:/home/ubuntu/testjson-*.tar.gz $DD_AGENT_TESTING_DIR/
-    - scp -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP:/home/ubuntu/junit-*.tar.gz $DD_AGENT_TESTING_DIR/
+    - ssh -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP "scp -o StrictHostKeyChecking=no -i /home/kernel-version-testing/ddvm_rsa root@${MICRO_VM_IP}:/ci-visibility/junit.tar.gz /home/ubuntu/junit.tar.gz"
+    - ssh -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP "scp -o StrictHostKeyChecking=no -i /home/kernel-version-testing/ddvm_rsa root@${MICRO_VM_IP}:/ci-visibility/testjson.tar.gz /home/ubuntu/testjson.tar.gz"
+    - scp -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP:/home/ubuntu/testjson.tar.gz $DD_AGENT_TESTING_DIR/
+    - scp -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP:/home/ubuntu/junit.tar.gz $DD_AGENT_TESTING_DIR/
     - ssh -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP "ssh -o StrictHostKeyChecking=no -i /home/kernel-version-testing/ddvm_rsa root@${MICRO_VM_IP} '/test-json-review'"
 
 kernel_matrix_testing_run_tests_x64:

--- a/test/new-e2e/scenarios/system-probe/main.go
+++ b/test/new-e2e/scenarios/system-probe/main.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !windows
+// +build !windows
+
 package main
 
 import (

--- a/test/new-e2e/system-probe/test-json-review/main.go
+++ b/test/new-e2e/system-probe/test-json-review/main.go
@@ -20,14 +20,14 @@ import (
 	"github.com/fatih/color"
 )
 
-const TestJSON = "/ci-visibility/testjson"
+const TestJSONOut = "/ci-visibility/testjson/out.json"
 
 func init() {
 	color.NoColor = false
 }
 
 func main() {
-	failedTests, err := reviewTests(TestJSON)
+	failedTests, err := reviewTests(TestJSONOut)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/new-e2e/system-probe/test-json-review/main.go
+++ b/test/new-e2e/system-probe/test-json-review/main.go
@@ -34,7 +34,7 @@ func main() {
 	if failedTests != "" {
 		fmt.Println(color.RedString(failedTests))
 	} else {
-		fmt.Println(color.GreenString("All test passed."))
+		fmt.Println(color.GreenString("All tests passed."))
 		return
 	}
 

--- a/test/new-e2e/system-probe/test-json-review/main.go
+++ b/test/new-e2e/system-probe/test-json-review/main.go
@@ -20,17 +20,10 @@ import (
 	"github.com/fatih/color"
 )
 
-const CIVisibility = "/ci-visibility"
 const TestJSON = "/ci-visibility/testjson"
 
 func init() {
 	color.NoColor = false
-}
-
-func printHeader(str string) {
-	magentaString := color.New(color.FgMagenta, color.Bold).Add(color.Underline)
-	fmt.Println()
-	magentaString.Println(str)
 }
 
 func main() {

--- a/test/new-e2e/system-probe/test-json-review/main.go
+++ b/test/new-e2e/system-probe/test-json-review/main.go
@@ -12,12 +12,8 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io/fs"
 	"log"
 	"os"
-	"path/filepath"
-	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -25,6 +21,7 @@ import (
 )
 
 const CIVisibility = "/ci-visibility"
+const TestJSON = "/ci-visibility/testjson"
 
 func init() {
 	color.NoColor = false
@@ -37,46 +34,15 @@ func printHeader(str string) {
 }
 
 func main() {
-	var matches []string
-	err := filepath.WalkDir(CIVisibility, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if !d.IsDir() {
-			return nil
-		}
-
-		present, err := regexp.Match("testjson-*", []byte(d.Name()))
-		if err != nil {
-			return fmt.Errorf("directory regex match: %s", err)
-		}
-
-		if !present {
-			return nil
-		}
-
-		matches = append(matches, path)
-
-		return nil
-	})
+	failedTests, err := reviewTests(TestJSON)
 	if err != nil {
 		log.Fatal(err)
 	}
-	sort.Strings(matches)
-
-	for i, testjson := range matches {
-		printHeader(fmt.Sprintf("Reviewing attempt %d", i+1))
-		failedTests, err := reviewTests(filepath.Join(testjson, "out.json"))
-		if err != nil {
-			log.Fatal(err)
-		}
-		if len(failedTests) > 0 {
-			fmt.Println(color.RedString(failedTests))
-		} else {
-			fmt.Println(color.GreenString(fmt.Sprintf("All tests cleared in attempt %d", i+1)))
-			return
-		}
+	if failedTests != "" {
+		fmt.Println(color.RedString(failedTests))
+	} else {
+		fmt.Println(color.GreenString("All test passed."))
+		return
 	}
 
 	// We want to make sure the exit code is correctly set to
@@ -93,6 +59,10 @@ type testEvent struct {
 	Output  string
 }
 
+func testKey(test, pkg string) string {
+	return fmt.Sprintf("%s/%s", test, pkg)
+}
+
 func reviewTests(jsonFile string) (string, error) {
 	var failedTests strings.Builder
 	jf, err := os.Open(jsonFile)
@@ -101,18 +71,38 @@ func reviewTests(jsonFile string) (string, error) {
 	}
 
 	scanner := bufio.NewScanner(jf)
+	testResults := make(map[string]testEvent)
 	for scanner.Scan() {
 		var ev testEvent
 		data := scanner.Bytes()
 		if err := json.Unmarshal(data, &ev); err != nil {
 			return "", fmt.Errorf("json unmarshal `%s`: %s", string(data), err)
 		}
-		if ev.Action == "fail" && ev.Test != "" {
-			failedTests.WriteString(fmt.Sprintf("FAIL: %s %s\n", ev.Package, ev.Test))
+		if ev.Test == "" {
+			continue
+		}
+		if res, ok := testResults[testKey(ev.Test, ev.Package)]; ok {
+			// If the test is already recorded as passed, it means the test
+			// eventually succeeded.
+			if res.Action == "pass" {
+				continue
+			}
+			if res.Action == "fail" && ev.Action == "pass" {
+				testResults[testKey(ev.Test, ev.Package)] = ev
+			}
+		} else {
+			testResults[testKey(ev.Test, ev.Package)] = ev
 		}
 	}
 	if err := scanner.Err(); err != nil {
 		return "", fmt.Errorf("json line scan: %s", err)
 	}
+
+	for _, ev := range testResults {
+		if ev.Action == "fail" {
+			failedTests.WriteString(fmt.Sprintf("FAIL: %s %s\n", ev.Package, ev.Test))
+		}
+	}
+
 	return failedTests.String(), nil
 }

--- a/test/new-e2e/system-probe/test-json-review/main.go
+++ b/test/new-e2e/system-probe/test-json-review/main.go
@@ -62,6 +62,7 @@ func reviewTests(jsonFile string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("open %s: %s", jsonFile, err)
 	}
+	defer jf.Close()
 
 	scanner := bufio.NewScanner(jf)
 	testResults := make(map[string]testEvent)

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -115,10 +115,10 @@ func pathToPackage(path string) string {
 	return dir
 }
 
-func testsToRunArg(pkg string, failedTests map[string][]string) string {
+func testsToRunArg(pkg string, failedTests map[string][]string) (string, int) {
 	var subTests []string
 	if _, ok := failedTests[pkg]; !ok {
-		return ""
+		return "", 0
 	}
 
 	testLs := failedTests[pkg]
@@ -139,7 +139,7 @@ func testsToRunArg(pkg string, failedTests map[string][]string) string {
 		}
 	}
 
-	return fmt.Sprintf("-test.run=%s", strings.Join(subTests, ","))
+	return fmt.Sprintf("-test.run=%s", strings.Join(subTests, ",")), len(subTests)
 }
 
 func buildCommandArgs(junitPath string, jsonPath string, file string, failedTests map[string][]string) []string {
@@ -154,7 +154,10 @@ func buildCommandArgs(junitPath string, jsonPath string, file string, failedTest
 		fmt.Sprintf("%s.json", junitfilePrefix),
 	)
 
-	rerun := testsToRunArg(pathToPackage(file), failedTests)
+	rerun, cnt := testsToRunArg(pathToPackage(file), failedTests)
+	if cnt != 0 {
+		fmt.Println(color.YellowString("Rerunning %d failed tests [%s]", cnt, rerun))
+	}
 	args := []string{
 		"--format", "dots",
 		"--junitfile", xmlpath,

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -115,10 +115,10 @@ func pathToPackage(path string) string {
 	return dir
 }
 
-func testsToRunArg(pkg string, failedTests map[string][]string) (string, int) {
+func testsToRunArg(pkg string, failedTests map[string][]string) string {
 	var subTests []string
 	if _, ok := failedTests[pkg]; !ok {
-		return "", 0
+		return ""
 	}
 
 	testLs := failedTests[pkg]
@@ -139,7 +139,10 @@ func testsToRunArg(pkg string, failedTests map[string][]string) (string, int) {
 		}
 	}
 
-	return fmt.Sprintf("-test.run=%s", strings.Join(subTests, ",")), len(subTests)
+	commaSeperatedLs := strings.Join(subTests, ",")
+	fmt.Println(color.YellowString("Rerunning %d failed tests [%s]", len(subTests), commaSeperatedLs))
+
+	return fmt.Sprintf("-test.run=%s", commaSeperatedLs)
 }
 
 func buildCommandArgs(junitPath string, jsonPath string, file string, failedTests map[string][]string) []string {
@@ -154,10 +157,7 @@ func buildCommandArgs(junitPath string, jsonPath string, file string, failedTest
 		fmt.Sprintf("%s.json", junitfilePrefix),
 	)
 
-	rerun, cnt := testsToRunArg(pathToPackage(file), failedTests)
-	if cnt != 0 {
-		fmt.Println(color.YellowString("Rerunning %d failed tests [%s]", cnt, rerun))
-	}
+	rerun := testsToRunArg(pathToPackage(file), failedTests)
 	args := []string{
 		"--format", "dots",
 		"--junitfile", xmlpath,

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -237,8 +237,7 @@ func buildRetryList(attempt int) (map[string][]string, error) {
 			if _, ok := retry[ev.Package]; !ok {
 				retry[ev.Package] = []string{ev.Test}
 			} else {
-				testLs := retry[ev.Package]
-				testLs = append(testLs, ev.Test)
+				retry[ev.Package] = append(retry[ev.Package], ev.Test)
 			}
 		}
 	}

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -110,6 +110,11 @@ func generatePackageName(file string) string {
 	return pkg
 }
 
+func pathToPackage(path string) string {
+	dir, _ := filepath.Rel(TestDirRoot, filepath.Dir(path))
+	return dir
+}
+
 func testsToRunArg(pkg string, failedTests map[string][]string) string {
 	if _, ok := failedTests[pkg]; !ok {
 		return ""
@@ -131,7 +136,7 @@ func buildCommandArgs(junitPath string, jsonPath string, file string, failedTest
 		fmt.Sprintf("%s.json", junitfilePrefix),
 	)
 
-	rerun := testsToRunArg(file, failedTests)
+	rerun := testsToRunArg(pathToPackage(file), failedTests)
 	args := []string{
 		"--format", "dots",
 		"--junitfile", xmlpath,
@@ -260,9 +265,8 @@ func testPass(testConfig *TestConfig, attempt int) (bool, error) {
 		}
 	}
 
-	fmt.Println(retryLs)
 	matches, err := glob(TestDirRoot, Testsuite, func(path string) bool {
-		dir, _ := filepath.Rel(TestDirRoot, filepath.Dir(path))
+		dir := pathToPackage(path)
 		if testConfig.retryOnlyFailedTests {
 			for pkg := range retryLs {
 				if dir == pkg {

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -116,12 +116,30 @@ func pathToPackage(path string) string {
 }
 
 func testsToRunArg(pkg string, failedTests map[string][]string) string {
+	var subTests []string
 	if _, ok := failedTests[pkg]; !ok {
 		return ""
 	}
 
 	testLs := failedTests[pkg]
-	return fmt.Sprintf("-test.run=%s", strings.Join(testLs, ","))
+	// We only want to run the subtests which actually failed.
+	for _, test := range testLs {
+		hasSubtest := false
+		for _, t := range testLs {
+			if test == t {
+				continue
+			}
+			if strings.HasPrefix(t, test) {
+				hasSubtest = true
+				break
+			}
+		}
+		if !hasSubtest {
+			subTests = append(subTests, test)
+		}
+	}
+
+	return fmt.Sprintf("-test.run=%s", strings.Join(subTests, ","))
 }
 
 func buildCommandArgs(junitPath string, jsonPath string, file string, failedTests map[string][]string) []string {

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -264,7 +264,7 @@ func testPass(testConfig *TestConfig, attempt int) (bool, error) {
 	matches, err := glob(TestDirRoot, Testsuite, func(path string) bool {
 		dir, _ := filepath.Rel(TestDirRoot, filepath.Dir(path))
 		if testConfig.retryOnlyFailedTests {
-			for pkg, _ := range retryLs {
+			for pkg := range retryLs {
 				if dir == pkg {
 					return true
 				}

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -111,36 +111,6 @@ func pathToPackage(path string) string {
 	return dir
 }
 
-func testsToRunArg(pkg string, failedTests map[string][]string) string {
-	var subTests []string
-	if _, ok := failedTests[pkg]; !ok {
-		return ""
-	}
-
-	testLs := failedTests[pkg]
-	// We only want to run the subtests which actually failed.
-	for _, test := range testLs {
-		hasSubtest := false
-		for _, t := range testLs {
-			if test == t {
-				continue
-			}
-			if strings.HasPrefix(t, test) {
-				hasSubtest = true
-				break
-			}
-		}
-		if !hasSubtest {
-			subTests = append(subTests, test)
-		}
-	}
-
-	commaSeperatedLs := strings.Join(subTests, ",")
-	fmt.Println(color.YellowString("Rerunning %d failed tests [%s]", len(subTests), commaSeperatedLs))
-
-	return fmt.Sprintf("-test.run=%s", commaSeperatedLs)
-}
-
 func buildCommandArgs(junitPath string, jsonPath string, file string, retryCnt int) []string {
 	pkg := generatePackageName(file)
 	junitfilePrefix := strings.ReplaceAll(pkg, "/", "-")
@@ -230,8 +200,6 @@ func buildCIVisibilityDirs() error {
 }
 
 func testPass(testConfig *TestConfig) error {
-	var err error
-
 	matches, err := glob(TestDirRoot, Testsuite, func(path string) bool {
 		dir := pathToPackage(path)
 		for _, p := range testConfig.excludePackages {

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -128,6 +128,7 @@ func buildCommandArgs(junitPath string, jsonPath string, file string, retryCnt i
 		"--junitfile", xmlpath,
 		"--jsonfile", jsonpath,
 		fmt.Sprintf("--rerun-fails=%d", retryCnt),
+		"--rerun-fails-max-failures=100",
 		"--raw-command", "--",
 		"/go/bin/test2json", "-t", "-p", pkg, file, "-test.v", "-test.count=1", "-test.timeout=" + getTimeout(pkg).String(),
 	}
@@ -308,7 +309,6 @@ func run() error {
 	var uname unix.Utsname
 
 	testConfig := buildTestConfiguration()
-
 	if err := unix.Uname(&uname); err != nil {
 		return fmt.Errorf("error calling uname: %w", err)
 	}

--- a/test/new-e2e/system-probe/test/micro-vm-init.sh
+++ b/test/new-e2e/system-probe/test/micro-vm-init.sh
@@ -23,7 +23,8 @@ rm -rf /ci-visibility
 CODE=0
 /test-runner -retry $RETRY_COUNT || CODE=$?
 
-find /ci-visibility -maxdepth 1 -type d -name testjson-* -exec tar czvf {}-$IP.tar.gz {} \;
-find /ci-visibility -maxdepth 1 -type d -name junit-* -exec tar czvf {}-$IP.tar.gz {} \;
+pushd /ci-visibility
+tar czvf testjson.tar.gz testjson
+tar czvf junit.tar.gz junit
 
 exit $CODE

--- a/test/new-e2e/system-probe/test/micro-vm-init.sh
+++ b/test/new-e2e/system-probe/test/micro-vm-init.sh
@@ -21,7 +21,7 @@ IP=$(ip route get 8.8.8.8 | grep -Po '(?<=(src ))(\S+)')
 rm -rf /ci-visibility
 
 CODE=0
-/test-runner -retry $RETRY_COUNT || CODE=$?
+/test-runner -retry-only-failed -retry $RETRY_COUNT || CODE=$?
 
 find /ci-visibility -maxdepth 1 -type d -name testjson-* -exec tar czvf {}-$IP.tar.gz {} \;
 find /ci-visibility -maxdepth 1 -type d -name junit-* -exec tar czvf {}-$IP.tar.gz {} \;

--- a/test/new-e2e/system-probe/test/micro-vm-init.sh
+++ b/test/new-e2e/system-probe/test/micro-vm-init.sh
@@ -21,7 +21,7 @@ IP=$(ip route get 8.8.8.8 | grep -Po '(?<=(src ))(\S+)')
 rm -rf /ci-visibility
 
 CODE=0
-/test-runner -retry-only-failed -retry $RETRY_COUNT || CODE=$?
+/test-runner -retry $RETRY_COUNT || CODE=$?
 
 find /ci-visibility -maxdepth 1 -type d -name testjson-* -exec tar czvf {}-$IP.tar.gz {} \;
 find /ci-visibility -maxdepth 1 -type d -name junit-* -exec tar czvf {}-$IP.tar.gz {} \;


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR adds support to only retry failed tests with the kernel matrix testing system.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
