### PR TITLE
[CWS] Bugfixing PID and Mount ID rate limiter

### DIFF
--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -377,9 +377,6 @@ func (mr *Resolver) ResolveMountPath(mountID, pid uint32, containerID string) (s
 
 func (mr *Resolver) syncCacheMiss(mountID uint32) {
 	mr.procMissStats.Inc()
-
-	// add to fallback limiter to avoid storm of file access
-	mr.fallbackLimiter.Count(mountID)
 }
 
 func (mr *Resolver) resolveMountPath(mountID uint32, containerID string, pid uint32) (string, error) {

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	deleteDelayTime                      = 5 * time.Second
-	numAllowedMountIDsToResolvePerPeriod = 50
+	numAllowedMountIDsToResolvePerPeriod = 100
 	fallbackLimiterPeriod                = 5 * time.Second
 )
 

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	deleteDelayTime                      = 5 * time.Second
-	numAllowedMountIDsToResolvePerPeriod = 100
+	numAllowedMountIDsToResolvePerPeriod = 75
 	fallbackLimiterPeriod                = 5 * time.Second
 )
 

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -30,9 +30,9 @@ import (
 )
 
 const (
-	deleteDelayTime                    = 5 * time.Second
-	numAllowedMountsToResolvePerPeriod = 50
-	fallbackLimiterPeriod              = 5 * time.Second
+	deleteDelayTime                      = 5 * time.Second
+	numAllowedMountIDsToResolvePerPeriod = 50
+	fallbackLimiterPeriod                = 5 * time.Second
 )
 
 // newMountFromMountInfo - Creates a new Mount from parsed MountInfo data
@@ -605,7 +605,7 @@ func NewResolver(statsdClient statsd.ClientInterface, cgroupsResolver *cgroup.Re
 	mr.redemption = redemption
 
 	// create a rate limiter that allows for 64 mount IDs
-	limiter, err := utils.NewLimiter[uint32](64, numAllowedMountsToResolvePerPeriod, fallbackLimiterPeriod)
+	limiter, err := utils.NewLimiter[uint32](64, numAllowedMountIDsToResolvePerPeriod, fallbackLimiterPeriod)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/resolvers/process/resolver.go
+++ b/pkg/security/resolvers/process/resolver.go
@@ -50,7 +50,7 @@ const (
 const (
 	procResolveMaxDepth                   = 16
 	maxParallelArgsEnvs                   = 512 // == number of parallel starting processes
-	numAllowedProcessesToResolvePerPeriod = 300
+	numAllowedProcessesToResolvePerPeriod = 1
 	procFallbackLimiterPeriod             = 30 * time.Second // proc fallback period by pid
 )
 
@@ -600,8 +600,6 @@ func (p *Resolver) resolve(pid, tid uint32, inode uint64, useProcFS bool) *model
 	}
 
 	if p.procFallbackLimiter.Allow(pid) {
-		p.procFallbackLimiter.Count(pid)
-
 		// fallback to /proc, the in-kernel LRU may have deleted the entry
 		if entry := p.resolveFromProcfs(pid, procResolveMaxDepth); entry != nil {
 			p.hitsStats[metrics.ProcFSTag].Inc()

--- a/pkg/security/resolvers/process/resolver.go
+++ b/pkg/security/resolvers/process/resolver.go
@@ -48,10 +48,10 @@ const (
 )
 
 const (
-	procResolveMaxDepth                   = 16
-	maxParallelArgsEnvs                   = 512 // == number of parallel starting processes
-	numAllowedProcessesToResolvePerPeriod = 1
-	procFallbackLimiterPeriod             = 30 * time.Second // proc fallback period by pid
+	procResolveMaxDepth              = 16
+	maxParallelArgsEnvs              = 512 // == number of parallel starting processes
+	numAllowedPIDsToResolvePerPeriod = 1
+	procFallbackLimiterPeriod        = 30 * time.Second // proc fallback period by pid
 )
 
 // ResolverOpts options of resolver
@@ -1317,7 +1317,7 @@ func NewResolver(manager *manager.Manager, config *config.Config, statsdClient s
 	p.processCacheEntryPool = NewProcessCacheEntryPool(p)
 
 	// Create rate limiter that allows for 128 pids
-	limiter, err := utils.NewLimiter[uint32](128, numAllowedProcessesToResolvePerPeriod, procFallbackLimiterPeriod)
+	limiter, err := utils.NewLimiter[uint32](128, numAllowedPIDsToResolvePerPeriod, procFallbackLimiterPeriod)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/utils/limiter.go
+++ b/pkg/security/utils/limiter.go
@@ -14,8 +14,8 @@ import (
 )
 
 type cacheEntry struct {
-	count int
-	last  time.Time
+	count         int
+	timeFirstSeen time.Time // marks the beginning of the time window during which a limited number of tokens are allowed
 }
 
 // LimiterStat return stats
@@ -55,8 +55,8 @@ func NewLimiter[K comparable](numUniqueTokens int, numAllowedTokensPerPeriod int
 // Allow returns whether an entry is allowed or not
 func (l *Limiter[K]) Allow(k K) bool {
 	if entry, ok := l.cache.Get(k); ok {
-		if time.Now().Sub(entry.last) >= l.period {
-			// If time elapsed between now and the last cache entry is longer than allowed period, reset the count and allow
+		if time.Now().Sub(entry.timeFirstSeen) >= l.period {
+			// If time elapsed between now and the first cache entry is longer than allowed period, reset the count and allow
 			l.init(k)
 		} else if entry.count < l.numAllowedTokensPerPeriod {
 			l.Count(k)
@@ -82,16 +82,16 @@ func (l *Limiter[K]) SwapStats() []LimiterStat {
 	}
 }
 
-// Init marks the key as used
+// init marks the key as used with a count of 1
 func (l *Limiter[K]) init(k K) {
 	entry := &cacheEntry{
-		count: 1,
-		last:  time.Now(),
+		count:         1,
+		timeFirstSeen: time.Now(),
 	}
 	l.cache.Add(k, entry)
 }
 
-// Count marks the key as used
+// Count marks the key as used and increments the count
 func (l *Limiter[K]) Count(k K) {
 	// use get to mark it as used so that it won't be evicted
 	if entry, ok := l.cache.Get(k); ok {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

The new implementation of the utils.Limiter resulted in flaky tests, which we bypassed with bumping the number of processes per PID and mount ID that were allowed to be resolved by checking `/proc`/ per time period. This PR fixes the underlying issues.

**The original logic:**
For every **PID**, allow if 30 seconds has passed since it was last seen, and then add to the cache. Effectively, a PID can be resolved by accessing `/proc` once every 30 seconds, with the 30 seconds being a rolling window from when the PID was last seen.

For every **mount ID**, it is only added to the cache if `syncCache(pids...)` errors out AND if it does not exist in the cache (it could have been removed).  If it is seen again within 5 seconds, the attempt to resolve the mount ID using `/proc` is abandoned and the cache stays as is. If it is seen again after 5 seconds, it is removed from the cache.

If the mount ID is repeatedly seen and syncCache does NOT fail, it is always allowed. This means that rate limiting by time was not in effect, and mount ID resolutions were only rate limited by `syncCache` failures.

**New logic:**
The difference between the new logic and the original logic for **PIDs** is that instead of rolling windows of 30 seconds, it's fixed windows of 30 seconds, starting from when a PID is first seen. Using the value of 1 for `numAllowedProcessesToResolvePeriod` actually results in more processes being allowed by the rate limiter. **This PR removes double counting that was causing the rate limiter to disallow valid PIDs.**
 
With **mount IDs**, the difference is that **we are introducing rate limiting that is NOT based on whether `syncCache` failed, but rather on time and number of events**. **This PR bumps `numAllowedMountIDsToResolvePerPeriod` to 75 per 5 second fixed windows.**

**Links**
New implementation of the utils.Limiter: https://github.com/DataDog/datadog-agent/pull/18026/files
Bugfix 1: https://github.com/DataDog/datadog-agent/pull/18078

Original implementation of utils.Limiter: https://github.com/DataDog/datadog-agent/commit/2976450d272be9eea59bc447ee75c9c1ad02ee3c

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
