### PR TITLE
[corechecks/ksm] Fix tag corruption in job service checks

### DIFF
--- a/releasenotes-dca/notes/fix-tags-corruption-ksm-job-servicechecks-1d447544b3e23b00.yaml
+++ b/releasenotes-dca/notes/fix-tags-corruption-ksm-job-servicechecks-1d447544b3e23b00.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a rare bug in the Kubernetes State check that causes the Agent to incorrectly tag the ``kubernetes_state.job.complete`` service check.

--- a/releasenotes/notes/fix-tags-corruption-ksm-job-servicechecks-1d447544b3e23b00.yaml
+++ b/releasenotes/notes/fix-tags-corruption-ksm-job-servicechecks-1d447544b3e23b00.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a rare bug in the Kubernetes State check that causes the Agent to incorrectly tag the ``kubernetes_state.job.complete`` service check.


### PR DESCRIPTION

### What does this PR do?

Fixes a bug in the KSM check. The bug triggers rarely and causes the agent to attach wrong tags to the `kubernetes_state.job.complete` service check.

The root cause is that the KSM check was reusing the labels slice after sending it to the `Sender`. We shouldn't do that, because the Sender might modify it, as mentioned here:
https://github.com/DataDog/datadog-agent/blob/c10824243f20a7524b507f76f0b9e3e99f6ab6e5/pkg/collector/corechecks/safesender.go#L28

Note that KSM doesn't use the sender safe implementation that clones all the tags.
https://github.com/DataDog/datadog-agent/blob/c10824243f20a7524b507f76f0b9e3e99f6ab6e5/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go#L466

### Describe how to test/QA your changes

This is difficult to QA because the bug triggers very rarely.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
