### PR TITLE
CONT-3979 Create “Linux only” multi-arch agent docker images

### DIFF
--- a/.gitlab/deploy_7/container.yml
+++ b/.gitlab/deploy_7/container.yml
@@ -18,9 +18,9 @@
     - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv agent.version --major-version 7 --url-safe)"; fi
     - export IMG_BASE_SRC="${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
     - export IMG_LINUX_SOURCES="${IMG_BASE_SRC}-7${JMX}-amd64,${IMG_BASE_SRC}-7${JMX}-arm64"
-    - export IMG_WINDOWS_SOURCES="${IMG_BASE_SRC}-7${JMX}-win1809${SERVERCORE}-amd64,${IMG_BASE_SRC}-7${JMX}-winltsc2022${SERVERCORE}-amd64"
-    - if [[ "$SERVERCORE" == "-servercore" ]]; then export IMG_SOURCES="${IMG_WINDOWS_SOURCES}"; else export IMG_SOURCES="${IMG_LINUX_SOURCES},${IMG_WINDOWS_SOURCES}"; fi
-    - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}${SERVERCORE}${JMX}"
+    - export IMG_WINDOWS_SOURCES="${IMG_BASE_SRC}-7${JMX}-win1809${FLAVOR}-amd64,${IMG_BASE_SRC}-7${JMX}-winltsc2022${FLAVOR}-amd64"
+    - if [[ "$FLAVOR" == "-linux"; then export IMG_SOURCES="${IMG_LINUX_SOURCES}"; elif [[ "$FLAVOR" == "-servercore" ]]; then export IMG_SOURCES="${IMG_WINDOWS_SOURCES}"; else export IMG_SOURCES="${IMG_LINUX_SOURCES},${IMG_WINDOWS_SOURCES}"; fi
+    - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}${FLAVOR}${JMX}"
 
 
 .deploy_containers-a7_external:
@@ -30,9 +30,10 @@
       - JMX:
           - ""
           - "-jmx"
-        SERVERCORE:
+        FLAVOR:
           - ""
           - "-servercore"
+          - "-linux"
 
 
 deploy_containers-a7:


### PR DESCRIPTION
### What does this PR do?

Create “Linux only” multi-arch (`amd64`+`arm64`) docker images for the agent.

### Motivation

Some users are using tools that are not supporting OCI images with “foreign layers”.
Those “foreign layers” were mandatory for Windows images for licensing issues.
Although users were not using any Windows image, having one referenced from the multi-arch manifest was problematic.
We could get rid of the multi-arch manifest and reference the images directly, but there’s a value for users to be able to use a single tag in an `amd64`/`arm64` hybrid environment.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Verify that, in addition to the usual agent docker images, there are new tags, with a `-linux` prefix that are Linux-only `amd64`/`arm64` multi-arch images.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
