### PR TITLE
Move process event consumer to be imported only by system-probe

### DIFF
--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -13,7 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	emconfig "github.com/DataDog/datadog-agent/pkg/eventmonitor/config"
 	"github.com/DataDog/datadog-agent/pkg/network/events"
-	procevents "github.com/DataDog/datadog-agent/pkg/process/events"
+	procconsumer "github.com/DataDog/datadog-agent/pkg/process/events/consumer"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
 	secmodule "github.com/DataDog/datadog-agent/pkg/security/module"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -65,7 +65,7 @@ var EventMonitor = module.Factory{
 		}
 
 		if emconfig.ProcessConsumerEnabled {
-			process, err := procevents.NewProcessConsumer(evm)
+			process, err := procconsumer.NewProcessConsumer(evm)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/process/events/consumer/process_events_consumer.go
+++ b/pkg/process/events/consumer/process_events_consumer.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package events
+package consumer
 
 import (
 	"time"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Moves process event consumer to a separate package only imported by `system-probe`

### Motivation

Reduce size of `process-agent` caused by unnecessary imports.

### Additional Notes

Change in `process-agent` size:
```
before: 124271832 = 118.51 MiB
after: 116646448 = 111.24 MiB
```
net: -7MiB

Change in `process-agent` imports:
```patch
-github.com/DataDog/agent-payload/v5/cws/dumpsv1
-github.com/DataDog/datadog-agent/cmd/system-probe/api/module
-github.com/DataDog/datadog-agent/comp/dogstatsd/listeners
-github.com/DataDog/datadog-agent/comp/dogstatsd/listeners/ratelimit
-github.com/DataDog/datadog-agent/comp/dogstatsd/mapper
-github.com/DataDog/datadog-agent/comp/dogstatsd/replay
-github.com/DataDog/datadog-agent/comp/dogstatsd/server
-github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug
-github.com/DataDog/datadog-agent/pkg/eventmonitor
-github.com/DataDog/datadog-agent/pkg/eventmonitor/config
-github.com/DataDog/datadog-agent/pkg/network/driver
-github.com/DataDog/datadog-agent/pkg/security/config
-github.com/DataDog/datadog-agent/pkg/security/ebpf
-github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel
-github.com/DataDog/datadog-agent/pkg/security/ebpf/probes
-github.com/DataDog/datadog-agent/pkg/security/events
-github.com/DataDog/datadog-agent/pkg/security/metrics
-github.com/DataDog/datadog-agent/pkg/security/probe
-github.com/DataDog/datadog-agent/pkg/security/probe/config
-github.com/DataDog/datadog-agent/pkg/security/probe/constantfetch
-github.com/DataDog/datadog-agent/pkg/security/probe/erpc
-github.com/DataDog/datadog-agent/pkg/security/probe/eventstream
-github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer
-github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/ringbuffer
-github.com/DataDog/datadog-agent/pkg/security/probe/kfilters
-github.com/DataDog/datadog-agent/pkg/security/probe/managerhelper
-github.com/DataDog/datadog-agent/pkg/security/probe/monitors/approver
-github.com/DataDog/datadog-agent/pkg/security/probe/monitors/cgroups
-github.com/DataDog/datadog-agent/pkg/security/probe/monitors/discarder
-github.com/DataDog/datadog-agent/pkg/security/probe/monitors/runtime
-github.com/DataDog/datadog-agent/pkg/security/probe/monitors/syscalls
-github.com/DataDog/datadog-agent/pkg/security/proto/api
-github.com/DataDog/datadog-agent/pkg/security/rconfig
-github.com/DataDog/datadog-agent/pkg/security/resolvers
-github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup
-github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model
-github.com/DataDog/datadog-agent/pkg/security/resolvers/container
-github.com/DataDog/datadog-agent/pkg/security/resolvers/dentry
-github.com/DataDog/datadog-agent/pkg/security/resolvers/envvars
-github.com/DataDog/datadog-agent/pkg/security/resolvers/hash
-github.com/DataDog/datadog-agent/pkg/security/resolvers/mount
-github.com/DataDog/datadog-agent/pkg/security/resolvers/netns
-github.com/DataDog/datadog-agent/pkg/security/resolvers/path
-github.com/DataDog/datadog-agent/pkg/security/resolvers/process
-github.com/DataDog/datadog-agent/pkg/security/resolvers/sbom
-github.com/DataDog/datadog-agent/pkg/security/resolvers/selinux
-github.com/DataDog/datadog-agent/pkg/security/resolvers/tags
-github.com/DataDog/datadog-agent/pkg/security/resolvers/tc
-github.com/DataDog/datadog-agent/pkg/security/resolvers/time
-github.com/DataDog/datadog-agent/pkg/security/resolvers/usergroup
-github.com/DataDog/datadog-agent/pkg/security/secl/args
-github.com/DataDog/datadog-agent/pkg/security/secl/compiler/ast
-github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval
-github.com/DataDog/datadog-agent/pkg/security/secl/log
-github.com/DataDog/datadog-agent/pkg/security/secl/model
-github.com/DataDog/datadog-agent/pkg/security/secl/rules
-github.com/DataDog/datadog-agent/pkg/security/secl/validators
-github.com/DataDog/datadog-agent/pkg/security/seclog
-github.com/DataDog/datadog-agent/pkg/security/security_profile
-github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree
-github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree/metadata
-github.com/DataDog/datadog-agent/pkg/security/security_profile/dump
-github.com/DataDog/datadog-agent/pkg/security/security_profile/profile
-github.com/DataDog/datadog-agent/pkg/security/serializers
-github.com/DataDog/datadog-agent/pkg/security/utils
-github.com/Masterminds/semver/v3
-github.com/alecthomas/participle
-github.com/alecthomas/participle/lexer
-github.com/alecthomas/participle/lexer/ebnf
-github.com/alecthomas/participle/lexer/ebnf/internal
-github.com/h2non/filetype
-github.com/hashicorp/golang-lru/v2
-github.com/hashicorp/golang-lru/v2/simplelru
-github.com/josharian/intern
-github.com/mailru/easyjson
-github.com/mailru/easyjson/buffer
-github.com/mailru/easyjson/jlexer
-github.com/mailru/easyjson/jwriter
-github.com/skydive-project/go-debouncer
-text/scanner
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
