### PR TITLE
PerCPU hashmaps for eBPF telemetry

### DIFF
--- a/pkg/network/telemetry/ebpf_telemetry.go
+++ b/pkg/network/telemetry/ebpf_telemetry.go
@@ -411,7 +411,8 @@ func ActivateBPFTelemetry(m *manager.Manager, undefinedProbes []manager.ProbeIde
 	return nil
 }
 
-// EBPF telemetry depends on the presence of the 'lock xadd' instruction
+// EBPF telemetry depends on the presence of per-cpu maps
+// and verifier from kernel 4.14+.
 func EBPFTelemetrySupported() bool {
 	kversion, err := kernel.HostVersion()
 	if err != nil {

--- a/pkg/network/telemetry/ebpf_telemetry.go
+++ b/pkg/network/telemetry/ebpf_telemetry.go
@@ -136,11 +136,7 @@ func lookupPerCPUMapTelemetry(mapErrMap *ebpf.Map, key uint64) (map[string]uint6
 	for _, v := range vals {
 		count := getMapErrCount(&v)
 		for errStr, cnt := range count {
-			if _, ok := totalCount[errStr]; ok {
-				totalCount[errStr] += cnt
-			} else {
-				totalCount[errStr] = cnt
-			}
+			totalCount[errStr] += cnt
 		}
 	}
 
@@ -185,13 +181,8 @@ func getHelpersTelemetryForProbe(percpuTelemetry []HelperErrTelemetry, probeName
 
 		for _, telemetry := range percpuTelemetry {
 			if count := getErrCount(&telemetry, indx); len(count) > 0 {
-
 				for errStr, errCount := range count {
-					if _, ok := totalHelperErrCount[errStr]; ok {
-						totalHelperErrCount[errStr] += errCount
-					} else {
-						totalHelperErrCount[errStr] = errCount
-					}
+					totalHelperErrCount[errStr] += errCount
 				}
 			}
 		}

--- a/pkg/network/telemetry/ebpf_telemetry.go
+++ b/pkg/network/telemetry/ebpf_telemetry.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/features"
 
 	manager "github.com/DataDog/ebpf-manager"
 
@@ -418,5 +419,5 @@ func EBPFTelemetrySupported() bool {
 		return false
 	}
 
-	return kversion >= kernel.VersionCode(4, 14, 0)
+	return (kversion >= kernel.VersionCode(4, 14, 0)) && (features.HaveMapType(ebpf.PerCPUHash) == nil)
 }

--- a/pkg/network/telemetry/ebpf_telemetry.go
+++ b/pkg/network/telemetry/ebpf_telemetry.go
@@ -114,7 +114,7 @@ func (b *EBPFTelemetry) getMapsTelemetry(ch chan<- prometheus.Metric) map[string
 				}
 			}
 		} else if err != nil {
-			log.Debugf("error getting telemetry for map %s: %v\n", err)
+			log.Debugf("error getting telemetry for map %s: %v\n", m, err)
 		}
 	}
 

--- a/pkg/network/telemetry/ebpf_telemetry.go
+++ b/pkg/network/telemetry/ebpf_telemetry.go
@@ -132,7 +132,7 @@ func lookupPerCPUMapTelemetry(mapErrMap *ebpf.Map, key uint64) (map[string]uint6
 	}
 
 	// Error telemetry is a monotonically increasing integer,
-	// so they can be combined communitatively.
+	// so they can be combined commutatively
 	totalCount := make(map[string]uint64)
 	for _, v := range vals {
 		count := getMapErrCount(&v)

--- a/pkg/network/telemetry/telemetry_manager.go
+++ b/pkg/network/telemetry/telemetry_manager.go
@@ -53,6 +53,9 @@ func initializeMaps(bpfTelemetry *EBPFTelemetry, opts *manager.Options) {
 		if opts.MapEditors == nil {
 			opts.MapEditors = make(map[string]*ebpf.Map)
 		}
+		if opts.MapSpecEditors == nil {
+			opts.MapSpecEditors = make(map[string]manager.MapSpecEditor)
+		}
 	}
 	if bpfTelemetry.MapErrMap != nil {
 		opts.MapEditors[probes.MapErrTelemetryMap] = bpfTelemetry.MapErrMap

--- a/pkg/network/telemetry/telemetry_manager.go
+++ b/pkg/network/telemetry/telemetry_manager.go
@@ -53,9 +53,6 @@ func initializeMaps(bpfTelemetry *EBPFTelemetry, opts *manager.Options) {
 		if opts.MapEditors == nil {
 			opts.MapEditors = make(map[string]*ebpf.Map)
 		}
-		if opts.MapSpecEditors == nil {
-			opts.MapSpecEditors = make(map[string]manager.MapSpecEditor)
-		}
 	}
 	if bpfTelemetry.MapErrMap != nil {
 		opts.MapEditors[probes.MapErrTelemetryMap] = bpfTelemetry.MapErrMap

--- a/pkg/network/tracer/connection/fentry/tracer.go
+++ b/pkg/network/tracer/connection/fentry/tracer.go
@@ -22,7 +22,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	errtelemetry "github.com/DataDog/datadog-agent/pkg/network/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
-	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/features"
 )

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/features"
 
 	manager "github.com/DataDog/ebpf-manager"
 
@@ -236,7 +237,7 @@ func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer boo
 	}
 
 	// Replace ebpf telemetry maps with Percpu maps if kernel supports
-	if perCPUSupported() {
+	if features.HaveMapType(ebpf.PerCPUHash) == nil {
 		if mgrOpts.MapSpecEditors == nil {
 			mgrOpts.MapSpecEditors = make(map[string]manager.MapSpecEditor)
 		}

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -182,15 +182,6 @@ func LoadTracer(cfg *config.Config, mgrOpts manager.Options, perfHandlerTCP *dde
 	return m, closeFn, TracerTypePrebuilt, err
 }
 
-func perCPUSupported() bool {
-	kv, err := kernel.HostVersion()
-	if err != nil {
-		return false
-	}
-
-	return kv >= kernel.VersionCode(4, 7, 0)
-}
-
 func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer bool, config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
 	m := &manager.Manager{}
 	if err := initManager(m, config, perfHandlerTCP, runtimeTracer); err != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Use percpu hashmaps when collecting eBPF telemetry,

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Reduce lock contention on map elements.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
