### PR TITLE
Add kube_node as a host tag

### DIFF
--- a/pkg/util/kubernetes/hostinfo/node_labels.go
+++ b/pkg/util/kubernetes/hostinfo/node_labels.go
@@ -58,3 +58,8 @@ func (n *NodeInfo) GetNodeLabels(ctx context.Context) (map[string]string, error)
 	}
 	return n.apiserverNodeLabelsFunc(ctx, nodeName)
 }
+
+// GetNodeName returns the node name for this host
+func (n *NodeInfo) GetNodeName(ctx context.Context) (string, error) {
+	return n.client.GetNodename(ctx)
+}

--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -58,7 +58,7 @@ func GetTags(ctx context.Context) (tags []string, err error) {
 		return
 	}
 	nodeName, err := ku.GetNodename(ctx)
-	if err == nil {
+	if err == nil && nodeName != "" {
 		tags = append(tags, "kube_node:"+nodeName)
 	}
 

--- a/releasenotes/notes/kube-node-tag-65b546a96e843bbc.yaml
+++ b/releasenotes/notes/kube-node-tag-65b546a96e843bbc.yaml
@@ -1,5 +1,4 @@
 ---
 enhancements:
   - |
-    The kube node name is now a host tag ``kube_node``
-    (was already a host alias)
+    The kube node name is now reported a host tag ``kube_node``

--- a/releasenotes/notes/kube-node-tag-65b546a96e843bbc.yaml
+++ b/releasenotes/notes/kube-node-tag-65b546a96e843bbc.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The kube node name is now a host tag ``kube_node``
+    (was already a host alias)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

 Add `kube_node` as a host tag

### Motivation

The `kube_node` tag is available in the Kubernetes resources but only as a host alias for now on metrics which breaks some of the queries as we cannot query on a host alias

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

this tag might not be unique across different clusters (node could have the same name in different clusters)

### Describe how to test/QA your changes

- deploy the agent in a kubernetes cluster
- check if the `kube_node` tag is reported for the nodes in the cluster
- check if the `kube_node` tag is attached to metrics/logs emitted from the relevant host

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
