### PR TITLE
[RCM] Remove the remote config db on package uninstall

### DIFF
--- a/omnibus/package-scripts/agent-deb/prerm
+++ b/omnibus/package-scripts/agent-deb/prerm
@@ -133,6 +133,18 @@ remove_sysprobe_files()
     fi
 }
 
+remove_remote_config_db()
+{
+    # Remote config stores a cache of the current repository state in
+    # /opt/datadog-agent/run. This is a best-effort solution, as users can
+    # decide to put this file in another place by changing the top-level
+    # run_path config value.
+    if [ -f "$INSTALL_DIR/run/remote-config.db" ]; then
+        echo "Removing remote configuration config database"
+        rm "$INSTALL_DIR/run/remote-config.db" || true
+    fi
+}
+
 stop_agent
 deregister_agent
 remove_custom_integrations
@@ -143,6 +155,7 @@ case "$1" in
         # We're uninstalling.
         remove_version_history
         remove_sysprobe_files
+        remove_remote_config_db
     ;;
     upgrade)
         # We're upgrading.

--- a/omnibus/package-scripts/agent-rpm/prerm
+++ b/omnibus/package-scripts/agent-rpm/prerm
@@ -117,6 +117,18 @@ remove_sysprobe_files()
     fi
 }
 
+remove_remote_config_db()
+{
+    # Remote config stores a cache of the current repository state in
+    # /opt/datadog-agent/run. This is a best-effort solution, as users can
+    # decide to put this file in another place by changing the top-level
+    # run_path config value.
+    if [ -f "$INSTALL_DIR/run/remote-config.db" ]; then
+        echo "Removing remote configuration config database"
+        rm "$INSTALL_DIR/run/remote-config.db" || true
+    fi
+}
+
 stop_agent
 deregister_agent
 
@@ -127,6 +139,7 @@ case "$*" in
         remove_py_compiled_files
         remove_version_history
         remove_sysprobe_files
+        remove_remote_config_db
     ;;
     1)
         # We're upgrading.

--- a/omnibus/package-scripts/iot-agent-deb/prerm
+++ b/omnibus/package-scripts/iot-agent-deb/prerm
@@ -48,6 +48,18 @@ remove_version_history()
     fi
 }
 
+remove_remote_config_db()
+{
+    # Remote config stores a cache of the current repository state in
+    # /opt/datadog-agent/run. This is a best-effort solution, as users can
+    # decide to put this file in another place by changing the top-level
+    # run_path config value.
+    if [ -f "$INSTALL_DIR/run/remote-config.db" ]; then
+        echo "Removing remote configuration config database"
+        rm "$INSTALL_DIR/run/remote-config.db" || true
+    fi
+}
+
 stop_agent
 deregister_agent
 
@@ -55,6 +67,7 @@ case "$1" in
     remove)
         # We're uninstalling.
         remove_version_history
+        remove_remote_config_db
     ;;
     upgrade)
         # We're upgrading.

--- a/omnibus/package-scripts/iot-agent-rpm/prerm
+++ b/omnibus/package-scripts/iot-agent-rpm/prerm
@@ -48,6 +48,18 @@ remove_version_history()
     fi
 }
 
+remove_remote_config_db()
+{
+    # Remote config stores a cache of the current repository state in
+    # /opt/datadog-agent/run. This is a best-effort solution, as users can
+    # decide to put this file in another place by changing the top-level
+    # run_path config value.
+    if [ -f "$INSTALL_DIR/run/remote-config.db" ]; then
+        echo "Removing remote configuration config database"
+        rm "$INSTALL_DIR/run/remote-config.db" || true
+    fi
+}
+
 stop_agent
 deregister_agent
 
@@ -55,6 +67,7 @@ case "$*" in
     0)
         # We're uninstalling.
         remove_version_history
+        remove_remote_config_db
     ;;
     1)
         # We're upgrading.


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Now that remote configuration is enabled by default, we should clean up the remote configuration config cache that lives at $INSTALL_DIR/run/remote-config.db when the agent package is uninstalled.

We don't do this on upgrade as our code is set up to handle agent version changes as needed for remote configuration.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Clean up remote config files on package uninstall

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Ensure that $INSTALL_DIR/datadog-agent/run/remote-config.db does not exist after the agent package is uninstalled.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
