### PR TITLE
Set AZ for all supported environments.

### DIFF
--- a/tasks/kernel_matrix_testing/stacks.py
+++ b/tasks/kernel_matrix_testing/stacks.py
@@ -215,6 +215,11 @@ def destroy_stack_force(ctx, stack):
         warn=True,
         hide=True,
     ).stdout.strip()
+
+    ctx.run(
+        f"PULUMI_CONFIG_PASSPHRASE=1234 pulumi cancel -y -C ../test-infra-definitions -s {pulumi_stack_name}",
+        warn=True,
+    )
     ctx.run(
         f"PULUMI_CONFIG_PASSPHRASE=1234 pulumi stack rm --force -y -C ../test-infra-definitions -s {pulumi_stack_name}",
         warn=True,

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
-	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -195,8 +195,8 @@ github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
-github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
+github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -187,6 +187,7 @@ func NewTestEnv(name, x86InstanceType, armInstanceType string, opts *SystemProbe
 	b = retry.WithMaxRetries(4, b)
 	if retryErr := retry.Do(ctx, b, func(_ context.Context) error {
 		// Set AZ in retry block so we can change if needed.
+		// Only set the default subnets if this is a CI run.
 		if isCIRun(opts.InfraEnv) {
 			config["ddinfra:aws/defaultSubnets"] = auto.ConfigValue{Value: getAvailabilityZone(currentAZ)}
 		}

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -45,8 +45,8 @@ const (
 )
 
 var availabilityZones = map[string][]string{
-	DatadogAgentQAEnv: []string{PrimaryAZ, SecondaryAZ, BackupAZ},
-	Sandbox:           []string{SandboxPrimaryAz, SandboxSecondaryAz, SandboxBackupAz},
+	DatadogAgentQAEnv: {PrimaryAZ, SecondaryAZ, BackupAZ},
+	Sandbox:           {SandboxPrimaryAz, SandboxSecondaryAz, SandboxBackupAz},
 }
 
 type SystemProbeEnvOpts struct {

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -32,21 +32,21 @@ import (
 )
 
 const (
-	PrimaryAZ   = "subnet-03061a1647c63c3c3"
-	SecondaryAZ = "subnet-0f1ca3e929eb3fb8b"
-	BackupAZ    = "subnet-071213aedb0e1ae54"
+	AgentQAPrimaryAZ   = "subnet-03061a1647c63c3c3"
+	AgentQASecondaryAZ = "subnet-0f1ca3e929eb3fb8b"
+	AgentQABackupAZ    = "subnet-071213aedb0e1ae54"
 
 	SandboxPrimaryAz   = "subnet-b89e00e2"
 	SandboxSecondaryAz = "subnet-8ee8b1c6"
 	SandboxBackupAz    = "subnet-3f5db45b"
 
 	DatadogAgentQAEnv = "aws/agent-qa"
-	Sandbox           = "aws/sandbox"
+	SandboxEnv        = "aws/sandbox"
 )
 
 var availabilityZones = map[string][]string{
-	DatadogAgentQAEnv: {PrimaryAZ, SecondaryAZ, BackupAZ},
-	Sandbox:           {SandboxPrimaryAz, SandboxSecondaryAz, SandboxBackupAz},
+	DatadogAgentQAEnv: {AgentQAPrimaryAZ, AgentQASecondaryAZ, AgentQABackupAZ},
+	SandboxEnv:        {SandboxPrimaryAz, SandboxSecondaryAz, SandboxBackupAz},
 }
 
 type SystemProbeEnvOpts struct {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
#18054 introduced the ability to change the default subnet to target when launching instances in the `datadog-agent-qa` account.
This PR adds support to do that for the sandbox account as well.

Moreover, it also updates the test-infra-definitions version, to incorporate [fix](https://github.com/DataDog/test-infra-definitions/pull/242) related with the configuration of the `kernel_matrix_testing` system when launching custom kernels.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
