### PR TITLE
Fix possible NPE if the nodeinfo client is not properly created

### DIFF
--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -14,36 +14,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // GetTags gets the tags from the kubernetes apiserver and the kubelet
 func GetTags(ctx context.Context) (tags []string, err error) {
-	labelsToTags := getLabelsToTags()
-
-	nodeInfo, e := NewNodeInfo()
-	if e != nil {
-		err = e
-	} else {
-		nodeName, e := nodeInfo.GetNodeName(ctx)
-		if e == nil && nodeName != "" {
-			tags = append(tags, "kube_node:"+nodeName)
-		}
-
-		if len(labelsToTags) > 0 {
-			var nodeLabels map[string]string
-			nodeLabels, e = nodeInfo.GetNodeLabels(ctx)
-			if e != nil {
-				err = e
-			}
-
-			if len(nodeLabels) > 0 {
-				tags = append(tags, extractTags(nodeLabels, labelsToTags)...)
-			}
-		}
-	}
+	tags = appendNodeInfoTags(ctx, tags)
 
 	annotationsToTags := getAnnotationsToTags()
-
 	if len(annotationsToTags) > 0 {
 		nodeAnnotations, e := GetNodeAnnotations(ctx)
 		if e != nil {
@@ -54,6 +32,34 @@ func GetTags(ctx context.Context) (tags []string, err error) {
 	}
 
 	return
+}
+
+func appendNodeInfoTags(ctx context.Context, tags []string) []string {
+	labelsToTags := getLabelsToTags()
+	nodeInfo, err := NewNodeInfo()
+	if err != nil {
+		log.Debugf("Unable to auto discover node info tags: %s", err)
+		return tags
+	}
+
+	nodeName, e := nodeInfo.GetNodeName(ctx)
+	if e == nil && nodeName != "" {
+		tags = append(tags, "kube_node:"+nodeName)
+	}
+
+	if len(labelsToTags) > 0 && err == nil {
+		var nodeLabels map[string]string
+		nodeLabels, e = nodeInfo.GetNodeLabels(ctx)
+		if e != nil {
+			err = e
+		}
+
+		if len(nodeLabels) > 0 {
+			tags = append(tags, extractTags(nodeLabels, labelsToTags)...)
+		}
+	}
+
+	return tags
 }
 
 func getDefaultLabelsToTags() map[string]string {

--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -35,7 +35,6 @@ func GetTags(ctx context.Context) (tags []string, err error) {
 }
 
 func appendNodeInfoTags(ctx context.Context, tags []string) []string {
-	labelsToTags := getLabelsToTags()
 	nodeInfo, err := NewNodeInfo()
 	if err != nil {
 		log.Debugf("Unable to auto discover node info tags: %s", err)
@@ -47,7 +46,8 @@ func appendNodeInfoTags(ctx context.Context, tags []string) []string {
 		tags = append(tags, "kube_node:"+nodeName)
 	}
 
-	if len(labelsToTags) > 0 && err == nil {
+	labelsToTags := getLabelsToTags()
+	if len(labelsToTags) > 0 {
 		var nodeLabels map[string]string
 		nodeLabels, e = nodeInfo.GetNodeLabels(ctx)
 		if e != nil {

--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -23,21 +23,22 @@ func GetTags(ctx context.Context) (tags []string, err error) {
 	nodeInfo, e := NewNodeInfo()
 	if e != nil {
 		err = e
-	}
-	nodeName, e := nodeInfo.GetNodeName(ctx)
-	if e == nil && nodeName != "" {
-		tags = append(tags, "kube_node:"+nodeName)
-	}
-
-	if len(labelsToTags) > 0 && err == nil {
-		var nodeLabels map[string]string
-		nodeLabels, e = nodeInfo.GetNodeLabels(ctx)
-		if e != nil {
-			err = e
+	} else {
+		nodeName, e := nodeInfo.GetNodeName(ctx)
+		if e == nil && nodeName != "" {
+			tags = append(tags, "kube_node:"+nodeName)
 		}
 
-		if len(nodeLabels) > 0 {
-			tags = append(tags, extractTags(nodeLabels, labelsToTags)...)
+		if len(labelsToTags) > 0 {
+			var nodeLabels map[string]string
+			nodeLabels, e = nodeInfo.GetNodeLabels(ctx)
+			if e != nil {
+				err = e
+			}
+
+			if len(nodeLabels) > 0 {
+				tags = append(tags, extractTags(nodeLabels, labelsToTags)...)
+			}
 		}
 	}
 

--- a/pkg/util/kubernetes/hostinfo/tags.go
+++ b/pkg/util/kubernetes/hostinfo/tags.go
@@ -41,20 +41,16 @@ func appendNodeInfoTags(ctx context.Context, tags []string) []string {
 		return tags
 	}
 
-	nodeName, e := nodeInfo.GetNodeName(ctx)
-	if e == nil && nodeName != "" {
+	nodeName, err := nodeInfo.GetNodeName(ctx)
+	if err == nil && nodeName != "" {
 		tags = append(tags, "kube_node:"+nodeName)
 	}
 
 	labelsToTags := getLabelsToTags()
 	if len(labelsToTags) > 0 {
 		var nodeLabels map[string]string
-		nodeLabels, e = nodeInfo.GetNodeLabels(ctx)
-		if e != nil {
-			err = e
-		}
-
-		if len(nodeLabels) > 0 {
+		nodeLabels, err = nodeInfo.GetNodeLabels(ctx)
+		if err == nil && len(nodeLabels) > 0 {
 			tags = append(tags, extractTags(nodeLabels, labelsToTags)...)
 		}
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix a possible NPE introduced by https://github.com/DataDog/datadog-agent/pull/17982 it can happen if the nodeinfo client is not created properly, calls to nodeinfo should only be made if it's initialized properly

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
