### PR TITLE
[backport][CWS] Set IsExecChild according to parent's IsThread attribute #18546

### DIFF
--- a/pkg/security/resolvers/process/resolver.go
+++ b/pkg/security/resolvers/process/resolver.go
@@ -1143,6 +1143,7 @@ func (p *Resolver) syncCache(proc *process.Process, filledProc *utils.FilledProc
 	}
 
 	entry = p.NewProcessCacheEntry(model.PIDContext{Pid: pid, Tid: pid})
+	entry.IsThread = true
 
 	// update the cache entry
 	if err := p.enrichEventFromProc(entry, proc, filledProc); err != nil {

--- a/pkg/security/secl/model/process_cache_entry.go
+++ b/pkg/security/secl/model/process_cache_entry.go
@@ -35,7 +35,6 @@ func (pc *ProcessCacheEntry) SetAncestor(parent *ProcessCacheEntry) {
 
 	pc.Ancestor = parent
 	pc.Parent = &parent.Process
-	pc.IsThread = false
 	parent.Retain()
 }
 
@@ -78,7 +77,7 @@ func (pc *ProcessCacheEntry) Exec(entry *ProcessCacheEntry) {
 
 	// use exec time as exit time
 	pc.Exit(entry.ExecTime)
-	entry.Process.IsExecChild = true
+	entry.Process.IsExecChild = !pc.IsThread
 
 	// keep some context
 	copyProcessContext(pc, entry)

--- a/pkg/security/security_profile/activity_tree/activity_tree_test.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_test.go
@@ -1913,6 +1913,318 @@ var activityTreeInsertExecEventTestCases = []struct {
 		},
 	},
 
+	// exec/12_bis
+	// ---------------
+	//
+	//      /bin/apache         +          systemd                                              ==>>              /bin/bash          /bin/apache
+	//          |                            |- /bin/bash                                                            |                    |
+	//       /bin/ls                         |- /bin/webserver                                                 /bin/webserver          /bin/ls
+	//          |                            |- /bin/apache                                                          |                    |
+	//       /bin/date                       |- /bin/wc                                                         /bin/apache           /bin/date
+	//          |                            |- /bin/id                                                              |                    |
+	//       /bin/du                         |- /bin/ls                                                           /bin/wc              /bin/du
+	//                                       |- /bin/date                                                            |
+	//                                       |- /bin/passwd                                                       /bin/id
+	//                                       |- /bin/bpftool                                                         |
+	//                                       |- /bin/du                                                           /bin/ls
+	//                                                                                                               |
+	//                                                                                                            /bin/date
+	//                                                                                                               |
+	//                                                                                                           /bin/passwd
+	//                                                                                                               |
+	//                                                                                                           /bin/bpftool
+	//                                                                                                               |
+	//                                                                                                           /bin/du
+	{
+		name: "exec/12_bis",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/apache",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/ls",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/date",
+										},
+									},
+									Children: []*ProcessNode{
+										{
+											Process: model.Process{
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/du",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 1,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/webserver",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/apache",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 3,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/wc",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 4,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/id",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 5,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/ls",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 6,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/date",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 7,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/passwd",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 8,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/bpftool",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 9,
+						},
+					},
+				},
+			},
+			{
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/du",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 10,
+						},
+					},
+				},
+			},
+		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "/bin/du",
+				},
+			},
+		},
+		wantNewEntry: true,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/apache",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/ls",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/date",
+										},
+									},
+									Children: []*ProcessNode{
+										{
+											Process: model.Process{
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/du",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Process: model.Process{
+						FileEvent: model.FileEvent{
+							PathnameStr: "/bin/bash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								FileEvent: model.FileEvent{
+									PathnameStr: "/bin/webserver",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										FileEvent: model.FileEvent{
+											PathnameStr: "/bin/apache",
+										},
+									},
+									Children: []*ProcessNode{
+										{
+											Process: model.Process{
+												FileEvent: model.FileEvent{
+													PathnameStr: "/bin/wc",
+												},
+											},
+											Children: []*ProcessNode{
+												{
+													Process: model.Process{
+														FileEvent: model.FileEvent{
+															PathnameStr: "/bin/id",
+														},
+													},
+													Children: []*ProcessNode{
+														{
+															Process: model.Process{
+																FileEvent: model.FileEvent{
+																	PathnameStr: "/bin/ls",
+																},
+															},
+															Children: []*ProcessNode{
+																{
+																	Process: model.Process{
+																		FileEvent: model.FileEvent{
+																			PathnameStr: "/bin/date",
+																		},
+																	},
+																	Children: []*ProcessNode{
+																		{
+																			Process: model.Process{
+																				FileEvent: model.FileEvent{
+																					PathnameStr: "/bin/passwd",
+																				},
+																			},
+																			Children: []*ProcessNode{
+																				{
+																					Process: model.Process{
+																						FileEvent: model.FileEvent{
+																							PathnameStr: "/bin/bpftool",
+																						},
+																					},
+																					Children: []*ProcessNode{
+																						{
+																							Process: model.Process{
+																								FileEvent: model.FileEvent{
+																									PathnameStr: "/bin/du",
+																								},
+																							},
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
 	// exec/13
 	// ---------------
 	//

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -108,7 +108,6 @@ func TestActivityDumps(t *testing.T) {
 			if node.Process.Pid < node.Process.PPid {
 				t.Errorf("PID < PPID")
 			}
-			assert.Equal(t, false, node.Process.IsThread)
 			assert.Equal(t, uint64(0), node.Process.SpanID)
 			assert.Equal(t, uint64(0), node.Process.TraceID)
 			assert.Equal(t, "", node.Process.TTYName)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Set the flag according to its parent IsThread attribute.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

When events are coming from runtime events and not from the snapshot,
the attribute IsExecChild is always true. This may cause activity profiles to
be inaccurate.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
