### PR TITLE
pkg/trace/stats: Fix concentrator flakes

### DIFF
--- a/pkg/trace/stats/concentrator_test.go
+++ b/pkg/trace/stats/concentrator_test.go
@@ -44,9 +44,8 @@ func getTsInBucket(alignedNow int64, bsize int64, offset int64) int64 {
 
 // testSpan avoids typo and inconsistency in test spans (typical pitfall: duration, start time,
 // and end time are aligned, and end time is the one that needs to be aligned
-func testSpan(spanID uint64, parentID uint64, duration, offset int64, service, resource string, err int32, meta map[string]string) *pb.Span {
-	now := time.Now().UnixNano()
-	alignedNow := now - now%testBucketInterval
+func testSpan(now time.Time, spanID uint64, parentID uint64, duration, offset int64, service, resource string, err int32, meta map[string]string) *pb.Span {
+	alignedNow := now.UnixNano() - now.UnixNano()%testBucketInterval
 
 	return &pb.Span{
 		SpanID:   spanID,
@@ -102,7 +101,7 @@ func TestTracerHostname(t *testing.T) {
 	now := time.Now()
 
 	spans := []*pb.Span{
-		testSpan(1, 0, 50, 5, "A1", "resource1", 0, nil),
+		testSpan(now, 1, 0, 50, 5, "A1", "resource1", 0, nil),
 	}
 	traceutil.ComputeTopLevel(spans)
 	testTrace := toProcessedTrace(spans, "none", "tracer-hostname")
@@ -121,12 +120,12 @@ func TestConcentratorOldestTs(t *testing.T) {
 
 	// Build that simply have spans spread over time windows.
 	spans := []*pb.Span{
-		testSpan(1, 0, 50, 5, "A1", "resource1", 0, nil),
-		testSpan(1, 0, 40, 4, "A1", "resource1", 0, nil),
-		testSpan(1, 0, 30, 3, "A1", "resource1", 0, nil),
-		testSpan(1, 0, 20, 2, "A1", "resource1", 0, nil),
-		testSpan(1, 0, 10, 1, "A1", "resource1", 0, nil),
-		testSpan(1, 0, 1, 0, "A1", "resource1", 0, nil),
+		testSpan(now, 1, 0, 50, 5, "A1", "resource1", 0, nil),
+		testSpan(now, 1, 0, 40, 4, "A1", "resource1", 0, nil),
+		testSpan(now, 1, 0, 30, 3, "A1", "resource1", 0, nil),
+		testSpan(now, 1, 0, 20, 2, "A1", "resource1", 0, nil),
+		testSpan(now, 1, 0, 10, 1, "A1", "resource1", 0, nil),
+		testSpan(now, 1, 0, 1, 0, "A1", "resource1", 0, nil),
 	}
 
 	traceutil.ComputeTopLevel(spans)
@@ -241,12 +240,12 @@ func TestConcentratorStatsTotals(t *testing.T) {
 
 	// Build that simply have spans spread over time windows.
 	spans := []*pb.Span{
-		testSpan(1, 0, 50, 5, "A1", "resource1", 0, nil),
-		testSpan(1, 0, 40, 4, "A1", "resource1", 0, nil),
-		testSpan(1, 0, 30, 3, "A1", "resource1", 0, nil),
-		testSpan(1, 0, 20, 2, "A1", "resource1", 0, nil),
-		testSpan(1, 0, 10, 1, "A1", "resource1", 0, nil),
-		testSpan(1, 0, 1, 0, "A1", "resource1", 0, nil),
+		testSpan(now, 1, 0, 50, 5, "A1", "resource1", 0, nil),
+		testSpan(now, 1, 0, 40, 4, "A1", "resource1", 0, nil),
+		testSpan(now, 1, 0, 30, 3, "A1", "resource1", 0, nil),
+		testSpan(now, 1, 0, 20, 2, "A1", "resource1", 0, nil),
+		testSpan(now, 1, 0, 10, 1, "A1", "resource1", 0, nil),
+		testSpan(now, 1, 0, 1, 0, "A1", "resource1", 0, nil),
 	}
 
 	traceutil.ComputeTopLevel(spans)
@@ -298,24 +297,24 @@ func TestConcentratorStatsCounts(t *testing.T) {
 	// Build a trace with stats which should cover 3 time buckets.
 	spans := []*pb.Span{
 		// more than 2 buckets old, should be added to the 2 bucket-old, first flush.
-		testSpan(1, 0, 111, 10, "A1", "resource1", 0, nil),
-		testSpan(1, 0, 222, 3, "A1", "resource1", 0, nil),
-		testSpan(11, 0, 333, 3, "A1", "resource3", 0, map[string]string{"span.kind": "client"}),
-		testSpan(12, 0, 444, 3, "A1", "resource3", 0, map[string]string{"span.kind": "server"}),
+		testSpan(now, 1, 0, 111, 10, "A1", "resource1", 0, nil),
+		testSpan(now, 1, 0, 222, 3, "A1", "resource1", 0, nil),
+		testSpan(now, 11, 0, 333, 3, "A1", "resource3", 0, map[string]string{"span.kind": "client"}),
+		testSpan(now, 12, 0, 444, 3, "A1", "resource3", 0, map[string]string{"span.kind": "server"}),
 		// 2 buckets old, part of the first flush
-		testSpan(1, 0, 24, 2, "A1", "resource1", 0, nil),
-		testSpan(2, 0, 12, 2, "A1", "resource1", 2, nil),
-		testSpan(3, 0, 40, 2, "A2", "resource2", 2, nil),
-		testSpan(4, 0, 300000000000, 2, "A2", "resource2", 2, nil), // 5 minutes trace
-		testSpan(5, 0, 30, 2, "A2", "resourcefoo", 0, nil),
+		testSpan(now, 1, 0, 24, 2, "A1", "resource1", 0, nil),
+		testSpan(now, 2, 0, 12, 2, "A1", "resource1", 2, nil),
+		testSpan(now, 3, 0, 40, 2, "A2", "resource2", 2, nil),
+		testSpan(now, 4, 0, 300000000000, 2, "A2", "resource2", 2, nil), // 5 minutes trace
+		testSpan(now, 5, 0, 30, 2, "A2", "resourcefoo", 0, nil),
 		// 1 bucket old, part of the second flush
-		testSpan(6, 0, 24, 1, "A1", "resource2", 0, nil),
-		testSpan(7, 0, 12, 1, "A1", "resource1", 2, nil),
-		testSpan(8, 0, 40, 1, "A2", "resource1", 2, nil),
-		testSpan(9, 0, 30, 1, "A2", "resource2", 2, nil),
-		testSpan(10, 0, 3600000000000, 1, "A2", "resourcefoo", 0, nil), // 1 hour trace
+		testSpan(now, 6, 0, 24, 1, "A1", "resource2", 0, nil),
+		testSpan(now, 7, 0, 12, 1, "A1", "resource1", 2, nil),
+		testSpan(now, 8, 0, 40, 1, "A2", "resource1", 2, nil),
+		testSpan(now, 9, 0, 30, 1, "A2", "resource2", 2, nil),
+		testSpan(now, 10, 0, 3600000000000, 1, "A2", "resourcefoo", 0, nil), // 1 hour trace
 		// present data, part of the third flush
-		testSpan(6, 0, 24, 0, "A1", "resource2", 0, nil),
+		testSpan(now, 6, 0, 24, 0, "A1", "resource2", 0, nil),
 	}
 
 	expectedCountValByKeyByTime := make(map[int64][]pb.ClientGroupedStats)
@@ -481,9 +480,8 @@ func TestConcentratorStatsCounts(t *testing.T) {
 	}
 }
 
-func generateDistribution(t *testing.T, generator func(i int) int64) *ddsketch.DDSketch {
+func generateDistribution(t *testing.T, now time.Time, generator func(i int) int64) *ddsketch.DDSketch {
 	assert := assert.New(t)
-	now := time.Now()
 	c := NewTestConcentrator(now)
 	alignedNow := alignTs(now.UnixNano(), c.bsize)
 	// update oldestTs as it running for quite some time, to avoid the fact that at startup
@@ -492,7 +490,7 @@ func generateDistribution(t *testing.T, generator func(i int) int64) *ddsketch.D
 	// Build a trace with stats representing the distribution given by the generator
 	spans := []*pb.Span{}
 	for i := 0; i < 100; i++ {
-		spans = append(spans, testSpan(uint64(i)+1, 0, generator(i), 0, "A1", "resource1", 0, nil))
+		spans = append(spans, testSpan(now, uint64(i)+1, 0, generator(i), 0, "A1", "resource1", 0, nil))
 	}
 	traceutil.ComputeTopLevel(spans)
 	c.addNow(toProcessedTrace(spans, "none", ""), "")
@@ -513,9 +511,10 @@ func generateDistribution(t *testing.T, generator func(i int) int64) *ddsketch.D
 
 func TestDistributions(t *testing.T) {
 	assert := assert.New(t)
+	now := time.Now()
 	testQuantiles := []float64{0.1, 0.5, 0.95, 0.99, 1}
 	t.Run("constant", func(t *testing.T) {
-		constantDistribution := generateDistribution(t, func(i int) int64 { return 42 })
+		constantDistribution := generateDistribution(t, now, func(i int) int64 { return 42 })
 		expectedConstant := []float64{42, 42, 42, 42, 42}
 		for i, q := range testQuantiles {
 			actual, err := constantDistribution.GetValueAtQuantile(q)
@@ -524,7 +523,7 @@ func TestDistributions(t *testing.T) {
 		}
 	})
 	t.Run("uniform", func(t *testing.T) {
-		uniformDistribution := generateDistribution(t, func(i int) int64 { return int64(i) + 1 })
+		uniformDistribution := generateDistribution(t, now, func(i int) int64 { return int64(i) + 1 })
 		expectedUniform := []float64{10, 50, 95, 99, 100}
 		for i, q := range testQuantiles {
 			actual, err := uniformDistribution.GetValueAtQuantile(q)
@@ -537,7 +536,7 @@ func TestIgnoresPartialSpans(t *testing.T) {
 	assert := assert.New(t)
 	now := time.Now()
 
-	span := testSpan(1, 0, 50, 5, "A1", "resource1", 0, nil)
+	span := testSpan(now, 1, 0, 50, 5, "A1", "resource1", 0, nil)
 	span.Metrics = map[string]float64{"_dd.partial_version": 830604}
 	spans := []*pb.Span{span}
 	traceutil.ComputeTopLevel(spans)
@@ -556,7 +555,7 @@ func TestForceFlush(t *testing.T) {
 	assert := assert.New(t)
 	now := time.Now()
 
-	spans := []*pb.Span{testSpan(1, 0, 50, 5, "A1", "resource1", 0, nil)}
+	spans := []*pb.Span{testSpan(now, 1, 0, 50, 5, "A1", "resource1", 0, nil)}
 	traceutil.ComputeTopLevel(spans)
 	testTrace := toProcessedTrace(spans, "none", "")
 	c := NewTestConcentrator(now)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

concentrator_test.go has a number of tests that rely on timestamps on spans and timing of flushing. This change refactors the tests to not call `time.Now()` within a helper function that generates spans, but instead passes the `now` value that is calculated at the start of each test.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
