### PR TITLE
[pkg/otlp] Fix duplicated ddtags in logs

### DIFF
--- a/pkg/otlp/internal/logsagentexporter/logs_exporter.go
+++ b/pkg/otlp/internal/logsagentexporter/logs_exporter.go
@@ -58,6 +58,7 @@ func createConsumeLogsFunc(logger *zap.Logger, logSource *sources.LogSource, log
 					} else {
 						tags = append(strings.Split(ddTags, ","), otelTag)
 					}
+					// Tags are set in the message origin instead
 					ddLog.Ddtags = nil
 					service := ""
 					if ddLog.Service != nil {

--- a/pkg/otlp/internal/logsagentexporter/logs_exporter_test.go
+++ b/pkg/otlp/internal/logsagentexporter/logs_exporter_test.go
@@ -32,9 +32,10 @@ func TestLogsExporter(t *testing.T) {
 		ld plog.Logs
 	}
 	tests := []struct {
-		name string
-		args args
-		want testutil.JSONLogs
+		name         string
+		args         args
+		want         testutil.JSONLogs
+		expectedTags [][]string
 	}{
 		{
 			name: "message",
@@ -51,7 +52,6 @@ func TestLogsExporter(t *testing.T) {
 					"status":               "Info",
 					"dd.span_id":           fmt.Sprintf("%d", spanIDToUint64(ld.SpanID())),
 					"dd.trace_id":          fmt.Sprintf("%d", traceIDToUint64(ld.TraceID())),
-					"ddtags":               "",
 					"otel.severity_text":   "Info",
 					"otel.severity_number": "9",
 					"otel.span_id":         spanIDToHexOrEmptyString(ld.SpanID()),
@@ -59,6 +59,7 @@ func TestLogsExporter(t *testing.T) {
 					"otel.timestamp":       fmt.Sprintf("%d", testutil.TestLogTime.UnixNano()),
 				},
 			},
+			expectedTags: [][]string{{"otel_source:datadog_agent"}},
 		},
 		{
 			name: "message-attribute",
@@ -80,7 +81,6 @@ func TestLogsExporter(t *testing.T) {
 					"status":               "Info",
 					"dd.span_id":           fmt.Sprintf("%d", spanIDToUint64(ld.SpanID())),
 					"dd.trace_id":          fmt.Sprintf("%d", traceIDToUint64(ld.TraceID())),
-					"ddtags":               "",
 					"otel.severity_text":   "Info",
 					"otel.severity_number": "9",
 					"otel.span_id":         spanIDToHexOrEmptyString(ld.SpanID()),
@@ -88,6 +88,7 @@ func TestLogsExporter(t *testing.T) {
 					"otel.timestamp":       fmt.Sprintf("%d", testutil.TestLogTime.UnixNano()),
 				},
 			},
+			expectedTags: [][]string{{"otel_source:datadog_agent"}},
 		},
 		{
 			name: "ddtags",
@@ -109,7 +110,6 @@ func TestLogsExporter(t *testing.T) {
 					"status":               "Info",
 					"dd.span_id":           fmt.Sprintf("%d", spanIDToUint64(ld.SpanID())),
 					"dd.trace_id":          fmt.Sprintf("%d", traceIDToUint64(ld.TraceID())),
-					"ddtags":               "tag1:true",
 					"otel.severity_text":   "Info",
 					"otel.severity_number": "9",
 					"otel.span_id":         spanIDToHexOrEmptyString(ld.SpanID()),
@@ -117,6 +117,7 @@ func TestLogsExporter(t *testing.T) {
 					"otel.timestamp":       fmt.Sprintf("%d", testutil.TestLogTime.UnixNano()),
 				},
 			},
+			expectedTags: [][]string{{"tag1:true", "otel_source:datadog_agent"}},
 		},
 		{
 			name: "ddtags submits same tags",
@@ -140,7 +141,6 @@ func TestLogsExporter(t *testing.T) {
 					"status":               "Info",
 					"dd.span_id":           fmt.Sprintf("%d", spanIDToUint64(ld.SpanID())),
 					"dd.trace_id":          fmt.Sprintf("%d", traceIDToUint64(ld.TraceID())),
-					"ddtags":               "tag1:true",
 					"otel.severity_text":   "Info",
 					"otel.severity_number": "9",
 					"otel.span_id":         spanIDToHexOrEmptyString(ld.SpanID()),
@@ -153,12 +153,12 @@ func TestLogsExporter(t *testing.T) {
 					"customer":             "acme",
 					"@timestamp":           testutil.TestLogTime.Format(time.RFC3339),
 					"status":               "Info",
-					"ddtags":               "tag1:true",
 					"otel.severity_text":   "Info",
 					"otel.severity_number": "9",
 					"otel.timestamp":       fmt.Sprintf("%d", testutil.TestLogTime.UnixNano()),
 				},
 			},
+			expectedTags: [][]string{{"tag1:true", "otel_source:datadog_agent"}, {"tag1:true", "otel_source:datadog_agent"}},
 		},
 		{
 			name: "ddtags submits different tags",
@@ -182,7 +182,6 @@ func TestLogsExporter(t *testing.T) {
 					"status":               "Info",
 					"dd.span_id":           fmt.Sprintf("%d", spanIDToUint64(ld.SpanID())),
 					"dd.trace_id":          fmt.Sprintf("%d", traceIDToUint64(ld.TraceID())),
-					"ddtags":               "tag1:true",
 					"otel.severity_text":   "Info",
 					"otel.severity_number": "9",
 					"otel.span_id":         spanIDToHexOrEmptyString(ld.SpanID()),
@@ -195,12 +194,12 @@ func TestLogsExporter(t *testing.T) {
 					"customer":             "acme",
 					"@timestamp":           testutil.TestLogTime.Format(time.RFC3339),
 					"status":               "Info",
-					"ddtags":               "tag2:true",
 					"otel.severity_text":   "Info",
 					"otel.severity_number": "9",
 					"otel.timestamp":       fmt.Sprintf("%d", testutil.TestLogTime.UnixNano()),
 				},
 			},
+			expectedTags: [][]string{{"tag1:true", "otel_source:datadog_agent"}, {"tag2:true", "otel_source:datadog_agent"}},
 		},
 	}
 	for _, tt := range tests {
@@ -222,6 +221,8 @@ func TestLogsExporter(t *testing.T) {
 				output := <-testChannel
 				outputJSON := make(map[string]interface{})
 				json.Unmarshal(output.Content, &outputJSON)
+				assert.Equal(t, logSourceName, output.Origin.Source())
+				assert.Equal(t, tt.expectedTags[i], output.Origin.Tags())
 				ans = append(ans, outputJSON)
 			}
 			assert.Equal(t, tt.want, ans)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

`ddtags` field erroneously appeared in log body (should be parsed out into tags). In log ingestion, null out the OTLP log tag field after it's parsed and before the log is serialized into the message content.

Also, populate previously null "source" field in logs-agent message.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Example erroneous log (before)
![image](https://github.com/DataDog/datadog-agent/assets/13734402/cd854478-357b-4689-bcb8-c1a09db450fd)

Example log AFTER:
<img width="752" alt="image" src="https://github.com/DataDog/datadog-agent/assets/13734402/2741f6e6-0007-438c-8801-d1c625d41f2e">


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Build and run logs-agent, and send any log; verify in the app that the "ddtags" field is missing from the log record.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
