### PR TITLE
NSTimestampToFloat() in O(1)

### DIFF
--- a/pkg/network/protocols/common.go
+++ b/pkg/network/protocols/common.go
@@ -5,16 +5,18 @@
 
 package protocols
 
+import "math"
+
 // below is copied from pkg/trace/stats/statsraw.go
-// 10 bits precision (any value will be +/- 1/1024)
-const roundMask uint64 = 1 << 10
 
 // NSTimestampToFloat converts a nanosec timestamp into a float nanosecond timestamp truncated to a fixed precision
 func NSTimestampToFloat(ns uint64) float64 {
-	var shift uint
-	for ns > roundMask {
-		ns = ns >> 1
-		shift++
-	}
-	return float64(ns << shift)
+	b := math.Float64bits(float64(ns))
+	// IEEE-754
+	// the mask include 1 bit sign 11 bits exponent (0xfff)
+	// then we filter the mantissa to 10bits (0xff8) (9 bits as it has implicit value of 1)
+	// 10 bits precision (any value will be +/- 1/1024)
+	// https://en.wikipedia.org/wiki/Double-precision_floating-point_format
+	b &= 0xfffff80000000000
+	return math.Float64frombits(b)
 }

--- a/pkg/network/protocols/common_test.go
+++ b/pkg/network/protocols/common_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 package protocols
 
 import (

--- a/pkg/network/protocols/common_test.go
+++ b/pkg/network/protocols/common_test.go
@@ -1,0 +1,43 @@
+package protocols
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const roundMask uint64 = 1 << 10
+
+func oldNSTimestampToFloat(ns uint64) float64 {
+	var shift uint
+	for ns > roundMask {
+		ns = ns >> 1
+		shift++
+	}
+	return float64(ns << shift)
+}
+
+func TestNSTimestampToFloat(t *testing.T) {
+	ns := []uint64{
+		uint64(1066789584153112 - 1066789583298779), // kernel boot time values
+		uint64(0),
+		uint64(1),
+		uint64(1066789584153112),
+		uint64(time.Hour * 24 * 3650), // 10 year
+		uint64(time.Now().UnixNano()),
+		uint64(0x000000000000ffff),
+		uint64(1023),
+		uint64(1024),
+		uint64(1025),
+		//^uint64(0), this can't be used here because float64 have only 52 bits of mantissa
+		// and filter(float(uint64)) will difference due to roundup than float(filter(uint64))
+		uint64(0x001fffffffffffff),
+		^uint64(0x001fffffffffffff), // ~584 years
+	}
+
+	for _, n := range ns {
+		require.Equal(t, oldNSTimestampToFloat(n), NSTimestampToFloat(n), "uint64 10 bits mantissa truncation failed "+fmt.Sprintf("%d 0x%x", n, n))
+	}
+}

--- a/pkg/trace/stats/statsraw_test.go
+++ b/pkg/trace/stats/statsraw_test.go
@@ -6,7 +6,9 @@
 package stats
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 
@@ -344,4 +346,38 @@ var benchSpans = []*pb.Span{
 		Metrics:  map[string]float64{"payloads": 0.3779600143407876, "loops": 0.20498295768971775, "size": 0.7947128947983215, "rowcount": 0.7478115781577667},
 		Type:     "lamar",
 	},
+}
+
+const roundMask int64 = 1 << 10
+
+func oldNSTimestampToFloat(ns int64) float64 {
+	var shift uint
+	for ns > roundMask {
+		ns = ns >> 1
+		shift++
+	}
+	return float64(ns << shift)
+}
+
+func TestNSTimestampToFloat(t *testing.T) {
+	ns := []int64{
+		int64(1066789584153112 - 1066789583298779), // kernel boot time values
+		int64(0),
+		int64(1),
+		int64(1066789584153112),
+		int64(time.Hour * 24 * 3650), // 10 year
+		int64(time.Now().UnixNano()),
+		int64(0x000000000000ffff),
+		int64(1023),
+		int64(1024),
+		int64(1025),
+		//^int64(0), this can't be used here because float64 have only 52 bits of mantissa
+		// and filter(float(int64)) will difference due to roundup than float(filter(int64))
+		int64(0x001fffffffffffff),
+		^int64(0x001fffffffffffff), // ~584 years
+	}
+
+	for _, n := range ns {
+		assert.Equal(t, oldNSTimestampToFloat(n), nsTimestampToFloat(n), "uint64 10 bits mantissa truncation failed "+fmt.Sprintf("%d 0x%x", n, n))
+	}
 }


### PR DESCRIPTION
### What does this PR do?

Simplify the mantissa 10bits truncation using IEEE-754 double format (float64)
and masking the include 1 bit sign 11 bits exponent (0xfff) and then we filter the mantissa to 10bits (0xff8) (9 bits as it has implicit value of 1)
with 10 bits precision (any value will be +/- 1/1024)

https://en.wikipedia.org/wiki/Double-precision_floating-point_format

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
