### PR TITLE
Specify job id, name, and stage for system-probe kitchen tests

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -19,8 +19,10 @@
     DD_PIPELINE_ID: $CI_PIPELINE_ID-fnct
     CHEF_VERSION: 14.15.6
   script:
-    - echo -n "--tags ci.job.name:${CI_JOB_NAME}" > $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/tags.txt
-    - echo -n "${CI_JOB_URL}" > $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/job_url.txt
+    - echo "CI_JOB_URL=${CI_JOB_URL}" >> $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/job_env.txt
+    - echo "CI_JOB_ID=${CI_JOB_ID}" >> $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/job_env.txt
+    - echo "CI_JOB_NAME=${CI_JOB_NAME}" >> $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/job_env.txt
+    - echo "CI_JOB_STAGE=${CI_JOB_STAGE}" >> $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/job_env.txt
     - tasks/run-test-kitchen.sh security-agent-test $AGENT_MAJOR_VERSION
     - popd
     - inv security-agent.print-failed-tests --output-dir $DD_AGENT_TESTING_DIR/testjson

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -18,8 +18,10 @@
     DD_PIPELINE_ID: $CI_PIPELINE_ID-fnct
     CHEF_VERSION: 14.15.6
   script:
-    - echo -n "--tags ci.job.name:${CI_JOB_NAME}" > $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/tags.txt
-    - echo -n "${CI_JOB_URL}" > $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/job_url.txt
+    - echo "CI_JOB_URL=${CI_JOB_URL}" >> $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/job_env.txt
+    - echo "CI_JOB_ID=${CI_JOB_ID}" >> $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/job_env.txt
+    - echo "CI_JOB_NAME=${CI_JOB_NAME}" >> $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/job_env.txt
+    - echo "CI_JOB_STAGE=${CI_JOB_STAGE}" >> $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/job_env.txt
     - tasks/run-test-kitchen.sh system-probe-test $AGENT_MAJOR_VERSION
     - popd
     - inv system-probe.print-failed-tests --output-dir $DD_AGENT_TESTING_DIR/testjson

--- a/.gitlab/junit_upload/functional_test_junit_upload_security-agent.yml
+++ b/.gitlab/junit_upload/functional_test_junit_upload_security-agent.yml
@@ -15,4 +15,5 @@ functional_test_junit_upload_security_agent:
     - set +x
     - export DATADOG_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
     - set -x
-    - find $DD_AGENT_TESTING_DIR -maxdepth 1 -type f -name "kitchen-junit-*.tar.gz" -exec inv -e junit-upload --tgz-path {} \;
+    - pushd $DD_AGENT_TESTING_DIR
+    - ss=0; for f in kitchen-junit-*.tar.gz; do inv -e junit-upload --tgz-path $f || ((ss++)); done; exit $ss

--- a/.gitlab/junit_upload/functional_test_junit_upload_security-agent.yml
+++ b/.gitlab/junit_upload/functional_test_junit_upload_security-agent.yml
@@ -15,4 +15,4 @@ functional_test_junit_upload_security_agent:
     - set +x
     - export DATADOG_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
     - set -x
-    - ss=0; for f in $DD_AGENT_TESTING_DIR/kitchen-junit-*.tar.gz; do inv -e junit-upload --tgz-path $f || ((ss++)); done; exit $ss
+    - ss=0; for f in $DD_AGENT_TESTING_DIR/kitchen-junit-*.tar.gz; do [[ -e "$f" ]] || continue; inv -e junit-upload --tgz-path $f || ((ss++)); done; exit $ss

--- a/.gitlab/junit_upload/functional_test_junit_upload_security-agent.yml
+++ b/.gitlab/junit_upload/functional_test_junit_upload_security-agent.yml
@@ -15,5 +15,4 @@ functional_test_junit_upload_security_agent:
     - set +x
     - export DATADOG_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
     - set -x
-    - pushd $DD_AGENT_TESTING_DIR
-    - ss=0; for f in kitchen-junit-*.tar.gz; do inv -e junit-upload --tgz-path $f || ((ss++)); done; exit $ss
+    - ss=0; for f in $DD_AGENT_TESTING_DIR/kitchen-junit-*.tar.gz; do inv -e junit-upload --tgz-path $f || ((ss++)); done; exit $ss

--- a/.gitlab/junit_upload/functional_test_junit_upload_system_probe.yml
+++ b/.gitlab/junit_upload/functional_test_junit_upload_system_probe.yml
@@ -18,5 +18,4 @@ functional_test_junit_upload_system_probe:
     - set +x
     - export DATADOG_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
     - set -x
-    - pushd $DD_AGENT_TESTING_DIR
-    - ss=0; for f in kitchen-junit-*.tar.gz; do inv -e junit-upload --tgz-path $f || ((ss++)); done; exit $ss
+    - ss=0; for f in $DD_AGENT_TESTING_DIR/kitchen-junit-*.tar.gz; do inv -e junit-upload --tgz-path $f || ((ss++)); done; exit $ss

--- a/.gitlab/junit_upload/functional_test_junit_upload_system_probe.yml
+++ b/.gitlab/junit_upload/functional_test_junit_upload_system_probe.yml
@@ -18,4 +18,5 @@ functional_test_junit_upload_system_probe:
     - set +x
     - export DATADOG_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
     - set -x
-    - find $DD_AGENT_TESTING_DIR -maxdepth 1 -type f -name "kitchen-junit-*.tar.gz" -exec inv -e junit-upload --tgz-path {} \;
+    - pushd $DD_AGENT_TESTING_DIR
+    - ss=0; for f in kitchen-junit-*.tar.gz; do inv -e junit-upload --tgz-path $f || ((ss++)); done; exit $ss

--- a/.gitlab/junit_upload/functional_test_junit_upload_system_probe.yml
+++ b/.gitlab/junit_upload/functional_test_junit_upload_system_probe.yml
@@ -18,4 +18,4 @@ functional_test_junit_upload_system_probe:
     - set +x
     - export DATADOG_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
     - set -x
-    - ss=0; for f in $DD_AGENT_TESTING_DIR/kitchen-junit-*.tar.gz; do inv -e junit-upload --tgz-path $f || ((ss++)); done; exit $ss
+    - ss=0; for f in $DD_AGENT_TESTING_DIR/kitchen-junit-*.tar.gz; do [[ -e "$f" ]] || continue; inv -e junit-upload --tgz-path $f || ((ss++)); done; exit $ss

--- a/tasks/libs/junit_upload.py
+++ b/tasks/libs/junit_upload.py
@@ -85,8 +85,10 @@ def upload_junitxmls(output_dir, owners, flavor, xmlfile_name, additional_tags=N
     processes = []
     process_env = os.environ.copy()
     if job_url:
+        print(f"CI_JOB_URL={job_url}")
         process_env["CI_JOB_URL"] = job_url
     if job_env:
+        print("\n".join(f"{k}={v}" for k, v in job_env.items()))
         process_env.update(job_env)
 
     for owner in owners:

--- a/tasks/libs/junit_upload.py
+++ b/tasks/libs/junit_upload.py
@@ -17,6 +17,7 @@ CODEOWNERS_ORG_PREFIX = "@DataDog/"
 REPO_NAME_PREFIX = "github.com/DataDog/datadog-agent/"
 DATADOG_CI_COMMAND = ["datadog-ci", "junit", "upload"]
 JOB_URL_FILE_NAME = "job_url.txt"
+JOB_ENV_FILE_NAME = "job_env.txt"
 TAGS_FILE_NAME = "tags.txt"
 
 
@@ -77,13 +78,17 @@ def split_junitxml(xml_path, codeowners, output_dir):
     return list(output_xmls), flavor
 
 
-def upload_junitxmls(output_dir, owners, flavor, xmlfile_name, additional_tags=None, job_url=""):
+def upload_junitxmls(output_dir, owners, flavor, xmlfile_name, additional_tags=None, job_url="", job_env=None):
     """
     Upload all per-team split JUnit XMLs from given directory.
     """
     processes = []
     process_env = os.environ.copy()
-    process_env["CI_JOB_URL"] = job_url
+    if job_url:
+        process_env["CI_JOB_URL"] = job_url
+    if job_env:
+        process_env.update(job_env)
+
     for owner in owners:
         codeowner = CODEOWNERS_ORG_PREFIX + owner
         slack_channel = GITHUB_SLACK_MAP.get(codeowner.lower(), DEFAULT_SLACK_CHANNEL)[1:]
@@ -130,13 +135,25 @@ def junit_upload_from_tgz(junit_tgz, codeowners_path=".github/CODEOWNERS"):
         with tarfile.open(junit_tgz) as tgz:
             tgz.extractall(path=unpack_dir)
         # read additional tags
+        tags = None
         tagsfile = os.path.join(unpack_dir, TAGS_FILE_NAME)
         if os.path.exists(tagsfile):
             with open(tagsfile) as tf:
                 tags = tf.read().split()
         # read job url (see comment in produce_junit_tar)
-        with open(os.path.join(unpack_dir, JOB_URL_FILE_NAME)) as jf:
-            job_url = jf.read()
+        job_url = None
+        if os.path.exists(JOB_URL_FILE_NAME):
+            with open(os.path.join(unpack_dir, JOB_URL_FILE_NAME)) as jf:
+                job_url = jf.read()
+
+        job_env = {}
+        if os.path.exists(JOB_ENV_FILE_NAME):
+            with open(os.path.join(unpack_dir, JOB_ENV_FILE_NAME)) as jf:
+                for line in jf:
+                    if not line.strip():
+                        continue
+                    key, val = line.strip().split('=', 1)
+                    job_env[key] = val
 
         # for each unpacked xml file, split it and submit all parts
         # NOTE: recursive=True is necessary for "**" to unpack into 0-n dirs, not just 1
@@ -148,7 +165,7 @@ def junit_upload_from_tgz(junit_tgz, codeowners_path=".github/CODEOWNERS"):
             xmls += 1
             with tempfile.TemporaryDirectory() as output_dir:
                 written_owners, flavor = split_junitxml(xmlfile, codeowners, output_dir)
-                upload_junitxmls(output_dir, written_owners, flavor, xmlfile.split("/")[-1], tags, job_url)
+                upload_junitxmls(output_dir, written_owners, flavor, xmlfile.split("/")[-1], tags, job_url, job_env)
         xmlcounts[junit_tgz] = xmls
 
     empty_tgzs = []

--- a/tasks/libs/junit_upload.py
+++ b/tasks/libs/junit_upload.py
@@ -144,13 +144,15 @@ def junit_upload_from_tgz(junit_tgz, codeowners_path=".github/CODEOWNERS"):
                 tags = tf.read().split()
         # read job url (see comment in produce_junit_tar)
         job_url = None
-        if os.path.exists(JOB_URL_FILE_NAME):
-            with open(os.path.join(unpack_dir, JOB_URL_FILE_NAME)) as jf:
+        urlfile = os.path.join(unpack_dir, JOB_URL_FILE_NAME)
+        if os.path.exists(urlfile):
+            with open(urlfile) as jf:
                 job_url = jf.read()
 
         job_env = {}
-        if os.path.exists(JOB_ENV_FILE_NAME):
-            with open(os.path.join(unpack_dir, JOB_ENV_FILE_NAME)) as jf:
+        envfile = os.path.join(unpack_dir, JOB_ENV_FILE_NAME)
+        if os.path.exists(envfile):
+            with open(envfile) as jf:
                 for line in jf:
                     if not line.strip():
                         continue

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/functional-tests.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/functional-tests.rb
@@ -80,15 +80,8 @@ directory "/tmp/junit" do
   recursive true
 end
 
-cookbook_file "/tmp/junit/job_url.txt" do
-  source "job_url.txt"
-  mode '0444'
-  action :create
-  ignore_failure true
-end
-
-cookbook_file "/tmp/junit/tags.txt" do
-  source "tags.txt"
+cookbook_file "/tmp/junit/job_env.txt" do
+  source "job_env.txt"
   mode '0444'
   action :create
   ignore_failure true

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -162,15 +162,8 @@ directory "/tmp/junit" do
   recursive true
 end
 
-cookbook_file "/tmp/junit/job_url.txt" do
-  source "job_url.txt"
-  mode '0444'
-  action :create
-  ignore_failure true
-end
-
-cookbook_file "/tmp/junit/tags.txt" do
-  source "tags.txt"
+cookbook_file "/tmp/junit/job_env.txt" do
+  source "job_env.txt"
   mode '0444'
   action :create
   ignore_failure true


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Overrides the Gitlab environment variables, so the CI visibility app points to the job where the tests were run, not where the upload occurred.

### Motivation

Better linking of test results to jobs and stages.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
