### PR TITLE
[CWS] cleanup types in syscall hooking

### DIFF
--- a/pkg/security/ebpf/c/include/constants/syscall_macro.h
+++ b/pkg/security/ebpf/c/include/constants/syscall_macro.h
@@ -86,20 +86,24 @@
 #define __SC_PASS(t, a) a
 
 #define SYSCALL_PREFIX "sys"
+#define KPROBE_CTX_TYPE struct pt_regs
+#define KRETPROBE_CTX_TYPE struct pt_regs
+#define FENTRY_CTX_TYPE ctx_t
+#define FEXIT_CTX_TYPE ctx_t
 
 #define SYSCALL_ABI_HOOKx(x,word_size,type,TYPE,prefix,syscall,suffix,...) \
-    int __attribute__((always_inline)) type##__##sys##syscall(void *ctx __JOIN(x,__SC_DECL,__VA_ARGS__)); \
+    int __attribute__((always_inline)) type##__##sys##syscall(TYPE##_CTX_TYPE *ctx __JOIN(x,__SC_DECL,__VA_ARGS__)); \
     SEC(#type "/" SYSCALL##word_size##_PREFIX #prefix SYSCALL_PREFIX #syscall #suffix) \
-    int type##__ ##word_size##_##prefix ##sys##syscall##suffix(void *ctx) { \
+    int type##__ ##word_size##_##prefix ##sys##syscall##suffix(TYPE##_CTX_TYPE *ctx) { \
         SYSCALL_##TYPE##_PROLOG(x,__SC_##word_size##_PARAM,syscall,__VA_ARGS__) \
         return type##__sys##syscall(ctx __JOIN(x,__SC_PASS,__VA_ARGS__)); \
     }
 
-#define SYSCALL_HOOK_COMMON(x,type,syscall,...) int __attribute__((always_inline)) type##__sys##syscall(void *ctx __JOIN(x,__SC_DECL,__VA_ARGS__))
+#define SYSCALL_HOOK_COMMON(x,type,TYPE,syscall,...) int __attribute__((always_inline)) type##__sys##syscall(TYPE##_CTX_TYPE *ctx __JOIN(x,__SC_DECL,__VA_ARGS__))
 #define SYSCALL_KRETPROBE_PROLOG(...)
 
 #define SYSCALL_FENTRY_PROLOG(x,m,syscall,...) \
-  struct pt_regs *rctx = (struct pt_regs *) ((ctx_t *)ctx)[0]; \
+  struct pt_regs *rctx = (struct pt_regs *) (ctx)[0]; \
   if (!rctx) return 0; \
   __MAP(x,m,__VA_ARGS__)
 
@@ -107,23 +111,23 @@
   #define __SC_64_PARAM(n, t, a) t a; bpf_probe_read(&a, sizeof(t), (void*) &SYSCALL64_PT_REGS_PARM##n(rctx));
   #define __SC_32_PARAM(n, t, a) t a; bpf_probe_read(&a, sizeof(t), (void*) &SYSCALL32_PT_REGS_PARM##n(rctx));
   #define SYSCALL_KPROBE_PROLOG(x,m,syscall,...) \
-    struct pt_regs *rctx = (struct pt_regs *) PT_REGS_PARM1((struct pt_regs *)ctx); \
+    struct pt_regs *rctx = (struct pt_regs *) PT_REGS_PARM1(ctx); \
     if (!rctx) return 0; \
     __MAP(x,m,__VA_ARGS__)
   #define SYSCALL_HOOKx(x,type,TYPE,prefix,name,...) \
     SYSCALL_ABI_HOOKx(x,32,type,TYPE,prefix,name,,__VA_ARGS__) \
     SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,,__VA_ARGS__) \
-    SYSCALL_HOOK_COMMON(x,type,name,__VA_ARGS__)
+    SYSCALL_HOOK_COMMON(x,type,TYPE,name,__VA_ARGS__)
   #define SYSCALL_COMPAT_HOOKx(x,type,TYPE,name,...) \
     SYSCALL_ABI_HOOKx(x,32,type,TYPE,compat_,name,,__VA_ARGS__) \
     SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,,__VA_ARGS__) \
-    SYSCALL_HOOK_COMMON(x,type,name,__VA_ARGS__)
+    SYSCALL_HOOK_COMMON(x,type,TYPE,name,__VA_ARGS__)
   #define SYSCALL_COMPAT_TIME_HOOKx(x,type,TYPE,name,...) \
     SYSCALL_ABI_HOOKx(x,32,type,TYPE,compat_,name,,__VA_ARGS__) \
     SYSCALL_ABI_HOOKx(x,32,type,TYPE,,name,_time32,__VA_ARGS__) \
     SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,,__VA_ARGS__) \
     SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,_time32,__VA_ARGS__) \
-    SYSCALL_HOOK_COMMON(x,type,name,__VA_ARGS__)
+    SYSCALL_HOOK_COMMON(x,type,TYPE,name,__VA_ARGS__)
 #else
   #define __SC_64_PARAM(n, t, a) t a = (t) SYSCALL64_PT_REGS_PARM##n(rctx);
   #define __SC_32_PARAM(n, t, a) t a = (t) SYSCALL32_PT_REGS_PARM##n(rctx);
@@ -134,15 +138,15 @@
   #define SYSCALL_HOOKx(x,type,TYPE,prefix,name,...) \
     SYSCALL_ABI_HOOKx(x,64,type,TYPE,compat_,name,,__VA_ARGS__) \
     SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,,__VA_ARGS__) \
-    SYSCALL_HOOK_COMMON(x,type,name,__VA_ARGS__)
+    SYSCALL_HOOK_COMMON(x,type,TYPE,name,__VA_ARGS__)
   #define SYSCALL_COMPAT_HOOKx(x,type,TYPE,name,...) \
     SYSCALL_ABI_HOOKx(x,64,type,TYPE,compat_,name,,__VA_ARGS__) \
     SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,,__VA_ARGS__) \
-    SYSCALL_HOOK_COMMON(x,type,name,__VA_ARGS__)
+    SYSCALL_HOOK_COMMON(x,type,TYPE,name,__VA_ARGS__)
   #define SYSCALL_COMPAT_TIME_HOOKx(x,type,TYPE,name,...) \
     SYSCALL_ABI_HOOKx(x,64,type,TYPE,compat_,name,,__VA_ARGS__) \
     SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,,__VA_ARGS__) \
-    SYSCALL_HOOK_COMMON(x,type,name,__VA_ARGS__)
+    SYSCALL_HOOK_COMMON(x,type,TYPE,name,__VA_ARGS__)
 #endif
 
 #define SYSCALL_KPROBE0(name, ...) SYSCALL_HOOKx(0,kprobe,KPROBE,,_##name,__VA_ARGS__)

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -7,7 +7,7 @@
 #include "helpers/syscalls.h"
 #include "constants/fentry_macro.h"
 
-int __attribute__((always_inline)) trace__sys_execveat(struct pt_regs *ctx, const char **argv, const char **env) {
+int __attribute__((always_inline)) trace__sys_execveat(ctx_t *ctx, const char **argv, const char **env) {
     struct syscall_cache_t syscall = {
         .type = EVENT_EXEC,
         .exec = {
@@ -72,7 +72,7 @@ int __attribute__((always_inline)) handle_interpreted_exec_event(struct pt_regs 
     return 0;
 }
 
-int __attribute__((always_inline)) handle_sys_fork(struct pt_regs *ctx) {
+int __attribute__((always_inline)) handle_sys_fork() {
     struct syscall_cache_t syscall = {
         .type = EVENT_FORK,
     };
@@ -83,19 +83,19 @@ int __attribute__((always_inline)) handle_sys_fork(struct pt_regs *ctx) {
 }
 
 SYSCALL_KPROBE0(fork) {
-    return handle_sys_fork(ctx);
+    return handle_sys_fork();
 }
 
 HOOK_SYSCALL_ENTRY0(clone) {
-    return handle_sys_fork(ctx);
+    return handle_sys_fork();
 }
 
 HOOK_SYSCALL_ENTRY0(clone3) {
-    return handle_sys_fork(ctx);
+    return handle_sys_fork();
 }
 
 SYSCALL_KPROBE0(vfork) {
-    return handle_sys_fork(ctx);
+    return handle_sys_fork();
 }
 
 #define DO_FORK_STRUCT_INPUT 1


### PR DESCRIPTION
### What does this PR do?

This PR cleans up the types in the syscall hooking path to skip the `struct pt_regs` to `ctx_t` type casts.
 
### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
