### PR TITLE
[RCM] Debug log when org is disabled

### DIFF
--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -291,7 +291,7 @@ func (s *Service) Start(ctx context.Context) error {
 			if s.previousOrgStatus != nil && s.previousOrgStatus.Enabled && s.previousOrgStatus.Authorized {
 				log.Errorf("Could not refresh Remote Config: %v", err)
 			} else {
-				log.Debugf("Could not refresh Remote Config (org is disabled): %v", err)
+				log.Debugf("Could not refresh Remote Config (org is disabled or key is not authorized): %v", err)
 			}
 		}
 
@@ -318,7 +318,7 @@ func (s *Service) Start(ctx context.Context) error {
 					exportedLastUpdateErr.Set(err.Error())
 					log.Errorf("Could not refresh Remote Config: %v", err)
 				} else {
-					log.Debugf("Could not refresh Remote Config (org is disabled): %v", err)
+					log.Debugf("Could not refresh Remote Config (org is disabled or key is not authorized): %v", err)
 				}
 			}
 		}

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -288,7 +288,11 @@ func (s *Service) Start(ctx context.Context) error {
 
 		err := s.refresh()
 		if err != nil {
-			log.Errorf("Could not refresh Remote Config: %v", err)
+			if s.previousOrgStatus != nil && s.previousOrgStatus.Enabled {
+				log.Errorf("Could not refresh Remote Config: %v", err)
+			} else {
+				log.Debugf("Could not refresh Remote Config (org is disabled): %v", err)
+			}
 		}
 
 		for {
@@ -310,8 +314,12 @@ func (s *Service) Start(ctx context.Context) error {
 			}
 
 			if err != nil {
-				exportedLastUpdateErr.Set(err.Error())
-				log.Errorf("Could not refresh Remote Config: %v", err)
+				if s.previousOrgStatus != nil && s.previousOrgStatus.Enabled {
+					exportedLastUpdateErr.Set(err.Error())
+					log.Errorf("Could not refresh Remote Config: %v", err)
+				} else {
+					log.Debugf("Could not refresh Remote Config (org is disabled): %v", err)
+				}
 			}
 		}
 	}()

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -288,7 +288,7 @@ func (s *Service) Start(ctx context.Context) error {
 
 		err := s.refresh()
 		if err != nil {
-			if s.previousOrgStatus != nil && s.previousOrgStatus.Enabled {
+			if s.previousOrgStatus != nil && s.previousOrgStatus.Enabled && s.previousOrgStatus.Authorized {
 				log.Errorf("Could not refresh Remote Config: %v", err)
 			} else {
 				log.Debugf("Could not refresh Remote Config (org is disabled): %v", err)
@@ -418,7 +418,6 @@ func (s *Service) refresh() error {
 			// If we saw the error enough time, we consider that RC not working is a normal behavior
 			// And we only log as INFO
 			// The agent will eventually log this error as INFO every maximalMaxBackoffTime
-			log.Infof("Could not refresh Remote Config: %v", err)
 			return nil
 		}
 		return err

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -48,7 +48,7 @@ const (
 	defaultCacheBypassLimit = 5
 	minCacheBypassLimit     = 1
 	maxCacheBypassLimit     = 10
-	orgStatusPollInterval   = 5 * time.Minute
+	orgStatusPollInterval   = 1 * time.Minute
 )
 
 // Constraints on the maximum backoff time when errors occur
@@ -314,7 +314,7 @@ func (s *Service) Start(ctx context.Context) error {
 			}
 
 			if err != nil {
-				if s.previousOrgStatus != nil && s.previousOrgStatus.Enabled {
+				if s.previousOrgStatus != nil && s.previousOrgStatus.Enabled && s.previousOrgStatus.Authorized {
 					exportedLastUpdateErr.Set(err.Error())
 					log.Errorf("Could not refresh Remote Config: %v", err)
 				} else {
@@ -416,8 +416,9 @@ func (s *Service) refresh() error {
 				return err
 			}
 			// If we saw the error enough time, we consider that RC not working is a normal behavior
-			// And we only log as INFO
-			// The agent will eventually log this error as INFO every maximalMaxBackoffTime
+			// And we only log as DEBUG
+			// The agent will eventually log this error as DEBUG every maximalMaxBackoffTime
+			log.Debugf("Could not refresh Remote Config: %v", err)
 			return nil
 		}
 		return err


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

RC QA: reduce error log noise when the org has RC disabled.
To be backported in 7.47

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
