### PR TITLE
Use distinct metrics for HTTP and HTTP2

### DIFF
--- a/pkg/network/protocols/http/incomplete_stats_test.go
+++ b/pkg/network/protocols/http/incomplete_stats_test.go
@@ -20,7 +20,7 @@ import (
 func TestOrphanEntries(t *testing.T) {
 	t.Run("orphan entries can be joined even after flushing", func(t *testing.T) {
 		now := time.Now()
-		tel := NewTelemetry()
+		tel := NewTelemetry("http")
 		buffer := newIncompleteBuffer(config.New(), tel)
 		request := &EbpfTx{
 			Request_fragment: requestFragment([]byte("GET /foo/bar")),
@@ -49,7 +49,7 @@ func TestOrphanEntries(t *testing.T) {
 	})
 
 	t.Run("orphan entries are not kept indefinitely", func(t *testing.T) {
-		tel := NewTelemetry()
+		tel := NewTelemetry("http")
 		buffer := newIncompleteBuffer(config.New(), tel)
 		now := time.Now()
 		buffer.minAgeNano = (30 * time.Second).Nanoseconds()

--- a/pkg/network/protocols/http/protocol.go
+++ b/pkg/network/protocols/http/protocol.go
@@ -70,7 +70,7 @@ func newHttpProtocol(cfg *config.Config) (protocols.Protocol, error) {
 		return nil, fmt.Errorf("http feature not available on pre %s kernels", MinimumKernelVersion.String())
 	}
 
-	telemetry := NewTelemetry()
+	telemetry := NewTelemetry("http")
 
 	return &protocol{
 		cfg:       cfg,

--- a/pkg/network/protocols/http/statkeeper_test.go
+++ b/pkg/network/protocols/http/statkeeper_test.go
@@ -23,7 +23,7 @@ import (
 func TestProcessHTTPTransactions(t *testing.T) {
 	cfg := config.New()
 	cfg.MaxHTTPStatsBuffered = 1000
-	tel := NewTelemetry()
+	tel := NewTelemetry("http")
 	sk := NewStatkeeper(cfg, tel)
 
 	srcString := "1.1.1.1"
@@ -69,7 +69,7 @@ func TestProcessHTTPTransactions(t *testing.T) {
 
 func BenchmarkProcessSameConn(b *testing.B) {
 	cfg := &config.Config{MaxHTTPStatsBuffered: 1000}
-	tel := NewTelemetry()
+	tel := NewTelemetry("http")
 	sk := NewStatkeeper(cfg, tel)
 	tx := generateIPv4HTTPTransaction(
 		util.AddressFromString("1.1.1.1"),
@@ -103,7 +103,7 @@ func TestPathProcessing(t *testing.T) {
 		c := cfg
 		c.HTTPReplaceRules = rules
 
-		tel := NewTelemetry()
+		tel := NewTelemetry("http")
 		return NewStatkeeper(c, tel)
 	}
 
@@ -195,7 +195,7 @@ func TestHTTPCorrectness(t *testing.T) {
 		cfg := config.New()
 		cfg.MaxHTTPStatsBuffered = 1000
 		libtelemetry.Clear()
-		tel := NewTelemetry()
+		tel := NewTelemetry("http")
 		sk := NewStatkeeper(cfg, tel)
 		tx := generateIPv4HTTPTransaction(
 			util.AddressFromString("1.1.1.1"),
@@ -219,7 +219,7 @@ func TestHTTPCorrectness(t *testing.T) {
 		cfg := config.New()
 		cfg.MaxHTTPStatsBuffered = 1000
 		libtelemetry.Clear()
-		tel := NewTelemetry()
+		tel := NewTelemetry("http")
 		sk := NewStatkeeper(cfg, tel)
 		tx := generateIPv4HTTPTransaction(
 			util.AddressFromString("1.1.1.1"),
@@ -244,7 +244,7 @@ func TestHTTPCorrectness(t *testing.T) {
 		cfg := config.New()
 		cfg.MaxHTTPStatsBuffered = 1000
 		libtelemetry.Clear()
-		tel := NewTelemetry()
+		tel := NewTelemetry("http")
 		sk := NewStatkeeper(cfg, tel)
 		tx := generateIPv4HTTPTransaction(
 			util.AddressFromString("1.1.1.1"),

--- a/pkg/network/protocols/http/telemetry.go
+++ b/pkg/network/protocols/http/telemetry.go
@@ -8,11 +8,15 @@
 package http
 
 import (
+	"fmt"
+
 	libtelemetry "github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type Telemetry struct {
+	protocol string
+
 	// metricGroup is used here mostly for building the log message below
 	metricGroup *libtelemetry.MetricGroup
 
@@ -25,10 +29,11 @@ type Telemetry struct {
 	aggregations *libtelemetry.Counter
 }
 
-func NewTelemetry() *Telemetry {
-	metricGroup := libtelemetry.NewMetricGroup("usm.http")
+func NewTelemetry(protocol string) *Telemetry {
+	metricGroup := libtelemetry.NewMetricGroup("usm.http", fmt.Sprintf("protocol:%s", protocol))
 
 	return &Telemetry{
+		protocol:    protocol,
 		metricGroup: metricGroup,
 
 		hits1XX:      metricGroup.NewCounter("hits", "status:1xx", libtelemetry.OptPrometheus),
@@ -64,5 +69,5 @@ func (t *Telemetry) Count(tx Transaction) {
 }
 
 func (t *Telemetry) Log() {
-	log.Debugf("http stats summary: %s", t.metricGroup.Summary())
+	log.Debugf("%s stats summary: %s", t.protocol, t.metricGroup.Summary())
 }

--- a/pkg/network/protocols/http/telemetry.go
+++ b/pkg/network/protocols/http/telemetry.go
@@ -30,7 +30,7 @@ type Telemetry struct {
 }
 
 func NewTelemetry(protocol string) *Telemetry {
-	metricGroup := libtelemetry.NewMetricGroup("usm.http", fmt.Sprintf("protocol:%s", protocol))
+	metricGroup := libtelemetry.NewMetricGroup(fmt.Sprintf("usm.%s", protocol))
 
 	return &Telemetry{
 		protocol:    protocol,

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -76,7 +76,7 @@ func newHttpProtocol(cfg *config.Config) (protocols.Protocol, error) {
 		return nil, fmt.Errorf("http2 feature not available on pre %s kernels", MinimumKernelVersion.String())
 	}
 
-	telemetry := http.NewTelemetry()
+	telemetry := http.NewTelemetry("http2")
 
 	return &protocol{
 		cfg:       cfg,

--- a/pkg/network/usm/monitor_windows.go
+++ b/pkg/network/usm/monitor_windows.go
@@ -48,7 +48,7 @@ func NewWindowsMonitor(c *config.Config, dh driver.Handle) (Monitor, error) {
 	hei.SetMaxRequestBytes(uint64(c.HTTPMaxRequestFragment))
 	hei.SetCapturedProtocols(c.EnableHTTPMonitoring, c.EnableHTTPSMonitoring)
 
-	telemetry := http.NewTelemetry()
+	telemetry := http.NewTelemetry("http")
 
 	return &WindowsMonitor{
 		di:         di,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Use distinct metrics for HTTP and HTTP2 by adding a `protocol` tag.

### Motivation

Until now HTTP and HTTP2 were inadvertently using the name metric names for reporting things such as hit count, dropped count etc. Please note that this affects only _internal_ telemetry and has nothing to do with USM customer-facing data.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
