### PR TITLE
Refactor `connection_protocol` data expiration

### DIFF
--- a/pkg/network/ebpf/c/port_range.h
+++ b/pkg/network/ebpf/c/port_range.h
@@ -14,9 +14,10 @@ static __always_inline int is_ephemeral_port(u16 port) {
 
 // ensure that the given tuple is in the (src: client, dst: server) format based
 // on the port range heuristic
-static __always_inline void normalize_tuple(conn_tuple_t *t) {
+// The return value is true when the tuple is modified (flipped) or false otherwise.
+static __always_inline bool normalize_tuple(conn_tuple_t *t) {
     if (is_ephemeral_port(t->sport) && !is_ephemeral_port(t->dport)) {
-        return;
+        return false;
     }
 
     if ((!is_ephemeral_port(t->sport) && is_ephemeral_port(t->dport)) || t->dport > t->sport) {
@@ -25,7 +26,10 @@ static __always_inline void normalize_tuple(conn_tuple_t *t) {
         // 2) unlikely: if both ports are in the same range we ensure that sport > dport to make
         // this function return a deterministic result for a given pair of ports;
         flip_tuple(t);
+        return true;
     }
+
+    return false;
 }
 
 #endif

--- a/pkg/network/ebpf/c/protocols/classification/defs.h
+++ b/pkg/network/ebpf/c/protocols/classification/defs.h
@@ -29,7 +29,11 @@
 #define LAYER_APPLICATION_MAX (LAYER_APPLICATION_BIT + MAX_ENTRIES_PER_LAYER)
 #define LAYER_ENCRYPTION_MAX  (LAYER_ENCRYPTION_BIT + MAX_ENTRIES_PER_LAYER)
 
-#define FLAG_FULLY_CLASSIFIED 1
+#define FLAG_FULLY_CLASSIFIED       1 << 0
+#define FLAG_USM_ENABLED            1 << 1
+#define FLAG_NPM_ENABLED            1 << 2
+#define FLAG_TCP_CLOSE_DELETION     1 << 3
+#define FLAG_SOCKET_FILTER_DELETION 1 << 4
 
 // The enum below represents all different protocols we're able to
 // classify. Entries are segmented such that it is possible to infer the

--- a/pkg/network/ebpf/c/protocols/classification/dispatcher-helpers.h
+++ b/pkg/network/ebpf/c/protocols/classification/dispatcher-helpers.h
@@ -78,6 +78,14 @@ static __always_inline void classify_protocol_for_dispatcher(protocol_t *protoco
     log_debug("[protocol_dispatcher_classifier]: Classified protocol as %d %d; %s\n", *protocol, size, buf);
 }
 
+static __always_inline void dispatcher_delete_protocol_stack(conn_tuple_t *tuple, protocol_stack_t *stack) {
+        bool flipped = normalize_tuple(tuple);
+        delete_protocol_stack(tuple, stack, FLAG_SOCKET_FILTER_DELETION);
+        if (flipped) {
+            flip_tuple(tuple);
+        }
+}
+
 // A shared implementation for the runtime & prebuilt socket filter that classifies & dispatches the protocols of the connections.
 static __always_inline void protocol_dispatcher_entrypoint(struct __sk_buff *skb) {
     skb_info_t skb_info = {0};
@@ -88,8 +96,9 @@ static __always_inline void protocol_dispatcher_entrypoint(struct __sk_buff *skb
         return;
     }
 
+    bool tcp_termination = is_tcp_termination(&skb_info);
     // We don't process non tcp packets, nor empty tcp packets which are not tcp termination packets, nor ACK only packets.
-    if (!is_tcp(&skb_tup) || is_tcp_ack(&skb_info) || (is_payload_empty(skb, &skb_info) && !is_tcp_termination(&skb_info))) {
+    if (!is_tcp(&skb_tup) || is_tcp_ack(&skb_info) || (is_payload_empty(skb, &skb_info) && !tcp_termination)) {
         return;
     }
 
@@ -104,9 +113,20 @@ static __always_inline void protocol_dispatcher_entrypoint(struct __sk_buff *skb
         // should never happen, but it is required by the eBPF verifier
         return;
     }
+
+    // This is used to signal the tracer program that this protocol stack
+    // is also shared with our USM program for the purposes of deletion.
+    // For more context refer to the comments in `delete_protocol_stack`
+    stack->flags |= FLAG_USM_ENABLED;
+
     // TODO: consider adding early return if `is_layer_known(stack, LAYER_ENCRYPTION)`
 
     protocol_t cur_fragment_protocol = get_protocol_from_stack(stack, LAYER_APPLICATION);
+    if (tcp_termination) {
+        dispatcher_delete_protocol_stack(&skb_tup, stack);
+        stack = NULL;
+    }
+
     if (cur_fragment_protocol == PROTOCOL_UNKNOWN) {
         log_debug("[protocol_dispatcher_entrypoint]: %p was not classified\n", skb);
         char request_fragment[CLASSIFICATION_MAX_BUFFER];

--- a/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
+++ b/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
@@ -35,4 +35,67 @@ __maybe_unused static __always_inline void update_protocol_stack(conn_tuple_t* s
     set_protocol(stack, cur_fragment_protocol);
 }
 
+__maybe_unused static __always_inline void delete_protocol_stack(conn_tuple_t* normalized_tuple, protocol_stack_t *stack, u8 deletion_flag) {
+    if (!normalized_tuple) {
+        return;
+    }
+
+    if (!stack) {
+        stack = bpf_map_lookup_elem(&connection_protocol, normalized_tuple);
+        if (!stack) {
+            return;
+        }
+    }
+
+    if (!(stack->flags&FLAG_USM_ENABLED) || !(stack->flags&FLAG_NPM_ENABLED)) {
+        // If either USM is disabled or NPM is disabled, we cant move rightaway
+        // to the deletion code since there is no chance of race between the two
+        // programs.
+        //
+        // There are two expectected scenarios where just one of the two programs
+        // is enabled:
+        //
+        // 1) When one of the programs is disabled by choice (via configuration);
+        //
+        // 2) During system-probe startup: when system-probe is initializing
+        // there is a short time window where the socket filter programs runs
+        // alone *before* the `tcp_close` probe is activated. In a host with a
+        // network-heavy workload this could easily result in thousands of
+        // leaked entries.
+        goto deletion;
+    }
+
+    // Otherwise we mark the protocol stack with the deletion flag
+    //
+    // In order to proceed with the deletion both the `tcp_close` probe and the
+    // socket filter program must have reached this codepath, to ensure that
+    // data is not prematurely deleted and both programs are able to handle the
+    // termination path.
+    //
+    // Given that we're not using an atomic operation below, in the unlikely
+    // event that tcp_close and the socket filter processing the FIN packet
+    // execute at the same time, there is a chance that none of the callers
+    // of this function will ever see both flags set.
+    // We assume this is rare and OK since we're using an LRU map which will
+    // eventually evict the leaked entry if it ever reaches capacity.
+    //
+    // Note that we could instead have a reference count field and increment it
+    // attomically using the __sync_fetch_and_add builtin, which produces a
+    // BPF_ATOMIC_ADD instruction. The problem is that this instruction requires
+    // a 64-bit operand that would increase the size of of `protocol_stack_t` by
+    // 3x. Since each `connection_tuple_t` embeds a `protocol_stack_t` that will
+    // bloat the eBPF stack size for some of the tracer programs.
+    //
+    // In any case, even if we were using atomic operations, there is still a
+    // chance of leak we can't avoid in the context of kprobe misses, so it's ok
+    // to rely on the LRU in those cases.
+    stack->flags |= deletion_flag;
+    if (!(stack->flags&FLAG_TCP_CLOSE_DELETION) ||
+        !(stack->flags&FLAG_SOCKET_FILTER_DELETION)) {
+        return;
+    }
+ deletion:
+    bpf_map_delete_elem(&connection_protocol, normalized_tuple);
+}
+
 #endif

--- a/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
+++ b/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
@@ -48,11 +48,11 @@ __maybe_unused static __always_inline void delete_protocol_stack(conn_tuple_t* n
     }
 
     if (!(stack->flags&FLAG_USM_ENABLED) || !(stack->flags&FLAG_NPM_ENABLED)) {
-        // If either USM is disabled or NPM is disabled, we cant move rightaway
+        // If either USM is disabled or NPM is disabled, we can move right away
         // to the deletion code since there is no chance of race between the two
         // programs.
         //
-        // There are two expectected scenarios where just one of the two programs
+        // There are two expected scenarios where just one of the two programs
         // is enabled:
         //
         // 1) When one of the programs is disabled by choice (via configuration);

--- a/pkg/network/ebpf/c/protocols/classification/stack-helpers.h
+++ b/pkg/network/ebpf/c/protocols/classification/stack-helpers.h
@@ -144,4 +144,12 @@ static __always_inline void merge_protocol_stacks(protocol_stack_t *this, protoc
     this->flags |= that->flags;
 }
 
+static __always_inline void set_protocol_flag(protocol_stack_t *stack, u8 flag) {
+    if (!stack) {
+        return;
+    }
+
+    stack->flags |= flag;
+}
+
 #endif

--- a/pkg/network/ebpf/c/tracer/events.h
+++ b/pkg/network/ebpf/c/tracer/events.h
@@ -22,7 +22,7 @@ static __always_inline void clean_protocol_classification(conn_tuple_t *tup) {
     conn_tuple.pid = 0;
     conn_tuple.netns = 0;
     normalize_tuple(&conn_tuple);
-    bpf_map_delete_elem(&connection_protocol, &conn_tuple);
+    delete_protocol_stack(&conn_tuple, NULL, FLAG_TCP_CLOSE_DELETION);
 
     conn_tuple_t *skb_tup_ptr = bpf_map_lookup_elem(&conn_tuple_to_socket_skb_conn_tuple, &conn_tuple);
     if (skb_tup_ptr == NULL) {
@@ -30,7 +30,7 @@ static __always_inline void clean_protocol_classification(conn_tuple_t *tup) {
     }
 
     conn_tuple_t skb_tup = *skb_tup_ptr;
-    bpf_map_delete_elem(&connection_protocol, &skb_tup);
+    delete_protocol_stack(&skb_tup, NULL, FLAG_TCP_CLOSE_DELETION);
     bpf_map_delete_elem(&conn_tuple_to_socket_skb_conn_tuple, &conn_tuple);
 }
 

--- a/pkg/network/ebpf/c/tracer/stats.h
+++ b/pkg/network/ebpf/c/tracer/stats.h
@@ -70,6 +70,7 @@ static __always_inline void update_protocol_classification_information(conn_tupl
     normalize_tuple(&conn_tuple_copy);
 
     protocol_stack_t *protocol_stack = bpf_map_lookup_elem(&connection_protocol, &conn_tuple_copy);
+    set_protocol_flag(protocol_stack, FLAG_NPM_ENABLED);
     merge_protocol_stacks(&stats->protocol_stack, protocol_stack);
 
     conn_tuple_t *cached_skb_conn_tup_ptr = bpf_map_lookup_elem(&conn_tuple_to_socket_skb_conn_tuple, &conn_tuple_copy);
@@ -79,6 +80,7 @@ static __always_inline void update_protocol_classification_information(conn_tupl
 
     conn_tuple_copy = *cached_skb_conn_tup_ptr;
     protocol_stack = bpf_map_lookup_elem(&connection_protocol, &conn_tuple_copy);
+    set_protocol_flag(protocol_stack, FLAG_NPM_ENABLED);
     merge_protocol_stacks(&stats->protocol_stack, protocol_stack);
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Improves how data is deleted from the `connection_protocol` in order to prevent entries from leaking;

Note that this is complementary to the PR https://github.com/DataDog/datadog-agent/pull/17839. By using an LRU map we ensure that we won't ever reach a situation where we're unable to insert new entries because we have reached capacity, but the present PR should address the underlying root cause

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Some of the possible leak scenarios I have considered and tried to address:

* If NPM is not running but USM is, we should ensure that entries are still deleted (this happens either when a customer disable NPM on purpose, but also happens during a short time window during system-probe initialization);
* If  the `tcp_close` kprobe is executed _after_ the socket filter program executes this would also cause a leak. In this PR I'm deliberately avoiding any assumptions about the ordering of execution between the different programs;

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
