### PR TITLE
[CWS][SEC-8451] Allow multiple "exec" children in an Activity Tree

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/CycloneDX/cyclonedx-go v0.7.1
-	github.com/DataDog/agent-payload/v5 v5.0.85
+	github.com/DataDog/agent-payload/v5 v5.0.89-0.20230704083421-b45a1d578078
 	github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a
 	github.com/DataDog/datadog-agent/pkg/gohai v0.46.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.46.0-rc.2

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CycloneDX/cyclonedx-go v0.7.1 h1:5w1SxjGm9MTMNTuRbEPyw21ObdbaagTWF/KfF0qHTRE=
 github.com/CycloneDX/cyclonedx-go v0.7.1/go.mod h1:N/nrdWQI2SIjaACyyDs/u7+ddCkyl/zkNs8xFsHF2Ps=
-github.com/DataDog/agent-payload/v5 v5.0.85 h1:kmcBpkNwbfKCP3fBENZ6uvahvheTMgwjVjONKajVbI8=
-github.com/DataDog/agent-payload/v5 v5.0.85/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
+github.com/DataDog/agent-payload/v5 v5.0.89-0.20230704083421-b45a1d578078 h1:SJykkle71k89zXijHQel7N2cLexLeyI6MZtyTRZdpjs=
+github.com/DataDog/agent-payload/v5 v5.0.89-0.20230704083421-b45a1d578078/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
 github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a h1:7ZiVdU4j19IYuy8rR0uUzC7I7HjWul61ZEyUgvLkZBM=
 github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a/go.mod h1:ILSJBuOg3E0Jg8qgSnm7+g8DXa0KrfahnS7jhS1DoWs=
 github.com/DataDog/aptly v1.5.1 h1:Znm0WZ/cSjjTLe0HY3rKN1uqa7YIu+uIo3UQG/0WlIM=

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -895,6 +895,11 @@ func ProcessSourceToString(source uint64) string {
 	return ProcessSources[source]
 }
 
+// IsExecChild returns whether the current entry was execed directly from its parent (no fork)
+func (pc *ProcessCacheEntry) IsExecChild() bool {
+	return pc.Ancestor != nil && !pc.ExecTime.IsZero() && pc.ExecTime.Equal(pc.Ancestor.ExitTime)
+}
+
 // IsContainerRoot returns whether this is a top level process in the container ID
 func (pc *ProcessCacheEntry) IsContainerRoot() bool {
 	return pc.ContainerID != "" && pc.Ancestor != nil && pc.Ancestor.ContainerID == ""

--- a/pkg/security/security_profile/activity_tree/activity_tree_proto_dec_v1.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_proto_dec_v1.go
@@ -30,6 +30,7 @@ func protoDecodeProcessActivityNode(pan *adproto.ProcessActivityNode) *ProcessNo
 	ppan := &ProcessNode{
 		Process:        protoDecodeProcessNode(pan.Process),
 		GenerationType: NodeGenerationType(pan.GenerationType),
+		IsExecChild:    pan.IsExecChild,
 		MatchedRules:   make([]*model.MatchedRule, 0, len(pan.MatchedRules)),
 		Children:       make([]*ProcessNode, 0, len(pan.Children)),
 		Files:          make(map[string]*FileNode, len(pan.Files)),

--- a/pkg/security/security_profile/activity_tree/activity_tree_proto_enc_v1.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_proto_enc_v1.go
@@ -35,6 +35,7 @@ func processActivityNodeToProto(pan *ProcessNode) *adproto.ProcessActivityNode {
 	*ppan = adproto.ProcessActivityNode{
 		Process:        processNodeToProto(&pan.Process),
 		GenerationType: adproto.GenerationType(pan.GenerationType),
+		IsExecChild:    pan.IsExecChild,
 		MatchedRules:   make([]*adproto.MatchedRule, 0, len(pan.MatchedRules)),
 		Children:       make([]*adproto.ProcessActivityNode, 0, len(pan.Children)),
 		Files:          make([]*adproto.FileActivityNode, 0, len(pan.Files)),

--- a/pkg/security/security_profile/activity_tree/activity_tree_test.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_test.go
@@ -462,6 +462,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 							},
 							Children: []*ProcessNode{
 								{
+									IsExecChild: true,
 									Process: model.Process{
 										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 										FileEvent: model.FileEvent{
@@ -542,6 +543,136 @@ var activityTreeInsertExecEventTestCases = []struct {
 		},
 	},
 
+	// exec/4_bis
+	// ---------------
+	//
+	//      /bin/bash          +          systemd                 ==>>              /bin/bash
+	//          |                            |- /bin/bash                               |
+	//      /bin/webserver---                |- /bin/ls                            /bin/webserver-----
+	//          | (exec)    | (exec)                                                    | (exec)     | (exec)
+	//       /bin/id     /bin/ls                                                     /bin/id      /bin/ls
+	{
+		name: "exec/4_bis",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+								ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									IsExecChild: true,
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/id",
+										},
+									},
+								},
+								{
+									IsExecChild: true,
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/ls",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 1,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+			},
+		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+				},
+			},
+		},
+		wantNewEntry: false,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+								ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/id",
+										},
+									},
+								},
+								{
+									Process: model.Process{
+										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/ls",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
 	// exec/5
 	// ---------------
 	//
@@ -564,6 +695,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 					},
 					Children: []*ProcessNode{
 						{
+							IsExecChild: true,
 							Process: model.Process{
 								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 								FileEvent: model.FileEvent{
@@ -661,6 +793,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 							},
 							Children: []*ProcessNode{
 								{
+									IsExecChild: true,
 									Process: model.Process{
 										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 										ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
@@ -677,6 +810,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 											},
 										},
 										{
+											IsExecChild: true,
 											Process: model.Process{
 												ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 												ExitTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
@@ -686,6 +820,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 											},
 											Children: []*ProcessNode{
 												{
+													IsExecChild: true,
 													Process: model.Process{
 														ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
 														ExitTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
@@ -695,6 +830,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 													},
 													Children: []*ProcessNode{
 														{
+															IsExecChild: true,
 															Process: model.Process{
 																ExecTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
 																FileEvent: model.FileEvent{
@@ -883,6 +1019,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 					},
 					Children: []*ProcessNode{
 						{
+							IsExecChild: true,
 							Process: model.Process{
 								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 								ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
@@ -899,6 +1036,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 									},
 								},
 								{
+									IsExecChild: true,
 									Process: model.Process{
 										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 										ExitTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
@@ -908,6 +1046,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 									},
 									Children: []*ProcessNode{
 										{
+											IsExecChild: true,
 											Process: model.Process{
 												ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
 												ExitTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
@@ -917,6 +1056,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 											},
 											Children: []*ProcessNode{
 												{
+													IsExecChild: true,
 													Process: model.Process{
 														ExecTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
 														FileEvent: model.FileEvent{
@@ -1923,6 +2063,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 							},
 							Children: []*ProcessNode{
 								{
+									IsExecChild: true,
 									Process: model.Process{
 										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 										FileEvent: model.FileEvent{
@@ -2055,6 +2196,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 					},
 					Children: []*ProcessNode{
 						{
+							IsExecChild: true,
 							Process: model.Process{
 								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 								FileEvent: model.FileEvent{
@@ -2207,6 +2349,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 					},
 					Children: []*ProcessNode{
 						{
+							IsExecChild: true,
 							Process: model.Process{
 								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 								ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
@@ -2216,6 +2359,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 							},
 							Children: []*ProcessNode{
 								{
+									IsExecChild: true,
 									Process: model.Process{
 										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 										FileEvent: model.FileEvent{
@@ -2415,6 +2559,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 							},
 							Children: []*ProcessNode{
 								{
+									IsExecChild: true,
 									Process: model.Process{
 										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 										ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
@@ -2431,6 +2576,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 											},
 										},
 										{
+											IsExecChild: true,
 											Process: model.Process{
 												ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 												FileEvent: model.FileEvent{
@@ -2448,6 +2594,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 													},
 													Children: []*ProcessNode{
 														{
+															IsExecChild: true,
 															Process: model.Process{
 																ExecTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
 																FileEvent: model.FileEvent{

--- a/pkg/security/security_profile/activity_tree/process_node.go
+++ b/pkg/security/security_profile/activity_tree/process_node.go
@@ -21,6 +21,7 @@ import (
 type ProcessNode struct {
 	Process        model.Process
 	GenerationType NodeGenerationType
+	IsExecChild    bool
 	MatchedRules   []*model.MatchedRule
 
 	Files    map[string]*FileNode
@@ -48,6 +49,7 @@ func (pn *ProcessNode) getNodeLabel(args string) string {
 func NewProcessNode(entry *model.ProcessCacheEntry, generationType NodeGenerationType) *ProcessNode {
 	return &ProcessNode{
 		Process:        entry.Process,
+		IsExecChild:    entry.IsExecChild(),
 		GenerationType: generationType,
 		Files:          make(map[string]*FileNode),
 		DNSNames:       make(map[string]*DNSNode),


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR allows a `ProcessActivityNode` to own multiple "exec" children. Up until now, we assumed that a parent node could "exec" into only one of its children.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Although our initial assumption makes sense when you look at a single event, it is actually incorrect looking at multiple repeated events. For example, a user could "exec" into a container multiple times using commands like "bash -c /bin/ls" and "bash -c /bin/date". In the Activity Tree, "bash" should have multiple "exec" children: "/bin/ls" and "/bin/date". This PR ensures that we support this use case in Activity Trees without loosing context.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
