### PR TITLE
[collector] commit the default sender in all cases every worker run

### DIFF
--- a/pkg/collector/worker/worker.go
+++ b/pkg/collector/worker/worker.go
@@ -169,8 +169,12 @@ func (w *Worker) Run() {
 
 		if sender != nil && !longRunning && config.Datadog.GetBool("integration_check_status_enabled") {
 			sender.ServiceCheck(serviceCheckStatusKey, serviceCheckStatus, hname, serviceCheckTags, "")
-			sender.Commit()
 		}
+
+		// FIXME(remy): this `Commit()` should be part of the above `if`, we keep
+		// it here for now to make sure it's not breaking any historical behavior
+		// with the shared default sender.
+		sender.Commit()
 
 		// Remove the check from the running list
 		w.checksTracker.DeleteCheck(check.ID())

--- a/pkg/collector/worker/worker.go
+++ b/pkg/collector/worker/worker.go
@@ -167,8 +167,8 @@ func (w *Worker) Run() {
 			serviceCheckStatus = servicecheck.ServiceCheckCritical
 		}
 
-		if sender != nil {
-			if !longRunning && config.Datadog.GetBool("integration_check_status_enabled") {
+		if sender != nil && !longRunning {
+			if config.Datadog.GetBool("integration_check_status_enabled") {
 				sender.ServiceCheck(serviceCheckStatusKey, serviceCheckStatus, hname, serviceCheckTags, "")
 			}
 			// FIXME(remy): this `Commit()` should be part of the `if` above, we keep

--- a/pkg/collector/worker/worker.go
+++ b/pkg/collector/worker/worker.go
@@ -167,14 +167,15 @@ func (w *Worker) Run() {
 			serviceCheckStatus = servicecheck.ServiceCheckCritical
 		}
 
-		if sender != nil && !longRunning && config.Datadog.GetBool("integration_check_status_enabled") {
-			sender.ServiceCheck(serviceCheckStatusKey, serviceCheckStatus, hname, serviceCheckTags, "")
+		if sender != nil {
+			if !longRunning && config.Datadog.GetBool("integration_check_status_enabled") {
+				sender.ServiceCheck(serviceCheckStatusKey, serviceCheckStatus, hname, serviceCheckTags, "")
+			}
+			// FIXME(remy): this `Commit()` should be part of the `if` above, we keep
+			// it here for now to make sure it's not breaking any historical behavior
+			// with the shared default sender.
+			sender.Commit()
 		}
-
-		// FIXME(remy): this `Commit()` should be part of the above `if`, we keep
-		// it here for now to make sure it's not breaking any historical behavior
-		// with the shared default sender.
-		sender.Commit()
 
 		// Remove the check from the running list
 		w.checksTracker.DeleteCheck(check.ID())


### PR DESCRIPTION
### What does this PR do?

Commits the default sender every worker run.

### Motivation

Make sure the shared default sender is committed as it always have in the previous releases.

### Describe how to test/QA your changes

Validate checks metrics are still present.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
