### PR TITLE
[Single-Machine-Performance] Update Regression Detector lading

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -15,7 +15,7 @@ single-machine-performance-regression_detector:
     when: always
   variables:
     SMP_VERSION: 0.8.0
-    LADING_VERSION: 0.17.0
+    LADING_VERSION: 0.17.1
     TOTAL_SAMPLES: 600
     WARMUP_SECONDS: 45
     REPLICAS: 20

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -15,7 +15,7 @@ single-machine-performance-regression_detector:
     when: always
   variables:
     SMP_VERSION: 0.7.3
-    LADING_VERSION: 0.15.3
+    LADING_VERSION: 0.17.0
     TOTAL_SAMPLES: 600
     WARMUP_SECONDS: 45
     REPLICAS: 20

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -14,7 +14,7 @@ single-machine-performance-regression_detector:
       - outputs/report.html              # for debugging, also on S3
     when: always
   variables:
-    SMP_VERSION: 0.7.3
+    SMP_VERSION: 0.8.0
     LADING_VERSION: 0.17.0
     TOTAL_SAMPLES: 600
     WARMUP_SECONDS: 45


### PR DESCRIPTION
### What does this PR do?

This commit updates the lading version in the Regression Detector flow to 0.17.0. The major change the collection CPU utilization in lading. Previously we collected tick information but absent precise measurement collection intervals and core count it was not possible to say what the CPU utilization of a target was. This proved to be important when examining the captured data from #17740 as we could not see a distinct regression in tick data, despite there being one present.

### Related Issues 

REF SMP-631
