### PR TITLE
[CWS] Fix exec-exec rebase to support siblings rebase

### DIFF
--- a/docs/cloud-workload-security/backend.md
+++ b/docs/cloud-workload-security/backend.md
@@ -879,6 +879,10 @@ CWS logs have the following JSON schema:
                     "type": "boolean",
                     "description": "Indicates whether the process is a kworker"
                 },
+                "is_exec_child": {
+                    "type": "boolean",
+                    "description": "Indicates wether the process is an exec child of its parent"
+                },
                 "source": {
                     "type": "string",
                     "description": "Process source"
@@ -998,6 +1002,10 @@ CWS logs have the following JSON schema:
                 "is_kworker": {
                     "type": "boolean",
                     "description": "Indicates whether the process is a kworker"
+                },
+                "is_exec_child": {
+                    "type": "boolean",
+                    "description": "Indicates wether the process is an exec child of its parent"
                 },
                 "source": {
                     "type": "string",
@@ -2604,6 +2612,10 @@ CWS logs have the following JSON schema:
             "type": "boolean",
             "description": "Indicates whether the process is a kworker"
         },
+        "is_exec_child": {
+            "type": "boolean",
+            "description": "Indicates wether the process is an exec child of its parent"
+        },
         "source": {
             "type": "string",
             "description": "Process source"
@@ -2646,6 +2658,7 @@ CWS logs have the following JSON schema:
 | `envs_truncated` | Indicator of environments variable truncation |
 | `is_thread` | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | `is_kworker` | Indicates whether the process is a kworker |
+| `is_exec_child` | Indicates wether the process is an exec child of its parent |
 | `source` | Process source |
 
 | References |
@@ -2766,6 +2779,10 @@ CWS logs have the following JSON schema:
             "type": "boolean",
             "description": "Indicates whether the process is a kworker"
         },
+        "is_exec_child": {
+            "type": "boolean",
+            "description": "Indicates wether the process is an exec child of its parent"
+        },
         "source": {
             "type": "string",
             "description": "Process source"
@@ -2819,6 +2836,7 @@ CWS logs have the following JSON schema:
 | `envs_truncated` | Indicator of environments variable truncation |
 | `is_thread` | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | `is_kworker` | Indicates whether the process is a kworker |
+| `is_exec_child` | Indicates wether the process is an exec child of its parent |
 | `source` | Process source |
 | `parent` | Parent process |
 | `ancestors` | Ancestor processes |

--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -863,6 +863,10 @@
           "type": "boolean",
           "description": "Indicates whether the process is a kworker"
         },
+        "is_exec_child": {
+          "type": "boolean",
+          "description": "Indicates wether the process is an exec child of its parent"
+        },
         "source": {
           "type": "string",
           "description": "Process source"
@@ -982,6 +986,10 @@
         "is_kworker": {
           "type": "boolean",
           "description": "Indicates whether the process is a kworker"
+        },
+        "is_exec_child": {
+          "type": "boolean",
+          "description": "Indicates wether the process is an exec child of its parent"
         },
         "source": {
           "type": "string",

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/CycloneDX/cyclonedx-go v0.7.1
-	github.com/DataDog/agent-payload/v5 v5.0.89-0.20230704083421-b45a1d578078
+	github.com/DataDog/agent-payload/v5 v5.0.90-0.20230717070528-bfb5d051f2ab
 	github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a
 	github.com/DataDog/datadog-agent/pkg/gohai v0.47.0-rc.2
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.47.0-rc.2

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CycloneDX/cyclonedx-go v0.7.1 h1:5w1SxjGm9MTMNTuRbEPyw21ObdbaagTWF/KfF0qHTRE=
 github.com/CycloneDX/cyclonedx-go v0.7.1/go.mod h1:N/nrdWQI2SIjaACyyDs/u7+ddCkyl/zkNs8xFsHF2Ps=
-github.com/DataDog/agent-payload/v5 v5.0.89-0.20230704083421-b45a1d578078 h1:SJykkle71k89zXijHQel7N2cLexLeyI6MZtyTRZdpjs=
-github.com/DataDog/agent-payload/v5 v5.0.89-0.20230704083421-b45a1d578078/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
+github.com/DataDog/agent-payload/v5 v5.0.90-0.20230717070528-bfb5d051f2ab h1:Y0SYoy3CuSVUSKJ3U9a6zevj3AGUGqRctmCBVaSgGrs=
+github.com/DataDog/agent-payload/v5 v5.0.90-0.20230717070528-bfb5d051f2ab/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
 github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a h1:7ZiVdU4j19IYuy8rR0uUzC7I7HjWul61ZEyUgvLkZBM=
 github.com/DataDog/appsec-internal-go v0.0.0-20230215162203-5149228be86a/go.mod h1:ILSJBuOg3E0Jg8qgSnm7+g8DXa0KrfahnS7jhS1DoWs=
 github.com/DataDog/aptly v1.5.1 h1:Znm0WZ/cSjjTLe0HY3rKN1uqa7YIu+uIo3UQG/0WlIM=

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -655,7 +655,8 @@ type Process struct {
 	ScrubbedArgsTruncated bool           `field:"-" json:"-"`
 	Variables             eval.Variables `field:"-" json:"-"`
 
-	IsThread bool `field:"is_thread"` // SECLDoc[is_thread] Definition:`Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)`
+	IsThread    bool `field:"is_thread"` // SECLDoc[is_thread] Definition:`Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)`
+	IsExecChild bool `field:"-"`         // Indicates whether the process is an exec child of its parent
 
 	Source uint64 `field:"-" json:"-"`
 }
@@ -957,6 +958,9 @@ func ProcessSourceToString(source uint64) string {
 
 // IsExecChild returns whether the current entry was execed directly from its parent (no fork)
 func (pc *ProcessCacheEntry) IsExecChild() bool {
+	if pc.ProcessContext.IsExecChild {
+		return true
+	}
 	return pc.Ancestor != nil && !pc.ExecTime.IsZero() && pc.ExecTime.Equal(pc.Ancestor.ExitTime)
 }
 

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -956,14 +956,6 @@ func ProcessSourceToString(source uint64) string {
 	return ProcessSources[source]
 }
 
-// IsExecChild returns whether the current entry was execed directly from its parent (no fork)
-func (pc *ProcessCacheEntry) IsExecChild() bool {
-	if pc.ProcessContext.IsExecChild {
-		return true
-	}
-	return pc.Ancestor != nil && !pc.ExecTime.IsZero() && pc.ExecTime.Equal(pc.Ancestor.ExitTime)
-}
-
 // IsContainerRoot returns whether this is a top level process in the container ID
 func (pc *ProcessCacheEntry) IsContainerRoot() bool {
 	return pc.ContainerID != "" && pc.Ancestor != nil && pc.Ancestor.ContainerID == ""

--- a/pkg/security/secl/model/process_cache_entry.go
+++ b/pkg/security/secl/model/process_cache_entry.go
@@ -76,8 +76,9 @@ func (pc *ProcessCacheEntry) ApplyExecTimeOf(entry *ProcessCacheEntry) {
 func (pc *ProcessCacheEntry) Exec(entry *ProcessCacheEntry) {
 	entry.SetAncestor(pc)
 
-	// use exec time a exit time
+	// use exec time as exit time
 	pc.Exit(entry.ExecTime)
+	entry.Process.IsExecChild = true
 
 	// keep some context
 	copyProcessContext(pc, entry)

--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -262,7 +262,7 @@ func (at *ActivityTree) insert(event *model.Event, dryRun bool, generationType N
 		return false, fmt.Errorf("invalid event: %s", err)
 	}
 
-	node, newProcessNode, err := at.CreateProcessNode(event.ProcessCacheEntry, nil, generationType, dryRun, resolvers)
+	node, _, newProcessNode, err := at.CreateProcessNode(event.ProcessCacheEntry, nil, generationType, dryRun, resolvers)
 	if err != nil {
 		return false, err
 	}
@@ -371,13 +371,13 @@ func eventHaveValidCookie(entry *model.ProcessCacheEntry) bool {
 
 // CreateProcessNode finds or a create a new process activity node in the activity dump if the entry
 // matches the activity dump selector.
-func (at *ActivityTree) CreateProcessNode(entry *model.ProcessCacheEntry, branch []*model.ProcessCacheEntry, generationType NodeGenerationType, dryRun bool, resolvers *resolvers.Resolvers) (node *ProcessNode, newProcessNode bool, err error) {
+func (at *ActivityTree) CreateProcessNode(entry *model.ProcessCacheEntry, branch []*model.ProcessCacheEntry, generationType NodeGenerationType, dryRun bool, resolvers *resolvers.Resolvers) (node *ProcessNode, siblings *[]*ProcessNode, newProcessNode bool, err error) {
 	if entry == nil {
-		return nil, false, nil
+		return nil, nil, false, nil
 	}
 
 	if !entry.HasCompleteLineage() {
-		return nil, false, ErrBrokenLineage
+		return nil, nil, false, ErrBrokenLineage
 	}
 
 	// look for a ProcessActivityNode by process cookie
@@ -390,7 +390,7 @@ func (at *ActivityTree) CreateProcessNode(entry *model.ProcessCacheEntry, branch
 		var found bool
 		node, found = at.CookieToProcessNode[cs]
 		if found {
-			return node, false, nil
+			return node, nil, false, nil
 		}
 	}
 
@@ -405,11 +405,11 @@ func (at *ActivityTree) CreateProcessNode(entry *model.ProcessCacheEntry, branch
 
 	// find or create a ProcessActivityNode for the parent of the input ProcessCacheEntry. If the parent is a fork entry,
 	// jump immediately to the next ancestor.
-	parentNode, newProcessNode, err := at.CreateProcessNode(GetNextAncestorBinaryOrArgv0(&entry.ProcessContext), branch, Snapshot, dryRun, resolvers)
+	parentNode, siblings, newProcessNode, err := at.CreateProcessNode(GetNextAncestorBinaryOrArgv0(&entry.ProcessContext), branch, Snapshot, dryRun, resolvers)
 	if err == nil && newProcessNode && dryRun {
 		// Explanation of (newProcessNode && dryRun): when dryRun is on, we can return as soon as we
 		// see something new in the tree.
-		return parentNode, newProcessNode, err
+		return parentNode, siblings, newProcessNode, err
 	}
 
 	// if parentNode is nil, the parent of the current node is out of tree (either because the parent is null, or it
@@ -418,17 +418,17 @@ func (at *ActivityTree) CreateProcessNode(entry *model.ProcessCacheEntry, branch
 
 		// since the parent of the current entry wasn't inserted, we need to know if the current entry needs to be inserted.
 		if !at.validator.MatchesSelector(entry) {
-			return nil, false, ErrContainerIDNotEqual
+			return nil, nil, false, ErrContainerIDNotEqual
 		}
 
 		// go through the root nodes and check if one of them matches the input ProcessCacheEntry:
-		if branchRoot, newChildNode := at.findBranchInChildrenNodes(&at.ProcessNodes, branch, dryRun, generationType, resolvers); branchRoot != nil {
-			return branchRoot, newChildNode, nil
+		if branchRoot, newChildNode := at.findBranch(&at.ProcessNodes, nil, branch, dryRun, generationType, resolvers); branchRoot != nil {
+			return branchRoot, &at.ProcessNodes, newChildNode, nil
 		}
 
 		// we're about to add a root process node, make sure this root node passes the root node sanitizer
 		if !isValidRootNode(&entry.ProcessContext) {
-			return nil, false, ErrNotValidRootNode
+			return nil, nil, false, ErrNotValidRootNode
 		}
 
 		// if it doesn't, create a new ProcessActivityNode for the input ProcessCacheEntry
@@ -443,9 +443,9 @@ func (at *ActivityTree) CreateProcessNode(entry *model.ProcessCacheEntry, branch
 		// if parentNode wasn't nil, then (at least) the parent is part of the activity dump. This means that we need
 		// to add the current entry no matter if it matches the selector or not. Go through the root children of the
 		// parent node and check if one of them matches the input ProcessCacheEntry.
-		branchRoot, newChildNode := at.findBranchInChildrenNodes(&parentNode.Children, branch, dryRun, generationType, resolvers)
+		branchRoot, newChildNode := at.findBranch(&parentNode.Children, siblings, branch, dryRun, generationType, resolvers)
 		if branchRoot != nil {
-			return branchRoot, newChildNode || newProcessNode, nil
+			return branchRoot, &parentNode.Children, newChildNode || newProcessNode, nil
 		}
 
 		// we haven't found anything, create a new ProcessActivityNode for the input processCacheEntry
@@ -464,22 +464,25 @@ func (at *ActivityTree) CreateProcessNode(entry *model.ProcessCacheEntry, branch
 		at.validator.NewProcessNodeCallback(node)
 	}
 
-	return node, true, nil
+	var nextSiblings *[]*ProcessNode
+	if parentNode != nil {
+		nextSiblings = &parentNode.Children
+	}
+	return node, nextSiblings, true, nil
 }
 
-// findBranchInChildrenNodes looks for the provided branch in the list of children. Returns the node that matches the
+// findBranch looks for the provided branch in the list of children. Returns the node that matches the
 // first node of the branch and true if a new entry was inserted.
-func (at *ActivityTree) findBranchInChildrenNodes(tree *[]*ProcessNode, branch []*model.ProcessCacheEntry, dryRun bool, generationType NodeGenerationType, resolvers *resolvers.Resolvers) (*ProcessNode, bool) {
+func (at *ActivityTree) findBranch(children *[]*ProcessNode, siblings *[]*ProcessNode, branch []*model.ProcessCacheEntry, dryRun bool, generationType NodeGenerationType, resolvers *resolvers.Resolvers) (*ProcessNode, bool) {
 	for i, branchCursor := range branch {
 
-		// look for branchCursor in the tree
-		treeNodeToRebase, treeNodeToRebaseIndex := at.findProcessCacheEntryInChildrenNodes(tree, branchCursor)
+		// look for branchCursor in the children
+		matchingNode, treeNodeToRebaseIndex := at.findProcessCacheEntryInTree(*children, branchCursor)
 
-		// if found, append the input process sequence and rebase the tree
-		if treeNodeToRebase != nil {
+		if matchingNode != nil {
 			// if this is the first iteration, we've just identified a direct match without looking for execs, return now
 			if i == 0 {
-				return treeNodeToRebase, false
+				return matchingNode, false
 			}
 
 			// we're about to rebase part of the tree, exit early if this is a dry run
@@ -488,42 +491,37 @@ func (at *ActivityTree) findBranchInChildrenNodes(tree *[]*ProcessNode, branch [
 			}
 
 			// here is the current state of the tree:
-			//   parentNode (owner of tree) -> treeNodeToRebase -> [...] -> an existing node that matched children[i]
+			//   parent (owner of "children") -> treeNodeToRebase -> [...] -> matchingNode
 			// here is what we want:
-			//   parentNode (owner of tree) -> children[0] -> children[i-1] -> treeNodeToRebase
+			//   parent (owner of "children") -> branch[0:i] -> treeNodeToRebase -> [...] -> matchingNode
+			newNodesRoot := at.rebaseTree(children, treeNodeToRebaseIndex, children, branch[:i], generationType, resolvers)
 
-			// start by appending the entry
-			newNodesRoot := NewProcessNode(branch[0], generationType, resolvers)
-			*tree = append(*tree, newNodesRoot)
-			at.Stats.ProcessNodes++
-			at.Stats.addedCount[model.ExecEventType][generationType].Inc()
-
-			// now add the children
-			childrenCursor := newNodesRoot
-			for _, eventExecChildTmp := range branch[1:i] {
-				n := NewProcessNode(eventExecChildTmp, generationType, resolvers)
-				childrenCursor.Children = append(childrenCursor.Children, n)
-				at.Stats.ProcessNodes++
-				at.Stats.addedCount[model.ExecEventType][generationType].Inc()
-
-				childrenCursor = n
-			}
-
-			// attach the head of  to the last newly inserted child
-			childrenCursor.Children = append(childrenCursor.Children, (*tree)[treeNodeToRebaseIndex])
-			// rebase the tree, break the link between parent and treeNodeToRebase
-			*tree = append((*tree)[0:treeNodeToRebaseIndex], (*tree)[treeNodeToRebaseIndex+1:]...)
-
-			// now that the tree is ready, call the validator on the first node
-			at.validator.NewProcessNodeCallback(newNodesRoot)
-
-			// we need to return the node that matched `entry`
+			// we need to return the node that matched branch[0]
 			return newNodesRoot, true
 		} else {
+			// are we looking for an exec child ?
+			if branchCursor.IsExecChild && siblings != nil {
+				// if yes, then look for branchCursor in the siblings of the parent of children
+				_, treeNodeToRebaseIndex = at.findProcessCacheEntryInTree(*siblings, branchCursor)
+				if treeNodeToRebaseIndex >= 0 {
+
+					// we're about to rebase part of the tree, exit early if this is a dry run
+					if i >= 1 && dryRun {
+						return nil, true
+					}
+
+					// rebase the siblings node below the branch
+					newNodesRoot := at.rebaseTree(siblings, treeNodeToRebaseIndex, children, branch[:i], generationType, resolvers)
+
+					// we need to return the node that matched branch[0]
+					return newNodesRoot, i >= 1
+				}
+			}
+
 			// We didn't find the current entry anywhere, has it execed into something else ? (i.e. are we missing something
 			// in the profile ?)
 			if i+1 < len(branch) {
-				if branch[i+1].IsExecChild() {
+				if branch[i+1].IsExecChild {
 					continue
 				}
 			}
@@ -536,10 +534,55 @@ func (at *ActivityTree) findBranchInChildrenNodes(tree *[]*ProcessNode, branch [
 	return nil, false
 }
 
-// findProcessCacheEntryInChildrenNodes looks for the provided entry in the list of process nodes, returns the node (if
-// found) and the index of the top level child that lead to the node (if found) and its index (or -1 if not found).
-func (at *ActivityTree) findProcessCacheEntryInChildrenNodes(tree *[]*ProcessNode, entry *model.ProcessCacheEntry) (*ProcessNode, int) {
-	for i, child := range *tree {
+// rebaseTree rebases the node identified by "nodeIndexToRebase" in the input "tree" onto a newly created branch made of
+// "branchToRebaseOnto" and appended to "treeToRebaseOnto". New nodes will be tagged with the input "generationType".
+// This function returns the top level node, owner of the newly inserted branch that lead to the rebased node
+func (at *ActivityTree) rebaseTree(tree *[]*ProcessNode, treeIndexToRebase int, treeToRebaseOnto *[]*ProcessNode, branchToInsert []*model.ProcessCacheEntry, generationType NodeGenerationType, resolvers *resolvers.Resolvers) *ProcessNode {
+
+	// create the new branch
+	var rebaseRoot, childrenCursor *ProcessNode
+	for i, eventExecChildTmp := range branchToInsert {
+		n := NewProcessNode(eventExecChildTmp, generationType, resolvers)
+		if i == 0 {
+			rebaseRoot = n
+		}
+		if childrenCursor != nil {
+			childrenCursor.Children = append(childrenCursor.Children, n)
+		}
+		at.Stats.ProcessNodes++
+		at.Stats.addedCount[model.ExecEventType][generationType].Inc()
+
+		childrenCursor = n
+	}
+
+	// mark the rebased node as an exec child
+	(*tree)[treeIndexToRebase].Process.IsExecChild = true
+
+	if rebaseRoot == nil {
+		rebaseRoot = (*tree)[treeIndexToRebase]
+	}
+
+	if childrenCursor != nil {
+		// attach the head of  to the last newly inserted child
+		childrenCursor.Children = append(childrenCursor.Children, (*tree)[treeIndexToRebase])
+	}
+
+	// rebase the node onto treeToRebaseOnto
+	*treeToRebaseOnto = append(*treeToRebaseOnto, rebaseRoot)
+
+	// break the link between parent and the node to rebase
+	*tree = append((*tree)[0:treeIndexToRebase], (*tree)[treeIndexToRebase+1:]...)
+
+	// now that the tree is ready, call the validator on the first node
+	at.validator.NewProcessNodeCallback(rebaseRoot)
+
+	return rebaseRoot
+}
+
+// findProcessCacheEntryInTree looks for the provided entry in the list of process nodes, returns the node (if
+// found) and the index of the top level child that lead to the matching node (or -1 if not found).
+func (at *ActivityTree) findProcessCacheEntryInTree(tree []*ProcessNode, entry *model.ProcessCacheEntry) (*ProcessNode, int) {
+	for i, child := range tree {
 		if child.Matches(&entry.Process, at.differentiateArgs) {
 			return child, i
 		}
@@ -563,7 +606,7 @@ func (at *ActivityTree) findProcessCacheEntryInChildExecedNodes(child *ProcessNo
 
 		// look for an execed child
 		for _, node := range cursor.Children {
-			if node.IsExecChild {
+			if node.Process.IsExecChild {
 				// there should always be only one
 				execChildren = append(execChildren, node)
 			}

--- a/pkg/security/security_profile/activity_tree/activity_tree_proto_dec_v1.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_proto_dec_v1.go
@@ -30,7 +30,6 @@ func protoDecodeProcessActivityNode(pan *adproto.ProcessActivityNode) *ProcessNo
 	ppan := &ProcessNode{
 		Process:        protoDecodeProcessNode(pan.Process),
 		GenerationType: NodeGenerationType(pan.GenerationType),
-		IsExecChild:    pan.IsExecChild,
 		MatchedRules:   make([]*model.MatchedRule, 0, len(pan.MatchedRules)),
 		Children:       make([]*ProcessNode, 0, len(pan.Children)),
 		Files:          make(map[string]*FileNode, len(pan.Files)),
@@ -84,6 +83,7 @@ func protoDecodeProcessNode(p *adproto.ProcessInfo) model.Process {
 		PPid:        p.Ppid,
 		Cookie:      p.Cookie,
 		IsThread:    p.IsThread,
+		IsExecChild: p.IsExecChild,
 		FileEvent:   *protoDecodeFileEvent(p.File),
 		ContainerID: p.ContainerId,
 		SpanID:      p.SpanId,

--- a/pkg/security/security_profile/activity_tree/activity_tree_proto_enc_v1.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_proto_enc_v1.go
@@ -35,7 +35,6 @@ func processActivityNodeToProto(pan *ProcessNode) *adproto.ProcessActivityNode {
 	*ppan = adproto.ProcessActivityNode{
 		Process:        processNodeToProto(&pan.Process),
 		GenerationType: adproto.GenerationType(pan.GenerationType),
-		IsExecChild:    pan.IsExecChild,
 		MatchedRules:   make([]*adproto.MatchedRule, 0, len(pan.MatchedRules)),
 		Children:       make([]*adproto.ProcessActivityNode, 0, len(pan.Children)),
 		Files:          make([]*adproto.FileActivityNode, 0, len(pan.Files)),
@@ -83,6 +82,7 @@ func processNodeToProto(p *model.Process) *adproto.ProcessInfo {
 		Ppid:        p.PPid,
 		Cookie:      p.Cookie,
 		IsThread:    p.IsThread,
+		IsExecChild: p.IsExecChild,
 		File:        fileEventToProto(&p.FileEvent),
 		ContainerId: p.ContainerID,
 		SpanId:      p.SpanID,

--- a/pkg/security/security_profile/activity_tree/activity_tree_test.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_test.go
@@ -34,7 +34,7 @@ func TestInsertFileEvent(t *testing.T) {
 		"/tmp/bar/test",
 	}
 	expectedDebugOuput := strings.TrimSpace(`
-- process: /test/pan
+- process: /test/pan (is_exec_child:false)
   files:
     - hello
     - test
@@ -72,7 +72,7 @@ func TestInsertFileEvent(t *testing.T) {
 func TestActivityTree_InsertExecEvent(t *testing.T) {
 	for _, tt := range activityTreeInsertExecEventTestCases {
 		t.Run(tt.name, func(t *testing.T) {
-			node, newEntry, err := tt.tree.CreateProcessNode(tt.inputEvent.ProcessCacheEntry, nil, Runtime, false, nil)
+			node, _, newEntry, err := tt.tree.CreateProcessNode(tt.inputEvent.ProcessCacheEntry, nil, Runtime, false, nil)
 			if tt.wantErr != nil {
 				if !tt.wantErr(t, err, fmt.Sprintf("unexpected error: %v", err)) {
 					return
@@ -329,7 +329,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/bash",
 						},
@@ -337,7 +336,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/webserver",
 								},
@@ -345,7 +343,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 							Children: []*ProcessNode{
 								{
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/ls",
 										},
@@ -393,7 +390,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/bash",
 						},
@@ -401,7 +397,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/webserver",
 								},
@@ -409,7 +404,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 							Children: []*ProcessNode{
 								{
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/ls",
 										},
@@ -446,7 +440,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/bash",
 						},
@@ -454,17 +447,14 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-								ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/webserver",
 								},
 							},
 							Children: []*ProcessNode{
 								{
-									IsExecChild: true,
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										IsExecChild: true,
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/ls",
 										},
@@ -512,7 +502,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/bash",
 						},
@@ -520,8 +509,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-								ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/webserver",
 								},
@@ -529,7 +516,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 							Children: []*ProcessNode{
 								{
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										IsExecChild: true,
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/ls",
 										},
@@ -559,7 +546,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/bash",
 						},
@@ -567,26 +553,22 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-								ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/webserver",
 								},
 							},
 							Children: []*ProcessNode{
 								{
-									IsExecChild: true,
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										IsExecChild: true,
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/id",
 										},
 									},
 								},
 								{
-									IsExecChild: true,
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										IsExecChild: true,
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/ls",
 										},
@@ -634,7 +616,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/bash",
 						},
@@ -642,8 +623,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-								ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/webserver",
 								},
@@ -651,7 +630,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 							Children: []*ProcessNode{
 								{
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										IsExecChild: true,
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/id",
 										},
@@ -659,7 +638,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 								},
 								{
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										IsExecChild: true,
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/ls",
 										},
@@ -687,17 +666,14 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-						ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/webserver",
 						},
 					},
 					Children: []*ProcessNode{
 						{
-							IsExecChild: true,
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								IsExecChild: true,
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/ls",
 								},
@@ -732,8 +708,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-						ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/webserver",
 						},
@@ -741,7 +715,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								IsExecChild: true,
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/ls",
 								},
@@ -777,7 +751,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/bash",
 						},
@@ -785,18 +758,14 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-								ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/webserver1",
 								},
 							},
 							Children: []*ProcessNode{
 								{
-									IsExecChild: true,
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
-										ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										IsExecChild: true,
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/webserver2",
 										},
@@ -810,29 +779,24 @@ var activityTreeInsertExecEventTestCases = []struct {
 											},
 										},
 										{
-											IsExecChild: true,
 											Process: model.Process{
-												ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
-												ExitTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+												IsExecChild: true,
 												FileEvent: model.FileEvent{
 													PathnameStr: "/bin/webserver3",
 												},
 											},
 											Children: []*ProcessNode{
 												{
-													IsExecChild: true,
 													Process: model.Process{
-														ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
-														ExitTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+														IsExecChild: true,
 														FileEvent: model.FileEvent{
 															PathnameStr: "/bin/webserver4",
 														},
 													},
 													Children: []*ProcessNode{
 														{
-															IsExecChild: true,
 															Process: model.Process{
-																ExecTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+																IsExecChild: true,
 																FileEvent: model.FileEvent{
 																	PathnameStr: "/bin/ls",
 																},
@@ -902,7 +866,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/bash",
 						},
@@ -910,8 +873,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-								ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/webserver1",
 								},
@@ -919,8 +880,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 							Children: []*ProcessNode{
 								{
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
-										ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										IsExecChild: true,
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/webserver2",
 										},
@@ -935,8 +895,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 										},
 										{
 											Process: model.Process{
-												ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
-												ExitTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+												IsExecChild: true,
 												FileEvent: model.FileEvent{
 													PathnameStr: "/bin/webserver3",
 												},
@@ -944,8 +903,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 											Children: []*ProcessNode{
 												{
 													Process: model.Process{
-														ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
-														ExitTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+														IsExecChild: true,
 														FileEvent: model.FileEvent{
 															PathnameStr: "/bin/webserver4",
 														},
@@ -953,7 +911,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 													Children: []*ProcessNode{
 														{
 															Process: model.Process{
-																ExecTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+																IsExecChild: true,
 																FileEvent: model.FileEvent{
 																	PathnameStr: "/bin/ls",
 																},
@@ -1011,18 +969,14 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-						ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/webserver1",
 						},
 					},
 					Children: []*ProcessNode{
 						{
-							IsExecChild: true,
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
-								ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+								IsExecChild: true,
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/webserver2",
 								},
@@ -1036,29 +990,24 @@ var activityTreeInsertExecEventTestCases = []struct {
 									},
 								},
 								{
-									IsExecChild: true,
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
-										ExitTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+										IsExecChild: true,
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/webserver3",
 										},
 									},
 									Children: []*ProcessNode{
 										{
-											IsExecChild: true,
 											Process: model.Process{
-												ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
-												ExitTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+												IsExecChild: true,
 												FileEvent: model.FileEvent{
 													PathnameStr: "/bin/webserver4",
 												},
 											},
 											Children: []*ProcessNode{
 												{
-													IsExecChild: true,
 													Process: model.Process{
-														ExecTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+														IsExecChild: true,
 														FileEvent: model.FileEvent{
 															PathnameStr: "/bin/ls",
 														},
@@ -1115,8 +1064,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-						ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/webserver1",
 						},
@@ -1124,8 +1071,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
-								ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+								IsExecChild: true,
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/webserver2",
 								},
@@ -1140,8 +1086,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 								},
 								{
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
-										ExitTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+										IsExecChild: true,
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/webserver3",
 										},
@@ -1149,8 +1094,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 									Children: []*ProcessNode{
 										{
 											Process: model.Process{
-												ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
-												ExitTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+												IsExecChild: true,
 												FileEvent: model.FileEvent{
 													PathnameStr: "/bin/webserver4",
 												},
@@ -1158,7 +1102,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 											Children: []*ProcessNode{
 												{
 													Process: model.Process{
-														ExecTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+														IsExecChild: true,
 														FileEvent: model.FileEvent{
 															PathnameStr: "/bin/ls",
 														},
@@ -1208,7 +1152,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/bash",
 						},
@@ -1216,7 +1159,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/ls",
 								},
@@ -1248,10 +1190,9 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-				ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 			},
 			{
+				IsExecChild: true,
 				ContainerID: "123",
 				FileEvent: model.FileEvent{
 					PathnameStr: "/bin/ls",
@@ -1261,7 +1202,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 			},
 		}),
 		wantNode: &ProcessNode{
@@ -1276,7 +1216,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/bash",
 						},
@@ -1284,8 +1223,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-								ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/webserver",
 								},
@@ -1293,7 +1230,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 							Children: []*ProcessNode{
 								{
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										IsExecChild: true,
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/ls",
 										},
@@ -1323,7 +1260,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/webserver",
 						},
@@ -1331,7 +1267,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/ls",
 								},
@@ -1352,10 +1287,9 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-				ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 			},
 			{
+				IsExecChild: true,
 				ContainerID: "123",
 				FileEvent: model.FileEvent{
 					PathnameStr: "/bin/webserver",
@@ -1365,7 +1299,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 			},
 			{
 				ContainerID: "123",
@@ -1377,7 +1310,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
 			},
 		}),
 		wantNode: &ProcessNode{
@@ -1392,8 +1324,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
-						ExitTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/bash",
 						},
@@ -1401,7 +1331,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+								IsExecChild: true,
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/webserver",
 								},
@@ -1409,7 +1339,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 							Children: []*ProcessNode{
 								{
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/ls",
 										},
@@ -1441,7 +1370,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/webserver",
 						},
@@ -1449,7 +1377,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/ls",
 								},
@@ -1470,10 +1397,9 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-				ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 			},
 			{
+				IsExecChild: true,
 				ContainerID: "123",
 				FileEvent: model.FileEvent{
 					PathnameStr: "/bin/webserver",
@@ -1483,10 +1409,9 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
-				ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 			},
 			{
+				IsExecChild: true,
 				ContainerID: "123",
 				FileEvent: model.FileEvent{
 					PathnameStr: "/bin/apache",
@@ -1496,7 +1421,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 			},
 			{
 				ContainerID: "123",
@@ -1508,7 +1432,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
 			},
 		}),
 		wantNode: &ProcessNode{
@@ -1523,8 +1446,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
-						ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/bash",
 						},
@@ -1532,8 +1453,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
-								ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+								IsExecChild: true,
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/webserver",
 								},
@@ -1541,7 +1461,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 							Children: []*ProcessNode{
 								{
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/ls",
 										},
@@ -1549,7 +1468,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 								},
 								{
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										IsExecChild: true,
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/apache",
 										},
@@ -1557,7 +1476,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 									Children: []*ProcessNode{
 										{
 											Process: model.Process{
-												ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
 												FileEvent: model.FileEvent{
 													PathnameStr: "/bin/ls",
 												},
@@ -1591,7 +1509,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/apache",
 						},
@@ -1599,7 +1516,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/ls",
 								},
@@ -1620,10 +1536,9 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-				ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 			},
 			{
+				IsExecChild: true,
 				ContainerID: "123",
 				FileEvent: model.FileEvent{
 					PathnameStr: "/bin/webserver",
@@ -1633,10 +1548,9 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
-				ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 			},
 			{
+				IsExecChild: true,
 				ContainerID: "123",
 				FileEvent: model.FileEvent{
 					PathnameStr: "/bin/apache",
@@ -1646,7 +1560,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 			},
 			{
 				ContainerID: "123",
@@ -1658,7 +1571,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
 			},
 		}),
 		wantNode: &ProcessNode{
@@ -1673,8 +1585,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
-						ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/bash",
 						},
@@ -1682,8 +1592,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
-								ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+								IsExecChild: true,
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/webserver",
 								},
@@ -1691,7 +1600,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 							Children: []*ProcessNode{
 								{
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										IsExecChild: true,
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/apache",
 										},
@@ -1699,7 +1608,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 									Children: []*ProcessNode{
 										{
 											Process: model.Process{
-												ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
 												FileEvent: model.FileEvent{
 													PathnameStr: "/bin/ls",
 												},
@@ -1745,7 +1653,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/apache",
 						},
@@ -1753,7 +1660,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/ls",
 								},
@@ -1761,7 +1667,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 							Children: []*ProcessNode{
 								{
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/date",
 										},
@@ -1769,7 +1674,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 									Children: []*ProcessNode{
 										{
 											Process: model.Process{
-												ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 												FileEvent: model.FileEvent{
 													PathnameStr: "/bin/du",
 												},
@@ -1794,10 +1698,9 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-				ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 			},
 			{
+				IsExecChild: true,
 				ContainerID: "123",
 				FileEvent: model.FileEvent{
 					PathnameStr: "/bin/webserver",
@@ -1807,10 +1710,9 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
-				ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 			},
 			{
+				IsExecChild: true,
 				ContainerID: "123",
 				FileEvent: model.FileEvent{
 					PathnameStr: "/bin/apache",
@@ -1820,7 +1722,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 			},
 			{
 				ContainerID: "123",
@@ -1832,10 +1733,9 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
-				ExitTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
 			},
 			{
+				IsExecChild: true,
 				ContainerID: "123",
 				FileEvent: model.FileEvent{
 					PathnameStr: "/bin/id",
@@ -1845,10 +1745,9 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
-				ExitTime: time.Date(2023, 06, 26, 1, 2, 3, 4, time.UTC),
 			},
 			{
+				IsExecChild: true,
 				ContainerID: "123",
 				FileEvent: model.FileEvent{
 					PathnameStr: "/bin/ls",
@@ -1858,7 +1757,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 26, 1, 2, 3, 4, time.UTC),
 			},
 			{
 				ContainerID: "123",
@@ -1870,7 +1768,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 27, 1, 2, 3, 4, time.UTC),
 			},
 			{
 				ContainerID: "123",
@@ -1882,10 +1779,9 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 28, 1, 2, 3, 4, time.UTC),
-				ExitTime: time.Date(2023, 06, 29, 1, 2, 3, 4, time.UTC),
 			},
 			{
+				IsExecChild: true,
 				ContainerID: "123",
 				FileEvent: model.FileEvent{
 					PathnameStr: "/bin/bpftool",
@@ -1895,10 +1791,9 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 29, 1, 2, 3, 4, time.UTC),
-				ExitTime: time.Date(2023, 06, 30, 1, 2, 3, 4, time.UTC),
 			},
 			{
+				IsExecChild: true,
 				ContainerID: "123",
 				FileEvent: model.FileEvent{
 					PathnameStr: "/bin/du",
@@ -1908,7 +1803,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 30, 1, 2, 3, 4, time.UTC),
 			},
 		}),
 		wantNode: &ProcessNode{
@@ -1923,8 +1817,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
-						ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/bash",
 						},
@@ -1932,8 +1824,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
-								ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+								IsExecChild: true,
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/webserver",
 								},
@@ -1941,7 +1832,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 							Children: []*ProcessNode{
 								{
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										IsExecChild: true,
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/apache",
 										},
@@ -1949,8 +1840,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 									Children: []*ProcessNode{
 										{
 											Process: model.Process{
-												ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
-												ExitTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
 												FileEvent: model.FileEvent{
 													PathnameStr: "/bin/wc",
 												},
@@ -1958,8 +1847,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 											Children: []*ProcessNode{
 												{
 													Process: model.Process{
-														ExecTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
-														ExitTime: time.Date(2023, 06, 26, 1, 2, 3, 4, time.UTC),
+														IsExecChild: true,
 														FileEvent: model.FileEvent{
 															PathnameStr: "/bin/id",
 														},
@@ -1967,7 +1855,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 													Children: []*ProcessNode{
 														{
 															Process: model.Process{
-																ExecTime: time.Date(2023, 06, 26, 1, 2, 3, 4, time.UTC),
+																IsExecChild: true,
 																FileEvent: model.FileEvent{
 																	PathnameStr: "/bin/ls",
 																},
@@ -1975,7 +1863,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 															Children: []*ProcessNode{
 																{
 																	Process: model.Process{
-																		ExecTime: time.Date(2023, 06, 27, 1, 2, 3, 4, time.UTC),
 																		FileEvent: model.FileEvent{
 																			PathnameStr: "/bin/date",
 																		},
@@ -1983,8 +1870,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 																	Children: []*ProcessNode{
 																		{
 																			Process: model.Process{
-																				ExecTime: time.Date(2023, 06, 28, 1, 2, 3, 4, time.UTC),
-																				ExitTime: time.Date(2023, 06, 29, 1, 2, 3, 4, time.UTC),
 																				FileEvent: model.FileEvent{
 																					PathnameStr: "/bin/passwd",
 																				},
@@ -1992,8 +1877,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 																			Children: []*ProcessNode{
 																				{
 																					Process: model.Process{
-																						ExecTime: time.Date(2023, 06, 29, 1, 2, 3, 4, time.UTC),
-																						ExitTime: time.Date(2023, 06, 30, 1, 2, 3, 4, time.UTC),
+																						IsExecChild: true,
 																						FileEvent: model.FileEvent{
 																							PathnameStr: "/bin/bpftool",
 																						},
@@ -2001,7 +1885,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 																					Children: []*ProcessNode{
 																						{
 																							Process: model.Process{
-																								ExecTime: time.Date(2023, 06, 30, 1, 2, 3, 4, time.UTC),
+																								IsExecChild: true,
 																								FileEvent: model.FileEvent{
 																									PathnameStr: "/bin/du",
 																								},
@@ -2047,7 +1931,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/webserver",
 						},
@@ -2055,17 +1938,14 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
-								ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/ls",
 								},
 							},
 							Children: []*ProcessNode{
 								{
-									IsExecChild: true,
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										IsExecChild: true,
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/wc",
 										},
@@ -2088,10 +1968,9 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-				ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 			},
 			{
+				IsExecChild: true,
 				ContainerID: "123",
 				FileEvent: model.FileEvent{
 					PathnameStr: "/bin/webserver",
@@ -2101,7 +1980,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 			},
 			{
 				ContainerID: "123",
@@ -2113,7 +1991,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
 			},
 		}),
 		wantNode: &ProcessNode{
@@ -2128,8 +2005,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
-						ExitTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/bash",
 						},
@@ -2137,7 +2012,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
+								IsExecChild: true,
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/webserver",
 								},
@@ -2145,8 +2020,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 							Children: []*ProcessNode{
 								{
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
-										ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/ls",
 										},
@@ -2154,7 +2027,8 @@ var activityTreeInsertExecEventTestCases = []struct {
 									Children: []*ProcessNode{
 										{
 											Process: model.Process{
-												ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+												IsExecChild: true,
+												ExecTime:    time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 												FileEvent: model.FileEvent{
 													PathnameStr: "/bin/wc",
 												},
@@ -2188,17 +2062,14 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
-						ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/webserver",
 						},
 					},
 					Children: []*ProcessNode{
 						{
-							IsExecChild: true,
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+								IsExecChild: true,
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/apache",
 								},
@@ -2206,7 +2077,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 							Children: []*ProcessNode{
 								{
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/wc",
 										},
@@ -2229,10 +2099,9 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-				ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 			},
 			{
+				IsExecChild: true,
 				ContainerID: "123",
 				FileEvent: model.FileEvent{
 					PathnameStr: "/bin/apache",
@@ -2242,7 +2111,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 			},
 			{
 				ContainerID: "123",
@@ -2254,7 +2122,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
 			},
 		}),
 		wantNode: &ProcessNode{
@@ -2269,8 +2136,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
-						ExitTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/bash",
 						},
@@ -2278,8 +2143,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-								ExitTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+								IsExecChild: true,
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/webserver",
 								},
@@ -2287,7 +2151,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 							Children: []*ProcessNode{
 								{
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+										IsExecChild: true,
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/apache",
 										},
@@ -2295,7 +2159,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 									Children: []*ProcessNode{
 										{
 											Process: model.Process{
-												ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 												FileEvent: model.FileEvent{
 													PathnameStr: "/bin/wc",
 												},
@@ -2303,7 +2166,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 										},
 										{
 											Process: model.Process{
-												ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 												FileEvent: model.FileEvent{
 													PathnameStr: "/bin/ls",
 												},
@@ -2341,27 +2203,22 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
-						ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/webserver",
 						},
 					},
 					Children: []*ProcessNode{
 						{
-							IsExecChild: true,
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
-								ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+								IsExecChild: true,
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/date",
 								},
 							},
 							Children: []*ProcessNode{
 								{
-									IsExecChild: true,
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										IsExecChild: true,
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/apache",
 										},
@@ -2369,7 +2226,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 									Children: []*ProcessNode{
 										{
 											Process: model.Process{
-												ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
 												FileEvent: model.FileEvent{
 													PathnameStr: "/bin/wc",
 												},
@@ -2394,10 +2250,9 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-				ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 			},
 			{
+				IsExecChild: true,
 				ContainerID: "123",
 				FileEvent: model.FileEvent{
 					PathnameStr: "/bin/du",
@@ -2407,10 +2262,9 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
-				ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 			},
 			{
+				IsExecChild: true,
 				ContainerID: "123",
 				FileEvent: model.FileEvent{
 					PathnameStr: "/bin/apache",
@@ -2420,7 +2274,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 			},
 			{
 				ContainerID: "123",
@@ -2432,7 +2285,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 						},
 					},
 				},
-				ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
 			},
 		}),
 		wantNode: &ProcessNode{
@@ -2447,8 +2299,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
-						ExitTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/bash",
 						},
@@ -2456,8 +2306,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-								ExitTime: time.Date(2023, 06, 21, 1, 2, 3, 4, time.UTC),
+								IsExecChild: true,
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/du",
 								},
@@ -2465,8 +2314,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 							Children: []*ProcessNode{
 								{
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 21, 1, 2, 3, 4, time.UTC),
-										ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
+										IsExecChild: true,
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/webserver",
 										},
@@ -2474,8 +2322,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 									Children: []*ProcessNode{
 										{
 											Process: model.Process{
-												ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
-												ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+												IsExecChild: true,
 												FileEvent: model.FileEvent{
 													PathnameStr: "/bin/date",
 												},
@@ -2483,7 +2330,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 											Children: []*ProcessNode{
 												{
 													Process: model.Process{
-														ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
+														IsExecChild: true,
 														FileEvent: model.FileEvent{
 															PathnameStr: "/bin/apache",
 														},
@@ -2491,7 +2338,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 													Children: []*ProcessNode{
 														{
 															Process: model.Process{
-																ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 																FileEvent: model.FileEvent{
 																	PathnameStr: "/bin/wc",
 																},
@@ -2499,7 +2345,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 														},
 														{
 															Process: model.Process{
-																ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
 																FileEvent: model.FileEvent{
 																	PathnameStr: "/bin/ls",
 																},
@@ -2543,7 +2388,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/bash",
 						},
@@ -2551,18 +2395,14 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-								ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/webserver1",
 								},
 							},
 							Children: []*ProcessNode{
 								{
-									IsExecChild: true,
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
-										ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										IsExecChild: true,
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/webserver2",
 										},
@@ -2576,9 +2416,8 @@ var activityTreeInsertExecEventTestCases = []struct {
 											},
 										},
 										{
-											IsExecChild: true,
 											Process: model.Process{
-												ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+												IsExecChild: true,
 												FileEvent: model.FileEvent{
 													PathnameStr: "/bin/webserver3",
 												},
@@ -2586,17 +2425,14 @@ var activityTreeInsertExecEventTestCases = []struct {
 											Children: []*ProcessNode{
 												{
 													Process: model.Process{
-														ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
-														ExitTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
 														FileEvent: model.FileEvent{
 															PathnameStr: "/bin/webserver4",
 														},
 													},
 													Children: []*ProcessNode{
 														{
-															IsExecChild: true,
 															Process: model.Process{
-																ExecTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+																IsExecChild: true,
 																FileEvent: model.FileEvent{
 																	PathnameStr: "/bin/ls",
 																},
@@ -2688,7 +2524,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 			ProcessNodes: []*ProcessNode{
 				{
 					Process: model.Process{
-						ExecTime: time.Date(2023, 06, 19, 1, 2, 3, 4, time.UTC),
 						FileEvent: model.FileEvent{
 							PathnameStr: "/bin/bash",
 						},
@@ -2696,8 +2531,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 					Children: []*ProcessNode{
 						{
 							Process: model.Process{
-								ExecTime: time.Date(2023, 06, 20, 1, 2, 3, 4, time.UTC),
-								ExitTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/webserver1",
 								},
@@ -2705,8 +2538,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 							Children: []*ProcessNode{
 								{
 									Process: model.Process{
-										ExecTime: time.Date(2023, 06, 22, 1, 2, 3, 4, time.UTC),
-										ExitTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+										IsExecChild: true,
 										FileEvent: model.FileEvent{
 											PathnameStr: "/bin/webserver2",
 										},
@@ -2721,7 +2553,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 										},
 										{
 											Process: model.Process{
-												ExecTime: time.Date(2023, 06, 23, 1, 2, 3, 4, time.UTC),
+												IsExecChild: true,
 												FileEvent: model.FileEvent{
 													PathnameStr: "/bin/webserver3",
 												},
@@ -2729,8 +2561,6 @@ var activityTreeInsertExecEventTestCases = []struct {
 											Children: []*ProcessNode{
 												{
 													Process: model.Process{
-														ExecTime: time.Date(2023, 06, 24, 1, 2, 3, 4, time.UTC),
-														ExitTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
 														FileEvent: model.FileEvent{
 															PathnameStr: "/bin/webserver4",
 														},
@@ -2738,7 +2568,7 @@ var activityTreeInsertExecEventTestCases = []struct {
 													Children: []*ProcessNode{
 														{
 															Process: model.Process{
-																ExecTime: time.Date(2023, 06, 25, 1, 2, 3, 4, time.UTC),
+																IsExecChild: true,
 																FileEvent: model.FileEvent{
 																	PathnameStr: "/bin/ls",
 																},
@@ -2766,6 +2596,387 @@ var activityTreeInsertExecEventTestCases = []struct {
 																	},
 																},
 															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// exec/17
+	// ---------------
+	//
+	//     /bin/bash -----------------           +          systemd                                ==>>             /bin/bash
+	//          |                    |                         |- /bin/bash                                             |
+	//     /bin/webserver1      /bin/apache                    |- /bin/apache -> /bin/webserver1                   /bin/apache
+	//                                                                                                                  | (exec)
+	//                                                                                                           /bin/webserver1
+	//
+	//
+	{
+		name: "exec/17",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver1",
+								},
+							},
+						},
+						{
+							Process: model.Process{
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/apache",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 1,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/apache",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+			},
+			{
+				IsExecChild: true,
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/webserver1",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 3,
+						},
+					},
+				},
+			},
+		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/webserver1",
+				},
+			},
+		},
+		wantNewEntry: false,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/apache",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										IsExecChild: true,
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/webserver1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// exec/18
+	// ---------------
+	//
+	//     /bin/bash        /bin/apache          +          systemd                                ==>>             /bin/bash -----------
+	//          |                                              |- /bin/bash -> /bin/apache                              |               | (exec)
+	//     /bin/webserver1                                                                                        /bin/webserver1    /bin/apache
+	//
+	//
+	{
+		name: "exec/18",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver1",
+								},
+							},
+						},
+					},
+				},
+				{
+					Process: model.Process{
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/apache",
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 1,
+						},
+					},
+				},
+			},
+			{
+				IsExecChild: true,
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/apache",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+			},
+		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/apache",
+				},
+			},
+		},
+		wantNewEntry: false,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver1",
+								},
+							},
+						},
+						{
+							Process: model.Process{
+								IsExecChild: true,
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/apache",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// exec/19
+	// ---------------
+	//
+	//     /bin/bash -----------------           +          systemd                                                              ==>>             /bin/bash
+	//          |                    |                         |- /bin/bash                                                                           |
+	//     /bin/webserver2      /bin/apache                    |- /bin/apache -> /bin/webserver1 -> /bin/webserver3                              /bin/apache
+	//          | (exec)                                                                                                                              | (exec)
+	//    /bin/webserver3                                                                                                                      /bin/webserver1
+	//                                                                                                                                                | (exec)
+	//                                                                                                                                         /bin/webserver2
+	//                                                                                                                                                | (exec)
+	//                                                                                                                                         /bin/webserver3
+	//
+	{
+		name: "exec/19",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver2",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										IsExecChild: true,
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/webserver3",
+										},
+									},
+								},
+							},
+						},
+						{
+							Process: model.Process{
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/apache",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 1,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/apache",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+			},
+			{
+				IsExecChild: true,
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/webserver1",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 3,
+						},
+					},
+				},
+			},
+			{
+				IsExecChild: true,
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/webserver3",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 4,
+						},
+					},
+				},
+			},
+		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/webserver3",
+				},
+			},
+		},
+		wantNewEntry: true,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/apache",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										IsExecChild: true,
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/webserver1",
+										},
+									},
+									Children: []*ProcessNode{
+										{
+											Process: model.Process{
+												IsExecChild: true,
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/webserver2",
+												},
+											},
+											Children: []*ProcessNode{
+												{
+													Process: model.Process{
+														IsExecChild: true,
+														FileEvent: model.FileEvent{
+															PathnameStr: "/bin/webserver3",
 														},
 													},
 												},

--- a/pkg/security/security_profile/activity_tree/process_node.go
+++ b/pkg/security/security_profile/activity_tree/process_node.go
@@ -23,7 +23,6 @@ import (
 type ProcessNode struct {
 	Process        model.Process
 	GenerationType NodeGenerationType
-	IsExecChild    bool
 	MatchedRules   []*model.MatchedRule
 
 	Files    map[string]*FileNode
@@ -64,7 +63,6 @@ func NewProcessNode(entry *model.ProcessCacheEntry, generationType NodeGeneratio
 	}
 	return &ProcessNode{
 		Process:        entry.Process,
-		IsExecChild:    entry.IsExecChild(),
 		GenerationType: generationType,
 		Files:          make(map[string]*FileNode),
 		DNSNames:       make(map[string]*DNSNode),
@@ -73,7 +71,7 @@ func NewProcessNode(entry *model.ProcessCacheEntry, generationType NodeGeneratio
 
 // nolint: unused
 func (pn *ProcessNode) debug(w io.Writer, prefix string) {
-	fmt.Fprintf(w, "%s- process: %s\n", prefix, pn.Process.FileEvent.PathnameStr)
+	fmt.Fprintf(w, "%s- process: %s (is_exec_child:%v)\n", prefix, pn.Process.FileEvent.PathnameStr, pn.Process.IsExecChild)
 	if len(pn.Files) > 0 {
 		fmt.Fprintf(w, "%s  files:\n", prefix)
 		sortedFiles := make([]*FileNode, 0, len(pn.Files))

--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -631,7 +631,7 @@ func (adm *ActivityDumpManager) SearchTracedProcessCacheEntryCallback(ad *Activi
 		}
 
 		for _, parent = range ancestors {
-			_, _, err := ad.ActivityTree.CreateProcessNode(parent, nil, activity_tree.Snapshot, false, adm.resolvers)
+			_, _, _, err := ad.ActivityTree.CreateProcessNode(parent, nil, activity_tree.Snapshot, false, adm.resolvers)
 			if err != nil {
 				// if one of the parents wasn't inserted, leave now
 				break

--- a/pkg/security/security_profile/tests/activity_tree_test.go
+++ b/pkg/security/security_profile/tests/activity_tree_test.go
@@ -11,14 +11,16 @@ import (
 	"path/filepath"
 	"testing"
 
-	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
 	"golang.org/x/exp/slices"
+
+	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
+
+	"gotest.tools/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/dump"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/profile"
-	"gotest.tools/assert"
 )
 
 type testIteration struct {
@@ -696,7 +698,7 @@ func TestActivityTree_CreateProcessNode(t *testing.T) {
 
 						process := craftFakeProcess(defaultContainerID, &ti)
 
-						node, newProcessNode, err := at.CreateProcessNode(process, []*model.ProcessCacheEntry{}, gentype, dryRun, nil)
+						node, _, newProcessNode, err := at.CreateProcessNode(process, []*model.ProcessCacheEntry{}, gentype, dryRun, nil)
 
 						assert.Equal(t, ti.resultErr, err)
 						assert.Equal(t, ti.resultNewProcessNode, newProcessNode)

--- a/pkg/security/serializers/serializers.go
+++ b/pkg/security/serializers/serializers.go
@@ -220,6 +220,8 @@ type ProcessSerializer struct {
 	IsThread bool `json:"is_thread,omitempty"`
 	// Indicates whether the process is a kworker
 	IsKworker bool `json:"is_kworker,omitempty"`
+	// Indicates wether the process is an exec child of its parent
+	IsExecChild bool `json:"is_exec_child,omitempty"`
 	// Process source
 	Source string `json:"source,omitempty"`
 }
@@ -728,6 +730,7 @@ func newProcessSerializer(ps *model.Process, e *model.Event, resolvers *resolver
 			EnvsTruncated: EnvsTruncated,
 			IsThread:      ps.IsThread,
 			IsKworker:     ps.IsKworker,
+			IsExecChild:   ps.IsExecChild,
 			Source:        model.ProcessSourceToString(ps.Source),
 		}
 
@@ -756,10 +759,11 @@ func newProcessSerializer(ps *model.Process, e *model.Event, resolvers *resolver
 		return psSerializer
 	} else {
 		return &ProcessSerializer{
-			Pid:       ps.Pid,
-			Tid:       ps.Tid,
-			IsKworker: ps.IsKworker,
-			Source:    model.ProcessSourceToString(ps.Source),
+			Pid:         ps.Pid,
+			Tid:         ps.Tid,
+			IsKworker:   ps.IsKworker,
+			IsExecChild: ps.IsExecChild,
+			Source:      model.ProcessSourceToString(ps.Source),
 			Credentials: &ProcessCredentialsSerializer{
 				CredentialsSerializer: &CredentialsSerializer{},
 			},

--- a/pkg/security/serializers/serializers_easyjson.go
+++ b/pkg/security/serializers/serializers_easyjson.go
@@ -844,6 +844,8 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers9(i
 			out.IsThread = bool(in.Bool())
 		case "is_kworker":
 			out.IsKworker = bool(in.Bool())
+		case "is_exec_child":
+			out.IsExecChild = bool(in.Bool())
 		case "source":
 			out.Source = string(in.String())
 		default:
@@ -1013,6 +1015,11 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers9(o
 		const prefix string = ",\"is_kworker\":"
 		out.RawString(prefix)
 		out.Bool(bool(in.IsKworker))
+	}
+	if in.IsExecChild {
+		const prefix string = ",\"is_exec_child\":"
+		out.RawString(prefix)
+		out.Bool(bool(in.IsExecChild))
 	}
 	if in.Source != "" {
 		const prefix string = ",\"source\":"
@@ -1485,6 +1492,8 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecuritySerializers11(
 			out.IsThread = bool(in.Bool())
 		case "is_kworker":
 			out.IsKworker = bool(in.Bool())
+		case "is_exec_child":
+			out.IsExecChild = bool(in.Bool())
 		case "source":
 			out.Source = string(in.String())
 		default:
@@ -1687,6 +1696,11 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecuritySerializers11(
 		const prefix string = ",\"is_kworker\":"
 		out.RawString(prefix)
 		out.Bool(bool(in.IsKworker))
+	}
+	if in.IsExecChild {
+		const prefix string = ",\"is_exec_child\":"
+		out.RawString(prefix)
+		out.Bool(bool(in.IsExecChild))
 	}
 	if in.Source != "" {
 		const prefix string = ",\"source\":"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR fixes an edge case of the `exec-exec` support added in 7.47 (more on that in the next section) and simplifies the way we identify `exec` children in the `ProcessCacheEntry` by introducing a new field to track them.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

In 7.47 the `ActivityTree` of CWS is able to "correct" itself if it discovers new missing nodes in its tree from complete events captured at runtime. For example, look at this example:

```
	// exec/8
	// ---------------
	//
	//      /bin/bash          +          systemd                              ==>>              /bin/bash
	//          |                            |- /bin/bash                                             |
	//      /bin/ls                          |- /bin/webserver -> /bin/ls                       /bin/webserver
	//                                                                                                | (exec)
	//                                                                                             /bin/ls
```

Part of this feature supports multiple edge cases where the missed node might be in the event captured at runtime or in the tree. The way we handle this today is simply by "adding" the new node without looking if it already exists in the siblings of the top level matching node. This is an issue because it means that we improperly clean up existing entries that may already exist. In the example below, before this fix, we weren't properly cleaning up the top level "webserver1" node (below the "bash" node).

```
	// exec/17
	// ---------------
	//
	//     /bin/bash -----------------           +          systemd                                ==>>             /bin/bash
	//          |                    |                         |- /bin/bash                                             |
	//     /bin/webserver1      /bin/apache                    |- /bin/apache -> /bin/webserver1                   /bin/apache
	//                                                                                                                  | (exec)
	//                                                                                                           /bin/webserver1
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
