### PR TITLE
[usm] Use `HashMap` for `http_in_flight`

### DIFF
--- a/pkg/network/ebpf/c/protocols/http/maps.h
+++ b/pkg/network/ebpf/c/protocols/http/maps.h
@@ -9,7 +9,7 @@
 #include "protocols/tls/sowatcher-types.h"
 
 /* This map is used to keep track of in-flight HTTP transactions for each TCP connection */
-BPF_LRU_MAP(http_in_flight, conn_tuple_t, http_transaction_t, 0)
+BPF_HASH_MAP(http_in_flight, conn_tuple_t, http_transaction_t, 0)
 
 BPF_LRU_MAP(ssl_sock_by_ctx, void *, ssl_sock_t, 1)
 

--- a/pkg/network/usm/shared_libraries_test.go
+++ b/pkg/network/usm/shared_libraries_test.go
@@ -620,7 +620,7 @@ func initEBPFProgram(t *testing.T) *ddebpf.PerfHandler {
 				EditorFlag: manager.EditMaxEntries,
 			},
 			"http_in_flight": {
-				Type:       ebpf.LRUHash,
+				Type:       ebpf.Hash,
 				MaxEntries: 1,
 				EditorFlag: manager.EditMaxEntries,
 			},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Change `http_in_flight` map type from LRU to a HashMap.

### Motivation

We've noticed that in some our internal nodes processing a high number of requests per second (~50k requests/s) were being negatively affected by CPU contention coming from the LRU map operations as shown in the stack trace below:

```
[Tue Jul 11 11:30:05 2023] watchdog: BUG: soft lockup - CPU#18 stuck for 22s! [haproxy:1142770]
[Tue Jul 11 11:30:05 2023]  bpf_lru_push_free+0x76/0x170
[Tue Jul 11 11:30:05 2023]  htab_lru_map_delete_elem+0x102/0x150
[Tue Jul 11 11:30:05 2023]  bpf_prog_9bb65ffee9be4970_socket__http_filter+0x1936/0x1c88
[Tue Jul 11 11:30:05 2023]  packet_rcv+0xf1/0x4b0
task ctx
[Tue Jul 11 11:30:05 2023]  bpf_common_lru_pop_free+0x2f3/0x360
[Tue Jul 11 11:30:05 2023]  bpf_lru_pop_free+0xf1/0x140
[Tue Jul 11 11:30:05 2023]  prealloc_lru_pop+0x25/0x50
[Tue Jul 11 11:30:05 2023]  htab_lru_map_update_elem+0x6c/0x2f0
[Tue Jul 11 11:30:05 2023]  ? lookup_nulls_elem_raw+0x59/0x80
[Tue Jul 11 11:30:05 2023]  bpf_prog_38e0b082286d7897_uretprobe__SSL_write+0x286f/0x3eac
```

This was ultimately causing a ena driver reset and putting the node on a bad state:
```
"ens5: The number of lost tx completions is above the threshold"
```

At first we assumed that this could be an artifact of a high LRU eviction rate, but then we realized that we don't ever even get close to an eviction scenario since this map never reaches capacity as entries get explicitly deleted by our program during TCP terminations.

Given that we're not benefiting from the use of the LRU map type in any way and that we're paying for its perf penalty, we decided to replace it by a plain HashMap.

Since its deployment we haven't seen any issues and kernel CPU usage looks much more stable:
![sys_cpu](https://github.com/DataDog/datadog-agent/assets/692520/70d1b7e6-2d80-40e6-ba7c-f4d07b73a044)



### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
