### PR TITLE
[serverless] AAS Hostname None by Default

### DIFF
--- a/cmd/serverless-init/cloudservice/appservice_test.go
+++ b/cmd/serverless-init/cloudservice/appservice_test.go
@@ -38,7 +38,7 @@ func TestGetLinuxAppServiceTags(t *testing.T) {
 		"aas.site.name":                 "test_site_name",
 		"aas.site.type":                 "app",
 		"aas.subscription.id":           "",
-		"hostname":                      "",
+		"hostname":                      "none",
 	}, tags)
 }
 
@@ -69,6 +69,6 @@ func TestGetWindowsAppServiceTags(t *testing.T) {
 		"aas.site.name":                 "test_site_name",
 		"aas.site.type":                 "app",
 		"aas.subscription.id":           "",
-		"hostname":                      "",
+		"hostname":                      "none",
 	}, tags)
 }

--- a/cmd/serverless-init/cloudservice/appservice_test.go
+++ b/cmd/serverless-init/cloudservice/appservice_test.go
@@ -38,6 +38,7 @@ func TestGetLinuxAppServiceTags(t *testing.T) {
 		"aas.site.name":                 "test_site_name",
 		"aas.site.type":                 "app",
 		"aas.subscription.id":           "",
+		"hostname":                      "",
 	}, tags)
 }
 
@@ -68,5 +69,6 @@ func TestGetWindowsAppServiceTags(t *testing.T) {
 		"aas.site.name":                 "test_site_name",
 		"aas.site.type":                 "app",
 		"aas.subscription.id":           "",
+		"hostname":                      "",
 	}, tags)
 }

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -337,15 +337,19 @@ func TestProcess(t *testing.T) {
 
 		for _, chunk := range tp.Chunks {
 			for i, span := range chunk.Spans {
-				if i == 0 {
-					// root span should contain all aas tags
-					for tag := range traceutil.GetAppServicesTags() {
+				for tag := range traceutil.GetAppServicesTags() {
+					if i == 0 || tag == "aas.site.name" || tag == "aas.site.type" {
+						// root span should contain all aas tags
 						assert.Contains(t, span.Meta, tag)
+
+						// hostname should be none for billing
+						if tag == "hostname" {
+							assert.Equal(t, span.Meta[tag], "")
+						}
+					} else {
+						// other spans should only contain site name and type
+						assert.NotContains(t, span.Meta, tag)
 					}
-				} else {
-					// other spans should only contain site name and type
-					assert.Contains(t, span.Meta, "aas.site.name")
-					assert.Contains(t, span.Meta, "aas.site.type")
 				}
 			}
 		}

--- a/pkg/trace/traceutil/azure.go
+++ b/pkg/trace/traceutil/azure.go
@@ -81,7 +81,7 @@ func getAppServicesTags(getenv func(string) string) map[string]string {
 	}
 
 	// Equivalent to DD_HOSTNAME=none, needed for billing
-	tags["hostname"] = ""
+	tags["hostname"] = "none"
 
 	return tags
 }

--- a/pkg/trace/traceutil/azure.go
+++ b/pkg/trace/traceutil/azure.go
@@ -37,12 +37,7 @@ const (
 	appService = "app"
 )
 
-var appServicesTags map[string]string
-
 func GetAppServicesTags() map[string]string {
-	if appServicesTags != nil {
-		return appServicesTags
-	}
 	return getAppServicesTags(os.Getenv)
 }
 
@@ -52,7 +47,6 @@ func getAppServicesTags(getenv func(string) string) map[string]string {
 	resourceGroup := getenv("WEBSITE_RESOURCE_GROUP")
 	instanceID := getEnvOrUnknown("WEBSITE_INSTANCE_ID", getenv)
 	computerName := getEnvOrUnknown("COMPUTERNAME", getenv)
-	extensionVersion := getenv("DD_AAS_EXTENSION_VERSION")
 
 	// Windows and linux environments provide the OS differently
 	// We should grab it from GO's builtin runtime pkg
@@ -77,7 +71,7 @@ func getAppServicesTags(getenv func(string) string) map[string]string {
 
 	// Remove the Java and .NET logic once non-universal extensions are deprecated
 	if websiteOS == "windows" {
-		if extensionVersion != "" {
+		if extensionVersion := getenv("DD_AAS_EXTENSION_VERSION"); extensionVersion != "" {
 			tags[aasExtensionVersion] = extensionVersion
 		} else if val := getenv("DD_AAS_JAVA_EXTENSION_VERSION"); val != "" {
 			tags[aasExtensionVersion] = val
@@ -86,7 +80,7 @@ func getAppServicesTags(getenv func(string) string) map[string]string {
 		}
 	}
 
-	// Same as setting DD_HOSTNAME=none
+	// Equivalent to DD_HOSTNAME=none, needed for billing
 	tags["hostname"] = ""
 
 	return tags

--- a/pkg/trace/traceutil/azure.go
+++ b/pkg/trace/traceutil/azure.go
@@ -86,6 +86,9 @@ func getAppServicesTags(getenv func(string) string) map[string]string {
 		}
 	}
 
+	// Same as setting DD_HOSTNAME=none
+	tags["hostname"] = ""
+
 	return tags
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Sets the `hostname` tag to `""` which has the same effect as setting `DD_HOSTNAME=none`. We ask customers to set this env var so this will just save them that step

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
All Azure App Service use cases fall under Serverless and there should be no hostname for billing reasons. This PR will take that burden to set the hostname off of the customers

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
