### PR TITLE
Automatically retry failed system-probe kitchen tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -148,8 +148,8 @@ variables:
   # Build images versions
   # To use images from datadog-agent-buildimages dev branches, set the corresponding
   # SUFFIX variable to _test_only
-  DATADOG_AGENT_BUILDIMAGES_SUFFIX: "_test_only"
-  DATADOG_AGENT_BUILDIMAGES: v17786724-ea073fd
+  DATADOG_AGENT_BUILDIMAGES_SUFFIX: ""
+  DATADOG_AGENT_BUILDIMAGES: v17824543-f518958
   DATADOG_AGENT_WINBUILDIMAGES_SUFFIX: ""
   DATADOG_AGENT_WINBUILDIMAGES: v17432894-4fdacd4
   DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX: ""

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -865,6 +865,7 @@ workflow:
       - test/new-e2e/runner/**/*
       - test/new-e2e-utils/**/*
       - test/new-e2e/go.mod
+      - tasks/system_probe.py
     when: on_success
   - when: manual
     allow_failure: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -148,8 +148,8 @@ variables:
   # Build images versions
   # To use images from datadog-agent-buildimages dev branches, set the corresponding
   # SUFFIX variable to _test_only
-  DATADOG_AGENT_BUILDIMAGES_SUFFIX: ""
-  DATADOG_AGENT_BUILDIMAGES: v17432894-4fdacd4
+  DATADOG_AGENT_BUILDIMAGES_SUFFIX: "_test_only"
+  DATADOG_AGENT_BUILDIMAGES: v17786724-ea073fd
   DATADOG_AGENT_WINBUILDIMAGES_SUFFIX: ""
   DATADOG_AGENT_WINBUILDIMAGES: v17432894-4fdacd4
   DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX: ""

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -28,6 +28,7 @@
     when: always
     paths:
       - $DD_AGENT_TESTING_DIR/kitchen-junit-*.tar.gz
+      - $DD_AGENT_TESTING_DIR/testjson
       - $CI_PROJECT_DIR/kitchen_logs
 
 .retrieve_test_dockers:

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -61,6 +61,7 @@ kitchen_test_system_probe_linux_x64_ec2:
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2
   needs: [ "tests_ebpf_x64", "prepare_ebpf_functional_tests_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
+  retry: 0
   variables:
     ARCH: amd64
     KITCHEN_ARCH: x86_64
@@ -124,6 +125,7 @@ kitchen_test_system_probe_linux_arm64:
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2
   needs: [ "tests_ebpf_arm64", "prepare_ebpf_functional_tests_arm64", "generate_minimized_btfs_arm64", "pull_test_dockers_arm64" ]
+  retry: 0
   variables:
     ARCH: arm64
     KITCHEN_ARCH: arm64

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/vektra/mockery/v2 v2.28.1
 	golang.org/x/mobile v0.0.0-20201217150744-e6ae53a27f4f
 	golang.org/x/perf v0.0.0-20210220033136-40a54f11e909
-	gotest.tools/gotestsum v1.8.2
+	gotest.tools/gotestsum v1.10.1
 )
 
 // we want to force this version, since 1.0.6 changed the public API

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -1158,8 +1158,8 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools/gotestsum v1.8.2 h1:szU3TaSz8wMx/uG+w/A2+4JUPwH903YYaMI9yOOYAyI=
-gotest.tools/gotestsum v1.8.2/go.mod h1:6JHCiN6TEjA7Kaz23q1bH0e2Dc3YJjDUZ0DmctFZf+w=
+gotest.tools/gotestsum v1.10.1 h1:TOV5xZVd5HDscBLSrPXpc4/MQm6QQr/YSI9iDC62d7E=
+gotest.tools/gotestsum v1.10.1/go.mod h1:6JHCiN6TEjA7Kaz23q1bH0e2Dc3YJjDUZ0DmctFZf+w=
 gotest.tools/v3 v3.3.0 h1:MfDY1b1/0xN1CyMlQDac0ziEy9zJQd9CXBRRDHw2jJo=
 gotest.tools/v3 v3.3.0/go.mod h1:Mcr9QNxkg0uMvy/YElmo4SpXgJKWgQvYrT7Kw5RzJ1A=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1513,7 +1513,8 @@ def print_failed_tests(_, output_dir):
                                     test_results[test_key] = action
                                     continue
 
-                                print(f"re-ran [{test_platform}] {package} {name}: {action}")
+                                if res == "fail":
+                                    print(f"re-ran [{test_platform}] {package} {name}: {action}")
                                 if action == "pass" and res == "fail":
                                     test_results[test_key] = action
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1512,13 +1512,14 @@ def print_failed_tests(_, output_dir):
                                 test_results[test_key] = action
                                 continue
 
+                            print(f"re-ran [{test_platform}] {package} {name}: {action}")
                             if action == "pass" and res == "fail":
                                 test_results[test_key] = action
 
         for key, res in test_results.items():
             if res == "fail":
                 package, name = key.split(".")
-                print(f"FAIL: [{test_platform}] {package} {name}")
+                print(color_message(f"FAIL: [{test_platform}] {package} {name}", "red"))
                 fail_count += 1
 
     if fail_count > 0:

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1491,6 +1491,7 @@ def print_failed_tests(_, output_dir):
     fail_count = 0
     for testjson_tgz in glob.glob(f"{output_dir}/**/testjson.tar.gz"):
         test_platform = os.path.basename(os.path.dirname(testjson_tgz))
+        test_results = {}
 
         with tempfile.TemporaryDirectory() as unpack_dir:
             with tarfile.open(testjson_tgz) as tgz:
@@ -1505,9 +1506,20 @@ def print_failed_tests(_, output_dir):
                             package = json_test['Package']
                             action = json_test["Action"]
 
-                            if action == "fail":
-                                print(f"FAIL: [{test_platform}] {package} {name}")
-                                fail_count += 1
+                            test_key = f"{package}.{name}"
+                            res = test_results.get(test_key)
+                            if res is None:
+                                test_results[test_key] = action
+                                continue
+
+                            if action == "pass" and res == "fail":
+                                test_results[test_key] = action
+
+        for key, res in test_results.items():
+            if res == "fail":
+                package, name = key.split(".")
+                print(f"FAIL: [{test_platform}] {package} {name}")
+                fail_count += 1
 
     if fail_count > 0:
         raise Exit(code=1)

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1506,15 +1506,16 @@ def print_failed_tests(_, output_dir):
                             package = json_test['Package']
                             action = json_test["Action"]
 
-                            test_key = f"{package}.{name}"
-                            res = test_results.get(test_key)
-                            if res is None:
-                                test_results[test_key] = action
-                                continue
+                            if action == "pass" or action == "fail":
+                                test_key = f"{package}.{name}"
+                                res = test_results.get(test_key)
+                                if res is None:
+                                    test_results[test_key] = action
+                                    continue
 
-                            print(f"re-ran [{test_platform}] {package} {name}: {action}")
-                            if action == "pass" and res == "fail":
-                                test_results[test_key] = action
+                                print(f"re-ran [{test_platform}] {package} {name}: {action}")
+                                if action == "pass" and res == "fail":
+                                    test_results[test_key] = action
 
         for key, res in test_results.items():
             if res == "fail":

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -1,11 +1,6 @@
 root_dir = "/tmp/ci/system-probe"
 tests_dir = ::File.join(root_dir, "tests")
 
-file "/tmp/color_idx" do
-  content node[:color_idx].to_s
-  mode 644
-end
-
 if platform?('centos')
   case node['platform_version'].to_i
   when 7

--- a/test/kitchen/test/integration/common/rspec_datadog/kernel_out_spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec_datadog/kernel_out_spec_helper.rb
@@ -10,12 +10,20 @@ COLORS = [
 
 class KernelOut
   @@release = `uname -r`.strip
-  color_idx = File.read('/tmp/color_idx').strip.to_i - 1
-  @@color = COLORS[color_idx]
+  if File.exist?('/tmp/color_idx')
+    color_idx = File.read('/tmp/color_idx').strip.to_i - 1
+    @@color = COLORS[color_idx]
+  else
+    @@color = :no_format
+  end
 
   def self.format(text, tag="")
     tag = "[#{tag}]" if tag != ""
-    RSpec::Core::Formatters::ConsoleCodes.wrap("[#{@@release}]#{tag} #{text}", @@color)
+    if @@color != :no_format
+      return RSpec::Core::Formatters::ConsoleCodes.wrap("[#{@@release}]#{tag} #{text}", @@color)
+    else
+      return "[#{@@release}]#{tag} #{text}"
+    end
   end
 end
 

--- a/test/kitchen/test/integration/system-probe-test/rspec_datadog/system-probe-test_spec.rb
+++ b/test/kitchen/test/integration/system-probe-test/rspec_datadog/system-probe-test_spec.rb
@@ -69,7 +69,9 @@ describe "system-probe" do
     final_env = {
       "DD_SYSTEM_PROBE_BPF_DIR"=>"#{tests_dir}/pkg/ebpf/bytecode/build",
       "DD_SYSTEM_PROBE_JAVA_DIR"=>"#{tests_dir}/pkg/network/protocols/tls/java",
-      "GOVERSION"=>"unknown"
+      "GOVERSION"=>"unknown",
+      # force color support to be detected
+      "GITLAB_CI"=>"true",
     }
     junitfile = pkg.gsub("/","-") + ".xml"
 

--- a/test/kitchen/test/integration/system-probe-test/rspec_datadog/system-probe-test_spec.rb
+++ b/test/kitchen/test/integration/system-probe-test/rspec_datadog/system-probe-test_spec.rb
@@ -81,6 +81,8 @@ describe "system-probe" do
           "--format", "dots",
           "--junitfile", xmlpath,
           "--jsonfile", "/tmp/pkgjson/#{pkg.gsub("/","-")}.json",
+          "--rerun-fails=2",
+          "--rerun-fails-max-failures=100",
           "--raw-command", "--",
           "/go/bin/test2json", "-t", "-p", pkg, f, "-test.v", "-test.count=1", "-test.timeout=#{get_timeout(pkg)}"
         ]

--- a/test/new-e2e/system-probe/test-json-review/main.go
+++ b/test/new-e2e/system-probe/test-json-review/main.go
@@ -72,7 +72,7 @@ func reviewTests(jsonFile string) (string, error) {
 		if err := json.Unmarshal(data, &ev); err != nil {
 			return "", fmt.Errorf("json unmarshal `%s`: %s", string(data), err)
 		}
-		if ev.Test == "" {
+		if ev.Test == "" || (ev.Action != "pass" && ev.Action != "fail") {
 			continue
 		}
 		if res, ok := testResults[testKey(ev.Test, ev.Package)]; ok {
@@ -80,6 +80,9 @@ func reviewTests(jsonFile string) (string, error) {
 			// eventually succeeded.
 			if res.Action == "pass" {
 				continue
+			}
+			if res.Action == "fail" {
+				fmt.Printf("re-ran %s %s: %s\n", ev.Package, ev.Test, ev.Action)
 			}
 			if res.Action == "fail" && ev.Action == "pass" {
 				testResults[testKey(ev.Test, ev.Package)] = ev

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -47,6 +47,7 @@ const (
 )
 
 var BaseEnv = map[string]interface{}{
+	"GITLAB_CI":                "true", // force color output support to be detected
 	"DD_SYSTEM_PROBE_BPF_DIR":  filepath.Join(TestDirRoot, "pkg/ebpf/bytecode/build"),
 	"DD_SYSTEM_PROBE_JAVA_DIR": filepath.Join(TestDirRoot, "pkg/network/protocols/tls/java"),
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Automatically retries failing system-probe kitchen tests up to 2 times. 
- Remove coloring to output that was only needed when multiple kernels were run in the same job
- Force `gotestsum` to output colored output for easier reading.
- Add `tasks/system_probe.py` to list of files triggering system-probe tests.

### Motivation

Prevent flaky tests from blocking pull requests.

### Additional Notes

Due to a [bug](https://github.com/gotestyourself/gotestsum/issues/341) in `gotestsum`, it will also re-run sub-tests in-between the root test and the failing sub-test.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
