### PR TITLE
fix the possible crash in kafka parsing

### DIFF
--- a/pkg/network/protocols/kafka/statkeeper.go
+++ b/pkg/network/protocols/kafka/statkeeper.go
@@ -65,6 +65,10 @@ func (statKeeper *StatKeeper) GetAndResetAllStats() map[Key]*RequestStat {
 }
 
 func (statKeeper *StatKeeper) extractTopicName(tx *EbpfTx) string {
+	// Limit tx.Topic_name_size to not exceed the actual length of tx.Topic_name
+	if tx.Topic_name_size > uint16(len(tx.Topic_name)) {
+		tx.Topic_name_size = uint16(len(tx.Topic_name))
+	}
 	b := tx.Topic_name[:tx.Topic_name_size]
 
 	// the trick here is that the Go runtime doesn't allocate the string used in

--- a/pkg/network/protocols/kafka/statkeeper.go
+++ b/pkg/network/protocols/kafka/statkeeper.go
@@ -8,10 +8,10 @@
 package kafka
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type StatKeeper struct {
@@ -68,7 +68,7 @@ func (statKeeper *StatKeeper) GetAndResetAllStats() map[Key]*RequestStat {
 func (statKeeper *StatKeeper) extractTopicName(tx *EbpfTx) string {
 	// Limit tx.Topic_name_size to not exceed the actual length of tx.Topic_name
 	if tx.Topic_name_size > uint16(len(tx.Topic_name)) {
-		log.Debugf("Topic name size was changed in extractTopicName from %d, to size: %d", tx.Topic_name_size, len(tx.Topic_name))
+		log.Debugf("Topic name size was changed from %d, to size: %d", tx.Topic_name_size, len(tx.Topic_name))
 		tx.Topic_name_size = uint16(len(tx.Topic_name))
 	}
 	b := tx.Topic_name[:tx.Topic_name_size]

--- a/pkg/network/protocols/kafka/statkeeper.go
+++ b/pkg/network/protocols/kafka/statkeeper.go
@@ -8,6 +8,7 @@
 package kafka
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/network/config"
@@ -67,6 +68,7 @@ func (statKeeper *StatKeeper) GetAndResetAllStats() map[Key]*RequestStat {
 func (statKeeper *StatKeeper) extractTopicName(tx *EbpfTx) string {
 	// Limit tx.Topic_name_size to not exceed the actual length of tx.Topic_name
 	if tx.Topic_name_size > uint16(len(tx.Topic_name)) {
+		log.Debugf("Topic name size was changed in extractTopicName from %d, to size: %d", tx.Topic_name_size, len(tx.Topic_name))
 		tx.Topic_name_size = uint16(len(tx.Topic_name))
 	}
 	b := tx.Topic_name[:tx.Topic_name_size]

--- a/pkg/network/protocols/kafka/statkeeper_test.go
+++ b/pkg/network/protocols/kafka/statkeeper_test.go
@@ -9,7 +9,6 @@ package kafka
 
 import (
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/network/config"
@@ -36,10 +35,6 @@ func BenchmarkStatKeeperSameTX(b *testing.B) {
 
 func TestStatKeeper_extractTopicName(t *testing.T) {
 	type fields struct {
-		stats      map[Key]*RequestStat
-		statsMutex sync.RWMutex
-		maxEntries int
-		telemetry  *Telemetry
 		topicNames map[string]string
 	}
 	type args struct {
@@ -54,19 +49,13 @@ func TestStatKeeper_extractTopicName(t *testing.T) {
 		{
 			name: "slice bigger then Topic_name",
 			fields: fields{
-				stats:      nil,
-				statsMutex: sync.RWMutex{},
-				maxEntries: 0,
-				telemetry:  nil,
 				topicNames: map[string]string{},
 			},
 			args: args{&EbpfTx{
-				Tup:                 ConnTuple{},
-				Request_api_key:     0,
-				Request_api_version: 0,
-				Topic_name:          [80]byte{},
-				Topic_name_size:     85,
-				Pad_cgo_0:           [2]byte{},
+				Tup:             ConnTuple{},
+				Topic_name:      [80]byte{},
+				Topic_name_size: 85,
+				Pad_cgo_0:       [2]byte{},
 			},
 			},
 			want: strings.Repeat("*", 80),
@@ -74,19 +63,13 @@ func TestStatKeeper_extractTopicName(t *testing.T) {
 		{
 			name: "slice smaller then Topic_name",
 			fields: fields{
-				stats:      nil,
-				statsMutex: sync.RWMutex{},
-				maxEntries: 0,
-				telemetry:  nil,
 				topicNames: map[string]string{},
 			},
 			args: args{&EbpfTx{
-				Tup:                 ConnTuple{},
-				Request_api_key:     0,
-				Request_api_version: 0,
-				Topic_name:          [80]byte{},
-				Topic_name_size:     60,
-				Pad_cgo_0:           [2]byte{},
+				Tup:             ConnTuple{},
+				Topic_name:      [80]byte{},
+				Topic_name_size: 60,
+				Pad_cgo_0:       [2]byte{},
 			},
 			},
 			want: strings.Repeat("*", 60),
@@ -95,10 +78,6 @@ func TestStatKeeper_extractTopicName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			statKeeper := &StatKeeper{
-				stats:      tt.fields.stats,
-				statsMutex: tt.fields.statsMutex,
-				maxEntries: tt.fields.maxEntries,
-				telemetry:  tt.fields.telemetry,
 				topicNames: tt.fields.topicNames,
 			}
 			if got := statKeeper.extractTopicName(tt.args.tx); len(got) != len(tt.want) {

--- a/pkg/network/protocols/kafka/statkeeper_test.go
+++ b/pkg/network/protocols/kafka/statkeeper_test.go
@@ -34,43 +34,24 @@ func BenchmarkStatKeeperSameTX(b *testing.B) {
 }
 
 func TestStatKeeper_extractTopicName(t *testing.T) {
-	type fields struct {
-		topicNames map[string]string
-	}
-	type args struct {
-		tx *EbpfTx
-	}
 	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   string
+		name string
+		tx   *EbpfTx
+		want string
 	}{
 		{
 			name: "slice bigger then Topic_name",
-			fields: fields{
-				topicNames: map[string]string{},
-			},
-			args: args{&EbpfTx{
-				Tup:             ConnTuple{},
+			tx: &EbpfTx{
 				Topic_name:      [80]byte{},
 				Topic_name_size: 85,
-				Pad_cgo_0:       [2]byte{},
-			},
 			},
 			want: strings.Repeat("*", 80),
 		},
 		{
 			name: "slice smaller then Topic_name",
-			fields: fields{
-				topicNames: map[string]string{},
-			},
-			args: args{&EbpfTx{
-				Tup:             ConnTuple{},
+			tx: &EbpfTx{
 				Topic_name:      [80]byte{},
 				Topic_name_size: 60,
-				Pad_cgo_0:       [2]byte{},
-			},
 			},
 			want: strings.Repeat("*", 60),
 		},
@@ -78,9 +59,10 @@ func TestStatKeeper_extractTopicName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			statKeeper := &StatKeeper{
-				topicNames: tt.fields.topicNames,
+				topicNames: map[string]string{},
 			}
-			if got := statKeeper.extractTopicName(tt.args.tx); len(got) != len(tt.want) {
+			copy(tt.tx.Topic_name[:], strings.Repeat("*", len(tt.tx.Topic_name)))
+			if got := statKeeper.extractTopicName(tt.tx); len(got) != len(tt.want) {
 				t.Errorf("extractTopicName() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Added a fix for a possible crash in kafka parsing

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
