### PR TITLE
pkg/trace: resolve `agent status` bug on start up

### DIFF
--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -1083,6 +1083,7 @@ func TestExpvar(t *testing.T) {
 
 	c := config.New()
 	c.DebugServerPort = 5012
+	info.InitInfo(c)
 	s := NewDebugServer(c)
 	s.Start()
 	defer s.Stop()
@@ -1090,13 +1091,18 @@ func TestExpvar(t *testing.T) {
 	resp, err := http.Get("http://127.0.0.1:5012/debug/vars")
 	assert.NoError(t, err)
 	defer resp.Body.Close()
-	assert.EqualValues(t, resp.StatusCode, http.StatusOK, "failed to read expvars from local server")
 
-	if resp.StatusCode == http.StatusOK {
-		var out map[string]interface{}
-		err = json.NewDecoder(resp.Body).Decode(&out)
-		assert.NoError(t, err, "/debug/vars must return valid json")
-	}
+	t.Run("read-expvars", func(t *testing.T) {
+		assert.EqualValues(t, resp.StatusCode, http.StatusOK, "failed to read expvars from local server")
+	})
+	t.Run("valid-response", func(t *testing.T) {
+		if resp.StatusCode == http.StatusOK {
+			var out map[string]interface{}
+			err = json.NewDecoder(resp.Body).Decode(&out)
+			assert.NoError(t, err, "/debug/vars must return valid json")
+			assert.NotNil(t, out["receiver"], "expvar receiver must not be nil")
+		}
+	})
 }
 
 func TestWatchdog(t *testing.T) {
@@ -1184,4 +1190,25 @@ func msgpTraces(t *testing.T, traces pb.Traces) []byte {
 		t.Fatal(err)
 	}
 	return bts
+}
+
+func TestAgentStatusOnStartup(t *testing.T) {
+	c := config.New()
+	c.DebugServerPort = 5012
+	s := NewDebugServer(c)
+	info.InitInfo(c)
+	s.Start()
+	defer s.Stop()
+
+	resp, err := http.Get("http://127.0.0.1:5012/debug/vars")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.EqualValues(t, resp.StatusCode, http.StatusOK, "failed to read expvars from local server")
+
+	if resp.StatusCode == http.StatusOK {
+		var out map[string]interface{}
+		err = json.NewDecoder(resp.Body).Decode(&out)
+		assert.NoError(t, err)
+		assert.NotNil(t, out["receiver"])
+	}
 }

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -1191,24 +1191,3 @@ func msgpTraces(t *testing.T, traces pb.Traces) []byte {
 	}
 	return bts
 }
-
-func TestAgentStatusOnStartup(t *testing.T) {
-	c := config.New()
-	c.DebugServerPort = 5012
-	s := NewDebugServer(c)
-	info.InitInfo(c)
-	s.Start()
-	defer s.Stop()
-
-	resp, err := http.Get("http://127.0.0.1:5012/debug/vars")
-	assert.NoError(t, err)
-	defer resp.Body.Close()
-	assert.EqualValues(t, resp.StatusCode, http.StatusOK, "failed to read expvars from local server")
-
-	if resp.StatusCode == http.StatusOK {
-		var out map[string]interface{}
-		err = json.NewDecoder(resp.Body).Decode(&out)
-		assert.NoError(t, err)
-		assert.NotNil(t, out["receiver"])
-	}
-}

--- a/pkg/trace/info/info.go
+++ b/pkg/trace/info/info.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	infoMu        sync.RWMutex
-	receiverStats []TagStats // only for the last minute
+	receiverStats = []TagStats{} // only for the last minute
 	languages     []string
 
 	// TODO: move from package globals to a clean single struct

--- a/pkg/trace/info/info_test.go
+++ b/pkg/trace/info/info_test.go
@@ -308,6 +308,8 @@ func TestInfoReceiverStats(t *testing.T) {
 	conf := testInit(t)
 	assert.NotNil(conf)
 
+	assert.NotNil(publishReceiverStats())
+
 	stats := NewReceiverStats()
 	t1 := &TagStats{
 		Tags{Lang: "python"},

--- a/releasenotes/notes/apm-fix-agent-status-bug-2385363a87144eba.yaml
+++ b/releasenotes/notes/apm-fix-agent-status-bug-2385363a87144eba.yaml
@@ -8,5 +8,5 @@
 ---
 fixes:
   - |
-    APM: fix issue of ``agent status`` returning an error when run shortly after 
+    APM: Fix issue of ``agent status`` returning an error when run shortly after 
     starting the trace agent.

--- a/releasenotes/notes/apm-fix-agent-status-bug-2385363a87144eba.yaml
+++ b/releasenotes/notes/apm-fix-agent-status-bug-2385363a87144eba.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: fix issue of ``agent status`` returning an error when run shortly after 
+    starting the trace agent.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR fixes a bug in which running `agent status` returns an error when run shortly after starting the trace-agent. The bug was caused since the receiver was initialized as `nil` for the first `10` seconds of the trace-agent starting up.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

`agent status` should not throw an error and should provide information regardless of when it is called. This can help with debugging the agent and providing clarity to users.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

This PR changes the initial value of the receiver stats to be an empty slice rather than `nil`. In most cases, they should behave in the same way, but is something to be aware of.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

The code should pass old and new unit tests. For manual testing, start the agent and the trace-agent. Run `agent status` within the first `10` seconds of the trace-agent starting. There should be no errors in the terminal, and the receiver should return:

`Receiver (previous minute)`
  `==========================`
    `No traces received in the previous minute.`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
