### PR TITLE
[config] Add DD_POD_NAME to list of known env vars

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1458,6 +1458,8 @@ func findUnknownEnvVars(config Config, environ []string, additionalKnownEnvVars 
 		"DD_VERSION":                   {},
 		// this variable is used by CWS functional tests
 		"DD_TESTS_RUNTIME_COMPILED": {},
+		// this variable is used by the Kubernetes leader election mechanism
+		"DD_POD_NAME": {},
 	}
 	for _, key := range config.GetEnvVars() {
 		knownVars[key] = struct{}{}

--- a/releasenotes-dca/notes/known-env-dd_pod_name-7a7c3fa007eb38d2.yaml
+++ b/releasenotes-dca/notes/known-env-dd_pod_name-7a7c3fa007eb38d2.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Removes an incorrect warning log message that mentions that the DD_POD_NAME
+    env var is unknown.


### PR DESCRIPTION
### What does this PR do?

Adds `DD_POD_NAME` to the list of known env vars.

This PR fixes this warning in the Cluster Agent:
```
 CLUSTER | WARN | (pkg/util/log/log.go:618 in func1) | Unknown environment variable: DD_POD_NAME
```

The env var was introduced in this PR: https://github.com/DataDog/datadog-agent/pull/17305


### Describe how to test/QA your changes

Deploy setting the DD_POD_NAME env and check that the warning above doesn't appear in the cluster agent.
Recent version of the helm chart set this env ( https://github.com/DataDog/helm-charts/pull/1065 ).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
