### PR TITLE
Replace agent-core with agent-release-management

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1161,7 +1161,13 @@ Make sure that milestone is open before trying again.""",
     updated_pr = github.update_pr(
         pull_number=pr["number"],
         milestone_number=milestone["number"],
-        labels=["changelog/no-changelog", "qa/skip-qa", "team/agent-platform", "team/agent-release-management", "category/release_operations"],
+        labels=[
+            "changelog/no-changelog",
+            "qa/skip-qa",
+            "team/agent-platform",
+            "team/agent-release-management",
+            "category/release_operations",
+        ],
     )
 
     if not updated_pr or not updated_pr.get("number") or not updated_pr.get("html_url"):

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1161,7 +1161,7 @@ Make sure that milestone is open before trying again.""",
     updated_pr = github.update_pr(
         pull_number=pr["number"],
         milestone_number=milestone["number"],
-        labels=["changelog/no-changelog", "qa/skip-qa", "team/agent-platform", "team/agent-core"],
+        labels=["changelog/no-changelog", "qa/skip-qa", "team/agent-platform", "team/agent-release-management", "category/release_operations"],
     )
 
     if not updated_pr or not updated_pr.get("number") or not updated_pr.get("html_url"):


### PR DESCRIPTION
### What does this PR do?

As agent-core team is deprecated we want to remove all references. One of the last places is the script for new RC PR generation. `team/agent-core` label will be replaced by `team/agent-release-management` as we still need team label on every PR.
Additionally the `category/release_operations` will be added to the newly created RC PR. Previously it had to be added manually after PR was created.

### Motivation

Cleanup after agent-core team deprecation.


### Describe how to test/QA your changes

It will be tested during new RC creation.