### PR TITLE
Accommodate cases where stat flags of `/proc/<pid>/stat` exceed int32

### DIFF
--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -615,9 +615,6 @@ func (p *probe) parseStatContent(statContent []byte, sInfo *statInfo, pid int32,
 	if err == nil {
 		sInfo.flags = uint32(flags)
 	}
-	if sInfo.flags == 0 {
-		log.Warnf("unable to parse flags for pid %d", pid)
-	}
 
 	utime, err := strconv.ParseFloat(utimeStr, 64)
 	if err == nil {

--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -611,9 +611,12 @@ func (p *probe) parseStatContent(statContent []byte, sInfo *statInfo, pid int32,
 		sInfo.ppid = int32(ppid)
 	}
 
-	flags, err := strconv.ParseInt(flagStr, 10, 32)
+	flags, err := strconv.ParseUint(flagStr, 10, 32)
 	if err == nil {
 		sInfo.flags = uint32(flags)
+	}
+	if sInfo.flags == 0 {
+		log.Warnf("unable to parse flags for pid %d", pid)
 	}
 
 	utime, err := strconv.ParseFloat(utimeStr, 64)

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -660,12 +660,12 @@ func TestParseStatContent(t *testing.T) {
 	probe.bootTime.Store(1606181252)
 	now := time.Now()
 
-	for _, tc := range []struct {
+	testCases := []struct {
+		name           string
 		line           []byte
 		expected       *statInfo
 		isKernelThread bool
 	}{
-		// standard content
 		{
 			line: []byte("1 (systemd) S 0 1 1 0 -1 4194560 425768 306165945 70 4299 4890 2184 563120 375308 20 0 1 0 15 189849600 1541 18446744073709551615 94223912931328 94223914360080 140733806473072 140733806469312 140053573122579 0 671173123 4096 1260 1 0 0 17 0 0 0 155 0 0 94223914368000 942\n23914514184 94223918080000 140733806477086 140733806477133 140733806477133 140733806477283 0"),
 			expected: &statInfo{
@@ -680,8 +680,8 @@ func TestParseStatContent(t *testing.T) {
 			},
 			isKernelThread: false,
 		},
-		// command line has brackets around
 		{
+			name: "command line has brackets around",
 			line: []byte("1 ((sd-pam)) S 0 1 1 0 -1 4194560 425768 306165945 70 4299 4890 2184 563120 375308 20 0 1 0 15 189849600 1541 18446744073709551615 94223912931328 94223914360080 140733806473072 140733806469312 140053573122579 0 671173123 4096 1260 1 0 0 17 0 0 0 155 0 0 94223914368000 942\n23914514184 94223918080000 140733806477086 140733806477133 140733806477133 140733806477283 0"),
 			expected: &statInfo{
 				ppid:       0,
@@ -695,8 +695,8 @@ func TestParseStatContent(t *testing.T) {
 			},
 			isKernelThread: false,
 		},
-		// fields are separated by multiple white spaces
 		{
+			name: "fields are separated by multiple white spaces",
 			line: []byte("5  (kworker/0:0H)   S 2 0 0 0 -1   69238880 0 0  0 0  0 0 0 0 0  -20 1 0 17 0 0 18446744073709551615 0 0 0 0 0 0 0 2147483647 0 0 0 0 17 0 0 0 0 0 0 0 0 0 0 0 0 0 0"),
 			expected: &statInfo{
 				ppid:       2,
@@ -710,8 +710,8 @@ func TestParseStatContent(t *testing.T) {
 			},
 			isKernelThread: true,
 		},
-		// flags are greater than int32
 		{
+			name: "flags are greater than int32",
 			line: []byte("44 (kintegrityd/0) S 2 0 0 0 -1 2216722496 0 0 0 0 0 0 0 0 20 0 1 0 31 0 0 18446744073709551615 0 0 0 0 0 0 0 2147483647 0 18446744071579499573 0 0 17 0 0 0 0 0 0"),
 			expected: &statInfo{
 				ppid:       2,
@@ -725,13 +725,15 @@ func TestParseStatContent(t *testing.T) {
 			},
 			isKernelThread: true,
 		},
-	} {
-
-		actual := probe.parseStatContent(tc.line, &statInfo{cpuStat: &CPUTimesStat{}}, int32(1), now)
-		// nice value is fetched at the run time so we just assign the actual value for the sake for comparison
-		tc.expected.nice = actual.nice
-		assert.EqualValues(t, tc.expected, actual)
-		assert.Equal(t, tc.isKernelThread, isKernelThread(actual.flags))
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := probe.parseStatContent(tc.line, &statInfo{cpuStat: &CPUTimesStat{}}, int32(1), now)
+			// nice value is fetched at the run time so we just assign the actual value for the sake for comparison
+			tc.expected.nice = actual.nice
+			assert.EqualValues(t, tc.expected, actual)
+			assert.Equal(t, tc.isKernelThread, isKernelThread(actual.flags))
+		})
 	}
 }
 

--- a/releasenotes/notes/fix-stat-flags-de59f48fea4ce5c2.yaml
+++ b/releasenotes/notes/fix-stat-flags-de59f48fea4ce5c2.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Accommodate cases where stat flags of ``/proc/<pid>/stat`` exceed int32.

--- a/releasenotes/notes/fix-stat-flags-de59f48fea4ce5c2.yaml
+++ b/releasenotes/notes/fix-stat-flags-de59f48fea4ce5c2.yaml
@@ -1,4 +1,5 @@
 ---
 fixes:
   - |
-    Accommodate cases where stat flags of ``/proc/<pid>/stat`` exceed int32.
+    Fix to the process-agent from picking up processes which are kernel
+    threads due integer overflow when parsing ``/proc/<pid>/stat``.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Accommodate cases where stat flags exceed int32.
*stat flags are read from `/proc/<pid>/stat`

### Motivation

To fix cases where kernel threads appear in the Datadog UI.

![Infrastructure List Datadog 2023-07-25 at 10 01 42 PM](https://github.com/DataDog/datadog-agent/assets/41987730/a5103bc0-9a48-4047-a32e-2f824993b5c8)

When stat flags exceed int32, it became `0` since `strconv.ParseInt(flagStr, 10, 32)` fails. Then, a process info will appear in the Datadog UI even though it is a kernel thread. A kernel thread should be excluded.

https://github.com/DataDog/datadog-agent/blob/73867119465d5e492d7674f222172bd800108842/pkg/process/procutil/process_linux.go#L224-L233

https://github.com/DataDog/datadog-agent/blob/73867119465d5e492d7674f222172bd800108842/pkg/process/procutil/process_linux.go#L894-L898

### Additional Notes

- Kernel version: `2.6.32-642.13.1.el6.x86_64`
- Processor: `x86_64`

Examples of `/proc/<pid>/stat` exceeding int32

```bash
$ tail -n -1 /proc/*/stat

...

==> /proc/2/stat <==
2 (kthreadd) S 0 0 0 0 -1 2149613632 0 0 0 0 0 0 0 0 20 0 1 0 10 0 0 18446744073709551615 0 0 0 0 0 0 0 2147483647 0 18446744073709551615 0 0 0 2 0 0 0 0 0

....

==> /proc/44/stat <==
44 (kintegrityd/0) S 2 0 0 0 -1 2216722496 0 0 0 0 0 0 0 0 20 0 1 0 24 0 0 18446744073709551615 0 0 0 0 0 0 0 2147483647 0 18446744071579499573 0 0 17 0 0 0 0 0 0

...

==> /proc/98/stat <==
98 (usbhid_resumer) S 2 0 0 0 -1 2149580864 0 0 0 0 0 0 0 0 20 0 1 0 187 0 0 18446744073709551615 0 0 0 0 0 0 0 2147483647 0 18446744073709551615 0 0 17 3 0 0 0 0 0
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
