### PR TITLE
process monitor telemetry

### DIFF
--- a/pkg/network/protocols/telemetry/prometheus.go
+++ b/pkg/network/protocols/telemetry/prometheus.go
@@ -16,7 +16,7 @@ var prometheusDelta deltaCalculator
 var prometheusMux sync.Mutex
 var prometheusMetrics map[string]any
 
-func ReportPrometheus() {
+func ReportPrometheus() map[string]any {
 	prometheusMux.Lock()
 	defer prometheusMux.Unlock()
 
@@ -44,6 +44,7 @@ func ReportPrometheus() {
 		default:
 		}
 	}
+	return prometheusMetrics
 }
 
 func metricToPrometheus(m metric) any {

--- a/pkg/network/protocols/telemetry/prometheus.go
+++ b/pkg/network/protocols/telemetry/prometheus.go
@@ -16,7 +16,7 @@ var prometheusDelta deltaCalculator
 var prometheusMux sync.Mutex
 var prometheusMetrics map[string]any
 
-func ReportPrometheus() map[string]any {
+func ReportPrometheus() {
 	prometheusMux.Lock()
 	defer prometheusMux.Unlock()
 
@@ -44,7 +44,6 @@ func ReportPrometheus() map[string]any {
 		default:
 		}
 	}
-	return prometheusMetrics
 }
 
 func metricToPrometheus(m metric) any {

--- a/pkg/network/protocols/telemetry/registry.go
+++ b/pkg/network/protocols/telemetry/registry.go
@@ -64,8 +64,12 @@ func (r *registry) GetMetrics(params ...string) []metric {
 // WARNING: Only intended for tests
 func Clear() {
 	globalRegistry.Lock()
-	defer globalRegistry.Unlock()
 	globalRegistry.metrics = nil
+	globalRegistry.Unlock()
+
+	telemetryDelta.mux.Lock()
+	telemetryDelta.stateByClientID = make(map[string]*clientState)
+	telemetryDelta.mux.Unlock()
 }
 
 func init() {

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -57,19 +57,21 @@ type processMonitorTelemetry struct {
 	callbackExecuted  *telemetry.Counter
 }
 
-func (pmt *processMonitorTelemetry) initialize() {
+func newProcessMonitorTelemetry() processMonitorTelemetry {
 	metricGroup := telemetry.NewMetricGroup(
 		"usm.process.monitor",
 		telemetry.OptPrometheus,
 	)
-	pmt.events = metricGroup.NewCounter("events")
-	pmt.exec = metricGroup.NewCounter("exec")
-	pmt.exit = metricGroup.NewCounter("exit")
-	pmt.restart = metricGroup.NewCounter("restart")
+	return processMonitorTelemetry{
+		events:  metricGroup.NewCounter("events"),
+		exec:    metricGroup.NewCounter("exec"),
+		exit:    metricGroup.NewCounter("exit"),
+		restart: metricGroup.NewCounter("restart"),
 
-	pmt.reinitFailed = metricGroup.NewCounter("reinit_failed")
-	pmt.processScanFailed = metricGroup.NewCounter("process_scan_failed")
-	pmt.callbackExecuted = metricGroup.NewCounter("callback_executed")
+		reinitFailed:      metricGroup.NewCounter("reinit_failed"),
+		processScanFailed: metricGroup.NewCounter("process_scan_failed"),
+		callbackExecuted:  metricGroup.NewCounter("callback_executed"),
+	}
 }
 
 // ProcessMonitor uses netlink process events like Exec and Exit and activate the registered callbacks for the relevant
@@ -283,7 +285,7 @@ func (pm *ProcessMonitor) Initialize() error {
 	var initErr error
 	pm.initOnce.Do(
 		func() {
-			pm.tel.initialize()
+			pm.tel = newProcessMonitorTelemetry()
 			pm.done = make(chan struct{})
 			pm.initCallbackRunner()
 

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -36,8 +36,8 @@ var (
 	}
 )
 
-// processMonitorTelemertry
-type processMonitorTelemertry struct {
+// processMonitorTelemetry
+type processMonitorTelemetry struct {
 	// process monitor will process :
 	//  o events refer to netlink events received (not only exec and exit)
 	//  o exec process netlink events
@@ -57,7 +57,7 @@ type processMonitorTelemertry struct {
 	callbackExecuted  *telemetry.Counter
 }
 
-func (pmt *processMonitorTelemertry) initialize() {
+func (pmt *processMonitorTelemetry) initialize() {
 	metricGroup := telemetry.NewMetricGroup(
 		"usm.process.monitor",
 		telemetry.OptPrometheus,
@@ -101,7 +101,7 @@ type ProcessMonitor struct {
 	processExitCallbacks      map[*ProcessCallback]struct{}
 	callbackRunner            chan func()
 
-	tel processMonitorTelemertry
+	tel processMonitorTelemetry
 }
 
 type ProcessCallback func(pid uint32)

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -60,7 +60,7 @@ type processMonitorTelemertry struct {
 func (pmt *processMonitorTelemertry) initialize() {
 	metricGroup := telemetry.NewMetricGroup(
 		"usm.process.monitor",
-		telemetry.OptPayloadTelemetry,
+		telemetry.OptPrometheus,
 	)
 	pmt.events = metricGroup.NewCounter("events")
 	pmt.exec = metricGroup.NewCounter("exec")

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -38,6 +38,7 @@ var (
 
 // processMonitorTelemetry
 type processMonitorTelemetry struct {
+	mg *telemetry.MetricGroup
 	// process monitor will process :
 	//  o events refer to netlink events received (not only exec and exit)
 	//  o exec process netlink events
@@ -63,6 +64,7 @@ func newProcessMonitorTelemetry() processMonitorTelemetry {
 		telemetry.OptPrometheus,
 	)
 	return processMonitorTelemetry{
+		mg:      metricGroup,
 		events:  metricGroup.NewCounter("events"),
 		exec:    metricGroup.NewCounter("exec"),
 		exit:    metricGroup.NewCounter("exit"),
@@ -263,11 +265,8 @@ func (pm *ProcessMonitor) mainEventLoop() {
 				return
 			}
 		case <-logTicker.C:
-			log.Debugf("process monitor stats - total events: %d; exec events: %d; exit events: %d; restart counter: %d; max channel size: %d / 2 minutes)",
-				pm.tel.events.Get(),
-				pm.tel.exec.Get(),
-				pm.tel.exit.Get(),
-				pm.tel.restart.Get(),
+			log.Debugf("process monitor stats - %s; max channel size: %d / 2 minutes)",
+				pm.tel.mg.Summary(),
 				maxChannelSize,
 			)
 			maxChannelSize = 0

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -44,7 +44,6 @@ type processMonitorTelemertry struct {
 	//  o exit process netlink events
 	//  o restart the netlink connection
 	//
-	//  o events_channel_size is the queue length of netlink messages channel
 	//  o reinit_failed is the number of failed re-initialisation after a netlink restart due to an error
 	//  o process_scan_failed would be > 0 if initial process scan failed
 	//  o callback_called numbers of callback called
@@ -60,7 +59,7 @@ type processMonitorTelemertry struct {
 
 func (pmt *processMonitorTelemertry) initialize() {
 	metricGroup := telemetry.NewMetricGroup(
-		"process.monitor",
+		"usm.process.monitor",
 		telemetry.OptPayloadTelemetry,
 	)
 	pmt.events = metricGroup.NewCounter("events")

--- a/pkg/process/monitor/process_monitor_test.go
+++ b/pkg/process/monitor/process_monitor_test.go
@@ -79,21 +79,14 @@ func TestProcessMonitorSanity(t *testing.T) {
 		return numberOfExecs.Load() > 1
 	}, time.Second, time.Millisecond*200, "didn't capture exec events %d", numberOfExecs.Load())
 
-	tel := telemetry.ReportPayloadTelemetry("1")
-	telEqual := func(t *testing.T, expected int64, m string) {
-		require.Equal(t, expected, tel[m], m)
-	}
-	telNotEqual := func(t *testing.T, expected int64, m string) {
-		require.NotEqual(t, expected, tel[m], m)
-	}
-	require.GreaterOrEqual(t, tel["process.monitor.events"], tel["process.monitor.exec"], "process.monitor.exec")
-	require.GreaterOrEqual(t, tel["process.monitor.events"], tel["process.monitor.exit"], "process.monitor.exit")
-	telNotEqual(t, 0, "process.monitor.exec")
-	telNotEqual(t, 0, "process.monitor.exit")
-	telEqual(t, 0, "process.monitor.restart")
-	telEqual(t, 0, "process.monitor.reinitFailed")
-	telEqual(t, 0, "process.monitor.process_scan_failed")
-	require.GreaterOrEqual(t, tel["process.monitor.callback_executed"], int64(1), "process.monitor.callback_executed")
+	require.GreaterOrEqual(t, pm.tel.events.Get(), pm.tel.exec.Get(), "events is not >= than exec")
+	require.GreaterOrEqual(t, pm.tel.events.Get(), pm.tel.exit.Get(), "events is not >= than exit")
+	require.NotEqual(t, int64(0), pm.tel.exec.Get())
+	require.NotEqual(t, int64(0), pm.tel.exit.Get())
+	require.Equal(t, int64(0), pm.tel.restart.Get())
+	require.Equal(t, int64(0), pm.tel.reinitFailed.Get())
+	require.Equal(t, int64(0), pm.tel.processScanFailed.Get())
+	require.GreaterOrEqual(t, pm.tel.callbackExecuted.Get(), int64(1), "callback_executed")
 }
 
 func TestProcessRegisterMultipleExecCallbacks(t *testing.T) {
@@ -146,21 +139,14 @@ func TestProcessRegisterMultipleExitCallbacks(t *testing.T) {
 		return true
 	}, time.Second, time.Millisecond*200, "at least of the callbacks didn't capture events")
 
-	tel := telemetry.ReportPayloadTelemetry("1")
-	telEqual := func(t *testing.T, expected int64, m string) {
-		require.Equal(t, expected, tel[m], m)
-	}
-	telNotEqual := func(t *testing.T, expected int64, m string) {
-		require.NotEqual(t, expected, tel[m], m)
-	}
-	require.GreaterOrEqual(t, tel["process.monitor.events"], tel["process.monitor.exec"], "process.monitor.exec")
-	require.GreaterOrEqual(t, tel["process.monitor.events"], tel["process.monitor.exit"], "process.monitor.exit")
-	telNotEqual(t, 0, "process.monitor.exec")
-	telNotEqual(t, 0, "process.monitor.exit")
-	telEqual(t, 0, "process.monitor.restart")
-	telEqual(t, 0, "process.monitor.reinit_failed")
-	telEqual(t, 0, "process.monitor.process_scan_failed")
-	require.GreaterOrEqual(t, tel["process.monitor.callback_executed"], int64(1), "process.monitor.callback_executed")
+	require.GreaterOrEqual(t, pm.tel.events.Get(), pm.tel.exec.Get(), "events is not >= than exec")
+	require.GreaterOrEqual(t, pm.tel.events.Get(), pm.tel.exit.Get(), "events is not >= than exit")
+	require.NotEqual(t, int64(0), pm.tel.exec.Get())
+	require.NotEqual(t, int64(0), pm.tel.exit.Get())
+	require.Equal(t, int64(0), pm.tel.restart.Get())
+	require.Equal(t, int64(0), pm.tel.reinitFailed.Get())
+	require.Equal(t, int64(0), pm.tel.processScanFailed.Get())
+	require.GreaterOrEqual(t, pm.tel.callbackExecuted.Get(), int64(1), "callback_executed")
 }
 
 func TestProcessMonitorRefcount(t *testing.T) {
@@ -215,19 +201,12 @@ func TestProcessMonitorInNamespace(t *testing.T) {
 		return captured
 	}, time.Second, 200*time.Millisecond, "did not capture process EXEC from other namespace")
 
-	tel := telemetry.ReportPayloadTelemetry("1")
-	telEqual := func(t *testing.T, expected int64, m string) {
-		require.Equal(t, expected, tel[m], m)
-	}
-	telNotEqual := func(t *testing.T, expected int64, m string) {
-		require.NotEqual(t, expected, tel[m], m)
-	}
-	require.GreaterOrEqual(t, tel["process.monitor.events"], tel["process.monitor.exec"], "process.monitor.exec")
-	require.GreaterOrEqual(t, tel["process.monitor.events"], tel["process.monitor.exit"], "process.monitor.exit")
-	telNotEqual(t, 0, "process.monitor.exec")
-	telNotEqual(t, 0, "process.monitor.exit")
-	telEqual(t, 0, "process.monitor.restart")
-	telEqual(t, 0, "process.monitor.reinit_failed")
-	telEqual(t, 0, "process.monitor.process_scan_failed")
-	require.GreaterOrEqual(t, tel["process.monitor.callback_executed"], int64(1), "process.monitor.callback_executed")
+	require.GreaterOrEqual(t, pm.tel.events.Get(), pm.tel.exec.Get(), "events is not >= than exec")
+	require.GreaterOrEqual(t, pm.tel.events.Get(), pm.tel.exit.Get(), "events is not >= than exit")
+	require.NotEqual(t, int64(0), pm.tel.exec.Get())
+	require.NotEqual(t, int64(0), pm.tel.exit.Get())
+	require.Equal(t, int64(0), pm.tel.restart.Get())
+	require.Equal(t, int64(0), pm.tel.reinitFailed.Get())
+	require.Equal(t, int64(0), pm.tel.processScanFailed.Get())
+	require.GreaterOrEqual(t, pm.tel.callbackExecuted.Get(), int64(1), "callback_executed")
 }

--- a/pkg/process/monitor/process_monitor_test.go
+++ b/pkg/process/monitor/process_monitor_test.go
@@ -20,14 +20,15 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
 	procutils "github.com/DataDog/datadog-agent/pkg/process/util"
+	libtelemetry "github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util"
 )
 
 func getProcessMonitor(t *testing.T) *ProcessMonitor {
 	pm := GetProcessMonitor()
+	telemetry.Clear()
 	t.Cleanup(func() {
 		pm.Stop()
-		telemetry.Clear()
 	})
 	return pm
 }
@@ -79,21 +80,35 @@ func TestProcessMonitorSanity(t *testing.T) {
 		return numberOfExecs.Load() > 1
 	}, time.Second, time.Millisecond*200, "didn't capture exec events %d", numberOfExecs.Load())
 
-	tel := telemetry.ReportPayloadTelemetry("1")
-	telEqual := func(t *testing.T, expected int64, m string) {
-		require.Equal(t, expected, tel[m], m)
+	tel := telemetry.ReportPrometheus()
+	getCounter := func(m string) float64 {
+		pm, ok := tel[m]
+		if !ok {
+			return 0
+		}
+		switch v := pm.(type) {
+		case libtelemetry.Counter:
+			return v.WithValues().Get()
+		case libtelemetry.Gauge:
+			return v.WithValues().Get()
+		}
+		return 0
 	}
-	telNotEqual := func(t *testing.T, expected int64, m string) {
-		require.NotEqual(t, expected, tel[m], m)
+	telEqual := func(t *testing.T, expected float64, m string) {
+		require.Equal(t, expected, getCounter(m), m)
 	}
-	require.GreaterOrEqual(t, tel["process.monitor.events"], tel["process.monitor.exec"], "process.monitor.exec")
-	require.GreaterOrEqual(t, tel["process.monitor.events"], tel["process.monitor.exit"], "process.monitor.exit")
-	telNotEqual(t, 0, "process.monitor.exec")
-	telNotEqual(t, 0, "process.monitor.exit")
-	telEqual(t, 0, "process.monitor.restart")
-	telEqual(t, 0, "process.monitor.reinitFailed")
-	telEqual(t, 0, "process.monitor.process_scan_failed")
-	require.GreaterOrEqual(t, tel["process.monitor.callback_executed"], int64(1), "process.monitor.callback_executed")
+	telNotEqual := func(t *testing.T, expected float64, m string) {
+		require.NotEqual(t, expected, getCounter(m), m)
+	}
+
+	require.GreaterOrEqual(t, getCounter("usm.process.monitor.events"), getCounter("usm.process.monitor.exec"), "usm.process.monitor.exec")
+	require.GreaterOrEqual(t, getCounter("usm.process.monitor.events"), getCounter("usm.process.monitor.exit"), "usm.process.monitor.exit")
+	telNotEqual(t, 0, "usm.process.monitor.exec")
+	telNotEqual(t, 0, "usm.process.monitor.exit")
+	telEqual(t, 0, "usm.process.monitor.restart")
+	telEqual(t, 0, "usm.process.monitor.reinitFailed")
+	telEqual(t, 0, "usm.process.monitor.process_scan_failed")
+	require.GreaterOrEqual(t, getCounter("usm.process.monitor.callback_executed"), float64(1), "usm.process.monitor.callback_executed")
 }
 
 func TestProcessRegisterMultipleExecCallbacks(t *testing.T) {
@@ -146,21 +161,35 @@ func TestProcessRegisterMultipleExitCallbacks(t *testing.T) {
 		return true
 	}, time.Second, time.Millisecond*200, "at least of the callbacks didn't capture events")
 
-	tel := telemetry.ReportPayloadTelemetry("1")
-	telEqual := func(t *testing.T, expected int64, m string) {
-		require.Equal(t, expected, tel[m], m)
+	tel := telemetry.ReportPrometheus()
+	getCounter := func(m string) float64 {
+		pm, ok := tel[m]
+		if !ok {
+			return 0
+		}
+		switch v := pm.(type) {
+		case libtelemetry.Counter:
+			return v.WithValues().Get()
+		case libtelemetry.Gauge:
+			return v.WithValues().Get()
+		}
+		return 0
 	}
-	telNotEqual := func(t *testing.T, expected int64, m string) {
-		require.NotEqual(t, expected, tel[m], m)
+	telEqual := func(t *testing.T, expected float64, m string) {
+		require.Equal(t, expected, getCounter(m), m)
 	}
-	require.GreaterOrEqual(t, tel["process.monitor.events"], tel["process.monitor.exec"], "process.monitor.exec")
-	require.GreaterOrEqual(t, tel["process.monitor.events"], tel["process.monitor.exit"], "process.monitor.exit")
-	telNotEqual(t, 0, "process.monitor.exec")
-	telNotEqual(t, 0, "process.monitor.exit")
-	telEqual(t, 0, "process.monitor.restart")
-	telEqual(t, 0, "process.monitor.reinit_failed")
-	telEqual(t, 0, "process.monitor.process_scan_failed")
-	require.GreaterOrEqual(t, tel["process.monitor.callback_executed"], int64(1), "process.monitor.callback_executed")
+	telNotEqual := func(t *testing.T, expected float64, m string) {
+		require.NotEqual(t, expected, getCounter(m), m)
+	}
+
+	require.GreaterOrEqual(t, getCounter("usm.process.monitor.events"), getCounter("usm.process.monitor.exec"), "usm.process.monitor.exec")
+	require.GreaterOrEqual(t, getCounter("usm.process.monitor.events"), getCounter("usm.process.monitor.exit"), "usm.process.monitor.exit")
+	telNotEqual(t, 0, "usm.process.monitor.exec")
+	telNotEqual(t, 0, "usm.process.monitor.exit")
+	telEqual(t, 0, "usm.process.monitor.restart")
+	telEqual(t, 0, "usm.process.monitor.reinit_failed")
+	telEqual(t, 0, "usm.process.monitor.process_scan_failed")
+	require.GreaterOrEqual(t, getCounter("usm.process.monitor.callback_executed"), float64(1), "usm.process.monitor.callback_executed")
 }
 
 func TestProcessMonitorRefcount(t *testing.T) {
@@ -215,19 +244,32 @@ func TestProcessMonitorInNamespace(t *testing.T) {
 		return captured
 	}, time.Second, 200*time.Millisecond, "did not capture process EXEC from other namespace")
 
-	tel := telemetry.ReportPayloadTelemetry("1")
-	telEqual := func(t *testing.T, expected int64, m string) {
-		require.Equal(t, expected, tel[m], m)
+	tel := telemetry.ReportPrometheus()
+	getCounter := func(m string) float64 {
+		pm, ok := tel[m]
+		if !ok {
+			return 0
+		}
+		switch v := pm.(type) {
+		case libtelemetry.Counter:
+			return v.WithValues().Get()
+		case libtelemetry.Gauge:
+			return v.WithValues().Get()
+		}
+		return 0
 	}
-	telNotEqual := func(t *testing.T, expected int64, m string) {
-		require.NotEqual(t, expected, tel[m], m)
+	telEqual := func(t *testing.T, expected float64, m string) {
+		require.Equal(t, expected, getCounter(m), m)
 	}
-	require.GreaterOrEqual(t, tel["process.monitor.events"], tel["process.monitor.exec"], "process.monitor.exec")
-	require.GreaterOrEqual(t, tel["process.monitor.events"], tel["process.monitor.exit"], "process.monitor.exit")
-	telNotEqual(t, 0, "process.monitor.exec")
-	telNotEqual(t, 0, "process.monitor.exit")
-	telEqual(t, 0, "process.monitor.restart")
-	telEqual(t, 0, "process.monitor.reinit_failed")
-	telEqual(t, 0, "process.monitor.process_scan_failed")
-	require.GreaterOrEqual(t, tel["process.monitor.callback_executed"], int64(1), "process.monitor.callback_executed")
+	telNotEqual := func(t *testing.T, expected float64, m string) {
+		require.NotEqual(t, expected, getCounter(m), m)
+	}
+	require.GreaterOrEqual(t, getCounter("usm.process.monitor.events"), getCounter("usm.process.monitor.exec"), "usm.process.monitor.exec")
+	require.GreaterOrEqual(t, getCounter("usm.process.monitor.events"), getCounter("usm.process.monitor.exit"), "usm.process.monitor.exit")
+	telNotEqual(t, 0, "usm.process.monitor.exec")
+	telNotEqual(t, 0, "usm.process.monitor.exit")
+	telEqual(t, 0, "usm.process.monitor.restart")
+	telEqual(t, 0, "usm.process.monitor.reinit_failed")
+	telEqual(t, 0, "usm.process.monitor.process_scan_failed")
+	require.GreaterOrEqual(t, getCounter("usm.process.monitor.callback_executed"), float64(1), "usm.process.monitor.callback_executed")
 }

--- a/pkg/process/monitor/process_monitor_test.go
+++ b/pkg/process/monitor/process_monitor_test.go
@@ -70,7 +70,7 @@ func TestProcessMonitorSanity(t *testing.T) {
 	pm := getProcessMonitor(t)
 	numberOfExecs := atomic.Int32{}
 	testBinaryPath := getTestBinaryPath(t)
-	callback := func(pid int) { numberOfExecs.Inc() }
+	callback := func(pid uint32) { numberOfExecs.Inc() }
 	registerCallback(t, pm, true, (*ProcessCallback)(&callback))
 
 	initializePM(t, pm)
@@ -104,7 +104,7 @@ func TestProcessRegisterMultipleExecCallbacks(t *testing.T) {
 	for i := 0; i < iterations; i++ {
 		counters[i] = &atomic.Int32{}
 		c := counters[i]
-		callback := func(pid int) { c.Inc() }
+		callback := func(pid uint32) { c.Inc() }
 		registerCallback(t, pm, true, (*ProcessCallback)(&callback))
 	}
 
@@ -130,7 +130,7 @@ func TestProcessRegisterMultipleExitCallbacks(t *testing.T) {
 		counters[i] = &atomic.Int32{}
 		c := counters[i]
 		// Sanity subscribing a callback.
-		callback := func(pid int) { c.Inc() }
+		callback := func(pid uint32) { c.Inc() }
 		registerCallback(t, pm, true, (*ProcessCallback)(&callback))
 	}
 
@@ -182,7 +182,7 @@ func TestProcessMonitorInNamespace(t *testing.T) {
 
 	pm := getProcessMonitor(t)
 
-	callback := func(pid int) { execSet.Store(pid, struct{}{}) }
+	callback := func(pid uint32) { execSet.Store(pid, struct{}{}) }
 	registerCallback(t, pm, true, (*ProcessCallback)(&callback))
 
 	monNs, err := netns.New()

--- a/pkg/process/monitor/process_monitor_test.go
+++ b/pkg/process/monitor/process_monitor_test.go
@@ -93,7 +93,7 @@ func TestProcessMonitorSanity(t *testing.T) {
 	telEqual(t, 0, "process.monitor.restart")
 	telEqual(t, 0, "process.monitor.reinitFailed")
 	telEqual(t, 0, "process.monitor.process_scan_failed")
-	require.GreaterOrEqual(t, tel["process.monitor.callback_called"], int64(1), "process.monitor.callback_called")
+	require.GreaterOrEqual(t, tel["process.monitor.callback_executed"], int64(1), "process.monitor.callback_executed")
 }
 
 func TestProcessRegisterMultipleExecCallbacks(t *testing.T) {
@@ -160,7 +160,7 @@ func TestProcessRegisterMultipleExitCallbacks(t *testing.T) {
 	telEqual(t, 0, "process.monitor.restart")
 	telEqual(t, 0, "process.monitor.reinit_failed")
 	telEqual(t, 0, "process.monitor.process_scan_failed")
-	require.GreaterOrEqual(t, tel["process.monitor.callback_called"], int64(1), "process.monitor.callback_called")
+	require.GreaterOrEqual(t, tel["process.monitor.callback_executed"], int64(1), "process.monitor.callback_executed")
 }
 
 func TestProcessMonitorRefcount(t *testing.T) {
@@ -229,5 +229,5 @@ func TestProcessMonitorInNamespace(t *testing.T) {
 	telEqual(t, 0, "process.monitor.restart")
 	telEqual(t, 0, "process.monitor.reinit_failed")
 	telEqual(t, 0, "process.monitor.process_scan_failed")
-	require.GreaterOrEqual(t, tel["process.monitor.callback_called"], int64(1), "process.monitor.callback_called")
+	require.GreaterOrEqual(t, tel["process.monitor.callback_executed"], int64(1), "process.monitor.callback_executed")
 }


### PR DESCRIPTION
### What does this PR do?

Add internal telemetry for process monitor

process monitor will process :
 o events refer to netlink events received (not only exec and exit)
 o exec process netlink events
 o exit process netlink events
 o restart the netlink connection

 o reinit_failed is the number of failed re-initialisation after a netlink restart due to an error
 o process_scan_failed would be > 0 if initial process scan failed
 o callback_executed numbers of executed callback 


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
