### PR TITLE
Backport MacOS artifacts download retry to 7.46

### DIFF
--- a/tasks/github.py
+++ b/tasks/github.py
@@ -3,7 +3,7 @@ import os
 from invoke import Exit, task
 
 from .libs.github_actions_tools import (
-    download_artifacts,
+    download_artifacts_with_retry,
     follow_workflow_run,
     print_workflow_conclusion,
     trigger_macos_workflow,
@@ -20,6 +20,8 @@ def trigger_macos_build(
     python_runtimes="3",
     destination=".",
     version_cache=None,
+    retry_download=3,
+    retry_interval=10,
 ):
     env = load_release_versions(ctx, release_version)
     github_action_ref = env["MACOS_BUILD_VERSION"]
@@ -42,7 +44,7 @@ def trigger_macos_build(
 
     print_workflow_conclusion(workflow_conclusion)
 
-    download_artifacts(run_id, destination)
+    download_artifacts_with_retry(run_id, destination, retry_download, retry_interval)
 
     if workflow_conclusion != "success":
         raise Exit(code=1)
@@ -55,6 +57,8 @@ def trigger_macos_test(
     release_version="nightly-a7",
     python_runtimes="3",
     destination=".",
+    retry_download=3,
+    retry_interval=10,
 ):
     env = load_release_versions(ctx, release_version)
     github_action_ref = env["MACOS_BUILD_VERSION"]
@@ -70,7 +74,7 @@ def trigger_macos_test(
 
     print_workflow_conclusion(workflow_conclusion)
 
-    download_artifacts(run_id, destination)
+    download_artifacts_with_retry(run_id, destination, retry_download, retry_interval)
 
     if workflow_conclusion != "success":
         raise Exit(code=1)

--- a/tasks/libs/common/remote_api.py
+++ b/tasks/libs/common/remote_api.py
@@ -98,6 +98,7 @@ class RemoteAPI(object):
             m = errno_regex.match(str(e))
             if not m:
                 print(f"Unknown error raised connecting to {self.api_name} ({url}): {e}")
+                raise e
 
             # Parse errno to give a better explanation
             # Requests doesn't have granularity at the level we want:

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import tempfile
 import zipfile
@@ -179,3 +180,25 @@ def download_artifacts(run_id, destination="."):
             # Unzip it in the target destination
             with zipfile.ZipFile(zip_path, "r") as zip_ref:
                 zip_ref.extractall(destination)
+
+
+def download_artifacts_with_retry(run_id, destination=".", retry_count=3, retry_interval=10):
+
+    import requests
+
+    retry = retry_count
+
+    while retry > 0:
+        try:
+            download_artifacts(run_id, destination)
+            print(color_message(f"Successfully downloaded artifacts for run {run_id} to {destination}", "blue"))
+            return
+        except requests.exceptions.RequestException:
+            retry -= 1
+            print(f'Connectivity issue while downloading the artifact, retrying... {retry} attempts left')
+            sleep(retry_interval)
+        except Exception as e:
+            print("Exception that is not a connectivity issue: ", type(e).__name__, " - ", e)
+            raise e
+    print(f'Download failed {retry_count} times, stop retry and exit')
+    raise Exit(code=os.EX_TEMPFAIL)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Backport changes made to retry MacOS artifacts download 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Reduce flakyness of macos build job 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
