### PR TITLE
[Single Machine Performance] Send nightly builds to SMP ECR

### DIFF
--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -222,6 +222,19 @@ dev_nightly-a7:
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-arm64
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}-py3-jmx,agent-dev:nightly-${CI_COMMIT_REF_SLUG}-py3-jmx
 
+# deploy nightly build to single-machine-performance
+single_machine_performance-nightly-amd64-a7:
+  extends: .docker_publish_job_definition
+  stage: container_build
+  rules:
+    !reference [.on_deploy_nightly_repo_branch_a7]
+  needs:
+    - docker_build_agent7
+  variables:
+    IMG_REGISTRIES: internal-aws-smp
+    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64
+    IMG_DESTINATIONS: 08450328-agent:nightly-${COMMIT_TIME}-${CI_COMMIT_SHA}-7-amd64
+
 # deploys nightlies to agent-dev
 dev_nightly-dogstatsd:
   extends: .docker_publish_job_definition

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -225,7 +225,7 @@ dev_nightly-a7:
 # deploy nightly build to single-machine-performance
 single_machine_performance-nightly-amd64-a7:
   extends: .docker_publish_job_definition
-  stage: container_build
+  stage: dev_container_deploy
   rules:
     !reference [.on_deploy_nightly_repo_branch_a7]
   needs:

--- a/.gitlab/docker_common/publish_job_templates.yml
+++ b/.gitlab/docker_common/publish_job_templates.yml
@@ -11,6 +11,8 @@
     <<: *docker_variables
     IMG_VARIABLES: ""
     IMG_SIGNING: ""
+  before_script:
+    - export COMMIT_TIME=$(git show -s --format=%ct $CI_COMMIT_SHA)
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
     - source /root/.bashrc
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)


### PR DESCRIPTION
### What does this PR do?

This commit introduces a new nightly job that will publish Agent amd64-a7 to Single Machine Performance's ECR, in preparation for a new nightly-only tool to be introduced in a follow-up PR. We have added `COMMIT_TIME` to the publish job definition to allow us to order imagines in time.

### Motivation

We intend to introduce a new nightly-only tool, see [this page](https://datadoghq.atlassian.net/wiki/spaces/SMP/pages/3092744360/Agent+Integration+RFC) for details. 

REF SMP-673
