### PR TITLE
[CWS] onboard simple kretprobes to fexit mechanism

### DIFF
--- a/pkg/security/ebpf/c/include/constants/fentry_macro.h
+++ b/pkg/security/ebpf/c/include/constants/fentry_macro.h
@@ -10,7 +10,7 @@ typedef unsigned long long ctx_t;
 #define CTX_PARM2(ctx) (u64)(ctx[1])
 #define CTX_PARM3(ctx) (u64)(ctx[2])
 
-#define CTX_PARMRET(ctx, argc) (u64)(ctx[argc+1])
+#define CTX_PARMRET(ctx, argc) (u64)(ctx[argc])
 
 #else
 

--- a/pkg/security/ebpf/c/include/constants/fentry_macro.h
+++ b/pkg/security/ebpf/c/include/constants/fentry_macro.h
@@ -4,6 +4,7 @@
 #ifdef USE_FENTRY
 
 #define HOOK_ENTRY(func_name) SEC("fentry/" func_name)
+#define HOOK_EXIT(func_name) SEC("fexit/" func_name)
 typedef unsigned long long ctx_t;
 #define CTX_PARM1(ctx) (u64)(ctx[0])
 #define CTX_PARM2(ctx) (u64)(ctx[1])
@@ -12,6 +13,7 @@ typedef unsigned long long ctx_t;
 #else
 
 #define HOOK_ENTRY(func_name) SEC("kprobe/" func_name)
+#define HOOK_EXIT(func_name) SEC("kretprobe/" func_name)
 typedef struct pt_regs ctx_t;
 #define CTX_PARM1(ctx) PT_REGS_PARM1(ctx)
 #define CTX_PARM2(ctx) PT_REGS_PARM2(ctx)

--- a/pkg/security/ebpf/c/include/constants/fentry_macro.h
+++ b/pkg/security/ebpf/c/include/constants/fentry_macro.h
@@ -10,6 +10,8 @@ typedef unsigned long long ctx_t;
 #define CTX_PARM2(ctx) (u64)(ctx[1])
 #define CTX_PARM3(ctx) (u64)(ctx[2])
 
+#define CTX_PARMRET(ctx, argc) (u64)(ctx[argc+1])
+
 #else
 
 #define HOOK_ENTRY(func_name) SEC("kprobe/" func_name)
@@ -18,6 +20,8 @@ typedef struct pt_regs ctx_t;
 #define CTX_PARM1(ctx) PT_REGS_PARM1(ctx)
 #define CTX_PARM2(ctx) PT_REGS_PARM2(ctx)
 #define CTX_PARM3(ctx) PT_REGS_PARM3(ctx)
+
+#define CTX_PARMRET(ctx, _argc) PT_REGS_RC(ctx)
 
 #endif
 

--- a/pkg/security/ebpf/c/include/hooks/iouring.h
+++ b/pkg/security/ebpf/c/include/hooks/iouring.h
@@ -1,6 +1,7 @@
 #ifndef _HOOKS_IOURING_H_
 #define _HOOKS_IOURING_H_
 
+#include "constants/fentry_macro.h"
 #include "constants/offsets/filesystem.h"
 #include "helpers/iouring.h"
 
@@ -11,9 +12,9 @@ int io_uring_create(struct tracepoint_io_uring_io_uring_create_t *args) {
     return 0;
 }
 
-SEC("kretprobe/io_ring_ctx_alloc")
-int kretprobe_io_ring_ctx_alloc(struct pt_regs *ctx) {
-    void *ioctx = (void *)PT_REGS_RC(ctx);
+HOOK_EXIT("io_ring_ctx_alloc")
+int rethook_io_ring_ctx_alloc(ctx_t *ctx) {
+    void *ioctx = (void *)CTX_PARMRET(ctx, 1);
     cache_ioctx_pid_tgid(ioctx);
     return 0;
 }

--- a/pkg/security/ebpf/c/include/hooks/link.h
+++ b/pkg/security/ebpf/c/include/hooks/link.h
@@ -151,6 +151,7 @@ int __attribute__((always_inline)) sys_link_ret(void *ctx, int retval, int dr_ty
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kretprobe/do_linkat")
 int kretprobe_do_linkat(struct pt_regs *ctx) {
     int retval = PT_REGS_RC(ctx);

--- a/pkg/security/ebpf/c/include/hooks/mkdir.h
+++ b/pkg/security/ebpf/c/include/hooks/mkdir.h
@@ -102,6 +102,7 @@ int kprobe_do_mkdirat(ctx_t *ctx) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kretprobe/do_mkdirat")
 int kretprobe_do_mkdirat(struct pt_regs *ctx) {
     int retval = PT_REGS_RC(ctx);

--- a/pkg/security/ebpf/c/include/hooks/mmap.h
+++ b/pkg/security/ebpf/c/include/hooks/mmap.h
@@ -72,6 +72,7 @@ SYSCALL_KRETPROBE(mmap) {
     return sys_mmap_ret(ctx, (int)PT_REGS_RC(ctx), (u64)PT_REGS_RC(ctx));
 }
 
+// fentry blocked by: tail call
 SEC("kretprobe/fget")
 int kretprobe_fget(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_MMAP);

--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -242,6 +242,7 @@ int tracepoint_handle_sys_open_exit(struct tracepoint_raw_syscalls_sys_exit_t *a
     return sys_open_ret(args, args->ret, DR_TRACEPOINT);
 }
 
+// fentry blocked by: tail call
 SEC("kretprobe/io_openat2")
 int kretprobe_io_openat2(struct pt_regs *ctx) {
     int retval = PT_REGS_RC(ctx);

--- a/pkg/security/ebpf/c/include/hooks/rename.h
+++ b/pkg/security/ebpf/c/include/hooks/rename.h
@@ -161,6 +161,7 @@ int __attribute__((always_inline)) sys_rename_ret(void *ctx, int retval, int dr_
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kretprobe/do_renameat2")
 int kretprobe_do_renameat2(struct pt_regs *ctx) {
     int retval = PT_REGS_RC(ctx);

--- a/pkg/security/ebpf/c/include/hooks/rmdir.h
+++ b/pkg/security/ebpf/c/include/hooks/rmdir.h
@@ -155,6 +155,7 @@ int __attribute__((always_inline)) sys_rmdir_ret(void *ctx, int retval) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kretprobe/do_rmdir")
 int kretprobe_do_rmdir(struct pt_regs *ctx) {
     int retval = PT_REGS_RC(ctx);

--- a/pkg/security/ebpf/c/include/hooks/signal.h
+++ b/pkg/security/ebpf/c/include/hooks/signal.h
@@ -46,9 +46,9 @@ int hook_kill_pid_info(ctx_t *ctx) {
 
 
 /* hook here to grab the EPERM retval */
-SEC("kretprobe/check_kill_permission")
-int kretprobe_check_kill_permission(struct pt_regs* ctx) {
-    int retval = (int)PT_REGS_RC(ctx);
+HOOK_EXIT("check_kill_permission")
+int rethook_check_kill_permission(ctx_t* ctx) {
+    int retval = (int)CTX_PARMRET(ctx, 3);
 
     struct syscall_cache_t *syscall = pop_syscall(EVENT_SIGNAL);
     if (!syscall) {

--- a/pkg/security/ebpf/c/include/hooks/splice.h
+++ b/pkg/security/ebpf/c/include/hooks/splice.h
@@ -40,6 +40,7 @@ int hook_get_pipe_info(ctx_t *ctx) {
     return 0;
 }
 
+// fentry blocked by: tail call
 SEC("kretprobe/get_pipe_info")
 int kretprobe_get_pipe_info(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_SPLICE);

--- a/pkg/security/ebpf/probes/builder.go
+++ b/pkg/security/ebpf/probes/builder.go
@@ -43,6 +43,28 @@ func kprobeOrFentry(funcName string, fentry bool, options ...psbOption) *manager
 	}
 }
 
+func kretprobeOrFexit(funcName string, fentry bool, options ...psbOption) *manager.ProbeSelector {
+	psb := &probeSelectorBuilder{
+		uid:          SecurityAgentUID,
+		skipIfFentry: false,
+	}
+
+	for _, opt := range options {
+		opt(psb)
+	}
+
+	if fentry && psb.skipIfFentry {
+		return nil
+	}
+
+	return &manager.ProbeSelector{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          psb.uid,
+			EBPFFuncName: fmt.Sprintf("rethook_%s", funcName),
+		},
+	}
+}
+
 func withSkipIfFentry(skip bool) psbOption {
 	return func(psb *probeSelectorBuilder) {
 		psb.skipIfFentry = skip

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -173,7 +173,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				&manager.OneOf{Selectors: []manager.ProbesSelector{
 					kprobeOrFentry("io_allocate_scq_urings", fentry),
 					kprobeOrFentry("io_sq_offload_start", fentry, withSkipIfFentry(true)),
-					&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_io_ring_ctx_alloc"}},
+					kretprobeOrFexit("io_ring_ctx_alloc", fentry),
 				}},
 			}},
 

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -415,7 +415,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 		// List of probes required to capture signal events
 		"signal": {
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kretprobe_check_kill_permission"}},
+				kretprobeOrFexit("check_kill_permission", fentry),
 				kprobeOrFentry("kill_pid_info", fentry),
 			}},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "kill", Entry)},

--- a/pkg/security/ebpf/probes/iouring.go
+++ b/pkg/security/ebpf/probes/iouring.go
@@ -20,7 +20,7 @@ func getIouringProbes(fentry bool) []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kretprobe_io_ring_ctx_alloc",
+				EBPFFuncName: "rethook_io_ring_ctx_alloc",
 			},
 		},
 		{

--- a/pkg/security/ebpf/probes/signal.go
+++ b/pkg/security/ebpf/probes/signal.go
@@ -14,7 +14,7 @@ var signalProbes = []*manager.Probe{
 	{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID:          SecurityAgentUID,
-			EBPFFuncName: "kretprobe_check_kill_permission",
+			EBPFFuncName: "rethook_check_kill_permission",
 		},
 	},
 }


### PR DESCRIPTION
### What does this PR do?

This PR implements the machinery needed to convert kretprobes to fexit functions, and convert the simple (no tail call, as with fentry).

Status update:

| type | count |
| ----| --- |
| kprobe | 217 |
| kretprobe | 156 |
| fentry | 41 |
| fexit | 2 |

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
