### PR TITLE
Adds performance regression in logging subsystem

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -15,7 +15,7 @@ single-machine-performance-regression_detector:
     when: always
   variables:
     SMP_VERSION: 0.8.0
-    LADING_VERSION: 0.15.3
+    LADING_VERSION: 0.17.2
     TOTAL_SAMPLES: 600
     WARMUP_SECONDS: 45
     REPLICAS: 20

--- a/comp/core/log/logger.go
+++ b/comp/core/log/logger.go
@@ -15,7 +15,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/cihub/seelog"
 )
 
 // logger implements the component
@@ -81,10 +80,7 @@ func (*logger) Trace(v ...interface{}) { log.TraceStackDepth(2, v...) }
 
 // Tracef implements Component#Tracef.
 func (*logger) Tracef(format string, params ...interface{}) {
-	currentLevel, _ := log.GetLogLevel()
-	if currentLevel <= seelog.TraceLvl {
-		log.TraceStackDepth(2, fmt.Sprintf(format, params...))
-	}
+	log.TraceStackDepth(2, fmt.Sprintf(format, params...))
 }
 
 // Debug implements Component#Debug.
@@ -92,10 +88,7 @@ func (*logger) Debug(v ...interface{}) { log.DebugStackDepth(2, v...) }
 
 // Debugf implements Component#Debugf.
 func (*logger) Debugf(format string, params ...interface{}) {
-	currentLevel, _ := log.GetLogLevel()
-	if currentLevel <= seelog.DebugLvl {
-		log.DebugStackDepth(2, fmt.Sprintf(format, params...))
-	}
+	log.DebugStackDepth(2, fmt.Sprintf(format, params...))
 }
 
 // Info implements Component#Info.
@@ -103,10 +96,7 @@ func (*logger) Info(v ...interface{}) { log.InfoStackDepth(2, v...) }
 
 // Infof implements Component#Infof.
 func (*logger) Infof(format string, params ...interface{}) {
-	currentLevel, _ := log.GetLogLevel()
-	if currentLevel <= seelog.InfoLvl {
-		log.InfoStackDepth(2, fmt.Sprintf(format, params...))
-	}
+	log.InfoStackDepth(2, fmt.Sprintf(format, params...))
 }
 
 // Warn implements Component#Warn.


### PR DESCRIPTION

### What does this PR do?
Goal of this PR is to re-introduce the change from https://github.com/DataDog/datadog-agent/pull/17740 and test that the regression detector collected telemetry would flag this.
Note that the acutal regression detector is not expected to fail as we do not have a regression experiment targeting CPU

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
