### PR TITLE
Update config_template.yaml

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1127,7 +1127,7 @@ api_key:
   # force_use_http: true
 
   ## @param force_use_tcp - boolean - optional - default: false
-  ## @env DD_LOGS_FORCE_USE_TCP - boolean - optional - default: false
+  ## @env DD_LOGS_CONFIG_FORCE_USE_TCP - boolean - optional - default: false
   ## By default, logs are sent through HTTPS if possible, set this parameter
   ## to `true` to always send logs via TCP. If `use_http` is set to `true`, this parameter
   ## is ignored.


### PR DESCRIPTION
### What does this PR do?

Correcting the environment variable for the `force_use_tcp` parameter from `DD_LOGS_FORCE_USE_TCP`  to `DD_LOGS_CONFIG_FORCE_USE_TCP` in the `config_template.yaml`

### Motivation

I am currently working on reviewing and updating this [KB](https://datadoghq.atlassian.net/wiki/spaces/TS/pages/328436380/What+environment+variables+are+available+for+Agent+6+7) when I found that the above environment variable is incorrectly listed in the `config_template.yaml`
