### PR TITLE
Adds skipped tests for alternate dogstatsd flavors

### DIFF
--- a/comp/dogstatsd/server/parse_metrics_test.go
+++ b/comp/dogstatsd/server/parse_metrics_test.go
@@ -560,4 +560,47 @@ func TestParseManyPipes(t *testing.T) {
 		assert.Equal(t, "environment:dev", sample.tags[0])
 		assert.InEpsilon(t, 1.0, sample.sampleRate, epsilon)
 	})
+
+}
+
+// https://github.com/influxdata/telegraf/tree/master/plugins/inputs/statsd#influx-statsd
+func TestTelegrafInfluxStatsdFormat(t *testing.T) {
+	t.Skip() // influx flavor is not supported
+	sample, err := parseMetricSample(t, make(map[string]any), []byte("service.messages.received,deployment=telemetryA,operation=none,model_name=customer:1|g"))
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "service.messages.received", sample.name)
+	assert.InEpsilon(t, 1, sample.value, epsilon)
+	require.Nil(t, sample.values)
+	assert.Equal(t, gaugeType, sample.metricType)
+
+	assert.Len(t, sample.tags, 3)
+	assert.Equal(t, "deployment=telemetryA", sample.tags[0])
+	assert.Equal(t, "operation=none", sample.tags[1])
+	assert.Equal(t, "model_name=customer", sample.tags[2])
+
+	assert.InEpsilon(t, 1.0, sample.sampleRate, epsilon)
+	assert.Zero(t, sample.ts)
+}
+
+// https://docs.sysdig.com/en/docs/sysdig-monitor/integrations/working-with-integrations/custom-integrations/integrate-statsd-metrics/#metric-labels
+func TestSysdigStatsdFormat(t *testing.T) {
+	t.Skip() // sysdig format is not supported
+	sample, err := parseMetricSample(t, make(map[string]any), []byte("service.messages.received#deployment=telemetryA,operation=none,model_name=customer:1|g"))
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, "service.messages.received", sample.name)
+	assert.InEpsilon(t, 1, sample.value, epsilon)
+	require.Nil(t, sample.values)
+	assert.Equal(t, gaugeType, sample.metricType)
+
+	assert.Len(t, sample.tags, 3)
+	assert.Equal(t, "deployment=telemetryA", sample.tags[0])
+	assert.Equal(t, "operation=none", sample.tags[1])
+	assert.Equal(t, "model_name=customer", sample.tags[2])
+
+	assert.InEpsilon(t, 1.0, sample.sampleRate, epsilon)
+	assert.Zero(t, sample.ts)
 }


### PR DESCRIPTION
### What does this PR do?
Adds two new tests that will not pass (and are therefore skipped) that aim to document the Agent's DogStatsD server does not support influx and sysdig flavored statsd messages.

### Motivation
Have a definitive place to point customers using these formats.

### Additional Notes
n/a

### Possible Drawbacks / Trade-offs
n/a

### Describe how to test/QA your changes
n/a

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
