### PR TITLE
Calculate signature for the normalized statement

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -377,7 +377,7 @@ func (c *Check) GetObfuscatedStatement(o *obfuscate.Obfuscator, statement string
 	if err == nil {
 		return common.ObfuscatedStatement{
 			Statement:      obfuscatedStatement.Query,
-			QuerySignature: common.GetQuerySignature(statement),
+			QuerySignature: common.GetQuerySignature(obfuscatedStatement.Query),
 			Commands:       obfuscatedStatement.Metadata.Commands,
 			Tables:         strings.Split(obfuscatedStatement.Metadata.TablesCSV, ","),
 			Comments:       obfuscatedStatement.Metadata.Comments,

--- a/releasenotes/notes/oracle-bug-fix-wrong-query-signature-a0042d253c831009.yaml
+++ b/releasenotes/notes/oracle-bug-fix-wrong-query-signature-a0042d253c831009.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Bug fix for the wrong query signature.


### PR DESCRIPTION
### What does this PR do?

A bug fix for the wrong query signature. The query signature was calculated for the captured instead for the normalised statement.

### Describe how to test/QA your changes

Start Orders app and check the query metrics view for duplicate statements.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
