### PR TITLE
[WIP][CI] Cancel pipelines running on the same ref to save some CI time

### DIFF
--- a/.gitlab/setup/setup.yml
+++ b/.gitlab/setup/setup.yml
@@ -3,9 +3,11 @@ setup_agent_version:
   stage: setup
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
+  variables:
+    DO_NOT_CANCEL_PIPELINES: ${{ contains(github.event.*.labels.*.name, 'dev/do-not-cancel-pipelines') }}
   script:
     - source /root/.bashrc
-    - inv -e pipeline.cancel_pipelines_on_same_ref --force --git-ref $DD_REPO_BRANCH_NAME
+    - if [ $DO_NOT_CANCEL_PIPELINES == "true" ]; then inv -e pipeline.cancel_pipelines_on_same_ref --force --git-ref $DD_REPO_BRANCH_NAME; fi
     - inv -e agent.version --version-cached
     - $S3_CP_CMD $CI_PROJECT_DIR/agent-version.cache $S3_ARTIFACTS_URI/agent-version.cache
 

--- a/.gitlab/setup/setup.yml
+++ b/.gitlab/setup/setup.yml
@@ -7,6 +7,7 @@ setup_agent_version:
     DO_NOT_CANCEL_PIPELINES: ${{ contains(github.event.*.labels.*.name, 'dev/do-not-cancel-pipelines') }}
   script:
     - source /root/.bashrc
+    - echo $DO_NOT_CANCEL_PIPELINES
     - if [ $DO_NOT_CANCEL_PIPELINES == "true" ]; then inv -e pipeline.cancel_pipelines_on_same_ref --force --git-ref $DD_REPO_BRANCH_NAME; fi
     - inv -e agent.version --version-cached
     - $S3_CP_CMD $CI_PROJECT_DIR/agent-version.cache $S3_ARTIFACTS_URI/agent-version.cache

--- a/.gitlab/setup/setup.yml
+++ b/.gitlab/setup/setup.yml
@@ -1,4 +1,13 @@
 ---
+cancel_pipelines_on_same_ref:
+  stage: setup
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  if: ${{ contains(github.event.*.labels.*.name, 'dev/do-not-cancel-pipelines') }}
+  script:
+    - source /root/.bashrc
+    - inv -e pipeline.cancel_pipelines_on_same_ref --force --git-ref $DD_REPO_BRANCH_NAME
+
 setup_agent_version:
   stage: setup
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -7,8 +16,6 @@ setup_agent_version:
     DO_NOT_CANCEL_PIPELINES: ${{ contains(github.event.*.labels.*.name, 'dev/do-not-cancel-pipelines') }}
   script:
     - source /root/.bashrc
-    - echo $DO_NOT_CANCEL_PIPELINES
-    - if [ $DO_NOT_CANCEL_PIPELINES == "true" ]; then inv -e pipeline.cancel_pipelines_on_same_ref --force --git-ref $DD_REPO_BRANCH_NAME; fi
     - inv -e agent.version --version-cached
     - $S3_CP_CMD $CI_PROJECT_DIR/agent-version.cache $S3_ARTIFACTS_URI/agent-version.cache
 

--- a/.gitlab/setup/setup.yml
+++ b/.gitlab/setup/setup.yml
@@ -12,8 +12,6 @@ setup_agent_version:
   stage: setup
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  variables:
-    DO_NOT_CANCEL_PIPELINES: ${{ contains(github.event.*.labels.*.name, 'dev/do-not-cancel-pipelines') }}
   script:
     - source /root/.bashrc
     - inv -e agent.version --version-cached

--- a/.gitlab/setup/setup.yml
+++ b/.gitlab/setup/setup.yml
@@ -3,7 +3,7 @@ cancel_pipelines_on_same_ref:
   stage: setup
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  if: ${{ contains(github.event.*.labels.*.name, 'dev/do-not-cancel-pipelines') }}
+  if: ${{ contains(github.event.*.labels.*.name, 'dev/do-not-cancel-pipelines') }} && $CI_COMMIT_BRANCH != "main" && $CI_COMMIT_BRANCH !~ /^[0-9]+\.[0-9]+\.x$/
   script:
     - source /root/.bashrc
     - inv -e pipeline.cancel_pipelines_on_same_ref --force --git-ref $DD_REPO_BRANCH_NAME

--- a/.gitlab/setup/setup.yml
+++ b/.gitlab/setup/setup.yml
@@ -5,6 +5,7 @@ setup_agent_version:
   tags: ["arch:amd64"]
   script:
     - source /root/.bashrc
+    - inv -e pipeline.cancel_pipelines_on_same_ref --force --git-ref $DD_REPO_BRANCH_NAME
     - inv -e agent.version --version-cached
     - $S3_CP_CMD $CI_PROJECT_DIR/agent-version.cache $S3_ARTIFACTS_URI/agent-version.cache
 

--- a/tasks/libs/pipeline_tools.py
+++ b/tasks/libs/pipeline_tools.py
@@ -32,7 +32,7 @@ def parse_datetime(dt):
     return datetime.datetime.strptime(dt, "%Y-%m-%dT%H:%M:%S.%f%z")
 
 
-def cancel_pipelines_with_confirmation(gitlab, pipelines, force=False):
+def cancel_pipelines_with_confirmation(gitlab, pipelines, force):
     for pipeline in pipelines:
         commit_author, commit_short_sha, commit_title = get_commit_for_pipeline(gitlab, pipeline['id'])
 

--- a/tasks/libs/pipeline_tools.py
+++ b/tasks/libs/pipeline_tools.py
@@ -32,7 +32,7 @@ def parse_datetime(dt):
     return datetime.datetime.strptime(dt, "%Y-%m-%dT%H:%M:%S.%f%z")
 
 
-def cancel_pipelines_with_confirmation(gitlab, pipelines):
+def cancel_pipelines_with_confirmation(gitlab, pipelines, force=False):
     for pipeline in pipelines:
         commit_author, commit_short_sha, commit_title = get_commit_for_pipeline(gitlab, pipeline['id'])
 
@@ -55,7 +55,7 @@ def cancel_pipelines_with_confirmation(gitlab, pipelines):
             color_message(commit_author, "bold"),
         )
 
-        if yes_no_question("Do you want to cancel this pipeline?", color="orange", default=True):
+        if force or yes_no_question("Do you want to cancel this pipeline?", color="orange", default=True):
             gitlab.cancel_pipeline(pipeline['id'])
             print(f"Pipeline {color_message(pipeline['id'], 'bold')} has been cancelled.\n")
         else:

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -161,14 +161,21 @@ instead.""",
 
 
 @task
-def cancel_same_ref_pipelines(
+def cancel_pipelines_on_same_ref(
     _,
-    gitlab,
-    git_ref
+    git_ref,
+    force = False
 ):
     """
-    Cancel the pipelines on the CI that runs on the same ref as the one you're on
+    Cancel the pipelines on the CI that runs on the same ref as git_ref
+
+    Use --force to bypass the confirmation and force cancel the pipelines.
     """
+
+    project_name = "DataDog/datadog-agent"
+    gitlab = Gitlab(project_name=project_name, api_token=get_gitlab_token())
+    gitlab.test_project_found()
+
     pipelines = get_running_pipelines_on_same_ref(gitlab, git_ref)
 
     if pipelines:
@@ -179,7 +186,7 @@ def cancel_same_ref_pipelines(
             "They are ordered from the newest one to the oldest one.\n",
             sep='\n',
         )
-        cancel_pipelines_with_confirmation(gitlab, pipelines)
+        cancel_pipelines_with_confirmation(gitlab, pipelines, force)
 
 
 
@@ -273,7 +280,7 @@ def run(
             kitchen_tests = True
 
     # Cancelling the pipelines with the same git_ref with user confirmation input
-    cancel_same_ref_pipelines(ctx, gitlab, git_ref)
+    cancel_pipelines_on_same_ref(ctx, git_ref)
 
     try:
         pipeline_id = trigger_agent_pipeline(

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -162,7 +162,7 @@ instead.""",
 
 @task
 def cancel_same_ref_pipelines(
-    ctx,
+    _,
     gitlab,
     git_ref
 ):


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds a job named `cancel_pipelines_on_same_ref` that is run by default on all pipelines. It will by default cancel the pipelines not running on the latest commit. If you want each commit to have its pipeline run you can add the `dev/do-not-cancel-pipelines` label on your PR.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The CI costs a lot and we could save a lot with just this small modification.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
