### PR TITLE
Increase the collection interval to 60s for non-activity checks

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -126,9 +126,9 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	initCfg := InitConfig{}
 
 	// Defaults begin
-	var DEFAULT_NON_ACTIVITY_COLLECTION_INTERVAL int64
-	DEFAULT_NON_ACTIVITY_COLLECTION_INTERVAL = 60
-	instance.MetricCollectionInterval = DEFAULT_NON_ACTIVITY_COLLECTION_INTERVAL
+	var DEFAULT_METRIC_COLLECTION_INTERVAL int64
+	DEFAULT_METRIC_COLLECTION_INTERVAL = 60
+	instance.MetricCollectionInterval = DEFAULT_METRIC_COLLECTION_INTERVAL
 
 	instance.ObfuscatorOptions.DBMS = common.IntegrationName
 	instance.ObfuscatorOptions.TableNames = true
@@ -138,7 +138,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	instance.QuerySamples.Enabled = true
 
 	instance.QueryMetrics.Enabled = true
-	instance.QueryMetrics.CollectionInterval = DEFAULT_NON_ACTIVITY_COLLECTION_INTERVAL
+	instance.QueryMetrics.CollectionInterval = DEFAULT_METRIC_COLLECTION_INTERVAL
 	instance.QueryMetrics.DBRowsLimit = 10000
 	instance.QueryMetrics.PlanCacheRetention = 15
 

--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -78,31 +78,31 @@ type CustomQuery struct {
 
 // InstanceConfig is used to deserialize integration instance config.
 type InstanceConfig struct {
-	Server                        string               `yaml:"server"`
-	Port                          int                  `yaml:"port"`
-	ServiceName                   string               `yaml:"service_name"`
-	Username                      string               `yaml:"username"`
-	Password                      string               `yaml:"password"`
-	TnsAlias                      string               `yaml:"tns_alias"`
-	TnsAdmin                      string               `yaml:"tns_admin"`
-	Protocol                      string               `yaml:"protocol"`
-	Wallet                        string               `yaml:"wallet"`
-	DBM                           bool                 `yaml:"dbm"`
-	Tags                          []string             `yaml:"tags"`
-	LogUnobfuscatedQueries        bool                 `yaml:"log_unobfuscated_queries"`
-	ObfuscatorOptions             obfuscate.SQLConfig  `yaml:"obfuscator_options"`
-	InstantClient                 bool                 `yaml:"instant_client"`
-	ReportedHostname              string               `yaml:"reported_hostname"`
-	QuerySamples                  QuerySamplesConfig   `yaml:"query_samples"`
-	QueryMetrics                  QueryMetricsConfig   `yaml:"query_metrics"`
-	SysMetrics                    SysMetricsConfig     `yaml:"sysmetrics"`
-	Tablespaces                   TablespacesConfig    `yaml:"tablespaces"`
-	ProcessMemory                 ProcessMemoryConfig  `yaml:"process_memory"`
-	SharedMemory                  SharedMemoryConfig   `yaml:"shared_memory"`
-	ExecutionPlans                ExecutionPlansConfig `yaml:"execution_plans"`
-	AgentSQLTrace                 AgentSQLTrace        `yaml:"agent_sql_trace"`
-	CustomQueries                 []CustomQuery        `yaml:"custom_queries"`
-	NonActivityCollectionInterval int64                `yaml:"non_activity_collection_interval"`
+	Server                   string               `yaml:"server"`
+	Port                     int                  `yaml:"port"`
+	ServiceName              string               `yaml:"service_name"`
+	Username                 string               `yaml:"username"`
+	Password                 string               `yaml:"password"`
+	TnsAlias                 string               `yaml:"tns_alias"`
+	TnsAdmin                 string               `yaml:"tns_admin"`
+	Protocol                 string               `yaml:"protocol"`
+	Wallet                   string               `yaml:"wallet"`
+	DBM                      bool                 `yaml:"dbm"`
+	Tags                     []string             `yaml:"tags"`
+	LogUnobfuscatedQueries   bool                 `yaml:"log_unobfuscated_queries"`
+	ObfuscatorOptions        obfuscate.SQLConfig  `yaml:"obfuscator_options"`
+	InstantClient            bool                 `yaml:"instant_client"`
+	ReportedHostname         string               `yaml:"reported_hostname"`
+	QuerySamples             QuerySamplesConfig   `yaml:"query_samples"`
+	QueryMetrics             QueryMetricsConfig   `yaml:"query_metrics"`
+	SysMetrics               SysMetricsConfig     `yaml:"sysmetrics"`
+	Tablespaces              TablespacesConfig    `yaml:"tablespaces"`
+	ProcessMemory            ProcessMemoryConfig  `yaml:"process_memory"`
+	SharedMemory             SharedMemoryConfig   `yaml:"shared_memory"`
+	ExecutionPlans           ExecutionPlansConfig `yaml:"execution_plans"`
+	AgentSQLTrace            AgentSQLTrace        `yaml:"agent_sql_trace"`
+	CustomQueries            []CustomQuery        `yaml:"custom_queries"`
+	MetricCollectionInterval int64                `yaml:"metric_collection_interval"`
 }
 
 // CheckConfig holds the config needed for an integration instance to run.
@@ -128,7 +128,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	// Defaults begin
 	var DEFAULT_NON_ACTIVITY_COLLECTION_INTERVAL int64
 	DEFAULT_NON_ACTIVITY_COLLECTION_INTERVAL = 60
-	instance.NonActivityCollectionInterval = DEFAULT_NON_ACTIVITY_COLLECTION_INTERVAL
+	instance.MetricCollectionInterval = DEFAULT_NON_ACTIVITY_COLLECTION_INTERVAL
 
 	instance.ObfuscatorOptions.DBMS = common.IntegrationName
 	instance.ObfuscatorOptions.TableNames = true

--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -78,30 +78,31 @@ type CustomQuery struct {
 
 // InstanceConfig is used to deserialize integration instance config.
 type InstanceConfig struct {
-	Server                 string               `yaml:"server"`
-	Port                   int                  `yaml:"port"`
-	ServiceName            string               `yaml:"service_name"`
-	Username               string               `yaml:"username"`
-	Password               string               `yaml:"password"`
-	TnsAlias               string               `yaml:"tns_alias"`
-	TnsAdmin               string               `yaml:"tns_admin"`
-	Protocol               string               `yaml:"protocol"`
-	Wallet                 string               `yaml:"wallet"`
-	DBM                    bool                 `yaml:"dbm"`
-	Tags                   []string             `yaml:"tags"`
-	LogUnobfuscatedQueries bool                 `yaml:"log_unobfuscated_queries"`
-	ObfuscatorOptions      obfuscate.SQLConfig  `yaml:"obfuscator_options"`
-	InstantClient          bool                 `yaml:"instant_client"`
-	ReportedHostname       string               `yaml:"reported_hostname"`
-	QuerySamples           QuerySamplesConfig   `yaml:"query_samples"`
-	QueryMetrics           QueryMetricsConfig   `yaml:"query_metrics"`
-	SysMetrics             SysMetricsConfig     `yaml:"sysmetrics"`
-	Tablespaces            TablespacesConfig    `yaml:"tablespaces"`
-	ProcessMemory          ProcessMemoryConfig  `yaml:"process_memory"`
-	SharedMemory           SharedMemoryConfig   `yaml:"shared_memory"`
-	ExecutionPlans         ExecutionPlansConfig `yaml:"execution_plans"`
-	AgentSQLTrace          AgentSQLTrace        `yaml:"agent_sql_trace"`
-	CustomQueries          []CustomQuery        `yaml:"custom_queries"`
+	Server                        string               `yaml:"server"`
+	Port                          int                  `yaml:"port"`
+	ServiceName                   string               `yaml:"service_name"`
+	Username                      string               `yaml:"username"`
+	Password                      string               `yaml:"password"`
+	TnsAlias                      string               `yaml:"tns_alias"`
+	TnsAdmin                      string               `yaml:"tns_admin"`
+	Protocol                      string               `yaml:"protocol"`
+	Wallet                        string               `yaml:"wallet"`
+	DBM                           bool                 `yaml:"dbm"`
+	Tags                          []string             `yaml:"tags"`
+	LogUnobfuscatedQueries        bool                 `yaml:"log_unobfuscated_queries"`
+	ObfuscatorOptions             obfuscate.SQLConfig  `yaml:"obfuscator_options"`
+	InstantClient                 bool                 `yaml:"instant_client"`
+	ReportedHostname              string               `yaml:"reported_hostname"`
+	QuerySamples                  QuerySamplesConfig   `yaml:"query_samples"`
+	QueryMetrics                  QueryMetricsConfig   `yaml:"query_metrics"`
+	SysMetrics                    SysMetricsConfig     `yaml:"sysmetrics"`
+	Tablespaces                   TablespacesConfig    `yaml:"tablespaces"`
+	ProcessMemory                 ProcessMemoryConfig  `yaml:"process_memory"`
+	SharedMemory                  SharedMemoryConfig   `yaml:"shared_memory"`
+	ExecutionPlans                ExecutionPlansConfig `yaml:"execution_plans"`
+	AgentSQLTrace                 AgentSQLTrace        `yaml:"agent_sql_trace"`
+	CustomQueries                 []CustomQuery        `yaml:"custom_queries"`
+	NonActivityCollectionInterval int64                `yaml:"non_activity_collection_interval"`
 }
 
 // CheckConfig holds the config needed for an integration instance to run.
@@ -125,6 +126,10 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	initCfg := InitConfig{}
 
 	// Defaults begin
+	var DEFAULT_NON_ACTIVITY_COLLECTION_INTERVAL int64
+	DEFAULT_NON_ACTIVITY_COLLECTION_INTERVAL = 60
+	instance.NonActivityCollectionInterval = DEFAULT_NON_ACTIVITY_COLLECTION_INTERVAL
+
 	instance.ObfuscatorOptions.DBMS = common.IntegrationName
 	instance.ObfuscatorOptions.TableNames = true
 	instance.ObfuscatorOptions.CollectCommands = true
@@ -133,7 +138,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	instance.QuerySamples.Enabled = true
 
 	instance.QueryMetrics.Enabled = true
-	instance.QueryMetrics.CollectionInterval = 60
+	instance.QueryMetrics.CollectionInterval = DEFAULT_NON_ACTIVITY_COLLECTION_INTERVAL
 	instance.QueryMetrics.DBRowsLimit = 10000
 	instance.QueryMetrics.PlanCacheRetention = 15
 

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -68,7 +68,7 @@ type Check struct {
 	dbHostname                              string
 	dbVersion                               string
 	driver                                  string
-	nonActivityLastRun                      time.Time
+	metricLastRun                           time.Time
 	statementsLastRun                       time.Time
 	filePath                                string
 	isRDS                                   bool
@@ -123,9 +123,9 @@ func (c *Check) Run() error {
 		c.db = db
 	}
 
-	nonActivityIntervalExpired := checkIntervalExpired(&c.nonActivityLastRun, c.config.NonActivityCollectionInterval)
+	metricIntervalExpired := checkIntervalExpired(&c.metricLastRun, c.config.MetricCollectionInterval)
 
-	if nonActivityIntervalExpired {
+	if metricIntervalExpired {
 		err := c.OS_Stats()
 		if err != nil {
 			db, errConnect := c.Connect()
@@ -178,7 +178,7 @@ func (c *Check) Run() error {
 				}
 			}
 		}
-		if nonActivityIntervalExpired {
+		if metricIntervalExpired {
 			if c.config.SharedMemory.Enabled {
 				err := c.SharedMemory()
 				if err != nil {

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -30,7 +30,6 @@ import (
 
 var MAX_OPEN_CONNECTIONS = 10
 var DEFAULT_SQL_TRACED_RUNS = 10
-
 var DB_TIMEOUT = "20000"
 
 // The structure is filled by activity sampling and serves as a filter for query metrics
@@ -69,6 +68,7 @@ type Check struct {
 	dbHostname                              string
 	dbVersion                               string
 	driver                                  string
+	nonActivityLastRun                      time.Time
 	statementsLastRun                       time.Time
 	filePath                                string
 	isRDS                                   bool
@@ -97,6 +97,15 @@ func handleServiceCheck(c *Check, err error) {
 	sender.Commit()
 }
 
+func checkIntervalExpired(lastRun *time.Time, collectionInterval int64) bool {
+	start := time.Now()
+	if lastRun.IsZero() || start.Sub(*lastRun).Milliseconds() >= collectionInterval*1000 {
+		*lastRun = start
+		return true
+	}
+	return false
+}
+
 // Run executes the check.
 func (c *Check) Run() error {
 	if c.db == nil {
@@ -114,41 +123,45 @@ func (c *Check) Run() error {
 		c.db = db
 	}
 
-	err := c.OS_Stats()
-	if err != nil {
-		db, errConnect := c.Connect()
-		if errConnect != nil {
-			handleServiceCheck(c, errConnect)
-		} else if db == nil {
-			handleServiceCheck(c, fmt.Errorf("empty connection"))
+	nonActivityIntervalExpired := checkIntervalExpired(&c.nonActivityLastRun, c.config.NonActivityCollectionInterval)
+
+	if nonActivityIntervalExpired {
+		err := c.OS_Stats()
+		if err != nil {
+			db, errConnect := c.Connect()
+			if errConnect != nil {
+				handleServiceCheck(c, errConnect)
+			} else if db == nil {
+				handleServiceCheck(c, fmt.Errorf("empty connection"))
+			} else {
+				handleServiceCheck(c, nil)
+			}
+			if errClosing := CloseDatabaseConnection(db); err != nil {
+				log.Errorf("Error closing connection %s", errClosing)
+			}
+			return fmt.Errorf("failed to collect os stats %w", err)
 		} else {
 			handleServiceCheck(c, nil)
 		}
-		if errClosing := CloseDatabaseConnection(db); err != nil {
-			log.Errorf("Error closing connection %s", errClosing)
-		}
-		return fmt.Errorf("failed to collect os stats %w", err)
-	} else {
-		handleServiceCheck(c, nil)
-	}
 
-	if c.config.SysMetrics.Enabled {
-		log.Trace("Entered sysmetrics")
-		err := c.SysMetrics()
-		if err != nil {
-			return fmt.Errorf("failed to collect sysmetrics %w", err)
+		if c.config.SysMetrics.Enabled {
+			log.Trace("Entered sysmetrics")
+			err := c.SysMetrics()
+			if err != nil {
+				return fmt.Errorf("failed to collect sysmetrics %w", err)
+			}
 		}
-	}
-	if c.config.Tablespaces.Enabled {
-		err := c.Tablespaces()
-		if err != nil {
-			return err
+		if c.config.Tablespaces.Enabled {
+			err := c.Tablespaces()
+			if err != nil {
+				return err
+			}
 		}
-	}
-	if c.config.ProcessMemory.Enabled {
-		err := c.ProcessMemory()
-		if err != nil {
-			return err
+		if c.config.ProcessMemory.Enabled {
+			err := c.ProcessMemory()
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -165,16 +178,18 @@ func (c *Check) Run() error {
 				}
 			}
 		}
-		if c.config.SharedMemory.Enabled {
-			err := c.SharedMemory()
-			if err != nil {
-				return err
+		if nonActivityIntervalExpired {
+			if c.config.SharedMemory.Enabled {
+				err := c.SharedMemory()
+				if err != nil {
+					return err
+				}
 			}
-		}
-		if len(c.config.CustomQueries) > 0 {
-			err := c.CustomQueries()
-			if err != nil {
-				log.Errorf("failed to execute custom queries %s", err)
+			if len(c.config.CustomQueries) > 0 {
+				err := c.CustomQueries()
+				if err != nil {
+					log.Errorf("failed to execute custom queries %s", err)
+				}
 			}
 		}
 	}

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -485,11 +485,10 @@ func (c *Check) copyToPreviousMap(newMap map[StatementMetricsKeyDB]StatementMetr
 }
 
 func (c *Check) StatementMetrics() (int, error) {
-	start := time.Now()
-
-	if !c.statementsLastRun.IsZero() && start.Sub(c.statementsLastRun).Milliseconds() < c.config.QueryMetrics.CollectionInterval*1000 {
+	if !checkIntervalExpired(&c.statementsLastRun, c.config.QueryMetrics.CollectionInterval) {
 		return 0, nil
 	}
+	start := c.statementsLastRun
 
 	sender, err := c.GetSender()
 	if err != nil {
@@ -910,7 +909,6 @@ func (c *Check) StatementMetrics() (int, error) {
 		}
 
 		c.copyToPreviousMap(newCache)
-		c.statementsLastRun = start
 	} else {
 		heartbeatStatement := "__other__"
 		queryRowHeartbeat := QueryRow{QuerySignature: heartbeatStatement}

--- a/releasenotes/notes/oracle-non-activity-collection-interval-ea616c0eeb683a78.yaml
+++ b/releasenotes/notes/oracle-non-activity-collection-interval-ea616c0eeb683a78.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Increasing the collection interval for all teh checks except for activity samples from 10s to 60s.
+    Increasing the collection interval for all the checks except for activity samples from 10s to 60s.

--- a/releasenotes/notes/oracle-non-activity-collection-interval-ea616c0eeb683a78.yaml
+++ b/releasenotes/notes/oracle-non-activity-collection-interval-ea616c0eeb683a78.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Increasing the collection interval for all teh checks except for activity samples from 10s to 60s.


### PR DESCRIPTION
### What does this PR do?

Increasing the default collection interval from 10s to 60s for all metrics except for activity sampling. 

### Motivation

There's no need for those metrics to be collected more frequently than once per minute. We don't want to put unnecessary load on customer's databases.

### Describe how to test/QA your changes

Check the agent log (with `log_level = TRACE`) how frequently the entries `Query metrics payload` and `physical_memory` are appearing.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
