### PR TITLE
usm: http: Allow disable http monitoring

### DIFF
--- a/cmd/system-probe/config/adjust_usm.go
+++ b/cmd/system-probe/config/adjust_usm.go
@@ -17,6 +17,13 @@ const (
 )
 
 func adjustUSM(cfg config.Config) {
+	if cfg.GetBool(smNS("enabled")) {
+		applyDefault(cfg, netNS("enable_http_monitoring"), true)
+		applyDefault(cfg, netNS("enable_https_monitoring"), true)
+		applyDefault(cfg, spNS("enable_runtime_compiler"), true)
+		applyDefault(cfg, spNS("enable_kernel_header_download"), true)
+	}
+
 	deprecateBool(cfg, netNS("enable_http_monitoring"), smNS("enable_http_monitoring"))
 	deprecateGeneric(cfg, netNS("http_replace_rules"), smNS("http_replace_rules"))
 	deprecateInt64(cfg, netNS("max_tracked_http_connections"), smNS("max_tracked_http_connections"))
@@ -35,14 +42,6 @@ func adjustUSM(cfg config.Config) {
 	if cfg.GetBool(dsmNS("enabled")) {
 		// DSM infers USM
 		cfg.Set(smNS("enabled"), true)
-	}
-
-	if cfg.GetBool(smNS("enabled")) {
-		// USM infers HTTP
-		cfg.Set(smNS("enable_http_monitoring"), true)
-		applyDefault(cfg, netNS("enable_https_monitoring"), true)
-		applyDefault(cfg, spNS("enable_runtime_compiler"), true)
-		applyDefault(cfg, spNS("enable_kernel_header_download"), true)
 	}
 
 	if cfg.GetBool(smNS("process_service_inference", "enabled")) &&


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Allowing overriding the enable_http_monitoring value by the customer

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fix a bug from before, we're setting the default (old) configuration value to true,
and then allowing overriding the value by setting `service_monitoring_config.enable_http_monitoring`

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
