### PR TITLE
[CWS] pass retval from beginning of dentry resolution

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/link.h
+++ b/pkg/security/ebpf/c/include/hooks/link.h
@@ -160,6 +160,7 @@ int __attribute__((always_inline)) sys_link_ret(void *ctx, int retval, int dr_ty
         syscall->resolver.callback = dr_type == DR_KPROBE ? DR_LINK_DST_CALLBACK_KPROBE_KEY : DR_LINK_DST_CALLBACK_TRACEPOINT_KEY;
         syscall->resolver.iteration = 0;
         syscall->resolver.ret = 0;
+        syscall->resolver.sysretval = retval;
 
         resolve_dentry(ctx, dr_type);
     }
@@ -194,11 +195,13 @@ int tracepoint_handle_sys_link_exit(struct tracepoint_raw_syscalls_sys_exit_t *a
     return sys_link_ret(args, args->ret, DR_TRACEPOINT);
 }
 
-int __attribute__((always_inline)) dr_link_dst_callback(void *ctx, int retval) {
+int __attribute__((always_inline)) dr_link_dst_callback(void *ctx) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_LINK);
     if (!syscall) {
         return 0;
     }
+
+    s64 retval = syscall->resolver.sysretval;
 
     if (IS_UNHANDLED_ERROR(retval)) {
         return 0;
@@ -224,24 +227,21 @@ int __attribute__((always_inline)) dr_link_dst_callback(void *ctx, int retval) {
 
 SEC("kprobe/dr_link_dst_callback")
 int kprobe_dr_link_dst_callback(struct pt_regs *ctx) {
-    int ret = PT_REGS_RC(ctx);
-    return dr_link_dst_callback(ctx, ret);
+    return dr_link_dst_callback(ctx);
 }
 
 #ifdef USE_FENTRY
 
 TAIL_CALL_TARGET("dr_link_dst_callback")
 int fentry_dr_link_dst_callback(ctx_t *ctx) {
-    // int ret = CTX_PARMRET(ctx);
-    int ret = 0; // TODO(paulcacheux): find a way to get the retval
-    return dr_link_dst_callback(ctx, ret);
+    return dr_link_dst_callback(ctx);
 }
 
 #endif // USE_FENTRY
 
 SEC("tracepoint/dr_link_dst_callback")
 int tracepoint_dr_link_dst_callback(struct tracepoint_syscalls_sys_exit_t *args) {
-    return dr_link_dst_callback(args, args->ret);
+    return dr_link_dst_callback(args);
 }
 
 #endif

--- a/pkg/security/ebpf/c/include/hooks/mount.h
+++ b/pkg/security/ebpf/c/include/hooks/mount.h
@@ -465,6 +465,7 @@ int __attribute__((always_inline)) sys_mount_ret(void *ctx, int retval, int dr_t
     syscall->resolver.callback = dr_type == DR_KPROBE ? DR_MOUNT_CALLBACK_KPROBE_KEY : DR_MOUNT_CALLBACK_TRACEPOINT_KEY;
     syscall->resolver.iteration = 0;
     syscall->resolver.ret = 0;
+    syscall->resolver.sysretval = retval;
 
     resolve_dentry(ctx, dr_type);
 
@@ -483,11 +484,13 @@ int tracepoint_handle_sys_mount_exit(struct tracepoint_raw_syscalls_sys_exit_t *
     return sys_mount_ret(args, args->ret, DR_TRACEPOINT);
 }
 
-int __attribute__((always_inline)) dr_mount_callback(void *ctx, int retval) {
+int __attribute__((always_inline)) dr_mount_callback(void *ctx) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_MOUNT);
     if (!syscall) {
         return 0;
     }
+
+    s64 retval = syscall->resolver.sysretval;
 
     struct mount_event_t event = {
         .syscall.retval = retval,
@@ -518,24 +521,21 @@ int __attribute__((always_inline)) dr_mount_callback(void *ctx, int retval) {
 
 SEC("kprobe/dr_mount_callback")
 int kprobe_dr_mount_callback(struct pt_regs *ctx) {
-    int ret = PT_REGS_RC(ctx);
-    return dr_mount_callback(ctx, ret);
+    return dr_mount_callback(ctx);
 }
 
 #ifdef USE_FENTRY
 
 TAIL_CALL_TARGET("dr_mount_callback")
 int fentry_dr_mount_callback(ctx_t *ctx) {
-    // int ret = PT_REGS_RC(ctx);
-    int ret = 0; // TODO(paulcacheux): fix this
-    return dr_mount_callback(ctx, ret);
+    return dr_mount_callback(ctx);
 }
 
 #endif // USE_FENTRY
 
 SEC("tracepoint/dr_mount_callback")
 int tracepoint_dr_mount_callback(struct tracepoint_syscalls_sys_exit_t *args) {
-    return dr_mount_callback(args, args->ret);
+    return dr_mount_callback(args);
 }
 
 #endif

--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -198,6 +198,7 @@ int __attribute__((always_inline)) sys_open_ret(void *ctx, int retval, int dr_ty
     syscall->resolver.callback = dr_type == DR_KPROBE ? DR_OPEN_CALLBACK_KPROBE_KEY : DR_OPEN_CALLBACK_TRACEPOINT_KEY;
     syscall->resolver.iteration = 0;
     syscall->resolver.ret = 0;
+    syscall->resolver.sysretval = retval;
 
     // tail call
     resolve_dentry(ctx, dr_type);
@@ -261,11 +262,13 @@ int hook_filp_close(ctx_t *ctx) {
     return 0;
 }
 
-int __attribute__((always_inline)) dr_open_callback(void *ctx, int retval) {
+int __attribute__((always_inline)) dr_open_callback(void *ctx) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_OPEN);
     if (!syscall) {
         return 0;
     }
+
+    s64 retval = syscall->resolver.sysretval;
 
     if (IS_UNHANDLED_ERROR(retval)) {
         return 0;
@@ -306,24 +309,21 @@ int __attribute__((always_inline)) dr_open_callback(void *ctx, int retval) {
 
 SEC("kprobe/dr_open_callback")
 int kprobe_dr_open_callback(struct pt_regs *ctx) {
-    int retval = PT_REGS_RC(ctx);
-    return dr_open_callback(ctx, retval);
+    return dr_open_callback(ctx);
 }
 
 #ifdef USE_FENTRY
 
 TAIL_CALL_TARGET("dr_open_callback")
 int fentry_dr_open_callback(ctx_t *ctx) {
-    // int retval = PT_REGS_RC(ctx);
-    int retval = 0; // TODO(paulcacheux): fix this
-    return dr_open_callback(ctx, retval);
+    return dr_open_callback(ctx);
 }
 
 #endif // USE_FENTRY
 
 SEC("tracepoint/dr_open_callback")
 int tracepoint_dr_open_callback(struct tracepoint_syscalls_sys_exit_t *args) {
-    return dr_open_callback(args, args->ret);
+    return dr_open_callback(args);
 }
 
 #endif

--- a/pkg/security/ebpf/c/include/hooks/rename.h
+++ b/pkg/security/ebpf/c/include/hooks/rename.h
@@ -152,6 +152,7 @@ int __attribute__((always_inline)) sys_rename_ret(void *ctx, int retval, int dr_
         syscall->resolver.callback = dr_type == DR_KPROBE ? DR_RENAME_CALLBACK_KPROBE_KEY : DR_RENAME_CALLBACK_TRACEPOINT_KEY;
         syscall->resolver.iteration = 0;
         syscall->resolver.ret = 0;
+        syscall->resolver.sysretval = retval;
 
         resolve_dentry(ctx, dr_type);
     }
@@ -190,11 +191,13 @@ int tracepoint_handle_sys_rename_exit(struct tracepoint_raw_syscalls_sys_exit_t 
     return sys_rename_ret(args, args->ret, DR_TRACEPOINT);
 }
 
-int __attribute__((always_inline)) dr_rename_callback(void *ctx, int retval) {
+int __attribute__((always_inline)) dr_rename_callback(void *ctx) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_RENAME);
     if (!syscall) {
         return 0;
     }
+
+    s64 retval = syscall->resolver.sysretval;
 
     if (IS_UNHANDLED_ERROR(retval)) {
         return 0;
@@ -218,24 +221,21 @@ int __attribute__((always_inline)) dr_rename_callback(void *ctx, int retval) {
 
 SEC("kprobe/dr_rename_callback")
 int kprobe_dr_rename_callback(struct pt_regs *ctx) {
-    int ret = PT_REGS_RC(ctx);
-    return dr_rename_callback(ctx, ret);
+    return dr_rename_callback(ctx);
 }
 
 #ifdef USE_FENTRY
 
 TAIL_CALL_TARGET("dr_rename_callback")
 int fentry_dr_rename_callback(ctx_t *ctx) {
-    // int ret = PT_REGS_RC(ctx);
-    int ret = 0; // TODO(paulcacheux): fix this
-    return dr_rename_callback(ctx, ret);
+    return dr_rename_callback(ctx);
 }
 
 #endif // USE_FENTRY
 
 SEC("tracepoint/dr_rename_callback")
 int tracepoint_dr_rename_callback(struct tracepoint_syscalls_sys_exit_t *args) {
-    return dr_rename_callback(args, args->ret);
+    return dr_rename_callback(args);
 }
 
 #endif

--- a/pkg/security/ebpf/c/include/structs/dentry_resolver.h
+++ b/pkg/security/ebpf/c/include/structs/dentry_resolver.h
@@ -33,6 +33,7 @@ struct dentry_resolver_input_t {
     struct path_key_t key;
     struct dentry *dentry;
     u64 discarder_type;
+    s64 sysretval;
     int callback;
     int ret;
     int iteration;


### PR DESCRIPTION
### What does this PR do?

fexit functions need the amount of arguments to get the return value, which is not possible in a common function deep in a tail call stack that can be called through multiple paths. This PR moves the syscall return value collection to the beginning of the dentry resolution and passes it through `syscall_cache_t`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
