### PR TITLE
Removed unused key to use latest chef cookbook

### DIFF
--- a/test/kitchen/Berksfile
+++ b/test/kitchen/Berksfile
@@ -1,6 +1,6 @@
 source 'https://supermarket.chef.io'
 
-cookbook 'datadog', '~> 4.12.0'
+cookbook 'datadog', '~> 4.18.0'
 
 # We pin an old version of the apt cookbook because this cookbook triggers an "apt update" by default
 # and in newer versions this update is not allowed to fail, while in 3.X it is. For some reason

--- a/test/kitchen/site-cookbooks/dd-agent-upgrade/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-upgrade/recipes/default.rb
@@ -95,21 +95,6 @@ if node['dd-agent-upgrade']['add_new_repo']
       ]
     end
   when 'suse'
-    old_key_local_path = ::File.join(Chef::Config[:file_cache_path], 'DATADOG_RPM_KEY.public')
-    remote_file 'DATADOG_RPM_KEY.public' do
-      path old_key_local_path
-      source node['datadog']['yumrepo_gpgkey']
-      # not_if 'rpm -q gpg-pubkey-4172a230' # (key already imported)
-      notifies :run, 'execute[rpm-import datadog key 4172a230]', :immediately
-    end
-
-    # Import key if fingerprint matches
-    execute 'rpm-import datadog key 4172a230' do
-      command "rpm --import #{old_key_local_path}"
-      only_if "gpg --dry-run --quiet --with-fingerprint #{old_key_local_path} | grep '60A3 89A4 4A0C 32BA E3C0  3F0B 069B 56F5 4172 A230'"
-      action :nothing
-    end
-
     zypper_repository 'datadog' do
       name 'datadog'
       description 'datadog'


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Pin to the latest version of chef-cookbook
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Being up to date
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Had to remove useless old gpg-key reference (was [failing the kitchen_suse jobs](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/18293486/failures) with this PR)
Validated current code works with a [full pipeline](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/18304179/builds) trigger and successful SUSE jobs
<img width="1019" alt="image" src="https://github.com/DataDog/datadog-agent/assets/24426034/1222b9b4-72ea-4a48-a6c3-f82ba413720e">
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
