### PR TITLE
Fix `windows-lint-go` CI job

### DIFF
--- a/test/new-e2e/ndm/snmp/snmpTestEnv.go
+++ b/test/new-e2e/ndm/snmp/snmpTestEnv.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/utils/infra"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent/docker"
+	"github.com/DataDog/test-infra-definitions/components/datadog/agent/dockerparams"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2vm"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
@@ -93,10 +94,10 @@ func NewTestEnv() (*TestEnv, error) {
 		envVars := map[string]string{"DATA_DIR": dataPath, "CONFIG_DIR": configPath}
 		composeDependencies := []pulumi.Resource{createDataDirCommand, configCommand}
 		composeDependencies = append(composeDependencies, fileCommands...)
-		_, err = docker.NewAgentDockerInstaller(
-			vm.UnixVM,
-			docker.WithComposeContent(snmpCompose, envVars),
-			docker.WithPulumiResources(pulumi.DependsOn(composeDependencies)),
+		_, err = docker.NewDaemon(
+			ctx,
+			dockerparams.WithComposeContent(snmpCompose, envVars),
+			dockerparams.WithPulumiResources(pulumi.DependsOn(composeDependencies)),
 		)
 		return err
 	}, false)


### PR DESCRIPTION
### What does this PR do?

Fix the Windows lint CI job.

### Motivation

The job is currently failing with this error:
```
Linters for module C:\buildroot\datadog-agent\test\new-e2e failed (base flavor)
Linter failures:
level=error msg="[linters_context] typechecking error: : # github.com/DataDog/datadog-agent/test/new-e2e/ndm/snmp\nndm\\snmp\\snmpTestEnv.go:96:19: undefined: docker.NewAgentDockerInstaller\nndm\\snmp\\snmpTestEnv.go:98:11: undefined: docker.WithComposeContent\nndm\\snmp\\snmpTestEnv.go:99:11: undefined: docker.WithPulumiResources"
level=error msg="[linters_context] typechecking error: C:\\buildroot\\datadog-agent\\test\\new-e2e\\scenarios\\ndm\\main.go:12:2: could not import github.com/DataDog/datadog-agent/test/new-e2e/ndm/snmp (-: # github.com/DataDog/datadog-agent/test/new-e2e/ndm/snmp\nndm\\snmp\\snmpTestEnv.go:96:19: undefined: docker.NewAgentDockerInstaller\nndm\\snmp\\snmpTestEnv.go:98:11: undefined: docker.WithComposeContent\nndm\\snmp\\snmpTestEnv.go:99:11: undefined: docker.WithPulumiResources)"
```

### Additional Notes

The Windows lint CI job has been broken by #18286 because it bumped the version of `test-infra-definitions` and the new version brought a big refactoring.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
