### PR TITLE
Use gitlab compare_to for better change detection

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -854,21 +854,23 @@ workflow:
 
 .on_system_probe_changes_or_manual:
   - changes:
-      - pkg/collector/corechecks/ebpf/**/*
-      - pkg/ebpf/**/*
-      - pkg/network/**/*
-      - pkg/util/kernel/**/*
-      - test/kitchen/site-cookbooks/dd-system-probe-check/**/*
-      - test/kitchen/test/integration/system-probe-test/**/*
-      - test/kitchen/test/integration/win-sysprobe-test/**/*
-      - .gitlab/functional_test/system_probe.yml
-      - .gitlab/kernel_version_testing/system_probe.yml
-      - test/new-e2e/system-probe/**/*
-      - test/new-e2e/scenarios/system-probe/**/*
-      - test/new-e2e/runner/**/*
-      - test/new-e2e-utils/**/*
-      - test/new-e2e/go.mod
-      - tasks/system_probe.py
+      paths:
+        - pkg/collector/corechecks/ebpf/**/*
+        - pkg/ebpf/**/*
+        - pkg/network/**/*
+        - pkg/util/kernel/**/*
+        - test/kitchen/site-cookbooks/dd-system-probe-check/**/*
+        - test/kitchen/test/integration/system-probe-test/**/*
+        - test/kitchen/test/integration/win-sysprobe-test/**/*
+        - .gitlab/functional_test/system_probe.yml
+        - .gitlab/kernel_version_testing/system_probe.yml
+        - test/new-e2e/system-probe/**/*
+        - test/new-e2e/scenarios/system-probe/**/*
+        - test/new-e2e/runner/**/*
+        - test/new-e2e-utils/**/*
+        - test/new-e2e/go.mod
+        - tasks/system_probe.py
+      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
     when: on_success
   - when: manual
     allow_failure: true

--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -116,6 +116,8 @@ upload_dependencies_arm64:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   allow_failure: true
   tags: ["arch:amd64"]
+  rules:
+    !reference [ .on_system_probe_changes_or_manual ]
   before_script:
     - !reference [.retrieve_linux_go_deps]
     - !reference [.kernel_matrix_testing_new_profile]
@@ -189,6 +191,8 @@ upload_system_probe_tests_arm64:
   stage: kernel_matrix_testing
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   tags: ["arch:amd64"]
+  rules:
+    !reference [ .on_system_probe_changes_or_manual ]
   allow_failure: true
   script:
     # Build dependencies directory
@@ -294,6 +298,8 @@ kernel_matrix_testing_setup_env:
   allow_failure: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
   tags: ["arch:amd64"]
+  rules:
+    !reference [ .on_system_probe_changes_or_manual ]
   variables:
     AWS_EC2_SSH_KEY_FILE: $CI_PROJECT_DIR/ssh_key
     RETRY: 2
@@ -348,6 +354,8 @@ kernel_matrix_testing_cleanup:
   needs: ["kernel_matrix_testing_setup_env", "kernel_matrix_testing_run_tests_x64", "kernel_matrix_testing_run_tests_arm64"]
   when: always
   tags: ["arch:amd64"]
+  rules:
+    !reference [ .on_system_probe_changes_or_manual ]
   before_script:
     - !reference [.kernel_matrix_testing_new_profile]
   script:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Uses new Gitlab feature `compare_to` to get better system-probe change detection. 

### Motivation

Not running system-probe tests on the first commit of every branch. 

### Additional Notes

Alternative to #16896. Includes changes from #18126 

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
