### PR TITLE
Internal profiling UDS & custom tags

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -847,6 +847,7 @@ func InitConfig(config Config) {
 	// internal profiling
 	config.BindEnvAndSetDefault("internal_profiling.enabled", false)
 	config.BindEnv("internal_profiling.profile_dd_url")
+	config.BindEnvAndSetDefault("internal_profiling.socket", "")
 	config.BindEnvAndSetDefault("internal_profiling.period", 5*time.Minute)
 	config.BindEnvAndSetDefault("internal_profiling.cpu_duration", 1*time.Minute)
 	config.BindEnvAndSetDefault("internal_profiling.block_profile_rate", 0)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -847,7 +847,7 @@ func InitConfig(config Config) {
 	// internal profiling
 	config.BindEnvAndSetDefault("internal_profiling.enabled", false)
 	config.BindEnv("internal_profiling.profile_dd_url")
-	config.BindEnvAndSetDefault("internal_profiling.socket", "")
+	config.BindEnvAndSetDefault("internal_profiling.unix_socket", "")
 	config.BindEnvAndSetDefault("internal_profiling.period", 5*time.Minute)
 	config.BindEnvAndSetDefault("internal_profiling.cpu_duration", 1*time.Minute)
 	config.BindEnvAndSetDefault("internal_profiling.block_profile_rate", 0)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -854,6 +854,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("internal_profiling.mutex_profile_fraction", 0)
 	config.BindEnvAndSetDefault("internal_profiling.enable_goroutine_stacktraces", false)
 	config.BindEnvAndSetDefault("internal_profiling.delta_profiles", true)
+	config.BindEnvAndSetDefault("internal_profiling.extra_tags", []string{})
 
 	config.BindEnvAndSetDefault("internal_profiling.capture_all_allocations", false)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -847,7 +847,7 @@ func InitConfig(config Config) {
 	// internal profiling
 	config.BindEnvAndSetDefault("internal_profiling.enabled", false)
 	config.BindEnv("internal_profiling.profile_dd_url")
-	config.BindEnvAndSetDefault("internal_profiling.unix_socket", "")
+	config.BindEnvAndSetDefault("internal_profiling.unix_socket", "") // file system path to a unix socket, e.g. `/var/run/datadog/apm.socket`
 	config.BindEnvAndSetDefault("internal_profiling.period", 5*time.Minute)
 	config.BindEnvAndSetDefault("internal_profiling.cpu_duration", 1*time.Minute)
 	config.BindEnvAndSetDefault("internal_profiling.block_profile_rate", 0)

--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -92,7 +92,7 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 
 		settings := profiling.Settings{
 			ProfilingURL:         site,
-			Socket:               cfg.GetString(l.ConfigPrefix + "internal_profiling.socket"),
+			Socket:               cfg.GetString(l.ConfigPrefix + "internal_profiling.unix_socket"),
 			Env:                  cfg.GetString(l.ConfigPrefix + "env"),
 			Service:              l.Service,
 			Period:               cfg.GetDuration(l.ConfigPrefix + "internal_profiling.period"),

--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -89,6 +89,7 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 
 		settings := profiling.Settings{
 			ProfilingURL:         site,
+			Socket:               cfg.GetString(l.ConfigPrefix + "internal_profiling.socket"),
 			Env:                  cfg.GetString(l.ConfigPrefix + "env"),
 			Service:              l.Service,
 			Period:               cfg.GetDuration(l.ConfigPrefix + "internal_profiling.period"),

--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -87,6 +87,9 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 		// invocation, as many of these settings may have changed at runtime.
 		v, _ := version.Agent()
 
+		tags := cfg.GetStringSlice(l.ConfigPrefix + "internal_profiling.extra_tags")
+		tags = append(tags, fmt.Sprintf("version:%v", v))
+
 		settings := profiling.Settings{
 			ProfilingURL:         site,
 			Socket:               cfg.GetString(l.ConfigPrefix + "internal_profiling.socket"),
@@ -98,7 +101,7 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 			BlockProfileRate:     cfg.GetInt(l.ConfigPrefix + "internal_profiling.block_profile_rate"),
 			WithGoroutineProfile: cfg.GetBool(l.ConfigPrefix + "internal_profiling.enable_goroutine_stacktraces"),
 			WithDeltaProfiles:    cfg.GetBool(l.ConfigPrefix + "internal_profiling.delta_profiles"),
-			Tags:                 []string{fmt.Sprintf("version:%v", v)},
+			Tags:                 tags,
 		}
 		err := profiling.Start(settings)
 		if err == nil {

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -44,13 +44,18 @@ func Start(settings Settings) error {
 	options := []profiler.Option{
 		profiler.WithEnv(settings.Env),
 		profiler.WithService(settings.Service),
-		profiler.WithURL(settings.ProfilingURL),
 		profiler.WithPeriod(settings.Period),
 		profiler.WithProfileTypes(types...),
 		profiler.CPUDuration(settings.CPUDuration),
 		profiler.WithDeltaProfiles(settings.WithDeltaProfiles),
 		profiler.WithTags(settings.Tags...),
 		profiler.WithAPIKey(""), // to silence the error log about `DD_API_KEY`
+	}
+
+	if settings.Socket != "" {
+		options = append(options, profiler.WithUDS(settings.Socket))
+	} else {
+		options = append(options, profiler.WithURL(settings.ProfilingURL))
 	}
 
 	// If block or mutex profiling was configured via runtime configuration, pass current

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -42,6 +42,7 @@ func Start(settings Settings) error {
 	}
 
 	options := []profiler.Option{
+		profiler.WithURL(settings.ProfilingURL),
 		profiler.WithEnv(settings.Env),
 		profiler.WithService(settings.Service),
 		profiler.WithPeriod(settings.Period),
@@ -54,8 +55,6 @@ func Start(settings Settings) error {
 
 	if settings.Socket != "" {
 		options = append(options, profiler.WithUDS(settings.Socket))
-	} else {
-		options = append(options, profiler.WithURL(settings.ProfilingURL))
 	}
 
 	// If block or mutex profiling was configured via runtime configuration, pass current

--- a/pkg/util/profiling/settings.go
+++ b/pkg/util/profiling/settings.go
@@ -14,7 +14,10 @@ import (
 
 // Settings contains the settings for internal profiling, to be passed to Start().
 type Settings struct {
-	// ProfilingURL specifies the URL to which profiles will be sent.  This can be constructed
+	// Socket specifies the UDS to which profiles will be sent. This takes
+	// precedence over ProfilingURL if set.
+	Socket string
+	// ProfilingURL specifies the URL to which profiles will be sent. This can be constructed
 	// from a site value with ProfilingURLTemplate.
 	ProfilingURL string
 	// Env specifies the environment to which profiles should be registered.
@@ -40,7 +43,8 @@ type Settings struct {
 }
 
 func (settings *Settings) String() string {
-	return fmt.Sprintf("[Target:%q][Env:%q][Period:%s][CPU:%s][Mutex:%d][Block:%d][Routines:%v][DeltaProfiles:%v]",
+	return fmt.Sprintf("[Socket:%q][Target:%q][Env:%q][Period:%s][CPU:%s][Mutex:%d][Block:%d][Routines:%v][DeltaProfiles:%v]",
+		settings.Socket,
 		settings.ProfilingURL,
 		settings.Env,
 		settings.Period,

--- a/pkg/util/profiling/settings.go
+++ b/pkg/util/profiling/settings.go
@@ -14,11 +14,11 @@ import (
 
 // Settings contains the settings for internal profiling, to be passed to Start().
 type Settings struct {
-	// Socket specifies the UDS to which profiles will be sent. This takes
-	// precedence over ProfilingURL if set.
+	// Socket specifies a unix socket to which profiles will be sent.
 	Socket string
-	// ProfilingURL specifies the URL to which profiles will be sent. This can be constructed
-	// from a site value with ProfilingURLTemplate.
+	// ProfilingURL specifies the URL to which profiles will be sent in
+	// agentless mode. This can be constructed from a site value with
+	// ProfilingURLTemplate.
 	ProfilingURL string
 	// Env specifies the environment to which profiles should be registered.
 	Env string


### PR DESCRIPTION
### What does this PR do?

Extend the internal profiling configuration with the ability to specify a UDS to send profiles on and add custom tags.

### Motivation

This will allow the Single Machine Performance team to run the agent with internal profiling enabled.

SMP-648

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
