### PR TITLE
Backport: fix security-agent.yaml config file inclusion in main Agent flare #18463

### DIFF
--- a/comp/core/flare/providers.go
+++ b/comp/core/flare/providers.go
@@ -86,7 +86,7 @@ func (f *flare) collectConfigFiles(fb flarehelpers.FlareBuilder) error {
 		fb.CopyFileTo(filepath.Join(confDir, "system-probe.yaml"), filepath.Join("etc", "system-probe.yaml"))
 
 		// use best effort to include security-agent.yaml to the flare
-		fb.CopyFileTo(filepath.Join(confDir, "security-agent.yaml"), filepath.Join("etc", "system-probe.yaml"))
+		fb.CopyFileTo(filepath.Join(confDir, "security-agent.yaml"), filepath.Join("etc", "security-agent.yaml"))
 	}
 	return nil
 }

--- a/releasenotes/notes/fix-security-agent-yaml-inclusion-in-flare-c8cf85a701a44433.yaml
+++ b/releasenotes/notes/fix-security-agent-yaml-inclusion-in-flare-c8cf85a701a44433.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes the inclusion of the ``security-agent.yaml`` file in the flare.


### PR DESCRIPTION
### What does this PR do?

Backport of #18463. This PR fixes a wrong file inclusion when creating the flare

### Motivation

One file was missing from the flare and the content of `system-probe.yaml` in flare was actually the content of the host `security-agent.yaml` file.

This was already fixed in https://github.com/DataDog/datadog-agent/pull/16718 but the code is  duplicated ([collectConfigFiles](https://github.com/DataDog/datadog-agent/blob/ee6f1a9b05c40fa4d197d333994f400678c18fb9/comp/core/flare/providers.go#L55-L92) and [getConfigFiles](https://github.com/DataDog/datadog-agent/blob/ee6f1a9b05c40fa4d197d333994f400678c18fb9/pkg/flare/archive.go#L230-L261)) so we need to fix it here also.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. In `/etc/datadog-agent/` (or platform equivalent) create `security-agent.yaml` and `system-proble.yaml` with a dummy yaml content.
```
# security-agent.yaml
file: "this is security-agent.yaml"
``` 

```
# system-probe.yaml
file: "this is system-probe.yaml"
```

2. Create a flare (with the 'main' agent): `sudo datadog-agent flare`
3. Verify that `<flare-folder>/etc/security-agent.yaml` and  `<flare-folder>/etc/system-probe.yaml` exists and have the right content

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
