### PR TITLE
pkg/util: support different stack depths

### DIFF
--- a/cmd/trace-agent/run.go
+++ b/cmd/trace-agent/run.go
@@ -258,7 +258,7 @@ func (corelogger) Trace(v ...interface{}) { log.TraceStackDepth(stackDepth, v...
 
 // Tracef implements Logger.
 func (corelogger) Tracef(format string, params ...interface{}) {
-	log.TracefStackDepth(format, stackDepth, params...)
+	log.TracefStackDepth(stackDepth, format, params...)
 }
 
 // Debug implements Logger.
@@ -266,7 +266,7 @@ func (corelogger) Debug(v ...interface{}) { log.DebugStackDepth(stackDepth, v...
 
 // Debugf implements Logger.
 func (corelogger) Debugf(format string, params ...interface{}) {
-	log.DebugfStackDepth(format, stackDepth, params...)
+	log.DebugfStackDepth(stackDepth, format, params...)
 }
 
 // Info implements Logger.
@@ -274,7 +274,7 @@ func (corelogger) Info(v ...interface{}) { log.InfoStackDepth(stackDepth, v...) 
 
 // Infof implements Logger.
 func (corelogger) Infof(format string, params ...interface{}) {
-	log.InfofStackDepth(format, stackDepth, params...)
+	log.InfofStackDepth(stackDepth, format, params...)
 }
 
 // Warn implements Logger.
@@ -282,7 +282,7 @@ func (corelogger) Warn(v ...interface{}) error { return log.WarnStackDepth(stack
 
 // Warnf implements Logger.
 func (corelogger) Warnf(format string, params ...interface{}) error {
-	return log.WarnfStackDepth(format, stackDepth, params...)
+	return log.WarnfStackDepth(stackDepth, format, params...)
 }
 
 // Error implements Logger.
@@ -290,7 +290,7 @@ func (corelogger) Error(v ...interface{}) error { return log.ErrorStackDepth(sta
 
 // Errorf implements Logger.
 func (corelogger) Errorf(format string, params ...interface{}) error {
-	return log.ErrorfStackDepth(format, stackDepth, params...)
+	return log.ErrorfStackDepth(stackDepth, format, params...)
 }
 
 // Critical implements Logger.
@@ -298,7 +298,7 @@ func (corelogger) Critical(v ...interface{}) error { return log.CriticalStackDep
 
 // Criticalf implements Logger.
 func (corelogger) Criticalf(format string, params ...interface{}) error {
-	return log.CriticalfStackDepth(format, stackDepth, params...)
+	return log.CriticalfStackDepth(stackDepth, format, params...)
 }
 
 // Flush implements Logger.

--- a/cmd/trace-agent/run.go
+++ b/cmd/trace-agent/run.go
@@ -48,6 +48,9 @@ const messageAgentDisabled = `trace-agent not enabled. Set the environment varia
 DD_APM_ENABLED=true or add "apm_config.enabled: true" entry
 to your datadog.yaml. Exiting...`
 
+// Stack depth of 3 since the `corelogger` struct adds a layer above the logger
+const stackDepth = 3
+
 // Run is the entrypoint of our code, which starts the agent.
 func Run(ctx context.Context) {
 	if flags.Version {
@@ -251,51 +254,51 @@ func Run(ctx context.Context) {
 type corelogger struct{}
 
 // Trace implements Logger.
-func (corelogger) Trace(v ...interface{}) { log.TraceStackDepth(3, v...) }
+func (corelogger) Trace(v ...interface{}) { log.TraceStackDepth(stackDepth, v...) }
 
 // Tracef implements Logger.
 func (corelogger) Tracef(format string, params ...interface{}) {
-	log.TracefStackDepth(format, 3, params...)
+	log.TracefStackDepth(format, stackDepth, params...)
 }
 
 // Debug implements Logger.
-func (corelogger) Debug(v ...interface{}) { log.DebugStackDepth(3, v...) }
+func (corelogger) Debug(v ...interface{}) { log.DebugStackDepth(stackDepth, v...) }
 
 // Debugf implements Logger.
 func (corelogger) Debugf(format string, params ...interface{}) {
-	log.DebugfStackDepth(format, 3, params...)
+	log.DebugfStackDepth(format, stackDepth, params...)
 }
 
 // Info implements Logger.
-func (corelogger) Info(v ...interface{}) { log.InfoStackDepth(3, v...) }
+func (corelogger) Info(v ...interface{}) { log.InfoStackDepth(stackDepth, v...) }
 
 // Infof implements Logger.
 func (corelogger) Infof(format string, params ...interface{}) {
-	log.InfofStackDepth(format, 3, params...)
+	log.InfofStackDepth(format, stackDepth, params...)
 }
 
 // Warn implements Logger.
-func (corelogger) Warn(v ...interface{}) error { return log.WarnStackDepth(3, v...) }
+func (corelogger) Warn(v ...interface{}) error { return log.WarnStackDepth(stackDepth, v...) }
 
 // Warnf implements Logger.
 func (corelogger) Warnf(format string, params ...interface{}) error {
-	return log.WarnfStackDepth(format, 3, params...)
+	return log.WarnfStackDepth(format, stackDepth, params...)
 }
 
 // Error implements Logger.
-func (corelogger) Error(v ...interface{}) error { return log.ErrorStackDepth(3, v...) }
+func (corelogger) Error(v ...interface{}) error { return log.ErrorStackDepth(stackDepth, v...) }
 
 // Errorf implements Logger.
 func (corelogger) Errorf(format string, params ...interface{}) error {
-	return log.ErrorfStackDepth(format, 3, params...)
+	return log.ErrorfStackDepth(format, stackDepth, params...)
 }
 
 // Critical implements Logger.
-func (corelogger) Critical(v ...interface{}) error { return log.CriticalStackDepth(3, v...) }
+func (corelogger) Critical(v ...interface{}) error { return log.CriticalStackDepth(stackDepth, v...) }
 
 // Criticalf implements Logger.
 func (corelogger) Criticalf(format string, params ...interface{}) error {
-	return log.CriticalfStackDepth(format, 3, params...)
+	return log.CriticalfStackDepth(format, stackDepth, params...)
 }
 
 // Flush implements Logger.

--- a/cmd/trace-agent/run.go
+++ b/cmd/trace-agent/run.go
@@ -251,45 +251,49 @@ func Run(ctx context.Context) {
 type corelogger struct{}
 
 // Trace implements Logger.
-func (corelogger) Trace(v ...interface{}) { log.Trace(v...) }
+func (corelogger) Trace(v ...interface{}) { log.TraceStackDepth(3, v...) }
 
 // Tracef implements Logger.
-func (corelogger) Tracef(format string, params ...interface{}) { log.Tracef(format, params...) }
+func (corelogger) Tracef(format string, params ...interface{}) {
+	log.Parsef(format, "TRACE", params...)
+}
 
 // Debug implements Logger.
-func (corelogger) Debug(v ...interface{}) { log.Debug(v...) }
+func (corelogger) Debug(v ...interface{}) { log.DebugStackDepth(3, v...) }
 
 // Debugf implements Logger.
-func (corelogger) Debugf(format string, params ...interface{}) { log.Debugf(format, params...) }
+func (corelogger) Debugf(format string, params ...interface{}) {
+	log.Parsef(format, "DEBUG", params...)
+}
 
 // Info implements Logger.
-func (corelogger) Info(v ...interface{}) { log.Info(v...) }
+func (corelogger) Info(v ...interface{}) { log.InfoStackDepth(3, v...) }
 
 // Infof implements Logger.
-func (corelogger) Infof(format string, params ...interface{}) { log.Infof(format, params...) }
+func (corelogger) Infof(format string, params ...interface{}) { log.Parsef(format, "INFO", params...) }
 
 // Warn implements Logger.
-func (corelogger) Warn(v ...interface{}) error { return log.Warn(v...) }
+func (corelogger) Warn(v ...interface{}) error { return log.WarnStackDepth(3, v...) }
 
 // Warnf implements Logger.
 func (corelogger) Warnf(format string, params ...interface{}) error {
-	return log.Warnf(format, params...)
+	return log.Parsef(format, "WARN", params...)
 }
 
 // Error implements Logger.
-func (corelogger) Error(v ...interface{}) error { return log.Error(v...) }
+func (corelogger) Error(v ...interface{}) error { return log.ErrorStackDepth(3, v...) }
 
 // Errorf implements Logger.
 func (corelogger) Errorf(format string, params ...interface{}) error {
-	return log.Errorf(format, params...)
+	return log.Parsef(format, "ERROR", params...)
 }
 
 // Critical implements Logger.
-func (corelogger) Critical(v ...interface{}) error { return log.Critical(v...) }
+func (corelogger) Critical(v ...interface{}) error { return log.CriticalStackDepth(3, v...) }
 
 // Criticalf implements Logger.
 func (corelogger) Criticalf(format string, params ...interface{}) error {
-	return log.Criticalf(format, params...)
+	return log.Parsef(format, "CRITICAL", params...)
 }
 
 // Flush implements Logger.

--- a/cmd/trace-agent/run.go
+++ b/cmd/trace-agent/run.go
@@ -255,7 +255,7 @@ func (corelogger) Trace(v ...interface{}) { log.TraceStackDepth(3, v...) }
 
 // Tracef implements Logger.
 func (corelogger) Tracef(format string, params ...interface{}) {
-	log.Parsef(format, "TRACE", params...)
+	log.TracefStackDepth(format, 3, params...)
 }
 
 // Debug implements Logger.
@@ -263,21 +263,23 @@ func (corelogger) Debug(v ...interface{}) { log.DebugStackDepth(3, v...) }
 
 // Debugf implements Logger.
 func (corelogger) Debugf(format string, params ...interface{}) {
-	log.Parsef(format, "DEBUG", params...)
+	log.DebugfStackDepth(format, 3, params...)
 }
 
 // Info implements Logger.
 func (corelogger) Info(v ...interface{}) { log.InfoStackDepth(3, v...) }
 
 // Infof implements Logger.
-func (corelogger) Infof(format string, params ...interface{}) { log.Parsef(format, "INFO", params...) }
+func (corelogger) Infof(format string, params ...interface{}) {
+	log.InfofStackDepth(format, 3, params...)
+}
 
 // Warn implements Logger.
 func (corelogger) Warn(v ...interface{}) error { return log.WarnStackDepth(3, v...) }
 
 // Warnf implements Logger.
 func (corelogger) Warnf(format string, params ...interface{}) error {
-	return log.Parsef(format, "WARN", params...)
+	return log.WarnfStackDepth(format, 3, params...)
 }
 
 // Error implements Logger.
@@ -285,7 +287,7 @@ func (corelogger) Error(v ...interface{}) error { return log.ErrorStackDepth(3, 
 
 // Errorf implements Logger.
 func (corelogger) Errorf(format string, params ...interface{}) error {
-	return log.Parsef(format, "ERROR", params...)
+	return log.ErrorfStackDepth(format, 3, params...)
 }
 
 // Critical implements Logger.
@@ -293,7 +295,7 @@ func (corelogger) Critical(v ...interface{}) error { return log.CriticalStackDep
 
 // Criticalf implements Logger.
 func (corelogger) Criticalf(format string, params ...interface{}) error {
-	return log.Parsef(format, "CRITICAL", params...)
+	return log.CriticalfStackDepth(format, 3, params...)
 }
 
 // Flush implements Logger.

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -538,8 +538,7 @@ func Tracef(format string, params ...interface{}) {
 func TracefStackDepth(format string, depth int, params ...interface{}) {
 	currentLevel, _ := GetLogLevel()
 	if currentLevel <= seelog.TraceLvl {
-		m := fmt.Sprintf(format, params...)
-		logContext(seelog.TraceLvl, func() { Tracec(m, nil) }, Logger.trace, m, depth, nil)
+		TraceStackDepth(depth+2, fmt.Sprintf(format, params...))
 	}
 }
 
@@ -575,8 +574,7 @@ func Debugf(format string, params ...interface{}) {
 func DebugfStackDepth(format string, depth int, params ...interface{}) {
 	currentLevel, _ := GetLogLevel()
 	if currentLevel <= seelog.DebugLvl {
-		m := fmt.Sprintf(format, params...)
-		logContext(seelog.DebugLvl, func() { Debugc(m, nil) }, Logger.debug, m, depth, nil)
+		DebugStackDepth(depth+2, fmt.Sprintf(format, params...))
 	}
 }
 
@@ -612,8 +610,7 @@ func Infof(format string, params ...interface{}) {
 func InfofStackDepth(format string, depth int, params ...interface{}) {
 	currentLevel, _ := GetLogLevel()
 	if currentLevel <= seelog.InfoLvl {
-		m := fmt.Sprintf(format, params...)
-		logContext(seelog.InfoLvl, func() { Infoc(m, nil) }, Logger.info, m, depth, nil)
+		InfoStackDepth(depth+2, fmt.Sprintf(format, params...))
 	}
 }
 
@@ -647,12 +644,7 @@ func Warnf(format string, params ...interface{}) error {
 
 // WarnfStackDepth logs with format at the warn level and the current stack depth plus the given depth
 func WarnfStackDepth(format string, depth int, params ...interface{}) error {
-	currentLevel, _ := GetLogLevel()
-	if currentLevel <= seelog.WarnLvl {
-		m := fmt.Sprintf(format, params...)
-		return logContextWithError(seelog.WarnLvl, func() { Warnc(m, nil) }, Logger.warn, m, false, depth, nil)
-	}
-	return nil
+	return WarnStackDepth(depth+2, fmt.Sprintf(format, params...))
 }
 
 // WarncStackDepth logs at the warn level with context and the current stack depth plus the additional given one and returns an error containing the formated log message
@@ -685,12 +677,7 @@ func Errorf(format string, params ...interface{}) error {
 
 // ErrorfStackDepth logs with format at the error level and the current stack depth plus the given depth
 func ErrorfStackDepth(format string, depth int, params ...interface{}) error {
-	currentLevel, _ := GetLogLevel()
-	if currentLevel <= seelog.ErrorLvl {
-		m := fmt.Sprintf(format, params...)
-		return logContextWithError(seelog.ErrorLvl, func() { Errorc(m, nil) }, Logger.error, m, false, depth, nil)
-	}
-	return nil
+	return ErrorStackDepth(depth+2, fmt.Sprintf(format, params...))
 }
 
 // ErrorcStackDepth logs at the error level with context and the current stack depth plus the additional given one and returns an error containing the formated log message
@@ -723,12 +710,7 @@ func Criticalf(format string, params ...interface{}) error {
 
 // CriticalfStackDepth logs with format at the critical level and the current stack depth plus the given depth
 func CriticalfStackDepth(format string, depth int, params ...interface{}) error {
-	currentLevel, _ := GetLogLevel()
-	if currentLevel <= seelog.CriticalLvl {
-		m := fmt.Sprintf(format, params...)
-		return logContextWithError(seelog.CriticalLvl, func() { Criticalc(m, nil) }, Logger.critical, m, false, depth, nil)
-	}
-	return nil
+	return CriticalStackDepth(depth+2, fmt.Sprintf(format, params...))
 }
 
 // CriticalcStackDepth logs at the critical level with context and the current stack depth plus the additional given one and returns an error containing the formated log message

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -535,8 +535,11 @@ func Tracef(format string, params ...interface{}) {
 }
 
 func TracefStackDepth(format string, depth int, params ...interface{}) {
-	m := fmt.Sprintf(format, params...)
-	logContext(seelog.TraceLvl, func() { Tracec(m, nil) }, Logger.trace, m, depth, nil)
+	currentLevel, _ := GetLogLevel()
+	if currentLevel <= seelog.TraceLvl {
+		m := fmt.Sprintf(format, params...)
+		logContext(seelog.TraceLvl, func() { Tracec(m, nil) }, Logger.trace, m, depth, nil)
+	}
 }
 
 // TracecStackDepth logs at the trace level with context and the current stack depth plus the additional given one
@@ -568,8 +571,11 @@ func Debugf(format string, params ...interface{}) {
 }
 
 func DebugfStackDepth(format string, depth int, params ...interface{}) {
-	m := fmt.Sprintf(format, params...)
-	logContext(seelog.DebugLvl, func() { Debugc(m, nil) }, Logger.debug, m, depth, nil)
+	currentLevel, _ := GetLogLevel()
+	if currentLevel <= seelog.DebugLvl {
+		m := fmt.Sprintf(format, params...)
+		logContext(seelog.DebugLvl, func() { Debugc(m, nil) }, Logger.debug, m, depth, nil)
+	}
 }
 
 // DebugcStackDepth logs at the debug level with context and the current stack depth plus the additional given one
@@ -601,8 +607,11 @@ func Infof(format string, params ...interface{}) {
 }
 
 func InfofStackDepth(format string, depth int, params ...interface{}) {
-	m := fmt.Sprintf(format, params...)
-	logContext(seelog.InfoLvl, func() { Infoc(m, nil) }, Logger.info, m, depth, nil)
+	currentLevel, _ := GetLogLevel()
+	if currentLevel <= seelog.InfoLvl {
+		m := fmt.Sprintf(format, params...)
+		logContext(seelog.InfoLvl, func() { Infoc(m, nil) }, Logger.info, m, depth, nil)
+	}
 }
 
 // InfocStackDepth logs at the info level with context and the current stack depth plus the additional given one
@@ -634,8 +643,12 @@ func Warnf(format string, params ...interface{}) error {
 }
 
 func WarnfStackDepth(format string, depth int, params ...interface{}) error {
-	m := fmt.Sprintf(format, params...)
-	return logContextWithError(seelog.WarnLvl, func() { Warnc(m, nil) }, Logger.warn, m, false, depth, nil)
+	currentLevel, _ := GetLogLevel()
+	if currentLevel <= seelog.WarnLvl {
+		m := fmt.Sprintf(format, params...)
+		return logContextWithError(seelog.WarnLvl, func() { Warnc(m, nil) }, Logger.warn, m, false, depth, nil)
+	}
+	return nil
 }
 
 // WarncStackDepth logs at the warn level with context and the current stack depth plus the additional given one and returns an error containing the formated log message
@@ -667,8 +680,12 @@ func Errorf(format string, params ...interface{}) error {
 }
 
 func ErrorfStackDepth(format string, depth int, params ...interface{}) error {
-	m := fmt.Sprintf(format, params...)
-	return logContextWithError(seelog.ErrorLvl, func() { Errorc(m, nil) }, Logger.error, m, false, depth, nil)
+	currentLevel, _ := GetLogLevel()
+	if currentLevel <= seelog.ErrorLvl {
+		m := fmt.Sprintf(format, params...)
+		return logContextWithError(seelog.ErrorLvl, func() { Errorc(m, nil) }, Logger.error, m, false, depth, nil)
+	}
+	return nil
 }
 
 // ErrorcStackDepth logs at the error level with context and the current stack depth plus the additional given one and returns an error containing the formated log message
@@ -700,8 +717,12 @@ func Criticalf(format string, params ...interface{}) error {
 }
 
 func CriticalfStackDepth(format string, depth int, params ...interface{}) error {
-	m := fmt.Sprintf(format, params...)
-	return logContextWithError(seelog.CriticalLvl, func() { Criticalc(m, nil) }, Logger.critical, m, false, depth, nil)
+	currentLevel, _ := GetLogLevel()
+	if currentLevel <= seelog.CriticalLvl {
+		m := fmt.Sprintf(format, params...)
+		return logContextWithError(seelog.CriticalLvl, func() { Criticalc(m, nil) }, Logger.critical, m, false, depth, nil)
+	}
+	return nil
 }
 
 // CriticalcStackDepth logs at the critical level with context and the current stack depth plus the additional given one and returns an error containing the formated log message

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -534,6 +534,7 @@ func Tracef(format string, params ...interface{}) {
 	logFormat(seelog.TraceLvl, func() { Tracef(format, params...) }, Logger.tracef, format, params...)
 }
 
+// TracefStackDepth logs with format at the trace level and the current stack depth plus the given depth
 func TracefStackDepth(format string, depth int, params ...interface{}) {
 	currentLevel, _ := GetLogLevel()
 	if currentLevel <= seelog.TraceLvl {
@@ -570,6 +571,7 @@ func Debugf(format string, params ...interface{}) {
 	logFormat(seelog.DebugLvl, func() { Debugf(format, params...) }, Logger.debugf, format, params...)
 }
 
+// DebugfStackDepth logs with format at the debug level and the current stack depth plus the given depth
 func DebugfStackDepth(format string, depth int, params ...interface{}) {
 	currentLevel, _ := GetLogLevel()
 	if currentLevel <= seelog.DebugLvl {
@@ -606,6 +608,7 @@ func Infof(format string, params ...interface{}) {
 	logFormat(seelog.InfoLvl, func() { Infof(format, params...) }, Logger.infof, format, params...)
 }
 
+// InfofStackDepth logs with format at the info level and the current stack depth plus the given depth
 func InfofStackDepth(format string, depth int, params ...interface{}) {
 	currentLevel, _ := GetLogLevel()
 	if currentLevel <= seelog.InfoLvl {
@@ -642,6 +645,7 @@ func Warnf(format string, params ...interface{}) error {
 	return logFormatWithError(seelog.WarnLvl, func() { Warnf(format, params...) }, Logger.warnf, format, false, params...)
 }
 
+// WarnfStackDepth logs with format at the warn level and the current stack depth plus the given depth
 func WarnfStackDepth(format string, depth int, params ...interface{}) error {
 	currentLevel, _ := GetLogLevel()
 	if currentLevel <= seelog.WarnLvl {
@@ -679,6 +683,7 @@ func Errorf(format string, params ...interface{}) error {
 	return logFormatWithError(seelog.ErrorLvl, func() { Errorf(format, params...) }, Logger.errorf, format, true, params...)
 }
 
+// ErrorfStackDepth logs with format at the error level and the current stack depth plus the given depth
 func ErrorfStackDepth(format string, depth int, params ...interface{}) error {
 	currentLevel, _ := GetLogLevel()
 	if currentLevel <= seelog.ErrorLvl {
@@ -716,6 +721,7 @@ func Criticalf(format string, params ...interface{}) error {
 	return logFormatWithError(seelog.CriticalLvl, func() { Criticalf(format, params...) }, Logger.criticalf, format, true, params...)
 }
 
+// CriticalfStackDepth logs with format at the critical level and the current stack depth plus the given depth
 func CriticalfStackDepth(format string, depth int, params ...interface{}) error {
 	currentLevel, _ := GetLogLevel()
 	if currentLevel <= seelog.CriticalLvl {

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -535,11 +535,15 @@ func Tracef(format string, params ...interface{}) {
 }
 
 // TracefStackDepth logs with format at the trace level and the current stack depth plus the given depth
-func TracefStackDepth(format string, depth int, params ...interface{}) {
+func TracefStackDepth(depth int, format string, params ...interface{}) {
 	currentLevel, _ := GetLogLevel()
-	if currentLevel <= seelog.TraceLvl {
-		TraceStackDepth(depth+2, fmt.Sprintf(format, params...))
+	if currentLevel > seelog.TraceLvl {
+		return
 	}
+	msg := fmt.Sprintf(format, params...)
+	Log(seelog.TraceLvl, func() { TraceStackDepth(depth, msg) }, func(s string) {
+		Logger.traceStackDepth(s, depth)
+	}, msg)
 }
 
 // TracecStackDepth logs at the trace level with context and the current stack depth plus the additional given one
@@ -571,11 +575,15 @@ func Debugf(format string, params ...interface{}) {
 }
 
 // DebugfStackDepth logs with format at the debug level and the current stack depth plus the given depth
-func DebugfStackDepth(format string, depth int, params ...interface{}) {
+func DebugfStackDepth(depth int, format string, params ...interface{}) {
 	currentLevel, _ := GetLogLevel()
-	if currentLevel <= seelog.DebugLvl {
-		DebugStackDepth(depth+2, fmt.Sprintf(format, params...))
+	if currentLevel > seelog.DebugLvl {
+		return
 	}
+	msg := fmt.Sprintf(format, params...)
+	Log(seelog.DebugLvl, func() { DebugStackDepth(depth, msg) }, func(s string) {
+		Logger.debugStackDepth(s, depth)
+	}, msg)
 }
 
 // DebugcStackDepth logs at the debug level with context and the current stack depth plus the additional given one
@@ -607,11 +615,15 @@ func Infof(format string, params ...interface{}) {
 }
 
 // InfofStackDepth logs with format at the info level and the current stack depth plus the given depth
-func InfofStackDepth(format string, depth int, params ...interface{}) {
+func InfofStackDepth(depth int, format string, params ...interface{}) {
 	currentLevel, _ := GetLogLevel()
-	if currentLevel <= seelog.InfoLvl {
-		InfoStackDepth(depth+2, fmt.Sprintf(format, params...))
+	if currentLevel > seelog.InfoLvl {
+		return
 	}
+	msg := fmt.Sprintf(format, params...)
+	Log(seelog.InfoLvl, func() { InfoStackDepth(depth, msg) }, func(s string) {
+		Logger.infoStackDepth(s, depth)
+	}, msg)
 }
 
 // InfocStackDepth logs at the info level with context and the current stack depth plus the additional given one
@@ -643,8 +655,11 @@ func Warnf(format string, params ...interface{}) error {
 }
 
 // WarnfStackDepth logs with format at the warn level and the current stack depth plus the given depth
-func WarnfStackDepth(format string, depth int, params ...interface{}) error {
-	return WarnStackDepth(depth+2, fmt.Sprintf(format, params...))
+func WarnfStackDepth(depth int, format string, params ...interface{}) error {
+	msg := fmt.Sprintf(format, params...)
+	return logWithError(seelog.WarnLvl, func() { WarnStackDepth(depth, msg) }, func(s string) error {
+		return Logger.warnStackDepth(s, depth)
+	}, false, msg)
 }
 
 // WarncStackDepth logs at the warn level with context and the current stack depth plus the additional given one and returns an error containing the formated log message
@@ -676,8 +691,11 @@ func Errorf(format string, params ...interface{}) error {
 }
 
 // ErrorfStackDepth logs with format at the error level and the current stack depth plus the given depth
-func ErrorfStackDepth(format string, depth int, params ...interface{}) error {
-	return ErrorStackDepth(depth+2, fmt.Sprintf(format, params...))
+func ErrorfStackDepth(depth int, format string, params ...interface{}) error {
+	msg := fmt.Sprintf(format, params...)
+	return logWithError(seelog.ErrorLvl, func() { ErrorStackDepth(depth, msg) }, func(s string) error {
+		return Logger.errorStackDepth(s, depth)
+	}, false, msg)
 }
 
 // ErrorcStackDepth logs at the error level with context and the current stack depth plus the additional given one and returns an error containing the formated log message
@@ -709,8 +727,11 @@ func Criticalf(format string, params ...interface{}) error {
 }
 
 // CriticalfStackDepth logs with format at the critical level and the current stack depth plus the given depth
-func CriticalfStackDepth(format string, depth int, params ...interface{}) error {
-	return CriticalStackDepth(depth+2, fmt.Sprintf(format, params...))
+func CriticalfStackDepth(depth int, format string, params ...interface{}) error {
+	msg := fmt.Sprintf(format, params...)
+	return logWithError(seelog.CriticalLvl, func() { CriticalStackDepth(depth, msg) }, func(s string) error {
+		return Logger.criticalStackDepth(s, depth)
+	}, false, msg)
 }
 
 // CriticalcStackDepth logs at the critical level with context and the current stack depth plus the additional given one and returns an error containing the formated log message

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -692,6 +692,34 @@ func CriticalFunc(logFunc func() string) {
 	}
 }
 
+func Parsef(format string, lvl string, params ...interface{}) error {
+	m := fmt.Sprintf(format, params...)
+	currentLevel, _ := GetLogLevel()
+	sLvl, ok := seelog.LogLevelFromString(strings.ToLower(lvl))
+	if ok && currentLevel > sLvl {
+		return nil
+	}
+
+	switch strings.ToUpper(lvl) {
+	case "TRACE":
+		TracecStackDepth(m, 3, nil)
+	case "DEBUG":
+		DebugcStackDepth(m, 3, nil)
+	case "INFO":
+		InfocStackDepth(m, 3, nil)
+	case "WARN":
+		return WarncStackDepth(m, 3, nil)
+	case "ERROR":
+		return ErrorcStackDepth(m, 3, nil)
+	case "CRITICAL":
+		return CriticalcStackDepth(m, 3, nil)
+	default:
+		// do nothing
+	}
+
+	return nil
+}
+
 // InfoStackDepth logs at the info level and the current stack depth plus the additional given one
 func InfoStackDepth(depth int, v ...interface{}) {
 	Log(seelog.InfoLvl, func() { InfoStackDepth(depth, v...) }, func(s string) {

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -534,6 +534,11 @@ func Tracef(format string, params ...interface{}) {
 	logFormat(seelog.TraceLvl, func() { Tracef(format, params...) }, Logger.tracef, format, params...)
 }
 
+func TracefStackDepth(format string, depth int, params ...interface{}) {
+	m := fmt.Sprintf(format, params...)
+	logContext(seelog.TraceLvl, func() { Tracec(m, nil) }, Logger.trace, m, depth, nil)
+}
+
 // TracecStackDepth logs at the trace level with context and the current stack depth plus the additional given one
 func TracecStackDepth(message string, depth int, context ...interface{}) {
 	logContext(seelog.TraceLvl, func() { Tracec(message, context...) }, Logger.trace, message, depth, context...)
@@ -560,6 +565,11 @@ func Debug(v ...interface{}) {
 // Debugf logs with format at the debug level
 func Debugf(format string, params ...interface{}) {
 	logFormat(seelog.DebugLvl, func() { Debugf(format, params...) }, Logger.debugf, format, params...)
+}
+
+func DebugfStackDepth(format string, depth int, params ...interface{}) {
+	m := fmt.Sprintf(format, params...)
+	logContext(seelog.DebugLvl, func() { Debugc(m, nil) }, Logger.debug, m, depth, nil)
 }
 
 // DebugcStackDepth logs at the debug level with context and the current stack depth plus the additional given one
@@ -590,6 +600,11 @@ func Infof(format string, params ...interface{}) {
 	logFormat(seelog.InfoLvl, func() { Infof(format, params...) }, Logger.infof, format, params...)
 }
 
+func InfofStackDepth(format string, depth int, params ...interface{}) {
+	m := fmt.Sprintf(format, params...)
+	logContext(seelog.InfoLvl, func() { Infoc(m, nil) }, Logger.info, m, depth, nil)
+}
+
 // InfocStackDepth logs at the info level with context and the current stack depth plus the additional given one
 func InfocStackDepth(message string, depth int, context ...interface{}) {
 	logContext(seelog.InfoLvl, func() { Infoc(message, context...) }, Logger.info, message, depth, context...)
@@ -616,6 +631,11 @@ func Warn(v ...interface{}) error {
 // Warnf logs with format at the warn level and returns an error containing the formated log message
 func Warnf(format string, params ...interface{}) error {
 	return logFormatWithError(seelog.WarnLvl, func() { Warnf(format, params...) }, Logger.warnf, format, false, params...)
+}
+
+func WarnfStackDepth(format string, depth int, params ...interface{}) error {
+	m := fmt.Sprintf(format, params...)
+	return logContextWithError(seelog.WarnLvl, func() { Warnc(m, nil) }, Logger.warn, m, false, depth, nil)
 }
 
 // WarncStackDepth logs at the warn level with context and the current stack depth plus the additional given one and returns an error containing the formated log message
@@ -646,6 +666,11 @@ func Errorf(format string, params ...interface{}) error {
 	return logFormatWithError(seelog.ErrorLvl, func() { Errorf(format, params...) }, Logger.errorf, format, true, params...)
 }
 
+func ErrorfStackDepth(format string, depth int, params ...interface{}) error {
+	m := fmt.Sprintf(format, params...)
+	return logContextWithError(seelog.ErrorLvl, func() { Errorc(m, nil) }, Logger.error, m, false, depth, nil)
+}
+
 // ErrorcStackDepth logs at the error level with context and the current stack depth plus the additional given one and returns an error containing the formated log message
 func ErrorcStackDepth(message string, depth int, context ...interface{}) error {
 	return logContextWithError(seelog.ErrorLvl, func() { Errorc(message, context...) }, Logger.error, message, true, depth, context...)
@@ -674,6 +699,11 @@ func Criticalf(format string, params ...interface{}) error {
 	return logFormatWithError(seelog.CriticalLvl, func() { Criticalf(format, params...) }, Logger.criticalf, format, true, params...)
 }
 
+func CriticalfStackDepth(format string, depth int, params ...interface{}) error {
+	m := fmt.Sprintf(format, params...)
+	return logContextWithError(seelog.CriticalLvl, func() { Criticalc(m, nil) }, Logger.critical, m, false, depth, nil)
+}
+
 // CriticalcStackDepth logs at the critical level with context and the current stack depth plus the additional given one and returns an error containing the formated log message
 func CriticalcStackDepth(message string, depth int, context ...interface{}) error {
 	return logContextWithError(seelog.CriticalLvl, func() { Criticalc(message, context...) }, Logger.critical, message, true, depth, context...)
@@ -690,34 +720,6 @@ func CriticalFunc(logFunc func() string) {
 	if currentLevel <= seelog.CriticalLvl {
 		CriticalStackDepth(2, logFunc())
 	}
-}
-
-func Parsef(format string, lvl string, params ...interface{}) error {
-	m := fmt.Sprintf(format, params...)
-	currentLevel, _ := GetLogLevel()
-	sLvl, ok := seelog.LogLevelFromString(strings.ToLower(lvl))
-	if ok && currentLevel > sLvl {
-		return nil
-	}
-
-	switch strings.ToUpper(lvl) {
-	case "TRACE":
-		TracecStackDepth(m, 3, nil)
-	case "DEBUG":
-		DebugcStackDepth(m, 3, nil)
-	case "INFO":
-		InfocStackDepth(m, 3, nil)
-	case "WARN":
-		return WarncStackDepth(m, 3, nil)
-	case "ERROR":
-		return ErrorcStackDepth(m, 3, nil)
-	case "CRITICAL":
-		return CriticalcStackDepth(m, 3, nil)
-	default:
-		// do nothing
-	}
-
-	return nil
 }
 
 // InfoStackDepth logs at the info level and the current stack depth plus the additional given one

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -463,7 +463,7 @@ func TestFuncVersions(t *testing.T) {
 }
 
 func TestStackDepthfLogging(t *testing.T) {
-	const stackDepth = 0
+	const stackDepth = 1
 
 	cases := []struct {
 		seelogLevel        seelog.LogLevel
@@ -488,12 +488,12 @@ func TestStackDepthfLogging(t *testing.T) {
 
 			SetupLogger(l, tc.strLogLevel)
 
-			TracefStackDepth("%s", stackDepth, "foo")
-			DebugfStackDepth("%s", stackDepth, "foo")
-			InfofStackDepth("%s", stackDepth, "foo")
-			WarnfStackDepth("%s", stackDepth, "foo")
-			ErrorfStackDepth("%s", stackDepth, "foo")
-			CriticalfStackDepth("%s", stackDepth, "foo")
+			TracefStackDepth(stackDepth, "%s", "foo")
+			DebugfStackDepth(stackDepth, "%s", "foo")
+			InfofStackDepth(stackDepth, "%s", "foo")
+			WarnfStackDepth(stackDepth, "%s", "foo")
+			ErrorfStackDepth(stackDepth, "%s", "foo")
+			CriticalfStackDepth(stackDepth, "%s", "foo")
 			w.Flush()
 
 			assert.Equal(t, tc.expectedToBeCalled, strings.Count(b.String(), "TestStackDepthfLogging"), tc)

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -463,6 +463,8 @@ func TestFuncVersions(t *testing.T) {
 }
 
 func TestStackDepthfLogging(t *testing.T) {
+	const stackDepth = 0
+
 	cases := []struct {
 		seelogLevel        seelog.LogLevel
 		strLogLevel        string
@@ -477,23 +479,24 @@ func TestStackDepthfLogging(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		var b bytes.Buffer
-		w := bufio.NewWriter(&b)
+		t.Run(tc.strLogLevel, func(t *testing.T) {
+			var b bytes.Buffer
+			w := bufio.NewWriter(&b)
 
-		l, err := seelog.LoggerFromWriterWithMinLevelAndFormat(w, tc.seelogLevel, "[%LEVEL] %FuncShort: %Msg\n")
-		assert.Nil(t, err)
+			l, err := seelog.LoggerFromWriterWithMinLevelAndFormat(w, tc.seelogLevel, "[%LEVEL] %Func: %Msg\n")
+			assert.Nil(t, err)
 
-		SetupLogger(l, tc.strLogLevel)
+			SetupLogger(l, tc.strLogLevel)
 
-		TracefStackDepth("%s", 0, "foo")
-		DebugfStackDepth("%s", 0, "foo")
-		InfofStackDepth("%s", 0, "foo")
-		WarnfStackDepth("%s", 0, "foo")
-		ErrorfStackDepth("%s", 0, "foo")
-		CriticalfStackDepth("%s", 0, "foo")
-		w.Flush()
+			TracefStackDepth("%s", stackDepth, "foo")
+			DebugfStackDepth("%s", stackDepth, "foo")
+			InfofStackDepth("%s", stackDepth, "foo")
+			WarnfStackDepth("%s", stackDepth, "foo")
+			ErrorfStackDepth("%s", stackDepth, "foo")
+			CriticalfStackDepth("%s", stackDepth, "foo")
+			w.Flush()
 
-		assert.Equal(t, tc.expectedToBeCalled, strings.Count(b.String(), "TestStackDepthfLogging"), tc)
-
+			assert.Equal(t, tc.expectedToBeCalled, strings.Count(b.String(), "TestStackDepthfLogging"), tc)
+		})
 	}
 }

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -461,3 +461,51 @@ func TestFuncVersions(t *testing.T) {
 	}
 
 }
+
+func TestParsef(t *testing.T) {
+	cases := []struct {
+		seelogLevel        seelog.LogLevel
+		strLogLevel        string
+		expectedToBeCalled bool
+	}{
+		{seelog.CriticalLvl, "debug", false},
+		{seelog.ErrorLvl, "debug", false},
+		{seelog.WarnLvl, "debug", false},
+		{seelog.InfoLvl, "debug", false},
+		{seelog.DebugLvl, "debug", true},
+		{seelog.TraceLvl, "debug", true},
+
+		{seelog.TraceLvl, "trace", true},
+		{seelog.InfoLvl, "trace", false},
+
+		{seelog.InfoLvl, "info", true},
+		{seelog.WarnLvl, "info", false},
+
+		{seelog.WarnLvl, "warn", true},
+		{seelog.ErrorLvl, "warn", false},
+
+		{seelog.ErrorLvl, "error", true},
+		{seelog.CriticalLvl, "error", false},
+
+		{seelog.CriticalLvl, "critical", true},
+	}
+
+	for _, tc := range cases {
+		var b bytes.Buffer
+		w := bufio.NewWriter(&b)
+
+		l, _ := seelog.LoggerFromWriterWithMinLevelAndFormat(w, tc.seelogLevel, "[%LEVEL] %FuncShort: %Msg")
+		SetupLogger(l, tc.seelogLevel.String())
+
+		Parsef("message %s", tc.strLogLevel, "hello")
+
+		w.Flush()
+
+		if tc.expectedToBeCalled {
+			assert.Equal(t, 1, strings.Count(b.String(), "hello"), tc)
+		} else {
+			assert.Equal(t, 0, strings.Count(b.String(), "hello"), tc)
+		}
+	}
+
+}

--- a/releasenotes/notes/apm-fix-trace-stack-depth-de7d3c0aff0c5fc2.yaml
+++ b/releasenotes/notes/apm-fix-trace-stack-depth-de7d3c0aff0c5fc2.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix incorrect filenames and line numbers in logs from the trace agent.
+    APM: Fix incorrect filenames and line numbers in logs from the trace agent.

--- a/releasenotes/notes/apm-fix-trace-stack-depth-de7d3c0aff0c5fc2.yaml
+++ b/releasenotes/notes/apm-fix-trace-stack-depth-de7d3c0aff0c5fc2.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix incorrect filenames and line numbers in logs from the trace agent.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR fixes a bug in which the agent logger displays the incorrect filename and line number for logs triggered by the `run.go` file. It introduces new functions that can print formatted logs with the correct stack depth.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The agent logger was displaying incorrect filenames for log lines, which can cause confusion or make debugging nearly impossible. 

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Old and new unit tests should all pass. For manual testing, run the agent and ensure that the filenames and line numbers are correct in the logs.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
