### PR TITLE
[CWS] flush syscalls map when applying a new ruleset

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -300,6 +300,7 @@ func InitSystemProbeConfig(cfg Config) {
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "events_stats.polling_interval"), 20)
 	cfg.BindEnvAndSetDefault(join(evNS, "socket"), "/opt/datadog-agent/run/event-monitor.sock")
 	cfg.BindEnvAndSetDefault(join(evNS, "event_server.burst"), 40)
+	cfg.BindEnvAndSetDefault(join(evNS, "use_hash_map_syscalls"), false)
 
 	// process event monitoring data limits for network tracer
 	eventMonitorBindEnv(cfg, join(evNS, "network_process", "max_processes_tracked"))

--- a/pkg/security/ebpf/c/include/hooks/bpf.h
+++ b/pkg/security/ebpf/c/include/hooks/bpf.h
@@ -55,6 +55,7 @@ HOOK_SYSCALL_ENTRY3(bpf, int, cmd, union bpf_attr __user *, uattr, unsigned int,
     }
 
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_BPF,
         .bpf = {
             .cmd = cmd,

--- a/pkg/security/ebpf/c/include/hooks/chmod.h
+++ b/pkg/security/ebpf/c/include/hooks/chmod.h
@@ -13,6 +13,7 @@ int __attribute__((always_inline)) trace__sys_chmod(umode_t mode) {
     }
 
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_CHMOD,
         .policy = policy,
         .setattr = {

--- a/pkg/security/ebpf/c/include/hooks/chown.h
+++ b/pkg/security/ebpf/c/include/hooks/chown.h
@@ -13,6 +13,7 @@ int __attribute__((always_inline)) trace__sys_chown(uid_t user, gid_t group) {
     }
 
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_CHOWN,
         .policy = policy,
         .setattr = {

--- a/pkg/security/ebpf/c/include/hooks/commit_creds.h
+++ b/pkg/security/ebpf/c/include/hooks/commit_creds.h
@@ -7,6 +7,7 @@
 
 int __attribute__((always_inline)) credentials_update(u64 type) {
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = type,
     };
 

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -9,6 +9,7 @@
 
 int __attribute__((always_inline)) trace__sys_execveat(ctx_t *ctx, const char **argv, const char **env) {
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_EXEC,
         .exec = {
             .args = {
@@ -77,6 +78,7 @@ int __attribute__((always_inline)) handle_interpreted_exec_event(void *ctx, stru
 
 int __attribute__((always_inline)) handle_sys_fork() {
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_FORK,
     };
 

--- a/pkg/security/ebpf/c/include/hooks/link.h
+++ b/pkg/security/ebpf/c/include/hooks/link.h
@@ -14,6 +14,7 @@ int __attribute__((always_inline)) trace__sys_link(u8 async) {
     }
 
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_LINK,
         .policy = policy,
         .async = async,

--- a/pkg/security/ebpf/c/include/hooks/mkdir.h
+++ b/pkg/security/ebpf/c/include/hooks/mkdir.h
@@ -14,6 +14,7 @@ long __attribute__((always_inline)) trace__sys_mkdir(u8 async, umode_t mode) {
     }
 
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_MKDIR,
         .policy = policy,
         .async = async,

--- a/pkg/security/ebpf/c/include/hooks/mmap.h
+++ b/pkg/security/ebpf/c/include/hooks/mmap.h
@@ -15,6 +15,7 @@ int tracepoint_syscalls_sys_enter_mmap(struct tracepoint_syscalls_sys_enter_mmap
     }
 
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_MMAP,
         .mmap = {
             .offset = args->offset,

--- a/pkg/security/ebpf/c/include/hooks/module.h
+++ b/pkg/security/ebpf/c/include/hooks/module.h
@@ -12,6 +12,7 @@ int __attribute__((always_inline)) trace_init_module(u32 loaded_from_memory) {
     }
 
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_INIT_MODULE,
         .init_module = {
             .loaded_from_memory = loaded_from_memory,
@@ -158,6 +159,7 @@ HOOK_SYSCALL_ENTRY1(delete_module, const char *, name_user) {
     }
 
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_DELETE_MODULE,
         .delete_module = {
             .name = name_user,

--- a/pkg/security/ebpf/c/include/hooks/mount.h
+++ b/pkg/security/ebpf/c/include/hooks/mount.h
@@ -117,6 +117,7 @@ int hook_mnt_want_write_file_path(ctx_t *ctx) {
 
 HOOK_SYSCALL_COMPAT_ENTRY3(mount, const char*, source, const char*, target, const char*, fstype) {
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_MOUNT,
     };
 
@@ -127,6 +128,7 @@ HOOK_SYSCALL_COMPAT_ENTRY3(mount, const char*, source, const char*, target, cons
 
 HOOK_SYSCALL_ENTRY1(unshare, unsigned long, flags) {
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_UNSHARE_MNTNS,
         .unshare_mntns = {
             .flags = flags,

--- a/pkg/security/ebpf/c/include/hooks/mprotect.h
+++ b/pkg/security/ebpf/c/include/hooks/mprotect.h
@@ -13,6 +13,7 @@ HOOK_SYSCALL_ENTRY0(mprotect) {
     }
 
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_MPROTECT,
     };
 

--- a/pkg/security/ebpf/c/include/hooks/network/bind.h
+++ b/pkg/security/ebpf/c/include/hooks/network/bind.h
@@ -18,6 +18,7 @@ HOOK_SYSCALL_ENTRY3(bind, int, socket, struct sockaddr*, addr, unsigned int, add
 
     /* cache the bind and wait to grab the retval to send it */
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_BIND,
     };
     cache_syscall(&syscall);

--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -17,6 +17,7 @@ int __attribute__((always_inline)) trace__sys_openat2(u8 async, int flags, umode
     }
 
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_OPEN,
         .policy = policy,
         .async = async,

--- a/pkg/security/ebpf/c/include/hooks/ptrace.h
+++ b/pkg/security/ebpf/c/include/hooks/ptrace.h
@@ -12,6 +12,7 @@ HOOK_SYSCALL_ENTRY3(ptrace, u32, request, pid_t, pid, void *, addr) {
     }
 
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_PTRACE,
         .ptrace = {
             .request = request,

--- a/pkg/security/ebpf/c/include/hooks/rename.h
+++ b/pkg/security/ebpf/c/include/hooks/rename.h
@@ -8,6 +8,7 @@
 
 int __attribute__((always_inline)) trace__sys_rename(u8 async) {
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .policy = fetch_policy(EVENT_RENAME),
         .async = async,
         .type = EVENT_RENAME,

--- a/pkg/security/ebpf/c/include/hooks/rmdir.h
+++ b/pkg/security/ebpf/c/include/hooks/rmdir.h
@@ -9,6 +9,7 @@
 
 int __attribute__((always_inline)) trace__sys_rmdir(u8 async, int flags) {
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_RMDIR,
         .policy = fetch_policy(EVENT_RMDIR),
         .async = async,

--- a/pkg/security/ebpf/c/include/hooks/selinux.h
+++ b/pkg/security/ebpf/c/include/hooks/selinux.h
@@ -8,6 +8,7 @@
 
 int __attribute__((always_inline)) handle_selinux_event(void *ctx, struct file *file, const char *buf, size_t count, enum selinux_source_event_t source_event) {
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_SELINUX,
         .policy = fetch_policy(EVENT_SELINUX),
         .selinux = {

--- a/pkg/security/ebpf/c/include/hooks/setxattr.h
+++ b/pkg/security/ebpf/c/include/hooks/setxattr.h
@@ -13,6 +13,7 @@ int __attribute__((always_inline)) trace__sys_setxattr(const char *xattr_name) {
     }
 
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_SETXATTR,
         .policy = policy,
         .xattr = {
@@ -44,6 +45,7 @@ int __attribute__((always_inline)) trace__sys_removexattr(const char *xattr_name
     }
 
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_REMOVEXATTR,
         .policy = policy,
         .xattr = {

--- a/pkg/security/ebpf/c/include/hooks/signal.h
+++ b/pkg/security/ebpf/c/include/hooks/signal.h
@@ -18,6 +18,7 @@ HOOK_SYSCALL_ENTRY2(kill, int, pid, int, type) {
 
     /* cache the signal and wait to grab the retval to send it */
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_SIGNAL,
         .signal = {
             .pid = 0, // 0 in case the root ns pid resolution failed

--- a/pkg/security/ebpf/c/include/hooks/splice.h
+++ b/pkg/security/ebpf/c/include/hooks/splice.h
@@ -15,6 +15,7 @@ HOOK_SYSCALL_ENTRY0(splice) {
     }
 
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_SPLICE,
     };
 

--- a/pkg/security/ebpf/c/include/hooks/umount.h
+++ b/pkg/security/ebpf/c/include/hooks/umount.h
@@ -9,6 +9,7 @@
 HOOK_ENTRY("security_sb_umount")
 int hook_security_sb_umount(ctx_t *ctx) {
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_UMOUNT,
         .umount = {
             .vfs = (struct vfsmount *)CTX_PARM1(ctx),

--- a/pkg/security/ebpf/c/include/hooks/unlink.h
+++ b/pkg/security/ebpf/c/include/hooks/unlink.h
@@ -10,6 +10,7 @@
 
 int __attribute__((always_inline)) trace__sys_unlink(u8 async, int flags) {
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_UNLINK,
         .policy = fetch_policy(EVENT_UNLINK),
         .async = async,

--- a/pkg/security/ebpf/c/include/hooks/utimes.h
+++ b/pkg/security/ebpf/c/include/hooks/utimes.h
@@ -12,6 +12,7 @@ int __attribute__((always_inline)) trace__sys_utimes() {
     }
 
     struct syscall_cache_t syscall = {
+        .time_ns = bpf_ktime_get_ns(),
         .type = EVENT_UTIME,
         .policy = policy,
     };

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -34,7 +34,6 @@ BPF_HASH_MAP(basename_approvers, struct basename_t, struct basename_filter_t, 25
 BPF_HASH_MAP(register_netdevice_cache, u64, struct register_netdevice_cache_t, 1024)
 BPF_HASH_MAP(netdevice_lookup_cache, u64, struct device_ifindex_t, 1024)
 BPF_HASH_MAP(fd_link_pid, u8, u32, 1)
-BPF_HASH_MAP(syscalls, u64, struct syscall_cache_t, 1) // max entries will be overridden at runtime
 
 BPF_LRU_MAP(activity_dump_rate_limiters, u32, struct activity_dump_rate_limiter_ctx, 1) // max entries will be overridden at runtime
 BPF_LRU_MAP(mount_ref, u32, struct mount_ref_t, 64000)
@@ -64,6 +63,7 @@ BPF_LRU_MAP(security_profiles, struct container_context_t, struct security_profi
 BPF_LRU_MAP(secprofs_syscalls, u64, struct security_profile_syscalls_t, 1) // max entries will be overriden at runtime
 
 BPF_LRU_MAP_FLAGS(tasks_in_coredump, u64, u8, 64, BPF_F_NO_COMMON_LRU)
+BPF_LRU_MAP_FLAGS(syscalls, u64, struct syscall_cache_t, 8192, BPF_F_NO_COMMON_LRU)
 
 BPF_PERCPU_ARRAY_MAP(dr_erpc_state, u32, struct dr_erpc_state_t, 1)
 BPF_PERCPU_ARRAY_MAP(syscalls_stats, u32, u32, EVENT_MAX)

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -34,6 +34,7 @@ BPF_HASH_MAP(basename_approvers, struct basename_t, struct basename_filter_t, 25
 BPF_HASH_MAP(register_netdevice_cache, u64, struct register_netdevice_cache_t, 1024)
 BPF_HASH_MAP(netdevice_lookup_cache, u64, struct device_ifindex_t, 1024)
 BPF_HASH_MAP(fd_link_pid, u8, u32, 1)
+BPF_HASH_MAP(syscalls, u64, struct syscall_cache_t, 1) // max entries will be overridden at runtime
 
 BPF_LRU_MAP(activity_dump_rate_limiters, u32, struct activity_dump_rate_limiter_ctx, 1) // max entries will be overridden at runtime
 BPF_LRU_MAP(mount_ref, u32, struct mount_ref_t, 64000)
@@ -63,7 +64,6 @@ BPF_LRU_MAP(security_profiles, struct container_context_t, struct security_profi
 BPF_LRU_MAP(secprofs_syscalls, u64, struct security_profile_syscalls_t, 1) // max entries will be overriden at runtime
 
 BPF_LRU_MAP_FLAGS(tasks_in_coredump, u64, u8, 64, BPF_F_NO_COMMON_LRU)
-BPF_LRU_MAP_FLAGS(syscalls, u64, struct syscall_cache_t, 1, BPF_F_NO_COMMON_LRU) // max entries will be overridden at runtime
 
 BPF_PERCPU_ARRAY_MAP(dr_erpc_state, u32, struct dr_erpc_state_t, 1)
 BPF_PERCPU_ARRAY_MAP(syscalls_stats, u32, u32, EVENT_MAX)

--- a/pkg/security/ebpf/c/include/structs/syscalls.h
+++ b/pkg/security/ebpf/c/include/structs/syscalls.h
@@ -20,12 +20,11 @@ struct syscall_table_key_t {
 };
 
 struct syscall_cache_t {
-    struct policy_t policy;
+    u64 time_ns;
     u64 type;
+    struct policy_t policy;
     u8 discarded;
     u8 async;
-
-    u32 time_ns;
 
     struct dentry_resolver_input_t resolver;
 

--- a/pkg/security/ebpf/c/include/structs/syscalls.h
+++ b/pkg/security/ebpf/c/include/structs/syscalls.h
@@ -25,6 +25,8 @@ struct syscall_cache_t {
     u8 discarded;
     u8 async;
 
+    u32 time_ns;
+
     struct dentry_resolver_input_t resolver;
 
     union {

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -158,7 +158,7 @@ type MapSpecEditorOpts struct {
 func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts) map[string]manager.MapSpecEditor {
 	editors := map[string]manager.MapSpecEditor{
 		"syscalls": {
-			MaxEntries: 16,
+			MaxEntries: 8192,
 			EditorFlag: manager.EditMaxEntries,
 		},
 		"proc_cache": {

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -152,15 +152,12 @@ type MapSpecEditorOpts struct {
 	RingBufferSize          uint32
 	PathResolutionEnabled   bool
 	SecurityProfileMaxCount int
+	UseSyscallsHashMap      bool
 }
 
 // AllMapSpecEditors returns the list of map editors
 func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts) map[string]manager.MapSpecEditor {
 	editors := map[string]manager.MapSpecEditor{
-		"syscalls": {
-			MaxEntries: 8192,
-			EditorFlag: manager.EditMaxEntries,
-		},
 		"proc_cache": {
 			MaxEntries: getMaxEntries(numCPU, minProcEntries, maxProcEntries),
 			EditorFlag: manager.EditMaxEntries,
@@ -190,6 +187,14 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts) map[string]manager.Ma
 			MaxEntries: uint32(opts.SecurityProfileMaxCount),
 			EditorFlag: manager.EditMaxEntries,
 		},
+	}
+
+	if opts.UseSyscallsHashMap {
+		editors["syscalls"] = manager.MapSpecEditor{
+			Type:       ebpf.Hash,
+			Flags:      0,
+			EditorFlag: manager.EditType | manager.EditFlags,
+		}
 	}
 
 	if opts.PathResolutionEnabled {

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -158,7 +158,7 @@ type MapSpecEditorOpts struct {
 func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts) map[string]manager.MapSpecEditor {
 	editors := map[string]manager.MapSpecEditor{
 		"syscalls": {
-			MaxEntries: 8192,
+			MaxEntries: 16,
 			EditorFlag: manager.EditMaxEntries,
 		},
 		"proc_cache": {

--- a/pkg/security/probe/config/config.go
+++ b/pkg/security/probe/config/config.go
@@ -95,6 +95,9 @@ type Config struct {
 	// EventStreamUseFentry specifies whether to use eBPF fentry when available instead of kprobes
 	EventStreamUseFentry bool
 
+	// UseSyscallsHashMap specifies if the syscalls cache should use an hash map instead of an LRU
+	UseSyscallsHashMap bool
+
 	// RuntimeCompilationEnabled defines if the runtime-compilation is enabled
 	RuntimeCompilationEnabled bool
 
@@ -157,6 +160,7 @@ func NewConfig() (*Config, error) {
 		EnvsWithValue:                getStringSlice("envs_with_value"),
 		NetworkEnabled:               getBool("network.enabled"),
 		StatsPollingInterval:         time.Duration(getInt("events_stats.polling_interval")) * time.Second,
+		UseSyscallsHashMap:           coreconfig.SystemProbe.GetBool(join(evNS, "use_hash_map_syscalls")),
 
 		// event server
 		SocketPath:       coreconfig.SystemProbe.GetString(join(evNS, "socket")),

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -1418,7 +1418,9 @@ func (p *Probe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetReport, e
 		return nil, fmt.Errorf("failed to flush discarders: %w", err)
 	}
 
-	p.FlushSyscalls()
+	if !p.Config.RuntimeSecurity.ActivityDumpEnabled {
+		p.FlushSyscalls()
+	}
 
 	if err := p.updateProbes(rs.GetEventTypes()); err != nil {
 		return nil, fmt.Errorf("failed to select probes: %w", err)

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -1437,7 +1437,7 @@ func (p *Probe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetReport, e
 		return nil, fmt.Errorf("failed to flush discarders: %w", err)
 	}
 
-	if !p.Config.RuntimeSecurity.ActivityDumpEnabled {
+	if p.Config.Probe.UseSyscallsHashMap {
 		p.FlushSyscalls()
 	}
 
@@ -1516,6 +1516,7 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 		RingBufferSize:          uint32(p.Config.Probe.EventStreamBufferSize),
 		PathResolutionEnabled:   p.Opts.PathResolutionEnabled,
 		SecurityProfileMaxCount: p.Config.RuntimeSecurity.SecurityProfileMaxCount,
+		UseSyscallsHashMap:      p.Config.Probe.UseSyscallsHashMap,
 	})
 
 	if config.RuntimeSecurity.ActivityDumpEnabled {

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -1225,14 +1225,22 @@ func (p *Probe) FlushSyscalls() {
 	// iteration in eBPF is a difficult subject since the map can be edited by the kernel side
 	// at the same time
 	// to resolve this issue we ignore errors
+	cleaned := 0
 	for iter.Next(&key, &value) {
 		// ignore error
-		_ = m.Delete(key)
+
+		timeNs := int64(model.ByteOrder.Uint32(value[20:24])) << 32
+		fmt.Println(time.Unix(0, timeNs))
+
+		if err := m.Delete(key); err == nil {
+			cleaned++
+		}
 	}
 
 	if err := iter.Err(); err != nil {
 		seclog.Errorf("syscall flushing encoutered an error: %v", err)
 	}
+	seclog.Errorf("syscall flushing: cleaned %d", cleaned)
 }
 
 // Snapshot runs the different snapshot functions of the resolvers that

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -1250,9 +1250,9 @@ func (p *Probe) FlushSyscalls() {
 		shouldRemoveSyscallEntry(value[:])
 
 		// ignore error
-		if err := m.Delete(key); err == nil {
-			cleaned++
-		}
+		// if err := m.Delete(key); err == nil {
+		cleaned++
+		// }
 	}
 
 	if err := iter.Err(); err != nil {

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -1222,8 +1222,12 @@ func (p *Probe) FlushSyscalls() {
 		iter  = m.Iterate()
 	)
 
+	// iteration in eBPF is a difficult subject since the map can be edited by the kernel side
+	// at the same time
+	// to resolve this issue we ignore errors
 	for iter.Next(&key, &value) {
-		m.Delete(key)
+		// ignore error
+		_ = m.Delete(key)
 	}
 
 	if err := iter.Err(); err != nil {

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -17,7 +17,6 @@ import (
 	"runtime"
 	"sync"
 	"time"
-	_ "unsafe"
 
 	"github.com/DataDog/ebpf-manager/tracefs"
 	cebpf "github.com/cilium/ebpf"

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -1217,8 +1217,8 @@ func (p *Probe) FlushSyscalls() {
 	}
 
 	var (
-		key   interface{}
-		value interface{}
+		key   uint64
+		value [352]byte
 		iter  = m.Iterate()
 	)
 

--- a/pkg/security/probe/syscalls_flusher.go
+++ b/pkg/security/probe/syscalls_flusher.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package probe
+
+import (
+	"time"
+	_ "unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
+	"github.com/cilium/ebpf"
+)
+
+//go:noescape
+//go:linkname nanotime runtime.nanotime
+func nanotime() int64
+
+// FlushSyscalls does a best effort flush of the in-flight syscalls map
+func FlushSyscalls(syscallsMaps *ebpf.Map) {
+	seclog.Debugf("Flushing in-flight syscalls")
+
+	if syscallsMaps == nil {
+		seclog.Errorf("flushing syscalls: nil-map")
+		return
+	}
+
+	var (
+		key   uint64
+		value struct {
+			Time      int64
+			EventType uint64
+		}
+		iter = syscallsMaps.Iterate()
+	)
+
+	startFlushTime := nanotime()
+	seclog.Errorf("begin flushing: time = %d", startFlushTime)
+
+	// iteration in eBPF is a difficult subject since the map can be edited by the kernel side
+	// at the same time
+	// to resolve this issue we ignore errors
+	cleaned := 0
+	for iter.Next(&key, &value) {
+		seclog.Errorf("syscall flushing: %v %d", value.EventType, value.Time)
+
+		if value.Time != 0 && value.Time <= startFlushTime-int64(10*time.Second) {
+			// ignore error
+			if err := syscallsMaps.Delete(key); err == nil {
+				cleaned++
+			}
+		}
+	}
+
+	if err := iter.Err(); err != nil {
+		seclog.Errorf("syscall flushing encoutered an error: %v", err)
+	}
+	seclog.Errorf("syscall flushing: cleaned %d", cleaned)
+}

--- a/pkg/security/tests/kernel_module_test.go
+++ b/pkg/security/tests/kernel_module_test.go
@@ -101,6 +101,8 @@ func getModulePath(modulePathFmt string, t *testing.T) (string, bool) {
 }
 
 func TestLoadModule(t *testing.T) {
+	t.Skip("TestLoadModule is known to be flacky")
+
 	if testEnvironment == DockerEnvironment {
 		t.Skip("skipping kernel module test in docker")
 	}

--- a/pkg/security/tests/kernel_module_test.go
+++ b/pkg/security/tests/kernel_module_test.go
@@ -101,8 +101,6 @@ func getModulePath(modulePathFmt string, t *testing.T) (string, bool) {
 }
 
 func TestLoadModule(t *testing.T) {
-	t.Skip("TestLoadModule is known to be flacky")
-
 	if testEnvironment == DockerEnvironment {
 		t.Skip("skipping kernel module test in docker")
 	}

--- a/test/kitchen/test/integration/security-agent-test/rspec_datadog/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec_datadog/security-agent-test_spec.rb
@@ -44,7 +44,8 @@ shared_examples "passes" do |bundle, env|
   base_env = {
     "CI"=>"true",
     "DD_SYSTEM_PROBE_BPF_DIR"=>"/tmp/security-agent/ebpf_bytecode",
-    "GOVERSION"=>"unknown"
+    "GOVERSION"=>"unknown",
+    "DD_EVENT_MONITORING_CONFIG_USE_HASH_MAP_SYSCALLS"=>"true",
   }
   final_env = base_env.merge(env)
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a new mechanism to cleanup the `syscalls` map when reloading a rule set. The goal of this is to ensure (in a best effort fashion) that the syscalls map is as empty as possible when reloading the rule set, especially targeted to tests (which are the main reloaders of rulesets).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
