### PR TITLE
[CSPM] Add a tool to product a JSON schema of our k8s configs

### DIFF
--- a/pkg/compliance/k8sconfig/types.go
+++ b/pkg/compliance/k8sconfig/types.go
@@ -49,7 +49,7 @@ type K8sConfigFileMeta struct {
 	User    string      `json:"user"`
 	Group   string      `json:"group"`
 	Mode    uint32      `json:"mode"`
-	Content interface{} `json:"content"`
+	Content interface{} `json:"content" jsonschema:"type=object"`
 }
 
 type K8sTokenFileMeta struct {

--- a/pkg/compliance/k8sconfig/types.go
+++ b/pkg/compliance/k8sconfig/types.go
@@ -25,7 +25,7 @@ type K8sNodeConfig struct {
 	} `json:"components"`
 	Manifests struct {
 		Etcd                 *K8sConfigFileMeta `json:"etcd,omitempty"`
-		KubeContollerManager *K8sConfigFileMeta `json:"kubeContollerManager,omitempty"`
+		KubeContollerManager *K8sConfigFileMeta `json:"kubeControllerManager,omitempty"`
 		KubeApiserver        *K8sConfigFileMeta `json:"kubeApiserver,omitempty"`
 		KubeScheduler        *K8sConfigFileMeta `json:"kubeScheduler,omitempty"`
 	} `json:"manifests"`

--- a/pkg/compliance/tools/k8s_schema_generator/main.go
+++ b/pkg/compliance/tools/k8s_schema_generator/main.go
@@ -8,18 +8,53 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance/k8sconfig"
 	"github.com/invopop/jsonschema"
 )
 
+func usage() {
+	fmt.Fprintf(os.Stderr, "k8s_schema_generator <kubernetes_worker_node|kubernetes_master_node>\n")
+	os.Exit(1)
+}
+
 // This tool produces a JSON schema of the k8sconfig types hierarchy.
 // go run ./pkg/compliance/tools/k8s_schema_generator/main.go
 func main() {
+	if len(os.Args) < 2 {
+		usage()
+	}
 	reflector := &jsonschema.Reflector{
 		RequiredFromJSONSchemaTags: true,
 	}
 	schema := reflector.Reflect(&k8sconfig.K8sNodeConfig{})
+	resource := os.Args[1]
+	switch resource {
+	case "kubernetes_worker_node":
+		n, ok := schema.Definitions["K8sNodeConfig"]
+		if !ok {
+			log.Fatal("bad schema: missing K8sNodeConfig definition")
+		}
+		cs, ok := n.Properties.Get("components")
+		if !ok {
+			log.Fatal("bad schema: missing components properties")
+		}
+		n.Properties.Delete("manifests")
+		c := cs.(*jsonschema.Schema)
+		c.Properties.Delete("kubeControllerManager")
+		c.Properties.Delete("kubeApiserver")
+		c.Properties.Delete("kubeScheduler")
+		c.Properties.Delete("kubeControllerManager")
+		delete(schema.Definitions, "K8sKubeApiserverConfig")
+		delete(schema.Definitions, "K8sEtcdConfig")
+		delete(schema.Definitions, "K8sKubeControllerManagerConfig")
+		delete(schema.Definitions, "K8sKubeSchedulerConfig")
+	case "kubernetes_master_node":
+		// do nothing
+	default:
+		log.Fatalf(`resource should be "kubernetes_master_node" or "kubernetes_worker_node": was %q`, resource)
+	}
 	b, err := json.MarshalIndent(schema, "", "    ")
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/compliance/tools/k8s_schema_generator/main.go
+++ b/pkg/compliance/tools/k8s_schema_generator/main.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/DataDog/datadog-agent/pkg/compliance/k8sconfig"
+	"github.com/invopop/jsonschema"
+)
+
+// This tool produces a JSON schema of the k8sconfig types hierarchy.
+// go run ./pkg/compliance/tools/k8s_schema_generator/main.go
+func main() {
+	reflector := &jsonschema.Reflector{
+		RequiredFromJSONSchemaTags: true,
+	}
+	schema := reflector.Reflect(&k8sconfig.K8sNodeConfig{})
+	b, err := json.MarshalIndent(schema, "", "    ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(b))
+}

--- a/pkg/compliance/tools/k8s_types_generator/main.go
+++ b/pkg/compliance/tools/k8s_types_generator/main.go
@@ -163,7 +163,7 @@ type komponent struct {
 	confs   []*conf
 }
 
-// go run ./pkg/compliance/tools/k8s_types_generator.go ./pkg/compliance/tools/bin | gofmt > ./pkg/compliance/k8sconfig/types_generated.go
+// go run ./pkg/compliance/tools/k8s_types_generator/main.go ./pkg/compliance/tools/bin | gofmt > ./pkg/compliance/k8sconfig/types_generated.go
 func main() {
 	dir, _ := os.Getwd()
 	if len(os.Args) < 2 {


### PR DESCRIPTION
### What does this PR do?

Introduce a tool to product k8sconfig types schema.

### Motivation


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
