### PR TITLE
pkg/trace/api: reduce flakiness of the UDS test

### DIFF
--- a/pkg/trace/api/api_nix_test.go
+++ b/pkg/trace/api/api_nix_test.go
@@ -10,6 +10,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"testing"
@@ -39,14 +40,18 @@ func TestUDS(t *testing.T) {
 	}
 
 	t.Run("off", func(t *testing.T) {
+		// running the tests on different ports to prevent
+		// flaky panics related to the port being already taken
+		port := 8126
 		conf := config.New()
 		conf.Endpoints[0].APIKey = "apikey_2"
+		conf.ReceiverPort = port
 
 		r := newTestReceiverFromConfig(conf)
 		r.Start()
 		defer r.Stop()
 
-		resp, err := client.Post("http://localhost:8126/v0.4/traces", "application/msgpack", bytes.NewReader(payload))
+		resp, err := client.Post(fmt.Sprintf("http://localhost:%v/v0.4/traces", port), "application/msgpack", bytes.NewReader(payload))
 		if err == nil {
 			resp.Body.Close()
 			t.Fatalf("expected to fail, got response %#v", resp)
@@ -54,15 +59,19 @@ func TestUDS(t *testing.T) {
 	})
 
 	t.Run("on", func(t *testing.T) {
+		// running the tests on different ports to prevent
+		// flaky panics related to the port being already taken
+		port := 8125
 		conf := config.New()
 		conf.Endpoints[0].APIKey = "apikey_2"
 		conf.ReceiverSocket = sockPath
+		conf.ReceiverPort = port
 
 		r := newTestReceiverFromConfig(conf)
 		r.Start()
 		defer r.Stop()
 
-		resp, err := client.Post("http://localhost:8126/v0.4/traces", "application/msgpack", bytes.NewReader(payload))
+		resp, err := client.Post(fmt.Sprintf("http://localhost:%v/v0.4/traces", port), "application/msgpack", bytes.NewReader(payload))
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR runs the subtests on different ports to prevent flaky panics related to the port being already taken 
		
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This test has been failing lately, [example pn of the jobs](https://github.com/DataDog/datadog-agent-macos-build/actions/runs/5336468653/job/14444553942). 
Previously, the test had two subtests both of which creating a NewHTTPReceiver on the same port. Sometimes, the test would panic due to port being already taken and not yet released since the subtests run in parallel. 

This PR runs the subtests on different ports, rather then running it consequentially, as it is cleaner and faster
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
