### PR TITLE
[omnibus] Update list of upstream patches in OpenSCAP

### DIFF
--- a/omnibus/config/patches/openscap/0005-Fix-leak-of-filename-in-oval_agent_new_session.patch
+++ b/omnibus/config/patches/openscap/0005-Fix-leak-of-filename-in-oval_agent_new_session.patch
@@ -1,0 +1,24 @@
+From e07bee9290f5dde4456ecef98eed2ac7d2092d9c Mon Sep 17 00:00:00 2001
+From: David du Colombier <djc@datadoghq.com>
+Date: Wed, 19 Jul 2023 08:53:23 +0200
+Subject: [PATCH 5/6] Fix leak of filename in oval_agent_new_session
+
+---
+ src/OVAL/oval_agent.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/OVAL/oval_agent.c b/src/OVAL/oval_agent.c
+index 1fbed8ae6..a4ee34d12 100644
+--- a/src/OVAL/oval_agent.c
++++ b/src/OVAL/oval_agent.c
+@@ -112,6 +112,7 @@ oval_agent_session_t * oval_agent_new_session(struct oval_definition_model *mode
+ 	/* probe sysinfo */
+ 	ret = oval_probe_query_sysinfo(ag_sess->psess, &sysinfo);
+ 	if (ret != 0) {
++		free(ag_sess->filename);
+ 		oval_probe_session_destroy(ag_sess->psess);
+ 		oval_syschar_model_free(ag_sess->sys_model);
+ 		free(ag_sess);
+-- 
+2.34.1
+

--- a/omnibus/config/patches/openscap/0006-Fix-leak-of-item-in-probe_item_collect.patch
+++ b/omnibus/config/patches/openscap/0006-Fix-leak-of-item-in-probe_item_collect.patch
@@ -1,0 +1,28 @@
+From 83592087efc58d72892d784cc709664ed91e81b3 Mon Sep 17 00:00:00 2001
+From: David du Colombier <djc@datadoghq.com>
+Date: Wed, 19 Jul 2023 08:46:55 +0200
+Subject: [PATCH 6/6] Fix leak of item in probe_item_collect
+
+---
+ src/OVAL/probes/probe/icache.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/OVAL/probes/probe/icache.c b/src/OVAL/probes/probe/icache.c
+index a397d35ec..04ddbfb9e 100644
+--- a/src/OVAL/probes/probe/icache.c
++++ b/src/OVAL/probes/probe/icache.c
+@@ -552,9 +552,11 @@ int probe_item_collect(struct probe_ctx *ctx, SEXP_t *item)
+ 	memcheck_ret = probe_cobj_memcheck(cobj_itemcnt, ctx->max_mem_ratio);
+ 	if (memcheck_ret == -1) {
+ 		dE("Failed to check available memory");
++		SEXP_free(item);
+ 		return -1;
+ 	}
+ 	if (memcheck_ret == 1) {
++		SEXP_free(item);
+ 
+ 		/*
+ 		 * Don't set the message again if the collected object is
+-- 
+2.34.1
+

--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -39,6 +39,10 @@ relative_path "openscap-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  # Fixes since release 1.3.8
+  patch source: "0005-Fix-leak-of-filename-in-oval_agent_new_session.patch", env: env
+  patch source: "0006-Fix-leak-of-item-in-probe_item_collect.patch", env: env
+
   patch source: "get_results_from_session.patch", env: env # add a function to retrieve results from session
   patch source: "session_result_reset.patch", env: env # add a function to reset results from session
   patch source: "session_reset_syschar.patch", env: env # also reset system characteristics


### PR DESCRIPTION
### What does this PR do?

This change updates the list of upstream patches in OpenSCAP by importing the new bug fixes since release 1.3.8.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
