### PR TITLE
Revert "Fix EBPF maps and helpers errors telemetry (#18247)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.47.0-rc.3
 	github.com/DataDog/datadog-go/v5 v5.1.1
 	github.com/DataDog/datadog-operator v1.0.3
-	github.com/DataDog/ebpf-manager v0.2.11
+	github.com/DataDog/ebpf-manager v0.2.10
 	github.com/DataDog/go-libddwaf v1.0.0
 	github.com/DataDog/go-tuf v1.0.1-0.5.2
 	github.com/DataDog/gopsutil v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/DataDog/datadog-go/v5 v5.1.1 h1:JLZ6s2K1pG2h9GkvEvMdEGqMDyVLEAccdX5Tl
 github.com/DataDog/datadog-go/v5 v5.1.1/go.mod h1:KhiYb2Badlv9/rofz+OznKoEF5XKTonWyhx5K83AP8E=
 github.com/DataDog/datadog-operator v1.0.3 h1:zBGNnmFsU99wttrt0PWXXRgJvTRGeWt3YD7wUh7VBd4=
 github.com/DataDog/datadog-operator v1.0.3/go.mod h1:CXTLg7VFcpaMvjbwkKTxKUIzxRumfSe01/CWOINo4c0=
-github.com/DataDog/ebpf-manager v0.2.11 h1:DK1VBC1pXjjHQwGqBhnEe1yoTlzzOI7Ek1DvHFkKYyE=
-github.com/DataDog/ebpf-manager v0.2.11/go.mod h1:KDs7en18FwWMVz3iCnGIvOCZdyuXozS+w4YrCIQbtM0=
+github.com/DataDog/ebpf-manager v0.2.10 h1:1efxFLMkn+N0uJ5BZT9qad5xRGBNJyWKZlR8FeYXWtQ=
+github.com/DataDog/ebpf-manager v0.2.10/go.mod h1:KDs7en18FwWMVz3iCnGIvOCZdyuXozS+w4YrCIQbtM0=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2 h1:uTE/QEU0oYtHnebKSMbxap7XMG5603WQxNP/UX63E7k=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2/go.mod h1:JgKVGTsjdTdtJjNyxRZjcs81/rng6LJ3XX/0D7Y12Gc=
 github.com/DataDog/glog v1.1.2-0.20230527101146-81a67cdbc7a1 h1:YpYdpEG3ohpETQTzz9u4bTvvJUzkRFwMyLrx/jtbU5g=

--- a/pkg/ebpf/c/bpf_helper_defs.h
+++ b/pkg/ebpf/c/bpf_helper_defs.h
@@ -74,13 +74,7 @@ static void *(*bpf_map_lookup_elem)(void *map, const void *key) = (void *) 1;
  * Returns
  * 	0 on success, or a negative error in case of failure.
  */
-
-// The return value of `bpf_map_update_elem` is changed from `long` to `int` purposefully.
-// On kernels uptil 6.3 the underlying function signature of the helper operation returns an `int`.
-// Specifying `long` as the return type here caused the compiler to omit sign extension code,
-// which is required for correctly interpreting a negative return value.
-// More details in this PR: https://github.com/DataDog/datadog-agent/pull/18247
-static int (*bpf_map_update_elem)(void *map, const void *key, const void *value, __u64 flags) = (void *) 2;
+static long (*bpf_map_update_elem)(void *map, const void *key, const void *value, __u64 flags) = (void *) 2;
 
 /*
  * bpf_map_delete_elem
@@ -90,13 +84,7 @@ static int (*bpf_map_update_elem)(void *map, const void *key, const void *value,
  * Returns
  * 	0 on success, or a negative error in case of failure.
  */
-
-// The return value of `bpf_map_delete_elem` is changed from `long` to `int` purposefully.
-// On kernels uptil 6.3 the underlying function signature of the helper operation returns an `int`.
-// Specifying `long` as the return type here caused the compiler to omit sign extension code,
-// which is required for correctly interpreting a negative return value.
-// More details in this PR: https://github.com/DataDog/datadog-agent/pull/18247
-static int (*bpf_map_delete_elem)(void *map, const void *key) = (void *) 3;
+static long (*bpf_map_delete_elem)(void *map, const void *key) = (void *) 3;
 
 /*
  * bpf_probe_read
@@ -2280,13 +2268,7 @@ static long (*bpf_sk_release)(void *sock) = (void *) 86;
  * Returns
  * 	0 on success, or a negative error in case of failure.
  */
-
-// The return value of `bpf_map_push_elem` is changed from `long` to `int` purposefully.
-// On kernels uptil 6.3 the underlying function signature of the helper operation returns an `int`.
-// Specifying `long` as the return type here caused the compiler to omit sign extension code,
-// which is required for correctly interpreting a negative return value.
-// More details in this PR: https://github.com/DataDog/datadog-agent/pull/18247
-static int (*bpf_map_push_elem)(void *map, const void *value, __u64 flags) = (void *) 87;
+static long (*bpf_map_push_elem)(void *map, const void *value, __u64 flags) = (void *) 87;
 
 /*
  * bpf_map_pop_elem
@@ -2296,13 +2278,7 @@ static int (*bpf_map_push_elem)(void *map, const void *value, __u64 flags) = (vo
  * Returns
  * 	0 on success, or a negative error in case of failure.
  */
-
-// The return value of `bpf_map_pop_elem` is changed from `long` to `int` purposefully.
-// On kernels uptil 6.3 the underlying function signature of the helper operation returns an `int`.
-// Specifying `long` as the return type here caused the compiler to omit sign extension code,
-// which is required for correctly interpreting a negative return value.
-// More details in this PR: https://github.com/DataDog/datadog-agent/pull/18247
-static int (*bpf_map_pop_elem)(void *map, void *value) = (void *) 88;
+static long (*bpf_map_pop_elem)(void *map, void *value) = (void *) 88;
 
 /*
  * bpf_map_peek_elem
@@ -2312,13 +2288,7 @@ static int (*bpf_map_pop_elem)(void *map, void *value) = (void *) 88;
  * Returns
  * 	0 on success, or a negative error in case of failure.
  */
-
-// The return value of `bpf_map_peek_elem` is changed from `long` to `int` purposefully.
-// On kernels uptil 6.3 the underlying function signature of the helper operation returns an `int`.
-// Specifying `long` as the return type here caused the compiler to omit sign extension code,
-// which is required for correctly interpreting a negative return value.
-// More details in this PR: https://github.com/DataDog/datadog-agent/pull/18247
-static int (*bpf_map_peek_elem)(void *map, void *value) = (void *) 89;
+static long (*bpf_map_peek_elem)(void *map, void *value) = (void *) 89;
 
 /*
  * bpf_msg_push_data

--- a/pkg/ebpf/c/bpf_telemetry.h
+++ b/pkg/ebpf/c/bpf_telemetry.h
@@ -14,33 +14,32 @@ BPF_HASH_MAP(helper_err_telemetry_map, unsigned long, helper_err_telemetry_t, 25
 #define PATCH_TARGET_TELEMETRY -1
 static void *(*bpf_telemetry_update_patch)(unsigned long, ...) = (void *)PATCH_TARGET_TELEMETRY;
 
-#define map_update_with_telemetry(fn, map, args...)                                \
-    ({                                                                             \
-        long errno_ret, errno_slot;                                                \
-        errno_ret = fn(&map, args);                                                \
-        if (errno_ret < 0) {                                                       \
-            unsigned long err_telemetry_key;                                       \
-            LOAD_CONSTANT(MK_KEY(map), err_telemetry_key);                         \
-            map_err_telemetry_t *entry =                                           \
-                bpf_map_lookup_elem(&map_err_telemetry_map, &err_telemetry_key);   \
-            if (entry) {                                                           \
-                errno_slot = errno_ret * -1;                                       \
-                if (errno_slot >= T_MAX_ERRNO) {                                   \
-                    errno_slot = T_MAX_ERRNO - 1;                                  \
-                    errno_slot &= (T_MAX_ERRNO - 1);                               \
-                }                                                                  \
-                errno_slot &= (T_MAX_ERRNO - 1);                                   \
-                long *target = &entry->err_count[errno_slot];                      \
-                unsigned long add = 1;                                             \
+#define map_update_with_telemetry(fn, map, args...)                                 \
+    do {                                                                            \
+        long errno_ret, errno_slot;                                                  \
+        errno_ret = fn(&map, args);                                                 \
+        if (errno_ret < 0) {                                                        \
+            unsigned long err_telemetry_key;                                        \
+            LOAD_CONSTANT(MK_KEY(map), err_telemetry_key);                          \
+            map_err_telemetry_t *entry =                                            \
+                bpf_map_lookup_elem(&map_err_telemetry_map, &err_telemetry_key);    \
+            if (entry) {                                                            \
+                errno_slot = errno_ret * -1;                                        \
+                if (errno_slot >= T_MAX_ERRNO) {                                    \
+                    errno_slot = T_MAX_ERRNO - 1;                                   \
+                    errno_slot &= (T_MAX_ERRNO - 1);                                \
+                }                                                                   \
+                errno_slot &= (T_MAX_ERRNO - 1);                                    \
+                long *target = &entry->err_count[errno_slot];                       \
+                unsigned long add = 1;                                              \
                 /* Patched instruction for 4.14+: __sync_fetch_and_add(target, 1);
                  * This patch point is placed here because the above instruction
                  * fails on the 4.4 verifier. On 4.4 this instruction is replaced
                  * with a nop: r1 = r1 */ \
-                bpf_telemetry_update_patch((unsigned long)target, add);            \
-            }                                                                      \
-        }                                                                          \
-        errno_ret;                                                                 \
-    })
+                bpf_telemetry_update_patch((unsigned long)target, add);             \
+            }                                                                       \
+        }                                                                           \
+    } while (0)
 
 #define MK_FN_INDX(fn) FN_INDX_##fn
 
@@ -83,7 +82,7 @@ static void *(*bpf_telemetry_update_patch)(unsigned long, ...) = (void *)PATCH_T
                     /* Patched instruction for 4.14+: __sync_fetch_and_add(target, 1);
                      * This patch point is placed here because the above instruction
                      * fails on the 4.4 verifier. On 4.4 this instruction is replaced
-                     * with a nop: r1 = r1 */          \
+                     * with a nop: r1 = r1 */         \
                     bpf_telemetry_update_patch((unsigned long)target, add);                     \
                 }                                                                               \
             }                                                                                   \

--- a/pkg/network/telemetry/ebpf_telemetry.go
+++ b/pkg/network/telemetry/ebpf_telemetry.go
@@ -27,9 +27,6 @@ import (
 const (
 	maxErrno    = 64
 	maxErrnoStr = "other"
-
-	EBPFMapTelemetryNS    = "ebpf_maps"
-	EBPFHelperTelemetryNS = "ebpf_helpers"
 )
 
 const (
@@ -40,8 +37,8 @@ const (
 	perfEventOutput
 )
 
-var ebpfMapOpsErrorsGauge = prometheus.NewDesc(fmt.Sprintf("%s__errors", EBPFMapTelemetryNS), "Failures of map operations for a specific ebpf map reported per error.", []string{"map_name", "error"}, nil)
-var ebpfHelperErrorsGauge = prometheus.NewDesc(fmt.Sprintf("%s__errors", EBPFHelperTelemetryNS), "Failures of bpf helper operations reported per helper per error for each probe.", []string{"helper", "probe_name", "error"}, nil)
+var ebpfMapOpsErrorsGauge = prometheus.NewDesc("ebpf_map_ops__errors", "Failures of map operations for a specific ebpf map reported per error.", []string{"map_name", "error"}, nil)
+var ebpfHelperErrorsGauge = prometheus.NewDesc("ebpf_helpers__errors", "Failures of bpf helper operations reported per helper per error for each probe.", []string{"helper", "probe_name", "error"}, nil)
 
 var helperNames = map[int]string{readIndx: "bpf_probe_read", readUserIndx: "bpf_probe_read_user", readKernelIndx: "bpf_probe_read_kernel", skbLoadBytes: "bpf_skb_load_bytes", perfEventOutput: "bpf_perf_event_output"}
 
@@ -86,16 +83,12 @@ func (b *EBPFTelemetry) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect returns the current state of all metrics of the collector
 func (b *EBPFTelemetry) Collect(ch chan<- prometheus.Metric) {
-	b.getHelpersTelemetry(ch)
-	b.getMapsTelemetry(ch)
+	b.GetHelperTelemetry(ch)
+	b.GetMapsTelemetry(ch)
 }
 
 // GetMapsTelemetry returns a map of error telemetry for each ebpf map
-func (b *EBPFTelemetry) GetMapsTelemetry() map[string]interface{} {
-	return b.getMapsTelemetry(nil)
-}
-
-func (b *EBPFTelemetry) getMapsTelemetry(ch chan<- prometheus.Metric) map[string]interface{} {
+func (b *EBPFTelemetry) GetMapsTelemetry(ch chan<- prometheus.Metric) map[string]interface{} {
 	if b == nil {
 		return nil
 	}
@@ -112,10 +105,7 @@ func (b *EBPFTelemetry) getMapsTelemetry(ch chan<- prometheus.Metric) map[string
 		if count := getMapErrCount(&val); len(count) > 0 {
 			t[m] = count
 			for errStr, errCount := range count {
-				select {
-				case ch <- prometheus.MustNewConstMetric(ebpfMapOpsErrorsGauge, prometheus.GaugeValue, float64(errCount), m, errStr):
-				default:
-				}
+				ch <- prometheus.MustNewConstMetric(ebpfMapOpsErrorsGauge, prometheus.GaugeValue, float64(errCount), m, errStr)
 			}
 		}
 	}
@@ -124,11 +114,7 @@ func (b *EBPFTelemetry) getMapsTelemetry(ch chan<- prometheus.Metric) map[string
 }
 
 // GetHelperTelemetry returns a map of error telemetry for each ebpf program
-func (b *EBPFTelemetry) GetHelpersTelemetry() map[string]interface{} {
-	return b.getHelpersTelemetry(nil)
-}
-
-func (b *EBPFTelemetry) getHelpersTelemetry(ch chan<- prometheus.Metric) map[string]interface{} {
+func (b *EBPFTelemetry) GetHelperTelemetry(ch chan<- prometheus.Metric) map[string]interface{} {
 	if b == nil {
 		return nil
 	}
@@ -143,7 +129,7 @@ func (b *EBPFTelemetry) getHelpersTelemetry(ch chan<- prometheus.Metric) map[str
 			continue
 		}
 
-		if t := getHelpersTelemetryForProbe(&val, probeName, ebpfHelperErrorsGauge, ch); len(t) > 0 {
+		if t := getHelperTelemetry(&val, probeName, ebpfHelperErrorsGauge, ch); len(t) > 0 {
 			helperTelemMap[probeName] = t
 		}
 	}
@@ -151,7 +137,7 @@ func (b *EBPFTelemetry) getHelpersTelemetry(ch chan<- prometheus.Metric) map[str
 	return helperTelemMap
 }
 
-func getHelpersTelemetryForProbe(v *HelperErrTelemetry, probeName string, desc *prometheus.Desc, ch chan<- prometheus.Metric) map[string]interface{} {
+func getHelperTelemetry(v *HelperErrTelemetry, probeName string, desc *prometheus.Desc, ch chan<- prometheus.Metric) map[string]interface{} {
 	helper := make(map[string]interface{})
 
 	for indx, helperName := range helperNames {
@@ -159,11 +145,7 @@ func getHelpersTelemetryForProbe(v *HelperErrTelemetry, probeName string, desc *
 			helper[helperName] = count
 
 			for errStr, errCount := range count {
-				// Do not block when nil channel is provided
-				select {
-				case ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, float64(errCount), helperName, probeName, errStr):
-				default:
-				}
+				ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, float64(errCount), helperName, probeName, errStr)
 			}
 		}
 	}
@@ -238,9 +220,6 @@ func buildHelperErrTelemetryKeys(mgr *manager.Manager) []manager.ConstantEditor 
 		keys = append(keys, manager.ConstantEditor{
 			Name:  "telemetry_program_id_key",
 			Value: h.Sum64(),
-			ProbeIdentificationPairs: []manager.ProbeIdentificationPair{
-				p.ProbeIdentificationPair,
-			},
 		})
 		h.Reset()
 	}

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -605,8 +605,6 @@ var allStats = []statsComp{
 	stateStats,
 	tracerStats,
 	httpStats,
-	bpfMapStats,
-	bpfHelperStats,
 }
 
 func (t *Tracer) getStats(comps ...statsComp) (map[string]interface{}, error) {
@@ -630,10 +628,6 @@ func (t *Tracer) getStats(comps ...statsComp) (map[string]interface{}, error) {
 			ret["tracer"] = tracerStats
 		case httpStats:
 			ret["universal_service_monitoring"] = t.usmMonitor.GetUSMStats()
-		case bpfMapStats:
-			ret[nettelemetry.EBPFMapTelemetryNS] = t.bpfTelemetry.GetMapsTelemetry()
-		case bpfHelperStats:
-			ret[nettelemetry.EBPFHelperTelemetryNS] = t.bpfTelemetry.GetHelpersTelemetry()
 		}
 	}
 

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -40,16 +40,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/config/sysctl"
-	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	netlinktestutil "github.com/DataDog/datadog-agent/pkg/network/netlink/testutil"
-	"github.com/DataDog/datadog-agent/pkg/network/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/network/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/connection"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/offsetguess"
 	tracertest "github.com/DataDog/datadog-agent/pkg/network/tracer/testutil"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	manager "github.com/DataDog/ebpf-manager"
 )
 
@@ -1783,95 +1780,6 @@ func (s *TracerSuite) TestPreexistingConnectionDirection() {
 	assert.Equal(t, addrPort(server.address), int(conn.DPort))
 	assert.Equal(t, network.OUTGOING, conn.Direction)
 	assert.True(t, conn.IntraHost)
-}
-
-func (s *TracerSuite) TestGetMapsTelemetry() {
-	t := s.T()
-	// We need the tracepoints on open syscall in order
-	// to test.
-	if !httpsSupported() {
-		t.Skip("HTTPS feature not available/supported for this setup")
-	}
-
-	t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", "true")
-	cfg := testConfig()
-	tr := setupTracer(t, cfg)
-
-	cmd := []string{"curl", "-k", "-o/dev/null", "example.com/[1-10]"}
-	err := exec.Command(cmd[0], cmd[1:]...).Run()
-	require.NoError(t, err)
-
-	stats, err := tr.GetStats()
-	require.NoError(t, err)
-
-	mapsTelemetry, ok := stats[telemetry.EBPFMapTelemetryNS].(map[string]interface{})
-	require.True(t, ok)
-	t.Logf("EBPF Maps telemetry: %v\n", mapsTelemetry)
-
-	tcpStatsErrors, ok := mapsTelemetry[probes.TCPStatsMap].(map[string]uint64)
-	require.True(t, ok)
-	assert.NotZero(t, tcpStatsErrors["file exists"])
-}
-
-func sysOpenAt2Supported() bool {
-	missing, err := ddebpf.VerifyKernelFuncs("do_sys_openat2")
-	if err == nil && len(missing) == 0 {
-		return true
-	}
-	kversion, err := kernel.HostVersion()
-	if err != nil {
-		log.Error("could not determine the current kernel version. fallback to do_sys_open")
-		return false
-	}
-
-	return kversion >= kernel.VersionCode(5, 6, 0)
-}
-
-func (s *TracerSuite) TestGetHelpersTelemetry() {
-	t := s.T()
-
-	// We need the tracepoints on open syscall in order
-	// to test.
-	if !httpsSupported() {
-		t.Skip("HTTPS feature not available/supported for this setup")
-	}
-
-	t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", "true")
-	cfg := testConfig()
-	cfg.EnableHTTPSMonitoring = true
-	cfg.EnableHTTPMonitoring = true
-	tr := setupTracer(t, cfg)
-
-	expectedErrorTP := "tracepoint__syscalls__sys_enter_openat"
-	syscallNumber := syscall.SYS_OPENAT
-	if sysOpenAt2Supported() {
-		expectedErrorTP = "tracepoint__syscalls__sys_enter_openat2"
-		// In linux kernel source dir run:
-		// printf SYS_openat2 | gcc -include sys/syscall.h -E -
-		syscallNumber = 437
-	}
-
-	// Ensure `bpf_probe_read_user` fails by passing an address guaranteed to pagefault to open syscall.
-	_, _, sysErr := syscall.Syscall6(syscall.SYS_MMAP, uintptr(0xdeadbeef), uintptr(syscall.Getpagesize()), syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_ANON|syscall.MAP_PRIVATE, 0, 0)
-	require.Zero(t, sysErr)
-	syscall.Syscall(uintptr(syscallNumber), uintptr(0), uintptr(0xdeadbeef), uintptr(0))
-
-	stats, err := tr.GetStats()
-	require.NoError(t, err)
-
-	helperTelemetry, ok := stats[telemetry.EBPFHelperTelemetryNS].(map[string]interface{})
-	require.True(t, ok)
-	t.Logf("EBPF helper telemetry: %v\n", helperTelemetry)
-
-	openAtErrors, ok := helperTelemetry[expectedErrorTP].(map[string]interface{})
-	require.True(t, ok)
-
-	probeReadUserError, ok := openAtErrors["bpf_probe_read_user"].(map[string]uint64)
-	require.True(t, ok)
-
-	badAddressCnt, ok := probeReadUserError["bad address"]
-	require.True(t, ok)
-	assert.NotZero(t, badAddressCnt)
 }
 
 func TestEbpfConntrackerFallback(t *testing.T) {


### PR DESCRIPTION
This reverts commit 70e0e6ffdbd80a8a9de3622f4d60e336ff58c635.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
