### PR TITLE
upgrade(remote-config): Disable Remote Config for FED customers

### DIFF
--- a/cmd/agent/subcommands/remoteconfig/command.go
+++ b/cmd/agent/subcommands/remoteconfig/command.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
+	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	agentgrpc "github.com/DataDog/datadog-agent/pkg/util/grpc"
@@ -54,7 +55,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 }
 
 func state(cliParams *cliParams, config config.Component) error {
-	if !config.GetBool("remote_configuration.enabled") {
+	if !pkgconfig.IsRemoteConfigEnabled(config) {
 		return fmt.Errorf("Remote configuration is not enabled")
 	}
 	fmt.Println("Fetching the configuration and director repos state..")

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -392,7 +392,7 @@ func startAgent(
 
 	// start remote configuration management
 	var configService *remoteconfig.Service
-	if pkgconfig.IsRemoteConfigEnabled() {
+	if pkgconfig.IsRemoteConfigEnabled(pkgconfig.Datadog) {
 		configService, err = remoteconfig.NewService()
 		if err != nil {
 			log.Errorf("Failed to initialize config management service: %s", err)

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -392,7 +392,7 @@ func startAgent(
 
 	// start remote configuration management
 	var configService *remoteconfig.Service
-	if pkgconfig.Datadog.GetBool("remote_configuration.enabled") {
+	if pkgconfig.IsRemoteConfigEnabled() {
 		configService, err = remoteconfig.NewService()
 		if err != nil {
 			log.Errorf("Failed to initialize config management service: %s", err)

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -150,7 +150,7 @@ func start(log log.Component, config config.Component, forwarder defaultforwarde
 
 	// Initialize remote configuration
 	var rcClient *remote.Client
-	if pkgconfig.IsRemoteConfigEnabled() {
+	if pkgconfig.IsRemoteConfigEnabled(pkgconfig.Datadog) {
 		var err error
 		rcClient, err = initializeRemoteConfig(mainCtx)
 		if err != nil {

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -150,7 +150,7 @@ func start(log log.Component, config config.Component, forwarder defaultforwarde
 
 	// Initialize remote configuration
 	var rcClient *remote.Client
-	if pkgconfig.Datadog.GetBool("remote_configuration.enabled") {
+	if pkgconfig.IsRemoteConfigEnabled() {
 		var err error
 		rcClient, err = initializeRemoteConfig(mainCtx)
 		if err != nil {

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -87,7 +87,7 @@ func prepareConfig(path string) (*config.AgentConfig, error) {
 		cfg.Proxy = httputils.GetProxyTransportFunc(p)
 	}
 	cfg.ConfigPath = path
-	if coreconfig.IsRemoteConfigEnabled() && coreconfig.Datadog.GetBool("remote_configuration.apm_sampling.enabled") {
+	if coreconfig.IsRemoteConfigEnabled(coreconfig.Datadog) && coreconfig.Datadog.GetBool("remote_configuration.apm_sampling.enabled") {
 		client, err := remote.NewGRPCClient(
 			rcClientName,
 			version.AgentVersion,

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -87,7 +87,7 @@ func prepareConfig(path string) (*config.AgentConfig, error) {
 		cfg.Proxy = httputils.GetProxyTransportFunc(p)
 	}
 	cfg.ConfigPath = path
-	if coreconfig.Datadog.GetBool("remote_configuration.enabled") && coreconfig.Datadog.GetBool("remote_configuration.apm_sampling.enabled") {
+	if coreconfig.IsRemoteConfigEnabled() && coreconfig.Datadog.GetBool("remote_configuration.apm_sampling.enabled") {
 		client, err := remote.NewGRPCClient(
 			rcClientName,
 			version.AgentVersion,

--- a/cmd/trace-agent/run.go
+++ b/cmd/trace-agent/run.go
@@ -194,7 +194,7 @@ func Run(ctx context.Context) {
 		}
 	}()
 
-	if coreconfig.IsRemoteConfigEnabled() {
+	if coreconfig.IsRemoteConfigEnabled(coreconfig.Datadog) {
 		// Auth tokens are handled by the rcClient
 		rcClient, err := rc.NewAgentGRPCConfigFetcher()
 		if err != nil {

--- a/cmd/trace-agent/run.go
+++ b/cmd/trace-agent/run.go
@@ -194,7 +194,7 @@ func Run(ctx context.Context) {
 		}
 	}()
 
-	if coreconfig.Datadog.GetBool("remote_configuration.enabled") {
+	if coreconfig.IsRemoteConfigEnabled() {
 		// Auth tokens are handled by the rcClient
 		rcClient, err := rc.NewAgentGRPCConfigFetcher()
 		if err != nil {

--- a/pkg/clusteragent/admission/patch/provider.go
+++ b/pkg/clusteragent/admission/patch/provider.go
@@ -21,7 +21,7 @@ type patchProvider interface {
 }
 
 func newPatchProvider(rcClient *remote.Client, isLeaderNotif <-chan struct{}, telemetryCollector telemetry.TelemetryCollector, clusterName string) (patchProvider, error) {
-	if config.Datadog.GetBool("remote_configuration.enabled") {
+	if config.IsRemoteConfigEnabled() {
 		return newRemoteConfigProvider(rcClient, isLeaderNotif, telemetryCollector, clusterName)
 	}
 	if config.Datadog.GetBool("admission_controller.auto_instrumentation.patcher.fallback_to_file_provider") {

--- a/pkg/clusteragent/admission/patch/provider.go
+++ b/pkg/clusteragent/admission/patch/provider.go
@@ -21,7 +21,7 @@ type patchProvider interface {
 }
 
 func newPatchProvider(rcClient *remote.Client, isLeaderNotif <-chan struct{}, telemetryCollector telemetry.TelemetryCollector, clusterName string) (patchProvider, error) {
-	if config.IsRemoteConfigEnabled() {
+	if config.IsRemoteConfigEnabled(config.Datadog) {
 		return newRemoteConfigProvider(rcClient, isLeaderNotif, telemetryCollector, clusterName)
 	}
 	if config.Datadog.GetBool("admission_controller.auto_instrumentation.patcher.fallback_to_file_provider") {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2077,3 +2077,12 @@ func GetTraceAgentDefaultEnv() string {
 
 	return defaultEnv
 }
+
+// IsRemoteConfigEnabled returns true if Remote Configuration should be enabled
+func IsRemoteConfigEnabled() bool {
+	// Disable Remote Config for GovCloud
+	if Datadog.GetBool("fips.enabled") || Datadog.GetString("site") == "ddog-gov.com" {
+		return false
+	}
+	return Datadog.GetBool("remote_configuration.enabled")
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2079,10 +2079,10 @@ func GetTraceAgentDefaultEnv() string {
 }
 
 // IsRemoteConfigEnabled returns true if Remote Configuration should be enabled
-func IsRemoteConfigEnabled() bool {
+func IsRemoteConfigEnabled(cfg ConfigReader) bool {
 	// Disable Remote Config for GovCloud
-	if Datadog.GetBool("fips.enabled") || Datadog.GetString("site") == "ddog-gov.com" {
+	if cfg.GetBool("fips.enabled") || cfg.GetString("site") == "ddog-gov.com" {
 		return false
 	}
-	return Datadog.GetBool("remote_configuration.enabled")
+	return cfg.GetBool("remote_configuration.enabled")
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -957,3 +957,18 @@ func TestComputeStatsBySpanKindEnv(t *testing.T) {
 	testConfig = SetupConfFromYAML("")
 	require.True(t, testConfig.GetBool("apm_config.compute_stats_by_span_kind"))
 }
+
+func TestIsRemoteConfigEnabled(t *testing.T) {
+	t.Setenv("DD_REMOTE_CONFIGURATION_ENABLED", "true")
+	testConfig := SetupConfFromYAML("")
+	require.True(t, IsRemoteConfigEnabled(testConfig))
+
+	t.Setenv("DD_FIPS_ENABLED", "true")
+	testConfig = SetupConfFromYAML("")
+	require.False(t, IsRemoteConfigEnabled(testConfig))
+
+	t.Setenv("DD_FIPS_ENABLED", "false")
+	t.Setenv("DD_SITE", "ddog-gov.com")
+	testConfig = SetupConfFromYAML("")
+	require.False(t, IsRemoteConfigEnabled(testConfig))
+}

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -112,7 +112,7 @@ func CompleteFlare(fb flarehelpers.FlareBuilder) error {
 		fb.AddFileFromFunc("telemetry.log", func() ([]byte, error) { return getHTTPCallContent(telemetryURL) })
 	}
 
-	if config.Datadog.GetBool("remote_configuration.enabled") {
+	if config.IsRemoteConfigEnabled() {
 		if err := exportRemoteConfig(fb); err != nil {
 			log.Errorf("Could not export remote-config state: %s", err)
 		}

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -112,7 +112,7 @@ func CompleteFlare(fb flarehelpers.FlareBuilder) error {
 		fb.AddFileFromFunc("telemetry.log", func() ([]byte, error) { return getHTTPCallContent(telemetryURL) })
 	}
 
-	if config.IsRemoteConfigEnabled() {
+	if config.IsRemoteConfigEnabled(config.Datadog) {
 		if err := exportRemoteConfig(fb); err != nil {
 			log.Errorf("Could not export remote-config state: %s", err)
 		}


### PR DESCRIPTION
### What does this PR do?
- Centralises Remote Configuration enablement check
- Disables Remote Configuration for FED customers as Remote Config isn't supported for them

### Motivation
[RCM-1079]

### Additional Notes
- This is prep work to enable Remote Config by default. Nothing will change functionally, Remote Configuration isn't enabled by default and isn't supported for FED customers. This PR just enforces that so such customers don't feel threatened when RC gets enabled by default.
- This won't cover all FED customers as some may be using proxies. We will update documentation accordingly before enabling Remote Configuration by default

### Possible Drawbacks / Trade-offs
Enabling Remote Configuration for FED customers will require another agent change in the future

### Describe how to test/QA your changes
Try to enable FIPS while enabling RC and see that RC is actually disabled in the agent

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.


[RCM-1079]: https://datadoghq.atlassian.net/browse/RCM-1079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ