### PR TITLE
Lowercase azure environment variables that we set as tags

### DIFF
--- a/cmd/serverless-init/cloudservice/containerapp.go
+++ b/cmd/serverless-init/cloudservice/containerapp.go
@@ -29,7 +29,7 @@ const (
 
 // GetTags returns a map of Azure-related tags
 func (c *ContainerApp) GetTags() map[string]string {
-	appName := os.Getenv(ContainerAppNameEnvVar)
+	appName := strings.ToLower(os.Getenv(ContainerAppNameEnvVar))
 	appDNSSuffix := os.Getenv(ContainerAppDNSSuffix)
 
 	appDNSSuffixTokens := strings.Split(appDNSSuffix, ".")
@@ -54,7 +54,7 @@ func (c *ContainerApp) GetTags() map[string]string {
 	}
 
 	if c.SubscriptionId != "" && c.ResourceGroup != "" {
-		tags["resource_id"] = fmt.Sprintf("/subscriptions/%v/resourcegroups/%v/providers/microsoft.app/containerapps/%v", c.SubscriptionId, c.ResourceGroup, strings.ToLower(appName))
+		tags["resource_id"] = fmt.Sprintf("/subscriptions/%v/resourcegroups/%v/providers/microsoft.app/containerapps/%v", c.SubscriptionId, c.ResourceGroup, appName)
 	}
 
 	return tags
@@ -87,13 +87,13 @@ func (c *ContainerApp) Init() error {
 	// These environment variables are optional for now. Once we go GA,
 	// return an error if these are not set.
 	if subscriptionId, exists := os.LookupEnv(AzureSubscriptionIdEnvVar); exists {
-		c.SubscriptionId = subscriptionId
+		c.SubscriptionId = strings.ToLower(subscriptionId)
 	} else {
 		log.Fatalf("Must set Subscription ID as an environment variable. Please set the %v value to your Subscription ID your App Container is in.", AzureSubscriptionIdEnvVar)
 	}
 
 	if resourceGroup, exists := os.LookupEnv(AzureResourceGroupEnvVar); exists {
-		c.ResourceGroup = resourceGroup
+		c.ResourceGroup = strings.ToLower(resourceGroup)
 	} else {
 		log.Fatalf("Must set Resource Group as an environment variable. Please set the %v value to your Resource Group your App Container is in.", AzureResourceGroupEnvVar)
 	}

--- a/cmd/serverless-init/cloudservice/containerapp_test.go
+++ b/cmd/serverless-init/cloudservice/containerapp_test.go
@@ -63,6 +63,35 @@ func TestGetContainerAppTagsWithOptionalEnvVars(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestContainerAppResourceIdIsLowercase(t *testing.T) {
+	service := NewContainerApp()
+
+	t.Setenv("CONTAINER_APP_NAME", "TEST_APP")
+	t.Setenv("CONTAINER_APP_ENV_DNS_SUFFIX", "test.bluebeach.eastus.azurecontainerapps.io")
+	t.Setenv("CONTAINER_APP_REVISION", "test_revision")
+
+	t.Setenv("DD_AZURE_SUBSCRIPTION_ID", "TEST_SUB")
+	t.Setenv("DD_AZURE_RESOURCE_GROUP", "TEST_RG")
+
+	err := service.Init()
+	assert.NoError(t, err)
+
+	tags := service.GetTags()
+
+	assert.Equal(t, map[string]string{
+		"app_name":        "test_app",
+		"origin":          "containerapp",
+		"region":          "eastus",
+		"revision":        "test_revision",
+		"_dd.origin":      "containerapp",
+		"subscription_id": "test_sub",
+		"resource_id":     "/subscriptions/test_sub/resourcegroups/test_rg/providers/microsoft.app/containerapps/test_app",
+		"resource_group":  "test_rg",
+	}, tags)
+
+	assert.Nil(t, err)
+}
+
 func TestInitHasErrorsWhenMissingSubscriptionId(t *testing.T) {
 	service := NewContainerApp()
 	if os.Getenv("SERVERLESS_TEST") == "true" {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Lowercase the values that we're setting for the `resource_id` tag as we expect those to be lowercased in Datadog.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
