### PR TITLE
[RCM-1130] No error log before the first successful attempt

### DIFF
--- a/comp/remote-config/rcclient/rcclient.go
+++ b/comp/remote-config/rcclient/rcclient.go
@@ -71,7 +71,7 @@ func newRemoteConfigClient(deps dependencies) (Component, error) {
 // Listen start the remote config client to listen to AGENT_TASK configurations
 func (rc rcClient) Listen(clientName string, products []data.Product) error {
 	c, err := remote.NewUnverifiedGRPCClient(
-		clientName, version.AgentVersion, products, 1*time.Second,
+		clientName, version.AgentVersion, products, 5*time.Second,
 	)
 	if err != nil {
 		return err

--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -251,7 +251,7 @@ func (c *Client) startFn() {
 // pollLoop should never be called manually and only be called via the client's `sync.Once`
 // structure in startFn.
 func (c *Client) pollLoop() {
-	firstRun := true
+	succcessfulFirstRun := false
 	for {
 		interval := c.backoffPolicy.GetBackoffDuration(c.backoffErrorCount)
 		select {
@@ -260,10 +260,10 @@ func (c *Client) pollLoop() {
 		case <-time.After(c.pollInterval + interval):
 			err := c.update()
 			if err != nil {
-				if firstRun {
+				if !succcessfulFirstRun {
 					// As some clients may start before the core-agent server is up, we log the first error
 					// as a debug log as the race is expected. If the error persists, we log with error logs
-					log.Debugf("retrying update of remote-config state after cold start (%v)", err)
+					log.Infof("retrying the first update of remote-config state (%v)", err)
 				} else {
 					c.lastUpdateError = err
 					c.backoffPolicy.IncError(c.backoffErrorCount)
@@ -271,10 +271,10 @@ func (c *Client) pollLoop() {
 				}
 			} else {
 				c.lastUpdateError = nil
+				succcessfulFirstRun = true
 				c.backoffPolicy.DecError(c.backoffErrorCount)
 			}
 		}
-		firstRun = false
 	}
 }
 

--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -251,7 +251,7 @@ func (c *Client) startFn() {
 // pollLoop should never be called manually and only be called via the client's `sync.Once`
 // structure in startFn.
 func (c *Client) pollLoop() {
-	succcessfulFirstRun := false
+	successfulFirstRun := false
 	for {
 		interval := c.backoffPolicy.GetBackoffDuration(c.backoffErrorCount)
 		select {
@@ -260,7 +260,7 @@ func (c *Client) pollLoop() {
 		case <-time.After(c.pollInterval + interval):
 			err := c.update()
 			if err != nil {
-				if !succcessfulFirstRun {
+				if !successfulFirstRun {
 					// As some clients may start before the core-agent server is up, we log the first error
 					// as a debug log as the race is expected. If the error persists, we log with error logs
 					log.Infof("retrying the first update of remote-config state (%v)", err)
@@ -271,7 +271,7 @@ func (c *Client) pollLoop() {
 				}
 			} else {
 				c.lastUpdateError = nil
-				succcessfulFirstRun = true
+				successfulFirstRun = true
 				c.backoffPolicy.DecError(c.backoffErrorCount)
 			}
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Reduce log noise by showing only info logs if there was no previous successful attempt.
We don't need error logs on the first few attempts.

If RC is not available, there will be one info log every 90sec.

QA of RCM-1128

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
