### PR TITLE
[Gohai][ASC-662] unify API implementations and introduce helper functions

### DIFF
--- a/pkg/gohai/cpu/cpu_test.go
+++ b/pkg/gohai/cpu/cpu_test.go
@@ -5,13 +5,10 @@
 package cpu
 
 import (
-	"bytes"
-	"encoding/json"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/gohai/utils"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCollectCPU(t *testing.T) {
@@ -43,11 +40,6 @@ func TestCollectCPU(t *testing.T) {
 
 func TestCPUAsJSON(t *testing.T) {
 	cpuInfo := CollectInfo()
-	marshallable, _, err := cpuInfo.AsJSON()
-	require.NoError(t, err)
-
-	marshalled, err := json.Marshal(marshallable)
-	require.NoError(t, err)
 
 	// Any change to this datastructure should be notified to the backend
 	// team to ensure compatibility.
@@ -68,16 +60,8 @@ func TestCPUAsJSON(t *testing.T) {
 		CPUPkgs              string `json:"cpu_pkgs"`
 	}
 
-	decoder := json.NewDecoder(bytes.NewReader(marshalled))
-	// do not ignore unknown fields
-	decoder.DisallowUnknownFields()
-
 	var decodedCPU CPU
-	err = decoder.Decode(&decodedCPU)
-	require.NoError(t, err)
-
-	// check that we read the full json
-	require.False(t, decoder.More())
+	utils.RequireMarshallJSON(t, cpuInfo, &decodedCPU)
 
 	utils.AssertDecodedValue(t, decodedCPU.CPUCores, &cpuInfo.CPUCores, "")
 	utils.AssertDecodedValue(t, decodedCPU.CPULogicalProcessors, &cpuInfo.CPULogicalProcessors, "")

--- a/pkg/gohai/gohai.go
+++ b/pkg/gohai/gohai.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/gohai/network"
 	"github.com/DataDog/datadog-agent/pkg/gohai/platform"
 	"github.com/DataDog/datadog-agent/pkg/gohai/processes"
+	"github.com/DataDog/datadog-agent/pkg/gohai/utils"
 )
 
 // Collector represents a group of information which can be collected
@@ -36,14 +37,9 @@ type Collector interface {
 
 // CollectorV2 is a compatibility layer between the old 'Collector' interface and
 // the way the new API is defined
-type CollectorV2[T Jsonable] struct {
+type CollectorV2[T utils.Jsonable] struct {
 	name    string
 	collect func() T
-}
-
-// Jsonable represents a type which can be converted to a mashallable object
-type Jsonable interface {
-	AsJSON() (interface{}, []string, error)
 }
 
 // Name returns the name of the CollectorV2

--- a/pkg/gohai/memory/memory_test.go
+++ b/pkg/gohai/memory/memory_test.go
@@ -4,36 +4,29 @@
 package memory
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/gohai/utils"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCollectMemory(t *testing.T) {
 	memInfo := CollectInfo()
 
-	_, err := memInfo.TotalBytes.Value()
-	if err != nil {
-		require.ErrorIs(t, err, utils.ErrNotCollectable)
+	errorGetters := map[string]error{
+		"TotalBytes":  memInfo.TotalBytes.Error(),
+		"SwapTotalKb": memInfo.SwapTotalKb.Error(),
 	}
 
-	_, err = memInfo.SwapTotalKb.Value()
-	if err != nil {
-		require.ErrorIs(t, err, utils.ErrNotCollectable)
+	for fieldname, err := range errorGetters {
+		if err != nil {
+			assert.ErrorIsf(t, err, utils.ErrNotCollectable, "memory: field %s could not be collected", fieldname)
+		}
 	}
 }
 
 func TestMemoryAsJSON(t *testing.T) {
 	memInfo := CollectInfo()
-	marshallable, _, err := memInfo.AsJSON()
-	require.NoError(t, err)
-
-	marshalled, err := json.Marshal(marshallable)
-	require.NoError(t, err)
 
 	// Any change to this datastructure should be notified to the backend
 	// team to ensure compatibility.
@@ -42,27 +35,9 @@ func TestMemoryAsJSON(t *testing.T) {
 		SwapTotal string `json:"swap_total"`
 	}
 
-	decoder := json.NewDecoder(bytes.NewReader(marshalled))
-	// do not ignore unknown fields
-	decoder.DisallowUnknownFields()
-
 	var decodedMem Memory
-	err = decoder.Decode(&decodedMem)
-	require.NoError(t, err)
+	utils.RequireMarshallJSON(t, memInfo, &decodedMem)
 
-	// check that we read the full json
-	require.False(t, decoder.More())
-
-	if totalBytes, err := memInfo.TotalBytes.Value(); err == nil {
-		require.Equal(t, fmt.Sprintf("%d", totalBytes), decodedMem.Total)
-	} else {
-		require.Empty(t, decodedMem.Total)
-	}
-
-	if swapTotalKb, err := memInfo.SwapTotalKb.Value(); err == nil {
-		// the swap total field is a number with unit kb
-		require.Equal(t, fmt.Sprintf("%dkb", swapTotalKb), decodedMem.SwapTotal)
-	} else {
-		require.Empty(t, decodedMem.SwapTotal)
-	}
+	utils.AssertDecodedValue(t, decodedMem.Total, &memInfo.TotalBytes, "")
+	utils.AssertDecodedValue(t, decodedMem.SwapTotal, &memInfo.SwapTotalKb, "kb")
 }

--- a/pkg/gohai/platform/platform_test.go
+++ b/pkg/gohai/platform/platform_test.go
@@ -5,13 +5,10 @@
 package platform
 
 import (
-	"bytes"
-	"encoding/json"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/gohai/utils"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCollectPlatform(t *testing.T) {
@@ -41,11 +38,6 @@ func TestCollectPlatform(t *testing.T) {
 
 func TestPlatformAsJSON(t *testing.T) {
 	platformInfo := CollectInfo()
-	marshallable, _, err := platformInfo.AsJSON()
-	require.NoError(t, err)
-
-	marshalled, err := json.Marshal(marshallable)
-	require.NoError(t, err)
 
 	// Any change to this datastructure should be notified to the backend
 	// team to ensure compatibility.
@@ -64,16 +56,8 @@ func TestPlatformAsJSON(t *testing.T) {
 		HardwarePlatform string `json:"hardware_platform"`
 	}
 
-	decoder := json.NewDecoder(bytes.NewReader(marshalled))
-	// do not ignore unknown fields
-	decoder.DisallowUnknownFields()
-
 	var decodedPlatform Platform
-	err = decoder.Decode(&decodedPlatform)
-	require.NoError(t, err)
-
-	// check that we read the full json
-	require.False(t, decoder.More())
+	utils.RequireMarshallJSON(t, platformInfo, &decodedPlatform)
 
 	utils.AssertDecodedValue(t, decodedPlatform.GoVersion, &platformInfo.GoVersion, "")
 	utils.AssertDecodedValue(t, decodedPlatform.GoOS, &platformInfo.GoOS, "")

--- a/pkg/gohai/utils/common.go
+++ b/pkg/gohai/utils/common.go
@@ -54,6 +54,11 @@ func getValueMethod(fieldTy reflect.StructField) (reflect.Method, bool) {
 	return valueMethod, true
 }
 
+// Jsonable represents a type which can be converted to a mashallable object
+type Jsonable interface {
+	AsJSON() (interface{}, []string, error)
+}
+
 // AsJSON takes a structure and returns a marshal-able object representing the fields of the struct,
 // the lists of errors for fields for which the collection failed, and an error if it failed.
 //

--- a/pkg/gohai/utils/test_helpers.go
+++ b/pkg/gohai/utils/test_helpers.go
@@ -33,8 +33,8 @@ func AssertDecodedValue[T any](t *testing.T, decoded string, value *Value[T], un
 }
 
 // RequireMarshallJSON checks that
-// - the given info struct can generate some object using AsJSON function
-// - that object can be marshalled into a json
+// - calling the AsJSON function succeeds
+// - the object returned generates a json without error
 // - the JSON can be unmarshalled into the given decoded struct
 // - the JSON doesn't contain unexpected fields
 func RequireMarshallJSON[T Jsonable, U any](t *testing.T, info T, decoded *U) {

--- a/pkg/gohai/utils/value.go
+++ b/pkg/gohai/utils/value.go
@@ -49,8 +49,7 @@ func NewErrorValue[T any](err error) Value[T] {
 
 // Value returns the value and the error stored in the Value[T].
 //
-// If the Value[T] represents an error, it returns the default value of type T
-// and a non-nil error, otherwise the stored value of type T and a nil error.
+// If it contains an error, the returned value is unspecified.
 func (value *Value[T]) Value() (T, error) {
 	if value.initialized {
 		return value.value, value.err
@@ -69,6 +68,11 @@ func (value *Value[T]) Error() error {
 // ValueOrDefault returns the value stored in the Value[T], or the default value of the type
 // in case of error.
 func (value *Value[T]) ValueOrDefault() T {
-	val, _ := value.Value()
-	return val
+	val, err := value.Value()
+	if err == nil {
+		return val
+	} else {
+		var def T
+		return def
+	}
 }

--- a/pkg/gohai/utils/value.go
+++ b/pkg/gohai/utils/value.go
@@ -65,3 +65,10 @@ func (value *Value[T]) Error() error {
 	_, err := value.Value()
 	return err
 }
+
+// ValueOrDefault returns the value stored in the Value[T], or the default value of the type
+// in case of error.
+func (value *Value[T]) ValueOrDefault() T {
+	val, _ := value.Value()
+	return val
+}

--- a/pkg/gohai/utils/value_test.go
+++ b/pkg/gohai/utils/value_test.go
@@ -28,9 +28,8 @@ func TestNewValue(t *testing.T) {
 func TestNewErrorValue(t *testing.T) {
 	myErr := errors.New("this is an error")
 	value := NewErrorValue[int](myErr)
-	result, err := value.Value()
+	_, err := value.Value()
 	require.ErrorIs(t, err, myErr)
-	require.Equal(t, 0, result)
 }
 
 func TestNewValueFrom(t *testing.T) {
@@ -52,4 +51,13 @@ func TestError(t *testing.T) {
 	myerr := fmt.Errorf("again an error !?")
 	errorValue := NewErrorValue[int](myerr)
 	require.ErrorIs(t, myerr, errorValue.Error())
+}
+
+func TestValueOrDefault(t *testing.T) {
+	value := NewValue(1)
+	val := value.ValueOrDefault()
+	require.Equal(t, 1, val)
+
+	value = NewErrorValue[int](fmt.Errorf("still an error"))
+	require.Empty(t, value.ValueOrDefault())
 }

--- a/pkg/metadata/host/host_windows.go
+++ b/pkg/metadata/host/host_windows.go
@@ -90,9 +90,9 @@ func getSystemStats() *systemStats {
 	} else {
 		cpuInfo := cpu.CollectInfo()
 		hostInfo := getHostInfo()
-		cores, _ := cpuInfo.CPUCores.Value()
+		cores := cpuInfo.CPUCores.ValueOrDefault()
 		c32 := int32(cores)
-		modelName, _ := cpuInfo.ModelName.Value()
+		modelName := cpuInfo.ModelName.ValueOrDefault()
 
 		stats = &systemStats{
 			Machine:   runtime.GOARCH,

--- a/pkg/metadata/inventories/host_metadata.go
+++ b/pkg/metadata/inventories/host_metadata.go
@@ -97,15 +97,15 @@ func getHostMetadata() *HostMetadata {
 	} else {
 		logWarnings(warnings)
 
-		metadata.CPUCores, _ = cpuInfo.CPUCores.Value()
-		metadata.CPULogicalProcessors, _ = cpuInfo.CPULogicalProcessors.Value()
-		metadata.CPUVendor, _ = cpuInfo.VendorID.Value()
-		metadata.CPUModel, _ = cpuInfo.ModelName.Value()
-		metadata.CPUModelID, _ = cpuInfo.Model.Value()
-		metadata.CPUFamily, _ = cpuInfo.Family.Value()
-		metadata.CPUStepping, _ = cpuInfo.Stepping.Value()
-		metadata.CPUFrequency, _ = cpuInfo.Mhz.Value()
-		cpuCacheSize, _ := cpuInfo.CacheSizeKB.Value()
+		metadata.CPUCores = cpuInfo.CPUCores.ValueOrDefault()
+		metadata.CPULogicalProcessors = cpuInfo.CPULogicalProcessors.ValueOrDefault()
+		metadata.CPUVendor = cpuInfo.VendorID.ValueOrDefault()
+		metadata.CPUModel = cpuInfo.ModelName.ValueOrDefault()
+		metadata.CPUModelID = cpuInfo.Model.ValueOrDefault()
+		metadata.CPUFamily = cpuInfo.Family.ValueOrDefault()
+		metadata.CPUStepping = cpuInfo.Stepping.ValueOrDefault()
+		metadata.CPUFrequency = cpuInfo.Mhz.ValueOrDefault()
+		cpuCacheSize := cpuInfo.CacheSizeKB.ValueOrDefault()
 		metadata.CPUCacheSize = cpuCacheSize * 1024
 	}
 
@@ -130,10 +130,9 @@ func getHostMetadata() *HostMetadata {
 	} else {
 		logWarnings(warnings)
 
-		// Value() returns the default value of the type in case of error so we can use it directly
-		memoryTotalKb, _ := memoryInfo.TotalBytes.Value()
+		memoryTotalKb := memoryInfo.TotalBytes.ValueOrDefault()
 		metadata.MemoryTotalKb = memoryTotalKb / 1024
-		metadata.MemorySwapTotalKb, _ = memoryInfo.SwapTotalKb.Value()
+		metadata.MemorySwapTotalKb = memoryInfo.SwapTotalKb.ValueOrDefault()
 	}
 
 	networkInfo, warnings, err := networkGet()

--- a/pkg/process/checks/system_info_windows.go
+++ b/pkg/process/checks/system_info_windows.go
@@ -34,7 +34,7 @@ func CollectSystemInfo() (*model.SystemInfo, error) {
 	// logicalcount will be the total number of logical processors on the system
 	// i.e. physCount * coreCount * 1 if not HT CPU
 	//      physCount * coreCount * 2 if an HT CPU.
-	logicalCount, _ := cpuInfo.CPULogicalProcessors.Value()
+	logicalCount := cpuInfo.CPULogicalProcessors.ValueOrDefault()
 
 	// shouldn't be possible, as `cpuInfo.CPUPkgs.Value()` should return an error in this case
 	// but double check before risking a divide by zero
@@ -42,12 +42,12 @@ func CollectSystemInfo() (*model.SystemInfo, error) {
 		return nil, fmt.Errorf("Returned zero physical processors")
 	}
 	logicalCountPerPhys := logicalCount / physCount
-	clockSpeed, _ := cpuInfo.Mhz.Value()
-	l2Cache, _ := cpuInfo.CacheSizeL2Bytes.Value()
+	clockSpeed := cpuInfo.Mhz.ValueOrDefault()
+	l2Cache := cpuInfo.CacheSizeL2Bytes.ValueOrDefault()
 	cpus := make([]*model.CPUInfo, 0)
-	vendor, _ := cpuInfo.VendorID.Value()
-	family, _ := cpuInfo.Family.Value()
-	modelName, _ := cpuInfo.Model.Value()
+	vendor := cpuInfo.VendorID.ValueOrDefault()
+	family := cpuInfo.Family.ValueOrDefault()
+	modelName := cpuInfo.Model.ValueOrDefault()
 	for i := uint64(0); i < physCount; i++ {
 		cpus = append(cpus, &model.CPUInfo{
 			Number:     int32(i),
@@ -62,10 +62,10 @@ func CollectSystemInfo() (*model.SystemInfo, error) {
 		})
 	}
 
-	kernelName, _ := hi.KernelName.Value()
-	osName, _ := hi.OS.Value()
-	platformFamily, _ := hi.Family.Value()
-	kernelRelease, _ := hi.KernelRelease.Value()
+	kernelName := hi.KernelName.ValueOrDefault()
+	osName := hi.OS.ValueOrDefault()
+	platformFamily := hi.Family.ValueOrDefault()
+	kernelRelease := hi.KernelRelease.ValueOrDefault()
 	m := &model.SystemInfo{
 		Uuid: "",
 		Os: &model.OSInfo{


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Unify the implementation of the `memory` package with the ones of the `cpu` and `platform` packages (ie. using the same helper functions, in order to have similar implementations).
Introduce a testing helper function to factor common testing code from each module.
Add `ValueOrDefault` function to explicitly get the default value in case of error, instead of using `Value` and ignoring the returned error.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Have a cleaner and more uniform implementation of the new API in Gohai.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Although the number of changes is small, reviewing commit by commit should help.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
There should be no functional difference, this is only cosmetic.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
