### PR TITLE
Push the `master` docker images to `datadog-agent-qa` ECR for e2e

### DIFF
--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -235,3 +235,42 @@ dev_nightly-dogstatsd:
     IMG_REGISTRIES: dev
     IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     IMG_DESTINATIONS: dogstatsd-dev:nightly-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA},dogstatsd-dev:nightly-${CI_COMMIT_REF_SLUG}
+
+# push images to `datadog-agent-qa` ECR for the end-to-end tests defined in `e2e.yml`
+agent_qa:
+  extends: .docker_publish_job_definition
+  stage: dev_container_deploy
+  rules:
+    !reference [.on_main_a7]
+  needs:
+    - docker_build_agent7
+    - docker_build_agent7_arm64
+  variables:
+    IMG_REGISTRIES: agent-qa
+    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
+    IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+
+dca_qa:
+  extends: .docker_publish_job_definition
+  stage: dev_container_deploy
+  rules:
+    !reference [.on_main_a7]
+  needs:
+    - docker_build_cluster_agent_amd64
+  variables:
+    IMG_REGISTRIES: agent-qa
+    IMG_SOURCES: ${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
+    IMG_DESTINATIONS: cluster-agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+
+dogstatsd_qa:
+  extends: .docker_publish_job_definition
+  stage: dev_container_deploy
+  rules:
+    !reference [.on_main_a7]
+  needs:
+    - docker_build_dogstatsd_amd64
+    - docker_build_dogstatsd_arm64
+  variables:
+    IMG_REGISTRIES: agent-qa
+    IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
+    IMG_DESTINATIONS: dogstatsd:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -169,7 +169,7 @@ new-e2e-containers-main:
   rules: !reference [.on_main]
   variables:
     TARGETS: ./containers
-    CONFIGPARAMS: "-c ddagent:fullImagePath=datadog/agent-dev:master-py3 -c ddagent:clusterAgentFullImagePath=datadog/cluster-agent-dev:master"
+    CONFIGPARAMS: "-c ddagent:fullImagePath=669783387624.dkr.ecr.us-east-1.amazonaws.com/agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA} -c ddagent:clusterAgentFullImagePath=669783387624.dkr.ecr.us-east-1.amazonaws.com/cluster-agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
   # Temporary, until we manage to stabilize those tests.
   allow_failure: true
 


### PR DESCRIPTION
### What does this PR do?

Push the `(cluster-)agent` docker images to the ECR of `datadog-agent-qa` AWS project with a tag containing the pipeline ID and the git commit sha.

### Motivation

The end-to-end tests currently running on the `main` branch are testing the `datadog/agent-dev:master-py3` image.
The problem is that this is a floating tag. And we can have many pipelines running on the `main` branch at one time, continuously overriding the `master-py3` tag.
As a consequence, the end-to-end tests of a pipeline were not testing the version of the agent corresponding to that pipeline, but the one corresponding to another pipeline, running in parallel, that has pushed to `master-py3` slightly later.

In order to ensure that a pipeline reliably tests the expected version of the agent, we need a docker tag containing the pipeline ID and/or the git commit sha.
Such images are pushed in the ECR of the `datadog-agent-qa` ECR because that’s the AWS project where the e2e tests are run.

### Additional Notes

* This PR relies and depends on DataDog/public-images#16.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Check that the `new-e2e-containers-main` job isn’t failing anymore on this kind of errors:
```
=== FAIL: containers TestKindSuite/TestAgent/Linux_agent_pods_are_running_the_good_version (0.61s)
    k8s_test.go:132: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/containers/k8s_test.go:132
        	            				/go/pkg/mod/github.com/stretchr/testify@v1.8.4/suite/suite.go:112
        	Error:      	Not equal: 
        	            	expected: "1234567"
        	            	actual  : "abcdef9"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-1234567
        	            	+abcdef9
        	Test:       	TestKindSuite/TestAgent/Linux_agent_pods_are_running_the_good_version
        	Messages:   	Agent isn’t running the expected version
        --- FAIL: TestKindSuite/TestAgent/Linux_agent_pods_are_running_the_good_version (0.61s)
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
