### PR TITLE
[pkg/otlp] Add config for OTLP log ingestion

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1301,11 +1301,11 @@ api_key:
   #         enabled: false
   ##        @param DD_APM_OBFUSCATION_ELASTICSEARCH_KEEP_VALUES - object - optional
   ##        List of keys that should not be obfuscated.
-  #         keep_values: 
+  #         keep_values:
   #             - client_id
   ##        @param DD_APM_OBFUSCATION_ELASTICSEARCH_OBFUSCATE_SQL_VALUES - boolean - optional
   ##        The set of keys for which their values will be passed through SQL obfuscation
-  #         obfuscate_sql_values: 
+  #         obfuscate_sql_values:
   #             - val1
   #
   #     http:
@@ -1327,7 +1327,7 @@ api_key:
   #         enabled: false
   ##        @param DD_APM_OBFUSCATION_MONGODB_KEEP_VALUES - object - optional
   ##        List of keys that should not be obfuscated.
-  #         keep_values: 
+  #         keep_values:
   #             - document_id
   ##        @param DD_APM_OBFUSCATION_MONGODB_OBFUSCATE_SQL_VALUES - object - optional
   ##        The set of keys for which their values will be passed through SQL obfuscation
@@ -1356,7 +1356,7 @@ api_key:
   #             - id1
   ##        @param DD_APM_SQL_EXEC_PLAN_OBFUSCATE_SQL_VALUES - boolean - optional
   ##        The set of keys for which their values will be passed through SQL obfuscation
-  #         obfuscate_sql_values: 
+  #         obfuscate_sql_values:
   #             - val1
   #
   #     sql_exec_plan_normalize:
@@ -3878,7 +3878,19 @@ api_key:
       #
       # sampling_percentage: 100
 
-  ## @param debug - custom object - optional
+  ## @param logs - custom object - optional
+  ## Logs-specific configuration for OTLP ingest in the Datadog Agent.
+  #
+  # logs:
+
+    ## @param enabled - boolean - optional - default: true
+    ## @env DD_OTLP_CONFIG_LOGS_ENABLED - boolean - optional - default: true
+    ## Set to false to disable logs support in the OTLP ingest endpoint.
+    ## To enable the OTLP ingest, the otlp_config.receiver section must be set.
+    #
+    # enabled: true
+
+## @param debug - custom object - optional
   ## Debug-specific configuration for OTLP ingest in the Datadog Agent.
   ## This template lists the most commonly used settings; see the OpenTelemetry Collector documentation
   ## for a full list of available settings:

--- a/pkg/config/otlp.go
+++ b/pkg/config/otlp.go
@@ -11,6 +11,8 @@ const (
 	OTLPTracesSubSectionKey   = "traces"
 	OTLPTracePort             = OTLPSection + "." + OTLPTracesSubSectionKey + ".internal_port"
 	OTLPTracesEnabled         = OTLPSection + "." + OTLPTracesSubSectionKey + ".enabled"
+	OTLPLogsSubSectionKey     = "logs"
+	OTLPLogsEnabled           = OTLPSection + "." + OTLPLogsSubSectionKey + ".enabled"
 	OTLPReceiverSubSectionKey = "receiver"
 	OTLPReceiverSection       = OTLPSection + "." + OTLPReceiverSubSectionKey
 	OTLPCensusReceiverSection = OTLPSection + ".opencensus"
@@ -27,6 +29,7 @@ func SetupOTLP(config Config) {
 	config.BindEnvAndSetDefault(OTLPTracePort, 5003)
 	config.BindEnvAndSetDefault(OTLPMetricsEnabled, true)
 	config.BindEnvAndSetDefault(OTLPTracesEnabled, true)
+	config.BindEnvAndSetDefault(OTLPLogsEnabled, true)
 
 	// NOTE: This only partially works.
 	// The environment variable is also manually checked in pkg/otlp/config.go

--- a/pkg/otlp/collector.go
+++ b/pkg/otlp/collector.go
@@ -108,6 +108,8 @@ type PipelineConfig struct {
 	MetricsEnabled bool
 	// TracesEnabled states whether OTLP traces support is enabled.
 	TracesEnabled bool
+	// LogsEnabled states whether OTLP logs support is enabled.
+	LogsEnabled bool
 	// Debug contains debug configurations.
 	Debug map[string]interface{}
 	// Metrics contains configuration options for the serializer metrics exporter

--- a/pkg/otlp/config.go
+++ b/pkg/otlp/config.go
@@ -79,6 +79,7 @@ func FromAgentConfig(cfg config.Config) (PipelineConfig, error) {
 
 	metricsEnabled := cfg.GetBool(config.OTLPMetricsEnabled)
 	tracesEnabled := cfg.GetBool(config.OTLPTracesEnabled)
+	logsEnabled := cfg.GetBool(config.OTLPLogsEnabled)
 	if !metricsEnabled && !tracesEnabled {
 		errs = append(errs, fmt.Errorf("at least one OTLP signal needs to be enabled"))
 	}
@@ -92,6 +93,7 @@ func FromAgentConfig(cfg config.Config) (PipelineConfig, error) {
 		TracePort:                tracePort,
 		MetricsEnabled:           metricsEnabled,
 		TracesEnabled:            tracesEnabled,
+		LogsEnabled:              logsEnabled,
 		Metrics:                  metricsConfig.ToStringMap(),
 		Debug:                    debugConfig.ToStringMap(),
 	}, multierr.Combine(errs...)

--- a/pkg/otlp/config_test.go
+++ b/pkg/otlp/config_test.go
@@ -58,6 +58,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				TracePort:                5003,
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
+				LogsEnabled:              true,
 				Metrics: map[string]interface{}{
 					"enabled":         true,
 					"tag_cardinality": "low",
@@ -78,6 +79,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				TracePort:                5003,
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
+				LogsEnabled:              true,
 				Metrics: map[string]interface{}{
 					"enabled":         true,
 					"tag_cardinality": "low",
@@ -98,6 +100,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				TracePort:                5003,
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
+				LogsEnabled:              true,
 				Metrics: map[string]interface{}{
 					"enabled":         true,
 					"tag_cardinality": "low",
@@ -135,6 +138,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				TracePort:                5003,
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
+				LogsEnabled:              true,
 				Metrics: map[string]interface{}{
 					"enabled":         true,
 					"tag_cardinality": "low",
@@ -181,6 +185,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OpenCensusReceiverConfig: map[string]interface{}{},
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
+				LogsEnabled:              true,
 				TracePort:                5003,
 				Metrics: map[string]interface{}{
 					"enabled":         true,
@@ -209,6 +214,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OpenCensusReceiverConfig: map[string]interface{}{},
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
+				LogsEnabled:              true,
 				TracePort:                5003,
 				Metrics: map[string]interface{}{
 					"enabled":         true,
@@ -240,6 +246,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OpenCensusReceiverConfig: map[string]interface{}{},
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
+				LogsEnabled:              true,
 				TracePort:                5003,
 				Metrics: map[string]interface{}{
 					"enabled":                                true,
@@ -270,6 +277,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OpenCensusReceiverConfig: map[string]interface{}{},
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
+				LogsEnabled:              true,
 				TracePort:                5003,
 				Metrics: map[string]interface{}{
 					"enabled":         true,
@@ -297,6 +305,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OpenCensusReceiverConfig: map[string]interface{}{},
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
+				LogsEnabled:              true,
 				TracePort:                5003,
 				Metrics: map[string]interface{}{
 					"enabled":         true,
@@ -325,6 +334,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OpenCensusReceiverConfig: map[string]interface{}{},
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
+				LogsEnabled:              true,
 				TracePort:                5003,
 				Metrics: map[string]interface{}{
 					"enabled":         true,
@@ -351,6 +361,45 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OpenCensusReceiverConfig: map[string]interface{}{"endpoint": "0.0.0.0:55678"},
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
+				LogsEnabled:              true,
+				TracePort:                5003,
+				Metrics: map[string]interface{}{
+					"enabled":         true,
+					"tag_cardinality": "low",
+				},
+				Debug: map[string]interface{}{},
+			},
+		},
+		{
+			name: "logs enabled",
+			env: map[string]string{
+				"DD_OTLP_CONFIG_LOGS_ENABLED": "true",
+			},
+			cfg: PipelineConfig{
+				OTLPReceiverConfig:       map[string]interface{}{},
+				OpenCensusReceiverConfig: map[string]interface{}{},
+				MetricsEnabled:           true,
+				TracesEnabled:            true,
+				LogsEnabled:              true,
+				TracePort:                5003,
+				Metrics: map[string]interface{}{
+					"enabled":         true,
+					"tag_cardinality": "low",
+				},
+				Debug: map[string]interface{}{},
+			},
+		},
+		{
+			name: "logs disabled",
+			env: map[string]string{
+				"DD_OTLP_CONFIG_LOGS_ENABLED": "false",
+			},
+			cfg: PipelineConfig{
+				OTLPReceiverConfig:       map[string]interface{}{},
+				OpenCensusReceiverConfig: map[string]interface{}{},
+				MetricsEnabled:           true,
+				TracesEnabled:            true,
+				LogsEnabled:              false,
 				TracePort:                5003,
 				Metrics: map[string]interface{}{
 					"enabled":         true,
@@ -391,6 +440,7 @@ func TestFromAgentConfigMetrics(t *testing.T) {
 				TracePort:                5003,
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
+				LogsEnabled:              true,
 				Metrics: map[string]interface{}{
 					"enabled":                     true,
 					"delta_ttl":                   2400,
@@ -441,6 +491,7 @@ func TestFromAgentConfigDebug(t *testing.T) {
 				TracePort:                5003,
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
+				LogsEnabled:              true,
 				Debug:                    map[string]interface{}{},
 				Metrics:                  map[string]interface{}{"enabled": true, "tag_cardinality": "low"},
 			},
@@ -454,6 +505,7 @@ func TestFromAgentConfigDebug(t *testing.T) {
 				TracePort:                5003,
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
+				LogsEnabled:              true,
 				Debug:                    map[string]interface{}{"loglevel": "debug"},
 				Metrics:                  map[string]interface{}{"enabled": true, "tag_cardinality": "low"},
 			},
@@ -467,6 +519,7 @@ func TestFromAgentConfigDebug(t *testing.T) {
 				TracePort:                5003,
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
+				LogsEnabled:              true,
 				Debug:                    map[string]interface{}{"loglevel": "disabled"},
 				Metrics:                  map[string]interface{}{"enabled": true, "tag_cardinality": "low"},
 			},
@@ -480,6 +533,7 @@ func TestFromAgentConfigDebug(t *testing.T) {
 				TracePort:                5003,
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
+				LogsEnabled:              true,
 				Debug:                    map[string]interface{}{"verbosity": "normal"},
 				Metrics:                  map[string]interface{}{"enabled": true, "tag_cardinality": "low"},
 			},

--- a/releasenotes/notes/otlp-log-ingestion-config-6da2fca24efe1fad.yaml
+++ b/releasenotes/notes/otlp-log-ingestion-config-6da2fca24efe1fad.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    Add config variables and environment variable ``DD_OTLP_CONFIG_LOGS_ENABLED `` related to OTLP log ingestion

--- a/releasenotes/notes/otlp-log-ingestion-config-6da2fca24efe1fad.yaml
+++ b/releasenotes/notes/otlp-log-ingestion-config-6da2fca24efe1fad.yaml
@@ -1,3 +1,3 @@
 features:
   - |
-    Add config variables and environment variable ``DD_OTLP_CONFIG_LOGS_ENABLED `` related to OTLP log ingestion
+    Adding new configuration setting ``otlp_config.logs.enabled`` to enable/disable logs support  in the OTLP ingest endpoint.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add configuration variables that will be used to enable log ingestion in the OTLP agent. These will be picked up by `map_provider.go` when the pipeline is being initialized, to create an exporter that handles logs.

Adding `logs:` to the `otlp_config:` in `datadog.yaml` will enable them.

[An RFC with more information can be found here.](https://docs.google.com/document/d/1nIcH_5YFFDCNzIy1gDL2OresVovrW2hbYfGY0v4Sp-A/edit)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
