### PR TITLE
Fix flaky test for security flare

### DIFF
--- a/pkg/flare/archive_security.go
+++ b/pkg/flare/archive_security.go
@@ -14,6 +14,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// for testing purpose
+var linuxKernelSymbols = getLinuxKernelSymbols
+
 // CreateSecurityAgentArchive packages up the files
 func CreateSecurityAgentArchive(local bool, logFilePath string, runtimeStatus, complianceStatus map[string]interface{}) (string, error) {
 	fb, err := flarehelpers.NewFlareBuilder(local)
@@ -48,7 +51,7 @@ func createSecurityAgentArchive(fb flarehelpers.FlareBuilder, logFilePath string
 	getRuntimeFiles(fb)    //nolint:errcheck
 	getExpVar(fb)          //nolint:errcheck
 	fb.AddFileFromFunc("envvars.log", getEnvVars)
-	getLinuxKernelSymbols(fb)                   //nolint:errcheck
+	linuxKernelSymbols(fb)                      //nolint:errcheck
 	getLinuxPid1MountInfo(fb)                   //nolint:errcheck
 	getLinuxDmesg(fb)                           //nolint:errcheck
 	getLinuxKprobeEvents(fb)                    //nolint:errcheck

--- a/pkg/flare/archive_security_test.go
+++ b/pkg/flare/archive_security_test.go
@@ -24,6 +24,15 @@ func TestCreateSecurityAgentArchive(t *testing.T) {
 	mockConfig.Set("compliance_config.dir", "./test/compliance.d")
 	logFilePath := "./test/logs/agent.log"
 
+	// Mock getLinuxKernelSymbols. It can take a long time to scrub when creating a flare.
+	defer func(f func(flarehelpers.FlareBuilder) error) {
+		linuxKernelSymbols = f
+	}(getLinuxKernelSymbols)
+	linuxKernelSymbols = func(fb flarehelpers.FlareBuilder) error {
+		fb.AddFile("kallsyms", []byte("some kernel symbol"))
+		return nil
+	}
+
 	tests := []struct {
 		name          string
 		local         bool


### PR DESCRIPTION
### What does this PR do?

On some runners, it can take a long time to scrub '/proc/kallsyms'. Mocking the path for the tests.