### PR TITLE
[clusteragent/clusterchecks] Delete unnecessary returned err

### DIFF
--- a/cmd/cluster-agent/api/v1/clusterchecks.go
+++ b/cmd/cluster-agent/api/v1/clusterchecks.go
@@ -59,12 +59,7 @@ func postCheckStatus(sc clusteragent.ServerContext) func(w http.ResponseWriter, 
 			return
 		}
 
-		response, err := sc.ClusterCheckHandler.PostStatus(identifier, clientIP, status)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
+		response := sc.ClusterCheckHandler.PostStatus(identifier, clientIP, status)
 		writeJSONResponse(w, response)
 	}
 }

--- a/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
@@ -39,7 +39,7 @@ func (d *dispatcher) getClusterCheckConfigs(nodeName string) ([]integration.Conf
 
 // processNodeStatus keeps the node's status in the store, and returns true
 // if the last configuration change matches the one sent by the node agent.
-func (d *dispatcher) processNodeStatus(nodeName, clientIP string, status types.NodeStatus) (bool, error) {
+func (d *dispatcher) processNodeStatus(nodeName, clientIP string, status types.NodeStatus) bool {
 	var warmingUp bool
 
 	d.store.Lock()
@@ -54,24 +54,24 @@ func (d *dispatcher) processNodeStatus(nodeName, clientIP string, status types.N
 	node.heartbeat = timestampNow()
 	// When we receive ExtraHeartbeatLastChangeValue, we only update heartbeat
 	if status.LastChange == types.ExtraHeartbeatLastChangeValue {
-		return true, nil
+		return true
 	}
 
 	if node.lastConfigChange == status.LastChange {
 		// Node-agent is up to date
-		return true, nil
+		return true
 	}
 	if warmingUp {
 		// During the initial warmup phase, we are counting active nodes
 		// without dispatching configurations.
 		// We tell node-agents they are up to date to keep their cached
 		// configurations running while we finish the warmup phase.
-		return true, nil
+		return true
 	}
 
 	// Node-agent needs to pull updated configs
 	log.Infof("Node %s needs to poll config, cluster config version: %d, node config version: %d", nodeName, node.lastConfigChange, status.LastChange)
-	return false, nil
+	return false
 }
 
 // getLeastBusyNode returns the name of the node that is assigned

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -195,8 +195,7 @@ func TestProcessNodeStatus(t *testing.T) {
 	status1 := types.NodeStatus{LastChange: 10}
 
 	// Warmup phase, upToDate is unconditionally true
-	upToDate, err := dispatcher.processNodeStatus("node1", "10.0.0.1", status1)
-	assert.NoError(t, err)
+	upToDate := dispatcher.processNodeStatus("node1", "10.0.0.1", status1)
 	assert.True(t, upToDate)
 	node1, found := dispatcher.store.getNodeStore("node1")
 	assert.True(t, found)
@@ -205,29 +204,25 @@ func TestProcessNodeStatus(t *testing.T) {
 
 	// Warmup is finished, timestamps differ
 	dispatcher.store.active = true
-	upToDate, err = dispatcher.processNodeStatus("node1", "10.0.0.1", status1)
-	assert.NoError(t, err)
+	upToDate = dispatcher.processNodeStatus("node1", "10.0.0.1", status1)
 	assert.False(t, upToDate)
 
 	// Give changes
 	node1.lastConfigChange = timestampNowNano()
 	node1.heartbeat = node1.heartbeat - 50
 	status2 := types.NodeStatus{LastChange: node1.lastConfigChange - 2}
-	upToDate, err = dispatcher.processNodeStatus("node1", "10.0.0.1", status2)
-	assert.NoError(t, err)
+	upToDate = dispatcher.processNodeStatus("node1", "10.0.0.1", status2)
 	assert.False(t, upToDate)
 	assert.True(t, timestampNow() >= node1.heartbeat)
 	assert.True(t, timestampNow() <= node1.heartbeat+1)
 
 	// No change
 	status3 := types.NodeStatus{LastChange: node1.lastConfigChange}
-	upToDate, err = dispatcher.processNodeStatus("node1", "10.0.0.1", status3)
-	assert.NoError(t, err)
+	upToDate = dispatcher.processNodeStatus("node1", "10.0.0.1", status3)
 	assert.True(t, upToDate)
 
 	// Change clientIP
-	upToDate, err = dispatcher.processNodeStatus("node1", "10.0.0.2", status3)
-	assert.NoError(t, err)
+	upToDate = dispatcher.processNodeStatus("node1", "10.0.0.2", status3)
 	assert.True(t, upToDate)
 	node1, found = dispatcher.store.getNodeStore("node1")
 	assert.True(t, found)
@@ -596,10 +591,8 @@ func TestUpdateRunnersStats(t *testing.T) {
 		},
 	}
 
-	_, err := dispatcher.processNodeStatus("node1", "10.0.0.1", status)
-	assert.NoError(t, err)
-	_, err = dispatcher.processNodeStatus("node2", "10.0.0.2", status)
-	assert.NoError(t, err)
+	_ = dispatcher.processNodeStatus("node1", "10.0.0.1", status)
+	_ = dispatcher.processNodeStatus("node2", "10.0.0.2", status)
 
 	node1, found := dispatcher.store.getNodeStore("node1")
 	assert.True(t, found)
@@ -624,10 +617,8 @@ func TestUpdateRunnersStats(t *testing.T) {
 	assert.EqualValues(t, stats2, node2.clcRunnerStats)
 
 	// Switch node1 and node2 stats
-	_, err = dispatcher.processNodeStatus("node2", "10.0.0.1", status)
-	assert.NoError(t, err)
-	_, err = dispatcher.processNodeStatus("node1", "10.0.0.2", status)
-	assert.NoError(t, err)
+	_ = dispatcher.processNodeStatus("node2", "10.0.0.1", status)
+	_ = dispatcher.processNodeStatus("node1", "10.0.0.2", status)
 
 	dispatcher.updateRunnersStats()
 

--- a/pkg/clusteragent/clusterchecks/handler_api.go
+++ b/pkg/clusteragent/clusterchecks/handler_api.go
@@ -69,12 +69,12 @@ func (h *Handler) GetConfigs(identifier string) (types.ConfigResponse, error) {
 }
 
 // PostStatus handles status reports from the node agents
-func (h *Handler) PostStatus(identifier, clientIP string, status types.NodeStatus) (types.StatusResponse, error) {
-	upToDate, err := h.dispatcher.processNodeStatus(identifier, clientIP, status)
+func (h *Handler) PostStatus(identifier, clientIP string, status types.NodeStatus) types.StatusResponse {
+	upToDate := h.dispatcher.processNodeStatus(identifier, clientIP, status)
 	response := types.StatusResponse{
 		IsUpToDate: upToDate,
 	}
-	return response, err
+	return response
 }
 
 // GetEndpointsConfigs returns endpoints configurations dispatched to a given node

--- a/pkg/clusteragent/clusterchecks/handler_test.go
+++ b/pkg/clusteragent/clusterchecks/handler_test.go
@@ -218,8 +218,8 @@ func TestHandlerRun(t *testing.T) {
 	ac.On("AddScheduler", schedulerName, mock.AnythingOfType("*clusterchecks.dispatcher"), true).Return()
 	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 1*time.Second, func() bool {
 		// Keep node-agent caches even when timestamp is off (warmup)
-		response, err := h.PostStatus("dummy", "10.0.0.1", types.NodeStatus{LastChange: -50})
-		return err == nil && response.IsUpToDate == true
+		response := h.PostStatus("dummy", "10.0.0.1", types.NodeStatus{LastChange: -50})
+		return response.IsUpToDate == true
 	})
 	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 2*time.Second, func() bool {
 		// Test whether we're connected to the AD
@@ -239,8 +239,8 @@ func TestHandlerRun(t *testing.T) {
 	})
 	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 1*time.Second, func() bool {
 		// Flush node-agent caches when timestamp is off
-		response, err := h.PostStatus("dummy", "10.0.0.1", types.NodeStatus{LastChange: -50})
-		return err == nil && response.IsUpToDate == false
+		response := h.PostStatus("dummy", "10.0.0.1", types.NodeStatus{LastChange: -50})
+		return response.IsUpToDate == false
 	})
 
 	//


### PR DESCRIPTION

### What does this PR do?

Small cleanup.

Removes the error returned in the signature of `processNodeStatus` in `pkg/clusteragent/clusterchecks/dispatcher_nodes.go` because it never produces an error.


### Describe how to test/QA your changes

Skip.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
