### PR TITLE
usm: process monitor: Simplify API

### DIFF
--- a/pkg/network/usm/ebpf_javatls.go
+++ b/pkg/network/usm/ebpf_javatls.go
@@ -309,22 +309,7 @@ func newJavaProcess(pid int) {
 }
 
 func (p *JavaTLSProgram) Start() {
-	var err error
-	defer func() {
-		if err == nil {
-			return
-		}
-		// In case of an error, we should cleanup the callbacks.
-		if p.cleanupExec != nil {
-			p.cleanupExec()
-		}
-	}()
-
-	p.cleanupExec, err = p.processMonitor.SubscribeExec(newJavaProcess)
-	if err != nil {
-		log.Errorf("process monitor Subscribe() error: %s", err)
-		return
-	}
+	p.cleanupExec = p.processMonitor.SubscribeExec(newJavaProcess)
 }
 
 func (p *JavaTLSProgram) Stop() {

--- a/pkg/network/usm/shared_libraries.go
+++ b/pkg/network/usm/shared_libraries.go
@@ -309,11 +309,7 @@ func (w *soWatcher) Start() {
 		return nil
 	})
 
-	cleanupExit, err := w.processMonitor.SubscribeExit(w.registry.unregister)
-	if err != nil {
-		log.Errorf("can't subscribe to process monitor exit event %s", err)
-		return
-	}
+	cleanupExit := w.processMonitor.SubscribeExit(w.registry.unregister)
 
 	w.wg.Add(1)
 	go func() {

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -281,7 +281,7 @@ func (pm *ProcessMonitor) Initialize() error {
 //
 // A callback can be registered only once, callback with a filter type (not ANY) must be registered before the matching
 // Exit callback.
-func (pm *ProcessMonitor) SubscribeExec(callback ProcessCallback) (func(), error) {
+func (pm *ProcessMonitor) SubscribeExec(callback ProcessCallback) func() {
 	pm.processExecCallbacksMutex.Lock()
 	pm.hasExecCallbacks.Store(true)
 	pm.processExecCallbacks[&callback] = struct{}{}
@@ -293,11 +293,11 @@ func (pm *ProcessMonitor) SubscribeExec(callback ProcessCallback) (func(), error
 		delete(pm.processExecCallbacks, &callback)
 		pm.hasExecCallbacks.Store(len(pm.processExecCallbacks) > 0)
 		pm.processExecCallbacksMutex.Unlock()
-	}, nil
+	}
 }
 
 // SubscribeExit register an exit callback and returns unsubscribe function callback that removes the callback.
-func (pm *ProcessMonitor) SubscribeExit(callback ProcessCallback) (func(), error) {
+func (pm *ProcessMonitor) SubscribeExit(callback ProcessCallback) func() {
 	pm.processExitCallbacksMutex.Lock()
 	pm.hasExitCallbacks.Store(true)
 	pm.processExitCallbacks[&callback] = struct{}{}
@@ -309,7 +309,7 @@ func (pm *ProcessMonitor) SubscribeExit(callback ProcessCallback) (func(), error
 		delete(pm.processExitCallbacks, &callback)
 		pm.hasExitCallbacks.Store(len(pm.processExitCallbacks) > 0)
 		pm.processExitCallbacksMutex.Unlock()
-	}, nil
+	}
 }
 
 // Stop decreasing the refcount, and if we reach 0 we terminate the main event loop.

--- a/pkg/process/monitor/process_monitor_test.go
+++ b/pkg/process/monitor/process_monitor_test.go
@@ -38,8 +38,7 @@ func registerCallback(t *testing.T, pm *ProcessMonitor, isExec bool, callback *P
 	if isExec {
 		registrationFunc = pm.SubscribeExec
 	}
-	unsubscribe, err := registrationFunc(*callback)
-	require.NoError(t, err)
+	unsubscribe := registrationFunc(*callback)
 	t.Cleanup(unsubscribe)
 	return unsubscribe
 }


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Simplifies process monitor registration functions to return only the cleanup functions, and drop the always `nil` error

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We used to return error code from exec and exit callbacks registration, while we never return an error. In such cases we needed to handle the theoretical use cases of regsitration failure, but the never could have happen. Now, we unregister the callbacks only during termination of the modules.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
