### PR TITLE
Update trace-agent benchmarks and codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -49,6 +49,8 @@
 /.gitlab/binary_build/system_probe.yml               @DataDog/ebpf-platform @DataDog/agent-platform
 /.gitlab/binary_build/windows.yml                    @DataDog/agent-platform @DataDog/windows-agent
 
+/.gitlab/benchmarks/                                 @DataDog/agent-platform @DataDog/apm-core-reliability-and-performance @DataDog/agent-apm
+
 /.gitlab/deploy_6/container.yml                      @DataDog/container-integrations @DataDog/agent-platform
 /.gitlab/deploy_6/windows.yml                        @DataDog/agent-platform @DataDog/windows-agent
 

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -11,6 +11,7 @@ variables:
     - when: manual
   # If you have a problem with Gitlab cache, see Troubleshooting section in Benchmarking Platform docs
   image: $BENCHMARKS_CI_IMAGE
+  needs: ["build_dogstatsd_static-binary_x64"]
   script:
     - export ARTIFACTS_DIR="$(pwd)/reports" && (mkdir "${ARTIFACTS_DIR}" || :)
     - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.dd_api_key --with-decryption --query "Parameter.Value" --out text)
@@ -38,6 +39,8 @@ trace-agent-v04-4cpus-avg_load-fixed_sps-macrobenchmarks:
     TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v04
     TRACE_AGENT_CPUS: 4
+    DD_APM_MAX_CPU_PERCENT: 0
+    DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-avg_load-fixed_sps
     BENCHMARK_TARGETS: "avg_load.*sps"
 
@@ -47,6 +50,8 @@ trace-agent-v04-4cpus-avg_load-fixed_mbps-macrobenchmarks:
     TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v04
     TRACE_AGENT_CPUS: 4
+    DD_APM_MAX_CPU_PERCENT: 0
+    DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-avg_load-fixed_mbps
     BENCHMARK_TARGETS: "avg_load.*Mbps"
 
@@ -57,6 +62,8 @@ trace-agent-v04-4cpus-high_load-fixed_sps-macrobenchmarks:
     TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v04
     TRACE_AGENT_CPUS: 4
+    DD_APM_MAX_CPU_PERCENT: 0
+    DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-high_load-fixed_sps
     BENCHMARK_TARGETS: "high_load.*sps"
 
@@ -67,6 +74,8 @@ trace-agent-v04-4cpus-high_load-fixed_mbps-macrobenchmarks:
     TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v04
     TRACE_AGENT_CPUS: 4
+    DD_APM_MAX_CPU_PERCENT: 0
+    DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-high_load-fixed_mbps
     BENCHMARK_TARGETS: "high_load.*Mbps"
 
@@ -77,6 +86,8 @@ trace-agent-v04-4cpus-stress_load-fixed_sps-macrobenchmarks:
     TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v04
     TRACE_AGENT_CPUS: 4
+    DD_APM_MAX_CPU_PERCENT: 0
+    DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-stress_load-fixed_sps
     BENCHMARK_TARGETS: "stress_load.*sps"
 
@@ -87,15 +98,19 @@ trace-agent-v04-4cpus-stress_load-fixed_mbps-macrobenchmarks:
     TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v04
     TRACE_AGENT_CPUS: 4
+    DD_APM_MAX_CPU_PERCENT: 0
+    DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-stress_load-fixed_mbps
     BENCHMARK_TARGETS: "stress_load.*Mbps"
-  
+
 trace-agent-v05-4cpus-avg_load-fixed_sps-macrobenchmarks:
   extends: .trace_agent_benchmarks
   variables:
     TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v05
     TRACE_AGENT_CPUS: 4
+    DD_APM_MAX_CPU_PERCENT: 0
+    DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-avg_load-fixed_sps
     BENCHMARK_TARGETS: "avg_load.*sps"
 
@@ -105,6 +120,8 @@ trace-agent-v05-4cpus-avg_load-fixed_mbps-macrobenchmarks:
     TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v05
     TRACE_AGENT_CPUS: 4
+    DD_APM_MAX_CPU_PERCENT: 0
+    DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-avg_load-fixed_mbps
     BENCHMARK_TARGETS: "avg_load.*Mbps"
 
@@ -115,6 +132,8 @@ trace-agent-v05-4cpus-high_load-fixed_sps-macrobenchmarks:
     TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v05
     TRACE_AGENT_CPUS: 4
+    DD_APM_MAX_CPU_PERCENT: 0
+    DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-high_load-fixed_sps
     BENCHMARK_TARGETS: "high_load.*sps"
 
@@ -125,6 +144,8 @@ trace-agent-v05-4cpus-high_load-fixed_mbps-macrobenchmarks:
     TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v05
     TRACE_AGENT_CPUS: 4
+    DD_APM_MAX_CPU_PERCENT: 0
+    DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-high_load-fixed_mbps
     BENCHMARK_TARGETS: "high_load.*Mbps"
 
@@ -135,6 +156,8 @@ trace-agent-v05-4cpus-stress_load-fixed_sps-macrobenchmarks:
     TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v05
     TRACE_AGENT_CPUS: 4
+    DD_APM_MAX_CPU_PERCENT: 0
+    DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-stress_load-fixed_sps
     BENCHMARK_TARGETS: "stress_load.*sps"
 
@@ -145,6 +168,8 @@ trace-agent-v05-4cpus-stress_load-fixed_mbps-macrobenchmarks:
     TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v05
     TRACE_AGENT_CPUS: 4
+    DD_APM_MAX_CPU_PERCENT: 0
+    DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-stress_load-fixed_mbps
     BENCHMARK_TARGETS: "stress_load.*Mbps"
- 
+

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -11,7 +11,7 @@ variables:
     - when: manual
   # If you have a problem with Gitlab cache, see Troubleshooting section in Benchmarking Platform docs
   image: $BENCHMARKS_CI_IMAGE
-  needs: ["build_dogstatsd_static-binary_x64"]
+  needs: ["setup_agent_version"]
   script:
     - export ARTIFACTS_DIR="$(pwd)/reports" && (mkdir "${ARTIFACTS_DIR}" || :)
     - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.dd_api_key --with-decryption --query "Parameter.Value" --out text)


### PR DESCRIPTION
1. Set `needs` to ensure that dd-agent is built before running benchmarks.
2. Set CODEOWNERS to trace-agent and APM R&P for benchmarks.yml.
3. Add extra configuration options for benchmark (trace-agent max mem and cpu % usage).

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
