### PR TITLE
[CWS] add functional test job for fentry

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -121,6 +121,9 @@ kitchen_test_security_agent_amazonlinux_x64:
       - KITCHEN_PLATFORM: "amazonlinux"
         KITCHEN_OSVERS: "amazonlinux2022-5-15,amazonlinux2023"
         KITCHEN_CWS_PLATFORM: [host, docker]
+      - KITCHEN_PLATFORM: "amazonlinux"
+        KITCHEN_OSVERS: "amazonlinux2-5-10"
+        KITCHEN_CWS_PLATFORM: [fentry]
 
 kitchen_stress_security_agent:
   extends:

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -130,7 +130,7 @@ kitchen_test_security_agent_amazonlinux_x64_fentry:
     matrix:
       - KITCHEN_PLATFORM: "amazonlinux"
         KITCHEN_OSVERS: "amazonlinux2-5-10"
-        KITCHEN_CWS_PLATFORM: [fentry]
+        KITCHEN_CWS_PLATFORM: [host-fentry, docker-fentry]
 
 kitchen_stress_security_agent:
   extends:

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -121,6 +121,13 @@ kitchen_test_security_agent_amazonlinux_x64:
       - KITCHEN_PLATFORM: "amazonlinux"
         KITCHEN_OSVERS: "amazonlinux2022-5-15,amazonlinux2023"
         KITCHEN_CWS_PLATFORM: [host, docker]
+
+kitchen_test_security_agent_amazonlinux_x64_fentry:
+  extends:
+    - kitchen_test_security_agent_amazonlinux_x64
+  allow_failure: true
+  parallel:
+    matrix:
       - KITCHEN_PLATFORM: "amazonlinux"
         KITCHEN_OSVERS: "amazonlinux2-5-10"
         KITCHEN_CWS_PLATFORM: [fentry]

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -129,7 +129,7 @@ kitchen_test_security_agent_amazonlinux_x64_fentry:
   parallel:
     matrix:
       - KITCHEN_PLATFORM: "amazonlinux"
-        KITCHEN_OSVERS: "amazonlinux2-5-10"
+        KITCHEN_OSVERS: "amazonlinux2023"
         KITCHEN_CWS_PLATFORM: [host-fentry, docker-fentry]
 
 kitchen_stress_security_agent:

--- a/pkg/security/ebpf/compile.go
+++ b/pkg/security/ebpf/compile.go
@@ -20,10 +20,12 @@ import (
 //go:generate $GOPATH/bin/integrity pkg/ebpf/bytecode/build/runtime/runtime-security.c pkg/ebpf/bytecode/runtime/runtime-security.go runtime
 //go:generate go run github.com/DataDog/datadog-agent/pkg/security/secl/model/bpf_maps_generator -runtime-path ../../ebpf/bytecode/build/runtime/runtime-security.c -output ../../security/secl/model/consts_map_names.go -pkg-name model
 
-func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper, useRingBuffer bool, client statsd.ClientInterface) (bytecode.AssetReader, error) {
+func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper, useFentry, useRingBuffer bool, client statsd.ClientInterface) (bytecode.AssetReader, error) {
 	var cflags []string
 
-	if useSyscallWrapper {
+	if useFentry {
+		cflags = append(cflags, "-DUSE_SYSCALL_WRAPPER=1", "-DUSE_FENTRY=1")
+	} else if useSyscallWrapper {
 		cflags = append(cflags, "-DUSE_SYSCALL_WRAPPER=1")
 	} else {
 		cflags = append(cflags, "-DUSE_SYSCALL_WRAPPER=0")

--- a/pkg/security/ebpf/compile.go
+++ b/pkg/security/ebpf/compile.go
@@ -24,8 +24,10 @@ func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper, useFen
 	var cflags []string
 
 	if useFentry {
-		cflags = append(cflags, "-DUSE_SYSCALL_WRAPPER=1", "-DUSE_FENTRY=1")
-	} else if useSyscallWrapper {
+		cflags = append(cflags, "-DUSE_FENTRY=1")
+	}
+
+	if useSyscallWrapper {
 		cflags = append(cflags, "-DUSE_SYSCALL_WRAPPER=1")
 	} else {
 		cflags = append(cflags, "-DUSE_SYSCALL_WRAPPER=0")

--- a/pkg/security/ebpf/compile_test.go
+++ b/pkg/security/ebpf/compile_test.go
@@ -23,7 +23,7 @@ func TestLoaderCompile(t *testing.T) {
 		require.NoError(t, err)
 		cfg, err := config.NewConfig()
 		require.NoError(t, err)
-		out, err := getRuntimeCompiledPrograms(cfg, false, false, nil)
+		out, err := getRuntimeCompiledPrograms(cfg, false, false, false, nil)
 		require.NoError(t, err)
 		_ = out.Close()
 	})

--- a/pkg/security/ebpf/compile_unsupported.go
+++ b/pkg/security/ebpf/compile_unsupported.go
@@ -15,6 +15,6 @@ import (
 	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
-func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper, useRingBuffer bool, client statsd.ClientInterface) (bytecode.AssetReader, error) {
+func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper, useFentry, useRingBuffer bool, client statsd.ClientInterface) (bytecode.AssetReader, error) {
 	return nil, fmt.Errorf("runtime compilation unsupported")
 }

--- a/pkg/security/ebpf/loader.go
+++ b/pkg/security/ebpf/loader.go
@@ -51,7 +51,7 @@ func (l *ProbeLoader) Load() (bytecode.AssetReader, bool, error) {
 	var err error
 	var runtimeCompiled bool
 	if l.config.RuntimeCompilationEnabled {
-		l.bytecodeReader, err = getRuntimeCompiledPrograms(l.config, l.useSyscallWrapper, l.useRingBuffer, l.statsdClient)
+		l.bytecodeReader, err = getRuntimeCompiledPrograms(l.config, l.useSyscallWrapper, l.useFentry, l.useRingBuffer, l.statsdClient)
 		if err != nil {
 			seclog.Warnf("error compiling runtime-security probe, falling back to pre-compiled: %s", err)
 		} else {

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/functional-tests.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/functional-tests.rb
@@ -165,7 +165,7 @@ if not ['redhat', 'suse', 'opensuseleap'].include?(node[:platform])
     end
   end
 
-  if node[:cws_platform] == "docker"
+  if ['docker', 'docker-fentry'].include?(node[:cws_platform])
     # Please see https://github.com/paulcacheux/cws-buildimages/blob/main/Dockerfile
     # for the definition of this base image.
     # If this successfully helps in reducing the amount of rate limits, this should be moved

--- a/test/kitchen/test/integration/security-agent-test/rspec_datadog/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec_datadog/security-agent-test_spec.rb
@@ -118,6 +118,13 @@ describe "security-agent" do
       }
       include_examples "passes", "host", env
     end
+  when "fentry"
+    context 'functional tests running directly on host (with fentry)' do
+      env = {
+        "DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_USE_FENTRY" => "true"
+      }
+      include_examples "passes", "host", env
+    end
   when "docker"
     context 'functional test running inside a container' do
       env = {}

--- a/test/kitchen/test/integration/security-agent-test/rspec_datadog/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec_datadog/security-agent-test_spec.rb
@@ -118,7 +118,7 @@ describe "security-agent" do
       }
       include_examples "passes", "host", env
     end
-  when "fentry"
+  when "host-fentry"
     context 'functional tests running directly on host (with fentry)' do
       env = {
         "DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_USE_FENTRY" => "true"
@@ -128,6 +128,13 @@ describe "security-agent" do
   when "docker"
     context 'functional test running inside a container' do
       env = {}
+      include_examples "passes", "docker", env
+    end
+  when "docker-fentry"
+    context 'functional tests running directly on docker (with fentry)' do
+      env = {
+        "DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_USE_FENTRY" => "true"
+      }
       include_examples "passes", "docker", env
     end
   when "ad"


### PR DESCRIPTION
### What does this PR do?

This PR adds a new CWS functional test responsible for running a set of tests running on fentry probes. This PR also fixes the runtime compilation of the fentry version of the CWS probes.

This test is currently extremely slow, still investigating why. The test is also allowed to fail for now while we continue testing this in more depth.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
