### PR TITLE
[ci] Run k8s-e2e-main job after dev_master jobs

### DIFF
--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -39,6 +39,7 @@ k8s-e2e-main:
   needs:
     - dev_master-a6
     - dev_master-a7
+    - dca_dev_master
   script:
     - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py2 --dca-image=datadog/cluster-agent-dev:master --argo-workflow=default
     - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py3 --dca-image=datadog/cluster-agent-dev:master --argo-workflow=default

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -36,9 +36,9 @@ k8s-e2e-main:
   extends: .k8s_e2e_template
   allow_failure: true # temporary while investigating
   rules: !reference [.on_main]
-  # needs:
-  #   - dev_master-a6
-  #   - dev_master-a7
+  needs:
+    - dev_master-a6
+    - dev_master-a7
   script:
     - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py2 --dca-image=datadog/cluster-agent-dev:master --argo-workflow=default
     - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py3 --dca-image=datadog/cluster-agent-dev:master --argo-workflow=default


### PR DESCRIPTION
### What does this PR do?

Runs the k8s-e2e-main gitlab job after the dev_master jobs succeed

### Motivation

Currently, with this block of code commented out, the e2e tests will only run when the stages ahead of it succeed. However, there are many jobs which are not necessarily related to what these tests cover.

This becomes a problem when it prevents the nightly deployment job from being triggered, because this job was skipped. The result of this is that we lose the visibility of being able to see regression happen in a timely manner.

Another option is that we could remove this job as a requirement for the nightly deployment job

### Additional Notes

It looks like this block was removed [here](https://github.com/DataDog/datadog-agent/pull/8545/files#diff-ef82ddf42fac4f3d2cea4532ca305be2ca01345a7f3a471ffb6652f8a5feded5R43), with the goal being to minimize the amount of false signal we get regarding the health of these tests.

### Possible Drawbacks / Trade-offs

These e2e tests running more often could result in more flakiness or failures of these tests which could be unrelated to the e2e tests themselves. It has the potential to increase the workload for the team, as we need to investigate such failures manually.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
