### PR TITLE
offboard security agent and system probe kitchen tests from junit step

### DIFF
--- a/.gitlab/kitchen_common/testing.yml
+++ b/.gitlab/kitchen_common/testing.yml
@@ -3,6 +3,16 @@
   stage: kitchen_testing
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/dd-agent-testing$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
+  artifacts:
+    expire_in: 2 weeks
+    when: always
+    paths:
+      - $CI_PROJECT_DIR/kitchen_logs
+  retry: 1
+
+.kitchen_common_with_junit:
+  extends:
+    - .kitchen_common
   after_script:
     - echo -n "--tags ci.job.name:${CI_JOB_NAME} --tags arch:${KITCHEN_ARCH} --tags os:${KITCHEN_PLATFORM} upload_option.os_version_from_name" > $CI_PROJECT_DIR/test/kitchen/tags.txt
     - echo -n "${CI_JOB_URL}" > $CI_PROJECT_DIR/test/kitchen/job_url.txt
@@ -15,7 +25,6 @@
     paths:
       - $CI_PROJECT_DIR/kitchen_logs
       - "**/kitchen-rspec-common-${CI_JOB_NAME}.tar.gz"
-  retry: 1
 
 # Kitchen: providers
 # ---------------
@@ -62,7 +71,7 @@
 # ---------------
 
 .kitchen_agent_a6:
-  extends: .kitchen_common
+  extends: .kitchen_common_with_junit
   rules:
     !reference [.on_kitchen_tests_a6]
   variables:
@@ -70,7 +79,7 @@
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
 
 .kitchen_agent_a7:
-  extends: .kitchen_common
+  extends: .kitchen_common_with_junit
   rules:
     !reference [.on_kitchen_tests_a7]
   variables:


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/datadog-agent/pull/17992 added automatic kitchen test result upload to CI-app, but this is currently not compatible with security agent and system probe functional tests. This PR offboards those kitchen tests from this feature.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
