### PR TITLE
[Single Machine Performance] Use new flows

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -83,13 +83,13 @@ single-machine-performance-regression_detector:
             --submission-metadata submission_metadata
     # Wait for job to complete.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job status --use-curta --use-consignor
+            job status --use-curta
             --wait
             --wait-delay-seconds 60
             --submission-metadata submission_metadata
     # Now that the job is completed pull the analysis report, output it to stdout.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job sync --use-curta --use-consignor
+            job sync --use-curta
             --submission-metadata submission_metadata
             --output-path outputs
     # Replace empty lines in the output with lines containing various unicode
@@ -120,5 +120,5 @@ single-machine-performance-regression_detector:
     - cat outputs/report.html | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME"
     # Finally, exit 1 if the job signals a regression else 0.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job result --use-curta --use-consignor
+            job result --use-curta
             --submission-metadata submission_metadata

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -68,7 +68,7 @@ single-machine-performance-regression_detector:
     - RUST_LOG="info,aws_config::profile::credentials=error"
     - RUST_LOG_DEBUG="debug,aws_config::profile::credentials=error"
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job submit
+            job submit --use-curta
             --lading-version ${LADING_VERSION}
             --baseline-image ${BASELINE_IMAGE}
             --comparison-image ${COMPARISON_IMAGE}
@@ -83,13 +83,13 @@ single-machine-performance-regression_detector:
             --submission-metadata submission_metadata
     # Wait for job to complete.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job status
+            job status --use-curta
             --wait
             --wait-delay-seconds 60
             --submission-metadata submission_metadata
     # Now that the job is completed pull the analysis report, output it to stdout.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job sync
+            job sync --use-curta --use-consignor
             --submission-metadata submission_metadata
             --output-path outputs
     # Replace empty lines in the output with lines containing various unicode
@@ -120,5 +120,5 @@ single-machine-performance-regression_detector:
     - cat outputs/report.html | /usr/local/bin/pr-commenter --for-pr="$CI_COMMIT_REF_NAME"
     # Finally, exit 1 if the job signals a regression else 0.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job result
+            job result --use-curta --use-consignor
             --submission-metadata submission_metadata

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -83,7 +83,7 @@ single-machine-performance-regression_detector:
             --submission-metadata submission_metadata
     # Wait for job to complete.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job status --use-curta
+            job status --use-curta --use-consignor
             --wait
             --wait-delay-seconds 60
             --submission-metadata submission_metadata


### PR DESCRIPTION
### What does this PR do?

This commit adds flags to switch `smp` to make calls into the SMP infrastructure through new paths. There should be no user-visible change.

REF SMP-673

