### PR TITLE
[pkg/otlp] Add support for otlp_config.metrics.sums.initial_cumulative_monotonic_value

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3818,6 +3818,15 @@ api_key:
         #
         # cumulative_monotonic_mode: to_delta
 
+        ## @param initial_cumulative_monotonic_value - string - optional - default: auto
+        ## How to report the initial value for cumulative monotonic sums. Valid values are:
+        ##
+        ## - `auto` reports the initial value if its start timestamp is set and it happens after the process was started.
+        ## - `drop` always drops the initial value.
+        ## - `keep` always reports the initial value.
+        #
+        # initial_cumulative_monotonic_value: auto   
+
     ## @param summaries - custom object - optional
     ## Configuration for OTLP Summaries.
     ## See https://docs.datadoghq.com/metrics/otlp/?tab=summary for more details.

--- a/pkg/otlp/internal/serializerexporter/config.go
+++ b/pkg/otlp/internal/serializerexporter/config.go
@@ -100,6 +100,37 @@ func (sm *CumulativeMonotonicSumMode) UnmarshalText(in []byte) error {
 	}
 }
 
+// InitialValueMode defines what the exporter should do with the initial value
+// of a time series when transforming from cumulative to delta.
+type InitialValueMode string
+
+const (
+	// InitialValueModeAuto reports the initial value if its start timestamp
+	// is set and it happens after the process was started.
+	InitialValueModeAuto InitialValueMode = "auto"
+
+	// InitialValueModeDrop always drops the initial value.
+	InitialValueModeDrop InitialValueMode = "drop"
+
+	// InitialValueModeKeep always reports the initial value.
+	InitialValueModeKeep InitialValueMode = "keep"
+)
+
+var _ encoding.TextUnmarshaler = (*InitialValueMode)(nil)
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (iv *InitialValueMode) UnmarshalText(in []byte) error {
+	switch mode := InitialValueMode(in); mode {
+	case InitialValueModeAuto,
+		InitialValueModeDrop,
+		InitialValueModeKeep:
+		*iv = mode
+		return nil
+	default:
+		return fmt.Errorf("invalid initial value mode %q", mode)
+	}
+}
+
 // sumConfig customizes export of OTLP Sums.
 type sumConfig struct {
 	// CumulativeMonotonicMode is the mode for exporting OTLP Cumulative Monotonic Sums.
@@ -110,6 +141,10 @@ type sumConfig struct {
 	// The default is 'to_delta'.
 	// See https://docs.datadoghq.com/metrics/otlp/?tab=sum#mapping for details and examples.
 	CumulativeMonotonicMode CumulativeMonotonicSumMode `mapstructure:"cumulative_monotonic_mode"`
+
+	// InitialCumulativeMonotonicMode defines the behavior of the exporter when receiving the first value
+	// of a cumulative monotonic sum.
+	InitialCumulativeMonotonicMode InitialValueMode `mapstructure:"initial_cumulative_monotonic_value"`
 }
 
 // SummaryMode is the export mode for OTLP Summary metrics.
@@ -197,6 +232,15 @@ func (e *exporterConfig) Unmarshal(configMap *confmap.Conf) error {
 		if configMap.IsSet("metrics::histograms::send_aggregation_metrics") {
 			e.warnings = append(e.warnings, warnOverrideSendAggregations)
 		}
+	}
+
+	const (
+		initialValueSetting = "metrics::sums::initial_cumulative_monotonic_value"
+		cumulMonoMode       = "metrics::sums::cumulative_monotonic_mode"
+	)
+	if configMap.IsSet(initialValueSetting) && e.Metrics.SumConfig.CumulativeMonotonicMode != CumulativeMonotonicSumModeToDelta {
+		return fmt.Errorf("%q can only be configured when %q is set to %q",
+			initialValueSetting, cumulMonoMode, CumulativeMonotonicSumModeToDelta)
 	}
 
 	return nil

--- a/pkg/otlp/internal/serializerexporter/exporter.go
+++ b/pkg/otlp/internal/serializerexporter/exporter.go
@@ -44,7 +44,8 @@ func newDefaultConfig() component.Config {
 				SendAggregations: false,
 			},
 			SumConfig: sumConfig{
-				CumulativeMonotonicMode: CumulativeMonotonicSumModeToDelta,
+				CumulativeMonotonicMode:        CumulativeMonotonicSumModeToDelta,
+				InitialCumulativeMonotonicMode: InitialValueModeAuto,
 			},
 			SummaryConfig: summaryConfig{
 				Mode: SummaryModeGauges,
@@ -126,6 +127,8 @@ func translatorFromConfig(logger *zap.Logger, cfg *exporterConfig) (*metrics.Tra
 		numberMode = metrics.NumberModeCumulativeToDelta
 	}
 	options = append(options, metrics.WithNumberMode(numberMode))
+	options = append(options, metrics.WithInitialCumulMonoValueMode(
+		metrics.InitialCumulMonoValueMode(cfg.Metrics.SumConfig.InitialCumulativeMonotonicMode)))
 
 	return metrics.NewTranslator(logger, options...)
 }

--- a/releasenotes/notes/cumulative-opt-otlp-d7e84f2b7cafd0c5.yaml
+++ b/releasenotes/notes/cumulative-opt-otlp-d7e84f2b7cafd0c5.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add support for the ``otlp_config.metrics.sums.initial_cumulative_monotonic_value`` setting.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add support for `otlp_config.metrics.sums.initial_cumulative_monotonic_value` setting. This is similar to open-telemetry/opentelemetry-collector-contrib/pull/21905 but for the Datadog Agent OTLP ingest cumulative to delta logic.

Counterpart to open-telemetry/opentelemetry-collector-contrib/pull/24544.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

DataDog/opentelemetry-mapping-go/issues/100

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Set the configuration to each possible value `auto`, `keep` and `drop` as well as leaving the setting unset.
Test that the behavior corresponds to the description on the configuration (i.e. with `auto` behavior is preserved or you `keep`/`drop` the first point).
Use the `debug.verbosity` to see the initial value.


```
otlp_config:
  receiver:
    protocols:
      grpc:
       endpoint: localhost:4317

  metrics:
    sums:
      initial_cumulative_monotonic_mode: <auto|keep|drop>

  debug:
    verbosity: detailed
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
