### PR TITLE
[CWS] onboard time syscall hooks to fentry

### DIFF
--- a/pkg/security/ebpf/c/include/constants/fentry_macro.h
+++ b/pkg/security/ebpf/c/include/constants/fentry_macro.h
@@ -22,6 +22,7 @@ typedef unsigned long long ctx_t;
 #define HOOK_SYSCALL_COMPAT_TIME_ENTRY0(name, ...) SYSCALL_TIME_FENTRY0(name, __VA_ARGS__)
 #define HOOK_SYSCALL_EXIT(name) SYSCALL_FEXIT(name)
 #define HOOK_SYSCALL_COMPAT_EXIT(name) SYSCALL_FEXIT(name)
+#define HOOK_SYSCALL_COMPAT_TIME_EXIT(name) SYSCALL_TIME_FEXIT(name)
 #define TAIL_CALL_TARGET(_name) SEC("fentry/start_kernel") // `start_kernel` is only used at boot time, the hook should never be hit
 
 #define CTX_PARM1(ctx) (u64)(ctx[0])
@@ -55,6 +56,7 @@ typedef struct pt_regs ctx_t;
 #define HOOK_SYSCALL_COMPAT_TIME_ENTRY0(name, ...) SYSCALL_COMPAT_TIME_KPROBE0(name, __VA_ARGS__)
 #define HOOK_SYSCALL_EXIT(name) SYSCALL_KRETPROBE(name)
 #define HOOK_SYSCALL_COMPAT_EXIT(name) SYSCALL_COMPAT_KRETPROBE(name)
+#define HOOK_SYSCALL_COMPAT_TIME_EXIT(name) SYSCALL_COMPAT_TIME_KRETPROBE(name)
 #define TAIL_CALL_TARGET(name) SEC("kprobe/" name)
 
 #define CTX_PARM1(ctx) PT_REGS_PARM1(ctx)

--- a/pkg/security/ebpf/c/include/constants/fentry_macro.h
+++ b/pkg/security/ebpf/c/include/constants/fentry_macro.h
@@ -19,6 +19,7 @@ typedef unsigned long long ctx_t;
 #define HOOK_SYSCALL_COMPAT_ENTRY2(name, ...) SYSCALL_FENTRY2(name, __VA_ARGS__)
 #define HOOK_SYSCALL_COMPAT_ENTRY3(name, ...) SYSCALL_FENTRY3(name, __VA_ARGS__)
 #define HOOK_SYSCALL_COMPAT_ENTRY4(name, ...) SYSCALL_FENTRY4(name, __VA_ARGS__)
+#define HOOK_SYSCALL_COMPAT_TIME_ENTRY0(name, ...) SYSCALL_TIME_FENTRY0(name, __VA_ARGS__)
 #define HOOK_SYSCALL_EXIT(name) SYSCALL_FEXIT(name)
 #define HOOK_SYSCALL_COMPAT_EXIT(name) SYSCALL_FEXIT(name)
 #define TAIL_CALL_TARGET(_name) SEC("fentry/start_kernel") // `start_kernel` is only used at boot time, the hook should never be hit
@@ -51,6 +52,7 @@ typedef struct pt_regs ctx_t;
 #define HOOK_SYSCALL_COMPAT_ENTRY2(name, ...) SYSCALL_COMPAT_KPROBE2(name, __VA_ARGS__)
 #define HOOK_SYSCALL_COMPAT_ENTRY3(name, ...) SYSCALL_COMPAT_KPROBE3(name, __VA_ARGS__)
 #define HOOK_SYSCALL_COMPAT_ENTRY4(name, ...) SYSCALL_COMPAT_KPROBE4(name, __VA_ARGS__)
+#define HOOK_SYSCALL_COMPAT_TIME_ENTRY0(name, ...) SYSCALL_COMPAT_TIME_KPROBE0(name, __VA_ARGS__)
 #define HOOK_SYSCALL_EXIT(name) SYSCALL_KRETPROBE(name)
 #define HOOK_SYSCALL_COMPAT_EXIT(name) SYSCALL_COMPAT_KRETPROBE(name)
 #define TAIL_CALL_TARGET(name) SEC("kprobe/" name)

--- a/pkg/security/ebpf/c/include/constants/syscall_macro.h
+++ b/pkg/security/ebpf/c/include/constants/syscall_macro.h
@@ -200,6 +200,8 @@
 
 #define SYSCALL_TIME_FENTRY0(name, ...) SYSCALL_TIME_HOOKx(0,fentry,FENTRY,_##name,__VA_ARGS__)
 
+#define SYSCALL_TIME_FEXIT(name) SYSCALL_TIME_HOOKx(0,fexit,FEXIT,_##name,__VA_ARGS__)
+
 #define SYSCALL_COMPAT_TIME_KRETPROBE(name, ...) SYSCALL_COMPAT_TIME_HOOKx(0,kretprobe,KRETPROBE,_##name)
 
 #endif

--- a/pkg/security/ebpf/c/include/constants/syscall_macro.h
+++ b/pkg/security/ebpf/c/include/constants/syscall_macro.h
@@ -123,6 +123,12 @@
     SYSCALL_ABI_HOOKx(x,32,type,TYPE,compat_,name,,__VA_ARGS__) \
     SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,,__VA_ARGS__) \
     SYSCALL_HOOK_COMMON(x,type,TYPE,name,__VA_ARGS__)
+  #define SYSCALL_TIME_HOOKx(x,type,TYPE,name,...) \
+    SYSCALL_ABI_HOOKx(x,32,type,TYPE,,name,,__VA_ARGS__) \
+    SYSCALL_ABI_HOOKx(x,32,type,TYPE,,name,_time32,__VA_ARGS__) \
+    SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,,__VA_ARGS__) \
+    SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,_time32,__VA_ARGS__) \
+    SYSCALL_HOOK_COMMON(x,type,TYPE,name,__VA_ARGS__)
   #define SYSCALL_COMPAT_TIME_HOOKx(x,type,TYPE,name,...) \
     SYSCALL_ABI_HOOKx(x,32,type,TYPE,compat_,name,,__VA_ARGS__) \
     SYSCALL_ABI_HOOKx(x,32,type,TYPE,,name,_time32,__VA_ARGS__) \
@@ -142,6 +148,10 @@
     SYSCALL_HOOK_COMMON(x,type,TYPE,name,__VA_ARGS__)
   #define SYSCALL_COMPAT_HOOKx(x,type,TYPE,name,...) \
     SYSCALL_ABI_HOOKx(x,64,type,TYPE,compat_,name,,__VA_ARGS__) \
+    SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,,__VA_ARGS__) \
+    SYSCALL_HOOK_COMMON(x,type,TYPE,name,__VA_ARGS__)
+  #define SYSCALL_TIME_HOOKx(x,type,TYPE,name,...) \
+    SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,,__VA_ARGS__) \
     SYSCALL_ABI_HOOKx(x,64,type,TYPE,,name,,__VA_ARGS__) \
     SYSCALL_HOOK_COMMON(x,type,TYPE,name,__VA_ARGS__)
   #define SYSCALL_COMPAT_TIME_HOOKx(x,type,TYPE,name,...) \
@@ -187,6 +197,8 @@
 #define SYSCALL_COMPAT_TIME_KPROBE4(name, ...) SYSCALL_COMPAT_TIME_HOOKx(4,kprobe,KPROBE,_##name,__VA_ARGS__)
 #define SYSCALL_COMPAT_TIME_KPROBE5(name, ...) SYSCALL_COMPAT_TIME_HOOKx(5,kprobe,KPROBE,_##name,__VA_ARGS__)
 #define SYSCALL_COMPAT_TIME_KPROBE6(name, ...) SYSCALL_COMPAT_TIME_HOOKx(6,kprobe,KPROBE,_##name,__VA_ARGS__)
+
+#define SYSCALL_TIME_FENTRY0(name, ...) SYSCALL_TIME_HOOKx(0,fentry,FENTRY,_##name,__VA_ARGS__)
 
 #define SYSCALL_COMPAT_TIME_KRETPROBE(name, ...) SYSCALL_COMPAT_TIME_HOOKx(0,kretprobe,KRETPROBE,_##name)
 

--- a/pkg/security/ebpf/c/include/hooks/utimes.h
+++ b/pkg/security/ebpf/c/include/hooks/utimes.h
@@ -31,15 +31,15 @@ SYSCALL_KPROBE0(utime32) {
     return trace__sys_utimes();
 }
 
-SYSCALL_COMPAT_TIME_KPROBE0(utimes) {
+HOOK_SYSCALL_COMPAT_TIME_ENTRY0(utimes) {
     return trace__sys_utimes();
 }
 
-SYSCALL_COMPAT_TIME_KPROBE0(utimensat) {
+HOOK_SYSCALL_COMPAT_TIME_ENTRY0(utimensat) {
     return trace__sys_utimes();
 }
 
-SYSCALL_COMPAT_TIME_KPROBE0(futimesat) {
+HOOK_SYSCALL_COMPAT_TIME_ENTRY0(futimesat) {
     return trace__sys_utimes();
 }
 

--- a/pkg/security/ebpf/c/include/hooks/utimes.h
+++ b/pkg/security/ebpf/c/include/hooks/utimes.h
@@ -23,11 +23,11 @@ int __attribute__((always_inline)) trace__sys_utimes() {
 
 // On old kernels, we have sys_utime and compat_sys_utime.
 // On new kernels, we have _x64_sys_utime32, __ia32_sys_utime32, __x64_sys_utime, __ia32_sys_utime
-SYSCALL_COMPAT_KPROBE0(utime) {
+HOOK_SYSCALL_COMPAT_ENTRY0(utime) {
     return trace__sys_utimes();
 }
 
-SYSCALL_KPROBE0(utime32) {
+HOOK_SYSCALL_ENTRY0(utime32) {
     return trace__sys_utimes();
 }
 

--- a/pkg/security/ebpf/c/include/hooks/utimes.h
+++ b/pkg/security/ebpf/c/include/hooks/utimes.h
@@ -71,29 +71,29 @@ int __attribute__((always_inline)) sys_utimes_ret(void *ctx, int retval) {
     return 0;
 }
 
-int __attribute__((always_inline)) kprobe_sys_utimes_ret(struct pt_regs *ctx) {
-    int retval = PT_REGS_RC(ctx);
+ HOOK_SYSCALL_COMPAT_EXIT(utime) {
+    int retval = SYSCALL_PARMRET(ctx);
     return sys_utimes_ret(ctx, retval);
 }
 
-SYSCALL_COMPAT_KRETPROBE(utime) {
-    return kprobe_sys_utimes_ret(ctx);
+HOOK_SYSCALL_EXIT(utime32) {
+    int retval = SYSCALL_PARMRET(ctx);
+    return sys_utimes_ret(ctx, retval);
 }
 
-SYSCALL_KRETPROBE(utime32) {
-    return kprobe_sys_utimes_ret(ctx);
+HOOK_SYSCALL_COMPAT_TIME_EXIT(utimes) {
+    int retval = SYSCALL_PARMRET(ctx);
+    return sys_utimes_ret(ctx, retval);
 }
 
-SYSCALL_COMPAT_TIME_KRETPROBE(utimes) {
-    return kprobe_sys_utimes_ret(ctx);
+HOOK_SYSCALL_COMPAT_TIME_EXIT(utimensat) {
+    int retval = SYSCALL_PARMRET(ctx);
+    return sys_utimes_ret(ctx, retval);
 }
 
-SYSCALL_COMPAT_TIME_KRETPROBE(utimensat) {
-    return kprobe_sys_utimes_ret(ctx);
-}
-
-SYSCALL_COMPAT_TIME_KRETPROBE(futimesat) {
-    return kprobe_sys_utimes_ret(ctx);
+HOOK_SYSCALL_COMPAT_TIME_EXIT(futimesat) {
+    int retval = SYSCALL_PARMRET(ctx);
+    return sys_utimes_ret(ctx, retval);
 }
 
 SEC("tracepoint/handle_sys_utimes_exit")

--- a/pkg/security/ebpf/probes/attr.go
+++ b/pkg/security/ebpf/probes/attr.go
@@ -90,13 +90,13 @@ func getAttrProbes(fentry bool) []*manager.Probe {
 			UID: SecurityAgentUID,
 		},
 		SyscallFuncName: "utime",
-	}, fentry, EntryAndExit, true)...)
+	}, fentry, EntryAndExit|SupportFentry, true)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,
 		},
 		SyscallFuncName: "utime32",
-	}, fentry, EntryAndExit)...)
+	}, fentry, EntryAndExit|SupportFentry)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,

--- a/pkg/security/ebpf/probes/attr.go
+++ b/pkg/security/ebpf/probes/attr.go
@@ -90,48 +90,48 @@ func getAttrProbes(fentry bool) []*manager.Probe {
 			UID: SecurityAgentUID,
 		},
 		SyscallFuncName: "utime",
-	}, fentry, EntryAndExit|SupportFentry, true)...)
+	}, fentry, EntryAndExit|SupportFentry|SupportFexit, true)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,
 		},
 		SyscallFuncName: "utime32",
-	}, fentry, EntryAndExit|SupportFentry)...)
+	}, fentry, EntryAndExit|SupportFentry|SupportFexit)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,
 		},
 		SyscallFuncName: "utimes",
-	}, fentry, EntryAndExit|SupportFentry, true)...)
+	}, fentry, EntryAndExit|SupportFentry|SupportFexit, true)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,
 		},
 		SyscallFuncName: "utimes",
-	}, fentry, EntryAndExit|SupportFentry|ExpandTime32)...)
+	}, fentry, EntryAndExit|SupportFentry|SupportFexit|ExpandTime32)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,
 		},
 		SyscallFuncName: "utimensat",
-	}, fentry, EntryAndExit|SupportFentry, true)...)
+	}, fentry, EntryAndExit|SupportFentry|SupportFexit, true)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,
 		},
 		SyscallFuncName: "utimensat",
-	}, fentry, EntryAndExit|SupportFentry|ExpandTime32)...)
+	}, fentry, EntryAndExit|SupportFentry|SupportFexit|ExpandTime32)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,
 		},
 		SyscallFuncName: "futimesat",
-	}, fentry, EntryAndExit|SupportFentry, true)...)
+	}, fentry, EntryAndExit|SupportFentry|SupportFexit, true)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,
 		},
 		SyscallFuncName: "futimesat",
-	}, fentry, EntryAndExit|SupportFentry|ExpandTime32)...)
+	}, fentry, EntryAndExit|SupportFentry|SupportFexit|ExpandTime32)...)
 	return attrProbes
 }

--- a/pkg/security/ebpf/probes/attr.go
+++ b/pkg/security/ebpf/probes/attr.go
@@ -102,36 +102,36 @@ func getAttrProbes(fentry bool) []*manager.Probe {
 			UID: SecurityAgentUID,
 		},
 		SyscallFuncName: "utimes",
-	}, fentry, EntryAndExit, true)...)
+	}, fentry, EntryAndExit|SupportFentry, true)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,
 		},
 		SyscallFuncName: "utimes",
-	}, fentry, EntryAndExit|ExpandTime32)...)
+	}, fentry, EntryAndExit|SupportFentry|ExpandTime32)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,
 		},
 		SyscallFuncName: "utimensat",
-	}, fentry, EntryAndExit, true)...)
+	}, fentry, EntryAndExit|SupportFentry, true)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,
 		},
 		SyscallFuncName: "utimensat",
-	}, fentry, EntryAndExit|ExpandTime32)...)
+	}, fentry, EntryAndExit|SupportFentry|ExpandTime32)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,
 		},
 		SyscallFuncName: "futimesat",
-	}, fentry, EntryAndExit, true)...)
+	}, fentry, EntryAndExit|SupportFentry, true)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,
 		},
 		SyscallFuncName: "futimesat",
-	}, fentry, EntryAndExit|ExpandTime32)...)
+	}, fentry, EntryAndExit|SupportFentry|ExpandTime32)...)
 	return attrProbes
 }

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -345,12 +345,12 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			}},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utime", fentry, EntryAndExit, true)},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utime32", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimes", fentry, EntryAndExit, true)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimes", fentry, EntryAndExit|ExpandTime32)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimensat", fentry, EntryAndExit, true)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimensat", fentry, EntryAndExit|ExpandTime32)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "futimesat", fentry, EntryAndExit, true)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "futimesat", fentry, EntryAndExit|ExpandTime32)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimes", fentry, EntryAndExit|SupportFentry, true)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimes", fentry, EntryAndExit|SupportFentry|ExpandTime32)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimensat", fentry, EntryAndExit|SupportFentry, true)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimensat", fentry, EntryAndExit|SupportFentry|ExpandTime32)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "futimesat", fentry, EntryAndExit|SupportFentry, true)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "futimesat", fentry, EntryAndExit|SupportFentry|ExpandTime32)},
 		},
 
 		// List of probes required to capture bpf events

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -343,14 +343,14 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				kprobeOrFentry("mnt_want_write", fentry),
 			}},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utime", fentry, EntryAndExit|SupportFentry, true)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utime32", fentry, EntryAndExit|SupportFentry)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimes", fentry, EntryAndExit|SupportFentry, true)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimes", fentry, EntryAndExit|SupportFentry|ExpandTime32)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimensat", fentry, EntryAndExit|SupportFentry, true)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimensat", fentry, EntryAndExit|SupportFentry|ExpandTime32)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "futimesat", fentry, EntryAndExit|SupportFentry, true)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "futimesat", fentry, EntryAndExit|SupportFentry|ExpandTime32)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utime", fentry, EntryAndExit|SupportFentry|SupportFexit, true)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utime32", fentry, EntryAndExit|SupportFentry|SupportFexit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimes", fentry, EntryAndExit|SupportFentry|SupportFexit, true)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimes", fentry, EntryAndExit|SupportFentry|SupportFexit|ExpandTime32)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimensat", fentry, EntryAndExit|SupportFentry|SupportFexit, true)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimensat", fentry, EntryAndExit|SupportFentry|SupportFexit|ExpandTime32)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "futimesat", fentry, EntryAndExit|SupportFentry|SupportFexit, true)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "futimesat", fentry, EntryAndExit|SupportFentry|SupportFexit|ExpandTime32)},
 		},
 
 		// List of probes required to capture bpf events

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -343,8 +343,8 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				kprobeOrFentry("mnt_want_write", fentry),
 			}},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utime", fentry, EntryAndExit, true)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utime32", fentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utime", fentry, EntryAndExit|SupportFentry, true)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utime32", fentry, EntryAndExit|SupportFentry)},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimes", fentry, EntryAndExit|SupportFentry, true)},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimes", fentry, EntryAndExit|SupportFentry|ExpandTime32)},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimensat", fentry, EntryAndExit|SupportFentry, true)},


### PR DESCRIPTION
### What does this PR do?

This PR onboards time syscall hooks to fentry mechanism.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
