### PR TITLE
Extract tags and trace helpers from the config package

### DIFF
--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/metric"
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/tag"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/serverless/metrics"
 	"github.com/DataDog/datadog-agent/pkg/serverless/otlp"
 	"github.com/DataDog/datadog-agent/pkg/serverless/random"
@@ -48,7 +49,7 @@ func setup() (cloudservice.CloudService, *log.Config, *trace.ServerlessTraceAgen
 	// and exit right away.
 	_ = cloudService.Init()
 
-	tags := tags.MergeWithOverwrite(tags.ArrayToMap(config.GetGlobalConfiguredTags(false)), cloudService.GetTags())
+	tags := tags.MergeWithOverwrite(tags.ArrayToMap(configUtils.GetConfiguredTags(config.Datadog, false)), cloudService.GetTags())
 	origin := cloudService.GetOrigin()
 	prefix := cloudService.GetPrefix()
 

--- a/cmd/serverless-init/tag/tag_test.go
+++ b/cmd/serverless-init/tag/tag_test.go
@@ -6,12 +6,14 @@
 package tag
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/serverless/tags"
 	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
+	"github.com/DataDog/datadog-agent/pkg/serverless/tags"
 )
 
 func TestGetBaseTagsArrayNoEnvNoMetadata(t *testing.T) {
@@ -93,7 +95,7 @@ func TestDdTags(t *testing.T) {
 	overwritingTags := map[string]string{
 		"originalKey": "overWrittenValue",
 	}
-	mergedTags := tags.MergeWithOverwrite(tags.ArrayToMap(config.GetGlobalConfiguredTags(false)), overwritingTags)
+	mergedTags := tags.MergeWithOverwrite(tags.ArrayToMap(configUtils.GetConfiguredTags(config.Datadog, false)), overwritingTags)
 	assert.Equal(t, "overWrittenValue", mergedTags["originalKey"])
 	assert.Equal(t, "value2", mergedTags["key2"])
 	assert.Equal(t, "value3", mergedTags["key3"])

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	logConfig "github.com/DataDog/datadog-agent/pkg/logs/config"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/serverless"
@@ -139,7 +140,7 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 	if err != nil {
 		log.Debug("Unable to restore the state from file")
 	} else {
-		serverlessDaemon.ComputeGlobalTags(config.GetGlobalConfiguredTags(true))
+		serverlessDaemon.ComputeGlobalTags(configUtils.GetConfiguredTags(config.Datadog, true))
 		serverlessDaemon.StartLogCollection()
 	}
 	// serverless parts

--- a/cmd/trace-agent/config/config.go
+++ b/cmd/trace-agent/config/config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/remote"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/otlp"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
@@ -184,7 +185,7 @@ func applyDatadogConfig(c *config.AgentConfig) error {
 		c.LogFilePath = coreconfig.Datadog.GetString("apm_config.log_file")
 	}
 
-	if env := coreconfig.GetTraceAgentDefaultEnv(); env != "" {
+	if env := configUtils.GetTraceAgentDefaultEnv(coreconfig.Datadog); env != "" {
 		c.DefaultEnv = env
 	}
 

--- a/pkg/autodiscovery/providers/config_reader.go
+++ b/pkg/autodiscovery/providers/config_reader.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/configresolver"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -383,7 +384,7 @@ func GetIntegrationConfigFromFile(name, fpath string) (integration.Config, error
 		if fargate.IsFargateInstance() {
 			// In Fargate, since no host tags are applied in the backend,
 			// add the configured DD_TAGS/DD_EXTRA_TAGS to the instance tags.
-			tags := config.GetGlobalConfiguredTags(false)
+			tags := configUtils.GetConfiguredTags(config.Datadog, false)
 			err := dataConf.MergeAdditionalTags(tags)
 			if err != nil {
 				log.Debugf("Could not add agent-level tags to instance of %v: %v", fpath, err)

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm/customresources"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	kubestatemetrics "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/builder"
 	ksmstore "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store"
 	hostnameUtil "github.com/DataDog/datadog-agent/pkg/util/hostname"
@@ -787,7 +788,7 @@ func (k *KSMCheck) initTags() {
 	}
 
 	if !k.instance.DisableGlobalTags {
-		k.instance.Tags = append(k.instance.Tags, config.GetConfiguredTags(k.agentConfig, false)...)
+		k.instance.Tags = append(k.instance.Tags, configUtils.GetConfiguredTags(k.agentConfig, false)...)
 	}
 }
 

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
@@ -150,7 +151,7 @@ func (d *DeviceCheck) setDeviceHostExternalTags() {
 	if deviceHostname == "" || err != nil {
 		return
 	}
-	agentTags := config.GetGlobalConfiguredTags(false)
+	agentTags := configUtils.GetConfiguredTags(config.Datadog, false)
 	log.Debugf("Set external tags for device host, host=`%s`, agentTags=`%v`", deviceHostname, agentTags)
 	externalhost.SetExternalTags(deviceHostname, common.SnmpExternalTagsSourceType, agentTags)
 }

--- a/pkg/compliance/reporter.go
+++ b/pkg/compliance/reporter.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
@@ -69,7 +70,7 @@ func NewLogReporter(stopper startstop.Stopper, sourceName, sourceType, runPath s
 	}
 
 	// merge tags from config
-	for _, tag := range coreconfig.GetConfiguredTags(coreconfig.Datadog, true) {
+	for _, tag := range configUtils.GetConfiguredTags(coreconfig.Datadog, true) {
 		if strings.HasPrefix(tag, "host") {
 			continue
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1992,34 +1992,6 @@ func getValidHostAliasesWithConfig(config Config) []string {
 	return aliases
 }
 
-// GetConfiguredTags returns list of tags from a configuration, based on
-// `tags` (DD_TAGS) and `extra_tags“ (DD_EXTRA_TAGS), with `dogstatsd_tags` (DD_DOGSTATSD_TAGS)
-// if includeDogdstatsd is true.
-func GetConfiguredTags(config Config, includeDogstatsd bool) []string {
-	tags := config.GetStringSlice("tags")
-	extraTags := config.GetStringSlice("extra_tags")
-
-	var dsdTags []string
-	if includeDogstatsd {
-		dsdTags = config.GetStringSlice("dogstatsd_tags")
-	}
-
-	combined := make([]string, 0, len(tags)+len(extraTags)+len(dsdTags))
-	combined = append(combined, tags...)
-	combined = append(combined, extraTags...)
-	combined = append(combined, dsdTags...)
-
-	return combined
-}
-
-// GetGlobalConfiguredTags returns complete list of user configured tags.
-//
-// This is composed of DD_TAGS and DD_EXTRA_TAGS, with DD_DOGSTATSD_TAGS included
-// if includeDogstatsd is true.
-func GetGlobalConfiguredTags(includeDogstatsd bool) []string {
-	return GetConfiguredTags(Datadog, includeDogstatsd)
-}
-
 func bindVectorOptions(config Config, datatype DataType) {
 	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.enabled", datatype), false)
 	config.BindEnvAndSetDefault(fmt.Sprintf("observability_pipelines_worker.%s.url", datatype), "")
@@ -2053,28 +2025,6 @@ func getObsPipelineURLForPrefix(datatype DataType, prefix string) (string, error
 		return pipelineURL, nil
 	}
 	return "", nil
-}
-
-// GetTraceAgentDefaultEnv returns the default env for the trace agent
-func GetTraceAgentDefaultEnv() string {
-	defaultEnv := ""
-	if Datadog.IsSet("apm_config.env") {
-		defaultEnv = Datadog.GetString("apm_config.env")
-		log.Debugf("Setting DefaultEnv to %q (from apm_config.env)", defaultEnv)
-	} else if Datadog.IsSet("env") {
-		defaultEnv = Datadog.GetString("env")
-		log.Debugf("Setting DefaultEnv to %q (from 'env' config option)", defaultEnv)
-	} else {
-		for _, tag := range GetConfiguredTags(Datadog, false) {
-			if strings.HasPrefix(tag, "env:") {
-				defaultEnv = strings.TrimPrefix(tag, "env:")
-				log.Debugf("Setting DefaultEnv to %q (from `env:` entry under the 'tags' config option: %q)", defaultEnv, tag)
-				return defaultEnv
-			}
-		}
-	}
-
-	return defaultEnv
 }
 
 // IsRemoteConfigEnabled returns true if Remote Configuration should be enabled

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -33,6 +33,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/remote/meta"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/uptane"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/util/backoff"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
@@ -240,7 +241,7 @@ func NewService() (*Service, error) {
 		products:                       make(map[rdata.Product]struct{}),
 		newProducts:                    make(map[rdata.Product]struct{}),
 		hostname:                       hname,
-		traceAgentEnv:                  config.GetTraceAgentDefaultEnv(),
+		traceAgentEnv:                  configUtils.GetTraceAgentDefaultEnv(config.Datadog),
 		clock:                          clock,
 		db:                             db,
 		api:                            http,

--- a/pkg/config/utils/tags.go
+++ b/pkg/config/utils/tags.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import "github.com/DataDog/datadog-agent/pkg/config"
+
+// GetConfiguredTags returns list of tags from a configuration, based on
+// `tags` (DD_TAGS) and `extra_tags“ (DD_EXTRA_TAGS), with `dogstatsd_tags` (DD_DOGSTATSD_TAGS)
+// if includeDogdstatsd is true.
+func GetConfiguredTags(c config.ConfigReader, includeDogstatsd bool) []string {
+	tags := c.GetStringSlice("tags")
+	extraTags := c.GetStringSlice("extra_tags")
+
+	var dsdTags []string
+	if includeDogstatsd {
+		dsdTags = c.GetStringSlice("dogstatsd_tags")
+	}
+
+	combined := make([]string, 0, len(tags)+len(extraTags)+len(dsdTags))
+	combined = append(combined, tags...)
+	combined = append(combined, extraTags...)
+	combined = append(combined, dsdTags...)
+
+	return combined
+}

--- a/pkg/config/utils/tags_test.go
+++ b/pkg/config/utils/tags_test.go
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetConfiguredaTags(t *testing.T) {
+	mockConfig := config.Mock(t)
+
+	set1 := []string{"1", "2", "3"}
+
+	mockConfig.Set("tags", set1)
+	assert.Equal(t, set1, GetConfiguredTags(mockConfig, false))
+}
+
+func TestGetConfiguredaTagsExtraTags(t *testing.T) {
+	mockConfig := config.Mock(t)
+
+	set1 := []string{"1", "2", "3"}
+
+	mockConfig.Set("extra_tags", set1)
+	assert.Equal(t, set1, GetConfiguredTags(mockConfig, false))
+}
+
+func TestGetConfiguredaTagsDSD(t *testing.T) {
+	mockConfig := config.Mock(t)
+
+	set1 := []string{"1", "2", "3"}
+
+	mockConfig.Set("dogstatsd_tags", set1)
+	assert.Equal(t, []string{}, GetConfiguredTags(mockConfig, false))
+	assert.Equal(t, set1, GetConfiguredTags(mockConfig, true))
+}
+
+func TestGetConfiguredaTagsCombined(t *testing.T) {
+	mockConfig := config.Mock(t)
+
+	set1 := []string{"1", "2", "3"}
+	set2 := []string{"4", "5", "6"}
+	set3 := []string{"7", "8", "9"}
+
+	mockConfig.Set("tags", set1)
+	mockConfig.Set("extra_tags", set2)
+	mockConfig.Set("dogstatsd_tags", set3)
+
+	expected := append(set1, set2...)
+	assert.Equal(t, expected, GetConfiguredTags(mockConfig, false))
+
+	expected = append(expected, set3...)
+	assert.Equal(t, expected, GetConfiguredTags(mockConfig, true))
+}

--- a/pkg/config/utils/trace.go
+++ b/pkg/config/utils/trace.go
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// GetTraceAgentDefaultEnv returns the default env for the trace agent
+func GetTraceAgentDefaultEnv(c config.ConfigReader) string {
+	defaultEnv := ""
+	if c.IsSet("apm_config.env") {
+		defaultEnv = c.GetString("apm_config.env")
+		log.Debugf("Setting DefaultEnv to %q (from apm_config.env)", defaultEnv)
+	} else if c.IsSet("env") {
+		defaultEnv = c.GetString("env")
+		log.Debugf("Setting DefaultEnv to %q (from 'env' config option)", defaultEnv)
+	} else {
+		for _, tag := range GetConfiguredTags(c, false) {
+			if strings.HasPrefix(tag, "env:") {
+				defaultEnv = strings.TrimPrefix(tag, "env:")
+				log.Debugf("Setting DefaultEnv to %q (from `env:` entry under the 'tags' config option: %q)", defaultEnv, tag)
+				return defaultEnv
+			}
+		}
+	}
+
+	return defaultEnv
+}

--- a/pkg/metadata/host/host_tags.go
+++ b/pkg/metadata/host/host_tags.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/gce"
@@ -82,7 +83,7 @@ func GetHostTags(ctx context.Context, cached bool) *Tags {
 		return appendAndSplitTags(old, new, splits)
 	}
 
-	rawHostTags := config.GetGlobalConfiguredTags(false)
+	rawHostTags := configUtils.GetConfiguredTags(config.Datadog, false)
 	hostTags := make([]string, 0, len(rawHostTags))
 	gceTags := []string{}
 	hostTags = appendToHostTags(hostTags, rawHostTags)

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -11,6 +11,7 @@ import (
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	logshttp "github.com/DataDog/datadog-agent/pkg/logs/client/http"
 	logsconfig "github.com/DataDog/datadog-agent/pkg/logs/config"
 	pconfig "github.com/DataDog/datadog-agent/pkg/security/probe/config"
@@ -329,7 +330,7 @@ func (c *RuntimeSecurityConfig) GetAnomalyDetectionMinimumStablePeriod(eventType
 
 // sanitize ensures that the configuration is properly setup
 func (c *RuntimeSecurityConfig) sanitize() error {
-	serviceName := utils.GetTagValue("service", coreconfig.GetGlobalConfiguredTags(true))
+	serviceName := utils.GetTagValue("service", configUtils.GetConfiguredTags(coreconfig.Datadog, true))
 	if len(serviceName) > 0 {
 		c.HostServiceName = fmt.Sprintf("service:%s", serviceName)
 	}

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -21,6 +21,7 @@ import (
 	"go.uber.org/atomic"
 
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	sbompkg "github.com/DataDog/datadog-agent/pkg/sbom"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors/host"
 	sbomscanner "github.com/DataDog/datadog-agent/pkg/sbom/scanner"
@@ -157,7 +158,7 @@ func (r *Resolver) prepareContextTags() {
 	r.contextTags = append(r.contextTags, fmt.Sprintf("host:%s", r.hostname))
 
 	// merge tags from config
-	for _, tag := range coreconfig.GetConfiguredTags(coreconfig.Datadog, true) {
+	for _, tag := range configUtils.GetConfiguredTags(coreconfig.Datadog, true) {
 		if strings.HasPrefix(tag, "host") {
 			continue
 		}

--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -22,6 +22,7 @@ import (
 	manager "github.com/DataDog/ebpf-manager"
 
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
@@ -311,7 +312,7 @@ func (adm *ActivityDumpManager) prepareContextTags() {
 	adm.contextTags = append(adm.contextTags, fmt.Sprintf("host:%s", adm.hostname))
 
 	// merge tags from config
-	for _, tag := range coreconfig.GetGlobalConfiguredTags(true) {
+	for _, tag := range configUtils.GetConfiguredTags(coreconfig.Datadog, true) {
 		if strings.HasPrefix(tag, "host") {
 			continue
 		}

--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/serverless/daemon"
 	"github.com/DataDog/datadog-agent/pkg/serverless/flush"
 	"github.com/DataDog/datadog-agent/pkg/serverless/metrics"
@@ -169,7 +170,7 @@ func callInvocationHandler(daemon *daemon.Daemon, arn string, deadlineMs int64, 
 func handleInvocation(doneChannel chan bool, daemon *daemon.Daemon, arn string, requestID string) {
 	log.Debug("Received invocation event...")
 	daemon.ExecutionContext.SetFromInvocation(arn, requestID)
-	daemon.ComputeGlobalTags(config.GetGlobalConfiguredTags(true))
+	daemon.ComputeGlobalTags(configUtils.GetConfiguredTags(config.Datadog, true))
 	daemon.StartLogCollection()
 	ecs := daemon.ExecutionContext.GetCurrentState()
 

--- a/pkg/serverless/trace/inferredspan/inferred_span.go
+++ b/pkg/serverless/trace/inferredspan/inferred_span.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/serverless/random"
 	"github.com/DataDog/datadog-agent/pkg/serverless/tags"
@@ -78,7 +79,7 @@ func FilterFunctionTags(input map[string]string) map[string]string {
 	}
 
 	// filter out DD_TAGS & DD_EXTRA_TAGS
-	ddTags := config.GetGlobalConfiguredTags(false)
+	ddTags := configUtils.GetConfiguredTags(config.Datadog, false)
 	for _, tag := range ddTags {
 		tagParts := strings.SplitN(tag, ":", 2)
 		if len(tagParts) != 2 {

--- a/pkg/util/static_tags.go
+++ b/pkg/util/static_tags.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -31,7 +32,7 @@ func GetStaticTagsSlice(ctx context.Context) []string {
 	tags := []string{}
 
 	// DD_TAGS / DD_EXTRA_TAGS
-	tags = append(tags, config.GetGlobalConfiguredTags(false)...)
+	tags = append(tags, configUtils.GetConfiguredTags(config.Datadog, false)...)
 
 	// EKS Fargate specific tags
 	if config.IsFeaturePresent(config.EKSFargate) {


### PR DESCRIPTION
### What does this PR do?

To help the migration to FX and components we extract all the helpers functions from pkg/config working on the global 'config.Datadog'.

`GetConfiguredTags` and `GetTraceAgentDefaultEnv` migration is required by moving 'pkg/metadata' to a component.

### Describe how to test/QA your changes

Sanity check to detect any regression

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
