### PR TITLE
Revert "[ci] Run k8s-e2e-main job after dev_master jobs"

### DIFF
--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -36,10 +36,9 @@ k8s-e2e-main:
   extends: .k8s_e2e_template
   allow_failure: true # temporary while investigating
   rules: !reference [.on_main]
-  needs:
-    - dev_master-a6
-    - dev_master-a7
-    - dca_dev_master
+  # needs:
+  #   - dev_master-a6
+  #   - dev_master-a7
   script:
     - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py2 --dca-image=datadog/cluster-agent-dev:master --argo-workflow=default
     - inv -e e2e-tests --agent-image=datadog/agent-dev:master-py3 --dca-image=datadog/cluster-agent-dev:master --argo-workflow=default


### PR DESCRIPTION
Reverts DataDog/datadog-agent#18075

Gitlab is failing to build the pipeline, so reverting while I investigate