### PR TITLE
[CWS] improvements to path reducer

### DIFF
--- a/pkg/security/security_profile/activity_tree/paths_reducer.go
+++ b/pkg/security/security_profile/activity_tree/paths_reducer.go
@@ -94,10 +94,10 @@ func getPathsReducerPatterns() []PatternReducer {
 			},
 		},
 		{
-			Pattern: regexp.MustCompile(`(kubepods-|cri-containerd-)([^/]*)\.(slice|scope)`), // kubernetes cgroup
+			Pattern: regexp.MustCompile(`(?:kubepods-|cri-containerd-)([^/]*)\.(?:slice|scope)`), // kubernetes cgroup
 			Callback: func(ctx *callbackContext) {
 				if ctx.fileEvent.Filesystem == "sysfs" {
-					start, end := ctx.getGroup(2)
+					start, end := ctx.getGroup(1)
 					ctx.path = ctx.path[:start] + "*" + ctx.path[end:]
 				}
 			},
@@ -110,10 +110,10 @@ func getPathsReducerPatterns() []PatternReducer {
 			},
 		},
 		{
-			Pattern: regexp.MustCompile(`/sys/devices/virtual/block/(dm-|loop)([0-9]+)`), // block devices
+			Pattern: regexp.MustCompile(`/sys/devices/virtual/block/(?:dm-|loop)([0-9]+)`), // block devices
 			Callback: func(ctx *callbackContext) {
 				if ctx.fileEvent.Filesystem == "sysfs" {
-					start, end := ctx.getGroup(2)
+					start, end := ctx.getGroup(1)
 					ctx.path = ctx.path[:start] + "*" + ctx.path[end:]
 				}
 			},

--- a/pkg/security/security_profile/activity_tree/paths_reducer.go
+++ b/pkg/security/security_profile/activity_tree/paths_reducer.go
@@ -16,53 +16,32 @@ import (
 
 // PathsReducer is used to reduce the paths in an activity tree according to predefined heuristics
 type PathsReducer struct {
-	patterns        *regexp.Regexp
-	callbackFuncs   map[int]func(ctx *callbackContext)
-	callbackIndexes []int
+	patterns []PatternReducer
 }
 
 // PatternReducer is used to reduce the paths in an activity tree according to a given pattern
 type PatternReducer struct {
-	Pattern            string
-	GroupIndexCallback int
-	GroupCount         int
-	Callback           func(ctx *callbackContext)
+	Pattern  *regexp.Regexp
+	Callback func(ctx *callbackContext)
 }
 
 // callbackContext is the input struct for the callback function
 type callbackContext struct {
-	start       int
-	end         int
+	groups      []int
 	path        string
 	fileEvent   *model.FileEvent
 	processNode *ProcessNode
 }
 
+func (cc *callbackContext) getGroup(index int) (int, int) {
+	return cc.groups[index*2], cc.groups[index*2+1]
+}
+
 // NewPathsReducer returns a new PathsReducer
 func NewPathsReducer() *PathsReducer {
-	patterns := getPathsReducerPatterns()
-	patternsCount := len(patterns)
-
-	r := &PathsReducer{
-		callbackFuncs:   make(map[int]func(ctx *callbackContext), patternsCount),
-		callbackIndexes: make([]int, patternsCount),
+	return &PathsReducer{
+		patterns: getPathsReducerPatterns(),
 	}
-
-	var fullPattern string
-	var groupCount int
-	for i, pattern := range patterns {
-		if i > 0 {
-			fullPattern += "|"
-		}
-		fullPattern += pattern.Pattern
-
-		r.callbackFuncs[groupCount+pattern.GroupIndexCallback] = pattern.Callback
-		r.callbackIndexes[patternsCount-1-i] = pattern.GroupIndexCallback + groupCount
-		groupCount += pattern.GroupCount
-	}
-
-	r.patterns = regexp.MustCompile(fullPattern)
-	return r
 }
 
 // ReducePath reduces a path according to the predefined heuristics
@@ -73,17 +52,17 @@ func (r *PathsReducer) ReducePath(path string, fileEvent *model.FileEvent, node 
 		processNode: node,
 	}
 
-	allMatches := r.patterns.FindAllStringSubmatchIndex(ctx.path, -1)
-	for matchSet := len(allMatches) - 1; matchSet >= 0; matchSet-- {
-		matches := allMatches[matchSet]
-		for _, i := range r.callbackIndexes {
-			if r.callbackFuncs[i] != nil && matches[2*i] != -1 && matches[2*i+1] != -1 {
-				ctx.start = matches[2*i]
-				ctx.end = matches[2*i+1]
-				r.callbackFuncs[i](ctx)
+	for _, pattern := range r.patterns {
+		allMatches := pattern.Pattern.FindAllStringSubmatchIndex(ctx.path, -1)
+
+		for matchSet := len(allMatches) - 1; matchSet >= 0; matchSet-- {
+			if pattern.Callback != nil {
+				ctx.groups = allMatches[matchSet]
+				pattern.Callback(ctx)
 			}
 		}
 	}
+
 	return ctx.path
 }
 
@@ -91,65 +70,59 @@ func (r *PathsReducer) ReducePath(path string, fileEvent *model.FileEvent, node 
 func getPathsReducerPatterns() []PatternReducer {
 	return []PatternReducer{
 		{
-			Pattern:            "(/proc/(\\d+))", // process PID
-			GroupIndexCallback: 2,
-			GroupCount:         2,
+			Pattern: regexp.MustCompile(`/proc/(\d+)/`), // process PID
 			Callback: func(ctx *callbackContext) {
+				start, end := ctx.getGroup(1)
 				// compute pid from path
-				pid, err := strconv.Atoi(ctx.path[ctx.start:ctx.end])
+				pid, err := strconv.Atoi(ctx.path[start:end])
 				if err != nil {
 					return
 				}
 				// replace the pid in the path between start and end with a * only if the replaced pid is not the pid of the process node
 				if ctx.processNode.Process.Pid == uint32(pid) {
-					ctx.path = ctx.path[:ctx.start] + "self" + ctx.path[ctx.end:]
+					ctx.path = ctx.path[:start] + "self" + ctx.path[end:]
 				} else {
-					ctx.path = ctx.path[:ctx.start] + "*" + ctx.path[ctx.end:]
+					ctx.path = ctx.path[:start] + "*" + ctx.path[end:]
 				}
 			},
 		},
 		{
-			Pattern:            "(/task/(\\d+))", // process TID
-			GroupIndexCallback: 2,
-			GroupCount:         2,
+			Pattern: regexp.MustCompile(`/task/(\d+)/`), // process TID
 			Callback: func(ctx *callbackContext) {
-				ctx.path = ctx.path[:ctx.start] + "*" + ctx.path[ctx.end:]
+				start, end := ctx.getGroup(1)
+				ctx.path = ctx.path[:start] + "*" + ctx.path[end:]
 			},
 		},
 		{
-			Pattern:            "((kubepods-|cri-containerd-)([^/]*)\\.(slice|scope))", // kubernetes cgroup
-			GroupIndexCallback: 3,
-			GroupCount:         4,
+			Pattern: regexp.MustCompile(`(kubepods-|cri-containerd-)([^/]*)\.(slice|scope)`), // kubernetes cgroup
 			Callback: func(ctx *callbackContext) {
 				if ctx.fileEvent.Filesystem == "sysfs" {
-					ctx.path = ctx.path[:ctx.start] + "*" + ctx.path[ctx.end:]
+					start, end := ctx.getGroup(2)
+					ctx.path = ctx.path[:start] + "*" + ctx.path[end:]
 				}
 			},
 		},
 		{
-			Pattern:            model.ContainerIDPatternStr, // container ID
-			GroupIndexCallback: 1,
-			GroupCount:         1,
+			Pattern: regexp.MustCompile(model.ContainerIDPatternStr), // container ID
 			Callback: func(ctx *callbackContext) {
-				ctx.path = ctx.path[:ctx.start] + "*" + ctx.path[ctx.end:]
+				start, end := ctx.getGroup(0)
+				ctx.path = ctx.path[:start] + "*" + ctx.path[end:]
 			},
 		},
 		{
-			Pattern:            "(/sys/devices/virtual/block/(dm-|loop)([0-9]+))", // block devices
-			GroupIndexCallback: 3,
-			GroupCount:         3,
+			Pattern: regexp.MustCompile(`/sys/devices/virtual/block/(dm-|loop)([0-9]+)`), // block devices
 			Callback: func(ctx *callbackContext) {
 				if ctx.fileEvent.Filesystem == "sysfs" {
-					ctx.path = ctx.path[:ctx.start] + "*" + ctx.path[ctx.end:]
+					start, end := ctx.getGroup(2)
+					ctx.path = ctx.path[:start] + "*" + ctx.path[end:]
 				}
 			},
 		},
 		{
-			Pattern:            "(secrets/kubernetes.io/serviceaccount/([0-9._]+))", // service account token date
-			GroupIndexCallback: 2,
-			GroupCount:         2,
+			Pattern: regexp.MustCompile(`secrets/kubernetes.io/serviceaccount/([0-9._]+)`), // service account token date
 			Callback: func(ctx *callbackContext) {
-				ctx.path = ctx.path[:ctx.start] + "*" + ctx.path[ctx.end:]
+				start, end := ctx.getGroup(1)
+				ctx.path = ctx.path[:start] + "*" + ctx.path[end:]
 			},
 		},
 	}

--- a/pkg/security/security_profile/activity_tree/paths_reducer.go
+++ b/pkg/security/security_profile/activity_tree/paths_reducer.go
@@ -39,11 +39,14 @@ func (cc *callbackContext) getGroup(index int) (int, int) {
 }
 
 func (cc *callbackContext) replaceBy(start, end int, replaceBy string) {
+	left := cc.path[:start]
+	right := cc.path[end:]
+
 	var b strings.Builder
-	b.Grow(len(cc.path[:start]) + len(replaceBy) + len(cc.path[end:]))
-	b.WriteString(cc.path[:start])
+	b.Grow(len(left) + len(replaceBy) + len(right))
+	b.WriteString(left)
 	b.WriteString(replaceBy)
-	b.WriteString(cc.path[end:])
+	b.WriteString(right)
 	cc.path = b.String()
 }
 

--- a/pkg/security/security_profile/activity_tree/paths_reducer.go
+++ b/pkg/security/security_profile/activity_tree/paths_reducer.go
@@ -114,7 +114,18 @@ func getPathsReducerPatterns() []PatternReducer {
 			},
 		},
 		{
-			Pattern: regexp.MustCompile(`(?:kubepods-|cri-containerd-)([^/]*)\.(?:slice|scope)`), // kubernetes cgroup
+			Pattern: regexp.MustCompile(`kubepods-([^/]*)\.(?:slice|scope)`), // kubernetes cgroup
+			Hint:    "kubepods",
+			Callback: func(ctx *callbackContext) {
+				if ctx.fileEvent.Filesystem == "sysfs" {
+					start, end := ctx.getGroup(1)
+					ctx.replaceBy(start, end, "*")
+				}
+			},
+		},
+		{
+			Pattern: regexp.MustCompile(`cri-containerd-([^/]*)\.(?:slice|scope)`), // kubernetes cgroup
+			Hint:    "cri-containerd",
 			Callback: func(ctx *callbackContext) {
 				if ctx.fileEvent.Filesystem == "sysfs" {
 					start, end := ctx.getGroup(1)


### PR DESCRIPTION
### What does this PR do?

This PR implements multiple optimizations to the path reducer:
- split the different pattern regexps
- add hint and pre-check to skip regexp all together if useless
- using non capturing groups
- splitting some regexp for better hint and literal checks

#### Benchmark:

before:
```
goos: linux
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree
BenchmarkPathsReducer_ReducePath/proc_1-4         	  600784	      1859 ns/op	     553 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/proc_2-4         	  779632	      1380 ns/op	     545 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/proc_3-4         	  606025	      1950 ns/op	      48 B/op	       1 allocs/op
BenchmarkPathsReducer_ReducePath/proc_4-4         	  587793	      1823 ns/op	     552 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/proc_task_1-4    	  517554	      2151 ns/op	     833 B/op	       6 allocs/op
BenchmarkPathsReducer_ReducePath/proc_task_1#01-4 	  357202	      3201 ns/op	     560 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/cgroup_1-4       	  128049	      9181 ns/op	    1009 B/op	       6 allocs/op
BenchmarkPathsReducer_ReducePath/proc_cgroup_1-4  	  111108	     10632 ns/op	    1409 B/op	       8 allocs/op
BenchmarkPathsReducer_ReducePath/container_id_1-4 	  188516	      6149 ns/op	     576 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/block_device_1-4 	  350930	      3185 ns/op	     592 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/block_device_2-4 	 1589284	       757.8 ns/op	     562 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/k8s_service_account_secret_1-4         	  460522	      2423 ns/op	     593 B/op	       4 allocs/op
PASS
ok  	github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree	14.974s
```

after:
```
goos: linux
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree
BenchmarkPathsReducer_ReducePath/proc_1-4         	 3240608	       367.4 ns/op	     362 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/proc_2-4         	 3328880	       355.3 ns/op	     354 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/proc_3-4         	 7948915	       148.9 ns/op	      64 B/op	       1 allocs/op
BenchmarkPathsReducer_ReducePath/proc_4-4         	 3503229	       341.8 ns/op	     362 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/proc_task_1-4    	 1768755	       679.3 ns/op	     675 B/op	       7 allocs/op
BenchmarkPathsReducer_ReducePath/proc_task_1#01-4 	 2308273	       513.0 ns/op	     370 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/cgroup_1-4       	  275413	      4090 ns/op	     834 B/op	       7 allocs/op
BenchmarkPathsReducer_ReducePath/proc_cgroup_1-4  	  235053	      4936 ns/op	    1283 B/op	      10 allocs/op
BenchmarkPathsReducer_ReducePath/container_id_1-4 	  612571	      1822 ns/op	     385 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/block_device_1-4 	 1579119	       759.7 ns/op	     401 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/block_device_2-4 	 2178434	       547.9 ns/op	     369 B/op	       4 allocs/op
BenchmarkPathsReducer_ReducePath/k8s_service_account_secret_1-4         	  353930	      3267 ns/op	     401 B/op	       4 allocs/op
PASS
ok  	github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree	18.116s
```
### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
