### PR TITLE
[CSPM] Deprecate compliance_config.xccdf.enabled in favor of compliance_config.host_benchmarks.enabled

### DIFF
--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -71,6 +71,10 @@ type Agent struct {
 	cancel context.CancelFunc
 }
 
+func xccdfEnabled() bool {
+	return config.Datadog.GetBool("compliance_config.xccdf.enabled") || config.Datadog.GetBool("compliance_config.host_benchmarks.enabled")
+}
+
 func DefaultRuleFilter(r *Rule) bool {
 	if config.IsKubernetes() {
 		if r.SkipOnK8s {
@@ -81,7 +85,7 @@ func DefaultRuleFilter(r *Rule) bool {
 			return false
 		}
 	}
-	if r.IsXCCDF() && !config.Datadog.GetBool("compliance_config.xccdf.enabled") {
+	if r.IsXCCDF() && !xccdfEnabled() {
 		return false
 	}
 	if len(r.Filters) > 0 {
@@ -248,7 +252,7 @@ func (a *Agent) runRegoBenchmarks(ctx context.Context) {
 }
 
 func (a *Agent) runXCCDFBenchmarks(ctx context.Context) {
-	if !config.Datadog.GetBool("compliance_config.xccdf.enabled") {
+	if !xccdfEnabled() {
 		return
 	}
 	benchmarks, err := LoadBenchmarks(a.opts.ConfigDir, "*.yaml", func(r *Rule) bool {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1174,7 +1174,8 @@ func InitConfig(config Config) {
 
 	// Datadog security agent (compliance)
 	config.BindEnvAndSetDefault("compliance_config.enabled", false)
-	config.BindEnvAndSetDefault("compliance_config.xccdf.enabled", false)
+	config.BindEnvAndSetDefault("compliance_config.xccdf.enabled", false) // deprecated, use host_benchmarks instead
+	config.BindEnvAndSetDefault("compliance_config.host_benchmarks.enabled", false)
 	config.BindEnvAndSetDefault("compliance_config.check_interval", 20*time.Minute)
 	config.BindEnvAndSetDefault("compliance_config.check_max_events_per_run", 100)
 	config.BindEnvAndSetDefault("compliance_config.dir", "/etc/datadog-agent/compliance.d")

--- a/releasenotes/notes/rename-xccdf-configuration-flag-19129eabe11a7bcc.yaml
+++ b/releasenotes/notes/rename-xccdf-configuration-flag-19129eabe11a7bcc.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    The `compliance_config.xccdf.enabled` configuration has been deprecated. Use `compliance_config.host_benchmarks.enabled` instead.


### PR DESCRIPTION
### What does this PR do?

This change deprecates `compliance_config.xccdf.enabled` configuration in favor of `compliance_config.host_benchmarks.enabled`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
