### PR TITLE
[usm] Fix early return when protocol is null

### DIFF
--- a/pkg/network/ebpf/c/protocols/classification/dispatcher-helpers.h
+++ b/pkg/network/ebpf/c/protocols/classification/dispatcher-helpers.h
@@ -124,7 +124,6 @@ static __always_inline void protocol_dispatcher_entrypoint(struct __sk_buff *skb
     protocol_t cur_fragment_protocol = get_protocol_from_stack(stack, LAYER_APPLICATION);
     if (tcp_termination) {
         dispatcher_delete_protocol_stack(&skb_tup, stack);
-        stack = NULL;
     }
 
     if (cur_fragment_protocol == PROTOCOL_UNKNOWN) {

--- a/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
+++ b/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
@@ -7,10 +7,15 @@
 
 // Maps a connection tuple to its classified protocol. Used to reduce redundant
 // classification procedures on the same connection
-// Note that LRU maps were introduced in Kernel 4.10, but protocol
-// classification is supported by >= 4.7. For kernel releases within this range
-// we replace the LRU map by a regular HashMap during eBPF program load time.
+#if(defined(COMPILE_RUNTIME) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0))
+// If *runtime compilation is enabled*, but we don't support LRUs, fallback to a HashMap
+BPF_HASH_MAP(connection_protocol, conn_tuple_t, protocol_stack_t, 0)
+#else
+// Otherwise use a LRU map instead. Note that Kernels older than 4.10 will use
+// this map definifition in the context of either pre-built or CO-RE, but in this
+// case we change the map spec during load time from userspace.
 BPF_LRU_MAP(connection_protocol, conn_tuple_t, protocol_stack_t, 0)
+#endif
 
 static __always_inline protocol_stack_t* get_protocol_stack(conn_tuple_t *skb_tup) {
     conn_tuple_t normalized_tup = *skb_tup;

--- a/pkg/network/ebpf/c/protocols/http/http.h
+++ b/pkg/network/ebpf/c/protocols/http/http.h
@@ -162,9 +162,6 @@ static __always_inline bool http_allow_packet(http_transaction_t *http, struct _
     }
 
     protocol_stack_t *stack = get_protocol_stack(&http->tup);
-    if (!stack) {
-        return false;
-    }
     bool empty_payload = skb_info->data_off == skb->len;
     if (empty_payload || is_protocol_layer_known(stack, LAYER_ENCRYPTION)) {
         // if the payload data is empty or encrypted packet, we only


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix early return when `protocol_stack_t` is null.
Even if the `protocol_stack_t` is NULL we should process TCP segment in the HTTP dispatcher code, and not return early as we were doing in this previously to the change.

In addition to that, we fix the map editing (replacing an LRU by a HashMap) for old kernels. The previous location with the `MapSpecEditor` was nested under `if classificationSupported`, and therefore was not happening for kernels that don't support protocol classification (< 4.7)

### Motivation

This is currently causing tests to fail on `main`. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
