### PR TITLE
fix(remote-config): Remove useless error log

### DIFF
--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -270,6 +270,7 @@ func (c *Client) pollLoop() {
 					log.Errorf("could not update remote-config state: %v", c.lastUpdateError)
 				}
 			} else {
+				c.lastUpdateError = nil
 				c.backoffPolicy.DecError(c.backoffErrorCount)
 			}
 		}

--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -251,20 +251,29 @@ func (c *Client) startFn() {
 // pollLoop should never be called manually and only be called via the client's `sync.Once`
 // structure in startFn.
 func (c *Client) pollLoop() {
+	firstRun := true
 	for {
 		interval := c.backoffPolicy.GetBackoffDuration(c.backoffErrorCount)
 		select {
 		case <-c.ctx.Done():
 			return
 		case <-time.After(c.pollInterval + interval):
-			c.lastUpdateError = c.update()
-			if c.lastUpdateError != nil {
-				c.backoffPolicy.IncError(c.backoffErrorCount)
-				log.Errorf("could not update remote-config state: %v", c.lastUpdateError)
+			err := c.update()
+			if err != nil {
+				if firstRun {
+					// As some clients may start before the core-agent server is up, we log the first error
+					// as a debug log as the race is expected. If the error persists, we log with error logs
+					log.Debugf("retrying update of remote-config state after cold start (%v)", err)
+				} else {
+					c.lastUpdateError = err
+					c.backoffPolicy.IncError(c.backoffErrorCount)
+					log.Errorf("could not update remote-config state: %v", c.lastUpdateError)
+				}
 			} else {
 				c.backoffPolicy.DecError(c.backoffErrorCount)
 			}
 		}
+		firstRun = false
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
Removes an useless error log that was caused by a race condition between the init of a RC client & the RC server

### Motivation
Less logs

### Additional Notes
N/A

### Possible Drawbacks / Trade-offs
N/A

### Describe how to test/QA your changes
See that the log isn't there

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
