### PR TITLE
[USM] enable_http_incomplete_buffer config

### DIFF
--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -247,6 +247,9 @@ type Config struct {
 	// EnableHTTPStatsByStatusCode specifies if the HTTP stats should be aggregated by the actual status code
 	// instead of the status code family.
 	EnableHTTPStatsByStatusCode bool
+
+	// EnableHTTPIncompleteBuffer specifies if the HTTP incomplete buffer need to be enable to associate orphan requests and responses due to NAT
+	EnableHTTPIncompleteBuffer bool
 }
 
 func join(pieces ...string) string {
@@ -296,11 +299,12 @@ func New() *Config {
 
 		ProtocolClassificationEnabled: cfg.GetBool(join(netNS, "enable_protocol_classification")),
 
-		EnableHTTPMonitoring:  cfg.GetBool(join(smNS, "enable_http_monitoring")),
-		EnableHTTP2Monitoring: cfg.GetBool(join(smNS, "enable_http2_monitoring")),
-		EnableHTTPSMonitoring: cfg.GetBool(join(netNS, "enable_https_monitoring")),
-		MaxHTTPStatsBuffered:  cfg.GetInt(join(smNS, "max_http_stats_buffered")),
-		MaxKafkaStatsBuffered: cfg.GetInt(join(smNS, "max_kafka_stats_buffered")),
+		EnableHTTPMonitoring:       cfg.GetBool(join(smNS, "enable_http_monitoring")),
+		EnableHTTP2Monitoring:      cfg.GetBool(join(smNS, "enable_http2_monitoring")),
+		EnableHTTPSMonitoring:      cfg.GetBool(join(netNS, "enable_https_monitoring")),
+		EnableHTTPIncompleteBuffer: cfg.GetBool(join(smNS, "enable_http_incomplete_buffer")),
+		MaxHTTPStatsBuffered:       cfg.GetInt(join(smNS, "max_http_stats_buffered")),
+		MaxKafkaStatsBuffered:      cfg.GetInt(join(smNS, "max_kafka_stats_buffered")),
 
 		MaxTrackedHTTPConnections: cfg.GetInt64(join(smNS, "max_tracked_http_connections")),
 		HTTPNotificationThreshold: cfg.GetInt64(join(smNS, "http_notification_threshold")),

--- a/pkg/network/protocols/http/incomplete_stats.go
+++ b/pkg/network/protocols/http/incomplete_stats.go
@@ -46,6 +46,8 @@ type incompleteBuffer struct {
 	maxEntries int
 	telemetry  *Telemetry
 	minAgeNano int64
+
+	enabled bool
 }
 
 type txParts struct {
@@ -66,10 +68,15 @@ func newIncompleteBuffer(c *config.Config, telemetry *Telemetry) *incompleteBuff
 		maxEntries: c.MaxHTTPStatsBuffered,
 		telemetry:  telemetry,
 		minAgeNano: defaultMinAge.Nanoseconds(),
+		enabled:    c.EnableHTTPIncompleteBuffer,
 	}
 }
 
 func (b *incompleteBuffer) Add(tx Transaction) {
+	if !b.enabled {
+		return
+	}
+
 	connTuple := tx.ConnTuple()
 	key := types.ConnectionKey{
 		SrcIPHigh: connTuple.SrcIPHigh,


### PR DESCRIPTION
### What does this PR do?

As discussed offline, incomplete buffer as implemented today doesn't associate the corresponding requests and responses so create request/response with high latency

This will reduced the accuracy as there will be less requests/responses hit but reduce the max latency of some endpoints
But the current implementation could wrongly associate response to other endpoint/resource.

Note: The accuracy will hit container to container http(s) requests/responses on the same node only


This PR add a configuration flag `enable_http_incomplete_buffer` disabled by default
`service_monitoring_config.enable_http_incomplete_buffer = false`

EnableHTTPIncompleteBuffer specifies if the HTTP incomplete buffer need to be enable to associate orphan requests and responses due to NAT

![mar  25 juil  2023 11_02_30 CEST](https://github.com/DataDog/datadog-agent/assets/334425/fdce7289-abb7-4c63-9495-ba077adf9393)

![mar  25 juil  2023 11_13_48 CEST](https://github.com/DataDog/datadog-agent/assets/334425/e2ba2a98-b1e6-43d9-ad68-ba000c05b443)

**Without post /api/v2/series endpoint**

![mar  25 juil  2023 11_22_58 CEST](https://github.com/DataDog/datadog-agent/assets/334425/772e7590-0529-4820-b9cf-5a75e3dad425)


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
