### PR TITLE
Remove high load scenarios for trace-agent benchmarks

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -55,30 +55,6 @@ trace-agent-v04-4cpus-avg_load-fixed_mbps-macrobenchmarks:
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-avg_load-fixed_mbps
     BENCHMARK_TARGETS: "avg_load.*Mbps"
 
-trace-agent-v04-4cpus-high_load-fixed_sps-macrobenchmarks:
-  extends: .trace_agent_benchmarks
-  when: manual
-  variables:
-    TRACE_AGENT_VERSION: main
-    TRACE_AGENT_ENDPOINT: v04
-    TRACE_AGENT_CPUS: 4
-    DD_APM_MAX_CPU_PERCENT: 0
-    DD_APM_MAX_MEMORY: 0
-    DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-high_load-fixed_sps
-    BENCHMARK_TARGETS: "high_load.*sps"
-
-trace-agent-v04-4cpus-high_load-fixed_mbps-macrobenchmarks:
-  extends: .trace_agent_benchmarks
-  when: manual
-  variables:
-    TRACE_AGENT_VERSION: main
-    TRACE_AGENT_ENDPOINT: v04
-    TRACE_AGENT_CPUS: 4
-    DD_APM_MAX_CPU_PERCENT: 0
-    DD_APM_MAX_MEMORY: 0
-    DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-high_load-fixed_mbps
-    BENCHMARK_TARGETS: "high_load.*Mbps"
-
 trace-agent-v04-4cpus-stress_load-fixed_sps-macrobenchmarks:
   extends: .trace_agent_benchmarks
   when: manual
@@ -124,30 +100,6 @@ trace-agent-v05-4cpus-avg_load-fixed_mbps-macrobenchmarks:
     DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-avg_load-fixed_mbps
     BENCHMARK_TARGETS: "avg_load.*Mbps"
-
-trace-agent-v05-4cpus-high_load-fixed_sps-macrobenchmarks:
-  extends: .trace_agent_benchmarks
-  when: manual
-  variables:
-    TRACE_AGENT_VERSION: main
-    TRACE_AGENT_ENDPOINT: v05
-    TRACE_AGENT_CPUS: 4
-    DD_APM_MAX_CPU_PERCENT: 0
-    DD_APM_MAX_MEMORY: 0
-    DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-high_load-fixed_sps
-    BENCHMARK_TARGETS: "high_load.*sps"
-
-trace-agent-v05-4cpus-high_load-fixed_mbps-macrobenchmarks:
-  extends: .trace_agent_benchmarks
-  when: manual
-  variables:
-    TRACE_AGENT_VERSION: main
-    TRACE_AGENT_ENDPOINT: v05
-    TRACE_AGENT_CPUS: 4
-    DD_APM_MAX_CPU_PERCENT: 0
-    DD_APM_MAX_MEMORY: 0
-    DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-high_load-fixed_mbps
-    BENCHMARK_TARGETS: "high_load.*Mbps"
 
 trace-agent-v05-4cpus-stress_load-fixed_sps-macrobenchmarks:
   extends: .trace_agent_benchmarks


### PR DESCRIPTION
We need only avg load and stress load scenarios to make conclusions about performance of trace-agent. High load scenarios don't add any additional information to the formula (they are like avg load case with slightly larger RPS).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
