### PR TITLE
AET-188 Add goroutine to clean payloads older than retention time

### DIFF
--- a/test/fakeintake/app/main.go
+++ b/test/fakeintake/app/main.go
@@ -18,7 +18,6 @@ import (
 
 func main() {
 	portPtr := flag.Int("port", 80, "fakeintake listening port, default to 80. Using -port=0 will use a random available port")
-	retentionPtr := flag.Int("retention", 15, "fakeintake metrics retention time in minutes, default to 15 minutes")
 	flag.Parse()
 
 	sigs := make(chan os.Signal, 1)
@@ -26,7 +25,7 @@ func main() {
 
 	log.Println("⌛️ Starting fake intake")
 	ready := make(chan bool, 1)
-	fi := fakeintake.NewServer(fakeintake.WithPort(*portPtr), fakeintake.WithReadyChannel(ready), fakeintake.WithRetention(time.Duration(*retentionPtr)*time.Minute))
+	fi := fakeintake.NewServer(fakeintake.WithPort(*portPtr), fakeintake.WithReadyChannel(ready))
 	fi.Start()
 	timeout := time.NewTimer(5 * time.Second)
 

--- a/test/fakeintake/app/main.go
+++ b/test/fakeintake/app/main.go
@@ -18,6 +18,7 @@ import (
 
 func main() {
 	portPtr := flag.Int("port", 80, "fakeintake listening port, default to 80. Using -port=0 will use a random available port")
+	retentionPtr := flag.Int("retention", 15, "fakeintake metrics retention time in minutes, default to 15 minutes")
 	flag.Parse()
 
 	sigs := make(chan os.Signal, 1)
@@ -25,7 +26,7 @@ func main() {
 
 	log.Println("⌛️ Starting fake intake")
 	ready := make(chan bool, 1)
-	fi := fakeintake.NewServer(fakeintake.WithPort(*portPtr), fakeintake.WithReadyChannel(ready))
+	fi := fakeintake.NewServer(fakeintake.WithPort(*portPtr), fakeintake.WithReadyChannel(ready), fakeintake.WithRetention(time.Duration(*retentionPtr)*time.Minute))
 	fi.Start()
 	timeout := time.NewTimer(5 * time.Second)
 

--- a/test/fakeintake/server/server.go
+++ b/test/fakeintake/server/server.go
@@ -168,6 +168,8 @@ func (fi *Server) IsRunning() bool {
 
 // Stop Gracefully stop the http server
 func (fi *Server) Stop() error {
+	defer close(fi.shutdown)
+
 	if !fi.IsRunning() {
 		return fmt.Errorf("server not running")
 	}
@@ -176,7 +178,6 @@ func (fi *Server) Stop() error {
 		return err
 	}
 
-	close(fi.shutdown)
 	fi.url = ""
 	return nil
 }

--- a/test/fakeintake/server/server.go
+++ b/test/fakeintake/server/server.go
@@ -52,6 +52,7 @@ func NewServer(options ...func(*Server)) *Server {
 		mu:           sync.RWMutex{},
 		payloadStore: map[string][]api.Payload{},
 		clock:        clock.New(),
+		retention:    15 * time.Minute,
 	}
 
 	mux := http.NewServeMux()
@@ -192,7 +193,6 @@ func (fi *Server) cleanUpPayloadsRoutine() {
 		case <-fi.shutdown:
 			return
 		case <-ticker.C:
-			fmt.Println("coucou")
 			fi.cleanUpPayloads()
 		}
 	}

--- a/test/fakeintake/server/server_test.go
+++ b/test/fakeintake/server/server_test.go
@@ -262,7 +262,7 @@ func TestServer(t *testing.T) {
 		fi.handleGetPayloads(response10Min, request)
 		json.NewDecoder(response10Min.Body).Decode(&getResponse10Min)
 
-		assert.Len(t, getResponse10Min.Payloads, 2, "should contain two element before cleanup %+v", getResponse10Min)
+		assert.Len(t, getResponse10Min.Payloads, 2, "should contain two elements before cleanup %+v", getResponse10Min)
 
 		clock.Add(10 * time.Minute)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Add a new goroutine to automatically clean payloads older than 15 minutes
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Prevent OOM for long running fakeintake
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
