### PR TITLE
Fix `lint_windows-x64` GitLab CI job

### DIFF
--- a/test/new-e2e/scenarios/system-probe/main.go
+++ b/test/new-e2e/scenarios/system-probe/main.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !windows
+// +build !windows
+
 package main
 
 import (


### PR DESCRIPTION
### What does this PR do?

Add missing Windows exclusion build tag to the `system-probe` new e2e tests.

### Motivation

The `lint_windows-x64` CI job is currently failing with this error:
```
Linters for module C:\dev\go\src\github.com\DataDog\datadog-agent\test\new-e2e failed (base flavor)
291Linter failures:
292level=error msg="[linters_context] typechecking error: C:\\dev\\go\\src\\github.com\\DataDog\\datadog-agent\\test\\new-e2e\\scenarios\\system-probe\\main.go:15:14: could not import github.com/DataDog/datadog-agent/test/new-e2e/system-probe (-: build constraints exclude all Go files in C:\\dev\\go\\src\\github.com\\DataDog\\datadog-agent\\test\\new-e2e\\system-probe)"
293level=warning msg="[runner] Can't run linter goanalysis_metalinter: inspect: failed to load package : could not load export data: no export data for \"github.com/DataDog/datadog-agent/test/new-e2e/system-probe\""
294level=error msg="Running error: 1 error occurred:\n\t* can't run linter goanalysis_metalinter: inspect: failed to load package : could not load export data: no export data for \"github.com/DataDog/datadog-agent/test/new-e2e/system-probe\"\n\n"
295Lint result is 1
296lint failed 1
```

### Additional Notes

I think that this error has been introduced by https://github.com/DataDog/datadog-agent/pull/17791/files#diff-1eff9de545b9e9fd188a73802442c06ba1cd81e4388880c3e845bd36c160372eR6-R8.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
