### PR TITLE
Add ebpf telemetry support for sowatcher

### DIFF
--- a/pkg/network/ebpf/c/shared-libraries/probes.h
+++ b/pkg/network/ebpf/c/shared-libraries/probes.h
@@ -1,6 +1,7 @@
 #ifndef __SHARED_LIBRARIES_PROBES_H
 #define __SHARED_LIBRARIES_PROBES_H
 
+#include "bpf_telemetry.h"
 #include "shared-libraries/types.h"
 
 static __always_inline void fill_path_safe(lib_path_t *path, const char *path_argument) {
@@ -16,7 +17,7 @@ static __always_inline void fill_path_safe(lib_path_t *path, const char *path_ar
 
 static __always_inline void do_sys_open_helper_enter(const char *filename) {
     lib_path_t path = {0};
-    if (bpf_probe_read_user(path.buf, sizeof(path.buf), filename) >= 0) {
+    if (bpf_probe_read_user_with_telemetry(path.buf, sizeof(path.buf), filename) >= 0) {
 // Find the null character and clean up the garbage following it
 #pragma unroll
         for (int i = 0; i < LIB_PATH_MAX_SIZE; i++) {
@@ -37,7 +38,7 @@ static __always_inline void do_sys_open_helper_enter(const char *filename) {
 
     u64 pid_tgid = bpf_get_current_pid_tgid();
     path.pid = pid_tgid >> 32;
-    bpf_map_update_elem(&open_at_args, &pid_tgid, &path, BPF_ANY);
+    bpf_map_update_with_telemetry(open_at_args, &pid_tgid, &path, BPF_ANY);
     return;
 }
 

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -212,7 +212,7 @@ func newSSLProgram(c *config.Config, m *manager.Manager, sockFDMap *ebpf.Map, bp
 		return nil
 	}
 
-	watcher, err := sharedlibraries.NewWatcher(c,
+	watcher, err := sharedlibraries.NewWatcher(c, bpfTelemetry,
 		sharedlibraries.Rule{
 			Re:           regexp.MustCompile(`libssl.so`),
 			RegisterCB:   addHooks(m, openSSLProbes),

--- a/pkg/network/usm/sharedlibraries/watcher.go
+++ b/pkg/network/usm/sharedlibraries/watcher.go
@@ -20,6 +20,7 @@ import (
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
+	errtelemetry "github.com/DataDog/datadog-agent/pkg/network/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
@@ -62,8 +63,8 @@ type Watcher struct {
 	libMatches *telemetry.Counter
 }
 
-func NewWatcher(cfg *config.Config, rules ...Rule) (*Watcher, error) {
-	ebpfProgram := newEBPFProgram(cfg)
+func NewWatcher(cfg *config.Config, bpfTelemetry *errtelemetry.EBPFTelemetry, rules ...Rule) (*Watcher, error) {
+	ebpfProgram := newEBPFProgram(cfg, bpfTelemetry)
 	err := ebpfProgram.Init()
 	if err != nil {
 		return nil, fmt.Errorf("error initializing shared library program: %w", err)

--- a/pkg/network/usm/sharedlibraries/watcher_test.go
+++ b/pkg/network/usm/sharedlibraries/watcher_test.go
@@ -83,6 +83,7 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetection() {
 	}
 
 	watcher, err := NewWatcher(config.New(),
+		nil,
 		Rule{
 			Re:         regexp.MustCompile(`foo-libssl.so`),
 			RegisterCB: callback,
@@ -164,6 +165,7 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetectionWithPIDandRootNameSpace()
 	}
 
 	watcher, err := NewWatcher(config.New(),
+		nil,
 		Rule{
 			Re:         regexp.MustCompile(`fooroot-crypto.so`),
 			RegisterCB: callback,
@@ -226,6 +228,7 @@ func (s *SharedLibrarySuite) TestSameInodeRegression() {
 	}
 
 	watcher, err := NewWatcher(config.New(),
+		nil,
 		Rule{
 			Re:         regexp.MustCompile(`foo-libssl.so`),
 			RegisterCB: callback,
@@ -287,6 +290,7 @@ func (s *SharedLibrarySuite) TestSoWatcherLeaks() {
 	unregisterCB := func(id utils.PathIdentifier) error { return errors.New("fake unregisterCB error") }
 
 	watcher, err := NewWatcher(config.New(),
+		nil,
 		Rule{
 			Re:           regexp.MustCompile(`foo-libssl.so`),
 			RegisterCB:   registerCB,
@@ -385,6 +389,7 @@ func (s *SharedLibrarySuite) TestSoWatcherProcessAlreadyHoldingReferences() {
 	unregisterCB := func(id utils.PathIdentifier) error { return nil }
 
 	watcher, err := NewWatcher(config.New(),
+		nil,
 		Rule{
 			Re:           regexp.MustCompile(`foo-libssl.so`),
 			RegisterCB:   registerCB,
@@ -534,6 +539,7 @@ func checkWatcherStateIsClean(t *testing.T, watcher *Watcher) {
 
 func BenchmarkScanSOWatcherNew(b *testing.B) {
 	w, _ := NewWatcher(config.New(),
+		nil,
 		Rule{
 			Re: regexp.MustCompile(`libssl.so`),
 		},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
#18247 added tests for ebpf telemetry, which depended upon `tracepoint__syscalls__sys_enter_openat*` eBPF programs to be loaded and activated in the kernel.

However, #17598 removed the `bpf_probe_read_user` telemetry macro which is used in the test.

This PR adds it back.


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
