### PR TITLE
pkg/trace/api: Reduce flakiness of TestOOMKill

### DIFF
--- a/pkg/trace/api/api_oom_test.go
+++ b/pkg/trace/api/api_oom_test.go
@@ -36,7 +36,7 @@ func TestOOMKill(t *testing.T) {
 	conf := config.New()
 	conf.Endpoints[0].APIKey = "apikey_2"
 	conf.WatchdogInterval = time.Millisecond
-	conf.MaxMemory = 0.5 * 1000 * 1000 // 0.5M
+	conf.MaxMemory = 0.4 * 1000 * 1000 // 0.4M
 
 	r := newTestReceiverFromConfig(conf)
 	r.Start()
@@ -47,8 +47,8 @@ func TestOOMKill(t *testing.T) {
 	}()
 
 	var traces pb.Traces
-	for i := 0; i < 20; i++ {
-		traces = append(traces, testutil.RandomTrace(10, 20))
+	for i := 0; i < 25; i++ {
+		traces = append(traces, testutil.RandomTrace(10, 25))
 	}
 	data := msgpTraces(t, traces)
 
@@ -78,7 +78,7 @@ func TestOOMKill(t *testing.T) {
 		}
 	}
 
-	timeout := time.After(500 * time.Millisecond)
+	timeout := time.After(750 * time.Millisecond)
 loop:
 	for {
 		select {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Reduce the flakiness of this test - The only good flakes are corn flakes.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
This test flaked recently, it seems that under heavy cpu load while running this test it's possible the agent doesn't OOM in time for this test. By increasing the load, lowering the limit and giving a bit of extra deadline we can reduce the flakiness here.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
