### PR TITLE
[Dockerfile][cluster-agent] Fix file perms in cluster agent image to allow copying

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -12,10 +12,10 @@ LABEL org.opencontainers.image.source "https://github.com/DataDog/datadog-agent"
 WORKDIR /output
 
 COPY datadog-cluster-agent.$TARGETARCH opt/datadog-agent/bin/datadog-cluster-agent
-COPY --chmod=644 ./conf.d etc/datadog-agent/conf.d
+COPY --chmod=744 ./conf.d etc/datadog-agent/conf.d
 COPY ./datadog-cluster.yaml etc/datadog-agent/datadog-cluster.yaml
 COPY ./security-agent-policies/compliance/containers/ etc/datadog-agent/compliance.d
-COPY --chmod=644 ./install_info etc/datadog-agent/install_info
+COPY --chmod=744 ./install_info etc/datadog-agent/install_info
 COPY entrypoint.sh .
 COPY readsecret.sh readsecret_multiple_providers.sh ./
 


### PR DESCRIPTION
### What does this PR do?

Change the file permissions of files in `/etc/datadog-agent/` from 644 to 744

### Motivation

The original change, setting the permissions to 644, was introduced here: https://github.com/DataDog/datadog-agent/pull/16347

As a result of this change, when the DCA was deployed via helm with a non-root security context set, the init-container would fail because it would be unable to copy the files in this folder with the following error:
```
cp: cannot stat '/etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default': Permission denied
cp: cannot stat '/etc/datadog-agent/conf.d/orchestrator.d/conf.yaml.default': Permission denied
```

A temporary fix was merged into the helm chart to mitigate the issue, by setting the permissions of this folder to 744 before trying to copy the files: https://github.com/DataDog/helm-charts/pull/1096

But it would be nice to have this change reflected directly in the image

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Deploy the cluster agent using the public helm chart with the following values set:
```
clusterAgent:
  securityContext:
    runAsUser: 101
```

Ensure that the cluster agent is able to start

Then, manually edit the cluster agent deployment to change the startup command of the init container:

```
          command:
            - bash
            - '-c'
          args:
            - |
              cp -r /etc/datadog-agent /opt
```

(you are removing the `chmod -R 744 /etc/datadog-agent;` command)

And verify that the cluster agent still starts up successfully.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
