### PR TITLE
Refactor RemoteAPI users to share more code [AP-2069]

### DIFF
--- a/tasks/libs/common/github_api.py
+++ b/tasks/libs/common/github_api.py
@@ -76,27 +76,11 @@ class GithubAPI(RemoteAPI):
                 return milestone
         return None
 
-    def make_request(self, path, headers=None, method="GET", data=None, json_output=False):
-        """
-        Utility to make an HTTP request to the GitHub API.
-        See RemoteAPI#request.
-
-        Adds "Authorization: token {self.api_token}" and "Accept: application/vnd.github.v3+json"
-        to the headers to be able to authenticate ourselves to GitHub.
-        """
-        headers = dict(headers or [])
-        headers["Authorization"] = f"token {self.api_token}"
-        headers["Accept"] = "application/vnd.github.v3+json"
-
-        return self.request(
-            path=path,
-            headers=headers,
-            data=data,
-            json_input=False,
-            json_output=json_output,
-            stream_output=False,
-            method=method,
-        )
+    def auth_headers(self):
+        return {
+            "Authorization": f"token {self.api_token}",
+            "Accept": "application/vnd.github.v3+json",
+        }
 
 
 def get_github_token():

--- a/tasks/libs/common/github_api.py
+++ b/tasks/libs/common/github_api.py
@@ -17,8 +17,8 @@ class GithubAPI(RemoteAPI):
 
     BASE_URL = "https://api.github.com"
 
-    def __init__(self, repository="", api_token=""):
-        super(GithubAPI, self).__init__("GitHub API")
+    def __init__(self, repository="", api_token="", api_name="Github API"):
+        super(GithubAPI, self).__init__(api_name)
         self.api_token = api_token
         self.repository = repository
         self.authorization_error_message = (

--- a/tasks/libs/common/github_workflows.py
+++ b/tasks/libs/common/github_workflows.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from .githubapp import GithubApp, GithubAppException
-from .remote_api import RemoteAPI
+from .github_api import GithubAPI
 
 __all__ = ["GithubWorkflows", "GithubException", "get_github_app_token"]
 
@@ -11,7 +11,7 @@ class GithubException(Exception):
     pass
 
 
-class GithubWorkflows(RemoteAPI):
+class GithubWorkflows(GithubAPI):
     """
     Helper class to perform API calls against the Github Workflows API, using a Github App.
     """
@@ -19,21 +19,11 @@ class GithubWorkflows(RemoteAPI):
     BASE_URL = "https://api.github.com"
 
     def __init__(self, repository="", api_token="", api_token_expiration_date=""):
-        super(GithubWorkflows, self).__init__("GitHub Workflows")
-        self.api_token = api_token
+        super(GithubWorkflows, self).__init__(repository, api_token, "GitHub Workflows")
         self.api_token_expiration_date = api_token_expiration_date
-        self.repository = repository
         self.authorization_error_message = (
             "HTTP 401: The token is invalid. Is the Github App still allowed to perform this action?"
         )
-
-    def repo(self):
-        """
-        Gets the repo info.
-        """
-
-        path = f"/repos/{self.repository}"
-        return self.make_request(path, method="GET", json_output=True)
 
     def trigger_workflow(self, workflow_name, ref, inputs=None):
         """
@@ -87,12 +77,6 @@ class GithubWorkflows(RemoteAPI):
         """
         path = f"/repos/{self.repository}/actions/workflows/{workflow_name}/runs"
         return self.make_request(path, method="GET", json_output=True)
-
-    def auth_headers(self):
-        return {
-            "Authorization": f"token {self.api_token}",
-            "Accept": "application/vnd.github.v3+json",
-        }
 
 
 def get_github_app_token():

--- a/tasks/libs/common/github_workflows.py
+++ b/tasks/libs/common/github_workflows.py
@@ -88,28 +88,11 @@ class GithubWorkflows(RemoteAPI):
         path = f"/repos/{self.repository}/actions/workflows/{workflow_name}/runs"
         return self.make_request(path, method="GET", json_output=True)
 
-    def make_request(self, path, headers=None, method="GET", data=None, json_output=False, raw_output=False):
-        """
-        Utility to make an HTTP request to the GitHub API.
-        See RemoteAPI#request.
-
-        Adds "Authorization: token {self.api_token}" and "Accept: application/vnd.github.v3+json"
-        to the headers to be able to authenticate ourselves to GitHub.
-        """
-        headers = dict(headers or [])
-        headers["Authorization"] = f"token {self.api_token}"
-        headers["Accept"] = "application/vnd.github.v3+json"
-
-        return self.request(
-            path=path,
-            headers=headers,
-            data=data,
-            json_input=False,
-            json_output=json_output,
-            raw_output=raw_output,
-            stream_output=False,
-            method=method,
-        )
+    def auth_headers(self):
+        return {
+            "Authorization": f"token {self.api_token}",
+            "Accept": "application/vnd.github.v3+json",
+        }
 
 
 def get_github_app_token():

--- a/tasks/libs/common/github_workflows.py
+++ b/tasks/libs/common/github_workflows.py
@@ -1,8 +1,8 @@
 import json
 import os
 
-from .githubapp import GithubApp, GithubAppException
 from .github_api import GithubAPI
+from .githubapp import GithubApp, GithubAppException
 
 __all__ = ["GithubWorkflows", "GithubException", "get_github_app_token"]
 

--- a/tasks/libs/common/githubapp.py
+++ b/tasks/libs/common/githubapp.py
@@ -16,7 +16,6 @@ class GithubAppException(Exception):
 
 
 class GithubApp(RemoteAPI):
-
     BASE_URL = 'https://api.github.com'
 
     def __init__(self):

--- a/tasks/libs/common/githubapp.py
+++ b/tasks/libs/common/githubapp.py
@@ -63,17 +63,13 @@ class GithubApp:
         If method is GET, the data parameter is ignored (no body can be sent in a GET request).
 
         """
-        import requests
+        headers = self.get_headers()
 
-        url = self.base_url + endpoint
-
-        if method == 'GET':
-            return requests.get(url, headers=self.get_headers())
-        if method == 'POST':
-            if data:
-                return requests.post(url, data=data, headers=self.get_headers())
-            else:
-                return requests.post(url, headers=self.get_headers())
+        return self.make_request(endpoint,
+                                 headers=headers,
+                                 data=data,
+                                 stream_output=False,
+                                 method=method)
 
     def get_token(self):
         """

--- a/tasks/libs/common/githubapp.py
+++ b/tasks/libs/common/githubapp.py
@@ -4,6 +4,8 @@ import os
 import time
 from datetime import datetime
 
+from .remote_api import RemoteAPI
+
 logger = logging.getLogger(__name__)
 logger.setLevel(os.environ.get('LOGGING_LEVEL', 'INFO'))
 
@@ -13,8 +15,9 @@ class GithubAppException(Exception):
     pass
 
 
-class GithubApp:
+class GithubApp(RemoteAPI):
     def __init__(self):
+        super(GithubApp, self).__init__("GitHub APP")
         self.key_b64 = os.environ['GITHUB_KEY_B64']
         self.app_id = os.environ['GITHUB_APP_ID']
         self.base_url = 'https://api.github.com'

--- a/tasks/libs/common/githubapp.py
+++ b/tasks/libs/common/githubapp.py
@@ -41,7 +41,7 @@ class GithubApp(RemoteAPI):
         payload = {'iat': epoch, 'exp': epoch + (5 * 60), 'iss': self.app_id}
         return payload
 
-    def get_headers(self):
+    def auth_headers(self):
         """
         Craft headers to make a request to the Github API as a Github App.
         """
@@ -54,25 +54,6 @@ class GithubApp(RemoteAPI):
             'Accept': 'application/vnd.github.v3+json',
         }
         return headers
-
-    def make_request(self, endpoint, method='GET', data=None):
-        """
-        Make an HTTP request to the Github API, while using a token crafted from the App ID and
-        private key to authenticate ourselves as a Github App.
-
-        endpoint is the HTTP enpoint that will be requested.
-
-        The method parameter dictates the type of request made (GET or POST).
-        If method is GET, the data parameter is ignored (no body can be sent in a GET request).
-
-        """
-        headers = self.get_headers()
-
-        return self.make_request(endpoint,
-                                 headers=headers,
-                                 data=data,
-                                 stream_output=False,
-                                 method=method)
 
     def get_token(self):
         """

--- a/tasks/libs/common/githubapp.py
+++ b/tasks/libs/common/githubapp.py
@@ -16,11 +16,13 @@ class GithubAppException(Exception):
 
 
 class GithubApp(RemoteAPI):
+
+    BASE_URL = 'https://api.github.com'
+
     def __init__(self):
         super(GithubApp, self).__init__("GitHub APP")
         self.key_b64 = os.environ['GITHUB_KEY_B64']
         self.app_id = os.environ['GITHUB_APP_ID']
-        self.base_url = 'https://api.github.com'
         self.installation_id = os.environ.get('GITHUB_INSTALLATION_ID', None)
         if self.installation_id is None:
             # Even if we don't know the installation id, there's an API endpoint to

--- a/tasks/libs/common/githubapp.py
+++ b/tasks/libs/common/githubapp.py
@@ -63,20 +63,8 @@ class GithubApp(RemoteAPI):
         the Github API with the permissions of this App.
         """
         endpoint = f'/app/installations/{self.installation_id}/access_tokens'
-        for _ in range(5):  # Retry up to 5 times
-            r = self.make_request(endpoint, method='POST')
-            if r.status_code != 200 and r.status_code != 201:
-                logger.warning(
-                    f"""Error in HTTP Request for access token.
-                Status code: {r.status_code} Response Text: {r.text}"""
-                )
-                time.sleep(1)
-                continue
-            return r.json().get("token"), datetime.strptime(r.json().get("expires_at"), "%Y-%m-%dT%H:%M:%SZ")
-        raise GithubAppException(
-            f"""Unable to retrieve an access token.
-        Status code: {r.status_code} Response Text: {r.text}"""
-        )
+        r = self.make_request(endpoint, method='POST', json_output=True)
+        return r.get("token"), datetime.strptime(r.get("expires_at"), "%Y-%m-%dT%H:%M:%SZ")
 
     def get_installation(self):
         """
@@ -87,17 +75,5 @@ class GithubApp(RemoteAPI):
         for our usage, but as of now we expect the App to only have one installation.
         """
         endpoint = '/app/installations'
-        for _ in range(5):  # Retry up to 5 times
-            r = self.make_request(endpoint, method='GET')
-            if r.status_code != 200 and r.status_code != 201:
-                logger.warning(
-                    f"""Error in HTTP Request for installation id.
-                Status code: {r.status_code} Response Text: {r.text}"""
-                )
-                time.sleep(1)
-                continue
-            return r.json()[0]["id"]
-        raise GithubAppException(
-            f"""Unable to retrieve installation id.
-        Status code: {r.status_code} Response Text: {r.text}"""
-        )
+        r = self.make_request(endpoint, method='GET', json_output=True)
+        return r[0]["id"]

--- a/tasks/libs/common/gitlab.py
+++ b/tasks/libs/common/gitlab.py
@@ -285,9 +285,7 @@ class Gitlab(RemoteAPI):
         """
         Adds "PRIVATE-TOKEN: {self.api_token}" to the headers to be able to authenticate ourselves to GitLab.
         """
-        return {
-            "PRIVATE-TOKEN": self.api_token
-        }
+        return {"PRIVATE-TOKEN": self.api_token}
 
 
 def get_gitlab_token():

--- a/tasks/libs/common/gitlab.py
+++ b/tasks/libs/common/gitlab.py
@@ -281,28 +281,13 @@ class Gitlab(RemoteAPI):
             else:
                 raise e
 
-    def make_request(
-        self, path, headers=None, data=None, json_input=False, json_output=False, stream_output=False, method=None
-    ):
+    def auth_headers(self):
         """
-        Utility to make a request to the Gitlab API.
-        See RemoteAPI#request.
-
         Adds "PRIVATE-TOKEN: {self.api_token}" to the headers to be able to authenticate ourselves to GitLab.
         """
-        headers = dict(headers or [])
-        headers["PRIVATE-TOKEN"] = self.api_token
-
-        return self.request(
-            path=path,
-            headers=headers,
-            data=data,
-            json_input=json_input,
-            json_output=json_output,
-            stream_output=stream_output,
-            raw_output=False,
-            method=method,
-        )
+        return {
+            "PRIVATE-TOKEN": self.api_token
+        }
 
 
 def get_gitlab_token():

--- a/tasks/libs/common/remote_api.py
+++ b/tasks/libs/common/remote_api.py
@@ -27,7 +27,10 @@ class RemoteAPI(object):
         self.requests_sleep_time = sleep_time
         self.requests_500_retry_count = retry_count
 
-    def request(
+    def auth_headers(self):
+        pass
+
+    def make_request(
         self,
         path,
         headers=None,
@@ -56,6 +59,8 @@ class RemoteAPI(object):
         import requests
 
         url = self.BASE_URL + path
+        headers = dict(headers or [])
+        headers.update(self.auth_headers())
 
         # TODO: Use the param argument of requests instead of handling URL params
         # manually


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR refactors the usage of RemoteAPI to use a single common implementation of `make_request` instead of having a duplicated version with minor differences in all subclasses.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

AP-2069

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
