### PR TITLE
[CSPM] Improve generated schema for KubeletConfiguration

### DIFF
--- a/pkg/compliance/tools/k8s_schema_generator/main.go
+++ b/pkg/compliance/tools/k8s_schema_generator/main.go
@@ -14,6 +14,76 @@ import (
 	"github.com/invopop/jsonschema"
 )
 
+// We hardcode some of the field of KubeletConfiguration file content which
+// are not yet in our type system.
+const kubeletConfigSchema = `{
+	"properties": {
+		"authentication": {
+			"properties": {
+				"anonymous": {
+					"properties": {
+						"enabled": {
+							"type": "boolean"
+						}
+					},
+					"type": "object"
+				},
+				"x509": {
+					"properties": {
+						"clientCAFile": {
+							"$ref": "#/$defs/K8sCertFileMeta"
+						}
+					},
+					"type": "object"
+				},
+				"webhook": {
+					"properties": {
+						"enabled": {
+							"type": "boolean"
+						}
+					},
+					"type": "object"
+				}
+			},
+			"type": "object"
+		},
+		"authorization": {
+			"properties": {
+				"mode": {
+					"type": "string"
+				}
+			},
+			"type": "object"
+		},
+		"tlsCertFile": {
+			"$ref": "#/$defs/K8sCertFileMeta"
+		},
+		"privateKeyFile": {
+			"$ref": "#/$defs/K8sKeyFileMeta"
+		},
+		"rotateCertificates": {
+			"type": "boolean"
+		},
+		"readOnlyPort": {
+			"type": "integer"
+		},
+		"streamingConnectionIdleTimeout": {
+			"type": "integer"
+		},
+		"protectKernelDefaults": {
+			"type": "boolean"
+		},
+		"makeIPTablesUtilChains": {
+			"type": "boolean"
+		},
+		"featureGates": {
+			"type": "object"
+		}
+	},
+	"additionalProperties": true,
+	"type": "object"
+}`
+
 func usage() {
 	fmt.Fprintf(os.Stderr, "k8s_schema_generator <kubernetes_worker_node|kubernetes_master_node>\n")
 	os.Exit(1)
@@ -56,6 +126,24 @@ func main() {
 	default:
 		log.Fatalf(`resource should be "kubernetes_master_node" or "kubernetes_worker_node": was %q`, resource)
 	}
+
+	var kubeletConfigContentSchema jsonschema.Schema
+	if err := json.Unmarshal([]byte(kubeletConfigSchema), &kubeletConfigContentSchema); err != nil {
+		log.Fatal(err)
+	}
+
+	configFileMetaCopy, err := schema.Definitions["K8sConfigFileMeta"].MarshalJSON()
+	if err != nil {
+		log.Fatal(err)
+	}
+	var kubeletConfigFileMeta jsonschema.Schema
+	if err := json.Unmarshal(configFileMetaCopy, &kubeletConfigFileMeta); err != nil {
+		log.Fatal(err)
+	}
+	kubeletConfigFileMeta.Properties.Set("content", &kubeletConfigContentSchema)
+
+	schema.Definitions["K8sKubeletConfig"].Properties.Set("config", &kubeletConfigFileMeta)
+
 	b, err := json.MarshalIndent(schema, "", "    ")
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/compliance/tools/k8s_schema_generator/main.go
+++ b/pkg/compliance/tools/k8s_schema_generator/main.go
@@ -58,7 +58,7 @@ const kubeletConfigSchema = `{
 		"tlsCertFile": {
 			"$ref": "#/$defs/K8sCertFileMeta"
 		},
-		"privateKeyFile": {
+		"tlsPrivateKeyFile": {
 			"$ref": "#/$defs/K8sKeyFileMeta"
 		},
 		"rotateCertificates": {
@@ -80,7 +80,7 @@ const kubeletConfigSchema = `{
 			"type": "object"
 		}
 	},
-	"additionalProperties": true,
+	"additionalProperties": false,
 	"type": "object"
 }`
 


### PR DESCRIPTION
### What does this PR do?

Improve generated schema for KubeletConfiguration supart of the k8sconfig.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
