### PR TITLE
[WIP] force repro of TestServerV3 flaky test failure.

### DIFF
--- a/pkg/snmp/traps/listener.go
+++ b/pkg/snmp/traps/listener.go
@@ -88,6 +88,7 @@ func (t *TrapListener) receiveTrap(p *gosnmp.SnmpPacket, u *net.UDPAddr) {
 
 	t.aggregator.Count("datadog.snmp_traps.received", 1, "", tags)
 	t.receivedTrapsCount.Inc()
+	time.Sleep(21 * time.Millisecond) //JMWREPRO receivePacket() ticker case returning nil after receivedTrapsCount is incremented but before trap is sent
 
 	if err := validatePacket(p, t.config); err != nil {
 		log.Debugf("Invalid credentials from %s on listener %s, dropping traps", u.String(), t.config.Addr())

--- a/pkg/snmp/traps/listener_test.go
+++ b/pkg/snmp/traps/listener_test.go
@@ -26,7 +26,7 @@ func TestListenV1GenericTrap(t *testing.T) {
 	config := Config{Port: serverPort, CommunityStrings: []string{"public"}, Namespace: "totoro"}
 	Configure(t, config)
 
-	packetOutChan := make(PacketsChannel)
+	packetOutChan := make(PacketsChannel, packetsChanSize)
 	trapListener, err := startSNMPTrapListener(config, mockSender, packetOutChan)
 	require.NoError(t, err)
 	defer trapListener.Stop()
@@ -45,7 +45,7 @@ func TestServerV1SpecificTrap(t *testing.T) {
 	config := Config{Port: serverPort, CommunityStrings: []string{"public"}}
 	Configure(t, config)
 
-	packetOutChan := make(PacketsChannel)
+	packetOutChan := make(PacketsChannel, packetsChanSize)
 	trapListener, err := startSNMPTrapListener(config, mockSender, packetOutChan)
 	require.NoError(t, err)
 	defer trapListener.Stop()
@@ -64,7 +64,7 @@ func TestServerV2(t *testing.T) {
 	config := Config{Port: serverPort, CommunityStrings: []string{"public"}}
 	Configure(t, config)
 
-	packetOutChan := make(PacketsChannel)
+	packetOutChan := make(PacketsChannel, packetsChanSize)
 	trapListener, err := startSNMPTrapListener(config, mockSender, packetOutChan)
 	require.NoError(t, err)
 	defer trapListener.Stop()
@@ -83,7 +83,7 @@ func TestServerV2BadCredentials(t *testing.T) {
 	config := Config{Port: serverPort, CommunityStrings: []string{"public"}, Namespace: "totoro"}
 	Configure(t, config)
 
-	packetOutChan := make(PacketsChannel)
+	packetOutChan := make(PacketsChannel, packetsChanSize)
 	trapListener, err := startSNMPTrapListener(config, mockSender, packetOutChan)
 	require.NoError(t, err)
 	defer trapListener.Stop()
@@ -104,7 +104,7 @@ func TestServerV3(t *testing.T) {
 	config := Config{Port: serverPort, Users: []UserV3{userV3}}
 	Configure(t, config)
 
-	packetOutChan := make(PacketsChannel)
+	packetOutChan := make(PacketsChannel, packetsChanSize)
 	trapListener, err := startSNMPTrapListener(config, mockSender, packetOutChan)
 	require.NoError(t, err)
 	defer trapListener.Stop()
@@ -130,7 +130,7 @@ func TestServerV3BadCredentials(t *testing.T) {
 	config := Config{Port: serverPort, Users: []UserV3{userV3}}
 	Configure(t, config)
 
-	packetOutChan := make(PacketsChannel)
+	packetOutChan := make(PacketsChannel, packetsChanSize)
 	trapListener, err := startSNMPTrapListener(config, mockSender, packetOutChan)
 	require.NoError(t, err)
 	defer trapListener.Stop()
@@ -153,7 +153,7 @@ func TestListenerTrapsReceivedTelemetry(t *testing.T) {
 	config := Config{Port: serverPort, CommunityStrings: []string{"public"}, Namespace: "totoro"}
 	Configure(t, config)
 
-	packetOutChan := make(PacketsChannel)
+	packetOutChan := make(PacketsChannel, packetsChanSize)
 	trapListener, err := startSNMPTrapListener(config, mockSender, packetOutChan)
 	require.NoError(t, err)
 	defer trapListener.Stop()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
