### PR TITLE
tasks: release: allow changelog generation without tag

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -105,38 +105,40 @@ def add_installscript_prelude(ctx, version):
 
 
 @task
-def update_changelog(ctx, new_version, target="all"):
+def update_changelog(ctx, new_version=None, target="all"):
     """
     Quick task to generate the new CHANGELOG using reno when releasing a minor
     version (linux/macOS only).
     By default generates Agent and Cluster Agent changelogs.
     Use target == "agent" or target == "cluster-agent" to only generate one or the other.
+    If new_version is omitted, a changelog since last tag on the current branch
+    will be generated.
     """
     generate_agent = target in ["all", "agent"]
     generate_cluster_agent = target in ["all", "cluster-agent"]
 
-    new_version_int = list(map(int, new_version.split(".")))
+    if new_version is not None:
+        new_version_int = list(map(int, new_version.split(".")))
+        if len(new_version_int) != 3:
+            print(f"Error: invalid version: {new_version_int}")
+            raise Exit(1)
 
-    if len(new_version_int) != 3:
-        print(f"Error: invalid version: {new_version_int}")
-        raise Exit(1)
+        # let's avoid losing uncommitted change with 'git reset --hard'
+        try:
+            ctx.run("git diff --exit-code HEAD", hide="both")
+        except Failure:
+            print("Error: You have uncommitted change, please commit or stash before using update_changelog")
+            return
 
-    # let's avoid losing uncommitted change with 'git reset --hard'
-    try:
-        ctx.run("git diff --exit-code HEAD", hide="both")
-    except Failure:
-        print("Error: You have uncommitted change, please commit or stash before using update_changelog")
-        return
+        # make sure we are up to date
+        ctx.run("git fetch")
 
-    # make sure we are up to date
-    ctx.run("git fetch")
-
-    # let's check that the tag for the new version is present (needed by reno)
-    try:
-        ctx.run(f"git tag --list | grep {new_version}")
-    except Failure:
-        print(f"Missing '{new_version}' git tag: mandatory to use 'reno'")
-        raise
+        # let's check that the tag for the new version is present
+        try:
+            ctx.run(f"git tag --list | grep {new_version}")
+        except Failure:
+            print(f"Missing '{new_version}' git tag: mandatory to use 'reno'")
+            raise
 
     if generate_agent:
         update_changelog_generic(ctx, new_version, "releasenotes", "CHANGELOG.rst")
@@ -145,6 +147,10 @@ def update_changelog(ctx, new_version, target="all"):
 
 
 def update_changelog_generic(ctx, new_version, changelog_dir, changelog_file):
+    if new_version is None:
+        latest_version = current_version(ctx, 7)
+        ctx.run(f"reno -q --rel-notes-dir {changelog_dir} report --ignore-cache --earliest-version {latest_version}")
+        return
     new_version_int = list(map(int, new_version.split(".")))
 
     # removing releasenotes from bugfix on the old minor.


### PR DESCRIPTION
`inv release.update_changelog` will now generate the changelog since the latest tag in the current branch.
Fix AP-2057

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR allows to generate a provisional changelog for the current branch, since the latest tag.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Per request from @kacper-murzyn (AP-2057)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

This will currently output the changelog to stdout as opposed to the same command when provided with a tag, which would commit the changelog:
```
 ~/go/src/github.com/DataDog/datadog-agent   chouquette/allow_changelog_without_tag ±  inv -e release.update-changelog  --target=agent
[WARN] Agent version cache file hasn't been loaded !
reno -q --rel-notes-dir releasenotes report --ignore-cache --earliest-version 7.48.0-devel
ignoring unknown configuration value 'no_show_source' = True
unable to find release notes file associated with unique id 'bfb7129a60c90dbd', skipping
=============
Release Notes
=============

.. _Release Notes_7.48.0-devel-214:

7.48.0-devel-214
================

.. _Release Notes_7.48.0-devel-214_New Features:

New Features
------------

.. releasenotes/notes/Decode-and-attach-sns-sqs-trace-context-59d296efe2e52a2b.yaml @ b'600fc9b113a84934ffd05c4cc4fe62d0e5948047'

- Grab, base64 decode, and attach trace context from message attributes passed through SNS->SQS->Lambda

.. releasenotes/notes/agent-diagnose-ext-first-cut-0b73b9442cf173e3.yaml @ b'bf133217771510573c672d1da4841a65c877bebc'
----------------8<-------------
```

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
