### PR TITLE
fix: When creating filers we now trim any that begin with '"'

### DIFF
--- a/releasenotes/notes/Fix-AD-container-exclude-include-filter-ad218d5784c91f4a.yaml
+++ b/releasenotes/notes/Fix-AD-container-exclude-include-filter-ad218d5784c91f4a.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    When following the documentation for `Docker Log collection <https://docs.datadoghq.com/containers/docker/log/?tab=containerinstallation>`,
+    the `DD_CONTAINER_EXCLUDE` or `DD_CONTAINER_INCLUDE` environment variable would not work as Agent would not trim `"` from the variable
+    resulting in the following warning in the logs `Container filter "\"name:datadog-agent\"" is unknown, ignoring it. The supported filters are 'image', 'name' and '
+  kube_namespace'`.


### PR DESCRIPTION
### What does this PR do?

This fixes the issue seen in #17804 where the Agent would not correctly exclude/include a container as the environment variable was wrapped in `"`. This has caused people confusion as our documentation for [Docker Log collection](https://docs.datadoghq.com/containers/docker/log/?tab=containerinstallation) tells people it should work. 

### Motivation

When using `DD_CONTAINER_EXCLUDE` or `DD_CONTAINER_INCLUDE`, the expectation is that when I use it with Docker that it is okay to have `"` around the value. For example I'd expect the following to work:

```
docker run -d --name datadog-agent \
           --cgroupns host \
           --pid host \
           -e DD_API_KEY=<DATADOG_API_KEY> \
           -e DD_LOGS_ENABLED=true \
           -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
           -e DD_CONTAINER_EXCLUDE="name:datadog-agent" \
           -e DD_SITE=<DD_SITE>
           -v /var/run/docker.sock:/var/run/docker.sock:ro \
           -v /var/lib/docker/containers:/var/lib/docker/containers:ro \
           -v /proc/:/host/proc/:ro \
           -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
           -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
           gcr.io/datadoghq/agent:latest
```

### Additional Notes

None.

### Possible Drawbacks / Trade-offs

In high container churn environments the Agent would check the exclude/include list multiple times.

### Describe how to test/QA your changes

Run the following docker-compose file:

```yaml
---
version: "3.9"
services:
  agent:
    image: datadog/agent:<version>
    pid: host
    environment:
      - DD_API_KEY=<DATADOG_API_KEY>
      - DD_CONTAINER_EXCLUDE="image:datadog/agent:<version>"
      - DD_LOGS_ENABLED=true
      - DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock
      - /var/lib/docker/containers:/var/lib/docker/containers:ro
      - /proc/:/host/proc/:ro
      - /sys/fs/cgroup:/host/sys/fs/cgroup:ro

  logger:
    image: bash
    command: bash -c 'while true; do echo "This is a log message"; sleep 2; done'

```

And when you execute `docker exec -it datadog-agent-agent-1 agent status ` the status should not have an entry for the Agent but should have one for the other container (`bash`).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
