### PR TITLE
pkg/serverless/appsec: run as a runtime api proxy only

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -276,21 +276,14 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 	}()
 
 	// start appsec
-	var (
-		appsecSubProcessor   invocationlifecycle.InvocationSubProcessor
-		appsecProxyProcessor *httpsec.ProxyLifecycleProcessor
-	)
+	var appsecProxyProcessor *httpsec.ProxyLifecycleProcessor
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		subProcessor, proxySubProcessor, err := appsec.New()
+		var err error
+		appsecProxyProcessor, err = appsec.New()
 		if err != nil {
 			log.Error("appsec: could not start: ", err)
-		}
-		if subProcessor != nil {
-			appsecSubProcessor = subProcessor
-		} else if proxySubProcessor != nil {
-			appsecProxyProcessor = proxySubProcessor
 		}
 	}()
 
@@ -322,11 +315,13 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 		ProcessTrace:         ta.Process,
 		DetectLambdaLibrary:  func() bool { return serverlessDaemon.LambdaLibraryDetected },
 		InferredSpansEnabled: inferredspan.IsInferredSpansEnabled(),
-		SubProcessor:         appsecSubProcessor, // Universal Instrumentation API mode - nil in the runtime api proxy mode
 	}
 
 	if appsecProxyProcessor != nil {
-		// Runtime API proxy mode
+		// AppSec runs as a Runtime API proxy. The reverse proxy was already
+		// started by appsec.New(). A span modifier needs to be added in order
+		// to detect the finished request spans and run the complete AppSec
+		// monitoring logic, and ultimately adding the AppSec events to them.
 		ta.ModifySpan = appsecProxyProcessor.WrapSpanModifier(serverlessDaemon.ExecutionContext, ta.ModifySpan)
 	} else if enabled, _ := strconv.ParseBool(os.Getenv("DD_EXPERIMENTAL_ENABLE_PROXY")); enabled {
 		// start the experimental proxy if enabled

--- a/pkg/serverless/appsec/appsec.go
+++ b/pkg/serverless/appsec/appsec.go
@@ -28,9 +28,7 @@ func New() (*httpsec.ProxyLifecycleProcessor, error) {
 	}
 
 	// AppSec monitors the invocations by acting as a proxy of the AWS Lambda Runtime API.
-	lp := &httpsec.ProxyLifecycleProcessor{
-		SubProcessor: httpsec.NewProxyProcessor(appsecInstance),
-	}
+	lp := httpsec.NewProxyLifecycleProcessor(appsecInstance)
 	proxy.Start(
 		"127.0.0.1:9000",
 		"127.0.0.1:9001",

--- a/pkg/serverless/appsec/appsec.go
+++ b/pkg/serverless/appsec/appsec.go
@@ -8,8 +8,6 @@
 package appsec
 
 import (
-	"os"
-	"strconv"
 	"time"
 
 	"github.com/DataDog/appsec-internal-go/appsec"
@@ -18,49 +16,28 @@ import (
 	"github.com/DataDog/go-libddwaf"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	"github.com/pkg/errors"
 )
 
-func New() (*httpsec.InvocationSubProcessor, *httpsec.ProxyLifecycleProcessor, error) {
+func New() (*httpsec.ProxyLifecycleProcessor, error) {
 	appsecInstance, err := newAppSec() // note that the assigned variable is in the parent scope
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	if appsecInstance == nil {
-		return nil, nil, nil // appsec disabled
+		return nil, nil // appsec disabled
 	}
 
-	var rtProxyMode bool
-	if rtProxyModeEnv := os.Getenv("DD_EXPERIMENTAL_ENABLE_PROXY"); rtProxyModeEnv != "" {
-		rtProxyMode, err = strconv.ParseBool(rtProxyModeEnv)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "parsing error of the environment variable DD_EXPERIMENTAL_ENABLE_PROXY")
-		}
+	// AppSec monitors the invocations by acting as a proxy of the AWS Lambda Runtime API.
+	lp := &httpsec.ProxyLifecycleProcessor{
+		SubProcessor: httpsec.NewProxyProcessor(appsecInstance),
 	}
-
-	switch {
-	case rtProxyMode:
-		// NodeJS and Python are currently supported by monitoring the invocations
-		// through the runtime API.
-		lp := &httpsec.ProxyLifecycleProcessor{
-			SubProcessor: httpsec.NewProxyProcessor(appsecInstance),
-		}
-		// start the experimental proxy if enabled
-		proxy.Start(
-			"127.0.0.1:9000",
-			"127.0.0.1:9001",
-			lp,
-		)
-		log.Debug("appsec: started successfully using the runtime api proxy monitoring mode")
-		return nil, lp, nil
-
-	default:
-		// Other runtimes are supported with the extension's universal instrumentation lifecycle subprocessor
-		lp := httpsec.NewInvocationSubProcessor(appsecInstance)
-		log.Info("appsec: started successfully")
-		return lp, nil, nil
-	}
+	proxy.Start(
+		"127.0.0.1:9000",
+		"127.0.0.1:9001",
+		lp,
+	)
+	log.Debug("appsec: started successfully using the runtime api proxy monitoring mode")
+	return lp, nil
 }
 
 type AppSec struct {

--- a/pkg/serverless/appsec/httpsec/http.go
+++ b/pkg/serverless/appsec/httpsec/http.go
@@ -159,38 +159,6 @@ func parseCookies(rawCookies []string) map[string][]string {
 	return cookies
 }
 
-// Parses the given raw response payload as an HTTP response payload in order
-// to retrieve its status code and response headers if any.
-// This function merges the single- and multi-value headers the response may
-// contain into a multi-value map of headers. A single-value header is ignored
-// if it already exists in the map of multi-value headers.
-// TODO: write unit-tests
-func parseResponseHeaders(rawPayload []byte) (headers map[string][]string, err error) {
-	var res struct {
-		Headers           map[string]string   `json:"headers"`
-		MultiValueHeaders map[string][]string `json:"multiValueHeaders"`
-	}
-
-	if err := json.Unmarshal(rawPayload, &res); err != nil {
-		return nil, err
-	}
-
-	if len(res.Headers) == 0 && len(res.MultiValueHeaders) == 0 {
-		return nil, nil
-	}
-
-	headers = res.MultiValueHeaders
-	if headers == nil {
-		headers = make(map[string][]string, len(res.Headers))
-	}
-	for k, v := range res.Headers {
-		if _, exists := res.MultiValueHeaders[k]; !exists {
-			headers[k] = []string{v}
-		}
-	}
-	return headers, nil
-}
-
 // Helper function to convert a single-value map of event values into a
 // multi-value one.
 func toMultiValueMap(m map[string]string) map[string][]string {

--- a/pkg/serverless/appsec/httpsec/proxy_test.go
+++ b/pkg/serverless/appsec/httpsec/proxy_test.go
@@ -74,7 +74,6 @@ func TestProxyLifecycleProcessor(t *testing.T) {
 			InvokedFunctionARN:    "arn:aws:lambda:us-east-1:123456789012:function:my-function",
 		})
 		span := chunk.Spans[0]
-		tags := span.Meta
 		require.Equal(t, 1.0, span.Metrics["_dd.appsec.enabled"])
 
 		// Second invocation containing attacks
@@ -83,8 +82,7 @@ func TestProxyLifecycleProcessor(t *testing.T) {
 			InvokedFunctionARN:    "arn:aws:lambda:us-east-1:123456789012:function:my-function",
 		})
 		span = chunk.Spans[0]
-		tags = span.Meta
-		require.Contains(t, tags, "_dd.appsec.json")
+		require.Contains(t, span.Meta, "_dd.appsec.json")
 		require.Equal(t, int32(sampler.PriorityUserKeep), chunk.Priority)
 		require.Equal(t, 1.0, span.Metrics["_dd.appsec.enabled"])
 	})

--- a/pkg/serverless/appsec/httpsec/proxy_test.go
+++ b/pkg/serverless/appsec/httpsec/proxy_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package httpsec_test
+package httpsec
 
 import (
 	"bytes"
@@ -13,15 +13,13 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/serverless/appsec"
-	"github.com/DataDog/datadog-agent/pkg/serverless/appsec/httpsec"
 	"github.com/DataDog/datadog-agent/pkg/serverless/invocationlifecycle"
 	"github.com/DataDog/datadog-agent/pkg/trace/api"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestLifecycleSubProcessor(t *testing.T) {
+func TestProxyLifecycleProcessor(t *testing.T) {
 	test := func(t *testing.T, appsecEnabled bool) {
 		t.Setenv("DD_SERVERLESS_APPSEC_ENABLED", strconv.FormatBool(appsecEnabled))
 		asm, _, err := appsec.New()
@@ -105,20 +103,4 @@ func getEventFromFile(filename string) []byte {
 	buf.Write(event)
 	buf.WriteString("0")
 	return buf.Bytes()
-}
-
-func TestInvocationSubProcessorNilInterface(t *testing.T) {
-	lp := &invocationlifecycle.LifecycleProcessor{
-		DetectLambdaLibrary: func() bool { return true },
-		SubProcessor:        (*httpsec.InvocationSubProcessor)(nil),
-	}
-
-	assert.True(t, lp.SubProcessor != nil)
-
-	lp.OnInvokeStart(&invocationlifecycle.InvocationStartDetails{
-		InvokeEventRawPayload: []byte(
-			`{"requestcontext":{"stage":"purple"},"httpmethod":"purple","resource":"purple"}`),
-	})
-
-	lp.OnInvokeEnd(&invocationlifecycle.InvocationEndDetails{})
 }

--- a/pkg/serverless/proxy/transport.go
+++ b/pkg/serverless/proxy/transport.go
@@ -99,7 +99,7 @@ func processRequest(p *proxyTransport, request *http.Request) error {
 		p.processor.OnInvokeEnd(details)
 
 	default:
-		log.Debugf("runtime api proxy: unknown verb/url (%s/%s) pattern found, ignoring", request.Method, request.URL.String())
+		log.Debugf("runtime api proxy: ignoring %s /%s", request.Method, request.URL.String())
 	}
 
 	return nil


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR generalizes the Runtime API proxy mode and removes the former Universal Instrumentation lifecycle processor that was used to monitor Go, Java and .NET.

This PR must be released along with https://github.com/DataDog/datadog-lambda-extension/pull/158

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The private beta of AppSec for AWS Lambda has been out for the past 4 quarters. Node.js and Python are supported thanks to the Runtime API proxy hosted in the extension. It proved to be working perfectly fine so far.

Current motivations:
1. Single AppSec monitoring and logic.
2. Simplified onboarding with:
    1. No more need to know if we must start the Runtime API proxy or not, as it now always needs to be.
    2. Related to the previous point: no more need to know if we need to start in universal instrumentation API mode or Runtime API proxy mode. This was making our setup instructions complex, but also very hard to automate in our onboarding tools as it needed to know what was the language being used.
4. Simplified implementation.
5. For the future: the ability to modify the invocation responses if we want to block the invocation with a blocking response.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

AppSec users of Go, Java and .NET functions will have to setup our datadog_wrapper script.
Not doing it will result in ASM unable to monitor their functions anymore and doesn't cause any issue.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
