### PR TITLE
Exit if we don't provide the required env vars of Azure Container Apps

### DIFF
--- a/cmd/serverless-init/cloudservice/containerapp.go
+++ b/cmd/serverless-init/cloudservice/containerapp.go
@@ -7,6 +7,7 @@ package cloudservice
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"strings"
 )
@@ -88,13 +89,13 @@ func (c *ContainerApp) Init() error {
 	if subscriptionId, exists := os.LookupEnv(AzureSubscriptionIdEnvVar); exists {
 		c.SubscriptionId = subscriptionId
 	} else {
-		return fmt.Errorf("must set %v", AzureSubscriptionIdEnvVar)
+		log.Fatalf("Must set Subscription ID as an environment variable. Please set the %v value to your Subscription ID your App Container is in.", AzureSubscriptionIdEnvVar)
 	}
 
 	if resourceGroup, exists := os.LookupEnv(AzureResourceGroupEnvVar); exists {
 		c.ResourceGroup = resourceGroup
 	} else {
-		return fmt.Errorf("must set %v", AzureResourceGroupEnvVar)
+		log.Fatalf("Must set Resource Group as an environment variable. Please set the %v value to your Resource Group your App Container is in.", AzureResourceGroupEnvVar)
 	}
 
 	return nil

--- a/cmd/serverless-init/cloudservice/containerapp_test.go
+++ b/cmd/serverless-init/cloudservice/containerapp_test.go
@@ -6,7 +6,8 @@
 package cloudservice
 
 import (
-	"fmt"
+	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,6 +19,9 @@ func TestGetContainerAppTags(t *testing.T) {
 	t.Setenv("CONTAINER_APP_NAME", "test_app_name")
 	t.Setenv("CONTAINER_APP_ENV_DNS_SUFFIX", "test.bluebeach.eastus.azurecontainerapps.io")
 	t.Setenv("CONTAINER_APP_REVISION", "test_revision")
+
+	t.Setenv("DD_AZURE_SUBSCRIPTION_ID", "test_subscription_id")
+	t.Setenv("DD_AZURE_RESOURCE_GROUP", "test_resource_group")
 
 	tags := service.GetTags()
 
@@ -59,20 +63,50 @@ func TestGetContainerAppTagsWithOptionalEnvVars(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestInitHasErrorsWhenMissingEnvVars(t *testing.T) {
+func TestInitHasErrorsWhenMissingSubscriptionId(t *testing.T) {
 	service := NewContainerApp()
+	if os.Getenv("SERVERLESS_TEST") == "true" {
+		t.Setenv("CONTAINER_APP_NAME", "test_app_name")
+		t.Setenv("CONTAINER_APP_ENV_DNS_SUFFIX", "test.bluebeach.eastus.azurecontainerapps.io")
+		t.Setenv("CONTAINER_APP_REVISION", "test_revision")
 
-	t.Setenv("CONTAINER_APP_NAME", "test_app_name")
-	t.Setenv("CONTAINER_APP_ENV_DNS_SUFFIX", "test.bluebeach.eastus.azurecontainerapps.io")
-	t.Setenv("CONTAINER_APP_REVISION", "test_revision")
+		t.Setenv("DD_AZURE_RESOURCE_GROUP", "test_resource_group")
 
-	err := service.Init()
-	assert.Equal(t, fmt.Errorf("must set %v", AzureSubscriptionIdEnvVar), err)
+		service.Init()
+		return
+	}
 
-	// Set the missing environment variable. We also need to set DD_AZURE_RESOURCE_GROUP,
-	// so we should still error when we call Init() again.
-	t.Setenv("DD_AZURE_SUBSCRIPTION_ID", "test_subscription_id")
+	// Re-run this test but set SERVERLESS_TEST to true to trigger the Init() function
+	cmd := exec.Command(os.Args[0], "-test.run=TestInitHasErrorsWhenMissingSubscriptionId")
+	cmd.Env = append(os.Environ(), "SERVERLESS_TEST=true")
+	err := cmd.Run()
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	} else {
+		assert.FailNow(t, "Process didn't exit when not specifying DD_AZURE_SUBSCRIPTION_ID")
+	}
+}
 
-	err = service.Init()
-	assert.Equal(t, fmt.Errorf("must set %v", AzureResourceGroupEnvVar), err)
+func TestInitHasErrorsWhenMissingResourceGroup(t *testing.T) {
+	service := NewContainerApp()
+	if os.Getenv("SERVERLESS_TEST") == "true" {
+		t.Setenv("CONTAINER_APP_NAME", "test_app_name")
+		t.Setenv("CONTAINER_APP_ENV_DNS_SUFFIX", "test.bluebeach.eastus.azurecontainerapps.io")
+		t.Setenv("CONTAINER_APP_REVISION", "test_revision")
+
+		t.Setenv("DD_AZURE_SUBSCRIPTION_ID", "test_subscription_id")
+
+		service.Init()
+		return
+	}
+
+	// Re-run this test but set SERVERLESS_TEST to true to trigger the Init() function
+	cmd := exec.Command(os.Args[0], "-test.run=TestInitHasErrorsWhenMissingResourceGroup")
+	cmd.Env = append(os.Environ(), "SERVERLESS_TEST=true")
+	err := cmd.Run()
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	} else {
+		assert.FailNow(t, "Process didn't exit when not specifying DD_AZURE_RESOURCE_GROUP")
+	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR causes the application to fail if we don't set the required Azure environment variables.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
