### PR TITLE
Add new metrics for resource aggregation to KSM check

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/customresources/pod.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/pod.go
@@ -10,6 +10,7 @@ package customresources
 import (
 	"context"
 
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -78,6 +79,100 @@ func (f *extendedPodFactory) MetricFamilyGenerators(allowAnnotationsList, allowL
 				return f.customResourceGenerator(p, resourcelimits)
 			}),
 		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_resource_with_owner_tag_requests",
+			"The number of requested request resource by a container, including pod owner information.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				return f.customResourceOwnerGenerator(p, resourceRequests)
+			}),
+		),
+		*generator.NewFamilyGenerator(
+			"kube_pod_container_resource_with_owner_tag_limits",
+			"The number of requested limit resource by a container, including pod owner information.",
+			metric.Gauge,
+			"",
+			wrapPodFunc(func(p *v1.Pod) *metric.Family {
+				return f.customResourceOwnerGenerator(p, resourcelimits)
+			}),
+		),
+	}
+}
+
+// customResourceOwnerGenerator is used to generate metrics related to resource requests or limits, tagged by the top-most
+// owner of the pod.
+func (f *extendedPodFactory) customResourceOwnerGenerator(p *v1.Pod, resourceType string) *metric.Family {
+	// We want to omit pods that have succeeded, as those no longer count towards resource allocation
+	if p.Status.Phase == v1.PodSucceeded || p.Status.Phase == v1.PodFailed {
+		return &metric.Family{}
+	}
+
+	ms := []*metric.Metric{}
+
+	for _, c := range p.Spec.Containers {
+		var resources v1.ResourceList
+		switch resourceType {
+		case resourceRequests:
+			resources = c.Resources.Requests
+		case resourcelimits:
+			resources = c.Resources.Limits
+		default:
+			log.Warnf("unknown resource type requested for pod container resources: %s", resourceType)
+		}
+		var kind, name string
+
+		owners := p.GetOwnerReferences()
+		if len(owners) == 0 {
+			kind = "<none>"
+			name = "<none>"
+		}
+
+		for _, owner := range owners {
+			kind = owner.Kind
+			name = owner.Name
+			if owner.Controller != nil {
+				break
+			}
+		}
+
+		// because of the way we handle aggregation (based on labels), if we want to drop the job / replicaset tag in the
+		// final metric being pushed up, then we should do it here. Otherwise, each job or replicaset will not be combined
+		// properly
+		switch kind {
+		case kubernetes.JobKind:
+			if cronjob, _ := kubernetes.ParseCronJobForJob(name); cronjob != "" {
+				kind = kubernetes.CronJobKind
+				name = cronjob
+			}
+		case kubernetes.ReplicaSetKind:
+			if deployment := kubernetes.ParseDeploymentForReplicaSet(name); deployment != "" {
+				kind = kubernetes.DeploymentKind
+				name = deployment
+			}
+		}
+
+		for resourceName, val := range resources {
+			if resourceName == v1.ResourceCPU {
+				ms = append(ms, &metric.Metric{
+					LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitCore), kind, name},
+					Value:       float64(val.MilliValue()) / 1000,
+				})
+			} else if resourceName == v1.ResourceMemory {
+				ms = append(ms, &metric.Metric{
+					LabelValues: []string{c.Name, p.Spec.NodeName, sanitizeLabelName(string(resourceName)), string(constant.UnitByte), kind, name},
+					Value:       float64(val.Value()),
+				})
+			}
+		}
+	}
+
+	for _, metric := range ms {
+		metric.LabelKeys = []string{"container", "node", "resource", "unit", "owner_kind", "owner_name"}
+	}
+
+	return &metric.Family{
+		Metrics: ms,
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
@@ -8,6 +8,8 @@
 package ksm
 
 import (
+	"fmt"
+
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	ksmstore "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store"
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
@@ -41,6 +43,18 @@ type sumValuesAggregator struct {
 
 type countObjectsAggregator struct {
 	counterAggregator
+}
+
+// resourceAggregator represents an aggregation on a resource metric, where the type of resource is part of the metric
+// in the form of a label, instead of in the name.
+type resourceAggregator struct {
+	ddMetricPrefix   string
+	ddMetricSuffix   string
+	ksmMetricName    string
+	allowedLabels    []string
+	allowedResources []string
+
+	accumulators map[string]map[[maxNumberOfAllowedLabels]string]float64
 }
 
 type cronJob struct {
@@ -101,6 +115,29 @@ func newCountObjectsAggregator(ddMetricName, ksmMetricName string, allowedLabels
 	}
 }
 
+func newResourceValuesAggregator(ddMetricPrefix, ddMetricSuffix, ksmMetricName string, allowedLabels, allowedResources []string) metricAggregator {
+	if len(allowedLabels) > maxNumberOfAllowedLabels {
+		// `maxNumberOfAllowedLabels` is hardcoded to the maximum number of labels passed to this function from the metricsAggregators definition below.
+		// The only possibility to arrive here is to add a new aggregator in `metricAggregator` below and to forget to update `maxNumberOfAllowedLabels` accordingly.
+		log.Error("BUG in KSM metric aggregator")
+		return nil
+	}
+
+	accumulators := make(map[string]map[[maxNumberOfAllowedLabels]string]float64)
+	for _, allowedResource := range allowedResources {
+		accumulators[allowedResource] = make(map[[maxNumberOfAllowedLabels]string]float64)
+	}
+
+	return &resourceAggregator{
+		ddMetricPrefix:   ddMetricPrefix,
+		ddMetricSuffix:   ddMetricSuffix,
+		ksmMetricName:    ksmMetricName,
+		allowedLabels:    allowedLabels,
+		allowedResources: allowedResources,
+		accumulators:     accumulators,
+	}
+}
+
 func newLastCronJobAggregator() *lastCronJobAggregator {
 	return &lastCronJobAggregator{
 		accumulator: make(map[cronJob]cronJobState),
@@ -133,6 +170,24 @@ func (a *countObjectsAggregator) accumulate(metric ksmstore.DDMetric) {
 	}
 
 	a.accumulator[labelValues]++
+}
+
+func (a *resourceAggregator) accumulate(metric ksmstore.DDMetric) {
+	var labelValues [maxNumberOfAllowedLabels]string
+
+	for i, allowedLabel := range a.allowedLabels {
+		if allowedLabel == "" {
+			break
+		}
+
+		labelValues[i] = metric.Labels[allowedLabel]
+	}
+
+	resource := metric.Labels["resource"]
+
+	if _, ok := a.accumulators[resource]; ok {
+		a.accumulators[resource][labelValues] += metric.Val
+	}
 }
 
 func (a *lastCronJobCompleteAggregator) accumulate(metric ksmstore.DDMetric) {
@@ -193,6 +248,28 @@ func (a *counterAggregator) flush(sender sender.Sender, k *KSMCheck, labelJoiner
 	}
 
 	a.accumulator = make(map[[maxNumberOfAllowedLabels]string]float64)
+}
+
+func (a *resourceAggregator) flush(sender sender.Sender, k *KSMCheck, labelJoiner *labelJoiner) {
+	for _, resource := range a.allowedResources {
+		metricName := fmt.Sprintf("%s%s.%s_%s", ksmMetricPrefix, a.ddMetricPrefix, resource, a.ddMetricSuffix)
+
+		for labelValues, count := range a.accumulators[resource] {
+			labels := make(map[string]string)
+			for i, allowedLabel := range a.allowedLabels {
+				if allowedLabel == "" {
+					break
+				}
+
+				labels[allowedLabel] = labelValues[i]
+			}
+
+			hostname, tags := k.hostnameAndTags(labels, labelJoiner, labelsMapperOverride(a.ksmMetricName))
+
+			sender.Gauge(metricName, count, hostname, tags)
+		}
+		a.accumulators[resource] = make(map[[maxNumberOfAllowedLabels]string]float64)
+	}
 }
 
 func (a *lastCronJobCompleteAggregator) flush(sender sender.Sender, k *KSMCheck, labelJoiner *labelJoiner) {
@@ -321,5 +398,33 @@ func defaultMetricAggregators() map[string]metricAggregator {
 		),
 		"kube_job_complete": &lastCronJobCompleteAggregator{aggregator: cronJobAggregator},
 		"kube_job_failed":   &lastCronJobFailedAggregator{aggregator: cronJobAggregator},
+		"kube_node_status_allocatable": newResourceValuesAggregator(
+			"node",
+			"allocatable.total",
+			"kube_node_status_allocatable",
+			[]string{},
+			[]string{"cpu", "memory"},
+		),
+		"kube_node_status_capacity": newResourceValuesAggregator(
+			"node",
+			"capacity.total",
+			"kube_node_status_capacity",
+			[]string{},
+			[]string{"cpu", "memory"},
+		),
+		"kube_pod_container_resource_with_owner_tag_requests": newResourceValuesAggregator(
+			"container",
+			"requested.total",
+			"kube_pod_container_resource_with_owner_tag_requests",
+			[]string{"namespace", "container", "owner_name", "owner_kind"},
+			[]string{"cpu", "memory"},
+		),
+		"kube_pod_container_resource_with_owner_tag_limits": newResourceValuesAggregator(
+			"container",
+			"limit.total",
+			"kube_pod_container_resource_with_owner_tag_limits",
+			[]string{"namespace", "container", "owner_name", "owner_kind"},
+			[]string{"cpu", "memory"},
+		),
 	}
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
@@ -175,12 +175,12 @@ func (a *countObjectsAggregator) accumulate(metric ksmstore.DDMetric) {
 func (a *resourceAggregator) accumulate(metric ksmstore.DDMetric) {
 	var labelValues [maxNumberOfAllowedLabels]string
 
-	for i, allowedLabel := range a.allowedLabels {
-		if allowedLabel == "" {
+	for i := range a.allowedLabels {
+		if a.allowedLabels[i] == "" {
 			break
 		}
 
-		labelValues[i] = metric.Labels[allowedLabel]
+		labelValues[i] = metric.Labels[a.allowedLabels[i]]
 	}
 
 	resource := metric.Labels["resource"]

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -386,6 +386,11 @@ func TestProcessMetrics(t *testing.T) {
 					tags:     []string{"node:nodename", "resource:cpu", "unit:core", "kube_region:europe-west1", "kube_zone:europe-west1-b"},
 					hostname: "nodename",
 				},
+				{
+					name: "kubernetes_state.node.cpu_capacity.total",
+					val:  4,
+					tags: []string{},
+				},
 			},
 		},
 		{
@@ -418,6 +423,11 @@ func TestProcessMetrics(t *testing.T) {
 					val:      4,
 					tags:     []string{"node:nodename", "resource:cpu", "unit:core", "container_runtime_version:docker://19.3.15", "kernel_version:5.4.109+", "kubelet_version:v1.18.20-gke.901", "os_image:Container-Optimized OS from Google"},
 					hostname: "nodename",
+				},
+				{
+					name: "kubernetes_state.node.cpu_capacity.total",
+					val:  4,
+					tags: []string{},
 				},
 			},
 		},
@@ -553,7 +563,7 @@ func TestProcessMetrics(t *testing.T) {
 			if len(test.expected) == 0 {
 				mocked.AssertNotCalled(t, "Gauge")
 			} else {
-				mocked.AssertNumberOfCalls(t, "Gauge", lenMetrics(test.metricsToProcess))
+				mocked.AssertNumberOfCalls(t, "Gauge", len(test.expected))
 			}
 		})
 	}
@@ -1419,16 +1429,6 @@ func TestCreationMetricsFiltering(t *testing.T) {
 		assert.True(t, allowDenyList.IsExcluded(metric))
 		assert.False(t, allowDenyList.IsIncluded(metric))
 	}
-}
-
-func lenMetrics(metricsToProcess map[string][]ksmstore.DDMetricsFam) int {
-	count := 0
-	for _, metricFamily := range metricsToProcess {
-		for _, metrics := range metricFamily {
-			count += len(metrics.ListMetrics)
-		}
-	}
-	return count
 }
 
 func TestKSMCheckInitTags(t *testing.T) {

--- a/releasenotes/notes/ksm-resource-aggregation-metrics-1e5744c53e7f10e1.yaml
+++ b/releasenotes/notes/ksm-resource-aggregation-metrics-1e5744c53e7f10e1.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add new metrics for resource aggregation to the Kubernetes State Core check:
+    - `kubernetes_state.node.<cpu|memory>_capacity.total`
+    - `kubernetes_state.node.<cpu|memory>_allocatable.total`
+    - `kubernetes_state.container.<cpu|memory>_requested.total`
+    - `kubernetes_state.container.<cpu|memory>_limit.total`


### PR DESCRIPTION

### What does this PR do?

This PR adds 8 new metrics to the KSM core check:
- `kubernetes_state.node.<cpu|memory>_capacity.total`
- `kubernetes_state.node.<cpu|memory>_allocatable.total`
- `kubernetes_state.container.<cpu|memory>_requested.total`
- `kubernetes_state.container.<cpu|memory>_limit.total`

The node metrics are tagged by kube_cluster_name

The container metrics are tagged by kube_cluster_name, kube_namespace, kube_container_name, as well as <top_owner_type>:<owner_name> (where top_owner_type is the top-most owner of the resource, eg kube_deployment or kube_stateful_set or kube_cronjob, etc)

### Motivation

Because the existing container resource metrics are tagged by replicaset, creating graphs and alerts off of these metrics becomes difficult, as during an application redeployment the value artificially spikes when aggregating over a long period of time.

The goal of this change is to introduce metrics which are not tagged by replicaset or other high cardinality tags, so that this use case can be better supported, and provide an easy way to monitor the capacity needs of a cluster.

### Additional Notes

- The new container metrics only collect metrics from pods in pending or running state, as pods which have succeeded or failed do not continue to keep resources allocated

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1) deploy the cluster agent
2) confirm the metrics show up (you can use [this dashboard](https://dddev.datadoghq.com/dashboard/r8n-8yr-nta?tpl_var_kube_cluster_name%5B0%5D=minikube-steve-agent-qa&from_ts=1688586595727&to_ts=1688590195727&live=true) to help validate)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
