### PR TITLE
latest stable set to 6/7.46.0

### DIFF
--- a/release.json
+++ b/release.json
@@ -1,8 +1,8 @@
 {
     "base_branch": "main",
     "last_stable": {
-        "6": "6.45.0",
-        "7": "7.45.0"
+        "6": "6.46.0",
+        "7": "7.46.0"
     },
     "nightly": {
         "INTEGRATIONS_CORE_VERSION": "master",


### PR DESCRIPTION
Set `latest_stable` to 6/7.46.0 in release.json.