### PR TITLE
[CSPM] Kubelet config: load key/cert stats data from config file

### DIFF
--- a/pkg/compliance/k8sconfig/loader.go
+++ b/pkg/compliance/k8sconfig/loader.go
@@ -167,6 +167,7 @@ func (l *loader) loadConfigFileMeta(name string) *K8sConfigFileMeta {
 	if !ok {
 		return nil
 	}
+
 	var content interface{}
 	switch filepath.Ext(name) {
 	case ".yaml", ".yml":
@@ -190,6 +191,36 @@ func (l *loader) loadConfigFileMeta(name string) *K8sConfigFileMeta {
 		Mode:    uint32(info.Mode()),
 		Content: content,
 	}
+}
+
+func (l *loader) loadKubeletConfigFileMeta(name string) *K8sConfigFileMeta {
+	meta := l.loadConfigFileMeta(name)
+	if meta == nil {
+		return nil
+	}
+	content, ok := meta.Content.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	if kind, _ := content["kind"]; kind != "KubeletConfiguration" {
+		l.pushError(fmt.Errorf(`kubelet configuration loaded from %q is expected to be of kind "KubeletConfiguration"`, name))
+		return nil
+	}
+	// specifically parse key/cert files path to load their associated meta info.
+	if keyPath, ok := content["tlsPrivateKeyFile"].(string); ok {
+		content["tlsPrivateKeyFile"] = l.loadKeyFileMeta(keyPath)
+	}
+	if certPath, ok := content["tlsCertFile"].(string); ok {
+		content["tlsCertFile"] = l.loadCertFileMeta(certPath)
+	}
+	if authentication, ok := content["authentication"].(map[string]interface{}); ok {
+		if x509, ok := authentication["x509"].(map[string]interface{}); ok {
+			if clientCAFile, ok := x509["clientCAFile"].(string); ok {
+				x509["clientCAFile"] = l.loadCertFileMeta(clientCAFile)
+			}
+		}
+	}
+	return meta
 }
 
 func (l *loader) loadAdmissionConfigFileMeta(name string) *K8sAdmissionConfigFileMeta {

--- a/pkg/compliance/k8sconfig/loader_test.go
+++ b/pkg/compliance/k8sconfig/loader_test.go
@@ -10,8 +10,6 @@ package k8sconfig
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -22,7 +20,19 @@ import (
 )
 
 const eksProcTable = `
-kubelet --config /etc/kubernetes/kubelet/kubelet-config.json --kubeconfig /var/lib/kubelet/kubeconfig --container-runtime-endpoint unix:///run/containerd/containerd.sock --image-credential-provider-config /etc/eks/image-credential-provider/config.json --image-credential-provider-bin-dir /etc/eks/image-credential-provider --node-ip=192.168.78.181 --pod-infra-container-image=602401143452.dkr.ecr.eu-west-3.amazonaws.com/eks/pause:3.5 --v=2 --cloud-provider=aws --container-runtime=remote --node-labels=eks.amazonaws.com/sourceLaunchTemplateVersion=1,alpha.eksctl.io/cluster-name=PierreGuilleminotGravitonSandbox,alpha.eksctl.io/nodegroup-name=standard,eks.amazonaws.com/nodegroup-image=ami-09f37ddb4a6ecc85e,eks.amazonaws.com/capacityType=ON_DEMAND,eks.amazonaws.com/nodegroup=standard,eks.amazonaws.com/sourceLaunchTemplateId=lt-0df2e04572534b928 --max-pods=17
+kubelet \
+	--config /etc/kubernetes/kubelet/kubelet-config.json \
+	--kubeconfig /var/lib/kubelet/kubeconfig \
+	--container-runtime-endpoint unix:///run/containerd/containerd.sock \
+	--image-credential-provider-config /etc/eks/image-credential-provider/config.json \
+	--image-credential-provider-bin-dir /etc/eks/image-credential-provider \
+	--node-ip=192.168.78.181 \
+	--pod-infra-container-image=602401143452.dkr.ecr.eu-west-3.amazonaws.com/eks/pause:3.5 \
+	--v=2 \
+	--cloud-provider=aws \
+	--container-runtime=remote \
+	--node-labels=eks.amazonaws.com/sourceLaunchTemplateVersion=1,alpha.eksctl.io/cluster-name=Sandbox,alpha.eksctl.io/nodegroup-name=standard,eks.amazonaws.com/nodegroup-image=ami-09f37ddb4a6ecc85e,eks.amazonaws.com/capacityType=ON_DEMAND,eks.amazonaws.com/nodegroup=standard,eks.amazonaws.com/sourceLaunchTemplateId=lt-0df2e04572534b928 \
+	--max-pods=17
 `
 
 // TODO(jinroh): use testdata files
@@ -32,82 +42,318 @@ var eksFs = []*mockFile{
 		mode: 0755, isDir: true,
 	},
 	{
-		name:    "/etc/eks/image-credential-provider/config.json",
-		mode:    0644,
-		content: `{\n  "apiVersion": "kubelet.config.k8s.io/v1alpha1",\n  "kind": "CredentialProviderConfig",\n  "providers": [\n    {\n      "name": "ecr-credential-provider",\n      "matchImages": [\n        "*.dkr.ecr.*.amazonaws.com",\n        "*.dkr.ecr.*.amazonaws.com.cn",\n        "*.dkr.ecr-fips.*.amazonaws.com",\n        "*.dkr.ecr.us-iso-east-1.c2s.ic.gov",\n        "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"\n      ],\n      "defaultCacheDuration": "12h",\n      "apiVersion": "credentialprovider.kubelet.k8s.io/v1alpha1"\n    }\n  ]\n}`,
+		name: "/etc/eks/image-credential-provider/config.json",
+		mode: 0644,
+		content: `{
+  "apiVersion": "kubelet.config.k8s.io/v1alpha1",
+  "kind": "CredentialProviderConfig",
+  "providers": [
+    {
+      "name": "ecr-credential-provider",
+      "matchImages": [
+        "*.dkr.ecr.*.amazonaws.com",
+        "*.dkr.ecr.*.amazonaws.com.cn",
+        "*.dkr.ecr-fips.*.amazonaws.com",
+        "*.dkr.ecr.us-iso-east-1.c2s.ic.gov",
+        "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"
+      ],
+      "defaultCacheDuration": "12h",
+      "apiVersion": "credentialprovider.kubelet.k8s.io/v1alpha1"
+    }
+  ]
+}`,
 	},
 	{
-		name:    "/etc/eks/release",
-		mode:    0664,
-		content: `BASE_AMI_ID="ami-0528ac959959021be"\nBUILD_TIME="Sat May 13 01:48:34 UTC 2023"\nBUILD_KERNEL="5.10.178-162.673.amzn2.aarch64"\nARCH="aarch64"`,
+		name: "/etc/eks/release",
+		mode: 0664,
+		content: `BASE_AMI_ID="ami-0528ac959959021be"
+BUILD_TIME="Sat May 13 01:48:34 UTC 2023"
+BUILD_KERNEL="5.10.178-162.673.amzn2.aarch64"
+ARCH="aarch64"`,
 	},
 	{
-		name:    "/etc/kubernetes/kubelet/kubelet-config.json",
-		mode:    0644,
-		content: `{\n  "kind": "KubeletConfiguration",\n  "apiVersion": "kubelet.config.k8s.io/v1beta1",\n  "address": "0.0.0.0",\n  "authentication": {\n    "anonymous": {\n      "enabled": false\n    },\n    "webhook": {\n      "cacheTTL": "2m0s",\n      "enabled": true\n    },\n    "x509": {\n      "clientCAFile": "/etc/kubernetes/pki/ca.crt"\n    }\n  },\n  "authorization": {\n    "mode": "Webhook",\n    "webhook": {\n      "cacheAuthorizedTTL": "5m0s",\n      "cacheUnauthorizedTTL": "30s"\n    }\n  },\n  "clusterDomain": "cluster.local",\n  "hairpinMode": "hairpin-veth",\n  "readOnlyPort": 0,\n  "cgroupDriver": "systemd",\n  "cgroupRoot": "/",\n  "featureGates": {\n    "RotateKubeletServerCertificate": true,\n    "KubeletCredentialProviders": true\n  },\n  "protectKernelDefaults": true,\n  "serializeImagePulls": false,\n  "serverTLSBootstrap": true,\n  "tlsCipherSuites": [\n    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",\n    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",\n    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",\n    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",\n    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",\n    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",\n    "TLS_RSA_WITH_AES_256_GCM_SHA384",\n    "TLS_RSA_WITH_AES_128_GCM_SHA256"\n  ],\n  "clusterDNS": [\n    "10.100.0.10"\n  ],\n  "kubeAPIQPS": 10,\n  "kubeAPIBurst": 20,\n  "evictionHard": {\n    "memory.available": "100Mi",\n    "nodefs.available": "10%",\n    "nodefs.inodesFree": "5%"\n  },\n  "kubeReserved": {\n    "cpu": "70m",\n    "ephemeral-storage": "1Gi",\n    "memory": "442Mi"\n  },\n  "systemReservedCgroup": "/system",\n  "kubeReservedCgroup": "/runtime"\n}`,
+		name: "/etc/kubernetes/kubelet/kubelet-config.json",
+		mode: 0644,
+		content: `{
+  "kind": "KubeletConfiguration",
+  "apiVersion": "kubelet.config.k8s.io/v1beta1",
+  "address": "0.0.0.0",
+  "authentication": {
+    "anonymous": {
+      "enabled": false
+    },
+    "webhook": {
+      "cacheTTL": "2m0s",
+      "enabled": true
+    },
+    "x509": {
+      "clientCAFile": "/etc/kubernetes/pki/ca.crt"
+    }
+  },
+  "authorization": {
+    "mode": "Webhook",
+    "webhook": {
+      "cacheAuthorizedTTL": "5m0s",
+      "cacheUnauthorizedTTL": "30s"
+    }
+  },
+  "clusterDomain": "cluster.local",
+  "hairpinMode": "hairpin-veth",
+  "readOnlyPort": 0,
+  "cgroupDriver": "systemd",
+  "cgroupRoot": "/",
+  "featureGates": {
+    "RotateKubeletServerCertificate": true,
+    "KubeletCredentialProviders": true
+  },
+  "protectKernelDefaults": true,
+  "serializeImagePulls": false,
+  "serverTLSBootstrap": true,
+  "tlsCipherSuites": [
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "TLS_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_RSA_WITH_AES_128_GCM_SHA256"
+  ],
+  "clusterDNS": [
+    "10.100.0.10"
+  ],
+  "kubeAPIQPS": 10,
+  "kubeAPIBurst": 20,
+  "evictionHard": {
+    "memory.available": "100Mi",
+    "nodefs.available": "10%",
+    "nodefs.inodesFree": "5%"
+  },
+  "kubeReserved": {
+    "cpu": "70m",
+    "ephemeral-storage": "1Gi",
+    "memory": "442Mi"
+  },
+  "systemReservedCgroup": "/system",
+  "kubeReservedCgroup": "/runtime"
+}`,
 	},
 	{
-		name:    "/etc/systemd/system/kubelet.service.d/10-kubelet-args.conf",
-		mode:    0644,
-		content: `[Service]\nEnvironment='KUBELET_ARGS=--node-ip=192.168.78.181 --pod-infra-container-image=602401143452.dkr.ecr.eu-west-3.amazonaws.com/eks/pause:3.5 --v=2 --cloud-provider=aws --container-runtime=remote'`,
+		name: "/etc/systemd/system/kubelet.service.d/10-kubelet-args.conf",
+		mode: 0644,
+		content: `[Service]
+Environment='KUBELET_ARGS=--node-ip=192.168.78.181 \
+	--pod-infra-container-image=602401143452.dkr.ecr.eu-west-3.amazonaws.com/eks/pause:3.5 \
+	--v=2 \
+	--cloud-provider=aws \
+	--container-runtime=remote'`,
 	},
 	{
-		name:    "/var/lib/kubelet/kubeconfig",
-		mode:    0644,
-		content: `apiVersion: v1\nkind: Config\nclusters:\n- cluster:\n    certificate-authority: /etc/kubernetes/pki/ca.crt\n    server: https://1DB2F34ED30B77AFEA800D56D3EBED0B.sk1.eu-west-3.eks.amazonaws.com\n  name: kubernetes\ncontexts:\n- context:\n    cluster: kubernetes\n    user: kubelet\n  name: kubelet\ncurrent-context: kubelet\nusers:\n- name: kubelet\n  user:\n    exec:\n      apiVersion: client.authentication.k8s.io/v1beta1\n      command: /usr/bin/aws-iam-authenticator\n      args:\n        - "token"\n        - "-i"\n        - "PierreGuilleminotGravitonSandbox"\n        - --region\n        - "eu-west-3"`,
+		name: "/etc/kubernetes/pki/ca.crt",
+		mode: 0644,
+		content: `-----BEGIN CERTIFICATE-----
+MIIDFTCCAf2gAwIBAgIBATANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRsb2Nh
+bGhvc3RAMTUxNTQ2MjIwNjAgFw0xODAxMDkwMTQzMjZaGA8yMTE4MDEwOTAxNDMy
+NlowHzEdMBsGA1UEAwwUbG9jYWxob3N0QDE1MTU0NjIyMDYwggEiMA0GCSqGSIb3
+DQEBAQUAA4IBDwAwggEKAoIBAQC2hIORzonehlNadYyI30v1Jj8lhhABuiWiTSkl
+KCLqZjwBfWfSC4w02zxi2SAH9ju20XCJrUauwPq1qXCp/CqXC/rVgZrzluDlpJpe
+gF9AilQvGOxhrZhV4kqpOjGVE78uOmpfxiOyNermoJ0OVE8ugh3s/LLTNK/qmCAX
+uEYTQccAvNEiPX3XPBCiaFlSCkUNS0zp12mJNP43+KF9y0CbtYs1gXKHmmJVSpjR
+YmcuJJUfHxNrV2YR3ek6O4IIJFIlnLxgpjRBseBPkTenAT3S2YY9MyQkkBrRSPBa
+vLM24al3KDvXYikYe3WpxeYNHGNcHIgR+hKlRTQ5VrWlfx9dAgMBAAGjWjBYMA4G
+A1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggrBgEFBQcDATAPBgNVHRMBAf8EBTAD
+AQH/MCAGA1UdEQQZMBeCCWxvY2FsaG9zdIcEfwAAAYcEfwAAATANBgkqhkiG9w0B
+AQsFAAOCAQEAFhW8cVTraHPNsE+Jo0ZvcE2ic8lEzeOhWI2O/fpkrUJS5LptPKHS
+nTK+CPxA0zhIS/vlJznIabeddXwtq7Xb5SwlJMHYMnHD6f5qwpD22D2dxJJa5sma
+3yrK/4CutuEae08qqSeakfgCjcHLL9p7FZWxujkV9/5CEH5lFWYLGumyIoS46Svf
+nSfDFKTrOj8P60ncCoWcSpMbdVQBDuKlIZuBMmz9CguC1CtuQWPDUmOGJuPs/+So
+yusHbBfj+ATUWDYTg1lLjOIOSJpHGUQkvS+8Bo47SThD/b4w2i6VC72ldxtBuxGf
+L7+jALMhMhiQD+Q4qsNuyvvNQLoYcTTFTw==
+-----END CERTIFICATE-----
+`,
+	},
+	{
+		name: "/var/lib/kubelet/kubeconfig",
+		mode: 0644,
+		content: `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority: /etc/kubernetes/pki/ca.crt
+    server: https://1DB2F34ED30B77AFEA800D56D3EBED0B.sk1.eu-west-3.eks.amazonaws.com
+  name: kubernetes
+  contexts:
+- context:
+    cluster: kubernetes
+    user: kubelet
+  name: kubelet
+  current-context: kubelet
+users:
+- name: kubelet
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: /usr/bin/aws-iam-authenticator
+      args:
+        - "token"
+        - "-i"
+        - "Sandbox"
+        - --region
+        - "eu-west-3"
+`,
 	},
 }
 
 const kubadmProcTable = `
-kube-proxy --config=/var/lib/kube-proxy/config.conf --hostname-override=lima-k8s
-kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --config=/var/lib/kubelet/config.yaml --container-runtime-endpoint=unix:///run/containerd/containerd.sock --pod-infra-container-image=registry.k8s.io/pause:3.9
-etcd --advertise-client-urls=https://192.168.5.15:2379 --cert-file=/etc/kubernetes/pki/etcd/server.crt --client-cert-auth=true --data-dir=/var/lib/etcd --experimental-initial-corrupt-check=true --experimental-watch-progress-notify-interval=5s --initial-advertise-peer-urls=https://192.168.5.15:2380 --initial-cluster=lima-k8s=https://192.168.5.15:2380 --key-file=/etc/kubernetes/pki/etcd/server.key --listen-client-urls=https://127.0.0.1:2379,https://192.168.5.15:2379 --listen-metrics-urls=http://127.0.0.1:2381 --listen-peer-urls=https://192.168.5.15:2380 --name=lima-k8s --peer-cert-file=/etc/kubernetes/pki/etcd/peer.crt --peer-client-cert-auth=true --peer-key-file=/etc/kubernetes/pki/etcd/peer.key --peer-trusted-ca-file=/etc/kubernetes/pki/etcd/ca.crt --snapshot-count=10000 --trusted-ca-file=/etc/kubernetes/pki/etcd/ca.crt
-kube-controller-manager --allocate-node-cidrs=true --authentication-kubeconfig=/etc/kubernetes/controller-manager.conf --authorization-kubeconfig=/etc/kubernetes/controller-manager.conf --bind-address=127.0.0.1 --client-ca-file=/etc/kubernetes/pki/ca.crt --cluster-cidr=10.244.0.0/16 --cluster-name=kubernetes --cluster-signing-cert-file=/etc/kubernetes/pki/ca.crt --cluster-signing-key-file=/etc/kubernetes/pki/ca.key --controllers=*,bootstrapsigner,tokencleaner --kubeconfig=/etc/kubernetes/controller-manager.conf --leader-elect=true --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt --root-ca-file=/etc/kubernetes/pki/ca.crt --service-account-private-key-file=/etc/kubernetes/pki/sa.key --service-cluster-ip-range=10.96.0.0/12 --use-service-account-credentials=true
-kube-scheduler --authentication-kubeconfig=/etc/kubernetes/scheduler.conf --authorization-kubeconfig=/etc/kubernetes/scheduler.conf --bind-address=127.0.0.1 --kubeconfig=/etc/kubernetes/scheduler.conf --leader-elect=true
-kube-apiserver --audit-policy-file=/etc/kubernetes/audit-policy.yaml --audit-log-path=/var/log/kubernetes/audit/audit.log --advertise-address=192.168.5.15 --allow-privileged=true --authorization-mode=Node,RBAC --client-ca-file=/etc/kubernetes/pki/ca.crt --enable-admission-plugins=NodeRestriction --enable-bootstrap-token-auth=true --etcd-cafile=/etc/kubernetes/pki/etcd/ca.crt --etcd-certfile=/etc/kubernetes/pki/apiserver-etcd-client.crt --etcd-keyfile=/etc/kubernetes/pki/apiserver-etcd-client.key --etcd-servers=https://127.0.0.1:2379 --kubelet-client-certificate=/etc/kubernetes/pki/apiserver-kubelet-client.crt --kubelet-client-key=/etc/kubernetes/pki/apiserver-kubelet-client.key --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname --proxy-client-cert-file=/etc/kubernetes/pki/front-proxy-client.crt --proxy-client-key-file=/etc/kubernetes/pki/front-proxy-client.key --requestheader-allowed-names=front-proxy-client --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt --requestheader-extra-headers-prefix=X-Remote-Extra- --requestheader-group-headers=X-Remote-Group --requestheader-username-headers=X-Remote-User --secure-port=6443 --service-account-issuer=https://kubernetes.default.svc.cluster.local --service-account-key-file=/etc/kubernetes/pki/sa.pub --service-account-signing-key-file=/etc/kubernetes/pki/sa.key --service-cluster-ip-range=10.96.0.0/12 --tls-cert-file=/etc/kubernetes/pki/apiserver.crt --tls-private-key-file=/etc/kubernetes/pki/apiserver.key
+kube-proxy \
+	--config=/var/lib/kube-proxy/config.conf \
+	--hostname-override=lima-k8s
+
+kubelet \
+	--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
+	--kubeconfig=/etc/kubernetes/kubelet.conf \
+	--config=/var/lib/kubelet/config.yaml \
+	--container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+	--pod-infra-container-image=registry.k8s.io/pause:3.9
+
+etcd \
+	--advertise-client-urls=https://192.168.5.15:2379 \
+	--cert-file=/etc/kubernetes/pki/etcd/server.crt \
+	--client-cert-auth=true \
+	--data-dir=/var/lib/etcd \
+	--experimental-initial-corrupt-check=true \
+	--experimental-watch-progress-notify-interval=5s \
+	--initial-advertise-peer-urls=https://192.168.5.15:2380 \
+	--initial-cluster=lima-k8s=https://192.168.5.15:2380 \
+	--key-file=/etc/kubernetes/pki/etcd/server.key \
+	--listen-client-urls=https://127.0.0.1:2379,https://192.168.5.15:2379 \
+	--listen-metrics-urls=http://127.0.0.1:2381 \
+	--listen-peer-urls=https://192.168.5.15:2380 \
+	--name=lima-k8s \
+	--peer-cert-file=/etc/kubernetes/pki/etcd/peer.crt \
+	--peer-client-cert-auth=true \
+	--peer-key-file=/etc/kubernetes/pki/etcd/peer.key \
+	--peer-trusted-ca-file=/etc/kubernetes/pki/etcd/ca.crt \
+	--snapshot-count=10000 \
+	--trusted-ca-file=/etc/kubernetes/pki/etcd/ca.crt
+
+kube-controller-manager \
+	--allocate-node-cidrs=true \
+	--authentication-kubeconfig=/etc/kubernetes/controller-manager.conf \
+	--authorization-kubeconfig=/etc/kubernetes/controller-manager.conf \
+	--bind-address=127.0.0.1 \
+	--client-ca-file=/etc/kubernetes/pki/ca.crt \
+	--cluster-cidr=10.244.0.0/16 \
+	--cluster-name=kubernetes \
+	--cluster-signing-cert-file=/etc/kubernetes/pki/ca.crt \
+	--cluster-signing-key-file=/etc/kubernetes/pki/ca.key \
+	--controllers=*,bootstrapsigner,tokencleaner \
+	--kubeconfig=/etc/kubernetes/controller-manager.conf \
+	--leader-elect=true \
+	--requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt \
+	--root-ca-file=/etc/kubernetes/pki/ca.crt \
+	--service-account-private-key-file=/etc/kubernetes/pki/sa.key \
+	--service-cluster-ip-range=10.96.0.0/12 \
+	--use-service-account-credentials=true
+
+kube-scheduler \
+	--authentication-kubeconfig=/etc/kubernetes/scheduler.conf \
+	--authorization-kubeconfig=/etc/kubernetes/scheduler.conf \
+	--bind-address=127.0.0.1 \
+	--kubeconfig=/etc/kubernetes/scheduler.conf \
+	--leader-elect=true
+
+kube-apiserver \
+	--audit-policy-file=/etc/kubernetes/audit-policy.yaml \
+	--audit-log-path=/var/log/kubernetes/audit/audit.log \
+	--advertise-address=192.168.5.15 \
+	--allow-privileged=true \
+	--authorization-mode=Node,RBAC \
+	--client-ca-file=/etc/kubernetes/pki/ca.crt \
+	--enable-admission-plugins=NodeRestriction \
+	--enable-bootstrap-token-auth=true \
+	--etcd-cafile=/etc/kubernetes/pki/etcd/ca.crt \
+	--etcd-certfile=/etc/kubernetes/pki/apiserver-etcd-client.crt \
+	--etcd-keyfile=/etc/kubernetes/pki/apiserver-etcd-client.key \
+	--etcd-servers=https://127.0.0.1:2379 \
+	--kubelet-client-certificate=/etc/kubernetes/pki/apiserver-kubelet-client.crt \
+	--kubelet-client-key=/etc/kubernetes/pki/apiserver-kubelet-client.key \
+	--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname \
+	--proxy-client-cert-file=/etc/kubernetes/pki/front-proxy-client.crt \
+	--proxy-client-key-file=/etc/kubernetes/pki/front-proxy-client.key \
+	--requestheader-allowed-names=front-proxy-client \
+	--requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt \
+	--requestheader-extra-headers-prefix=X-Remote-Extra- \
+	--requestheader-group-headers=X-Remote-Group \
+	--requestheader-username-headers=X-Remote-User \
+	--secure-port=6443 \
+	--service-account-issuer=https://kubernetes.default.svc.cluster.local \
+	--service-account-key-file=/etc/kubernetes/pki/sa.pub \
+	--service-account-signing-key-file=/etc/kubernetes/pki/sa.key \
+	--service-cluster-ip-range=10.96.0.0/12 \
+	--tls-cert-file=/etc/kubernetes/pki/apiserver.crt \
+	--tls-private-key-file=/etc/kubernetes/pki/apiserver.key
 `
 
-func TestKubAdmConfigLoader(t *testing.T) {
+func procTable(str string) []proc {
 	var table []proc
-	for _, l := range strings.Split(kubadmProcTable, "\n") {
+	str = strings.ReplaceAll(str, "\\\n", "")
+	for _, l := range strings.Split(str, "\n") {
 		if l == "" {
 			continue
 		}
 		cmdline := strings.Fields(l)
 		table = append(table, buildProc(cmdline[0], cmdline))
 	}
+	return table
+}
 
+func TestKubAdmConfigLoader(t *testing.T) {
 	tmpDir := t.TempDir()
-	conf := loadTestConfiguration(tmpDir, table)
+	conf := loadTestConfiguration(tmpDir, kubadmProcTable)
 	assert.Empty(t, conf.Errors)
 }
 
 func TestKubEksConfigLoader(t *testing.T) {
-	var table []proc
-	for _, l := range strings.Split(eksProcTable, "\n") {
-		if l == "" {
-			continue
-		}
-		cmdline := strings.Fields(l)
-		table = append(table, buildProc(cmdline[0], cmdline))
-	}
 	tmpDir := t.TempDir()
 	for _, f := range eksFs {
 		f.create(t, tmpDir)
 	}
-	conf := loadTestConfiguration(tmpDir, table)
-	b, _ := json.MarshalIndent(conf, "", "  ")
+	conf := loadTestConfiguration(tmpDir, eksProcTable)
 	assert.Empty(t, conf.Errors)
+
 	assert.NotNil(t, conf.ManagedEnvironment)
 	assert.Equal(t, conf.ManagedEnvironment.Name, "eks")
 	assert.True(t, strings.HasPrefix(conf.ManagedEnvironment.Metadata.(string), `BASE_AMI_ID="ami-0528ac959959021be"`))
-	fmt.Println(string(b))
+
+	assert.Nil(t, conf.Components.KubeApiserver)
+	assert.Nil(t, conf.Components.Etcd)
+	assert.Nil(t, conf.Components.KubeControllerManager)
+	assert.Nil(t, conf.Components.KubeScheduler)
+	assert.Nil(t, conf.Components.KubeProxy)
+
+	assert.NotNil(t, conf.Components.Kubelet)
+	assert.NotNil(t, conf.Components.Kubelet.Config)
+	assert.NotNil(t, conf.Components.Kubelet.Kubeconfig)
+	assert.NotNil(t, conf.Components.Kubelet.Config.Content)
+
+	{
+		content, ok := conf.Components.Kubelet.Config.Content.(map[string]interface{})
+		assert.True(t, ok)
+		authentication, ok := content["authentication"].(map[string]interface{})
+		assert.True(t, ok)
+		x509, ok := authentication["x509"].(map[string]interface{})
+		assert.True(t, ok)
+		clientCAFile, ok := x509["clientCAFile"].(*K8sCertFileMeta)
+		assert.True(t, ok)
+		assert.NotNil(t, clientCAFile)
+	}
 }
 
-func loadTestConfiguration(hostroot string, table []proc) *K8sNodeConfig {
+func loadTestConfiguration(hostroot string, table string) *K8sNodeConfig {
 	l := &loader{hostroot: hostroot}
 	_, data := l.load(context.Background(), func(ctx context.Context) []proc {
-		return table
+		return procTable(table)
 	})
 	return data
 }
@@ -128,7 +374,7 @@ func (f *mockFile) create(t *testing.T, root string) {
 		if err := os.MkdirAll(filepath.Join(root, filepath.Dir(f.name)), fs.FileMode(0755)); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(filepath.Join(root, f.name), []byte(strings.ReplaceAll(f.content, "\\n", "\n")), os.FileMode(f.mode)); err != nil {
+		if err := os.WriteFile(filepath.Join(root, f.name), []byte(f.content), os.FileMode(f.mode)); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/pkg/compliance/k8sconfig/types_generated.go
+++ b/pkg/compliance/k8sconfig/types_generated.go
@@ -612,7 +612,7 @@ func (l *loader) newK8sKubeletConfig(flags map[string]string) *K8sKubeletConfig 
 	}
 	if v, ok := flags["--config"]; ok {
 		delete(flags, "--config")
-		res.Config = l.loadConfigFileMeta(v)
+		res.Config = l.loadKubeletConfigFileMeta(v)
 	}
 	if v, ok := flags["--event-burst"]; ok {
 		delete(flags, "--event-burst")

--- a/pkg/compliance/tools/k8s_types_generator/main.go
+++ b/pkg/compliance/tools/k8s_types_generator/main.go
@@ -223,7 +223,7 @@ func main() {
 	}
 }
 
-func defaultedType(conf *conf) *conf {
+func defaultedType(componentName string, conf *conf) *conf {
 	if conf.flagName == "kubeconfig" || conf.flagName == "authentication-kubeconfig" {
 		conf.flagType = "kubeconfig"
 	} else if conf.flagType == "string" || conf.flagType == "stringArray" {
@@ -389,7 +389,13 @@ func printKomponentCode(komp *komponent) string {
 		case "*K8sTokenFileMeta":
 			return fmt.Sprintf("res.%s = l.loadTokenFileMeta(%s)", toGoField(c.flagName), v)
 		case "*K8sConfigFileMeta":
-			return fmt.Sprintf("res.%s = l.loadConfigFileMeta(%s)", toGoField(c.flagName), v)
+			if komp.name == "kubelet" && c.flagName == "config" {
+				return fmt.Sprintf("res.%s = l.loadKubeletConfigFileMeta(%s)", toGoField(c.flagName), v)
+			} else {
+				return fmt.Sprintf("res.%s = l.loadConfigFileMeta(%s)", toGoField(c.flagName), v)
+			}
+		case "*K8sKubeletConfigFileMeta":
+			return fmt.Sprintf("res.%s = l.loadKubeletConfigFileMeta(%s)", toGoField(c.flagName), v)
 		case "*K8sAdmissionConfigFileMeta":
 			return fmt.Sprintf("res.%s = l.loadAdmissionConfigFileMeta(%s)", toGoField(c.flagName), v)
 		case "*K8sEncryptionProviderConfigFileMeta":
@@ -496,7 +502,7 @@ func downloadEtcdAndExtractFlags(componentVersion string) *komponent {
 		line := scanner.Text()
 		conf, ok := scanEtcdHelpLine(line)
 		if ok {
-			confs = append(confs, defaultedType(conf))
+			confs = append(confs, defaultedType(componentName, conf))
 		}
 	}
 	return &komponent{
@@ -534,7 +540,7 @@ func downloadKubeComponentAndExtractFlags(componentName, componentVersion string
 		line := scanner.Text()
 		conf, ok := scanK8sHelpLine(line)
 		if ok {
-			confs = append(confs, defaultedType(conf))
+			confs = append(confs, defaultedType(componentName, conf))
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

Add specific decoding procedure to handle some certificate and keys field of the kubelet configuration file.

### Motivation

Some of our checks require to extract metadata (specifically file stats) for specified certificates and keys in the kubelet configuration. We were already doing so for certs and files specified via CLI flags, but are missing the one specified via KubeletConfiguration file.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
