### PR TITLE
[clusteragent/clusterchecks/dispatcher_rebalance] Fix busyness avg calculation

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
@@ -43,7 +43,7 @@ func (d *dispatcher) calculateAvg() (int, error) {
 	defer d.store.RUnlock()
 
 	for _, node := range d.store.nodes {
-		busyness = node.GetBusyness(busynessFunc)
+		busyness += node.GetBusyness(busynessFunc)
 		length++
 	}
 

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -1366,8 +1365,14 @@ func TestRebalance(t *testing.T) {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
 			// Tests have been written with this value hardcoded
 			// Changing the values rather than re-writing all the tests.
+			originalCheckExecutionTimeWeight := checkExecutionTimeWeight
+			originalMetricSamplesWeight := checkMetricSamplesWeight
 			checkExecutionTimeWeight = 0.8
 			checkMetricSamplesWeight = 0.2
+			defer func() {
+				checkExecutionTimeWeight = originalCheckExecutionTimeWeight
+				checkMetricSamplesWeight = originalMetricSamplesWeight
+			}()
 
 			dispatcher := newDispatcher()
 

--- a/releasenotes-dca/notes/fix-avg-busyness-clusterchecks-dispatcher-a5f0f5bdca3919dd.yaml
+++ b/releasenotes-dca/notes/fix-avg-busyness-clusterchecks-dispatcher-a5f0f5bdca3919dd.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed an error in the calculations performed by the algorithm that rebalances cluster checks. Cluster checks are now more evenly distributed when advanced dispatching is enabled (``cluster_checks.advanced_dispatching_enabled`` is set to true).


### PR DESCRIPTION
### What does this PR do?

Fixes an error in the calculations performed by the algorithm that rebalances cluster checks.

The average busyness score was not calculated correctly.

This should help in distributing the cluster checks more evenly across check runners, but notice that the rebalance algorithm has other known limitations, so it might not always help.


### Describe how to test/QA your changes

Probably the best is to check that cluster checks are more evenly distributed than before in clusters with several checks and the rebalancing enabled ("cluster_checks.advanced_dispatching_enabled" set to true). But notice that as mentioned above, it might not always be the case.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
