### PR TITLE
Allow for psycopg 3 package install in agent build

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -13,9 +13,6 @@ dependency 'pip2'
 
 
 if arm?
-  # psycopg2 doesn't come with pre-built wheel on the arm architecture.
-  # to compile from source, it requires the `pg_config` executable present on the $PATH
-  dependency 'postgresql'
   # same with libffi to build the cffi wheel
   dependency 'libffi'
   # same with libxml2 and libxslt to build the lxml wheel
@@ -28,6 +25,14 @@ if osx?
 end
 
 if linux?
+  # * Psycopg2 doesn't come with pre-built wheel on the arm architecture.
+  #   to compile from source, it requires the `pg_config` executable present on the $PATH
+  # * We also need it to build psycopg[c] Python dependency
+  # * Note: because having unixodbc already built breaks postgresql build,
+  #   we made unixodbc depend on postgresql to ensure proper build order.
+  #   If we're ever removing/changing one of these dependencies, we need to
+  #   take this into account.
+  dependency 'postgresql'
   # add nfsiostat script
   dependency 'unixodbc'
   dependency 'freetds'  # needed for SQL Server integration

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -237,6 +237,9 @@ build do
         # In any case we add the lib to the requirements files to avoid inconsistency in the installed versions
         # For example if aerospike has dependency A>1.2.3 and a package in the big requirements file has A<1.2.3, the install process would succeed but the integration wouldn't work.
         end
+        if line.include?('psycopg[binary]') && !windows?
+            line = 'psycopg[c]'
+        end
         requirements.push(line)
       end
     end

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -21,6 +21,7 @@ if arm?
 end
 
 if osx?
+  dependency 'postgresql'
   dependency 'unixodbc'
 end
 

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -229,6 +229,9 @@ build do
       end
 
       if !blacklist_flag
+        if line.start_with?('psycopg[binary]') && !windows?
+            line.sub! 'psycopg[binary]', 'psycopg[c]'
+        end
         # Keeping the custom env requirements lines apart to install them with a specific env
         requirements_custom.each do |lib, lib_req|
           if Regexp.new('^' + lib + '==').freeze.match line
@@ -236,9 +239,6 @@ build do
           end
         # In any case we add the lib to the requirements files to avoid inconsistency in the installed versions
         # For example if aerospike has dependency A>1.2.3 and a package in the big requirements file has A<1.2.3, the install process would succeed but the integration wouldn't work.
-        end
-        if line.include?('psycopg[binary]') && !windows?
-            line = 'psycopg[c]'
         end
         requirements.push(line)
       end

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -28,8 +28,13 @@ if osx?
 end
 
 if linux?
-  # psycopg2 & psycopg3 don't come with pre-built wheel on linux.
-  # to compile from source, it requires the `pg_config` executable present on the $PATH
+  # * Psycopg2 doesn't come with pre-built wheel on the arm architecture.
+  #   to compile from source, it requires the `pg_config` executable present on the $PATH
+  # * We also need it to build psycopg[c] Python dependency
+  # * Note: because having unixodbc already built breaks postgresql build,
+  #   we made unixodbc depend on postgresql to ensure proper build order.
+  #   If we're ever removing/changing one of these dependencies, we need to
+  #   take this into account.
   dependency 'postgresql'
   # add nfsiostat script
   dependency 'unixodbc'

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -250,6 +250,10 @@ build do
       end
 
       if !blacklist_flag
+        # on non windows OS, we use the c version of the psycopg installation
+        if line.include?('psycopg[binary]') && !windows?
+          line = 'psycopg[c]'
+        end
         # Keeping the custom env requirements lines apart to install them with a specific env
         requirements_custom.each do |lib, lib_req|
           if Regexp.new('^' + lib + '==').freeze.match line

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -16,9 +16,6 @@ dependency 'snowflake-connector-python-py3'
 dependency 'confluent-kafka-python'
 
 if arm?
-  # psycopg2 doesn't come with pre-built wheel on the arm architecture.
-  # to compile from source, it requires the `pg_config` executable present on the $PATH
-  dependency 'postgresql'
   # same with libffi to build the cffi wheel
   dependency 'libffi'
   # same with libxml2 and libxslt to build the lxml wheel
@@ -31,6 +28,9 @@ if osx?
 end
 
 if linux?
+  # psycopg2 & psycopg3 don't come with pre-built wheel on linux.
+  # to compile from source, it requires the `pg_config` executable present on the $PATH
+  dependency 'postgresql'
   # add nfsiostat script
   dependency 'unixodbc'
   dependency 'freetds'  # needed for SQL Server integration

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -24,6 +24,7 @@ if arm?
 end
 
 if osx?
+  dependency 'postgresql'
   dependency 'unixodbc'
 end
 

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -251,8 +251,8 @@ build do
 
       if !blacklist_flag
         # on non windows OS, we use the c version of the psycopg installation
-        if line.include?('psycopg[binary]') && !windows?
-          line = 'psycopg[c]'
+        if line.start_with?('psycopg[binary]') && !windows?
+          line.sub! 'psycopg[binary]', 'psycopg[c]'
         end
         # Keeping the custom env requirements lines apart to install them with a specific env
         requirements_custom.each do |lib, lib_req|

--- a/release.json
+++ b/release.json
@@ -5,8 +5,8 @@
         "7": "7.46.0"
     },
     "nightly": {
-        "INTEGRATIONS_CORE_VERSION": "e72c545b8c49426a6ef28f53532fc77361730ed3",
-        "OMNIBUS_SOFTWARE_VERSION": "slavek.kabrda/unixodbc-depend-postgresql",
+        "INTEGRATIONS_CORE_VERSION": "master",
+        "OMNIBUS_SOFTWARE_VERSION": "master",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
         "JMXFETCH_VERSION": "0.47.9",
         "JMXFETCH_HASH": "fb5c3fc2fb42db1ee5c3a7c6187b316d79d69c50b967db0b7ffde590622d0395",
@@ -17,8 +17,8 @@
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
-        "INTEGRATIONS_CORE_VERSION": "e72c545b8c49426a6ef28f53532fc77361730ed3",
-        "OMNIBUS_SOFTWARE_VERSION": "slavek.kabrda/unixodbc-depend-postgresql",
+        "INTEGRATIONS_CORE_VERSION": "master",
+        "OMNIBUS_SOFTWARE_VERSION": "master",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
         "JMXFETCH_VERSION": "0.47.9",
         "JMXFETCH_HASH": "fb5c3fc2fb42db1ee5c3a7c6187b316d79d69c50b967db0b7ffde590622d0395",

--- a/release.json
+++ b/release.json
@@ -5,7 +5,7 @@
         "7": "7.46.0"
     },
     "nightly": {
-        "INTEGRATIONS_CORE_VERSION": "3b7c87956dcafbcb791280242f113b03df39264b",
+        "INTEGRATIONS_CORE_VERSION": "e72c545b8c49426a6ef28f53532fc77361730ed3",
         "OMNIBUS_SOFTWARE_VERSION": "slavek.kabrda/unixodbc-depend-postgresql",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
         "JMXFETCH_VERSION": "0.47.9",
@@ -17,7 +17,7 @@
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
-        "INTEGRATIONS_CORE_VERSION": "3b7c87956dcafbcb791280242f113b03df39264b",
+        "INTEGRATIONS_CORE_VERSION": "e72c545b8c49426a6ef28f53532fc77361730ed3",
         "OMNIBUS_SOFTWARE_VERSION": "slavek.kabrda/unixodbc-depend-postgresql",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
         "JMXFETCH_VERSION": "0.47.9",

--- a/release.json
+++ b/release.json
@@ -5,7 +5,7 @@
         "7": "7.46.0"
     },
     "nightly": {
-        "INTEGRATIONS_CORE_VERSION": "master",
+        "INTEGRATIONS_CORE_VERSION": "3b7c87956dcafbcb791280242f113b03df39264b",
         "OMNIBUS_SOFTWARE_VERSION": "master",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
         "JMXFETCH_VERSION": "0.47.9",
@@ -17,7 +17,7 @@
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
-        "INTEGRATIONS_CORE_VERSION": "master",
+        "INTEGRATIONS_CORE_VERSION": "3b7c87956dcafbcb791280242f113b03df39264b",
         "OMNIBUS_SOFTWARE_VERSION": "master",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
         "JMXFETCH_VERSION": "0.47.9",

--- a/release.json
+++ b/release.json
@@ -6,7 +6,7 @@
     },
     "nightly": {
         "INTEGRATIONS_CORE_VERSION": "3b7c87956dcafbcb791280242f113b03df39264b",
-        "OMNIBUS_SOFTWARE_VERSION": "master",
+        "OMNIBUS_SOFTWARE_VERSION": "slavek.kabrda/unixodbc-2.3.10",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
         "JMXFETCH_VERSION": "0.47.9",
         "JMXFETCH_HASH": "fb5c3fc2fb42db1ee5c3a7c6187b316d79d69c50b967db0b7ffde590622d0395",
@@ -18,7 +18,7 @@
     },
     "nightly-a7": {
         "INTEGRATIONS_CORE_VERSION": "3b7c87956dcafbcb791280242f113b03df39264b",
-        "OMNIBUS_SOFTWARE_VERSION": "master",
+        "OMNIBUS_SOFTWARE_VERSION": "slavek.kabrda/unixodbc-2.3.10",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
         "JMXFETCH_VERSION": "0.47.9",
         "JMXFETCH_HASH": "fb5c3fc2fb42db1ee5c3a7c6187b316d79d69c50b967db0b7ffde590622d0395",

--- a/release.json
+++ b/release.json
@@ -6,7 +6,7 @@
     },
     "nightly": {
         "INTEGRATIONS_CORE_VERSION": "3b7c87956dcafbcb791280242f113b03df39264b",
-        "OMNIBUS_SOFTWARE_VERSION": "slavek.kabrda/unixodbc-2.3.10",
+        "OMNIBUS_SOFTWARE_VERSION": "slavek.kabrda/unixodbc-depend-postgresql",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
         "JMXFETCH_VERSION": "0.47.9",
         "JMXFETCH_HASH": "fb5c3fc2fb42db1ee5c3a7c6187b316d79d69c50b967db0b7ffde590622d0395",
@@ -18,7 +18,7 @@
     },
     "nightly-a7": {
         "INTEGRATIONS_CORE_VERSION": "3b7c87956dcafbcb791280242f113b03df39264b",
-        "OMNIBUS_SOFTWARE_VERSION": "slavek.kabrda/unixodbc-2.3.10",
+        "OMNIBUS_SOFTWARE_VERSION": "slavek.kabrda/unixodbc-depend-postgresql",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
         "JMXFETCH_VERSION": "0.47.9",
         "JMXFETCH_HASH": "fb5c3fc2fb42db1ee5c3a7c6187b316d79d69c50b967db0b7ffde590622d0395",


### PR DESCRIPTION
### What does this PR do?

This PR is to allow for the datadog-agent build to work with the `psycopg3`  dependency, which was added as part of the integrations-core PR https://github.com/DataDog/integrations-core/pull/15411


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
