### PR TITLE
Bump gcc version to 10.4.0 to build python dependencies

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -49,6 +49,11 @@ whitelist_file "embedded/lib/python3.9/site-packages/pymqi"
 
 source git: 'https://github.com/DataDog/integrations-core.git'
 
+gcc_version = ENV['GCC_VERSION']
+if gcc_version.nil? || gcc_version.empty?
+  gcc_version = '10.4.0'
+end
+
 integrations_core_version = ENV['INTEGRATIONS_CORE_VERSION']
 if integrations_core_version.nil? || integrations_core_version.empty?
   integrations_core_version = 'master'
@@ -161,8 +166,8 @@ build do
       "PIP_CONFIG_FILE" => "#{pip_config_file}",
       # Specify C99 standard explicitly to avoid issues while building some
       # wheels (eg. ddtrace)
-      "CC" => "/opt/gcc-10.4.0/bin/gcc",
-      "CXX" => "/opt/gcc-10.4.0/bin/g++",
+      "CC" => "/opt/gcc-#{gcc_version}/bin/gcc",
+      "CXX" => "/opt/gcc-#{gcc_version}/bin/g++",
       "CFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
       "CXXFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
       "LDFLAGS" => "-L#{install_dir}/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib",

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -161,6 +161,8 @@ build do
       "PIP_CONFIG_FILE" => "#{pip_config_file}",
       # Specify C99 standard explicitly to avoid issues while building some
       # wheels (eg. ddtrace)
+      "CC" => "/opt/gcc-10.4.0/bin/gcc",
+      "CXX" => "/opt/gcc-10.4.0/bin/g++",
       "CFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
       "CXXFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
       "LDFLAGS" => "-L#{install_dir}/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib",

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -166,8 +166,6 @@ build do
       "PIP_CONFIG_FILE" => "#{pip_config_file}",
       # Specify C99 standard explicitly to avoid issues while building some
       # wheels (eg. ddtrace)
-      "CC" => "/opt/gcc-#{gcc_version}/bin/gcc",
-      "CXX" => "/opt/gcc-#{gcc_version}/bin/g++",
       "CFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
       "CXXFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
       "LDFLAGS" => "-L#{install_dir}/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib",
@@ -193,6 +191,12 @@ build do
     # See: https://github.com/python/cpython/blob/v3.8.8/Lib/distutils/sysconfig.py#L227
     if linux? || windows?
       nix_build_env["CFLAGS"] += " -std=c99"
+    end
+
+    # We only have gcc 10.4.0 on linux for now
+    if linux?
+      nix_build_env["CC"] = "/opt/gcc-#{gcc_version}/bin/gcc"
+      nix_build_env["CXX"] = "/opt/gcc-#{gcc_version}/bin/g++"
     end
 
     #


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Bump gcc version to 10.4.0 to build python dependencies for all the nix images.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

- We want to bump ddtrace to 1.11.2 [here](https://github.com/DataDog/integrations-core/pull/15144). The agent build is failing on rpm x64 (and only this one) because it uses gcc 4.4.7 and some flags are not supported.
- Each image is currently using its own version of gcc (7.3.1 for rpm arm for instance) so that's our chance to use the same version everywhere.
- This is also needed to build pydantic 2.0

### Additional Notes

This version of gcc was added [here](https://github.com/DataDog/datadog-agent-buildimages/pull/351)

The error we had: 

```
      /opt/rh/devtoolset-1.1/root/usr/bin/gcc -shared -Wl,-rpath,/opt/datadog-agent/embedded/lib -L/opt/datadog-agent/embedded/lib -Wl,-rpath,/opt/datadog-agent/embedded/lib -L/opt/datadog-agent/embedded/lib -L/opt/datadog-agent/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib -I/opt/datadog-agent/embedded/include -I/opt/mqm/inc -std=c99 build/temp.linux-x86_64-cpython-39/ddtrace/appsec/iast/_stacktrace.o -L/opt/datadog-agent/embedded/lib -o build/lib.linux-x86_64-cpython-39/ddtrace/appsec/iast/_stacktrace.cpython-39-x86_64-linux-gnu.so
      building 'ddtrace.appsec.iast._taint_tracking._native' extension
      creating build/temp.linux-x86_64-cpython-39/ddtrace/appsec/iast/_taint_tracking
      /opt/rh/devtoolset-1.1/root/usr/bin/gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -I/opt/datadog-agent/embedded/include -O2 -g -pipe -I/opt/datadog-agent/embedded/include -O2 -g -pipe -I/opt/datadog-agent/embedded/include -I/opt/mqm/inc -std=c99 -fPIC -I/opt/datadog-agent/embedded/include/python3.9 -c ddtrace/appsec/iast/_taint_tracking/_native.cpp -o build/temp.linux-x86_64-cpython-39/ddtrace/appsec/iast/_taint_tracking/_native.o -std=c++17
      gcc: error: unrecognized command line option ‘-std=c++17’
      error: command '/opt/rh/devtoolset-1.1/root/usr/bin/gcc' failed with exit code 1
      [end of output]
```

I tested the image switching the integrations-core branch to my ddtrace branch and everything seems to be working properly. Pipeline: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/17557110

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
