### PR TITLE
Fix EBPF maps and helpers errors telemetry 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.47.0-rc.3
 	github.com/DataDog/datadog-go/v5 v5.1.1
 	github.com/DataDog/datadog-operator v1.0.3
-	github.com/DataDog/ebpf-manager v0.2.10
+	github.com/DataDog/ebpf-manager v0.2.11
 	github.com/DataDog/go-libddwaf v1.0.0
 	github.com/DataDog/go-tuf v1.0.1-0.5.2
 	github.com/DataDog/gopsutil v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/DataDog/datadog-go/v5 v5.1.1 h1:JLZ6s2K1pG2h9GkvEvMdEGqMDyVLEAccdX5Tl
 github.com/DataDog/datadog-go/v5 v5.1.1/go.mod h1:KhiYb2Badlv9/rofz+OznKoEF5XKTonWyhx5K83AP8E=
 github.com/DataDog/datadog-operator v1.0.3 h1:zBGNnmFsU99wttrt0PWXXRgJvTRGeWt3YD7wUh7VBd4=
 github.com/DataDog/datadog-operator v1.0.3/go.mod h1:CXTLg7VFcpaMvjbwkKTxKUIzxRumfSe01/CWOINo4c0=
-github.com/DataDog/ebpf-manager v0.2.10 h1:1efxFLMkn+N0uJ5BZT9qad5xRGBNJyWKZlR8FeYXWtQ=
-github.com/DataDog/ebpf-manager v0.2.10/go.mod h1:KDs7en18FwWMVz3iCnGIvOCZdyuXozS+w4YrCIQbtM0=
+github.com/DataDog/ebpf-manager v0.2.11 h1:DK1VBC1pXjjHQwGqBhnEe1yoTlzzOI7Ek1DvHFkKYyE=
+github.com/DataDog/ebpf-manager v0.2.11/go.mod h1:KDs7en18FwWMVz3iCnGIvOCZdyuXozS+w4YrCIQbtM0=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2 h1:uTE/QEU0oYtHnebKSMbxap7XMG5603WQxNP/UX63E7k=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2/go.mod h1:JgKVGTsjdTdtJjNyxRZjcs81/rng6LJ3XX/0D7Y12Gc=
 github.com/DataDog/glog v1.1.2-0.20230527101146-81a67cdbc7a1 h1:YpYdpEG3ohpETQTzz9u4bTvvJUzkRFwMyLrx/jtbU5g=

--- a/pkg/ebpf/c/bpf_helper_defs.h
+++ b/pkg/ebpf/c/bpf_helper_defs.h
@@ -76,10 +76,9 @@ static void *(*bpf_map_lookup_elem)(void *map, const void *key) = (void *) 1;
  */
 
 // The return value of `bpf_map_update_elem` is changed from `long` to `int` purposefully.
-// On kernels uptil 6.3 the underlying function signature of the helper operation returns an
-// `int`. 
-// Specifying `long` as the return type here caused the compiler to omit sign extension code
-// which is required for a negative return value. This caused error code to be misinterpreted.
+// On kernels uptil 6.3 the underlying function signature of the helper operation returns an `int`.
+// Specifying `long` as the return type here caused the compiler to omit sign extension code,
+// which is required for correctly interpreting a negative return value.
 // More details in this PR: https://github.com/DataDog/datadog-agent/pull/18247
 static int (*bpf_map_update_elem)(void *map, const void *key, const void *value, __u64 flags) = (void *) 2;
 
@@ -93,10 +92,9 @@ static int (*bpf_map_update_elem)(void *map, const void *key, const void *value,
  */
 
 // The return value of `bpf_map_delete_elem` is changed from `long` to `int` purposefully.
-// On kernels uptil 6.3 the underlying function signature of the helper operation returns an
-// `int`. 
-// Specifying `long` as the return type here caused the compiler to omit sign extension code
-// which is required for a negative return value. This caused error code to be misinterpreted.
+// On kernels uptil 6.3 the underlying function signature of the helper operation returns an `int`.
+// Specifying `long` as the return type here caused the compiler to omit sign extension code,
+// which is required for correctly interpreting a negative return value.
 // More details in this PR: https://github.com/DataDog/datadog-agent/pull/18247
 static int (*bpf_map_delete_elem)(void *map, const void *key) = (void *) 3;
 
@@ -2284,10 +2282,9 @@ static long (*bpf_sk_release)(void *sock) = (void *) 86;
  */
 
 // The return value of `bpf_map_push_elem` is changed from `long` to `int` purposefully.
-// On kernels uptil 6.3 the underlying function signature of the helper operation returns an
-// `int`. 
-// Specifying `long` as the return type here caused the compiler to omit sign extension code
-// which is required for a negative return value. This caused error code to be misinterpreted.
+// On kernels uptil 6.3 the underlying function signature of the helper operation returns an `int`.
+// Specifying `long` as the return type here caused the compiler to omit sign extension code,
+// which is required for correctly interpreting a negative return value.
 // More details in this PR: https://github.com/DataDog/datadog-agent/pull/18247
 static int (*bpf_map_push_elem)(void *map, const void *value, __u64 flags) = (void *) 87;
 
@@ -2301,10 +2298,9 @@ static int (*bpf_map_push_elem)(void *map, const void *value, __u64 flags) = (vo
  */
 
 // The return value of `bpf_map_pop_elem` is changed from `long` to `int` purposefully.
-// On kernels uptil 6.3 the underlying function signature of the helper operation returns an
-// `int`. 
-// Specifying `long` as the return type here caused the compiler to omit sign extension code
-// which is required for a negative return value. This caused error code to be misinterpreted.
+// On kernels uptil 6.3 the underlying function signature of the helper operation returns an `int`.
+// Specifying `long` as the return type here caused the compiler to omit sign extension code,
+// which is required for correctly interpreting a negative return value.
 // More details in this PR: https://github.com/DataDog/datadog-agent/pull/18247
 static int (*bpf_map_pop_elem)(void *map, void *value) = (void *) 88;
 
@@ -2318,10 +2314,9 @@ static int (*bpf_map_pop_elem)(void *map, void *value) = (void *) 88;
  */
 
 // The return value of `bpf_map_peek_elem` is changed from `long` to `int` purposefully.
-// On kernels uptil 6.3 the underlying function signature of the helper operation returns an
-// `int`. 
-// Specifying `long` as the return type here caused the compiler to omit sign extension code
-// which is required for a negative return value. This caused error code to be misinterpreted.
+// On kernels uptil 6.3 the underlying function signature of the helper operation returns an `int`.
+// Specifying `long` as the return type here caused the compiler to omit sign extension code,
+// which is required for correctly interpreting a negative return value.
 // More details in this PR: https://github.com/DataDog/datadog-agent/pull/18247
 static int (*bpf_map_peek_elem)(void *map, void *value) = (void *) 89;
 

--- a/pkg/ebpf/c/bpf_helper_defs.h
+++ b/pkg/ebpf/c/bpf_helper_defs.h
@@ -76,7 +76,7 @@ static void *(*bpf_map_lookup_elem)(void *map, const void *key) = (void *) 1;
  */
 
 // The return value of `bpf_map_update_elem` is changed from `long` to `int` purposefully.
-// On kernels uptil 6.3 the underlying function signature of the helper operation returns an `int`.
+// On kernels until 6.3 the underlying function signature of the helper operation returns an `int`.
 // Specifying `long` as the return type here caused the compiler to omit sign extension code,
 // which is required for correctly interpreting a negative return value.
 // More details in this PR: https://github.com/DataDog/datadog-agent/pull/18247
@@ -92,7 +92,7 @@ static int (*bpf_map_update_elem)(void *map, const void *key, const void *value,
  */
 
 // The return value of `bpf_map_delete_elem` is changed from `long` to `int` purposefully.
-// On kernels uptil 6.3 the underlying function signature of the helper operation returns an `int`.
+// On kernels until 6.3 the underlying function signature of the helper operation returns an `int`.
 // Specifying `long` as the return type here caused the compiler to omit sign extension code,
 // which is required for correctly interpreting a negative return value.
 // More details in this PR: https://github.com/DataDog/datadog-agent/pull/18247
@@ -2282,7 +2282,7 @@ static long (*bpf_sk_release)(void *sock) = (void *) 86;
  */
 
 // The return value of `bpf_map_push_elem` is changed from `long` to `int` purposefully.
-// On kernels uptil 6.3 the underlying function signature of the helper operation returns an `int`.
+// On kernels until 6.3 the underlying function signature of the helper operation returns an `int`.
 // Specifying `long` as the return type here caused the compiler to omit sign extension code,
 // which is required for correctly interpreting a negative return value.
 // More details in this PR: https://github.com/DataDog/datadog-agent/pull/18247
@@ -2298,7 +2298,7 @@ static int (*bpf_map_push_elem)(void *map, const void *value, __u64 flags) = (vo
  */
 
 // The return value of `bpf_map_pop_elem` is changed from `long` to `int` purposefully.
-// On kernels uptil 6.3 the underlying function signature of the helper operation returns an `int`.
+// On kernels until 6.3 the underlying function signature of the helper operation returns an `int`.
 // Specifying `long` as the return type here caused the compiler to omit sign extension code,
 // which is required for correctly interpreting a negative return value.
 // More details in this PR: https://github.com/DataDog/datadog-agent/pull/18247
@@ -2314,7 +2314,7 @@ static int (*bpf_map_pop_elem)(void *map, void *value) = (void *) 88;
  */
 
 // The return value of `bpf_map_peek_elem` is changed from `long` to `int` purposefully.
-// On kernels uptil 6.3 the underlying function signature of the helper operation returns an `int`.
+// On kernels until 6.3 the underlying function signature of the helper operation returns an `int`.
 // Specifying `long` as the return type here caused the compiler to omit sign extension code,
 // which is required for correctly interpreting a negative return value.
 // More details in this PR: https://github.com/DataDog/datadog-agent/pull/18247

--- a/pkg/ebpf/c/bpf_helper_defs.h
+++ b/pkg/ebpf/c/bpf_helper_defs.h
@@ -74,7 +74,14 @@ static void *(*bpf_map_lookup_elem)(void *map, const void *key) = (void *) 1;
  * Returns
  * 	0 on success, or a negative error in case of failure.
  */
-static long (*bpf_map_update_elem)(void *map, const void *key, const void *value, __u64 flags) = (void *) 2;
+
+// The return value of `bpf_map_update_elem` is changed from `long` to `int` purposefully.
+// On kernels uptil 6.3 the underlying function signature of the helper operation returns an
+// `int`. 
+// Specifying `long` as the return type here caused the compiler to omit sign extension code
+// which is required for a negative return value. This caused error code to be misinterpreted.
+// More details in this PR: https://github.com/DataDog/datadog-agent/pull/18247
+static int (*bpf_map_update_elem)(void *map, const void *key, const void *value, __u64 flags) = (void *) 2;
 
 /*
  * bpf_map_delete_elem
@@ -84,7 +91,14 @@ static long (*bpf_map_update_elem)(void *map, const void *key, const void *value
  * Returns
  * 	0 on success, or a negative error in case of failure.
  */
-static long (*bpf_map_delete_elem)(void *map, const void *key) = (void *) 3;
+
+// The return value of `bpf_map_delete_elem` is changed from `long` to `int` purposefully.
+// On kernels uptil 6.3 the underlying function signature of the helper operation returns an
+// `int`. 
+// Specifying `long` as the return type here caused the compiler to omit sign extension code
+// which is required for a negative return value. This caused error code to be misinterpreted.
+// More details in this PR: https://github.com/DataDog/datadog-agent/pull/18247
+static int (*bpf_map_delete_elem)(void *map, const void *key) = (void *) 3;
 
 /*
  * bpf_probe_read
@@ -2268,7 +2282,14 @@ static long (*bpf_sk_release)(void *sock) = (void *) 86;
  * Returns
  * 	0 on success, or a negative error in case of failure.
  */
-static long (*bpf_map_push_elem)(void *map, const void *value, __u64 flags) = (void *) 87;
+
+// The return value of `bpf_map_push_elem` is changed from `long` to `int` purposefully.
+// On kernels uptil 6.3 the underlying function signature of the helper operation returns an
+// `int`. 
+// Specifying `long` as the return type here caused the compiler to omit sign extension code
+// which is required for a negative return value. This caused error code to be misinterpreted.
+// More details in this PR: https://github.com/DataDog/datadog-agent/pull/18247
+static int (*bpf_map_push_elem)(void *map, const void *value, __u64 flags) = (void *) 87;
 
 /*
  * bpf_map_pop_elem
@@ -2278,7 +2299,14 @@ static long (*bpf_map_push_elem)(void *map, const void *value, __u64 flags) = (v
  * Returns
  * 	0 on success, or a negative error in case of failure.
  */
-static long (*bpf_map_pop_elem)(void *map, void *value) = (void *) 88;
+
+// The return value of `bpf_map_pop_elem` is changed from `long` to `int` purposefully.
+// On kernels uptil 6.3 the underlying function signature of the helper operation returns an
+// `int`. 
+// Specifying `long` as the return type here caused the compiler to omit sign extension code
+// which is required for a negative return value. This caused error code to be misinterpreted.
+// More details in this PR: https://github.com/DataDog/datadog-agent/pull/18247
+static int (*bpf_map_pop_elem)(void *map, void *value) = (void *) 88;
 
 /*
  * bpf_map_peek_elem
@@ -2288,7 +2316,14 @@ static long (*bpf_map_pop_elem)(void *map, void *value) = (void *) 88;
  * Returns
  * 	0 on success, or a negative error in case of failure.
  */
-static long (*bpf_map_peek_elem)(void *map, void *value) = (void *) 89;
+
+// The return value of `bpf_map_peek_elem` is changed from `long` to `int` purposefully.
+// On kernels uptil 6.3 the underlying function signature of the helper operation returns an
+// `int`. 
+// Specifying `long` as the return type here caused the compiler to omit sign extension code
+// which is required for a negative return value. This caused error code to be misinterpreted.
+// More details in this PR: https://github.com/DataDog/datadog-agent/pull/18247
+static int (*bpf_map_peek_elem)(void *map, void *value) = (void *) 89;
 
 /*
  * bpf_msg_push_data

--- a/pkg/ebpf/c/bpf_telemetry.h
+++ b/pkg/ebpf/c/bpf_telemetry.h
@@ -16,7 +16,7 @@ static void *(*bpf_telemetry_update_patch)(unsigned long, ...) = (void *)PATCH_T
 
 #define map_update_with_telemetry(fn, map, args...)                                 \
     do {                                                                            \
-        int errno_ret, errno_slot;                                                  \
+        long errno_ret, errno_slot;                                                  \
         errno_ret = fn(&map, args);                                                 \
         if (errno_ret < 0) {                                                        \
             unsigned long err_telemetry_key;                                        \
@@ -58,7 +58,7 @@ static void *(*bpf_telemetry_update_patch)(unsigned long, ...) = (void *)PATCH_T
     ({                                                                                          \
         int helper_indx = -1;                                                                   \
         long errno_slot;                                                                        \
-        int errno_ret = fn(__VA_ARGS__);                                                       \
+        long errno_ret = fn(__VA_ARGS__);                                                       \
         if (errno_ret < 0) {                                                                    \
             unsigned long telemetry_program_id;                                                 \
             LOAD_CONSTANT("telemetry_program_id_key", telemetry_program_id);                    \

--- a/pkg/ebpf/c/bpf_telemetry.h
+++ b/pkg/ebpf/c/bpf_telemetry.h
@@ -16,7 +16,7 @@ static void *(*bpf_telemetry_update_patch)(unsigned long, ...) = (void *)PATCH_T
 
 #define map_update_with_telemetry(fn, map, args...)                                 \
     do {                                                                            \
-        long errno_ret, errno_slot;                                                  \
+        int errno_ret, errno_slot;                                                  \
         errno_ret = fn(&map, args);                                                 \
         if (errno_ret < 0) {                                                        \
             unsigned long err_telemetry_key;                                        \
@@ -58,7 +58,7 @@ static void *(*bpf_telemetry_update_patch)(unsigned long, ...) = (void *)PATCH_T
     ({                                                                                          \
         int helper_indx = -1;                                                                   \
         long errno_slot;                                                                        \
-        long errno_ret = fn(__VA_ARGS__);                                                       \
+        int errno_ret = fn(__VA_ARGS__);                                                       \
         if (errno_ret < 0) {                                                                    \
             unsigned long telemetry_program_id;                                                 \
             LOAD_CONSTANT("telemetry_program_id_key", telemetry_program_id);                    \

--- a/pkg/ebpf/c/bpf_telemetry.h
+++ b/pkg/ebpf/c/bpf_telemetry.h
@@ -15,8 +15,8 @@ BPF_HASH_MAP(helper_err_telemetry_map, unsigned long, helper_err_telemetry_t, 25
 static void *(*bpf_telemetry_update_patch)(unsigned long, ...) = (void *)PATCH_TARGET_TELEMETRY;
 
 #define map_update_with_telemetry(fn, map, args...)                                 \
-    do {                                                                            \
-        long errno_ret, errno_slot;                                                  \
+    ({                                                                            \
+        long errno_ret, errno_slot;                                                 \
         errno_ret = fn(&map, args);                                                 \
         if (errno_ret < 0) {                                                        \
             unsigned long err_telemetry_key;                                        \
@@ -39,7 +39,8 @@ static void *(*bpf_telemetry_update_patch)(unsigned long, ...) = (void *)PATCH_T
                 bpf_telemetry_update_patch((unsigned long)target, add);             \
             }                                                                       \
         }                                                                           \
-    } while (0)
+        errno_ret;                                                                  \
+    })
 
 #define MK_FN_INDX(fn) FN_INDX_##fn
 

--- a/pkg/network/ebpf/c/shared-libraries/probes.h
+++ b/pkg/network/ebpf/c/shared-libraries/probes.h
@@ -1,6 +1,7 @@
 #ifndef __SHARED_LIBRARIES_PROBES_H
 #define __SHARED_LIBRARIES_PROBES_H
 
+#include "bpf_telemetry.h"
 #include "shared-libraries/types.h"
 
 static __always_inline void fill_path_safe(lib_path_t *path, const char *path_argument) {
@@ -16,7 +17,7 @@ static __always_inline void fill_path_safe(lib_path_t *path, const char *path_ar
 
 static __always_inline void do_sys_open_helper_enter(const char *filename) {
     lib_path_t path = {0};
-    if (bpf_probe_read_user(path.buf, sizeof(path.buf), filename) >= 0) {
+    if (bpf_probe_read_user_with_telemetry(path.buf, sizeof(path.buf), filename) >= 0) {
 // Find the null character and clean up the garbage following it
 #pragma unroll
         for (int i = 0; i < LIB_PATH_MAX_SIZE; i++) {
@@ -37,7 +38,7 @@ static __always_inline void do_sys_open_helper_enter(const char *filename) {
 
     u64 pid_tgid = bpf_get_current_pid_tgid();
     path.pid = pid_tgid >> 32;
-    bpf_map_update_elem(&open_at_args, &pid_tgid, &path, BPF_ANY);
+    bpf_map_update_with_telemetry(open_at_args, &pid_tgid, &path, BPF_ANY);
     return;
 }
 

--- a/pkg/network/telemetry/ebpf_telemetry.go
+++ b/pkg/network/telemetry/ebpf_telemetry.go
@@ -224,7 +224,7 @@ func buildHelperErrTelemetryKeys(mgr *manager.Manager) []manager.ConstantEditor 
 			Name:  "telemetry_program_id_key",
 			Value: h.Sum64(),
 			ProbeIdentificationPairs: []manager.ProbeIdentificationPair{
-				manager.ProbeIdentificationPair{EBPFFuncName: p.EBPFFuncName},
+				p.ProbeIdentificationPair,
 			},
 		})
 		h.Reset()

--- a/pkg/network/telemetry/ebpf_telemetry.go
+++ b/pkg/network/telemetry/ebpf_telemetry.go
@@ -223,6 +223,9 @@ func buildHelperErrTelemetryKeys(mgr *manager.Manager) []manager.ConstantEditor 
 		keys = append(keys, manager.ConstantEditor{
 			Name:  "telemetry_program_id_key",
 			Value: h.Sum64(),
+			ProbeIdentificationPairs: []manager.ProbeIdentificationPair{
+				manager.ProbeIdentificationPair{EBPFFuncName: p.EBPFFuncName},
+			},
 		})
 		h.Reset()
 	}

--- a/pkg/network/telemetry/ebpf_telemetry.go
+++ b/pkg/network/telemetry/ebpf_telemetry.go
@@ -27,6 +27,9 @@ import (
 const (
 	maxErrno    = 64
 	maxErrnoStr = "other"
+
+	EBPFMapTelemetryNS    = "ebpf_maps"
+	EBPFHelperTelemetryNS = "ebpf_helpers"
 )
 
 const (
@@ -37,8 +40,8 @@ const (
 	perfEventOutput
 )
 
-var ebpfMapOpsErrorsGauge = prometheus.NewDesc("ebpf_map_ops__errors", "Failures of map operations for a specific ebpf map reported per error.", []string{"map_name", "error"}, nil)
-var ebpfHelperErrorsGauge = prometheus.NewDesc("ebpf_helpers__errors", "Failures of bpf helper operations reported per helper per error for each probe.", []string{"helper", "probe_name", "error"}, nil)
+var ebpfMapOpsErrorsGauge = prometheus.NewDesc(fmt.Sprintf("%s__errors", EBPFMapTelemetryNS), "Failures of map operations for a specific ebpf map reported per error.", []string{"map_name", "error"}, nil)
+var ebpfHelperErrorsGauge = prometheus.NewDesc(fmt.Sprintf("%s__errors", EBPFHelperTelemetryNS), "Failures of bpf helper operations reported per helper per error for each probe.", []string{"helper", "probe_name", "error"}, nil)
 
 var helperNames = map[int]string{readIndx: "bpf_probe_read", readUserIndx: "bpf_probe_read_user", readKernelIndx: "bpf_probe_read_kernel", skbLoadBytes: "bpf_skb_load_bytes", perfEventOutput: "bpf_perf_event_output"}
 

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -633,7 +633,7 @@ func (t *Tracer) getStats(comps ...statsComp) (map[string]interface{}, error) {
 		case bpfMapStats:
 			ret[nettelemetry.EBPFMapTelemetryNS] = t.bpfTelemetry.GetMapsTelemetry()
 		case bpfHelperStats:
-			ret[nettelemetry.EBPFHelperTelemetryNS] = t.bpfTelemetry.GetHelperTelemetry()
+			ret[nettelemetry.EBPFHelperTelemetryNS] = t.bpfTelemetry.GetHelpersTelemetry()
 		}
 	}
 

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -605,6 +605,8 @@ var allStats = []statsComp{
 	stateStats,
 	tracerStats,
 	httpStats,
+	bpfMapStats,
+	bpfHelperStats,
 }
 
 func (t *Tracer) getStats(comps ...statsComp) (map[string]interface{}, error) {
@@ -628,6 +630,10 @@ func (t *Tracer) getStats(comps ...statsComp) (map[string]interface{}, error) {
 			ret["tracer"] = tracerStats
 		case httpStats:
 			ret["universal_service_monitoring"] = t.usmMonitor.GetUSMStats()
+		case bpfMapStats:
+			ret[nettelemetry.EBPFMapTelemetryNS] = t.bpfTelemetry.GetMapsTelemetry()
+		case bpfHelperStats:
+			ret[nettelemetry.EBPFHelperTelemetryNS] = t.bpfTelemetry.GetHelperTelemetry()
 		}
 	}
 

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1835,11 +1835,12 @@ func (s *TracerSuite) TestUDPIncomingDirectionFix() {
 func (s *TracerSuite) TestGetMapsTelemetry() {
 	t := s.T()
 
-	// This is required for telemetry collection to be activated.
 	t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", "true")
-	tr := setupTracer(t, testConfig())
+	cfg := testConfig()
+	cfg.EnableHTTPSMonitoring = true
+	tr := setupTracer(t, cfg)
 
-	cmd := []string{"curl", "-k", "-o/dev/null", "--parallel", "example.com/[1-10]"}
+	cmd := []string{"curl", "-k", "-o/dev/null", "example.com/[1-10]"}
 	err := exec.Command(cmd[0], cmd[1:]...).Run()
 	require.NoError(t, err)
 
@@ -1872,9 +1873,16 @@ func sysOpenAt2Supported() bool {
 func (s *TracerSuite) TestGetHelpersTelemetry() {
 	t := s.T()
 
-	// This is required for telemetry collection to be activated.
+	// We need the tracepoints on open syscall in order
+	// to test.
+	if !httpsSupported() {
+		t.Skip("HTTPS feature not available/supported for this setup")
+	}
+
 	t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", "true")
-	tr := setupTracer(t, testConfig())
+	cfg := testConfig()
+	cfg.EnableHTTPSMonitoring = true
+	tr := setupTracer(t, cfg)
 
 	expectedErrorTP := "tracepoint__syscalls__sys_enter_openat"
 	syscallNumber := syscall.SYS_OPENAT

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1842,7 +1842,6 @@ func (s *TracerSuite) TestGetMapsTelemetry() {
 
 	t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", "true")
 	cfg := testConfig()
-	cfg.EnableHTTPSMonitoring = true
 	tr := setupTracer(t, cfg)
 
 	cmd := []string{"curl", "-k", "-o/dev/null", "example.com/[1-10]"}
@@ -1887,6 +1886,7 @@ func (s *TracerSuite) TestGetHelpersTelemetry() {
 	t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", "true")
 	cfg := testConfig()
 	cfg.EnableHTTPSMonitoring = true
+	cfg.EnableHTTPMonitoring = true
 	tr := setupTracer(t, cfg)
 
 	expectedErrorTP := "tracepoint__syscalls__sys_enter_openat"

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1834,8 +1834,6 @@ func (s *TracerSuite) TestUDPIncomingDirectionFix() {
 
 func (s *TracerSuite) TestGetMapsTelemetry() {
 	t := s.T()
-	// We need the tracepoints on open syscall in order
-	// to test.
 	if !httpsSupported() {
 		t.Skip("HTTPS feature not available/supported for this setup")
 	}

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1888,7 +1888,7 @@ func (s *TracerSuite) TestGetHelpersTelemetry() {
 	// Ensure `bpf_probe_read_user` fails by passing an address guaranteed to pagefault to open syscall.
 	_, _, sysErr := syscall.Syscall6(syscall.SYS_MMAP, uintptr(0xdeadbeef), uintptr(syscall.Getpagesize()), syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_ANON|syscall.MAP_PRIVATE, 0, 0)
 	require.Zero(t, sysErr)
-	_, _, sysErr = syscall.Syscall(uintptr(syscallNumber), uintptr(0), uintptr(0xdeadbeef), uintptr(0))
+	syscall.Syscall(uintptr(syscallNumber), uintptr(0), uintptr(0xdeadbeef), uintptr(0))
 
 	stats, err := tr.GetStats()
 	require.NoError(t, err)

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1876,10 +1876,10 @@ func (s *TracerSuite) TestGetHelpersTelemetry() {
 	t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", "true")
 	tr := setupTracer(t, testConfig())
 
-	expectedErrorTP := "tracepoint__syscalls__sys_exit_openat"
+	expectedErrorTP := "tracepoint__syscalls__sys_enter_openat"
 	syscallNumber := syscall.SYS_OPENAT
 	if sysOpenAt2Supported() {
-		expectedErrorTP = "tracepoint__syscalls__sys_exit_openat2"
+		expectedErrorTP = "tracepoint__syscalls__sys_enter_openat2"
 		// In linux kernel source dir run:
 		// printf SYS_openat2 | gcc -include sys/syscall.h -E -
 		syscallNumber = 437

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1834,6 +1834,11 @@ func (s *TracerSuite) TestUDPIncomingDirectionFix() {
 
 func (s *TracerSuite) TestGetMapsTelemetry() {
 	t := s.T()
+	// We need the tracepoints on open syscall in order
+	// to test.
+	if !httpsSupported() {
+		t.Skip("HTTPS feature not available/supported for this setup")
+	}
 
 	t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", "true")
 	cfg := testConfig()

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -41,13 +41,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/config/sysctl"
+	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	netlinktestutil "github.com/DataDog/datadog-agent/pkg/network/netlink/testutil"
+	"github.com/DataDog/datadog-agent/pkg/network/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/network/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/connection"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/offsetguess"
 	tracertest "github.com/DataDog/datadog-agent/pkg/network/tracer/testutil"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	manager "github.com/DataDog/ebpf-manager"
 )
 
@@ -1827,6 +1830,82 @@ func (s *TracerSuite) TestUDPIncomingDirectionFix() {
 	}, 3*time.Second, 500*time.Millisecond)
 
 	assert.Equal(t, network.OUTGOING, conn.Direction)
+}
+
+func (s *TracerSuite) TestGetMapsTelemetry() {
+	t := s.T()
+
+	// This is required for telemetry collection to be activated.
+	t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", "true")
+	tr := setupTracer(t, testConfig())
+
+	cmd := []string{"curl", "-k", "-o/dev/null", "--parallel", "example.com/[1-10]"}
+	err := exec.Command(cmd[0], cmd[1:]...).Run()
+	require.NoError(t, err)
+
+	stats, err := tr.GetStats()
+	require.NoError(t, err)
+
+	mapsTelemetry, ok := stats[telemetry.EBPFMapTelemetryNS].(map[string]interface{})
+	require.True(t, ok)
+	t.Logf("EBPF Maps telemetry: %v\n", mapsTelemetry)
+
+	tcpStatsErrors, ok := mapsTelemetry[probes.TCPStatsMap].(map[string]uint64)
+	require.True(t, ok)
+	assert.NotZero(t, tcpStatsErrors["file exists"])
+}
+
+func sysOpenAt2Supported() bool {
+	missing, err := ddebpf.VerifyKernelFuncs("do_sys_openat2")
+	if err == nil && len(missing) == 0 {
+		return true
+	}
+	kversion, err := kernel.HostVersion()
+	if err != nil {
+		log.Error("could not determine the current kernel version. fallback to do_sys_open")
+		return false
+	}
+
+	return kversion >= kernel.VersionCode(5, 6, 0)
+}
+
+func (s *TracerSuite) TestGetHelpersTelemetry() {
+	t := s.T()
+
+	// This is required for telemetry collection to be activated.
+	t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", "true")
+	tr := setupTracer(t, testConfig())
+
+	expectedErrorTP := "tracepoint__syscalls__sys_exit_openat"
+	syscallNumber := syscall.SYS_OPENAT
+	if sysOpenAt2Supported() {
+		expectedErrorTP = "tracepoint__syscalls__sys_exit_openat2"
+		// In linux kernel source dir run:
+		// printf SYS_openat2 | gcc -include sys/syscall.h -E -
+		syscallNumber = 437
+	}
+
+	// Ensure `bpf_probe_read_user` fails by passing an address guaranteed to pagefault to open syscall.
+	_, _, sysErr := syscall.Syscall6(syscall.SYS_MMAP, uintptr(0xdeadbeef), uintptr(syscall.Getpagesize()), syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_ANON|syscall.MAP_PRIVATE, 0, 0)
+	require.Zero(t, sysErr)
+	_, _, sysErr = syscall.Syscall(uintptr(syscallNumber), uintptr(0), uintptr(0xdeadbeef), uintptr(0))
+
+	stats, err := tr.GetStats()
+	require.NoError(t, err)
+
+	helperTelemetry, ok := stats[telemetry.EBPFHelperTelemetryNS].(map[string]interface{})
+	require.True(t, ok)
+	t.Logf("EBPF helper telemetry: %v\n", helperTelemetry)
+
+	openAtErrors, ok := helperTelemetry[expectedErrorTP].(map[string]interface{})
+	require.True(t, ok)
+
+	probeReadUserError, ok := openAtErrors["bpf_probe_read_user"].(map[string]uint64)
+	require.True(t, ok)
+
+	badAddressCnt, ok := probeReadUserError["bad address"]
+	require.True(t, ok)
+	assert.NotZero(t, badAddressCnt)
 }
 
 func TestEbpfConntrackerFallback(t *testing.T) {

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -212,7 +212,7 @@ func newSSLProgram(c *config.Config, m *manager.Manager, sockFDMap *ebpf.Map, bp
 		return nil
 	}
 
-	watcher, err := sharedlibraries.NewWatcher(c,
+	watcher, err := sharedlibraries.NewWatcher(c, bpfTelemetry,
 		sharedlibraries.Rule{
 			Re:           regexp.MustCompile(`libssl.so`),
 			RegisterCB:   addHooks(m, openSSLProbes),

--- a/pkg/network/usm/sharedlibraries/watcher.go
+++ b/pkg/network/usm/sharedlibraries/watcher.go
@@ -20,6 +20,7 @@ import (
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
+	errtelemetry "github.com/DataDog/datadog-agent/pkg/network/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
@@ -62,8 +63,8 @@ type Watcher struct {
 	libMatches *telemetry.Counter
 }
 
-func NewWatcher(cfg *config.Config, rules ...Rule) (*Watcher, error) {
-	ebpfProgram := newEBPFProgram(cfg)
+func NewWatcher(cfg *config.Config, bpfTelemetry *errtelemetry.EBPFTelemetry, rules ...Rule) (*Watcher, error) {
+	ebpfProgram := newEBPFProgram(cfg, bpfTelemetry)
 	err := ebpfProgram.Init()
 	if err != nil {
 		return nil, fmt.Errorf("error initializing shared library program: %w", err)

--- a/pkg/network/usm/sharedlibraries/watcher_test.go
+++ b/pkg/network/usm/sharedlibraries/watcher_test.go
@@ -83,6 +83,7 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetection() {
 	}
 
 	watcher, err := NewWatcher(config.New(),
+		nil,
 		Rule{
 			Re:         regexp.MustCompile(`foo-libssl.so`),
 			RegisterCB: callback,
@@ -164,6 +165,7 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetectionWithPIDandRootNameSpace()
 	}
 
 	watcher, err := NewWatcher(config.New(),
+		nil,
 		Rule{
 			Re:         regexp.MustCompile(`fooroot-crypto.so`),
 			RegisterCB: callback,
@@ -226,6 +228,7 @@ func (s *SharedLibrarySuite) TestSameInodeRegression() {
 	}
 
 	watcher, err := NewWatcher(config.New(),
+		nil,
 		Rule{
 			Re:         regexp.MustCompile(`foo-libssl.so`),
 			RegisterCB: callback,
@@ -287,6 +290,7 @@ func (s *SharedLibrarySuite) TestSoWatcherLeaks() {
 	unregisterCB := func(id utils.PathIdentifier) error { return errors.New("fake unregisterCB error") }
 
 	watcher, err := NewWatcher(config.New(),
+		nil,
 		Rule{
 			Re:           regexp.MustCompile(`foo-libssl.so`),
 			RegisterCB:   registerCB,
@@ -385,6 +389,7 @@ func (s *SharedLibrarySuite) TestSoWatcherProcessAlreadyHoldingReferences() {
 	unregisterCB := func(id utils.PathIdentifier) error { return nil }
 
 	watcher, err := NewWatcher(config.New(),
+		nil,
 		Rule{
 			Re:           regexp.MustCompile(`foo-libssl.so`),
 			RegisterCB:   registerCB,
@@ -534,6 +539,7 @@ func checkWatcherStateIsClean(t *testing.T, watcher *Watcher) {
 
 func BenchmarkScanSOWatcherNew(b *testing.B) {
 	w, _ := NewWatcher(config.New(),
+		nil,
 		Rule{
 			Re: regexp.MustCompile(`libssl.so`),
 		},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR implements two fixes for ebpf maps and helpers errors telemetry.    
The PR also adds unit tests for the telemetry package.   
Finally, the PR adds telemetry support to the sowatcher programs in order to enable some of the unit tests.


#### EBPF maps errors telemetry
The map errors telemetry was broken after https://github.com/DataDog/datadog-agent/pull/14580.
The root cause of this was a kernel bug described in this [commit](https://github.com/torvalds/linux/commit/d7ba4cc900bf1eea2d8c807c6b1fc6bd61f41237).

In short, the return types of some map helpers in the kernel is actually `int`, whereas we define these to be `long`. Since the compiler expects a `long` to be returned it does not generate the sign extension code which is required when interpreting `int` negative values as a `long`. As a result the `errno_ret < 0` check never succeeds. Hence, no telemetry.

The PR implements the fix by changing the definitions of the relevant helpers to return int instead of long.

#### EBPF helpers errors telemetry.
The ebpf helpers telemetry was broken, such that all errors were being associated with a single probe of the relevant manager.
We do constant patching to get the map entry associated with the telemetry of [each probe](https://github.com/DataDog/datadog-agent/blob/main/pkg/ebpf/c/bpf_telemetry.h#L64).
Since all helper calls in a probe will write to a struct in the same map entry, the scope of this key can be the probe level.
However, the way constant patching works in the ebpf-manager is that it replaces all instances of the constant in all probes.
So all probes would end up using the key of the last probe in the list of Probes in the manager.
We fix this by adding a ProbeIdentificationPair to the relevant ConstantEditor to target the correct program.
The relevant https://github.com/DataDog/ebpf-manager/pull/116 to support this usecase.

#### Sowatcher
This PR also adds ebpf helper telemetry support to sowatcher. The primary motivation here is to use the hooks on `sys_open*` syscall to test the helper telemetry.

#### Unit tests
This PR also adds tests for the ebpf telemetry.
The map update telemetry is triggered by relying on map update with the `BPF_NOEXIST` flag. This flag causes the update helper to fail whenever there is an entry present, thus generating failure telemetry.

The helper telemetry is tested by passing a pointer to an unmapped page to the open syscall. This causes `bpf_probe_read_user` to fail because of a page fault, getting us helper failure telemetry,

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
