### PR TITLE
Adding oracle.can_connect metric

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -77,13 +77,12 @@ type Check struct {
 	connectedToPdb                          bool
 	fqtEmitted                              *cache.Cache
 	planEmitted                             *cache.Cache
-	configTagsSet                           bool
 }
 
 func handleServiceCheck(c *Check, err error) {
 	sender, errSender := c.GetSender()
 	if errSender != nil {
-		log.Errorf("failed to get sender for service check %w", err)
+		log.Errorf("failed to get sender for service check %s", err)
 	}
 
 	message := ""

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -91,8 +91,7 @@ func handleServiceCheck(c *Check, err error) {
 		status = servicecheck.ServiceCheckOK
 	} else {
 		status = servicecheck.ServiceCheckCritical
-		message = fmt.Sprintf("%s", err)
-		log.Errorf("connect error %s", message)
+		log.Errorf("failed to connect: %s", err)
 	}
 	sender.ServiceCheck("oracle.can_connect", status, "", c.tags, message)
 	sender.Commit()

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -633,7 +633,7 @@ func (c *Check) StatementMetrics() (int, error) {
 					c.fqtEmitted.Set(queryRow.QuerySignature, "1", cache.DefaultExpiration)
 				}
 			} else {
-				log.Error("fqtEmitted = nil")
+				log.Error("Internal error: fqtEmitted = nil. The check might have been restarted. Ignore if it doesn't appear anymore.")
 			}
 
 			if c.config.ExecutionPlans.Enabled {

--- a/releasenotes/notes/oracle-can-connect-3daeca9536e1a6ea.yaml
+++ b/releasenotes/notes/oracle-can-connect-3daeca9536e1a6ea.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Add `oracle.can_connect` metric.
+    Add the `oracle.can_connect` metric.

--- a/releasenotes/notes/oracle-can-connect-3daeca9536e1a6ea.yaml
+++ b/releasenotes/notes/oracle-can-connect-3daeca9536e1a6ea.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add `oracle.can_connect` metric.


### PR DESCRIPTION
### What does this PR do?

Adding `oracle.can_connect` check.

### Motivation

The metric is a prerequisite for the service check.

### QA Testing

Check the metric [here](https://dd.datad0g.com/check/summary?id=oracle.can_connect). Restart the database and check if the status is changing.