### PR TITLE
[Serverless] AAS Universal Extension Support

### DIFF
--- a/cmd/serverless-init/cloudservice/appservice.go
+++ b/cmd/serverless-init/cloudservice/appservice.go
@@ -8,6 +8,7 @@ package cloudservice
 import (
 	"os"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 )
 
@@ -58,7 +59,5 @@ func (a *AppService) Init() error {
 }
 
 func isAppService() bool {
-	_, exists_linux := os.LookupEnv(RunZip)
-	_, exists_win := os.LookupEnv(AppLogsTrace)
-	return exists_linux || exists_win
+	return config.InAzureAppServices(os.LookupEnv)
 }

--- a/cmd/serverless-init/cloudservice/appservice.go
+++ b/cmd/serverless-init/cloudservice/appservice.go
@@ -8,7 +8,6 @@ package cloudservice
 import (
 	"os"
 
-	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 )
 
@@ -56,8 +55,4 @@ func (a *AppService) GetPrefix() string {
 // Init is empty for AppService
 func (a *AppService) Init() error {
 	return nil
-}
-
-func isAppService() bool {
-	return config.InAzureAppServices(os.LookupEnv)
 }

--- a/cmd/serverless-init/cloudservice/appservice.go
+++ b/cmd/serverless-init/cloudservice/appservice.go
@@ -15,9 +15,10 @@ import (
 type AppService struct{}
 
 const (
-	WebsiteName = "WEBSITE_SITE_NAME"
-	RegionName  = "REGION_NAME"
-	RunZip      = "APPSVC_RUN_ZIP"
+	WebsiteName  = "WEBSITE_SITE_NAME"
+	RegionName   = "REGION_NAME"
+	RunZip       = "APPSVC_RUN_ZIP"
+	AppLogsTrace = "WEBSITE_APPSERVICEAPPLOGS_TRACE_ENABLED"
 )
 
 // GetTags returns a map of Azure-related tags
@@ -57,6 +58,7 @@ func (a *AppService) Init() error {
 }
 
 func isAppService() bool {
-	_, exists := os.LookupEnv(RunZip)
-	return exists
+	_, exists_linux := os.LookupEnv(RunZip)
+	_, exists_win := os.LookupEnv(AppLogsTrace)
+	return exists_linux || exists_win
 }

--- a/cmd/serverless-init/cloudservice/appservice_test.go
+++ b/cmd/serverless-init/cloudservice/appservice_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetAppServiceTags(t *testing.T) {
+func TestGetLinuxAppServiceTags(t *testing.T) {
 	service := &AppService{}
 
 	t.Setenv("WEBSITE_SITE_NAME", "test_site_name")
@@ -19,7 +19,7 @@ func TestGetAppServiceTags(t *testing.T) {
 	t.Setenv("APPSVC_RUN_ZIP", "false")
 
 	tags := service.GetTags()
-	tags["aas.environment.os"] = "test_os"
+	tags["aas.environment.os"] = "linux"
 	tags["aas.environment.runtime"] = "test_runtime"
 	tags["aas.environment.instance_name"] = "test_instance_name"
 
@@ -28,9 +28,39 @@ func TestGetAppServiceTags(t *testing.T) {
 		"origin":                        "appservice",
 		"region":                        "eastus",
 		"_dd.origin":                    "appservice",
-		"aas.environment.instance_id":   "",
+		"aas.environment.instance_id":   "unknown",
 		"aas.environment.instance_name": "test_instance_name",
-		"aas.environment.os":            "test_os",
+		"aas.environment.os":            "linux",
+		"aas.environment.runtime":       "test_runtime",
+		"aas.resource.group":            "",
+		"aas.resource.id":               "",
+		"aas.site.kind":                 "app",
+		"aas.site.name":                 "test_site_name",
+		"aas.site.type":                 "app",
+		"aas.subscription.id":           "",
+	}, tags)
+}
+
+func TestGetWindowsAppServiceTags(t *testing.T) {
+	service := &AppService{}
+
+	t.Setenv("WEBSITE_SITE_NAME", "test_site_name")
+	t.Setenv("REGION_NAME", "eastus")
+	t.Setenv("WEBSITE_APPSERVICEAPPLOGS_TRACE_ENABLED", "false")
+
+	tags := service.GetTags()
+	tags["aas.environment.os"] = "windows"
+	tags["aas.environment.runtime"] = "test_runtime"
+	tags["aas.environment.instance_name"] = "test_instance_name"
+
+	assert.Equal(t, map[string]string{
+		"app_name":                      "test_site_name",
+		"origin":                        "appservice",
+		"region":                        "eastus",
+		"_dd.origin":                    "appservice",
+		"aas.environment.instance_id":   "unknown",
+		"aas.environment.instance_name": "test_instance_name",
+		"aas.environment.os":            "windows",
 		"aas.environment.runtime":       "test_runtime",
 		"aas.resource.group":            "",
 		"aas.resource.id":               "",

--- a/cmd/serverless-init/cloudservice/service.go
+++ b/cmd/serverless-init/cloudservice/service.go
@@ -5,6 +5,8 @@
 
 package cloudservice
 
+import "github.com/DataDog/datadog-agent/pkg/trace/config"
+
 // CloudService implements getting tags from each Cloud Provider.
 type CloudService interface {
 	// GetTags returns a map of tags for a given cloud service. These tags are then attached to
@@ -56,7 +58,7 @@ func GetCloudServiceType() CloudService {
 		return NewContainerApp()
 	}
 
-	if isAppService() {
+	if config.InAzureAppServices() {
 		return &AppService{}
 	}
 

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -215,6 +215,12 @@ func (a *Agent) setRootSpanTags(root *pb.Span) {
 		rate := ratelimiter.RealRate()
 		sampler.SetPreSampleRate(root, rate)
 	}
+
+	if a.conf.InAzureAppServices {
+		for k, v := range traceutil.GetAppServicesTags() {
+			traceutil.SetMeta(root, k, v)
+		}
+	}
 }
 
 // Process is the default work unit that receives a trace, transforms it and
@@ -272,6 +278,7 @@ func (a *Agent) Process(p *api.Payload) {
 		}
 
 		// Extra sanitization steps of the trace.
+		appServicesTags := traceutil.GetAppServicesTags()
 		for _, span := range chunk.Spans {
 			for k, v := range a.conf.GlobalTags {
 				if k == tagOrigin {
@@ -281,9 +288,8 @@ func (a *Agent) Process(p *api.Payload) {
 				}
 			}
 			if a.conf.InAzureAppServices {
-				for k, v := range traceutil.GetAppServicesTags() {
-					traceutil.SetMeta(span, k, v)
-				}
+				traceutil.SetMeta(span, "aas.site.name", appServicesTags["aas.site.name"])
+				traceutil.SetMeta(span, "aas.site.type", appServicesTags["aas.site.type"])
 			}
 			if a.ModifySpan != nil {
 				a.ModifySpan(chunk, span)

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -280,6 +280,11 @@ func (a *Agent) Process(p *api.Payload) {
 					traceutil.SetMeta(span, k, v)
 				}
 			}
+			if a.conf.InAzureAppServices {
+				for k, v := range traceutil.GetAppServicesTags() {
+					traceutil.SetMeta(span, k, v)
+				}
+			}
 			if a.ModifySpan != nil {
 				a.ModifySpan(chunk, span)
 			}
@@ -290,15 +295,6 @@ func (a *Agent) Process(p *api.Payload) {
 			}
 		}
 		a.Replacer.Replace(chunk.Spans)
-
-		// Set aas tags on all spans
-		if a.conf.InAzureAppServices {
-			for _, span := range chunk.Spans {
-				for k, v := range traceutil.GetAppServicesTags() {
-					traceutil.SetMeta(span, k, v)
-				}
-			}
-		}
 
 		a.setRootSpanTags(root)
 		if !p.ClientComputedTopLevel {

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -215,6 +215,12 @@ func (a *Agent) setRootSpanTags(root *pb.Span) {
 		rate := ratelimiter.RealRate()
 		sampler.SetPreSampleRate(root, rate)
 	}
+
+	if a.conf.InAzureAppServices {
+		for k, v := range traceutil.GetAppServicesTags() {
+			traceutil.SetMeta(root, k, v)
+		}
+	}
 }
 
 // Process is the default work unit that receives a trace, transforms it and

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -215,12 +215,6 @@ func (a *Agent) setRootSpanTags(root *pb.Span) {
 		rate := ratelimiter.RealRate()
 		sampler.SetPreSampleRate(root, rate)
 	}
-
-	if a.conf.InAzureAppServices {
-		for k, v := range traceutil.GetAppServicesTags() {
-			traceutil.SetMeta(root, k, v)
-		}
-	}
 }
 
 // Process is the default work unit that receives a trace, transforms it and
@@ -296,6 +290,15 @@ func (a *Agent) Process(p *api.Payload) {
 			}
 		}
 		a.Replacer.Replace(chunk.Spans)
+
+		// Set aas tags on all spans
+		if a.conf.InAzureAppServices {
+			for _, span := range chunk.Spans {
+				for k, v := range traceutil.GetAppServicesTags() {
+					traceutil.SetMeta(span, k, v)
+				}
+			}
+		}
 
 		a.setRootSpanTags(root)
 		if !p.ClientComputedTopLevel {

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -1971,3 +1971,18 @@ func TestSpanSampling(t *testing.T) {
 		})
 	}
 }
+
+func TestSetRootSpanTagsInAzureAppServices(t *testing.T) {
+	cfg := config.New()
+	cfg.Endpoints[0].APIKey = "test"
+	cfg.InAzureAppServices = true
+	ctx, cancel := context.WithCancel(context.Background())
+	agnt := NewAgent(ctx, cfg, telemetry.NewNoopCollector())
+	defer cancel()
+
+	span := &pb.Span{}
+
+	agnt.setRootSpanTags(span)
+
+	assert.Contains(t, span.Meta, "aas.site.kind")
+}

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -334,7 +334,9 @@ func TestProcess(t *testing.T) {
 		case <-timeout:
 			t.Fatal("timed out")
 		}
-		assert.Contains(t, tp.Chunks[0].Spans[0].Meta, "aas.site.kind")
+		for tag := range traceutil.GetAppServicesTags() {
+			assert.Contains(t, tp.Chunks[0].Spans[0].Meta, tag)
+		}
 	})
 
 	t.Run("DiscardSpans", func(t *testing.T) {

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -537,7 +537,7 @@ func New() *AgentConfig {
 			MaxPayloadSize: 5 * 1024 * 1024,
 		},
 
-		InAzureAppServices: inAzureAppServices(os.Getenv),
+		InAzureAppServices: InAzureAppServices(os.LookupEnv),
 
 		Features: make(map[string]struct{}),
 	}
@@ -599,8 +599,8 @@ func (c *AgentConfig) AllFeatures() []string {
 	return feats
 }
 
-func inAzureAppServices(getenv func(string) string) bool {
-	exists_linux := getenv(RunZip)
-	exists_win := getenv(AppLogsTrace)
-	return len(exists_linux)+len(exists_win) > 0
+func InAzureAppServices(lookupEnv func(string) (string, bool)) bool {
+	_, existsLinux := lookupEnv(RunZip)
+	_, existsWin := lookupEnv(AppLogsTrace)
+	return existsLinux || existsWin
 }

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -537,7 +537,7 @@ func New() *AgentConfig {
 			MaxPayloadSize: 5 * 1024 * 1024,
 		},
 
-		InAzureAppServices: InAzureAppServices(os.LookupEnv),
+		InAzureAppServices: InAzureAppServices(),
 
 		Features: make(map[string]struct{}),
 	}
@@ -599,8 +599,8 @@ func (c *AgentConfig) AllFeatures() []string {
 	return feats
 }
 
-func InAzureAppServices(lookupEnv func(string) (string, bool)) bool {
-	_, existsLinux := lookupEnv(RunZip)
-	_, existsWin := lookupEnv(AppLogsTrace)
+func InAzureAppServices() bool {
+	_, existsLinux := os.LookupEnv(RunZip)
+	_, existsWin := os.LookupEnv(AppLogsTrace)
 	return existsLinux || existsWin
 }

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"time"
 
@@ -34,6 +35,10 @@ type Endpoint struct {
 
 // TelemetryEndpointPrefix specifies the prefix of the telemetry endpoint URL.
 const TelemetryEndpointPrefix = "https://instrumentation-telemetry-intake."
+
+// App Services env vars
+const RunZip = "APPSVC_RUN_ZIP"
+const AppLogsTrace = "WEBSITE_APPSERVICEAPPLOGS_TRACE_ENABLED"
 
 // OTLP holds the configuration for the OpenTelemetry receiver.
 type OTLP struct {
@@ -448,6 +453,9 @@ type AgentConfig struct {
 	// ContainerProcRoot is the root dir for `proc` info
 	ContainerProcRoot string
 
+	// Azure App Services
+	InAzureAppServices bool
+
 	// DebugServerPort defines the port used by the debug server
 	DebugServerPort int
 }
@@ -529,6 +537,8 @@ func New() *AgentConfig {
 			MaxPayloadSize: 5 * 1024 * 1024,
 		},
 
+		InAzureAppServices: inAzureAppServices(os.Getenv),
+
 		Features: make(map[string]struct{}),
 	}
 }
@@ -587,4 +597,10 @@ func (c *AgentConfig) AllFeatures() []string {
 		feats = append(feats, feat)
 	}
 	return feats
+}
+
+func inAzureAppServices(getenv func(string) string) bool {
+	exists_linux := getenv(RunZip)
+	exists_win := getenv(AppLogsTrace)
+	return len(exists_linux)+len(exists_win) > 0
 }

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -6,15 +6,23 @@
 package config
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestInAzureAppServices(t *testing.T) {
-	isLinuxAzure := InAzureAppServices(func(s string) (string, bool) { return "", true })
-	isWindowsAzure := InAzureAppServices(func(s string) (string, bool) { return "", true })
-	isNotAzure := InAzureAppServices(func(s string) (string, bool) { return "", false })
+	os.Setenv(RunZip, " ")
+	isLinuxAzure := InAzureAppServices()
+	os.Unsetenv(RunZip)
+
+	os.Setenv(AppLogsTrace, " ")
+	isWindowsAzure := InAzureAppServices()
+	os.Unsetenv(AppLogsTrace)
+
+	isNotAzure := InAzureAppServices()
+
 	assert.True(t, isLinuxAzure)
 	assert.True(t, isWindowsAzure)
 	assert.False(t, isNotAzure)

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func TestInAzureAppServices(t *testing.T) {
-	isLinuxAzure := inAzureAppServices(func(s string) string { return "APPSVC_RUN_ZIP" })
-	isWindowsAzure := inAzureAppServices(func(s string) string { return "WEBSITE_APPSERVICEAPPLOGS_TRACE_ENABLED" })
-	isNotAzure := inAzureAppServices(func(s string) string { return "" })
+	isLinuxAzure := InAzureAppServices(func(s string) (string, bool) { return "", true })
+	isWindowsAzure := InAzureAppServices(func(s string) (string, bool) { return "", true })
+	isNotAzure := InAzureAppServices(func(s string) (string, bool) { return "", false })
 	assert.True(t, isLinuxAzure)
 	assert.True(t, isWindowsAzure)
 	assert.False(t, isNotAzure)

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInAzureAppServices(t *testing.T) {
+	isLinuxAzure := inAzureAppServices(func(s string) string { return "APPSVC_RUN_ZIP" })
+	isWindowsAzure := inAzureAppServices(func(s string) string { return "WEBSITE_APPSERVICEAPPLOGS_TRACE_ENABLED" })
+	isNotAzure := inAzureAppServices(func(s string) string { return "" })
+	assert.True(t, isLinuxAzure)
+	assert.True(t, isWindowsAzure)
+	assert.False(t, isNotAzure)
+}

--- a/pkg/trace/traceutil/azure.go
+++ b/pkg/trace/traceutil/azure.go
@@ -101,7 +101,7 @@ func getRuntime(websiteOS string, getenv func(string) string) (rt string) {
 	switch websiteOS {
 	case "windows":
 		rt = getWindowsRuntime(getenv)
-	case "linux":
+	case "linux", "darwin":
 		rt = getLinuxRuntime(getenv)
 	default:
 		rt = unknown
@@ -111,10 +111,9 @@ func getRuntime(websiteOS string, getenv func(string) string) (rt string) {
 }
 
 func getWindowsRuntime(getenv func(string) string) (rt string) {
-	env := getenv("WEBSITE_STACK")
-	if env == "JAVA" {
+	if getenv("WEBSITE_STACK") == "JAVA" {
 		rt = javaFramework
-	} else if env == "NODE" || hasEnv("WEBSITE_NODE_DEFAULT_VERSION", getenv) {
+	} else if hasEnv("WEBSITE_NODE_DEFAULT_VERSION", getenv) {
 		rt = nodeFramework
 	} else if hasEnv("DOTNET_CLI_TELEMETRY_PROFILE", getenv) {
 		rt = dotnetFramework

--- a/pkg/trace/traceutil/azure.go
+++ b/pkg/trace/traceutil/azure.go
@@ -115,10 +115,10 @@ func getWindowsRuntime(getenv func(string) string) (rt string) {
 		rt = javaFramework
 	} else if hasEnv("WEBSITE_NODE_DEFAULT_VERSION", getenv) {
 		rt = nodeFramework
-	} else if hasEnv("DOTNET_CLI_TELEMETRY_PROFILE", getenv) {
-		rt = dotnetFramework
 	} else {
-		rt = unknown
+		// Windows AAS only supports Java, Node, and .NET so we can infer this
+		// Needs to be inferred because no other env vars give us context
+		rt = dotnetFramework
 	}
 
 	return rt

--- a/pkg/trace/traceutil/azure.go
+++ b/pkg/trace/traceutil/azure.go
@@ -116,8 +116,8 @@ func getWindowsRuntime(getenv func(string) string) (rt string) {
 	} else if val := getenv("WEBSITE_NODE_DEFAULT_VERSION"); val != "" {
 		rt = nodeFramework
 	} else {
-		// Windows AAS only supports Java, Node, and .NET so we can infer this
-		// Needs to be inferred because no other env vars give us context
+		// FIXME: Windows AAS only supports Java, Node, and .NET so we can infer this
+		// Needs to be inferred because no other env vars give us context on the runtime
 		rt = dotnetFramework
 	}
 

--- a/pkg/trace/traceutil/azure.go
+++ b/pkg/trace/traceutil/azure.go
@@ -77,12 +77,12 @@ func getAppServicesTags(getenv func(string) string) map[string]string {
 
 	// Remove the Java and .NET logic once non-universal extensions are deprecated
 	if websiteOS == "windows" {
-		if len(extensionVersion) > 0 {
+		if extensionVersion != "" {
 			tags[aasExtensionVersion] = extensionVersion
-		} else if hasEnv("DD_AAS_JAVA_EXTENSION_VERSION", getenv) {
-			tags[aasExtensionVersion] = getenv("DD_AAS_JAVA_EXTENSION_VERSION")
-		} else if hasEnv("DD_AAS_DOTNET_EXTENSION_VERSION", getenv) {
-			tags[aasExtensionVersion] = getenv("DD_AAS_DOTNET_EXTENSION_VERSION")
+		} else if val := getenv("DD_AAS_JAVA_EXTENSION_VERSION"); val != "" {
+			tags[aasExtensionVersion] = val
+		} else if val := getenv("DD_AAS_DOTNET_EXTENSION_VERSION"); val != "" {
+			tags[aasExtensionVersion] = val
 		}
 	}
 
@@ -113,7 +113,7 @@ func getRuntime(websiteOS string, getenv func(string) string) (rt string) {
 func getWindowsRuntime(getenv func(string) string) (rt string) {
 	if getenv("WEBSITE_STACK") == "JAVA" {
 		rt = javaFramework
-	} else if hasEnv("WEBSITE_NODE_DEFAULT_VERSION", getenv) {
+	} else if val := getenv("WEBSITE_NODE_DEFAULT_VERSION"); val != "" {
 		rt = nodeFramework
 	} else {
 		// Windows AAS only supports Java, Node, and .NET so we can infer this
@@ -131,7 +131,7 @@ func getLinuxRuntime(getenv func(string) string) (rt string) {
 	case "DOCKER":
 		rt = containerFramework
 	case "":
-		if hasEnv("DOCKER_SERVER_VERSION", getenv) {
+		if val := getenv("DOCKER_SERVER_VERSION"); val != "" {
 			rt = containerFramework
 		}
 	case "NODE":
@@ -147,10 +147,6 @@ func getLinuxRuntime(getenv func(string) string) (rt string) {
 	}
 
 	return rt
-}
-
-func hasEnv(env string, getenv func(string) string) bool {
-	return len(getenv(env)) > 0
 }
 
 func parseAzureSubscriptionID(subID string) (id string) {

--- a/pkg/trace/traceutil/azure.go
+++ b/pkg/trace/traceutil/azure.go
@@ -110,7 +110,7 @@ func getRuntime(getenv func(string) string) (rt string) {
 }
 
 func hasEnv(env string, getenv func(string) string) bool {
-	return len(getenv(env)) != 0
+	return len(getenv(env)) > 0
 }
 
 func parseAzureSubscriptionID(subID string) (id string) {

--- a/pkg/trace/traceutil/azure_test.go
+++ b/pkg/trace/traceutil/azure_test.go
@@ -35,20 +35,28 @@ func TestGetEnvOrUnknown(t *testing.T) {
 	assert.Equal(t, "unknown", unknownEnvVar)
 }
 
-func TestGetRuntime(t *testing.T) {
-	dotnet := getRuntime(func(s string) string {
+func TestHasEnv(t *testing.T) {
+	has := hasEnv("WEBSITE_STACK", mockGetEnvVar)
+	notHas := hasEnv("DD_SERVICE", mockGetEnvVar)
+
+	assert.Equal(t, true, has)
+	assert.Equal(t, false, notHas)
+}
+
+func TestGetWindowsRuntime(t *testing.T) {
+	dotnet := getRuntime("windows", func(s string) string {
 		if s == "DOTNET_CLI_TELEMETRY_PROFILE" {
 			return "AzureKudu"
 		}
 		return ""
 	})
-	java := getRuntime(func(s string) string {
+	java := getRuntime("windows", func(s string) string {
 		if s == "WEBSITE_STACK" {
 			return "JAVA"
 		}
 		return ""
 	})
-	node := getRuntime(func(s string) string {
+	node := getRuntime("windows", func(s string) string {
 		if s == "WEBSITE_STACK" {
 			return "NODE"
 		}
@@ -57,11 +65,41 @@ func TestGetRuntime(t *testing.T) {
 		}
 		return ""
 	})
-	unknown := getRuntime(func(s string) string { return "" })
+	unknown := getRuntime("windows", func(s string) string { return "" })
 
 	assert.Equal(t, ".NET", dotnet)
 	assert.Equal(t, "Java", java)
 	assert.Equal(t, "Node.js", node)
+	assert.Equal(t, "unknown", unknown)
+}
+
+func TestGetLinuxRuntime(t *testing.T) {
+	docker := getRuntime("linux", func(s string) string { return "DOCKER" })
+	compose := getRuntime("linux", func(s string) string {
+		if s == "WEBSITE_STACK" {
+			return ""
+		}
+		if s == "DOCKER_SERVER_VERSION" {
+			return "19.03.15+azure"
+		}
+		return ""
+	})
+	java := getRuntime("linux", func(s string) string { return "JAVA" })
+	tomcat := getRuntime("linux", func(s string) string { return "TOMCAT" })
+	node := getRuntime("linux", func(s string) string { return "NODE" })
+	python := getRuntime("linux", func(s string) string { return "PYTHON" })
+	dotnet := getRuntime("linux", func(s string) string { return "DOTNETCORE" })
+	php := getRuntime("linux", func(s string) string { return "PHP" })
+	unknown := getRuntime("linux", func(s string) string { return "" })
+
+	assert.Equal(t, "Container", docker)
+	assert.Equal(t, "Container", compose)
+	assert.Equal(t, "Java", java)
+	assert.Equal(t, "Java", tomcat)
+	assert.Equal(t, "Node.js", node)
+	assert.Equal(t, "Python", python)
+	assert.Equal(t, ".NET", dotnet)
+	assert.Equal(t, "PHP", php)
 	assert.Equal(t, "unknown", unknown)
 }
 

--- a/pkg/trace/traceutil/azure_test.go
+++ b/pkg/trace/traceutil/azure_test.go
@@ -44,12 +44,6 @@ func TestHasEnv(t *testing.T) {
 }
 
 func TestGetWindowsRuntime(t *testing.T) {
-	dotnet := getRuntime("windows", func(s string) string {
-		if s == "DOTNET_CLI_TELEMETRY_PROFILE" {
-			return "AzureKudu"
-		}
-		return ""
-	})
 	java := getRuntime("windows", func(s string) string {
 		if s == "WEBSITE_STACK" {
 			return "JAVA"
@@ -62,12 +56,12 @@ func TestGetWindowsRuntime(t *testing.T) {
 		}
 		return ""
 	})
-	unknown := getRuntime("windows", func(s string) string { return "" })
+	dotnet := getRuntime("windows", func(s string) string { return "" })
 
 	assert.Equal(t, ".NET", dotnet)
 	assert.Equal(t, "Java", java)
 	assert.Equal(t, "Node.js", node)
-	assert.Equal(t, "unknown", unknown)
+	assert.Equal(t, ".NET", dotnet)
 }
 
 func TestGetLinuxRuntime(t *testing.T) {

--- a/pkg/trace/traceutil/azure_test.go
+++ b/pkg/trace/traceutil/azure_test.go
@@ -123,6 +123,7 @@ func mockAzureAppServiceMetadata() map[string]string {
 	aasMetadata["WEBSITE_INSTANCE_ID"] = "1234abcd"
 	aasMetadata["COMPUTERNAME"] = "test-instance"
 	aasMetadata["WEBSITE_STACK"] = "NODE"
+	aasMetadata["WEBSITE_NODE_DEFAULT_VERSION"] = "~18"
 
 	return aasMetadata
 }

--- a/pkg/trace/traceutil/azure_test.go
+++ b/pkg/trace/traceutil/azure_test.go
@@ -57,9 +57,6 @@ func TestGetWindowsRuntime(t *testing.T) {
 		return ""
 	})
 	node := getRuntime("windows", func(s string) string {
-		if s == "WEBSITE_STACK" {
-			return "NODE"
-		}
 		if s == "WEBSITE_NODE_DEFAULT_VERSION" {
 			return "~18"
 		}

--- a/pkg/trace/traceutil/azure_test.go
+++ b/pkg/trace/traceutil/azure_test.go
@@ -35,14 +35,6 @@ func TestGetEnvOrUnknown(t *testing.T) {
 	assert.Equal(t, "unknown", unknownEnvVar)
 }
 
-func TestHasEnv(t *testing.T) {
-	has := hasEnv("WEBSITE_STACK", mockGetEnvVar)
-	notHas := hasEnv("DD_SERVICE", mockGetEnvVar)
-
-	assert.Equal(t, true, has)
-	assert.Equal(t, false, notHas)
-}
-
 func TestGetWindowsRuntime(t *testing.T) {
 	java := getRuntime("windows", func(s string) string {
 		if s == "WEBSITE_STACK" {

--- a/pkg/trace/traceutil/azure_test.go
+++ b/pkg/trace/traceutil/azure_test.go
@@ -66,7 +66,6 @@ func mockAzureAppServiceMetadata() map[string]string {
 	aasMetadata["WEBSITE_RESOURCE_GROUP"] = "test-resource-group"
 	aasMetadata["WEBSITE_INSTANCE_ID"] = "1234abcd"
 	aasMetadata["COMPUTERNAME"] = "test-instance"
-	aasMetadata["DD_RUNTIME"] = "node"
 
 	return aasMetadata
 }

--- a/pkg/trace/traceutil/azure_test.go
+++ b/pkg/trace/traceutil/azure_test.go
@@ -36,10 +36,31 @@ func TestGetEnvOrUnknown(t *testing.T) {
 }
 
 func TestGetRuntime(t *testing.T) {
-	dotnet := getRuntime(func(s string) string { return "dotnet" })
-	node := getRuntime(func(s string) string { return "node" })
-	unknown := getRuntime(func(s string) string { return "hahaha" })
+	dotnet := getRuntime(func(s string) string {
+		if s == "DOTNET_CLI_TELEMETRY_PROFILE" {
+			return "AzureKudu"
+		}
+		return ""
+	})
+	java := getRuntime(func(s string) string {
+		if s == "WEBSITE_STACK" {
+			return "JAVA"
+		}
+		return ""
+	})
+	node := getRuntime(func(s string) string {
+		if s == "WEBSITE_STACK" {
+			return "NODE"
+		}
+		if s == "WEBSITE_NODE_DEFAULT_VERSION" {
+			return "~18"
+		}
+		return ""
+	})
+	unknown := getRuntime(func(s string) string { return "" })
+
 	assert.Equal(t, ".NET", dotnet)
+	assert.Equal(t, "Java", java)
 	assert.Equal(t, "Node.js", node)
 	assert.Equal(t, "unknown", unknown)
 }
@@ -66,6 +87,7 @@ func mockAzureAppServiceMetadata() map[string]string {
 	aasMetadata["WEBSITE_RESOURCE_GROUP"] = "test-resource-group"
 	aasMetadata["WEBSITE_INSTANCE_ID"] = "1234abcd"
 	aasMetadata["COMPUTERNAME"] = "test-instance"
+	aasMetadata["WEBSITE_STACK"] = "NODE"
 
 	return aasMetadata
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR adds support for the Azure App Services Universal Extension

* We're removing the `DD_RUNTIME` env variable in favor of just detecting the runtime based on the existence/values of other variables
* Updating `isAppService()` to also work on Windows, current impl was only tested for Linux
* Adding the logic to tag the version of the AAS extension here, it's currently being done in each tracer
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
https://github.com/DataDog/datadog-aas-extension/pull/202
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
This PR is also adding back some core logic that was accidentally removed in https://github.com/DataDog/datadog-agent/pull/17591

The Java and .NET tracers will have some more duplication but they already do with the span tags. We can simply disable the tagging done in the tracers by setting `DD_AZURE_APP_SERVICES=0`. Once we deprecate the non-universal extensions we can go ahead and remove the codepaths entirely.
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Testing
Here is a screenshot of the aas span tags for a Windows Java app: 
<img width="1058" alt="Screenshot 2023-07-06 at 12 49 16 PM" src="https://github.com/DataDog/datadog-agent/assets/25130402/f01d1db5-efaf-4afc-931d-c0f1586024a0">
