### PR TITLE
`inv agent.hacky-dev-image-build`: Copy rtloader in the image

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -396,7 +396,7 @@ ENV DELVE_PAGER=less
 COPY --from=dlv /go/bin/dlv /usr/local/bin/dlv
 COPY --from=src /usr/src/datadog-agent {os.getcwd()}
 COPY --from=bin /opt/datadog-agent/bin/agent/agent /opt/datadog-agent/bin/agent/agent
-COPY dev/lib/libdatadog-agent-rtloader.so* /opt/datadog-agent/embedded/lib/
+COPY dev/lib/libdatadog-agent-* /opt/datadog-agent/embedded/lib/
 {copy_extra_agents}
 RUN agent completion bash > /usr/share/bash-completion/completions/agent
 

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -382,6 +382,7 @@ ENV DELVE_PAGER=less
 COPY --from=dlv /go/bin/dlv /usr/local/bin/dlv
 COPY --from=src /usr/src/datadog-agent {os.getcwd()}
 COPY --from=bin /opt/datadog-agent/bin/agent/agent /opt/datadog-agent/bin/agent/agent
+COPY dev/lib/libdatadog-agent-rtloader.so* /opt/datadog-agent/embedded/lib/
 RUN agent completion bash > /usr/share/bash-completion/completions/agent
 
 ENV DD_SSLKEYLOGFILE=/tmp/sslkeylog.txt


### PR DESCRIPTION
### What does this PR do?

1. Make the `agent.hacky-dev-image-build` `invoke` task copy the `rtloader` library in the docker image.
2. Add option to `agent.hacky-dev-image-build` `invoke` task to also build and update the `process-agent` and `trace-agent` in addition to the core `agent`.

### Motivation

1. Not be annoyed when a PR modifying the `rtloader` ABI is merged on `main` branch.

For ex., #16719 makes the current version of `inv agent.hacky-dev-image-build` fail with the following error:
```
agent: symbol lookup error: agent: undefined symbol: get_check_diagnoses
```

2. Be able to test changes that imply a cross-agent communication (I’m thinking about dev about remote workload meta for ex.)

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Try to build agent docker images with:
```
inv agent.hacky-dev-image-build --target-image=$YOUR_DOCKER_ACCOUNT/agent --process-agent --trace-agent
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
