### PR TITLE
upgrade(RC): Enable Remote Configuration by default

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -286,7 +286,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("fips.tls_verify", true)
 
 	// Remote config
-	config.BindEnvAndSetDefault("remote_configuration.enabled", false)
+	config.BindEnvAndSetDefault("remote_configuration.enabled", true)
 	config.BindEnvAndSetDefault("remote_configuration.key", "")
 	config.BindEnv("remote_configuration.api_key")
 	config.BindEnv("remote_configuration.rc_dd_url")

--- a/releasenotes/notes/remote-config-enabled-by-default-9f6d968f7995915d.yaml
+++ b/releasenotes/notes/remote-config-enabled-by-default-9f6d968f7995915d.yaml
@@ -6,10 +6,10 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
-enhancements:
+features:
   - |
-    With this release, remote_config.enabled is set to true by default in the agent configuration file.
-    This will cause the agent to request configuration updates from the Datadog site.
+    With this release, ``remote_config.enabled`` is set to ``true`` by default in the Agent configuration file.
+    This causes the Agent to request configuration updates from the Datadog site.
 
-    To receive configurations from Datadog, you still need to enable Remote Configuration at the organization level and enable Remote Configuration capability on your API Key from the Datadog UI.
-    If you don't want your agent requesting configurations from Datadog, you can set ``remote_config.enabled`` to ``false`` in the agent configuration file.
+    To receive configurations from Datadog, you still need to enable Remote Configuration at the organization level and enable Remote Configuration capability on your API Key from the Datadog application.
+    If you don't want the Agent to request configurations from Datadog, set ``remote_config.enabled`` to ``false`` in the Agent configuration file.

--- a/releasenotes/notes/remote-config-enabled-by-default-9f6d968f7995915d.yaml
+++ b/releasenotes/notes/remote-config-enabled-by-default-9f6d968f7995915d.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    With this release, remote_config.enabled is set to true by default in the agent configuration file.
+    This will cause the agent to request configuration updates from the Datadog site.
+
+    To receive configurations from Datadog, you still need to enable Remote Configuration at the organization level and enable Remote Configuration capability on your API Key from the Datadog UI.
+    If you don't want your agent requesting configurations from Datadog, you can set ``remote_config.enabled`` to ``false`` in the agent configuration file.


### PR DESCRIPTION
### What does this PR do?
Enables Remote Configuration by default in the agent.

### Motivation
[RCM-1079]
Reducing friction when activating Remote Config

### Additional Notes
The Helm chart & Operator must be updated to enable Remote Config by default too

### Possible Drawbacks / Trade-offs
N/A

### Describe how to test/QA your changes
Create an agent without touching RC settings in a new org, see that the agent can query RC. Then enable RC in the org and see that you get config, again without touching RC settings.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.


[RCM-1079]: https://datadoghq.atlassian.net/browse/RCM-1079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ