### PR TITLE
[USM] PathIdentifier Key() return safe filename

### DIFF
--- a/pkg/network/usm/utils/path_identifier.go
+++ b/pkg/network/usm/utils/path_identifier.go
@@ -12,6 +12,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"strings"
 	"syscall"
 
 	"github.com/twmb/murmur3"
@@ -45,7 +46,8 @@ func (p *PathIdentifier) Key() string {
 	m := murmur3.Sum64(buffer)
 	bufferSum := make([]byte, 8)
 	binary.LittleEndian.PutUint64(bufferSum, m)
-	return base64.StdEncoding.EncodeToString(bufferSum)
+	// avoid '/' in filename used later by ebpf-manager to register uprobe
+	return strings.ReplaceAll(base64.StdEncoding.EncodeToString(bufferSum), "/", "@")
 }
 
 // NewPathIdentifier returns a new PathIdentifier instance


### PR DESCRIPTION
### What does this PR do?

We relay on Key() to register uprobe. uprobes are created via `ebpf-manager/utils.go:GenerateEventName()`
Base64 is used in Key() and charsets is [a-z][A-Z][0-9]+/=

### Motivation

Avoiding potential failure earlier if Key() is used in filepath
Potentially avoid collision as / is replaced by _ later (see below)

ebpf-manager relay on safeEventRegexp to replace not a-zA-Z0-9 chars by _

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
