### PR TITLE
Improve timeout handling in pkg/snmp/traps/listener_test.go.

### DIFF
--- a/pkg/snmp/traps/listener_test.go
+++ b/pkg/snmp/traps/listener_test.go
@@ -26,7 +26,7 @@ func TestListenV1GenericTrap(t *testing.T) {
 	config := Config{Port: serverPort, CommunityStrings: []string{"public"}, Namespace: "totoro"}
 	Configure(t, config)
 
-	packetOutChan := make(PacketsChannel)
+	packetOutChan := make(PacketsChannel, packetsChanSize)
 	trapListener, err := startSNMPTrapListener(config, mockSender, packetOutChan)
 	require.NoError(t, err)
 	defer trapListener.Stop()
@@ -45,7 +45,7 @@ func TestServerV1SpecificTrap(t *testing.T) {
 	config := Config{Port: serverPort, CommunityStrings: []string{"public"}}
 	Configure(t, config)
 
-	packetOutChan := make(PacketsChannel)
+	packetOutChan := make(PacketsChannel, packetsChanSize)
 	trapListener, err := startSNMPTrapListener(config, mockSender, packetOutChan)
 	require.NoError(t, err)
 	defer trapListener.Stop()
@@ -64,7 +64,7 @@ func TestServerV2(t *testing.T) {
 	config := Config{Port: serverPort, CommunityStrings: []string{"public"}}
 	Configure(t, config)
 
-	packetOutChan := make(PacketsChannel)
+	packetOutChan := make(PacketsChannel, packetsChanSize)
 	trapListener, err := startSNMPTrapListener(config, mockSender, packetOutChan)
 	require.NoError(t, err)
 	defer trapListener.Stop()
@@ -83,7 +83,7 @@ func TestServerV2BadCredentials(t *testing.T) {
 	config := Config{Port: serverPort, CommunityStrings: []string{"public"}, Namespace: "totoro"}
 	Configure(t, config)
 
-	packetOutChan := make(PacketsChannel)
+	packetOutChan := make(PacketsChannel, packetsChanSize)
 	trapListener, err := startSNMPTrapListener(config, mockSender, packetOutChan)
 	require.NoError(t, err)
 	defer trapListener.Stop()
@@ -104,7 +104,7 @@ func TestServerV3(t *testing.T) {
 	config := Config{Port: serverPort, Users: []UserV3{userV3}}
 	Configure(t, config)
 
-	packetOutChan := make(PacketsChannel)
+	packetOutChan := make(PacketsChannel, packetsChanSize)
 	trapListener, err := startSNMPTrapListener(config, mockSender, packetOutChan)
 	require.NoError(t, err)
 	defer trapListener.Stop()
@@ -130,7 +130,7 @@ func TestServerV3BadCredentials(t *testing.T) {
 	config := Config{Port: serverPort, Users: []UserV3{userV3}}
 	Configure(t, config)
 
-	packetOutChan := make(PacketsChannel)
+	packetOutChan := make(PacketsChannel, packetsChanSize)
 	trapListener, err := startSNMPTrapListener(config, mockSender, packetOutChan)
 	require.NoError(t, err)
 	defer trapListener.Stop()
@@ -153,7 +153,7 @@ func TestListenerTrapsReceivedTelemetry(t *testing.T) {
 	config := Config{Port: serverPort, CommunityStrings: []string{"public"}, Namespace: "totoro"}
 	Configure(t, config)
 
-	packetOutChan := make(PacketsChannel)
+	packetOutChan := make(PacketsChannel, packetsChanSize)
 	trapListener, err := startSNMPTrapListener(config, mockSender, packetOutChan)
 	require.NoError(t, err)
 	defer trapListener.Stop()

--- a/pkg/snmp/traps/listener_test.go
+++ b/pkg/snmp/traps/listener_test.go
@@ -6,6 +6,7 @@
 package traps
 
 import (
+	"errors"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"testing"
 	"time"
@@ -32,8 +33,8 @@ func TestListenV1GenericTrap(t *testing.T) {
 	defer trapListener.Stop()
 
 	sendTestV1GenericTrap(t, config, "public")
-	packet := receivePacket(t, trapListener, defaultTimeout)
-	require.NotNil(t, packet)
+	packet, err := receivePacket(t, trapListener, defaultTimeout)
+	require.NoError(t, err)
 	packet.Content.SnmpTrap.Variables = packet.Content.Variables
 	assert.Equal(t, LinkDownv1GenericTrap, packet.Content.SnmpTrap)
 }
@@ -51,8 +52,8 @@ func TestServerV1SpecificTrap(t *testing.T) {
 	defer trapListener.Stop()
 
 	sendTestV1SpecificTrap(t, config, "public")
-	packet := receivePacket(t, trapListener, defaultTimeout)
-	require.NotNil(t, packet)
+	packet, err := receivePacket(t, trapListener, defaultTimeout)
+	require.NoError(t, err)
 	packet.Content.SnmpTrap.Variables = packet.Content.Variables
 	assert.Equal(t, AlarmActiveStatev1SpecificTrap, packet.Content.SnmpTrap)
 }
@@ -70,8 +71,8 @@ func TestServerV2(t *testing.T) {
 	defer trapListener.Stop()
 
 	sendTestV2Trap(t, config, "public")
-	packet := receivePacket(t, trapListener, defaultTimeout)
-	require.NotNil(t, packet)
+	packet, err := receivePacket(t, trapListener, defaultTimeout)
+	require.NoError(t, err)
 	assertIsValidV2Packet(t, packet, config)
 	assertVariables(t, packet)
 }
@@ -89,8 +90,8 @@ func TestServerV2BadCredentials(t *testing.T) {
 	defer trapListener.Stop()
 
 	sendTestV2Trap(t, config, "wrong-community")
-	packet := receivePacket(t, trapListener, defaultTimeout)
-	require.Nil(t, packet)
+	_, err2 := receivePacket(t, trapListener, defaultTimeout)
+	require.EqualError(t, err2, "invalid packet")
 
 	mockSender.AssertMetric(t, "Count", "datadog.snmp_traps.received", 1, "", []string{"snmp_device:127.0.0.1", "device_namespace:totoro", "snmp_version:2"})
 	mockSender.AssertMetric(t, "Count", "datadog.snmp_traps.invalid_packet", 1, "", []string{"snmp_device:127.0.0.1", "device_namespace:totoro", "snmp_version:2", "reason:unknown_community_string"})
@@ -117,8 +118,8 @@ func TestServerV3(t *testing.T) {
 		PrivacyPassphrase:        "password",
 		PrivacyProtocol:          gosnmp.AES,
 	})
-	packet := receivePacket(t, trapListener, defaultTimeout)
-	require.NotNil(t, packet)
+	packet, err := receivePacket(t, trapListener, defaultTimeout)
+	require.NoError(t, err)
 	assertVariables(t, packet)
 }
 
@@ -159,12 +160,12 @@ func TestListenerTrapsReceivedTelemetry(t *testing.T) {
 	defer trapListener.Stop()
 
 	sendTestV1GenericTrap(t, config, "public")
-	packet := receivePacket(t, trapListener, defaultTimeout) // Wait for packet
-	require.NotNil(t, packet)
+	_, err2 := receivePacket(t, trapListener, defaultTimeout) // Wait for packet
+	require.NoError(t, err2)
 	mockSender.AssertMetric(t, "Count", "datadog.snmp_traps.received", 1, "", []string{"snmp_device:127.0.0.1", "device_namespace:totoro", "snmp_version:1"})
 }
 
-func receivePacket(t *testing.T, listener *TrapListener, timeoutDuration time.Duration) *SnmpPacket {
+func receivePacket(t *testing.T, listener *TrapListener, timeoutDuration time.Duration) (*SnmpPacket, error) {
 	timeout := time.After(timeoutDuration)
 	ticker := time.NewTicker(20 * time.Millisecond)
 	defer ticker.Stop()
@@ -172,15 +173,14 @@ func receivePacket(t *testing.T, listener *TrapListener, timeoutDuration time.Du
 	// Wait for a packet to be received, if packet is invalid wait until receivedTrapsCount is incremented
 	for {
 		select {
-		// Got a timeout! fail with a timeout error
 		case <-timeout:
-			t.Error("timeout error waiting for trap")
-			return nil
+			return nil, errors.New("timeout waiting for trap")
 		case packet := <-listener.packets:
-			return packet
+			return packet, nil
 		case <-ticker.C:
 			if listener.receivedTrapsCount.Load() > 0 {
-				return nil // We received an invalid packet
+				// invalid packet/bad credentials
+				return nil, errors.New("invalid packet")
 			}
 		}
 	}


### PR DESCRIPTION
### What does this PR do?
Improve timeout handling in pkg/snmp/traps/listener_test.go.

### Motivation
Related to NDM-2102

### Additional Notes
Unit test only changes. 

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes
Run standard unit test suite.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
