### PR TITLE
[RFC] Add 'persist' CLI command to modify configuration file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -574,21 +574,32 @@ require (
 	github.com/godror/godror v0.37.0
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/kr/pretty v0.3.1
+	github.com/mikefarah/yq/v4 v4.34.1
+	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver v0.75.0
 	github.com/protocolbuffers/protoscope v0.0.0-20221109213918-8e7a6aafa2c9
 	github.com/sijms/go-ora/v2 v2.7.6
+	gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473
 )
 
 require (
+	github.com/a8m/envsubst v1.4.2 // indirect
+	github.com/alecthomas/participle/v2 v2.0.0 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect
+	github.com/elliotchance/orderedmap v1.5.0 // indirect
+	github.com/goccy/go-json v0.10.2 // indirect
+	github.com/goccy/go-yaml v1.11.0 // indirect
 	github.com/godror/knownpb v0.1.0 // indirect
 	github.com/google/s2a-go v0.1.2 // indirect
 	github.com/hashicorp/hcl/v2 v2.17.0 // indirect
+	github.com/jinzhu/copier v0.3.5 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/mikefarah/yq v2.4.0+incompatible // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.75.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.75.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.75.0 // indirect
+	github.com/pelletier/go-toml/v2 v2.0.7 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/rs/zerolog v1.29.1 // indirect
 	github.com/sigstore/rekor v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -601,7 +601,10 @@ require (
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230525234020-1aefcd67740a // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230530153820-e85fd2cbaebc // indirect
+	gopkg.in/imdario/mergo.v0 v0.3.9 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/mikefarah/yaml.v2 v2.1.0 // indirect
+	gopkg.in/spf13/cobra.v0 v0.0.3 // indirect
 	gotest.tools/v3 v3.3.0 // indirect
 	honnef.co/go/tools v0.3.2 // indirect
 	inet.af/netaddr v0.0.0-20220617031823-097006376321 // indirect

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -41,6 +41,9 @@ ALL_TAGS = {
     "secrets",
     "systemd",
     "trivy",
+    "yq_noxml",
+    "yq_notml",
+    "yq_nojson",
     "zk",
     "zlib",
     "test",  # used for unit-tests


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds a `agent config persist` command to modify the configuration of the agent.

`agent config persist api_key "123"`
`agent config persist --append sbom.host.analyzers os`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Configuration of the agent is done in many ways. Most of the time, we give a snippet of the configuration for the customer to apply:

- https://docs.datadoghq.com/getting_started/tracing/#enable-apm
- https://docs.datadoghq.com/getting_started/agent/#setting-tags-through-the-agent-configuration-file
- https://docs.datadoghq.com/security/cloud_workload_security/setup/?tab=hostothers
- https://docs.datadoghq.com/security/cspm/setup/?tab=docker
- https://docs.datadoghq.com/agent/remote_config/?tab=configurationyamlfile#setup
- https://docs.datadoghq.com/getting_started/logs/#server

We also have scripts that alter the configuration, either by using `sed`, by overwriting the file or by appending content to it

- https://github.com/DataDog/auto_inject/blob/9e0dc0f689b5acb49a1ffee53081abe994754421/packaging/dd-host-install.template#L50-L63
- https://github.com/DataDog/agent-linux-install-script/blob/main/install_script.sh.template#L1082
- echo `"my.configuration.setting.enabled: true" >> /etc/datadog-agent/datadog.yaml`

This is probably also done in other recipes to deploy the agent such as ansible, puppet, chef, ...

Most of these methods are error prone (sed modifying the wrong section, duplicated section in the configuration file, wrong permissions ...).

### Additional Notes

The library used tries, as much as possible, to keep the comment (commented lines, comments at the EOL, ...)

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

This command adds a 1M overhead to the binary size that could probably be reduced.

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
