### PR TITLE
Update default port in Fake intake README.md

### DIFF
--- a/test/fakeintake/docs/README.md
+++ b/test/fakeintake/docs/README.md
@@ -26,7 +26,7 @@ docker run -i datadog/fakeintake
 
 ```yaml
 # datadog.yaml
-DD_DD_URL: "http://localhost:8080"
+DD_DD_URL: "http://localhost:80"
 ```
 
 ### Locally
@@ -41,7 +41,7 @@ go run $DATADOG_ROOT/datadog-agent/test/fakeintake/app/main.go
 
 ```yaml
 # datadog.yaml
-DD_DD_URL: "http://localhost:8080"
+DD_DD_URL: "http://localhost:80"
 ```
 
 ## How to build
@@ -98,9 +98,9 @@ Example:
 curl ${SERVICE_IP}/fakeintake/payloads/?endpoint=/api/V2/series
 ```
 
-#### Juniper Notebook
+#### Jupyter Notebook
 
-Play with fakeintake in a Juniper Notebook
+Play with fakeintake in a Jupyter Notebook
 
 ```python
 # POST payloads
@@ -109,7 +109,7 @@ import requests
 import json
 
 data = "totoro|25|owner:kiki"
-response = requests.post("http://localhost:8080/api/v2/series", data)
+response = requests.post("http://localhost:80/api/v2/series", data)
 
 json_content = response.content.decode('utf8')
 
@@ -120,7 +120,7 @@ import base64
 import requests
 import json
 
-response = requests.get("http://localhost:8080/fakeintake/payloads/?endpoint=/api/v2/series")
+response = requests.get("http://localhost:80/fakeintake/payloads/?endpoint=/api/v2/series")
 
 json_content = response.content.decode('utf8')
 


### PR DESCRIPTION

### What does this PR do?

Change the default port of the fake intake in the README


### Motivation

Default port used by the container is 80.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
