### PR TITLE
CONT-3894, CONT-3969  Fix the processing of `%%` pattern inside AD annotations

### DIFF
--- a/pkg/autodiscovery/configresolver/configresolver.go
+++ b/pkg/autodiscovery/configresolver/configresolver.go
@@ -272,6 +272,11 @@ func resolveDataWithTemplateVars(ctx context.Context, data integration.Data, svc
 			if err != nil {
 				return data, err
 			}
+			// If a `‰` character hasn’t been consumed by a `%%var%%` template variable replacement,
+			// let’s restore it to the initial `%%` value it had in the original string.
+			if str, ok := s.(string); ok {
+				s = strings.ReplaceAll(str, "‰", "%%")
+			}
 			top.set(s)
 
 		case nil, int, bool:

--- a/pkg/autodiscovery/configresolver/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver/configresolver_test.go
@@ -735,6 +735,25 @@ func TestResolve(t *testing.T) {
 				ServiceID:     "a5901276aed1",
 			},
 		},
+		{
+			testName: "%% that is not a template variable delimiter",
+			svc: &dummyService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Hosts:         map[string]string{"bridge": "127.0.0.1"},
+			},
+			tpl: integration.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []integration.Data{integration.Data("host: %%host%%\ntags:\n- password:\"complex%%password\"")},
+			},
+			out: integration.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []integration.Data{integration.Data("host: 127.0.0.1\ntags:\n- foo:bar\n- password:\"complex%%password\"\n")},
+				ServiceID:     "a5901276aed1",
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/releasenotes/notes/fix-%%-AD-annotations-cfddac3fb363fab9.yaml
+++ b/releasenotes/notes/fix-%%-AD-annotations-cfddac3fb363fab9.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fixes a bug in auto-discovery annotations processing where two consecutive percent characters were wrongly altered even if they were not part of a ``%%var%%` template variable pattern.
+    Fixes a bug in auto-discovery annotations processing where two consecutive percent characters were wrongly altered even if they were not part of a ``%%var%%`` template variable pattern.

--- a/releasenotes/notes/fix-%%-AD-annotations-cfddac3fb363fab9.yaml
+++ b/releasenotes/notes/fix-%%-AD-annotations-cfddac3fb363fab9.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a bug in auto-discovery annotations processing where two consecutive percent characters were wrongly altered even if they were not part of a ``%%var%%` template variable pattern.


### PR DESCRIPTION
### What does this PR do?

Inside auto-discovery annotations, it’s possible to use template variables delimited by `%%` like `%%host%%` or `%%port%%` for ex.
#11462 introduced a bug that was altering `%%` parts that were not a template variable delimiter. Like if two consecutive percent characters were present in a password field for ex.
This change ensures that two consecutive percent characters that are not part of a template variable delimiter are not altered anymore.

### Motivation

* Fixes DataDog/integrations-core#13938

### Additional Notes

If there are two groups of two consecutive percent characters, it will still be considered as an invalid template variable error because it was already the case before #11462. See https://github.com/DataDog/datadog-agent/pull/11462/files#diff-28d3ec6050c4ca2252de7911385d2439559448491b9b05fe972b8e0a2eda054aR528

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Annotate a kubernetes pod with auto-discovery annotations.
* `%%host%%` and `%%port%%` parts should be properly substituted.
* A field containing two consecutive percent characters not part of a template variable should be left untouched.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
