### PR TITLE
usm: http2: Increase kernel path limit to 160

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -18,8 +18,7 @@
 #define HTTP2_MAX_HEADERS_COUNT_FOR_PROCESSING 3
 
 // Maximum size for the path buffer.
-// NOTE: we may need to change the max size.
-#define HTTP2_MAX_PATH_LEN 30
+#define HTTP2_MAX_PATH_LEN 160
 
 // The maximum index which may be in the static table.
 #define MAX_STATIC_TABLE_INDEX 61

--- a/pkg/network/protocols/http2/types.go
+++ b/pkg/network/protocols/http2/types.go
@@ -13,6 +13,10 @@ package http2
 */
 import "C"
 
+const (
+	maxHTTP2Path = C.HTTP2_MAX_PATH_LEN
+)
+
 type connTuple = C.conn_tuple_t
 type EbpfTx C.http2_stream_t
 

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -3,6 +3,10 @@
 
 package http2
 
+const (
+	maxHTTP2Path = 0xa0
+)
+
 type connTuple = struct {
 	Saddr_h  uint64
 	Saddr_l  uint64
@@ -23,8 +27,7 @@ type EbpfTx struct {
 	Path_size             uint8
 	Request_end_of_stream bool
 	Pad_cgo_0             [6]byte
-	Request_path          [30]uint8
-	Pad_cgo_1             [2]byte
+	Request_path          [160]uint8
 }
 
 type StaticTableEnumKey = uint32


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Increases the kernel limit for encoded path (http2) to 160.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Support longer paths.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
