### PR TITLE
Add duration to the plan payload

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -358,12 +358,15 @@ type FQTPayload struct {
 }
 
 type OraclePlan struct {
-	PlanHashValue uint64 `json:"plan_hash_value,omitempty"`
-	SQLID         string `json:"sql_id,omitempty"`
-	Timestamp     string `json:"created,omitempty"`
-	OptimizerMode string `json:"optimizer_mode,omitempty"`
-	Other         string `json:"other"`
-	PDBName       string `json:"pdb_name"`
+	PlanHashValue          uint64  `json:"plan_hash_value,omitempty"`
+	SQLID                  string  `json:"sql_id,omitempty"`
+	Timestamp              string  `json:"created,omitempty"`
+	OptimizerMode          string  `json:"optimizer_mode,omitempty"`
+	Other                  string  `json:"other"`
+	PDBName                string  `json:"pdb_name"`
+	Executions             float64 `json:"executions,omitempty"`
+	ElapsedTime            float64 `json:"elapsed_time,omitempty"`
+	ForceMatchingSignature string  `json:"force_matching_signature,omitempty"`
 }
 
 type PlanStatementMetadata struct {
@@ -858,7 +861,10 @@ func (c *Check) StatementMetrics() (int, error) {
 								}
 
 								oraclePlan.PDBName = statementMetricRow.PDBName
-								oraclePlan.SQLID = stepRow.SQLID
+								oraclePlan.SQLID = statementMetricRow.SQLID
+								oraclePlan.ForceMatchingSignature = statementMetricRow.ForceMatchingSignature
+								oraclePlan.Executions = statementMetricRow.Executions
+								oraclePlan.ElapsedTime = statementMetricRow.ElapsedTime
 
 								planStepsPayload = append(planStepsPayload, stepPayload)
 							}

--- a/releasenotes/notes/oracle-duration-8e59705eed588637.yaml
+++ b/releasenotes/notes/oracle-duration-8e59705eed588637.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add duration to the plan payload.


### PR DESCRIPTION
### What does this PR do?

The PR primarily adds the field `elapsed_time` to the plan payload. This field will be mapped to the execution plan `DURATION` in the frontend. Secondly, we are adding `executions` to distinguish whether a single or multiple executions contributed to the `elapsed_time`. Lastly, we are correcting the `SQLID` field in the payload, which wasn't initialised properly.

https://datadoghq.atlassian.net/browse/DBM-2668

https://datadoghq.atlassian.net/browse/DBM-2652


### Describe how to test/QA your changes

Check if the new fields appear are displayed in the payload in the frontend. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
