### PR TITLE
[RCM-1070] Add remote config to the status command

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -496,6 +496,17 @@
   </div>
 
   <div class="stat">
+    <span class="stat_title">Remote Configuration</span>
+    <span class="stat_data">
+      {{ with .remoteConfiguration }}
+        API Key: {{ if .apiKeyScoped }}Authorized{{ else }}Not authorized{{ end }}
+        Feature: {{ if .orgEnabled }}Enabled{{ else }}Disabled{{ end }}
+        {{ if .lastError }}Last error: {{ .lastError }}{{ end }}
+      {{ end }}
+    </span>
+  </div>
+
+  <div class="stat">
     <span class="stat_title">OTLP</span>
     <span class="stat_data">
       {{ with .otlp }}

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -501,7 +501,9 @@
       {{ with .remoteConfiguration }}
         API Key: {{ if .apiKeyScoped }}Authorized{{ else }}Not authorized{{ end }}
         Feature: {{ if .orgEnabled }}Enabled{{ else }}Disabled{{ end }}
-        {{ if .lastError }}Last error: {{ .lastError }}{{ end }}
+        Last error: {{ if .lastError }}{{ .lastError }}{{ else }}None{{ end }}
+      {{ else }}
+        Remote Configuration is disabled
       {{ end }}
     </span>
   </div>

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -63,6 +63,8 @@ const (
 	initialFetchErrorLog uint64 = 5
 )
 
+var exportedMapStatus = expvar.NewMap("remoteConfigStatus")
+
 // Service defines the remote config management service responsible for fetching, storing
 // and dispatching the configurations
 type Service struct {
@@ -221,7 +223,7 @@ func NewService() (*Service, error) {
 	}
 
 	// Exported variable to get the state of remote-config
-	exportedMapStatus := expvar.NewMap("remoteConfigStatus")
+	exportedMapStatus.Init()
 	exportedStatusOrgEnabled := new(expvar.String)
 	exportedMapStatus.Set("orgEnabled", exportedStatusOrgEnabled)
 	exportedStatusKeyAuthorized := new(expvar.String)

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -96,6 +96,12 @@ func FormatStatus(data []byte) (string, error) {
 		}
 		return nil
 	}
+	remoteConfigFunc := func() error {
+		if config.Datadog.GetBool("remote_configuration.enabled") {
+			return RenderStatusTemplate(b, "/remoteconfig.tmpl", stats)
+		}
+		return nil
+	}
 	otlpFunc := func() error {
 		if otlp.IsDisplayed() {
 			return RenderStatusTemplate(b, "/otlp.tmpl", stats)
@@ -110,7 +116,7 @@ func FormatStatus(data []byte) (string, error) {
 	} else {
 		renderFuncs = []func() error{headerFunc, checkStatsFunc, jmxFetchFunc, forwarderFunc, endpointsFunc,
 			logsAgentFunc, systemProbeFunc, processAgentFunc, traceAgentFunc, aggregatorFunc, dogstatsdFunc,
-			clusterAgentFunc, snmpTrapFunc, autodiscoveryFunc, otlpFunc}
+			clusterAgentFunc, snmpTrapFunc, autodiscoveryFunc, remoteConfigFunc, otlpFunc}
 	}
 	var errs []error
 	for _, f := range renderFuncs {

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -97,10 +97,7 @@ func FormatStatus(data []byte) (string, error) {
 		return nil
 	}
 	remoteConfigFunc := func() error {
-		if config.Datadog.GetBool("remote_configuration.enabled") {
-			return RenderStatusTemplate(b, "/remoteconfig.tmpl", stats)
-		}
-		return nil
+		return RenderStatusTemplate(b, "/remoteconfig.tmpl", stats)
 	}
 	otlpFunc := func() error {
 		if otlp.IsDisplayed() {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -98,6 +98,9 @@ func GetStatus(verbose bool) (map[string]interface{}, error) {
 		stats["filterErrors"] = containers.GetFilterErrors()
 	}
 
+	if config.Datadog.GetBool("remote_configuration.enabled") {
+		stats["remoteConfiguration"] = getRemoteConfigStatus()
+	}
 	return stats, nil
 }
 
@@ -297,6 +300,18 @@ func getEndpointsInfos() (map[string]interface{}, error) {
 	}
 
 	return endpointsInfos, nil
+}
+
+// getRemoteConfigStatus return the current status of remote config
+func getRemoteConfigStatus() map[string]interface{} {
+	status := make(map[string]interface{})
+
+	if expvar.Get("remoteConfigStatus") != nil {
+		remoteConfigStatusJSON := expvar.Get("remoteConfigStatus").String()
+		json.Unmarshal([]byte(remoteConfigStatusJSON), &status) //nolint:errcheck
+	}
+
+	return status
 }
 
 // getCommonStatus grabs the status from expvar and puts it into a map.

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -98,9 +98,7 @@ func GetStatus(verbose bool) (map[string]interface{}, error) {
 		stats["filterErrors"] = containers.GetFilterErrors()
 	}
 
-	if config.Datadog.GetBool("remote_configuration.enabled") {
-		stats["remoteConfiguration"] = getRemoteConfigStatus()
-	}
+	stats["remoteConfiguration"] = getRemoteConfigStatus()
 	return stats, nil
 }
 

--- a/pkg/status/templates/remoteconfig.tmpl
+++ b/pkg/status/templates/remoteconfig.tmpl
@@ -8,7 +8,7 @@ Remote Configuration
     {{ with .remoteConfiguration }}
     API Key: {{ if .apiKeyScoped }}Authorized{{ else }}Not authorized{{ end }}
     Feature: {{ if .orgEnabled }}Enabled{{ else }}Disabled{{ end }}
-    {{- if .lastError }}
-    Last error: {{ .lastError }}
-    {{- end }}
+    Last error: {{ if .lastError }}{{ .lastError }}{{ else }}None{{ end }}
+    {{ else }}
+    Remote Configuration is disabled
     {{ end }}

--- a/pkg/status/templates/remoteconfig.tmpl
+++ b/pkg/status/templates/remoteconfig.tmpl
@@ -1,0 +1,14 @@
+{{/*
+NOTE: Changes made to this template should be reflected on the following templates, if applicable:
+* cmd/agent/gui/views/templates/generalStatus.tmpl
+*/}}
+====================
+Remote Configuration
+====================
+    {{ with .remoteConfiguration }}
+    API Key: {{ if .apiKeyScoped }}Authorized{{ else }}Not authorized{{ end }}
+    Feature: {{ if .orgEnabled }}Enabled{{ else }}Disabled{{ end }}
+    {{- if .lastError }}
+    Last error: {{ .lastError }}
+    {{- end }}
+    {{ end }}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add remote config to the status command

Example
```
====================
Remote Configuration
====================

    API Key: Authorized
    Feature: Enabled
    Last error: failed to issue request: Post "https://config.datadoghq.com/api/v0.1/configurations": dial tcp: lookup config.datad0g.com: no such host

```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

* Without RC enabled, check that the section is not here
* With RC enabled, check that `API Key` and `Feature` are always here
    * Trigger an error to be seen in the status command

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
