### PR TITLE
[CWS] improve exec exec rebase algorithm CPU usage

### DIFF
--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -587,7 +587,9 @@ func (at *ActivityTree) findProcessCacheEntryInTree(tree []*ProcessNode, entry *
 		if child.Matches(&entry.Process, at.differentiateArgs) {
 			return child, i
 		}
+	}
 
+	for i, child := range tree {
 		// has the parent execed into one of its own children ?
 		if execChild := at.findProcessCacheEntryInChildExecedNodes(child, entry); execChild != nil {
 			return execChild, i

--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -614,17 +614,14 @@ func (at *ActivityTree) findProcessCacheEntryInChildExecedNodes(child *ProcessNo
 		for _, node := range cursor.Children {
 			if node.Process.IsExecChild && !slices.Contains(visited, node) {
 				// there should always be only one
+
+				// does this execed child match the entry ?
+				if node.Matches(&entry.Process, at.differentiateArgs) {
+					return node
+				}
+
 				execChildren = append(execChildren, node)
 			}
-		}
-
-		if len(execChildren) == 0 {
-			break
-		}
-
-		// does this execed child match the entry ?
-		if execChildren[0].Matches(&entry.Process, at.differentiateArgs) {
-			return execChildren[0]
 		}
 	}
 

--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -605,8 +605,8 @@ func (at *ActivityTree) findProcessCacheEntryInChildExecedNodes(child *ProcessNo
 	visited := make([]*ProcessNode, 0, 64)
 
 	for len(execChildren) > 0 {
-		cursor := execChildren[0]
-		execChildren = execChildren[1:]
+		cursor := execChildren[len(execChildren)-1]
+		execChildren = execChildren[:len(execChildren)-1]
 
 		visited = append(visited, cursor)
 

--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -598,6 +598,18 @@ func (at *ActivityTree) findProcessCacheEntryInTree(tree []*ProcessNode, entry *
 
 // findProcessCacheEntryInChildExecedNodes look for entry in the execed nodes of child
 func (at *ActivityTree) findProcessCacheEntryInChildExecedNodes(child *ProcessNode, entry *model.ProcessCacheEntry) *ProcessNode {
+	// fast path
+	for _, node := range child.Children {
+		if node.Process.IsExecChild {
+			// does this execed child match the entry ?
+			if node.Matches(&entry.Process, at.differentiateArgs) {
+				return node
+			}
+		}
+	}
+
+	// slow path
+
 	// children is used to iterate over the tree below child
 	execChildren := make([]*ProcessNode, 1, 64)
 	execChildren[0] = child


### PR DESCRIPTION
### What does this PR do?

This PR improves the CPU usage of the exec exec rebase algorithm by:
- improving the allocation patterns
- creating a simple, alloc-free, fast path
- implementing cycle detection (to protect ourselves against a potential bug)
- moving from a queue to a stack when visiting children

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
