### PR TITLE
[gohai] simplify helper functions, add more explicit comments

### DIFF
--- a/pkg/gohai/utils/test_helpers.go
+++ b/pkg/gohai/utils/test_helpers.go
@@ -11,14 +11,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// AssertDecodedValue asserts that either the value is an error and the decoded string is empty, or
-// that the value with its unit is equal to the decoded string
+// AssertDecodedValue asserts that either
+// - the field is an error and the decoded string is empty
+// - the field is not an error and the value with its unit is equal to the decoded string
+//
+// decoded should be a string read by unmarshalling a json, and value the original Value[T]
+// which corresponds to that string.
 func AssertDecodedValue[T any](t *testing.T, decoded string, value *Value[T], unit string) {
 	val, err := value.Value()
 	if err == nil {
+		// if the field is a real value then it should have the following format once rendered
 		expected := fmt.Sprintf("%v%s", val, unit)
 		assert.Equal(t, expected, decoded)
 	} else {
+		// if the field is an error then the json string associated to that field should be empty
 		assert.Empty(t, decoded)
 	}
 }

--- a/pkg/gohai/utils/value.go
+++ b/pkg/gohai/utils/value.go
@@ -59,3 +59,9 @@ func (value *Value[T]) Value() (T, error) {
 		return def, errors.New("value not initialized")
 	}
 }
+
+// Error returns the error stored in the Value[T], or nil if it doesn't contain an error.
+func (value *Value[T]) Error() error {
+	_, err := value.Value()
+	return err
+}

--- a/pkg/gohai/utils/value_helpers.go
+++ b/pkg/gohai/utils/value_helpers.go
@@ -6,21 +6,6 @@ package utils
 
 import "strconv"
 
-// ValueErrorGetter returns a function to get the error from the Value
-func ValueErrorGetter[T any](value *Value[T]) func() error {
-	return func() error {
-		_, err := value.Value()
-		return err
-	}
-}
-
-// ValueErrorSetter returns a function to set the error in the Value
-func ValueErrorSetter[T any](value *Value[T]) func(error) {
-	return func(err error) {
-		(*value) = NewErrorValue[T](err)
-	}
-}
-
 // ValueParseSetter returns a function which parses its input and stores the result in the given Value
 func ValueParseSetter[T any](value *Value[T], parse func(string) (T, error)) func(string, error) {
 	return func(val string, err error) {

--- a/pkg/gohai/utils/value_test.go
+++ b/pkg/gohai/utils/value_test.go
@@ -44,3 +44,12 @@ func TestNewValueFrom(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 42, val)
 }
+
+func TestError(t *testing.T) {
+	value := NewValue(1)
+	require.NoError(t, value.Error())
+
+	myerr := fmt.Errorf("again an error !?")
+	errorValue := NewErrorValue[int](myerr)
+	require.ErrorIs(t, myerr, errorValue.Error())
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Remove previously added
- `ValueErrorSetter`: the error can be set directly
- `ValueErrorGetter`: replaced by `Value[T].Error()`

Add better description of the `AssertDecodedValue` helper function.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Address review comments on https://github.com/DataDog/datadog-agent/pull/17986, and simplify the logic in the new API.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
The removed functions are exported but not used in any merged code yet.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
No QA as these are only helper functions.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
