### PR TITLE
[E2E]: Add FakeIntakeStackDef

### DIFF
--- a/test/new-e2e/examples/agentenv_checkruns_test.go
+++ b/test/new-e2e/examples/agentenv_checkruns_test.go
@@ -16,11 +16,11 @@ import (
 )
 
 type agentSuiteEx5 struct {
-	e2e.Suite[e2e.AgentEnv]
+	e2e.Suite[e2e.FakeIntakeEnv]
 }
 
 func TestAgentSuiteEx5(t *testing.T) {
-	e2e.Run(t, &agentSuiteEx5{}, e2e.AgentStackDef(nil))
+	e2e.Run(t, &agentSuiteEx5{}, e2e.FakeIntakeStackDef(nil))
 }
 
 func (s *agentSuiteEx5) TestCheckRuns() {

--- a/test/new-e2e/examples/agentenv_logs_test.go
+++ b/test/new-e2e/examples/agentenv_logs_test.go
@@ -27,12 +27,12 @@ import (
 )
 
 type vmFakeintakeSuite struct {
-	e2e.Suite[e2e.AgentEnv]
+	e2e.Suite[e2e.FakeIntakeEnv]
 }
 
-func logsExampleStackDef(vmParams []ec2params.Option, agentParams ...agentparams.Option) *e2e.StackDefinition[e2e.AgentEnv] {
+func logsExampleStackDef(vmParams []ec2params.Option, agentParams ...agentparams.Option) *e2e.StackDefinition[e2e.FakeIntakeEnv] {
 	return e2e.EnvFactoryStackDef(
-		func(ctx *pulumi.Context) (*e2e.AgentEnv, error) {
+		func(ctx *pulumi.Context) (*e2e.FakeIntakeEnv, error) {
 			vm, err := ec2vm.NewEc2VM(ctx, vmParams...)
 			if err != nil {
 				return nil, err
@@ -55,7 +55,7 @@ func logsExampleStackDef(vmParams []ec2params.Option, agentParams ...agentparams
 			if err != nil {
 				return nil, err
 			}
-			return &e2e.AgentEnv{
+			return &e2e.FakeIntakeEnv{
 				VM:         client.NewVM(vm),
 				Agent:      client.NewAgent(installer),
 				Fakeintake: client.NewFakeintake(fakeintakeExporter),

--- a/test/new-e2e/examples/agentenv_metrics_test.go
+++ b/test/new-e2e/examples/agentenv_metrics_test.go
@@ -17,11 +17,11 @@ import (
 )
 
 type vmSuiteEx5 struct {
-	e2e.Suite[e2e.AgentEnv]
+	e2e.Suite[e2e.FakeIntakeEnv]
 }
 
 func TestVMSuiteEx5(t *testing.T) {
-	e2e.Run(t, &vmSuiteEx5{}, e2e.AgentStackDef(nil))
+	e2e.Run(t, &vmSuiteEx5{}, e2e.FakeIntakeStackDef(nil))
 }
 
 func (v *vmSuiteEx5) Test1_FakeIntakeReceivesMetrics() {

--- a/test/new-e2e/utils/e2e/stack_definition.go
+++ b/test/new-e2e/utils/e2e/stack_definition.go
@@ -63,9 +63,8 @@ func CustomEC2VMStackDef[T any](fct func(vm.VM) (T, error), options ...ec2params
 }
 
 type AgentEnv struct {
-	VM         *client.VM
-	Agent      *client.Agent
-	Fakeintake *client.Fakeintake
+	VM    *client.VM
+	Agent *client.Agent
 }
 
 // AgentStackDef creates a stack definition containing a virtual machine and an Agent.
@@ -84,6 +83,40 @@ func AgentStackDef(vmParams []ec2params.Option, agentParameters ...agentparams.O
 				return nil, err
 			}
 
+			installer, err := agent.NewInstaller(vm, agentParameters...)
+			if err != nil {
+				return nil, err
+			}
+			return &AgentEnv{
+				VM:    client.NewVM(vm),
+				Agent: client.NewAgent(installer),
+			}, nil
+		},
+	)
+}
+
+type FakeIntakeEnv struct {
+	VM         *client.VM
+	Agent      *client.Agent
+	Fakeintake *client.Fakeintake
+}
+
+// FakeIntake creates a stack definition containing a virtual machine the Agent and the fake intake.
+//
+// See [ec2vm.Params] for available options for vmParams.
+//
+// See [agent.Params] for available options for agentParams.
+//
+// [ec2vm.Params]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/scenarios/aws/vm/ec2VM#Params
+// [agent.Params]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/components/datadog/agent#Params
+func FakeIntakeStackDef(vmParams []ec2params.Option, agentParameters ...agentparams.Option) *StackDefinition[FakeIntakeEnv] {
+	return EnvFactoryStackDef(
+		func(ctx *pulumi.Context) (*FakeIntakeEnv, error) {
+			vm, err := ec2vm.NewEc2VM(ctx, vmParams...)
+			if err != nil {
+				return nil, err
+			}
+
 			fakeintakeExporter, err := aws.NewEcsFakeintake(vm.GetAwsEnvironment())
 			if err != nil {
 				return nil, err
@@ -94,7 +127,7 @@ func AgentStackDef(vmParams []ec2params.Option, agentParameters ...agentparams.O
 			if err != nil {
 				return nil, err
 			}
-			return &AgentEnv{
+			return &FakeIntakeEnv{
 				VM:         client.NewVM(vm),
 				Agent:      client.NewAgent(installer),
 				Fakeintake: client.NewFakeintake(fakeintakeExporter),


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR adds a `FakeIntakeStackDef` which contains a VM, the Agent and the fake intake. 
Note: The fakeIntake was removed from `AgentStackDef`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Some e2e tests don't need the fake intake which takes time to setup (For example, e2e tests on the command line of the Agent).

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
