### PR TITLE
Add cache helpers and extract helpers

### DIFF
--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -190,7 +191,7 @@ func getClusterAgentAuthToken(tokenCreationAllowed bool) (string, error) {
 	}
 
 	// load the cluster agent auth token from filesystem
-	tokenAbsPath := filepath.Join(config.FileUsedDir(), clusterAgentAuthTokenFilename)
+	tokenAbsPath := filepath.Join(configUtils.ConfFileDirectory(config.Datadog), clusterAgentAuthTokenFilename)
 	log.Debugf("Empty cluster_agent.auth_token, loading from %s", tokenAbsPath)
 
 	// Create a new token if it doesn't exist

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1836,12 +1836,6 @@ func IsCloudProviderEnabled(cloudProviderName string) bool {
 	return false
 }
 
-// FileUsedDir returns the absolute path to the folder containing the config
-// file used to populate the registry
-func FileUsedDir() string {
-	return filepath.Dir(Datadog.ConfigFileUsed())
-}
-
 func isLocalAddress(address string) (string, error) {
 	if address == "localhost" {
 		return address, nil

--- a/pkg/config/utils/miscellaneous.go
+++ b/pkg/config/utils/miscellaneous.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import (
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// ConfFileDirectory returns the absolute path to the folder containing the config
+// file used to populate the registry
+func ConfFileDirectory(c config.ConfigReader) string {
+	return filepath.Dir(c.ConfigFileUsed())
+}

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/api/security"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/diagnose"
 	"github.com/DataDog/datadog-agent/pkg/diagnose/connectivity"
 	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
@@ -101,7 +102,7 @@ func CompleteFlare(fb flarehelpers.FlareBuilder) error {
 	getRegistryJSON(fb)
 
 	getVersionHistory(fb)
-	fb.CopyFile(filepath.Join(config.FileUsedDir(), "install_info"))
+	fb.CopyFile(filepath.Join(configUtils.ConfFileDirectory(config.Datadog), "install_info"))
 
 	getExpVar(fb) //nolint:errcheck
 	getWindowsData(fb)

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -13,21 +13,21 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/logs/status"
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
+	"github.com/DataDog/datadog-agent/pkg/metadata/host/container"
 	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 	"github.com/DataDog/datadog-agent/pkg/otlp"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
+	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	"github.com/DataDog/datadog-agent/pkg/metadata/host/container"
-	"github.com/DataDog/datadog-agent/pkg/util/ec2"
-	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -230,7 +230,7 @@ func buildKey(key string) string {
 }
 
 func getInstallInfoPath() string {
-	return path.Join(config.FileUsedDir(), "install_info")
+	return path.Join(configUtils.ConfFileDirectory(config.Datadog), "install_info")
 }
 
 func getInstallInfo(infoPath string) (*installInfo, error) {

--- a/pkg/util/version_history.go
+++ b/pkg/util/version_history.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -40,7 +41,7 @@ const maxVersionHistoryEntries = 60
 // JSON file, trim the file if too many entries then save the file.
 func LogVersionHistory() {
 	versionHistoryFilePath := filepath.Join(config.Datadog.GetString("run_path"), "version-history.json")
-	installInfoFilePath := filepath.Join(config.FileUsedDir(), "install_info")
+	installInfoFilePath := filepath.Join(configUtils.ConfFileDirectory(config.Datadog), "install_info")
 	logVersionHistoryToFile(versionHistoryFilePath, installInfoFilePath, version.AgentVersion, time.Now().UTC())
 }
 


### PR DESCRIPTION
### What does this PR do?

This is preparatory work for the migration of the `V5` metadata payload to component.

### Describe how to test/QA your changes

Sanity check.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
