### PR TITLE
Adds inv agent.exec <subcommand> for convenience

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -279,18 +279,20 @@ def run(
     ctx.run(f"{agent_bin} run -c {config_path}")
 
 @task
-def status(
+def exec(
     ctx,
+    subcommand,
     config_path=None,
 ):
     """
-    Execute 'agent status' against the currently running Agent.
+    Execute 'agent <subcommand>' against the currently running Agent.
 
     This works against an agent run via `inv agent.run`.
+    Basically this just simplifies creating the path for both the agent binary and config.
     """
     agent_bin = os.path.join(BIN_PATH, bin_name("agent"))
     config_path = os.path.join(BIN_PATH, "dist", "datadog.yaml") if not config_path else config_path
-    ctx.run(f"{agent_bin} status -c {config_path}")
+    ctx.run(f"{agent_bin} -c {config_path} {subcommand}")
 
 
 @task

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -278,6 +278,7 @@ def run(
     config_path = os.path.join(BIN_PATH, "dist", "datadog.yaml") if not config_path else config_path
     ctx.run(f"{agent_bin} run -c {config_path}")
 
+
 @task
 def exec(
     ctx,

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -278,6 +278,20 @@ def run(
     config_path = os.path.join(BIN_PATH, "dist", "datadog.yaml") if not config_path else config_path
     ctx.run(f"{agent_bin} run -c {config_path}")
 
+@task
+def status(
+    ctx,
+    config_path=None,
+):
+    """
+    Execute 'agent status' against the currently running Agent.
+
+    This works against an agent run via `inv agent.run`.
+    """
+    agent_bin = os.path.join(BIN_PATH, bin_name("agent"))
+    config_path = os.path.join(BIN_PATH, "dist", "datadog.yaml") if not config_path else config_path
+    ctx.run(f"{agent_bin} status -c {config_path}")
+
 
 @task
 def system_tests(_):


### PR DESCRIPTION
### What does this PR do?
The invoke task `inv agent.run` is commonly used to build/run the agent, however the paths to the config are hidden from you, making running a subcommand a bit of a chore.

This simply adds a shortcut for developers who use `inv agent.run`.
Usage is `inv agent.exec status` or `inv agent.status configcheck`.

Help message is accessible using `inv agent.exec -h` or `inv agent.exec --help`

### Motivation
Save some keys.

### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
