### PR TITLE
trace-agent benchmarks: Change scenario names, remove outdated scenarios

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -33,7 +33,7 @@ variables:
   # benchmarks get changed to run on every PR)
   allow_failure: true
 
-trace-agent-v04-4cpus-avg_load-fixed_sps-macrobenchmarks:
+trace-agent-v04-4cpus-normal_load-fixed_sps-macrobenchmarks:
   extends: .trace_agent_benchmarks
   variables:
     TRACE_AGENT_VERSION: main
@@ -41,19 +41,8 @@ trace-agent-v04-4cpus-avg_load-fixed_sps-macrobenchmarks:
     TRACE_AGENT_CPUS: 4
     DD_APM_MAX_CPU_PERCENT: 0
     DD_APM_MAX_MEMORY: 0
-    DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-avg_load-fixed_sps
-    BENCHMARK_TARGETS: "avg_load.*sps"
-
-trace-agent-v04-4cpus-avg_load-fixed_mbps-macrobenchmarks:
-  extends: .trace_agent_benchmarks
-  variables:
-    TRACE_AGENT_VERSION: main
-    TRACE_AGENT_ENDPOINT: v04
-    TRACE_AGENT_CPUS: 4
-    DD_APM_MAX_CPU_PERCENT: 0
-    DD_APM_MAX_MEMORY: 0
-    DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-avg_load-fixed_mbps
-    BENCHMARK_TARGETS: "avg_load.*Mbps"
+    DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-normal_load-fixed_sps
+    BENCHMARK_TARGETS: "normal_load.*sps"
 
 trace-agent-v04-4cpus-stress_load-fixed_sps-macrobenchmarks:
   extends: .trace_agent_benchmarks
@@ -67,19 +56,7 @@ trace-agent-v04-4cpus-stress_load-fixed_sps-macrobenchmarks:
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-stress_load-fixed_sps
     BENCHMARK_TARGETS: "stress_load.*sps"
 
-trace-agent-v04-4cpus-stress_load-fixed_mbps-macrobenchmarks:
-  extends: .trace_agent_benchmarks
-  when: manual
-  variables:
-    TRACE_AGENT_VERSION: main
-    TRACE_AGENT_ENDPOINT: v04
-    TRACE_AGENT_CPUS: 4
-    DD_APM_MAX_CPU_PERCENT: 0
-    DD_APM_MAX_MEMORY: 0
-    DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-stress_load-fixed_mbps
-    BENCHMARK_TARGETS: "stress_load.*Mbps"
-
-trace-agent-v05-4cpus-avg_load-fixed_sps-macrobenchmarks:
+trace-agent-v05-4cpus-normal_load-fixed_sps-macrobenchmarks:
   extends: .trace_agent_benchmarks
   variables:
     TRACE_AGENT_VERSION: main
@@ -87,19 +64,8 @@ trace-agent-v05-4cpus-avg_load-fixed_sps-macrobenchmarks:
     TRACE_AGENT_CPUS: 4
     DD_APM_MAX_CPU_PERCENT: 0
     DD_APM_MAX_MEMORY: 0
-    DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-avg_load-fixed_sps
-    BENCHMARK_TARGETS: "avg_load.*sps"
-
-trace-agent-v05-4cpus-avg_load-fixed_mbps-macrobenchmarks:
-  extends: .trace_agent_benchmarks
-  variables:
-    TRACE_AGENT_VERSION: main
-    TRACE_AGENT_ENDPOINT: v05
-    TRACE_AGENT_CPUS: 4
-    DD_APM_MAX_CPU_PERCENT: 0
-    DD_APM_MAX_MEMORY: 0
-    DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-avg_load-fixed_mbps
-    BENCHMARK_TARGETS: "avg_load.*Mbps"
+    DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-normal_load-fixed_sps
+    BENCHMARK_TARGETS: "normal_load.*sps"
 
 trace-agent-v05-4cpus-stress_load-fixed_sps-macrobenchmarks:
   extends: .trace_agent_benchmarks
@@ -112,16 +78,3 @@ trace-agent-v05-4cpus-stress_load-fixed_sps-macrobenchmarks:
     DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-stress_load-fixed_sps
     BENCHMARK_TARGETS: "stress_load.*sps"
-
-trace-agent-v05-4cpus-stress_load-fixed_mbps-macrobenchmarks:
-  extends: .trace_agent_benchmarks
-  when: manual
-  variables:
-    TRACE_AGENT_VERSION: main
-    TRACE_AGENT_ENDPOINT: v05
-    TRACE_AGENT_CPUS: 4
-    DD_APM_MAX_CPU_PERCENT: 0
-    DD_APM_MAX_MEMORY: 0
-    DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-stress_load-fixed_mbps
-    BENCHMARK_TARGETS: "stress_load.*Mbps"
-


### PR DESCRIPTION
### What does this PR do?

Updates benchmarking pipeline to match the changes in Benchmarking Platform scripts for trace-agent benchmarks.

### Motivation

Keep benchmarks running, reduce clutter due to excessive number of scenarios.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
