### PR TITLE
[CWS][SEC-9561] Check policy names in e2e tests

### DIFF
--- a/test/e2e/cws-tests/tests/lib/cws/app.py
+++ b/test/e2e/cws-tests/tests/lib/cws/app.py
@@ -38,7 +38,7 @@ def get_app_log(api_client, query):
     api_instance = logs_api.LogsApi(api_client)
     body = LogsListRequest(
         filter=LogsQueryFilter(
-            _from="now-15m",
+            _from="now-10m",
             indexes=["*"],
             query=query,
             to="now",
@@ -198,3 +198,19 @@ class App(common.App):
             for policy in policies["policies"]:
                 if "rules_ignored" in policy:
                     test_case.assertEqual(len(policy["rules_ignored"]), 0)
+
+    def __find_policy(self, policies, policy_source, policy_name):
+        found = False
+        if "policies" in policies:
+            for policy in policies["policies"]:
+                if "source" in policy and "name" in policy:
+                    if policy["source"] == policy_source and policy["name"] == policy_name:
+                        found = True
+                        break
+        return found
+
+    def check_policy_found(self, test_case, policies, policy_source, policy_name):
+        test_case.assertTrue(self.__find_policy(policies, policy_source, policy_name), msg=f"should find policy in log (source:{policy_source} name:{policy_name})")
+
+    def check_policy_not_found(self, test_case, policies, policy_source, policy_name):
+        test_case.assertFalse(self.__find_policy(policies, policy_source, policy_name), msg=f"shouldn't find policy in log (source:{policy_source} name:{policy_name})")

--- a/test/e2e/cws-tests/tests/lib/cws/app.py
+++ b/test/e2e/cws-tests/tests/lib/cws/app.py
@@ -210,7 +210,13 @@ class App(common.App):
         return found
 
     def check_policy_found(self, test_case, policies, policy_source, policy_name):
-        test_case.assertTrue(self.__find_policy(policies, policy_source, policy_name), msg=f"should find policy in log (source:{policy_source} name:{policy_name})")
+        test_case.assertTrue(
+            self.__find_policy(policies, policy_source, policy_name),
+            msg=f"should find policy in log (source:{policy_source} name:{policy_name})",
+        )
 
     def check_policy_not_found(self, test_case, policies, policy_source, policy_name):
-        test_case.assertFalse(self.__find_policy(policies, policy_source, policy_name), msg=f"shouldn't find policy in log (source:{policy_source} name:{policy_name})")
+        test_case.assertFalse(
+            self.__find_policy(policies, policy_source, policy_name),
+            msg=f"shouldn't find policy in log (source:{policy_source} name:{policy_name})",
+        )

--- a/test/e2e/cws-tests/tests/lib/kubernetes.py
+++ b/test/e2e/cws-tests/tests/lib/kubernetes.py
@@ -79,7 +79,7 @@ class KubernetesHelper(LogGetter):
         temppolicy.close()
         temppolicy_path = temppolicy.name
         self.exec_command("security-agent", command=["mkdir", "-p", "/tmp/runtime-security.d"])
-        self.cp_to_agent("security-agent", temppolicy_path, "/tmp/runtime-security.d/custom.policy")
+        self.cp_to_agent("security-agent", temppolicy_path, "/tmp/runtime-security.d/downloaded.policy")
         os.remove(temppolicy_path)
 
     def cp_to_agent(self, agent_name, src_file, dst_file):

--- a/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
@@ -48,7 +48,7 @@ class TestE2EDocker(unittest.TestCase):
         desc = f"e2e test rule {test_id}"
         data = None
         agent_rule_name = f"e2e_agent_rule_{test_id}"
-        rc_enabled = os.getenv("DD_RC_ENABLED") != ""
+        rc_enabled = os.getenv("DD_RC_ENABLED") is not None
 
         with Step(msg=f"check agent rule({test_id}) creation", emoji=":straight_ruler:"):
             self.agent_rule_id = self.app.create_cws_agent_rule(

--- a/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
@@ -122,7 +122,9 @@ class TestE2EDocker(unittest.TestCase):
 
         policy_source = "remote-config" if rc_enabled else "file"
         with Step(msg=f"check ruleset_loaded `{policy_source}` for default.policy", emoji=":delivery_truck:"):
-            event = self.app.wait_app_log(f"rule_id:ruleset_loaded @policies.source:{policy_source} @policies.name:default.policy")
+            event = self.app.wait_app_log(
+                f"rule_id:ruleset_loaded @policies.source:{policy_source} @policies.name:default.policy"
+            )
             attributes = event["data"][-1]["attributes"]["attributes"]
             if rc_enabled:
                 self.app.check_policy_found(self, attributes, "remote-config", "default.policy")

--- a/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
@@ -90,11 +90,18 @@ class TestE2EDocker(unittest.TestCase):
             wait_agent_log("system-probe", self.docker_helper, SYS_PROBE_START_LOG)
 
         if rc_enabled:
-            with Step(msg="check `remote-config` ruleset_loaded", emoji=":delivery_truck:"):
+            with Step(msg="wait for host tags and remote-config policies (3m)", emoji=":alarm_clock:"):
+                time.sleep(3 * 60)
+
+            with Step(msg="check ruleset_loaded for `remote-config` policies", emoji=":delivery_truck:"):
                 event = self.app.wait_app_log("rule_id:ruleset_loaded @policies.source:remote-config")
                 attributes = event["data"][-1]["attributes"]["attributes"]
-                prev_load_date = attributes["date"]
+                self.app.check_policy_found(self, attributes, "remote-config", "default.policy")
+                self.app.check_policy_found(self, attributes, "remote-config", "cws_custom")
                 self.app.check_for_ignored_policies(self, attributes)
+        else:
+            with Step(msg="wait for host tags (3m)", emoji=":alarm_clock:"):
+                time.sleep(3 * 60)
 
         with Step(msg="download policies", emoji=":file_folder:"):
             self.policies = self.docker_helper.download_policies().output.decode()
@@ -113,21 +120,16 @@ class TestE2EDocker(unittest.TestCase):
         with Step(msg="reload policies", emoji=":file_folder:"):
             self.docker_helper.reload_policies()
 
-        with Step(msg="check `downloaded` ruleset_loaded", emoji=":delivery_truck:"):
-            for _i in range(60):  # retry 60 times
-                event = self.app.wait_app_log("rule_id:ruleset_loaded  @policies.source:file")
-                attributes = event["data"][-1]["attributes"]["attributes"]
-                load_date = attributes["date"]
-                # search for restart log until the timestamp differs
-                if load_date != prev_load_date:
-                    break
-                time.sleep(1)
+        policy_source = "remote-config" if rc_enabled else "file"
+        with Step(msg=f"check ruleset_loaded `{policy_source}` for default.policy", emoji=":delivery_truck:"):
+            event = self.app.wait_app_log(f"rule_id:ruleset_loaded @policies.source:{policy_source} @policies.name:default.policy")
+            attributes = event["data"][-1]["attributes"]["attributes"]
+            if rc_enabled:
+                self.app.check_policy_found(self, attributes, "remote-config", "default.policy")
+                self.app.check_policy_found(self, attributes, "remote-config", "cws_custom")
             else:
-                self.fail("check ruleset_loaded timeouted")
+                self.app.check_policy_found(self, attributes, "file", "default.policy")
             self.app.check_for_ignored_policies(self, attributes)
-
-        with Step(msg="wait for host tags (3m)", emoji=":alarm_clock:"):
-            time.sleep(3 * 60)
 
         with Step(msg="wait for datadog.security_agent.runtime.running metric", emoji="\N{beer mug}"):
             self.app.wait_for_metric("datadog.security_agent.runtime.running", host=socket.gethostname())

--- a/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
@@ -76,6 +76,24 @@ class TestE2EKubernetes(unittest.TestCase):
         with Step(msg="check system-probe start", emoji=":customs:"):
             wait_agent_log("system-probe", self.kubernetes_helper, SYS_PROBE_START_LOG)
 
+        with Step(msg="check ruleset_loaded for `file` test.policy", emoji=":delivery_truck:"):
+            event = self.app.wait_app_log("rule_id:ruleset_loaded @policies.source:file @policies.name:test.policy -@policies.source:remote-config")
+            attributes = event["data"][-1]["attributes"]["attributes"]
+            self.app.check_policy_found(self, attributes, "file", "test.policy")
+            self.app.check_for_ignored_policies(self, attributes)
+
+        with Step(msg="wait for host tags and remote-config policies (3m)", emoji=":alarm_clock:"):
+            time.sleep(3 * 60)
+
+        with Step(msg="check ruleset_loaded for `remote-config` policies", emoji=":delivery_truck:"):
+            event = self.app.wait_app_log("rule_id:ruleset_loaded @policies.source:remote-config")
+            attributes = event["data"][-1]["attributes"]["attributes"]
+            self.app.check_policy_found(self, attributes, "remote-config", "default.policy")
+            self.app.check_policy_found(self, attributes, "remote-config", "cws_custom")
+            self.app.check_policy_found(self, attributes, "file", "test.policy")
+            self.app.check_for_ignored_policies(self, attributes)
+            prev_load_date = attributes["date"]
+
         with Step(msg="copy default policies", emoji=":delivery_truck:"):
             self.kubernetes_helper.exec_command("security-agent", command=["mkdir", "-p", "/tmp/runtime-security.d"])
             command = [
@@ -88,20 +106,22 @@ class TestE2EKubernetes(unittest.TestCase):
         with Step(msg="reload policies", emoji=":rocket:"):
             self.kubernetes_helper.reload_policies()
 
-        with Step(msg="check `file` ruleset_loaded", emoji=":delivery_truck:"):
-            event = self.app.wait_app_log("rule_id:ruleset_loaded @policies.source:file")
-            attributes = event["data"][-1]["attributes"]["attributes"]
-            prev_load_date = attributes["date"]
+        with Step(msg="check ruleset_loaded for `remote-config` default.policy precedence over `file` default.policy", emoji=":delivery_truck:"):
+            for _i in range(60):
+                event = self.app.wait_app_log("rule_id:ruleset_loaded @policies.name:default.policy")
+                attributes = event["data"][-1]["attributes"]["attributes"]
+                load_date = attributes["date"]
+                # search for restart log until the timestamp differs because this log query and the previous one conflict
+                if load_date != prev_load_date:
+                    break
+                time.sleep(3)
+            else:
+                self.fail("check ruleset_loaded timed out")
+            self.app.check_policy_not_found(self, attributes, "file", "default.policy")
+            self.app.check_policy_found(self, attributes, "remote-config", "default.policy")
+            self.app.check_policy_found(self, attributes, "remote-config", "cws_custom")
+            self.app.check_policy_found(self, attributes, "file", "test.policy")
             self.app.check_for_ignored_policies(self, attributes)
-
-        with Step(msg="check `remote-config` ruleset_loaded", emoji=":delivery_truck:"):
-            event = self.app.wait_app_log("rule_id:ruleset_loaded @policies.source:remote-config")
-            attributes = event["data"][-1]["attributes"]["attributes"]
-            prev_load_date = attributes["date"]
-            self.app.check_for_ignored_policies(self, attributes)
-
-        with Step(msg="wait for host tags (3m)", emoji=":alarm_clock:"):
-            time.sleep(3 * 60)
 
         with Step(msg="check policies download", emoji=":file_folder:"):
             self.policies = self.kubernetes_helper.download_policies()
@@ -120,17 +140,14 @@ class TestE2EKubernetes(unittest.TestCase):
         with Step(msg="reload policies", emoji=":rocket:"):
             self.kubernetes_helper.reload_policies()
 
-        with Step(msg="check `downloaded` ruleset_loaded", emoji=":delivery_truck:"):
-            for _i in range(60):  # retry 60 times
-                event = self.app.wait_app_log("rule_id:ruleset_loaded  @policies.source:file")
-                attributes = event["data"][-1]["attributes"]["attributes"]
-                load_date = attributes["date"]
-                # search for restart log until the timestamp differs
-                if load_date != prev_load_date:
-                    break
-                time.sleep(1)
-            else:
-                self.fail("check ruleset_loaded timeouted")
+        with Step(msg="check ruleset_loaded for `file` downloaded.policy", emoji=":delivery_truck:"):
+            event = self.app.wait_app_log("rule_id:ruleset_loaded @policies.source:file @policies.name:downloaded.policy")
+            attributes = event["data"][-1]["attributes"]["attributes"]
+            self.app.check_policy_found(self, attributes, "file", "downloaded.policy")
+            self.app.check_policy_not_found(self, attributes, "file", "default.policy")
+            self.app.check_policy_found(self, attributes, "remote-config", "default.policy")
+            self.app.check_policy_found(self, attributes, "remote-config", "cws_custom")
+            self.app.check_policy_found(self, attributes, "file", "test.policy")
             self.app.check_for_ignored_policies(self, attributes)
 
         with Step(msg="wait for datadog.security_agent.runtime.running metric", emoji="\N{beer mug}"):

--- a/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
@@ -77,7 +77,9 @@ class TestE2EKubernetes(unittest.TestCase):
             wait_agent_log("system-probe", self.kubernetes_helper, SYS_PROBE_START_LOG)
 
         with Step(msg="check ruleset_loaded for `file` test.policy", emoji=":delivery_truck:"):
-            event = self.app.wait_app_log("rule_id:ruleset_loaded @policies.source:file @policies.name:test.policy -@policies.source:remote-config")
+            event = self.app.wait_app_log(
+                "rule_id:ruleset_loaded @policies.source:file @policies.name:test.policy -@policies.source:remote-config"
+            )
             attributes = event["data"][-1]["attributes"]["attributes"]
             self.app.check_policy_found(self, attributes, "file", "test.policy")
             self.app.check_for_ignored_policies(self, attributes)
@@ -106,7 +108,10 @@ class TestE2EKubernetes(unittest.TestCase):
         with Step(msg="reload policies", emoji=":rocket:"):
             self.kubernetes_helper.reload_policies()
 
-        with Step(msg="check ruleset_loaded for `remote-config` default.policy precedence over `file` default.policy", emoji=":delivery_truck:"):
+        with Step(
+            msg="check ruleset_loaded for `remote-config` default.policy precedence over `file` default.policy",
+            emoji=":delivery_truck:",
+        ):
             for _i in range(60):
                 event = self.app.wait_app_log("rule_id:ruleset_loaded @policies.name:default.policy")
                 attributes = event["data"][-1]["attributes"]["attributes"]
@@ -141,7 +146,9 @@ class TestE2EKubernetes(unittest.TestCase):
             self.kubernetes_helper.reload_policies()
 
         with Step(msg="check ruleset_loaded for `file` downloaded.policy", emoji=":delivery_truck:"):
-            event = self.app.wait_app_log("rule_id:ruleset_loaded @policies.source:file @policies.name:downloaded.policy")
+            event = self.app.wait_app_log(
+                "rule_id:ruleset_loaded @policies.source:file @policies.name:downloaded.policy"
+            )
             attributes = event["data"][-1]["attributes"]["attributes"]
             self.app.check_policy_found(self, attributes, "file", "downloaded.policy")
             self.app.check_policy_not_found(self, attributes, "file", "default.policy")


### PR DESCRIPTION
This PR makes the CWS e2e tests more precise by checking the expected policy names and sources.   

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
