### PR TITLE
Reduce TRACE_AGENT_CPUS to 2 for trace-agent benchmarks

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -30,7 +30,6 @@ variables:
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: datadog-agent
 
     # Uncomment to force k8s memory limits for CI job container.
-    # You might also want to set DD_APM_MAX_MEMORY to 500000000 or similar to avoid OOMs in constrained environment.
     # KUBERNETES_MEMORY_REQUEST: "4Gi"
     # KUBERNETES_MEMORY_LIMIT: "4Gi"
 

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -28,6 +28,12 @@ variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true" # Important tweak for stability of benchmarks
     K6_RUN_ID_PREFIX: ci
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: datadog-agent
+
+    # Uncomment to force k8s memory limits for CI job container.
+    # You might also want to set DD_APM_MAX_MEMORY to 500000000 or similar to avoid OOMs in constrained environment.
+    # KUBERNETES_MEMORY_REQUEST: "4Gi"
+    # KUBERNETES_MEMORY_LIMIT: "4Gi"
+
   # Workaround: Currently we're not running the benchmarks on every PR, but GitHub still shows them as pending.
   # By marking the benchmarks as allow_failure, this should go away. (This workaround should be removed once the
   # benchmarks get changed to run on every PR)
@@ -38,7 +44,7 @@ trace-agent-v04-4cpus-normal_load-fixed_sps-macrobenchmarks:
   variables:
     TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v04
-    TRACE_AGENT_CPUS: 4
+    TRACE_AGENT_CPUS: 2
     DD_APM_MAX_CPU_PERCENT: 0
     DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-normal_load-fixed_sps
@@ -50,7 +56,7 @@ trace-agent-v04-4cpus-stress_load-fixed_sps-macrobenchmarks:
   variables:
     TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v04
-    TRACE_AGENT_CPUS: 4
+    TRACE_AGENT_CPUS: 2
     DD_APM_MAX_CPU_PERCENT: 0
     DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v04-4cpus-stress_load-fixed_sps
@@ -61,7 +67,7 @@ trace-agent-v05-4cpus-normal_load-fixed_sps-macrobenchmarks:
   variables:
     TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v05
-    TRACE_AGENT_CPUS: 4
+    TRACE_AGENT_CPUS: 2
     DD_APM_MAX_CPU_PERCENT: 0
     DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-normal_load-fixed_sps
@@ -73,7 +79,7 @@ trace-agent-v05-4cpus-stress_load-fixed_sps-macrobenchmarks:
   variables:
     TRACE_AGENT_VERSION: main
     TRACE_AGENT_ENDPOINT: v05
-    TRACE_AGENT_CPUS: 4
+    TRACE_AGENT_CPUS: 2
     DD_APM_MAX_CPU_PERCENT: 0
     DD_APM_MAX_MEMORY: 0
     DD_BENCHMARKS_CONFIGURATION: trace-agent-v05-4cpus-stress_load-fixed_sps


### PR DESCRIPTION
`TRACE_AGENT_CPUS: 4` that we currently have is too high -- in this case trace-agent is able to process ~1 million of spans/s, leading to situation that k6 is not able to generate adequate stress load. Reducing TRACE_AGENT_CPUS ensures that k6 is able to stress load trace-agent.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
