### PR TITLE
Add debian 10 daily Azure image

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -67,7 +67,7 @@ kitchen_test_security_agent_x64:
         KITCHEN_OSVERS: "opensuse-15-3"
         KITCHEN_CWS_PLATFORM: [host]
       - KITCHEN_PLATFORM: "debian"
-        KITCHEN_OSVERS: "debian-10,debian-11"
+        KITCHEN_OSVERS: "debian-10-daily,debian-11"
         KITCHEN_CWS_PLATFORM: [host, docker]
       - KITCHEN_PLATFORM: "oracle"
         KITCHEN_OSVERS: "oracle-7-9"

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -33,7 +33,7 @@
             "x86_64": {
                 "debian-8": "urn,credativ:Debian:8:8.0.201901221",
                 "debian-9": "urn,credativ:Debian:9:9.20200722.0",
-                "debian-10": "urn,Debian:debian-10:10:0.20230601.1398",
+                "debian-10": "urn,Debian:debian-10-daily:10:0.20230727.1454",
                 "debian-11": "urn,Debian:debian-11:11:0.20230717.1444"
             }
         },

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -33,8 +33,8 @@
             "x86_64": {
                 "debian-8": "urn,credativ:Debian:8:8.0.201901221",
                 "debian-9": "urn,credativ:Debian:9:9.20200722.0",
-                "debian-10": "urn,Debian:debian-10:10:0.20230222.1299",
-                "debian-11": "urn,Debian:debian-11:11:0.20230501.1367"
+                "debian-10": "urn,Debian:debian-10:10:0.20230601.1398",
+                "debian-11": "urn,Debian:debian-11:11:0.20230717.1444"
             }
         },
         "ec2": {

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -33,8 +33,9 @@
             "x86_64": {
                 "debian-8": "urn,credativ:Debian:8:8.0.201901221",
                 "debian-9": "urn,credativ:Debian:9:9.20200722.0",
-                "debian-10": "urn,Debian:debian-10-daily:10:0.20230727.1454",
-                "debian-11": "urn,Debian:debian-11:11:0.20230717.1444"
+                "debian-10": "urn,Debian:debian-10:10:0.20230222.1299",
+                "debian-10-daily": "urn,Debian:debian-10-daily:10:0.20230727.1454",
+                "debian-11": "urn,Debian:debian-11:11:0.20230501.1367"
             }
         },
         "ec2": {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds a new Azure daily-built image for Debian 10 and changes the security-agent kitchen tests to use this new image.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The current debian-10 image is missing a gpg key that causes kernel header packages download to fail, which in turn, causes the security-agent functional tests to fail on Debian 10. Using a newer Debian 10 image fixes the issue.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

This is just a temporary solution to fix the security-agent tests, once the stable image is released we will switch from this daily image to the latest stable.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
