### PR TITLE
Add logging to artifact download to try to debug flakyness

### DIFF
--- a/tasks/libs/common/github_workflows.py
+++ b/tasks/libs/common/github_workflows.py
@@ -60,7 +60,7 @@ class GithubWorkflows(RemoteAPI):
         """
         path = f"/repos/{self.repository}/actions/artifacts/{artifact_id}/zip"
         content = self.make_request(path, method="GET", raw_output=True)
-
+        print("Downloaded artifact with id: ", artifact_id, "content length is: ", len(content))
         zip_target_path = os.path.join(destination_dir, f"{artifact_id}.zip")
         with open(zip_target_path, "wb") as f:
             f.write(content)

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -166,6 +166,8 @@ def download_artifacts(run_id, destination="."):
 
     github_workflows = create_or_refresh_macos_build_github_workflows()
     run_artifacts = github_workflows.workflow_run_artifacts(run_id)
+    print("Found the following artifacts: ", run_artifacts)
+
     if run_artifacts is None:
         print("Workflow run not found.")
         raise Exit(code=1)
@@ -176,6 +178,7 @@ def download_artifacts(run_id, destination="."):
             # Download artifact
             github_workflows = create_or_refresh_macos_build_github_workflows(github_workflows)
             zip_path = github_workflows.download_artifact(artifact["id"], tmpdir)
+            print("Downloading artifact: ", artifact)
 
             # Unzip it in the target destination
             with zipfile.ZipFile(zip_path, "r") as zip_ref:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add some logging when downloading artifacts for MacOS
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Try to understand why the test is flaky
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
