### PR TITLE
[Do not merge] Use redis cache for SBOM collection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -362,7 +362,7 @@ require (
 	github.com/go-openapi/strfmt v0.21.7 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/go-openapi/validate v0.22.1 // indirect
-	github.com/go-redis/redis/v8 v8.11.5 // indirect
+	github.com/go-redis/redis/v8 v8.11.5
 	github.com/go-test/deep v1.0.7 // indirect
 	github.com/godbus/dbus/v5 v5.0.6 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1123,7 +1123,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("sbom.cache.clean_interval", "30m")        // used by custom cache.
 
 	// Container SBOM configuration
-	config.BindEnvAndSetDefault("sbom.svc.tainer_image.enabled", false)
+	config.BindEnvAndSetDefault("sbom.container_image.enabled", false)
 	config.BindEnvAndSetDefault("sbom.container_image.use_mount", false)
 	config.BindEnvAndSetDefault("sbom.container_image.scan_interval", 0)    // Integer seconds
 	config.BindEnvAndSetDefault("sbom.container_image.scan_timeout", 10*60) // Integer seconds

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1111,19 +1111,19 @@ func InitConfig(config Config) {
 
 	config.BindEnvAndSetDefault("sbom.cache_directory", filepath.Join(defaultRunPath, "sbom-agent"))
 	config.BindEnvAndSetDefault("sbom.clear_cache_on_exit", false)
+	config.BindEnvAndSetDefault("sbom.clear_cache_on_start", false)
 	config.BindEnvAndSetDefault("sbom.cache.enabled", false)
 	config.BindEnvAndSetDefault("sbom.cache.remote", false)
-	config.BindEnvAndSetDefault("sbom.cache.remote.ttl", "256h")  // used by redis cache.
-	config.BindEnvAndSetDefault("sbom.cache.remote.addr", "")     // used by redis cache.
-	config.BindEnvAndSetDefault("sbom.cache.remote.password", "") // used by redis cache.
-	config.BindEnvAndSetDefault("sbom.cache.remote.DB", "0")      // used by redis cache.
-
+	config.BindEnvAndSetDefault("sbom.cache.remote.ttl", "256h")           // used by redis cache.
+	config.BindEnvAndSetDefault("sbom.cache.remote.addr", "")              // used by redis cache.
+	config.BindEnvAndSetDefault("sbom.cache.remote.password", "")          // used by redis cache.
+	config.BindEnvAndSetDefault("sbom.cache.remote.DB", "0")               // used by redis cache.
 	config.BindEnvAndSetDefault("sbom.cache.max_disk_size", 1000*1000*100) // used by custom cache: max disk space used by cached objects. Not equal to max disk usage
 	config.BindEnvAndSetDefault("sbom.cache.max_cache_entries", 10000)     // used by custom cache keys stored in memory
 	config.BindEnvAndSetDefault("sbom.cache.clean_interval", "30m")        // used by custom cache.
 
 	// Container SBOM configuration
-	config.BindEnvAndSetDefault("sbom.container_image.enabled", false)
+	config.BindEnvAndSetDefault("sbom.svc.tainer_image.enabled", false)
 	config.BindEnvAndSetDefault("sbom.container_image.use_mount", false)
 	config.BindEnvAndSetDefault("sbom.container_image.scan_interval", 0)    // Integer seconds
 	config.BindEnvAndSetDefault("sbom.container_image.scan_timeout", 10*60) // Integer seconds

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1112,6 +1112,12 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("sbom.cache_directory", filepath.Join(defaultRunPath, "sbom-agent"))
 	config.BindEnvAndSetDefault("sbom.clear_cache_on_exit", false)
 	config.BindEnvAndSetDefault("sbom.cache.enabled", false)
+	config.BindEnvAndSetDefault("sbom.cache.remote", false)
+	config.BindEnvAndSetDefault("sbom.cache.remote.ttl", "256h")  // used by redis cache.
+	config.BindEnvAndSetDefault("sbom.cache.remote.addr", "")     // used by redis cache.
+	config.BindEnvAndSetDefault("sbom.cache.remote.password", "") // used by redis cache.
+	config.BindEnvAndSetDefault("sbom.cache.remote.DB", "0")      // used by redis cache.
+
 	config.BindEnvAndSetDefault("sbom.cache.max_disk_size", 1000*1000*100) // used by custom cache: max disk space used by cached objects. Not equal to max disk usage
 	config.BindEnvAndSetDefault("sbom.cache.max_cache_entries", 10000)     // used by custom cache keys stored in memory
 	config.BindEnvAndSetDefault("sbom.cache.clean_interval", "30m")        // used by custom cache.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1113,7 +1113,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("sbom.clear_cache_on_exit", false)
 	config.BindEnvAndSetDefault("sbom.clear_cache_on_start", false)
 	config.BindEnvAndSetDefault("sbom.cache.enabled", false)
-	config.BindEnvAndSetDefault("sbom.cache.remote", false)
+	config.BindEnvAndSetDefault("sbom.cache.remote.enabled", false)
 	config.BindEnvAndSetDefault("sbom.cache.remote.ttl", "256h")           // used by redis cache.
 	config.BindEnvAndSetDefault("sbom.cache.remote.addr", "")              // used by redis cache.
 	config.BindEnvAndSetDefault("sbom.cache.remote.password", "")          // used by redis cache.

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -66,6 +66,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault("sbom.cache_directory", filepath.Join(defaultRunPath, "sbom-sysprobe"))
 	cfg.BindEnvAndSetDefault("sbom.clear_cache_on_exit", false)
 	cfg.BindEnvAndSetDefault("sbom.cache.enabled", false)
+	cfg.BindEnvAndSetDefault("sbom.cache.remote", false)
 	cfg.BindEnvAndSetDefault("sbom.cache.max_disk_size", 1000*1000*100) // used by custom cache: max disk space used by cached objects. Not equal to max disk usage
 	cfg.BindEnvAndSetDefault("sbom.cache.max_cache_entries", 10000)     // used by custom cache keys stored in memory
 	cfg.BindEnvAndSetDefault("sbom.cache.clean_interval", "30m")        // used by custom cache.

--- a/pkg/config/viper_test.go
+++ b/pkg/config/viper_test.go
@@ -7,7 +7,6 @@ package config
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -190,41 +189,4 @@ test:
 	config.Set("yetanothertest_key", "value")
 	res = config.IsSectionSet("yetanothertest")
 	assert.Equal(t, false, res)
-}
-
-func TestMapUnserialize(t *testing.T) {
-	config := NewConfig("test", "DD", strings.NewReplacer(".", "_"))
-	type instance struct {
-		Metrics []interface{} `mapstructure:"metrics" yaml:"metrics,omitempty" json:"metrics,omitempty"`
-	}
-
-	type check struct {
-		Instances []*instance `mapstructure:"configurations" yaml:"configurations,omitempty" json:"configurations"`
-	}
-
-	transformer := func(in string) interface{} {
-		var promChecks []*check
-		if err := json.Unmarshal([]byte(in), &promChecks); err != nil {
-			panic(err)
-		}
-		return promChecks
-	}
-
-	config.BindEnv("prometheus_check")
-	config.SetConfigType("yaml")
-	config.SetEnvKeyTransformer("prometheus_check", transformer)
-	//jsonString := "[{\"metrics\":[{\"vertx_http_server_connections\":{\"type\":\"gauge\",\"name\":\"vertx_http_server_connections\"}},{\"instance_locks\":{\"type\":\"gauge\",\"name\":\"instance_locks\"}},{\"trigger_pipeline_invocation_seconds\":{\"type\":\"summary\",\"name\":\"trigger_pipeline_invocation_seconds\"}},{\"refresh_deployments_error_count\":{\"type\":\"gauge\",\"name\":\"refresh_deployments_error_count\"}},{\"trigger_use_limit_factor\":{\"type\":\"gauge\",\"name\":\"trigger_use_limit_factor\"}},{\"trigger_pipeline_deployed\":{\"type\":\"gauge\",\"name\":\"trigger_pipeline_deployed\"}}]},{\"metrics\":[{\"abc\":\"efg\"},{\"dcf\":\"pt\"}]}]"
-	//jsonString := "[{\"metrics\":[{\"vertx_http_server_connections\":{\"type\":\"gauge\",\"name\":\"vertx_http_server_connections\"}}]}]"
-	//jsonString := "[{\"metrics\":[{\"vertx_http_server_connections\":{\"type\":\"gauge\",\"name\":\"vertx_http_server_connections\"}},{\"instance_locks\":{\"type\":\"gauge\",\"name\":\"instance_locks\"}},{\"trigger_pipeline_invocation_seconds\":{\"type\":\"summary\",\"name\":\"trigger_pipeline_invocation_seconds\"}},{\"refresh_deployments_error_count\":{\"type\":\"gauge\",\"name\":\"refresh_deployments_error_count\"}},{\"trigger_use_limit_factor\":{\"type\":\"gauge\",\"name\":\"trigger_use_limit_factor\"}},{\"trigger_pipeline_deployed\":{\"type\":\"gauge\",\"name\":\"trigger_pipeline_deployed\"}}]},{\"metrics\":[{\"abc\":\"efg\"},{\"dcf\":\"pt\"},\"jt\"]}]"
-	//jsonString := "[{\"configurations\":[{\"metrics\":[{\"vertx_http_server_connections\":{\"type\":\"gauge\",\"name\":\"vertx_http_server_connections\"}},{\"instance_locks\":{\"type\":\"gauge\",\"name\":\"instance_locks\"}},{\"trigger_pipeline_invocation_seconds\":{\"type\":\"summary\",\"name\":\"trigger_pipeline_invocation_seconds\"}},{\"refresh_deployments_error_count\":{\"type\":\"gauge\",\"name\":\"refresh_deployments_error_count\"}},{\"trigger_use_limit_factor\":{\"type\":\"gauge\",\"name\":\"trigger_use_limit_factor\"}},{\"trigger_pipeline_deployed\":{\"type\":\"gauge\",\"name\":\"trigger_pipeline_deployed\"}}]},{\"metrics\":[{\"abc\":\"efg\"},{\"dcf\":\"pt\"},\"jt\"]}]}]"
-	jsonString := "[{\"configurations\":[{\"metrics\":[{\"vertx_http_server_connections\":{\"type\":\"gauge\",\"name\":\"vertx_http_server_connections\"}},{\"instance_locks\":{\"type\":\"gauge\",\"name\":\"instance_locks\"}},{\"trigger_pipeline_invocation_seconds\":{\"type\":\"summary\",\"name\":\"trigger_pipeline_invocation_seconds\"}},{\"refresh_deployments_error_count\":{\"type\":\"gauge\",\"name\":\"refresh_deployments_error_count\"}},{\"trigger_use_limit_factor\":{\"type\":\"gauge\",\"name\":\"trigger_use_limit_factor\"}},{\"trigger_pipeline_deployed\":{\"type\":\"gauge\",\"name\":\"trigger_pipeline_deployed\"}}]},{\"metrics\":[{\"abc\":\"efg\"},{\"dcf\":\"pt\"},\"jt\"]}]},{\"configurations\":[{\"metrics\":[{\"vertx_http_server_connections\":{\"type\":\"gauge\",\"name\":\"vertx_http_server_connections\"}},{\"instance_locks\":{\"type\":\"gauge\",\"name\":\"instance_locks\"}},{\"trigger_pipeline_invocation_seconds\":{\"type\":\"summary\",\"name\":\"trigger_pipeline_invocation_seconds\"}},{\"refresh_deployments_error_count\":{\"type\":\"gauge\",\"name\":\"refresh_deployments_error_count\"}},{\"trigger_use_limit_factor\":{\"type\":\"gauge\",\"name\":\"trigger_use_limit_factor\"}},{\"trigger_pipeline_deployed\":{\"type\":\"gauge\",\"name\":\"trigger_pipeline_deployed\"}}]},{\"metrics\":[{\"abc\":\"efg\"},{\"dcf\":\"pt\"},\"jt\"]}]}]"
-	t.Setenv("DD_PROMETHEUS_CHECK", jsonString)
-
-	var conf []*check
-	err := config.UnmarshalKey("prometheus_check", &conf)
-	assert.NoError(t, err)
-
-	_, err = json.Marshal(conf)
-	assert.NoError(t, err)
-
 }

--- a/pkg/sbom/telemetry/telemetry.go
+++ b/pkg/sbom/telemetry/telemetry.go
@@ -38,9 +38,19 @@ var (
 	SBOMGenerationDuration = telemetry.NewHistogramWithOpts(
 		subsystem,
 		"generation_duration",
-		[]string{"source", "type"},
+		[]string{"source", "scan_type"},
 		"SBOM generation duration (in seconds)",
 		[]float64{10, 30, 60, 120, 180, 240, 300, 360, 420, 480, 540, 600},
+		commonOpts,
+	)
+
+	// SBOMExportSize is the size of the archive written on disk
+	SBOMExportSize = telemetry.NewHistogramWithOpts(
+		subsystem,
+		"export_size",
+		[]string{"source", "scan_ref"},
+		"Size of the archive written on disk",
+		[]float64{10_000_000, 50_000_000, 100_000_000, 200_000_000, 400_000_000, 600_000_000, 800_000_000, 1_000_000_000, 1_500_000_000},
 		commonOpts,
 	)
 

--- a/pkg/util/trivy/cache.go
+++ b/pkg/util/trivy/cache.go
@@ -657,6 +657,8 @@ func (c *redisCache) Contains(key string) bool {
 		item, err := c.remoteClient.Get(c.ctx, key).Bytes()
 		if err == nil {
 			c.localCache.Set(key, item)
+		} else {
+			remoteContains = false
 		}
 	}
 

--- a/pkg/util/trivy/containerd.go
+++ b/pkg/util/trivy/containerd.go
@@ -33,6 +33,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
+const CONTAINERD_COLLECTOR = "containerd"
+
 // Code ported from https://github.com/aquasecurity/trivy/blob/2206e008ea6e5f4e5c1aa7bc8fc77dae7041de6a/pkg/fanal/image/daemon/containerd.go
 type familiarNamed string
 
@@ -92,7 +94,7 @@ func convertContainerdImage(ctx context.Context, client *containerd.Client, imgM
 
 	return &image{
 		name:    img.Name(),
-		opener:  imageOpener(ctx, ref.String(), f, imageWriter(client, img)),
+		opener:  imageOpener(ctx, CONTAINERD_COLLECTOR, ref.String(), f, imageWriter(client, img)),
 		inspect: insp,
 		history: history,
 	}, cleanup, nil

--- a/pkg/util/trivy/db.go
+++ b/pkg/util/trivy/db.go
@@ -52,6 +52,7 @@ type BoltDB struct {
 // NewBoltDB creates a new BoltDB instance.
 func NewBoltDB(cacheDir string) (BoltDB, error) {
 	dir := filepath.Join(cacheDir, cacheDirName)
+	os.RemoveAll(dir)
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return BoltDB{}, fmt.Errorf("failed to create cache dir: %v", err)
 	}

--- a/pkg/util/trivy/db.go
+++ b/pkg/util/trivy/db.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -52,7 +53,9 @@ type BoltDB struct {
 // NewBoltDB creates a new BoltDB instance.
 func NewBoltDB(cacheDir string) (BoltDB, error) {
 	dir := filepath.Join(cacheDir, cacheDirName)
-	os.RemoveAll(dir)
+	if config.Datadog.GetBool("sbom.clear_cache_on_exit") {
+		os.RemoveAll(dir)
+	}
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return BoltDB{}, fmt.Errorf("failed to create cache dir: %v", err)
 	}

--- a/pkg/util/trivy/docker.go
+++ b/pkg/util/trivy/docker.go
@@ -18,6 +18,8 @@ import (
 	"golang.org/x/xerrors"
 )
 
+const DOCKER_COLLECTOR = "docker"
+
 // Custom code based on https://github.com/aquasecurity/trivy/blob/2206e008ea6e5f4e5c1aa7bc8fc77dae7041de6a/pkg/fanal/image/daemon/docker.go `DockerImage`
 func convertDockerImage(ctx context.Context, client client.ImageAPIClient, imgMeta *workloadmeta.ContainerImageMetadata) (types.Image, func(), error) {
 	cleanup := func() {}
@@ -51,7 +53,7 @@ func convertDockerImage(ctx context.Context, client client.ImageAPIClient, imgMe
 	}
 
 	return &image{
-		opener:  imageOpener(ctx, imageID, f, client.ImageSave),
+		opener:  imageOpener(ctx, DOCKER_COLLECTOR, imageID, f, client.ImageSave),
 		inspect: inspect,
 		history: configHistory(history),
 	}, cleanup, nil

--- a/pkg/util/trivy/image.go
+++ b/pkg/util/trivy/image.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/sbom/telemetry"
 	fimage "github.com/aquasecurity/trivy/pkg/fanal/image"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -33,7 +34,7 @@ type opener func() (v1.Image, error)
 
 type imageSave func(context.Context, []string) (io.ReadCloser, error)
 
-func imageOpener(ctx context.Context, ref string, f *os.File, imageSave imageSave) opener {
+func imageOpener(ctx context.Context, collector, ref string, f *os.File, imageSave imageSave) opener {
 	return func() (v1.Image, error) {
 		// Store the tarball in local filesystem and return a new reader into the bytes each time we need to access something.
 		rc, err := imageSave(ctx, []string{ref})
@@ -42,10 +43,13 @@ func imageOpener(ctx context.Context, ref string, f *os.File, imageSave imageSav
 		}
 		defer rc.Close()
 
-		if _, err = io.Copy(f, rc); err != nil {
+		written, err := io.Copy(f, rc)
+		if err != nil {
 			return nil, xerrors.Errorf("failed to copy the image: %w", err)
 		}
 		defer f.Close()
+
+		telemetry.SBOMExportSize.Observe(float64(written), collector, ref)
 
 		img, err := tarball.ImageFromPath(f.Name(), nil)
 		if err != nil {

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -103,7 +103,7 @@ func defaultCollectorConfig(cacheLocation string) CollectorConfig {
 		ClearCacheOnClose: true,
 	}
 
-	collectorConfig.CacheProvider = cacheProvider(cacheLocation, config.Datadog.GetBool("sbom.cache.enabled"), config.Datadog.GetBool("sbom.cache.remote"))
+	collectorConfig.CacheProvider = cacheProvider(cacheLocation, config.Datadog.GetBool("sbom.cache.enabled"), config.Datadog.GetBool("sbom.cache.remote.enabled"))
 
 	return collectorConfig
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Uses a redis cache for sbom collection.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Trivy items can be shared accross nodes, reducing the resource usage.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Do not merge this PR. This is just a Proof of Concept.
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
N/A
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
