### PR TITLE
[pkg/logs] Add getter to expose logs-agent pipeline

### DIFF
--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -114,6 +114,11 @@ func (a *Agent) Stop() {
 	}
 }
 
+// GetPipelineProvider gets the pipeline provider
+func (a *Agent) GetPipelineProvider() pipeline.Provider {
+	return a.pipelineProvider
+}
+
 // AddScheduler adds the given scheduler to the agent.
 func (a *Agent) AddScheduler(scheduler schedulers.Scheduler) {
 	a.schedulers.AddScheduler(scheduler)

--- a/pkg/logs/agent_test.go
+++ b/pkg/logs/agent_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
@@ -156,6 +158,39 @@ func (suite *AgentTestSuite) TestAgentStopsWithWrongBackendTcp() {
 	assert.Equal(suite.T(), int64(0), metrics.LogsSent.Value())
 	assert.Equal(suite.T(), "2", metrics.DestinationLogsDropped.Get("fake:").String())
 	assert.True(suite.T(), metrics.DestinationErrors.Value() > 0)
+}
+
+func (suite *AgentTestSuite) TestGetPipelineProvider() {
+	l := mock.NewMockLogsIntake(suite.T())
+	defer l.Close()
+
+	endpoint := tcp.AddrToEndPoint(l.Addr())
+	endpoints := config.NewEndpoints(endpoint, nil, true, false)
+
+	agent, _, _ := createAgent(endpoints)
+
+	cfg := &config.LogsConfig{
+		Type:    "type",
+		Source:  "source",
+		Service: "service",
+	}
+	src := sources.NewLogSource("source", cfg)
+	origin := message.NewOrigin(src)
+	msg := message.NewMessage([]byte("a"), origin, "", 0)
+
+	agent.Start()
+	testChannel := agent.GetPipelineProvider().NextPipelineChan()
+	testChannel <- msg
+
+	testutil.AssertTrueBeforeTimeout(suite.T(), 10*time.Millisecond, 2*time.Second, func() bool {
+		return 1 == metrics.LogsProcessed.Value()
+	})
+	agent.Stop()
+
+	assert.Equal(suite.T(), int64(1), metrics.LogsDecoded.Value())
+	assert.Equal(suite.T(), int64(1), metrics.LogsProcessed.Value())
+	assert.Equal(suite.T(), int64(1), metrics.LogsSent.Value())
+	assert.Equal(suite.T(), int64(0), metrics.DestinationErrors.Value())
 }
 
 func TestAgentTestSuite(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add GetPipelineProvider to logs-agent in order to access pipeline channel in other services within datadog-agent, e.g. via `logsAgent.GetPipelineProvider().NextPipelineChan()`. This will be used by services that want to send logs internally - in a followup PR, this will be used in OTLP log ingestion.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

[An RFC with context for the OTLP feature that requires this change can be found here.](https://docs.google.com/document/d/1nIcH_5YFFDCNzIy1gDL2OresVovrW2hbYfGY0v4Sp-A/edit)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
