### PR TITLE
[autodiscovery/integration/config] Add json tag to ServiceID

### DIFF
--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -78,7 +78,7 @@ type Config struct {
 
 	// ServiceID is the ID of the service (set only for resolved templates and
 	// for service configs)
-	ServiceID string `json:"-"` // (include in digest: true)
+	ServiceID string `json:"service_id"` // (include in digest: true)
 
 	// TaggerEntity is the tagger entity ID
 	TaggerEntity string `json:"-"` // (include in digest: false)

--- a/pkg/autodiscovery/providers/config_reader_test.go
+++ b/pkg/autodiscovery/providers/config_reader_test.go
@@ -67,6 +67,13 @@ func TestGetIntegrationConfig(t *testing.T) {
 	// autodiscovery: check if we correctly refuse to load if a 'docker_images' section is present
 	config, err = GetIntegrationConfigFromFile("foo", "tests/ad_deprecated.yaml")
 	assert.NotNil(t, err)
+
+	// autodiscovery: check that the service ID is ignored when set explicitly.
+	// Service ID is not meant to be set in configs provided by users. It's set
+	// automatically when needed.
+	config, err = GetIntegrationConfigFromFile("foo", "tests/ad_with_service_id.yaml")
+	assert.Nil(t, err)
+	assert.Empty(t, config.ServiceID)
 }
 
 func TestReadConfigFiles(t *testing.T) {
@@ -75,12 +82,12 @@ func TestReadConfigFiles(t *testing.T) {
 
 	configs, errors, err := ReadConfigFiles(GetAll)
 	require.Nil(t, err)
-	require.Equal(t, 17, len(configs))
+	require.Equal(t, 18, len(configs))
 	require.Equal(t, 3, len(errors))
 
 	configs, _, err = ReadConfigFiles(WithoutAdvancedAD)
 	require.Nil(t, err)
-	require.Equal(t, 16, len(configs))
+	require.Equal(t, 17, len(configs))
 
 	configs, _, err = ReadConfigFiles(WithAdvancedADOnly)
 	require.Nil(t, err)

--- a/pkg/autodiscovery/providers/file_test.go
+++ b/pkg/autodiscovery/providers/file_test.go
@@ -73,7 +73,7 @@ func TestCollect(t *testing.T) {
 	assert.Equal(t, 0, len(get("ignored")))
 
 	// total number of configurations found
-	assert.Equal(t, 15, len(configs))
+	assert.Equal(t, 16, len(configs))
 
 	// incorrect configs get saved in the Errors map (invalid.yaml & notaconfig.yaml & ad_deprecated.yaml)
 	assert.Equal(t, 3, len(provider.Errors))

--- a/pkg/autodiscovery/providers/tests/ad_with_service_id.yaml
+++ b/pkg/autodiscovery/providers/tests/ad_with_service_id.yaml
@@ -1,0 +1,13 @@
+ad_identifiers:
+  - foo_id
+  - bar_id
+
+init_config:
+
+instances:
+  # No configuration is needed for this check.
+  - foo: bar
+
+# service_id is here just for testing that the code ignores it. This field is
+# not meant to be set in configs provided by users.
+service_id: some_service_id

--- a/pkg/util/clusteragent/clusterchecks_test.go
+++ b/pkg/util/clusteragent/clusterchecks_test.go
@@ -57,6 +57,44 @@ func (suite *clusterAgentSuite) TestClusterChecksNominal() {
 	assert.Equal(suite.T(), "two", configs.Configs[1].Name)
 }
 
+// Regression test. ServiceID was not propagated to the runners and as a
+// consequence, the cluster checks rebalancing algorithm wasn't working
+// properly.
+func (suite *clusterAgentSuite) TestClusterChecksWithServiceID() {
+	ctx := context.Background()
+	dca, err := newDummyClusterAgent()
+	require.NoError(suite.T(), err)
+
+	dca.rawResponses["/api/v1/clusterchecks/status/mynode"] = dummyStatusResponse
+	dca.rawResponses["/api/v1/clusterchecks/configs/mynode"] = `{
+"last_change": 42,
+"configs": [
+  {
+    "check_name": "one",
+    "service_id": "kube_service://namespace_1/service_1"
+  }
+]
+}`
+
+	ts, p, err := dca.StartTLS()
+	require.NoError(suite.T(), err)
+	defer ts.Close()
+	mockConfig.Set("cluster_agent.url", fmt.Sprintf("https://127.0.0.1:%d", p))
+
+	ca, err := GetClusterAgentClient()
+	require.NoError(suite.T(), err)
+
+	response, err := ca.PostClusterCheckStatus(ctx, "mynode", types.NodeStatus{})
+	require.NoError(suite.T(), err)
+	assert.True(suite.T(), response.IsUpToDate)
+
+	configs, err := ca.GetClusterCheckConfigs(ctx, "mynode")
+	require.NoError(suite.T(), err)
+	assert.Equal(suite.T(), int64(42), configs.LastChange)
+	assert.Equal(suite.T(), "one", configs.Configs[0].Name)
+	assert.Equal(suite.T(), "kube_service://namespace_1/service_1", configs.Configs[0].ServiceID)
+}
+
 func (suite *clusterAgentSuite) TestClusterChecksRedirect() {
 	ctx := context.Background()
 

--- a/releasenotes-dca/notes/fix-rebalance-service-checks-d268aa7c791a1c30.yaml
+++ b/releasenotes-dca/notes/fix-rebalance-service-checks-d268aa7c791a1c30.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Service checks are no longer excluded from rebalancing decisions when advanced dispatching is enabled (``cluster_checks.advanced_dispatching_enabled`` is set to true).


### PR DESCRIPTION
### What does this PR do?

Adds the json tag to the `ServiceID` of `Config`.

The missing json tag breaks the cluster checks rebalancing algorithm for service checks.

ServiceID is used to calculate the digest of a check. In service checks it follows this format: `kube_service://<namespace>/<name>`. The problem is that, because of the missing json tag, this field is not propagated to the check runners, so they calculate a different digest for the same check.

As a consequence, this breaks the cluster checks rebalancing algorithm, because it doesn't detect service checks as cluster checks, so they're never considered in rebalancing decisions.

Reference:
https://github.com/DataDog/datadog-agent/blob/29fd4466c00da9f6ef1768c1337aa93cb15229cd/pkg/clusteragent/clusterchecks/dispatcher_nodes.go#L191

Cluster checks that are not service checks were not affected because in that case, the service ID is empty.

I don't think that adding the json tag to serviceID breaks anything, but let me know if I missed something.

### Describe how to test/QA your changes

Deploy with check runners and the rebalancing of checks enabled ("cluster_checks.advanced_dispatching_enabled" set to true). Deploy a service check (example: https://docs.datadoghq.com/containers/cluster_agent/clusterchecks/?tab=helm#example-http-check-on-an-nginx-backed-service).

After this change, the service check could be moved when rebalancing cluster checks (this is done every 10 min by default. It can also be done manually with `datadog-cluster-agent clusterchecks rebalance`).

It might be a bit difficult to force a situation in which the rebalance algorithm decides to move that specific check. As an alternative you can verify that this log line is printed for service checks: https://github.com/DataDog/datadog-agent/blob/29fd4466c00da9f6ef1768c1337aa93cb15229cd/pkg/clusteragent/clusterchecks/dispatcher_nodes.go#L193

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
