### PR TITLE
Explicit the dependencies of the `new-e2e-container-main` GitLab job

### DIFF
--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -237,7 +237,7 @@ dev_nightly-dogstatsd:
     IMG_DESTINATIONS: dogstatsd-dev:nightly-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA},dogstatsd-dev:nightly-${CI_COMMIT_REF_SLUG}
 
 # push images to `datadog-agent-qa` ECR for the end-to-end tests defined in `e2e.yml`
-agent_qa:
+qa_agent:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
   rules:
@@ -245,12 +245,14 @@ agent_qa:
   needs:
     - docker_build_agent7
     - docker_build_agent7_arm64
+    - docker_build_agent7_windows1809
+    - docker_build_agent7_windows2022
   variables:
     IMG_REGISTRIES: agent-qa
-    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
+    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-winltsc2022-amd64
     IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
 
-dca_qa:
+qa_dca:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
   rules:
@@ -262,7 +264,7 @@ dca_qa:
     IMG_SOURCES: ${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
     IMG_DESTINATIONS: cluster-agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
 
-dogstatsd_qa:
+qa_dogstatsd:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
   rules:

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -167,6 +167,10 @@ new-e2e-containers-dev:
 new-e2e-containers-main:
   extends: .new_e2e_template
   rules: !reference [.on_main]
+  needs:
+    - qa_agent
+    - qa_dca
+    - qa_dogstatsd
   variables:
     TARGETS: ./containers
     CONFIGPARAMS: "-c ddagent:fullImagePath=669783387624.dkr.ecr.us-east-1.amazonaws.com/agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA} -c ddagent:clusterAgentFullImagePath=669783387624.dkr.ecr.us-east-1.amazonaws.com/cluster-agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"


### PR DESCRIPTION
### What does this PR do?

* Explicit the dependencies of the `new-e2e-containers-main` job.
* Add Windows to the multi-arch docker images used by the `new-e2e-containers-main` job.

### Motivation

Without any explicit dependencies, the `new-e2e-containers-main` job was:
* uselessly downloading all the artifacts of all the jobs of all the previous stages and it took a lot of time; and it was
* often skipped because of a failure in a previous job that shouldn’t be a requirement.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Check that the `new-e2e-containers-main` job isn’t taking ages to download artifacts anymore.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
