### PR TITLE
Offering: changes required for macOS agent builds on Apple Silicon

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -2,11 +2,14 @@ source 'https://rubygems.org'
 
 # Install omnibus
 gem 'chef-sugar', git: 'https://github.com/chef/chef-sugar.git', tag: 'v3.6.0'
-gem 'omnibus', git: 'https://github.com/DataDog/omnibus-ruby.git', branch: (ENV['OMNIBUS_RUBY_VERSION'] || 'datadog-5.5.0')
 
+# from tip of https://github.com/timsutton/omnibus-ruby/tree/tsutton/datadog-5.5.0-apple-silicon
+gem 'omnibus', git: 'https://github.com/timsutton/omnibus-ruby.git', ref: 'fd30852b5774db318372e146806a5d08d0211d90'
 # Use Chef's software definitions. It is recommended that you write your own
 # software definitions, but you can clone/fork Chef's to get you started.
-gem 'omnibus-software', git: 'https://github.com/DataDog/omnibus-software.git', branch: (ENV['OMNIBUS_SOFTWARE_VERSION'] || 'master')
+
+# from tip of https://github.com/timsutton/omnibus-software/tree/apple-silicon
+gem 'omnibus-software', git: 'https://github.com/timsutton/omnibus-software.git', ref: 'b36fcb54d16f1a9e8f17387548a42c3b0ef6904e'
 
 
 gem 'mixlib-cli', '~> 1.7.0'

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -12,7 +12,7 @@ dependency 'datadog-agent'
 dependency 'pip2'
 
 
-if arm?
+if arm? && !osx?
   # psycopg2 doesn't come with pre-built wheel on the arm architecture.
   # to compile from source, it requires the `pg_config` executable present on the $PATH
   dependency 'postgresql'

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -15,7 +15,7 @@ dependency 'setuptools3'
 dependency 'snowflake-connector-python-py3'
 dependency 'confluent-kafka-python'
 
-if arm?
+if arm? && !osx?
   # psycopg2 doesn't come with pre-built wheel on the arm architecture.
   # to compile from source, it requires the `pg_config` executable present on the $PATH
   dependency 'postgresql'

--- a/omnibus/config/software/datadog-agent-mac-app.rb
+++ b/omnibus/config/software/datadog-agent-mac-app.rb
@@ -20,7 +20,7 @@ build do
 
     # Add swift runtime libs in Frameworks (same thing a full xcode build would do for a GUI app).
     # They are needed for the gui to run on MacOS 10.14.3 and lower
-    command "$(xcrun --find swift-stdlib-tool) --copy --scan-executable \"#{app_temp_dir}/MacOS/gui\" --scan-folder \"#{app_temp_dir}/Frameworks\" --platform macosx --destination \"#{app_temp_dir}/Frameworks\" --strip-bitcode --strip-bitcode-tool $(xcrun --find bitcode_strip)"
+    command "$(xcrun --find swift-stdlib-tool) --copy --scan-executable \"#{app_temp_dir}/MacOS/gui\" --scan-folder \"#{app_temp_dir}/Frameworks\" --platform macosx --destination \"#{app_temp_dir}/Frameworks\" --strip-bitcode"
 
     block do # defer in a block to allow getting the project's build version
       erb source: "Info.plist.erb",

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -259,7 +259,7 @@ build do
     systray_build_dir = "#{project_dir}/cmd/agent/gui/systray"
     # Target OSX 10.10 (it brings significant changes to Cocoa and Foundation APIs, and older versions of OSX are EOL'ed)
     # Add @executable_path/../Frameworks to rpath to find the swift libs in the Frameworks folder.
-    command 'swiftc -O -swift-version "5" -target "x86_64-apple-macosx10.10" -Xlinker \'-rpath\' -Xlinker \'@executable_path/../Frameworks\' Sources/*.swift -o gui', cwd: systray_build_dir
+    command 'swiftc -O -swift-version "5" -target "arm64-apple-macos11" -Xlinker \'-rpath\' -Xlinker \'@executable_path/../Frameworks\' Sources/*.swift -o gui', cwd: systray_build_dir
     copy "#{systray_build_dir}/gui", "#{app_temp_dir}/MacOS/"
     copy "#{systray_build_dir}/agent.png", "#{app_temp_dir}/MacOS/"
   end


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR is a demonstration of changes I needed to make in order to perform a full agent build on Apple Silicon, including a couple changes in Datadog's forks of omnibus and omnibus-software. Many of the changes are explicit overrides to use arm arch over x86_64, so those should all be considered as hacks and not intended to actually merge. I have been just hacking at trying to get something that builds end to end and installs + runs on a machine without Rosetta.

The high-level summary:

* pull in a current libffi dependency
* replace x86_64 with arm build target on the DD Mac App and openssl3 dependencies
* skip including some extra dependencies that ended up building and shipping pgadmin/pg tools, lxml etc. when it wasn't needed
* tell omnibus to ignore git-fsmonitor stuff from .git (a quick hack, not related to Apple Silicon but just due to newer git tooling – I didn't check omnibus upstream for this)
* hack to include the proper architectures in the Distribution XML ERB used in omnibus resources (best would be if we could directly use https://github.com/chef/omnibus/pull/1005 but it relies on some other methods we didn't have in the DD fork)
* as a bonus, remove a `swift-stdlib-tool` flag that seems to have been removed in Xcode 14.3, so that current Xcode versions can be used to build this

### Motivation

At my dayjob I work for a large customer of DataDog. We've opened a feature req (via a support ticket) but so far it's been hinted that this is probably not coming up around the corner. We run a fairly large Mac build cluster that is very performance-sensitive and currently this agent is the only reason we need to install Rosetta2. 

### Additional Notes

I am _definitely_ not aiming to get these changes landed in exactly their current form. I just wanted to present these changes as something for y'all to use if you haven't done this work internally already. I'm also happy to work with folks on making some of these changes more backwards-compatible. However they do also still require changes in the omnibus/omnibus-software forks as well.

I don't think there's value in trying to compile all these dependencies as Universal, btw. The python stuff gets annoying, go doesn't provide an out-of-the-box way to do it and it would make the package extremely large. I'd assume that when you folks are building Apple Silicon packages that you'd be building packages which aren't dual-architecture.

I also realize that you maybe don't have Apple Silicon machines available for CI. My goal here is to first just get the support landed into the main branches, and leave that part up to you :). In doing this work I'm now confident that I'm able to build these independently out of tagged branches.


### Possible Drawbacks / Trade-offs

This branch can only be used to build an arm64 darwin pkg, x86_64 code won't work.

### Describe how to test/QA your changes

I took an empty Ventura (macOS 13) VM with:
* brew + python@3.9 + ruby-installed a Ruby 2.7
* Xcode 14.3.1
* [this build script](https://github.com/DataDog/datadog-agent/commit/1090a2a66c9ada0d570b1368d69d424aef7c47d4), which I mostly assembled from trial-and-error and from what I gleaned from the scripts in https://github.com/DataDog/datadog-agent-macos-build. I didn't actually use any of the forked brew formulae from [here](https://github.com/DataDog/homebrew-datadog-agent-macos-build), to avoid needing to rebuild more things from scratch.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
