### PR TITLE
upgrade(rcclient): Deactivate thin client when server is disabled

### DIFF
--- a/cmd/agent/api/grpc.go
+++ b/cmd/agent/api/grpc.go
@@ -12,12 +12,13 @@ package api
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	workloadmetaServer "github.com/DataDog/datadog-agent/pkg/workloadmeta/server"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	dsdReplay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay"
@@ -115,18 +116,20 @@ func (s *serverSecure) DogstatsdSetTaggerState(ctx context.Context, req *pb.Tagg
 	return &pb.TaggerStateResponse{Loaded: true}, nil
 }
 
+var rcNotInitializedErr = status.Error(codes.Unimplemented, "remote configuration service not initialized")
+
 func (s *serverSecure) ClientGetConfigs(ctx context.Context, in *pb.ClientGetConfigsRequest) (*pb.ClientGetConfigsResponse, error) {
 	if s.configService == nil {
-		log.Debug("Remote configuration service not initialized")
-		return nil, errors.New("remote configuration service not initialized")
+		log.Debug(rcNotInitializedErr.Error())
+		return nil, rcNotInitializedErr
 	}
 	return s.configService.ClientGetConfigs(ctx, in)
 }
 
 func (s *serverSecure) GetConfigState(ctx context.Context, e *emptypb.Empty) (*pb.GetStateConfigResponse, error) {
 	if s.configService == nil {
-		log.Debug("Remote configuration service not initialized")
-		return nil, errors.New("remote configuration service not initialized")
+		log.Debug(rcNotInitializedErr.Error())
+		return nil, rcNotInitializedErr
 	}
 	return s.configService.ConfigGetState()
 }

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -199,7 +199,9 @@ func startSystemProbe(cliParams *cliParams, log log.Component, telemetry telemet
 
 	setupInternalProfiling(sysprobeconfig, configPrefix, log)
 
-	if ddconfig.Datadog.GetBool("remote_configuration.enabled") {
+	if ddconfig.IsRemoteConfigEnabled(ddconfig.Datadog) {
+		// Even if the system-probe happen to not have access to ddconfig.Datadog, the
+		// thin client will deactivate itself if the core-agent RC server is disabled
 		err = rcclient.Listen("system-probe", []data.Product{data.ProductAgentConfig})
 		if err != nil {
 			return log.Criticalf("unable to start remote configuration client: %s", err)


### PR DESCRIPTION
### What does this PR do?
Adds a safeguard in the RC thin client to deactivate it when it receives an `Unimplemented` response from the server. 

### Motivation
The system probe uses another config and may not properly compute whether RC is enabled or not.

### Additional Notes
The `Unimplemented` code was used because it fits a resource that needs to be enabled, and because it is different from `Unavailable` that would be returned if the server fails to initialize / hasn't initialized yet. `Unavailable` is a case we want to retry.

### Possible Drawbacks / Trade-offs
N/A

### Describe how to test/QA your changes
This PR is a bit tricky to QA. If you have access to the system probe, you can try to enable RC in the system probe but disable it in the core agent and check that the client is disabled. 

If not, I'd recommend building the agent twice and testing it with remote config disabled:
- Once with [these lines](https://github.com/DataDog/datadog-agent/blob/cecf63f/cmd/agent/subcommands/run/command.go#L428-L430) commented, and with [this block](https://github.com/DataDog/datadog-agent/blob/cecf63f/cmd/agent/subcommands/run/command.go#L409-L411) out of the "is rc enabled" check.
- Once with only [this block](https://github.com/DataDog/datadog-agent/blob/cecf63f/cmd/agent/subcommands/run/command.go#L409-L411) out of the "is rc enabled" check. 

The first one should return `Unavailable` and the client should retry. The second one should return `Unimplemented` and the client should stop polling (check debug logs)

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
