### PR TITLE
[Single-Machine-Performance] Rollback lading update

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -15,7 +15,7 @@ single-machine-performance-regression_detector:
     when: always
   variables:
     SMP_VERSION: 0.8.0
-    LADING_VERSION: 0.17.1
+    LADING_VERSION: 0.15.3
     TOTAL_SAMPLES: 600
     WARMUP_SECONDS: 45
     REPLICAS: 20


### PR DESCRIPTION
We're seeing failed regression analysis for some PRs and suspect that the lading update from #18057 has something to do with it. We are investigating but queue this PR up in case we do wish to roll back lading entirely.
