### PR TITLE
Use cython<3.0.0 to build oracledb and pyyaml python dependencies

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -93,6 +93,12 @@ if arm? || !_64_bit?
   blacklist_packages.push(/^orjson==/)
 end
 
+if linux?
+  # We need to use cython<3.0.0 to build pyyaml for py2
+  dependency 'pyyaml-py2'
+  blacklist_packages.push(/^pyyaml==/)
+end
+
 final_constraints_file = 'final_constraints-py2.txt'
 agent_requirements_file = 'agent_requirements-py2.txt'
 filtered_agent_requirements_in = 'agent_requirements-py2.in'

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -93,7 +93,7 @@ if arm? || !_64_bit?
   blacklist_packages.push(/^orjson==/)
 end
 
-if redhat?
+if linux?
   # We need to use cython<3.0.0 to build pyyaml for py2
   dependency 'pyyaml-py2'
   blacklist_packages.push(/^pyyaml==/)

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -97,7 +97,8 @@ if linux?
   # We need to use cython<3.0.0 to build pyyaml for py2
   dependency 'pyyaml-py2'
   blacklist_packages.push(/^pyyaml==/)
-  blacklist_packages.push(/^PyYAML==/)
+  dependency 'kubernetes-py2'
+  blacklist_packages.push(/^kubernetes==/)
 end
 
 final_constraints_file = 'final_constraints-py2.txt'

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -97,6 +97,7 @@ if linux?
   # We need to use cython<3.0.0 to build pyyaml for py2
   dependency 'pyyaml-py2'
   blacklist_packages.push(/^pyyaml==/)
+  blacklist_packages.push(/^PyYAML==/)
 end
 
 final_constraints_file = 'final_constraints-py2.txt'

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -93,7 +93,7 @@ if arm? || !_64_bit?
   blacklist_packages.push(/^orjson==/)
 end
 
-if linux?
+if redhat?
   # We need to use cython<3.0.0 to build pyyaml for py2
   dependency 'pyyaml-py2'
   blacklist_packages.push(/^pyyaml==/)

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -101,6 +101,12 @@ if arm? || !_64_bit? || (windows? && windows_arch_i386?)
   blacklist_packages.push(/^orjson==/)
 end
 
+if linux?
+  # We need to use cython<3.0.0 to build oracledb
+  dependency 'oracledb-py3'
+  blacklist_packages.push(/^oracledb==/)
+end
+
 final_constraints_file = 'final_constraints-py3.txt'
 agent_requirements_file = 'agent_requirements-py3.txt'
 filtered_agent_requirements_in = 'agent_requirements-py3.in'

--- a/omnibus/config/software/kubernetes-py2.rb
+++ b/omnibus/config/software/kubernetes-py2.rb
@@ -1,0 +1,18 @@
+name "kubernetes-py2"
+default_version "18.20.0"
+
+dependency "pip2"
+dependency "pyyaml-py2"
+
+source :url => "https://files.pythonhosted.org/packages/9c/f8/0eb10c6939b77788c10449d47d85a4740bb4a5608e1a504807fcdb5babd0/kubernetes-#{version}.tar.gz",
+       :sha256 => "0c72d00e7883375bd39ae99758425f5e6cb86388417cf7cc84305c211b2192cf",
+       :extract => :seven_zip
+
+relative_path "kubernetes-#{version}"
+
+build do
+  license "Apache-2.0"
+  license_file "./LICENSE.txt"
+
+  command "#{install_dir}/embedded/bin/pip2 install ."
+end

--- a/omnibus/config/software/oracledb-py3.rb
+++ b/omnibus/config/software/oracledb-py3.rb
@@ -1,0 +1,25 @@
+name "oracledb-py3"
+default_version "1.3.2"
+
+dependency "pip3"
+
+source :url => "https://github.com/oracle/python-oracledb/archive/refs/tags/v#{version}.tar.gz",
+       :sha256 => "0a8a6bd2aacf7db0f26b0cb9991316f3e02f4bf671c67ca38b0baa9fd6fbb21f",
+       :extract => :seven_zip
+
+relative_path "python-oracledb-#{version}"
+
+build do
+  license "Apache-2.0"
+  license_file "./LICENSE.txt"
+
+  command "sed -i 's/cython/cython<3.0.0/g' pyproject.toml"
+
+  if windows?
+    pip = "#{windows_safe_path(python_3_embedded)}\\Scripts\\pip.exe"
+  else
+    pip = "#{install_dir}/embedded/bin/pip3"
+  end
+
+  command "#{pip} install ."
+end

--- a/omnibus/config/software/oracledb-py3.rb
+++ b/omnibus/config/software/oracledb-py3.rb
@@ -3,8 +3,10 @@ default_version "1.3.2"
 
 dependency "pip3"
 
-source :url => "https://github.com/oracle/python-oracledb/archive/refs/tags/v#{version}.tar.gz",
-       :sha256 => "0a8a6bd2aacf7db0f26b0cb9991316f3e02f4bf671c67ca38b0baa9fd6fbb21f",
+# The github repository contains a submodule which is not shipped with their released file.
+# Grabbing the tar from PyPi instead
+source :url => "https://files.pythonhosted.org/packages/05/18/516f38a55c99d8ac417a817afff88f484300ce7e4d94058055af1f1461e5/oracledb-#{version}.tar.gz",
+       :sha256 => "bb3c391c167b5778ddb15a7538a2b36db5c9b88a50c86c61781ca9ff302bb643",
        :extract => :seven_zip
 
 relative_path "python-oracledb-#{version}"

--- a/omnibus/config/software/oracledb-py3.rb
+++ b/omnibus/config/software/oracledb-py3.rb
@@ -9,7 +9,7 @@ source :url => "https://files.pythonhosted.org/packages/05/18/516f38a55c99d8ac41
        :sha256 => "bb3c391c167b5778ddb15a7538a2b36db5c9b88a50c86c61781ca9ff302bb643",
        :extract => :seven_zip
 
-relative_path "python-oracledb-#{version}"
+relative_path "oracledb-#{version}"
 
 build do
   license "Apache-2.0"

--- a/omnibus/config/software/oracledb-py3.rb
+++ b/omnibus/config/software/oracledb-py3.rb
@@ -15,11 +15,5 @@ build do
 
   command "sed -i 's/cython/cython<3.0.0/g' pyproject.toml"
 
-  if windows?
-    pip = "#{windows_safe_path(python_3_embedded)}\\Scripts\\pip.exe"
-  else
-    pip = "#{install_dir}/embedded/bin/pip3"
-  end
-
-  command "#{pip} install ."
+  command "#{install_dir}/embedded/bin/pip3 install ."
 end

--- a/omnibus/config/software/pyyaml-py2.rb
+++ b/omnibus/config/software/pyyaml-py2.rb
@@ -1,0 +1,25 @@
+name "pyyaml-py2"
+default_version "5.4.1"
+
+dependency "pip2"
+
+source :url => "https://github.com/yaml/pyyaml/archive/refs/tags/#{version}.tar.gz",
+       :sha256 => "75f966559c5f262dfc44da0f958cc2aa18953ae5021f2c3657b415c5a370045f",
+       :extract => :seven_zip
+
+relative_path "pyyaml-#{version}"
+
+build do
+  license "MIT"
+  license_file "./LICENSE.txt"
+
+  command "sed -i 's/Cython/Cython<3.0.0/g' pyproject.toml"
+
+  if windows?
+    pip = "#{windows_safe_path(python_2_embedded)}\\Scripts\\pip.exe"
+  else
+    pip = "#{install_dir}/embedded/bin/pip2"
+  end
+
+  command "#{pip} install ."
+end

--- a/omnibus/config/software/pyyaml-py2.rb
+++ b/omnibus/config/software/pyyaml-py2.rb
@@ -15,11 +15,5 @@ build do
 
   command "sed -i 's/Cython/Cython<3.0.0/g' pyproject.toml"
 
-  if windows?
-    pip = "#{windows_safe_path(python_2_embedded)}\\Scripts\\pip.exe"
-  else
-    pip = "#{install_dir}/embedded/bin/pip2"
-  end
-
-  command "#{pip} install ."
+  command "#{install_dir}/embedded/bin/pip2 install ."
 end


### PR DESCRIPTION
### What does this PR do?

- Use cython<3.0.0 to build oracledb, only used with py3
- Use cython<3.0.0 to build pyyaml 5.4.1, only for py2 since we can't upgrade its version to 6.0.1
- Kubernetes 18.20.0 (for py2) depends on pyyaml 5.4.1 and should not be compiled by piptools so we manually compile it

### Motivation

Cython 3.0.0 broke our rpm x64 build with the following error when building the oracledb dependency: 

```
Error compiling Cython file:
      ------------------------------------------------------------
      ...
                  session_callback_bytes = params.session_callback.encode()
                  create_params.plsqlFixupCallback = session_callback_bytes
                  create_params.plsqlFixupCallbackLength = \
                          <uint32_t> len(session_callback_bytes)
              if params.access_token_callback is not None:
                  create_params.accessTokenCallback = _token_callback_handler
                                                      ^
      ------------------------------------------------------------
      
      src/oracledb/impl/thick/pool.pyx:116:48: Cannot assign type 'int (void *, dpiAccessToken *) except? -1 nogil' to 'dpiAccessTokenCallback'
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
              params.portNumber = self.port
              params.timeout = self.timeout
              params.name = name_buf.ptr
              params.nameLength = name_buf.length
              if self.callback is not None:
                  params.callback = _callback_handler
                                    ^
      ------------------------------------------------------------
      
      src/oracledb/impl/thick/subscr.pyx:159:30: Cannot assign type 'void (void *, dpiSubscrMessage *) except * nogil' to 'dpiSubscrCallback'
```

It also broke our rpm/deb arm build on py2 when building the pyyaml dependency: 

```
    $ CFLAGS=-I/opt/datadog-agent/embedded/include -I/opt/mqm/inc -std=c99 CXXFLAGS=-I/opt/datadog-agent/embedded/include -I/opt/mqm/inc LDFLAGS=-L/opt/datadog-agent/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib LD_RUN_PATH=/opt/datadog-agent/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib PATH=/opt/datadog-agent/embedded/bin:/usr/local/rvm/gems/ruby-2.7.2/bin:/usr/local/rvm/gems/ruby-2.7.2@global/bin:/usr/local/rvm/rubies/ruby-2.7.2/bin:/root/miniforge3/envs/ddpy3/bin:/root/miniforge3/condabin:/opt/clang/bin:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/rvm/bin PIP_CONFIG_FILE=/go/src/github.com/ENN298S5/0/DataDog/datadog-agent/pip.conf PIP_FIND_LINKS=/omnibus/src/datadog-agent-integrations-py2/integrations-core/.build_deps /opt/datadog-agent/embedded/bin/python2 -m piptools compile --generate-hashes --output-file /opt/datadog-agent/agent_requirements-py2.txt /omnibus/src/datadog-agent-integrations-py2/integrations-core/agent_requirements-py2.in --pip-args "--retries 20 --timeout 20"
Output:
    (nothing)
Error:
    ERROR: Command errored out with exit status 1:
     command: /opt/datadog-agent/embedded/bin/python2 /opt/datadog-agent/embedded/lib/python2.7/site-packages/pip-20.3.3-py2.7.egg/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpj9UMdL
         cwd: /tmp/pip-resolver-GXEfWC/pyyaml
    Complete output (46 lines):
    running egg_info
    creating lib/PyYAML.egg-info
    writing lib/PyYAML.egg-info/PKG-INFO
    writing top-level names to lib/PyYAML.egg-info/top_level.txt
    writing dependency_links to lib/PyYAML.egg-info/dependency_links.txt
    writing manifest file 'lib/PyYAML.egg-info/SOURCES.txt'
    Traceback (most recent call last):
      File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/pip-20.3.3-py2.7.egg/pip/_vendor/pep517/_in_process.py", line 280, in <module>
        main()
      File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/pip-20.3.3-py2.7.egg/pip/_vendor/pep517/_in_process.py", line 263, in main
        json_out['return_val'] = hook(**hook_input['kwargs'])
      File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/pip-20.3.3-py2.7.egg/pip/_vendor/pep517/_in_process.py", line 114, in get_requires_for_build_wheel
        return hook(config_settings)
      File "/tmp/pip-build-env-ggUqbz/overlay/lib/python2.7/site-packages/setuptools/build_meta.py", line 146, in get_requires_for_build_wheel
        return self._get_build_requires(config_settings, requirements=['wheel'])
      File "/tmp/pip-build-env-ggUqbz/overlay/lib/python2.7/site-packages/setuptools/build_meta.py", line 127, in _get_build_requires
        self.run_setup()
      File "/tmp/pip-build-env-ggUqbz/overlay/lib/python2.7/site-packages/setuptools/build_meta.py", line 142, in run_setup
        exec(compile(code, __file__, 'exec'), locals())
      File "setup.py", line 295, in <module>
        python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',
      File "/tmp/pip-build-env-ggUqbz/overlay/lib/python2.7/site-packages/setuptools/__init__.py", line 162, in setup
        return distutils.core.setup(**attrs)
      File "/opt/datadog-agent/embedded/lib/python2.7/distutils/core.py", line 151, in setup
        dist.run_commands()
      File "/opt/datadog-agent/embedded/lib/python2.7/distutils/dist.py", line 953, in run_commands
        self.run_command(cmd)
      File "/opt/datadog-agent/embedded/lib/python2.7/distutils/dist.py", line 972, in run_command
        cmd_obj.run()
      File "/tmp/pip-build-env-ggUqbz/overlay/lib/python2.7/site-packages/setuptools/command/egg_info.py", line 296, in run
        self.find_sources()
      File "/tmp/pip-build-env-ggUqbz/overlay/lib/python2.7/site-packages/setuptools/command/egg_info.py", line 303, in find_sources
        mm.run()
      File "/tmp/pip-build-env-ggUqbz/overlay/lib/python2.7/site-packages/setuptools/command/egg_info.py", line 534, in run
        self.add_defaults()
      File "/tmp/pip-build-env-ggUqbz/overlay/lib/python2.7/site-packages/setuptools/command/egg_info.py", line 570, in add_defaults
        sdist.add_defaults(self)
      File "/tmp/pip-build-env-ggUqbz/overlay/lib/python2.7/site-packages/setuptools/command/py36compat.py", line 36, in add_defaults
        self._add_defaults_ext()
      File "/tmp/pip-build-env-ggUqbz/overlay/lib/python2.7/site-packages/setuptools/command/py36compat.py", line 120, in _add_defaults_ext
        self.filelist.extend(build_ext.get_source_files())
      File "setup.py", line 201, in get_source_files
        self.cython_sources(ext.sources, ext)
      File "/opt/datadog-agent/embedded/lib/python2.7/distutils/cmd.py", line 105, in __getattr__
        raise AttributeError, attr
    AttributeError: cython_sources
    ----------------------------------------
Traceback (most recent call last):
  File "/opt/datadog-agent/embedded/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/opt/datadog-agent/embedded/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/piptools/__main__.py", line 17, in <module>
    cli()
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/piptools/scripts/compile.py", line 458, in cli
    results = resolver.resolve(max_rounds=max_rounds)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/piptools/resolver.py", line 173, in resolve
    has_changed, best_matches = self._resolve_one_round()
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/piptools/resolver.py", line 278, in _resolve_one_round
    their_constraints.extend(self._iter_dependencies(best_match))
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/piptools/resolver.py", line 388, in _iter_dependencies
    dependencies = self.repository.get_dependencies(ireq)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/piptools/repositories/pypi.py", line 244, in get_dependencies
    download_dir, ireq, wheel_cache
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/piptools/repositories/pypi.py", line 194, in resolve_reqs
    results = resolver._resolve_one(reqset, ireq)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/pip-20.3.3-py2.7.egg/pip/_internal/resolution/legacy/resolver.py", line 385, in _resolve_one
    dist = self._get_dist_for(req_to_install)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/pip-20.3.3-py2.7.egg/pip/_internal/resolution/legacy/resolver.py", line 337, in _get_dist_for
    dist = self.preparer.prepare_linked_requirement(req)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/pip-20.3.3-py2.7.egg/pip/_internal/operations/prepare.py", line 480, in prepare_linked_requirement
    return self._prepare_linked_requirement(req, parallel_builds)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/pip-20.3.3-py2.7.egg/pip/_internal/operations/prepare.py", line 524, in _prepare_linked_requirement
    req, self.req_tracker, self.finder, self.build_isolation,
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/pip-20.3.3-py2.7.egg/pip/_internal/operations/prepare.py", line 88, in _get_prepared_distribution
    abstract_dist.prepare_distribution_metadata(finder, build_isolation)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/pip-20.3.3-py2.7.egg/pip/_internal/distributions/sdist.py", line 39, in prepare_distribution_metadata
    self._setup_isolation(finder)
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/pip-20.3.3-py2.7.egg/pip/_internal/distributions/sdist.py", line 97, in _setup_isolation
    reqs = backend.get_requires_for_build_wheel()
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/pip-20.3.3-py2.7.egg/pip/_vendor/pep517/wrappers.py", line 178, in get_requires_for_build_wheel
    'config_settings': config_settings
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/pip-20.3.3-py2.7.egg/pip/_vendor/pep517/wrappers.py", line 277, in _call_hook
    extra_environ=extra_environ
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/pip-20.3.3-py2.7.egg/pip/_internal/utils/subprocess.py", line 275, in runner
    spinner=spinner,
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/pip-20.3.3-py2.7.egg/pip/_internal/utils/subprocess.py", line 240, in call_subprocess
    raise InstallationError(exc_msg)
pip._internal.exceptions.InstallationError: Command errored out with exit status 1: /opt/datadog-agent/embedded/bin/python2 /opt/datadog-agent/embedded/lib/python2.7/site-packages/pip-20.3.3-py2.7.egg/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpj9UMdL Check the logs for full command output.
```

We can't directly override the cython versions declared in the pyproject files:
- [oracledb](https://github.com/oracle/python-oracledb/blob/main/pyproject.toml)
- [pyyaml](https://github.com/yaml/pyyaml/blob/master/pyproject.toml) 


We saw two options: 

- Manually install the dependencies with pip, build the wheel with the `-no-build-isolation` flag, drop the dependencies and move on the next dependency
- Clone the project, patch the pyproject file and build the wheel locally. This is the quick and very dirty solution we decided to choose for now. We already do that for snowflake

### Additional Notes

We will investigate to find a better solution in the near feature. For now we need to fix the build on master, 7.47 and possibly 7.46.

I opened a discussion (wanted to open an issue but their template says to open a discussion instead) on the oracledb repo: https://github.com/oracle/python-oracledb/discussions/203

I will revert and bump the versions if/when they release new versions for pyyaml and oracledb. 

Pyyaml maintainers declared that they are probably not going to backport this fix and create a 5.4.2 release so we will have to keep this hack until we drop py2 altogether

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
