### PR TITLE
Download QCOW2 images from S3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -186,8 +186,8 @@ variables:
   ARTIFACTORY_GEMS_PATH: artifactory/api/gems/agent-gems
   ARTIFACTORY_PYPI_PATH: artifactory/api/pypi/agent-pypi/simple
   CLANG_LLVM_VER: 12.0.1
-  KERNEL_MATRIX_TESTING_X86_AMI_ID: "ami-08d9716d20480186e"
-  KERNEL_MATRIX_TESTING_ARM_AMI_ID: "ami-044d1c0f7ab0e3537"
+  KERNEL_MATRIX_TESTING_X86_AMI_ID: "ami-098ea4991ff2d244c"
+  KERNEL_MATRIX_TESTING_ARM_AMI_ID: "ami-04493daab2918046c"
 
 #
 # Condition mixins for simplification of rules

--- a/test/new-e2e/system-probe/config/vmconfig.json
+++ b/test/new-e2e/system-probe/config/vmconfig.json
@@ -1,7 +1,7 @@
 {
     "vmsets": [
         {
-            "name": "distro_distro_x86_64",
+            "name": "distro_x86_64",
             "recipe": "distro-x86_64",
             "arch": "x86_64",
             "kernels": [
@@ -29,7 +29,7 @@
             ]
         },
         {
-            "name": "distro_distro_arm64",
+            "name": "distro_arm64",
             "recipe": "distro-arm64",
             "arch": "arm64",
             "kernels": [

--- a/test/new-e2e/system-probe/config/vmconfig.json
+++ b/test/new-e2e/system-probe/config/vmconfig.json
@@ -1,52 +1,56 @@
 {
-   "vmsets": [
+    "vmsets": [
         {
-            "name": "ubuntu_x86_64",
+            "name": "distro_distro_x86_64",
             "recipe": "distro-x86_64",
             "arch": "x86_64",
             "kernels": [
                 {
+                    "dir": "bionic-server-cloudimg-amd64.qcow2",
+                    "tag": "bionic",
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bionic-server-cloudimg-amd64.qcow2"
+                },
+                {
                     "dir": "jammy-server-cloudimg-amd64.qcow2",
-                    "tag": "jammy_22",
-                    "image_source": "file:///home/kernel-version-testing/rootfs/jammy-server-cloudimg-amd64.qcow2"
+                    "tag": "jammy",
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/jammy-server-cloudimg-amd64.qcow2"
                 },
                 {
                     "dir": "focal-server-cloudimg-amd64.qcow2",
-                    "tag": "focal_20",
-                    "image_source": "file:///home/kernel-version-testing/rootfs/focal-server-cloudimg-amd64.qcow2"
-                },
-                {
-                    "dir": "bionic-server-cloudimg-amd64.qcow2",
-                    "tag": "bionic_18",
-                    "image_source": "file:///home/kernel-version-testing/rootfs/bionic-server-cloudimg-amd64.qcow2"
+                    "tag": "focal",
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/focal-server-cloudimg-amd64.qcow2"
                 }
             ],
-            "vcpu": [4],
-            "memory": [4096]
+            "vcpu": [
+                4
+            ],
+            "memory": [
+                8192
+            ]
         },
         {
-            "name": "ubuntu_arm64",
+            "name": "distro_distro_arm64",
             "recipe": "distro-arm64",
             "arch": "arm64",
             "kernels": [
                 {
-                    "dir": "jammy-server-cloudimg-arm64.qcow2",
-                    "tag": "jammy_22",
-                    "image_source": "file:///home/kernel-version-testing/rootfs/jammy-server-cloudimg-arm64.qcow2"
-                },
-                {
                     "dir": "focal-server-cloudimg-arm64.qcow2",
-                    "tag": "focal_20",
-                    "image_source": "file:///home/kernel-version-testing/rootfs/focal-server-cloudimg-arm64.qcow2"
+                    "tag": "focal",
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/focal-server-cloudimg-arm64.qcow2"
                 },
                 {
-                    "dir": "bionic-server-cloudimg-arm64.qcow2",
-                    "tag": "bionic_18",
-                    "image_source": "file:///home/kernel-version-testing/rootfs/bionic-server-cloudimg-arm64.qcow2"
+                    "dir": "jammy-server-cloudimg-arm64.qcow2",
+                    "tag": "jammy",
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/jammy-server-cloudimg-arm64.qcow2"
                 }
             ],
-            "vcpu": [4],
-            "memory": [4096]
+            "machine": "virt",
+            "vcpu": [
+                4
+            ],
+            "memory": [
+                8192
+            ]
         }
-   ]
+    ]
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Updates the `vmconfig.json` file to specify image source as an S3 URL.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
https://github.com/DataDog/test-infra-definitions/pull/221

To summarize, this should help reduce the time of the environment setup step as the number of qcow2 images to download increases. 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
