### PR TITLE
[process-agent] Enrich ProcessEntity with ContainerId

### DIFF
--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -42,7 +42,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
-
 	// register all workloadmeta collectors
 	_ "github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors"
 )

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -42,6 +42,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+
 	// register all workloadmeta collectors
 	_ "github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors"
 )

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -222,10 +222,6 @@ func (p *ProcessCheck) run(groupID int32, collectRealTime bool) (RunResult, erro
 		return nil, err
 	}
 
-	for _, extractor := range p.extractors {
-		extractor.Extract(procs)
-	}
-
 	// stores lastPIDs to be used by RTProcess
 	p.lastPIDs = p.lastPIDs[:0]
 	for pid := range procs {
@@ -254,6 +250,10 @@ func (p *ProcessCheck) run(groupID int32, collectRealTime bool) (RunResult, erro
 	// Notify the workload meta extractor that the mapping between pid and cid has changed
 	if p.workloadmetaExtractor != nil {
 		p.workloadmetaExtractor.SetLastPidToCid(pidToCid)
+	}
+
+	for _, extractor := range p.extractors {
+		extractor.Extract(procs)
 	}
 
 	// Keep track of containers addresses

--- a/pkg/process/metadata/workloadmeta/extractor.go
+++ b/pkg/process/metadata/workloadmeta/extractor.go
@@ -102,9 +102,9 @@ func (w *WorkloadMetaExtractor) Extract(procs map[int32]*procutil.Process) {
 
 	deadProcs := getDifference(w.cache, newCache)
 
-	// If no process has been created or terminated, there's no need to update the cache
+	// If no process has been created, terminated, or updated, there's no need to update the cache
 	// or generate a new diff
-	if len(newProcs) == 0 && len(deadProcs) == 0 {
+	if len(newProcs) == 0 && len(deadProcs) == 0 && len(newEntities) == 0 {
 		return
 	}
 

--- a/pkg/process/metadata/workloadmeta/extractor_test.go
+++ b/pkg/process/metadata/workloadmeta/extractor_test.go
@@ -43,6 +43,7 @@ func TestExtractor(t *testing.T) {
 		proc4 = testProc(Pid4, []string{"python", "test.py"})
 	)
 
+	// Silly test container id's for fun, doesn't matter what they are they just have to be unique.
 	var (
 		ctrId1 = "containers-are-awesome"
 		ctrId2 = "we-all-live-in-a-yellow-container"

--- a/pkg/process/metadata/workloadmeta/extractor_test.go
+++ b/pkg/process/metadata/workloadmeta/extractor_test.go
@@ -262,6 +262,9 @@ func BenchmarkHashProcess(b *testing.B) {
 	})
 }
 
+// Occasionally, WorkloadMeta will not have the ContainerID by the first time a process collection is executed. This test
+// asserts that the extractor is able to properly handle updating a ContainerID from "" to a valid cid, and
+// will re-generate the EventSet for that process once the pidToCid mapping is up-to-date.
 func TestLateContainerId(t *testing.T) {
 	extractor := NewWorkloadMetaExtractor(config.Mock(t))
 
@@ -286,7 +289,6 @@ func TestLateContainerId(t *testing.T) {
 		deletion: []*ProcessEntity{},
 	}, <-extractor.ProcessCacheDiff())
 
-	// Silly test container id's for fun, doesn't matter what they are they just have to be unique.
 	var (
 		ctrId1 = "containers-are-awesome"
 	)

--- a/pkg/process/metadata/workloadmeta/extractor_test.go
+++ b/pkg/process/metadata/workloadmeta/extractor_test.go
@@ -43,6 +43,17 @@ func TestExtractor(t *testing.T) {
 		proc4 = testProc(Pid4, []string{"python", "test.py"})
 	)
 
+	var (
+		ctrId1 = "containers-are-awesome"
+		ctrId2 = "we-all-live-in-a-yellow-container"
+	)
+	extractor.SetLastPidToCid(map[int]string{
+		Pid1: ctrId1,
+		Pid2: ctrId1,
+		Pid3: ctrId1,
+		Pid4: ctrId2,
+	})
+
 	// Assert that first run generates creation events for all processes
 	extractor.Extract(map[int32]*procutil.Process{
 		Pid1: proc1,
@@ -58,12 +69,14 @@ func TestExtractor(t *testing.T) {
 			NsPid:        proc1.NsPid,
 			CreationTime: proc1.Stats.CreateTime,
 			Language:     &languagemodels.Language{Name: languagemodels.Java},
+			ContainerId:  ctrId1,
 		},
 		hashProcess(Pid2, proc2.Stats.CreateTime): {
 			Pid:          proc2.Pid,
 			NsPid:        proc2.NsPid,
 			CreationTime: proc2.Stats.CreateTime,
 			Language:     &languagemodels.Language{Name: languagemodels.Python},
+			ContainerId:  ctrId1,
 		},
 	}, procs)
 
@@ -77,12 +90,14 @@ func TestExtractor(t *testing.T) {
 			NsPid:        proc1.NsPid,
 			CreationTime: proc1.Stats.CreateTime,
 			Language:     &languagemodels.Language{Name: languagemodels.Java},
+			ContainerId:  ctrId1,
 		},
 		{
 			Pid:          proc2.Pid,
 			NsPid:        proc2.NsPid,
 			CreationTime: proc2.Stats.CreateTime,
 			Language:     &languagemodels.Language{Name: languagemodels.Python},
+			ContainerId:  ctrId1,
 		},
 	}, diff.creation)
 	assert.ElementsMatch(t, []*ProcessEntity{}, diff.deletion)
@@ -101,12 +116,14 @@ func TestExtractor(t *testing.T) {
 			NsPid:        proc1.NsPid,
 			CreationTime: proc1.Stats.CreateTime,
 			Language:     &languagemodels.Language{Name: languagemodels.Java},
+			ContainerId:  ctrId1,
 		},
 		hashProcess(Pid2, proc2.Stats.CreateTime): {
 			Pid:          proc2.Pid,
 			NsPid:        proc2.NsPid,
 			CreationTime: proc2.Stats.CreateTime,
 			Language:     &languagemodels.Language{Name: languagemodels.Python},
+			ContainerId:  ctrId1,
 		},
 	}, procs)
 
@@ -125,6 +142,7 @@ func TestExtractor(t *testing.T) {
 			NsPid:        proc2.NsPid,
 			CreationTime: proc2.Stats.CreateTime,
 			Language:     &languagemodels.Language{Name: languagemodels.Python},
+			ContainerId:  ctrId1,
 		},
 	}, procs)
 
@@ -137,6 +155,7 @@ func TestExtractor(t *testing.T) {
 			NsPid:        proc1.NsPid,
 			CreationTime: proc1.Stats.CreateTime,
 			Language:     &languagemodels.Language{Name: languagemodels.Java},
+			ContainerId:  ctrId1,
 		},
 	}, diff.deletion)
 
@@ -154,12 +173,14 @@ func TestExtractor(t *testing.T) {
 			NsPid:        proc2.NsPid,
 			CreationTime: proc2.Stats.CreateTime,
 			Language:     &languagemodels.Language{Name: languagemodels.Python},
+			ContainerId:  ctrId1,
 		},
 		hashProcess(Pid3, proc3.Stats.CreateTime): {
 			Pid:          proc3.Pid,
 			NsPid:        proc3.NsPid,
 			CreationTime: proc3.Stats.CreateTime,
 			Language:     &languagemodels.Language{Name: languagemodels.Unknown},
+			ContainerId:  ctrId1,
 		},
 	}, procs)
 
@@ -171,6 +192,7 @@ func TestExtractor(t *testing.T) {
 			NsPid:        proc3.NsPid,
 			CreationTime: proc3.Stats.CreateTime,
 			Language:     &languagemodels.Language{Name: languagemodels.Unknown},
+			ContainerId:  ctrId1,
 		},
 	}, diff.creation)
 	assert.ElementsMatch(t, []*ProcessEntity{}, diff.deletion)
@@ -189,12 +211,14 @@ func TestExtractor(t *testing.T) {
 			NsPid:        proc3.NsPid,
 			CreationTime: proc3.Stats.CreateTime,
 			Language:     &languagemodels.Language{Name: languagemodels.Unknown},
+			ContainerId:  ctrId1,
 		},
 		hashProcess(Pid4, proc4.Stats.CreateTime): {
 			Pid:          proc4.Pid,
 			NsPid:        proc4.NsPid,
 			CreationTime: proc4.Stats.CreateTime,
 			Language:     &languagemodels.Language{Name: languagemodels.Python},
+			ContainerId:  ctrId2,
 		},
 	}, procs)
 
@@ -206,6 +230,7 @@ func TestExtractor(t *testing.T) {
 			NsPid:        proc4.NsPid,
 			CreationTime: proc4.Stats.CreateTime,
 			Language:     &languagemodels.Language{Name: languagemodels.Python},
+			ContainerId:  ctrId2,
 		},
 	}, diff.creation)
 	assert.ElementsMatch(t, []*ProcessEntity{
@@ -214,6 +239,7 @@ func TestExtractor(t *testing.T) {
 			NsPid:        proc2.NsPid,
 			CreationTime: proc2.Stats.CreateTime,
 			Language:     &languagemodels.Language{Name: languagemodels.Python},
+			ContainerId:  ctrId1,
 		},
 	}, diff.deletion)
 }

--- a/pkg/process/metadata/workloadmeta/grpc.go
+++ b/pkg/process/metadata/workloadmeta/grpc.go
@@ -179,6 +179,7 @@ func processEntityToEventSet(proc *ProcessEntity) *pbgo.ProcessEventSet {
 
 	return &pbgo.ProcessEventSet{
 		Pid:          proc.Pid,
+		ContainerId:  proc.ContainerId,
 		Nspid:        proc.NsPid,
 		CreationTime: proc.CreationTime,
 		Language:     language,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds support for enriching Process Entities with their associated `ContainerID`, via the container entity collected in either the process check, or the process collector (not implemented yet).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Joining container data with process data in workloadmeta

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Occasionally, WorkloadMeta will not resolve the container until after the first time a process is collected. As a result, this PR also adds the capability for the extractor to send duplicate add events in the case where a process' ContainerId is populated after it's first collection. In the future, it may be possible to extend this functionality to other fields, if we need to do this sort of late binding again.

Processes in the WorkloadMeta store can be updated via an EventSet if either:
- it did not exist before
- `reflect.DeepEquals(previous, current)` returns false ([code](https://github.com/DataDog/datadog-agent/blob/eba5f5c106c27c30b5c7b4124e224307b5a9a355/pkg/workloadmeta/store.go#L598))

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

Adding a `SetLastPidToCid` increases coupling with the process check and process collector. This method was designed however to avoid the O(n) cost of calling `workloadmeta.ListContainers()`, which copies the entire store. In the future, if we would like to decouple it, we could add a flag that tells the WorkloadMetaExtractor to use `workloadmeta` instead.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
```yaml
api_key: <secret>
language_detection: { enabled: true }
```

Using the above config, on a machine with more than one container running (and support for container collection), follow these steps:
1. Run both the process agent and the core agent.
2. Wait 30 seconds and then run `agent workload-list` and see if ContainerId is populated for the processes that are running in a container.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
