### PR TITLE
[process-agent][language-detection] Add Ruby CLI parsing support

### DIFF
--- a/pkg/languagedetection/detector.go
+++ b/pkg/languagedetection/detector.go
@@ -39,6 +39,14 @@ var exactMatches = map[string]languageFromCLI{
 	"node": {name: languagemodels.Node},
 
 	"dotnet": {name: languagemodels.Dotnet},
+
+	"rails":   {name: languagemodels.Ruby},
+	"ruby":    {name: languagemodels.Ruby},
+	"rubyw":   {name: languagemodels.Ruby},
+	"sidekiq": {name: languagemodels.Ruby},
+	"irb":     {name: languagemodels.Ruby},
+	"puma":    {name: languagemodels.Ruby},
+	"puma:":   {name: languagemodels.Ruby},
 }
 
 func languageNameFromCommandLine(cmdline []string) languagemodels.LanguageName {

--- a/pkg/languagedetection/detector_nix_test.go
+++ b/pkg/languagedetection/detector_nix_test.go
@@ -86,24 +86,29 @@ func TestLanguageFromCommandline(t *testing.T) {
 			expected: languagemodels.Dotnet,
 		},
 		{
-			name:    "rails",
-			cmdline: []string{"ruby", "bin/rails", "asdf"},
+			name:     "rails",
+			cmdline:  []string{"bin/rails", "asdf"},
+			expected: languagemodels.Ruby,
 		},
 		{
-			name:    "ruby",
-			cmdline: []string{"ruby", "myapp.rb"},
+			name:     "ruby",
+			cmdline:  []string{"ruby", "myapp.rb"},
+			expected: languagemodels.Ruby,
 		},
 		{
-			name:    "rubyw",
-			cmdline: []string{"rubyw", "myapp.rb"},
+			name:     "rubyw",
+			cmdline:  []string{"rubyw", "myapp.rb"},
+			expected: languagemodels.Ruby,
 		},
 		{
-			name:    "ruby interactive shell",
-			cmdline: []string{"irb"},
+			name:     "ruby interactive shell",
+			cmdline:  []string{"irb"},
+			expected: languagemodels.Ruby,
 		},
 		{
-			name:    "sidekiq",
-			cmdline: []string{"sidekiq"},
+			name:     "sidekiq",
+			cmdline:  []string{"sidekiq"},
+			expected: languagemodels.Ruby,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/languagedetection/detector_nix_test.go
+++ b/pkg/languagedetection/detector_nix_test.go
@@ -85,6 +85,26 @@ func TestLanguageFromCommandline(t *testing.T) {
 			cmdline:  []string{"dotnet", "myApp"},
 			expected: languagemodels.Dotnet,
 		},
+		{
+			name:    "rails",
+			cmdline: []string{"ruby", "bin/rails", "asdf"},
+		},
+		{
+			name:    "ruby",
+			cmdline: []string{"ruby", "myapp.rb"},
+		},
+		{
+			name:    "rubyw",
+			cmdline: []string{"rubyw", "myapp.rb"},
+		},
+		{
+			name:    "ruby interactive shell",
+			cmdline: []string{"irb"},
+		},
+		{
+			name:    "sidekiq",
+			cmdline: []string{"sidekiq"},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expected, languageNameFromCommandLine(tc.cmdline))

--- a/pkg/languagedetection/detector_nix_test.go
+++ b/pkg/languagedetection/detector_nix_test.go
@@ -110,6 +110,16 @@ func TestLanguageFromCommandline(t *testing.T) {
 			cmdline:  []string{"sidekiq"},
 			expected: languagemodels.Ruby,
 		},
+		{
+			name:     "not ruby",
+			cmdline:  []string{"rubywow!"},
+			expected: languagemodels.Unknown,
+		},
+		{
+			name:     "not puma",
+			cmdline:  []string{"pumascript"},
+			expected: languagemodels.Unknown,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expected, languageNameFromCommandLine(tc.cmdline))

--- a/pkg/languagedetection/languagemodels/types.go
+++ b/pkg/languagedetection/languagemodels/types.go
@@ -13,6 +13,7 @@ const (
 	Dotnet  LanguageName = "dotnet"
 	Python  LanguageName = "python"
 	Java    LanguageName = "java"
+	Ruby    LanguageName = "ruby"
 	Unknown LanguageName = ""
 )
 

--- a/pkg/process/metadata/workloadmeta/releasenotes/notes/add-ruby-support-b3d44210b8e99961.yaml
+++ b/pkg/process/metadata/workloadmeta/releasenotes/notes/add-ruby-support-b3d44210b8e99961.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Add support for detecting ruby processes via commandline.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
This PR adds the `Ruby` language to `pkg/langaugedetection/languagemodels`, and adds support for the following exact matches (which all match to ruby):
- `rails`
- `ruby`
- `rubyw`
- `sidekiq`
- `irb`
- `puma`
- `puma:`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Support for detecting ruby programs

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
```yaml
api_key: <secret>
process_config:
  process_collection: {enabled: true}
  language_detection: {enabled: true}
workloadmeta:
  remote_process_collector: {enabled: true}
```
Using the above config:
1. Run the agent
2. Run a long running ruby program using one of the above matches
3. Wait 20 seconds and ensure that ruby is detected and exposed in `agent workload-list`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
