### PR TITLE
Eliminate empty plan payloads

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -33,6 +33,7 @@ type QueryMetricsConfig struct {
 	CollectionInterval int64 `yaml:"collection_interval"`
 	DBRowsLimit        int   `yaml:"db_rows_limit"`
 	PlanCacheRetention int   `yaml:"plan_cache_retention"`
+	DisableLastActive  bool  `yaml:"disable_last_active"`
 }
 
 type SysMetricsConfig struct {

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -26,15 +26,82 @@ import (
  * sql_fulltext, despite "full" in its name, truncates the text after the first 1000 characters.
  * For such statements, we will have to get the text from v$sql which has the complete text.
  */
-
-const QUERY_FMS_RANDOM = `SELECT /* DD_QM_FMS */ c.name pdb_name, s.force_matching_signature, plan_hash_value, max(dbms_lob.substr(sql_fulltext, 1000, 1)) sql_text, max(length(sql_text)) sql_text_length, max(s.sql_id) sql_id, %s
+const QUERY_FMS_RANDOM = `SELECT /* DD_QM_FMS */ c.name pdb_name, s.force_matching_signature, plan_hash_value, max(dbms_lob.substr(sql_fulltext, 1000, 1)) sql_text, max(length(sql_text)) sql_text_length, max(s.sql_id) sql_id, 
+	sum(parse_calls) as parse_calls,
+	sum(disk_reads) as disk_reads,
+	sum(direct_writes) as direct_writes,
+	sum(direct_reads) as direct_reads,
+	sum(buffer_gets) as buffer_gets,
+	sum(rows_processed) as rows_processed,
+	sum(serializable_aborts) as serializable_aborts,
+	sum(fetches) as fetches,
+	sum(executions) as executions,
+	sum(end_of_fetch_count) as end_of_fetch_count,
+	sum(loads) as loads,
+	sum(version_count) as version_count,
+	sum(invalidations) as invalidations,
+	sum(px_servers_executions) as px_servers_executions,
+	sum(cpu_time) as cpu_time,
+	sum(elapsed_time) as elapsed_time,
+	sum(application_wait_time) as application_wait_time,
+	sum(concurrency_wait_time) as concurrency_wait_time,
+	sum(cluster_wait_time) as cluster_wait_time,
+	sum(user_io_wait_time) as user_io_wait_time,
+	sum(plsql_exec_time) as plsql_exec_time,
+	sum(java_exec_time) as java_exec_time,
+	sum(sorts) as sorts,
+	sum(sharable_mem) as sharable_mem,
+	sum(typecheck_mem) as typecheck_mem,
+	sum(io_cell_offload_eligible_bytes) as io_cell_offload_eligible_bytes,
+	sum(io_interconnect_bytes) as io_interconnect_bytes,
+	sum(physical_read_requests) as physical_read_requests,
+	sum(physical_read_bytes) as physical_read_bytes,
+	sum(physical_write_requests) as physical_write_requests,
+	sum(physical_write_bytes) as physical_write_bytes,
+	sum(io_cell_uncompressed_bytes) as io_cell_uncompressed_bytes,
+	sum(io_cell_offload_returned_bytes) as io_cell_offload_returned_bytes,
+	sum(avoided_executions) as avoided_executions
 FROM v$sqlstats s, v$containers c 
 WHERE s.con_id = c.con_id (+) AND force_matching_signature != 0
 GROUP BY c.name, force_matching_signature, plan_hash_value 
 HAVING MAX (last_active_time) > sysdate - :seconds/24/60/60
 FETCH FIRST :limit ROWS ONLY`
 
-const QUERY_FMS_LAST_ACTIVE = `SELECT /* DD_QM_FMS */ c.name pdb_name, s.force_matching_signature, plan_hash_value, max(dbms_lob.substr(sql_fulltext, 1000, 1)) sql_text, max(length(sql_text)) sql_text_length, sq.sql_id, %s
+const QUERY_FMS_LAST_ACTIVE = `SELECT /* DD_QM_FMS */ c.name pdb_name, s.force_matching_signature, plan_hash_value, max(dbms_lob.substr(sql_fulltext, 1000, 1)) sql_text, max(length(sql_text)) sql_text_length, sq.sql_id,
+	sum(parse_calls) as parse_calls,
+	sum(disk_reads) as disk_reads,
+	sum(direct_writes) as direct_writes,
+	sum(direct_reads) as direct_reads,
+	sum(buffer_gets) as buffer_gets,
+	sum(rows_processed) as rows_processed,
+	sum(serializable_aborts) as serializable_aborts,
+	sum(fetches) as fetches,
+	sum(executions) as executions,
+	sum(end_of_fetch_count) as end_of_fetch_count,
+	sum(loads) as loads,
+	sum(version_count) as version_count,
+	sum(invalidations) as invalidations,
+	sum(px_servers_executions) as px_servers_executions,
+	sum(cpu_time) as cpu_time,
+	sum(elapsed_time) as elapsed_time,
+	sum(application_wait_time) as application_wait_time,
+	sum(concurrency_wait_time) as concurrency_wait_time,
+	sum(cluster_wait_time) as cluster_wait_time,
+	sum(user_io_wait_time) as user_io_wait_time,
+	sum(plsql_exec_time) as plsql_exec_time,
+	sum(java_exec_time) as java_exec_time,
+	sum(sorts) as sorts,
+	sum(sharable_mem) as sharable_mem,
+	sum(typecheck_mem) as typecheck_mem,
+	sum(io_cell_offload_eligible_bytes) as io_cell_offload_eligible_bytes,
+	sum(io_interconnect_bytes) as io_interconnect_bytes,
+	sum(physical_read_requests) as physical_read_requests,
+	sum(physical_read_bytes) as physical_read_bytes,
+	sum(physical_write_requests) as physical_write_requests,
+	sum(physical_write_bytes) as physical_write_bytes,
+	sum(io_cell_uncompressed_bytes) as io_cell_uncompressed_bytes,
+	sum(io_cell_offload_returned_bytes) as io_cell_offload_returned_bytes,
+	sum(avoided_executions) as avoided_executions
 FROM v$sqlstats s, v$containers c, ( 
     SELECT * 
     FROM ( 
@@ -48,7 +115,41 @@ WHERE s.con_id = c.con_id (+) AND sq.force_matching_signature = s.force_matching
 GROUP BY c.name, s.force_matching_signature, plan_hash_value, sq.sql_id 
 FETCH FIRST :limit ROWS ONLY`
 
-const QUERY_SQLID = `SELECT /* DD_QM_SQLID */ c.name pdb_name, sql_id, plan_hash_value, sql_fulltext sql_text, length (sql_fulltext) sql_text_length, %s
+const QUERY_SQLID = `SELECT /* DD_QM_SQLID */ c.name pdb_name, sql_id, plan_hash_value, sql_fulltext sql_text, length (sql_fulltext) sql_text_length, 
+	parse_calls,
+	disk_reads,
+	direct_writes,
+	direct_reads,
+	buffer_gets,
+	rows_processed,
+	serializable_aborts,
+	fetches,
+	executions,
+	end_of_fetch_count,
+	loads,
+	version_count,
+	invalidations,
+	px_servers_executions,
+	cpu_time,
+	elapsed_time,
+	application_wait_time,
+	concurrency_wait_time,
+	cluster_wait_time,
+	user_io_wait_time,
+	plsql_exec_time,
+	java_exec_time,
+	sorts,
+	sharable_mem,
+	typecheck_mem,
+	io_cell_offload_eligible_bytes,
+	io_interconnect_bytes,
+	physical_read_requests,
+	physical_read_bytes,
+	physical_write_requests,
+	physical_write_bytes,
+	io_cell_uncompressed_bytes,
+	io_cell_offload_returned_bytes,
+	avoided_executions
 FROM v$sqlstats s, v$containers c 
 WHERE s.con_id = c.con_id (+) AND last_active_time > sysdate - :seconds/24/60/60 AND force_matching_signature = 0
 FETCH FIRST :limit ROWS ONLY`
@@ -377,52 +478,6 @@ type PlanRows struct {
 	PlanStepRows
 }
 
-func getStatisticsColumns() []string {
-	return []string{"parse_calls",
-		"disk_reads",
-		"direct_writes",
-		"direct_reads",
-		"buffer_gets",
-		"rows_processed",
-		"serializable_aborts",
-		"fetches",
-		"executions",
-		"end_of_fetch_count",
-		"loads",
-		"version_count",
-		"invalidations",
-		"px_servers_executions",
-		"cpu_time",
-		"elapsed_time",
-		"application_wait_time",
-		"concurrency_wait_time",
-		"cluster_wait_time",
-		"user_io_wait_time",
-		"plsql_exec_time",
-		"java_exec_time",
-		"sorts",
-		"sharable_mem",
-		"typecheck_mem",
-		"io_cell_offload_eligible_bytes",
-		"io_interconnect_bytes",
-		"physical_read_requests",
-		"physical_read_bytes",
-		"physical_write_requests",
-		"physical_write_bytes",
-		"io_cell_uncompressed_bytes",
-		"io_cell_offload_returned_bytes",
-		"avoided_executions",
-	}
-}
-
-func getColumnSums() string {
-	var sums []string
-	for _, column := range getStatisticsColumns() {
-		sums = append(sums, fmt.Sprintf("sum(%s) as %s", column, column))
-	}
-	return strings.Join(sums, ",")
-}
-
 func (c *Check) copyToPreviousMap(newMap map[StatementMetricsKeyDB]StatementMetricsMonotonicCountDB) {
 	c.statementMetricsMonotonicCountsPrevious = make(map[StatementMetricsKeyDB]StatementMetricsMonotonicCountDB)
 	for k, v := range newMap {
@@ -454,7 +509,6 @@ func (c *Check) StatementMetrics() (int, error) {
 		} else {
 			sql = QUERY_FMS_LAST_ACTIVE
 		}
-		sql = fmt.Sprintf(sql, getColumnSums())
 		err := selectWrapper(
 			c,
 			&statementMetrics,
@@ -470,7 +524,7 @@ func (c *Check) StatementMetrics() (int, error) {
 		statementMetricsAll := make([]StatementMetricsDB, len(statementMetrics))
 		copy(statementMetricsAll, statementMetrics)
 
-		sql = fmt.Sprintf(QUERY_SQLID, strings.Join(getStatisticsColumns(), ","))
+		sql = QUERY_SQLID
 		err = selectWrapper(
 			c,
 			&statementMetrics,

--- a/pkg/collector/corechecks/oracle-dbm/statements_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements_test.go
@@ -51,21 +51,8 @@ func TestUInt64Binding(t *testing.T) {
 		m["2267897546238586672"] = 1
 		chk.statementsFilter = StatementsFilter{ForceMatchingSignatures: m}
 
-		statementMetrics, err := GetStatementsMetricsForKeys(&chk, "force_matching_signature", "AND force_matching_signature != 0", chk.statementsFilter.ForceMatchingSignatures)
-		assert.NoError(t, err, "running GetStatementsMetricsForKeys with %s driver", driver)
-		assert.Lenf(t, statementMetrics, 1, "test query metrics captured with %s driver", driver)
 		err = chk.db.Get(&r, "select force_matching_signature, sql_text from v$sqlstats where sql_text like '%t111%'") // force_matching_signature=17202440635181618732
 		assert.NoError(t, err, "running statement with large force_matching_signature with %s driver", driver)
-
-		m = make(map[string]int)
-		m["17202440635181618732"] = 1
-		chk.statementsFilter = StatementsFilter{ForceMatchingSignatures: m}
-		assert.Lenf(t, statementMetrics, 1, "test query metrics for uint64 overflow with %s driver", driver)
-
-		chk.statementsFilter = StatementsFilter{ForceMatchingSignatures: m}
-		n, err := chk.StatementMetrics()
-		assert.NoError(t, err, "query metrics with %s driver", driver)
-		assert.Equal(t, 1, n, "total query metrics captured with %s driver", driver)
 
 		slice := []any{"17202440635181618732"}
 		var retValue int
@@ -96,21 +83,5 @@ func TestUInt64Binding(t *testing.T) {
 			}
 			assert.Equalf(t, retValue, 1, "IN uint64 with %s driver", driver)
 		}
-	}
-}
-
-func TestStatementMetrics(t *testing.T) {
-	initAndStartAgentDemultiplexer()
-	chk.config.QueryMetrics.IncludeDatadogQueries = true
-	var retValue int
-	for i := 1; i <= 2; i++ {
-		err := chk.db.Get(&retValue, "SELECT /* DD */ 1 FROM dual")
-		if err != nil {
-			log.Fatalf("row error %s", err)
-			return
-		}
-		chk.SampleSession()
-		_, err = chk.StatementMetrics()
-		assert.NoErrorf(t, err, "statement metrics check failed")
 	}
 }


### PR DESCRIPTION
### What does this PR do?

For a captured `plan_hash_value` we are currently picking a random `SQL_ID` for fetching the execution plan. During a high cardinality workload, the randomly chosen statement was sometimes already evicted from shared pool (SQL cache), which resulted in an empty execution plan payload. To reduce the likelihood of fetching the execution plan for the evicted statement, we're replacing the random `SQL_ID` with the one that was executed most recently.

### Motivation

We want to provide the execution plans even on a stressed database with a high eviction rate.

### Possible Drawbacks / Trade-offs

There's an additional join with a subquery with an analytic function to identify the last active `SQL_ID`. Due to the additional join, the query metrics query runs 30% slower (~600ms on a test system under load). With the configuration parameter `disable_last_active: true`, we can disable the new feature, if it's causing a problem on a customer's database.

### Describe how to test/QA your changes

Start the agent and check the query in query metrics.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
