### PR TITLE
[CSPM] remove `run/compliance-registry.json` as well in prerm scripts

### DIFF
--- a/omnibus/package-scripts/agent-deb/prerm
+++ b/omnibus/package-scripts/agent-deb/prerm
@@ -110,7 +110,7 @@ remove_version_history()
     fi
 }
 
-remove_sysprobe_files()
+remove_sysprobe_secagent_files()
 {
     # removing sbom files and dirs
     find "$INSTALL_DIR/run" -name "sbom*" -type d -exec rm -r {} +
@@ -119,7 +119,7 @@ remove_sysprobe_files()
     find "$INSTALL_DIR/run/runtime-security/profiles" -delete || true
 
     # remove other runtime files
-    for file in run/runtime-security-registry.json run/sysprobe.sock run/event-monitor.sock run/runtime-security.sock run/system-probe.pid run/runtime-security
+    for file in run/runtime-security-registry.json run/compliance-registry.json run/sysprobe.sock run/event-monitor.sock run/runtime-security.sock run/system-probe.pid run/runtime-security
     do
         if [ -d "$INSTALL_DIR/$file" ]; then
             rmdir "$INSTALL_DIR/$file" 2>/dev/null || true
@@ -154,7 +154,7 @@ case "$1" in
     remove)
         # We're uninstalling.
         remove_version_history
-        remove_sysprobe_files
+        remove_sysprobe_secagent_files
         remove_remote_config_db
     ;;
     upgrade)

--- a/omnibus/package-scripts/agent-rpm/prerm
+++ b/omnibus/package-scripts/agent-rpm/prerm
@@ -94,7 +94,7 @@ remove_version_history()
     fi
 }
 
-remove_sysprobe_files()
+remove_sysprobe_secagent_files()
 {
     # removing sbom files and dirs
     find "$INSTALL_DIR/run" -name "sbom*" -type d -exec rm -r {} +
@@ -103,7 +103,7 @@ remove_sysprobe_files()
     find "$INSTALL_DIR/run/runtime-security/profiles" -delete || true
 
     # remove other runtime files
-    for file in run/runtime-security-registry.json run/sysprobe.sock run/event-monitor.sock run/runtime-security.sock run/system-probe.pid run/runtime-security
+    for file in run/runtime-security-registry.json run/compliance-registry.json run/sysprobe.sock run/event-monitor.sock run/runtime-security.sock run/system-probe.pid run/runtime-security
     do
         if [ -d "$INSTALL_DIR/$file" ]; then
             rmdir "$INSTALL_DIR/$file" 2>/dev/null || true
@@ -138,7 +138,7 @@ case "$*" in
         remove_custom_integrations
         remove_py_compiled_files
         remove_version_history
-        remove_sysprobe_files
+        remove_sysprobe_secagent_files
         remove_remote_config_db
     ;;
     1)


### PR DESCRIPTION
### What does this PR do?

Similarly to `run/runtime-security-registry.json` this PR removes the `run/compliance-registry.json ` before uninstalling deb and rpm packages.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
