### PR TITLE
Create fake SNMP session for testing.

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/session/fake_session.go
+++ b/pkg/collector/corechecks/snmp/internal/session/fake_session.go
@@ -1,0 +1,250 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package session
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// oidToNumbers parses an OID into a list of numbers.
+// It is the inverse of numbersToOID.
+func oidToNumbers(oid string) ([]int, error) {
+	oid = strings.TrimLeft(oid, ".")
+	strNumbers := strings.Split(oid, ".")
+	var numbers []int
+	for _, strNumber := range strNumbers {
+		num, err := strconv.Atoi(strNumber)
+		if err != nil {
+			return nil, fmt.Errorf("error converting digit %s (oid=%s)", strNumber, oid)
+		}
+		numbers = append(numbers, num)
+	}
+	return numbers, nil
+}
+
+// numbersToOID converts a list of numbers back to an OID.
+// It is the inverse of oidToNumbers.
+func numbersToOID(nums []int) string {
+	segments := make([]string, len(nums))
+	for i, k := range nums {
+		segments[i] = fmt.Sprint(k)
+	}
+	return strings.Join(segments, ".")
+}
+
+// cmpOIDs return -1 if a < b, 1 if a > b, and 0 otherwise.
+// Ordering is lexicographic by OID.
+func cmpOIDs(a, b []int) int {
+	for i := range a {
+		if i >= len(b) {
+			return 1
+		}
+		if a[i] > b[i] {
+			return 1
+		}
+		if a[i] < b[i] {
+			return -1
+		}
+	}
+	if len(b) > len(a) {
+		return -1
+	}
+	return 0
+}
+
+// FakeSession implements Session wrapping around a fixed set of PDUs.
+// Caveats:
+//   - Fetching an object that isn't there will always return NoSuchObject,
+//     never NoSuchInstance. I don't think we can do NoSuchInstance without
+//     parsing a MIB to know what paths could exist.
+type FakeSession struct {
+	data map[string]gosnmp.SnmpPDU
+	// oids is a sorted slice of all OIDs in data, stored as []ints.
+	oids [][]int
+	// dirty indicates whether oids needs to be rebuilt.
+	dirty bool
+}
+
+// CreateFakeSession creates a new FakeSession with an empty set of data.
+func CreateFakeSession() *FakeSession {
+	return &FakeSession{
+		data: make(map[string]gosnmp.SnmpPDU),
+	}
+}
+
+// Set creates a new PDU with the given attributes, replacing any in the
+// session with the same OID.
+func (fs *FakeSession) Set(oid string, typ gosnmp.Asn1BER, val any) *FakeSession {
+	if _, ok := fs.data[oid]; !ok {
+		// new OID, need to rebuild oids
+		fs.dirty = true
+	}
+	fs.data[oid] = gosnmp.SnmpPDU{
+		Name:  oid,
+		Type:  typ,
+		Value: val,
+	}
+	return fs
+}
+
+// SetMany adds many PDUs to the session at once.
+func (fs *FakeSession) SetMany(pdus ...gosnmp.SnmpPDU) {
+	fs.dirty = true
+	for _, pdu := range pdus {
+		fs.data[pdu.Name] = pdu
+	}
+}
+
+// getOIDs returns a sorted list of all OIDs in fs.data.
+func (fs *FakeSession) getOIDs() [][]int {
+	if fs.dirty {
+		fs.oids = [][]int{}
+		for oid := range fs.data {
+			nums, err := oidToNumbers(oid)
+			if err != nil {
+				continue
+			}
+			fs.oids = append(fs.oids, nums)
+		}
+		sort.Slice(fs.oids, func(i, j int) bool {
+			return cmpOIDs(fs.oids[i], fs.oids[j]) < 0
+		})
+		fs.dirty = false
+	}
+	return fs.oids
+}
+
+// Connect is a no-op.
+func (fs *FakeSession) Connect() error {
+	return nil
+}
+
+// Close is a no-op.
+func (fs *FakeSession) Close() error {
+	return nil
+}
+
+// GetVersion always returns 3.
+func (fs *FakeSession) GetVersion() gosnmp.SnmpVersion {
+	return gosnmp.Version3
+}
+
+// Get gets the values for the given OIDs. OIDs not in the session will return
+// PDUs of type NoSuchObject.
+func (fs *FakeSession) Get(oids []string) (result *gosnmp.SnmpPacket, err error) {
+	vars := make([]gosnmp.SnmpPDU, len(oids))
+	for i, oid := range oids {
+		v, ok := fs.data[oid]
+		if !ok {
+			v = gosnmp.SnmpPDU{
+				Name:  oid,
+				Type:  gosnmp.NoSuchObject,
+				Value: nil,
+			}
+		}
+		vars[i] = v
+	}
+	return &gosnmp.SnmpPacket{
+		Variables: vars,
+	}, nil
+}
+
+// nextIndex finds the index of the first OID greater than the input.
+// If oid is later than all known OIDs, it returns len(fs.OIDs).
+func (fs *FakeSession) nextIndex(oid []int) int {
+	oids := fs.getOIDs()
+	return sort.Search(len(oids), func(i int) bool {
+		return cmpOIDs(oid, oids[i]) < 0
+	})
+}
+
+// getNexts returns the items expected by a GetBulk request.
+func (fs *FakeSession) getNexts(oids []string, count int) ([]gosnmp.SnmpPDU, error) {
+	knownOIDs := fs.getOIDs()
+	vars := make([]gosnmp.SnmpPDU, len(oids)*count)
+	for i, oid := range oids {
+		index := len(knownOIDs)
+		nums, err := oidToNumbers(oid)
+		if err == nil {
+			index = fs.nextIndex(nums)
+		}
+		for offset := 0; offset < count; offset++ {
+			var v gosnmp.SnmpPDU
+			if index+offset >= len(knownOIDs) {
+				// out of bounds
+				v = gosnmp.SnmpPDU{
+					Name:  oid,
+					Type:  gosnmp.EndOfMibView,
+					Value: nil,
+				}
+			} else {
+				v = fs.data[numbersToOID(knownOIDs[index+offset])]
+			}
+			vars[offset*len(oids)+i] = v
+		}
+	}
+	return vars, nil
+}
+
+// GetBulk returns the `count` next PDUs after each of the given oids.
+// If it runs off the end of the data the extra values will all be EndOfMibView
+// PDUs.
+func (fs *FakeSession) GetBulk(oids []string, count uint32) (*gosnmp.SnmpPacket, error) {
+	vars, err := fs.getNexts(oids, int(count))
+	if err != nil {
+		return nil, err
+	}
+	return &gosnmp.SnmpPacket{
+		Variables: vars,
+	}, nil
+}
+
+// GetNext returns the first PDU after each of the given OIDs. An OID with
+// nothing greater than it will result in an EndOfMibView PDU.
+func (fs *FakeSession) GetNext(oids []string) (*gosnmp.SnmpPacket, error) {
+	vars, err := fs.getNexts(oids, 1)
+	if err != nil {
+		return nil, err
+	}
+	return &gosnmp.SnmpPacket{
+		Variables: vars,
+	}, nil
+}
+
+// SetByte adds an OctetString PDU with the given OID and value
+func (fs *FakeSession) SetByte(oid string, value []byte) *FakeSession {
+	return fs.Set(oid, gosnmp.OctetString, value)
+}
+
+// SetStr adds an OctetString PDU with the given OID and value
+func (fs *FakeSession) SetStr(oid string, value string) *FakeSession {
+	return fs.SetByte(oid, []byte(value))
+}
+
+// SetObj adds an ObjectIdentifier PDU with the given OID and value
+func (fs *FakeSession) SetObj(oid string, value string) *FakeSession {
+	return fs.Set(oid, gosnmp.ObjectIdentifier, value)
+}
+
+// SetTime adds a TimeTicks PDU with the given OID and value
+func (fs *FakeSession) SetTime(oid string, ticks int) *FakeSession {
+	return fs.Set(oid, gosnmp.TimeTicks, ticks)
+}
+
+// SetInt adds an Integer PDU with the given OID and value
+func (fs *FakeSession) SetInt(oid string, value int) *FakeSession {
+	return fs.Set(oid, gosnmp.Integer, value)
+}
+
+// SetIP adds an IP PDU with the given OID and value
+func (fs *FakeSession) SetIP(oid string, value string) *FakeSession {
+	return fs.Set(oid, gosnmp.IPAddress, value)
+}

--- a/pkg/collector/corechecks/snmp/internal/session/fake_session_test.go
+++ b/pkg/collector/corechecks/snmp/internal/session/fake_session_test.go
@@ -1,0 +1,206 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package session
+
+import (
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+)
+
+func BytePDU(oid string, value []byte) gosnmp.SnmpPDU {
+	return gosnmp.SnmpPDU{
+		Name:  oid,
+		Type:  gosnmp.OctetString,
+		Value: value,
+	}
+}
+
+func StrPDU(oid string, value string) gosnmp.SnmpPDU {
+	return BytePDU(oid, []byte(value))
+}
+
+func ObjPDU(oid string, value string) gosnmp.SnmpPDU {
+	return gosnmp.SnmpPDU{
+		Name:  oid,
+		Type:  gosnmp.ObjectIdentifier,
+		Value: value,
+	}
+}
+
+func NoObjPDU(oid string) gosnmp.SnmpPDU {
+	return gosnmp.SnmpPDU{
+		Name:  oid,
+		Type:  gosnmp.NoSuchObject,
+		Value: nil,
+	}
+}
+
+func EndOfMibViewPDU(oid string) gosnmp.SnmpPDU {
+	return gosnmp.SnmpPDU{
+		Name:  oid,
+		Type:  gosnmp.EndOfMibView,
+		Value: nil,
+	}
+}
+
+func Packet(pdus ...gosnmp.SnmpPDU) *gosnmp.SnmpPacket {
+	return &gosnmp.SnmpPacket{
+		Variables: pdus,
+	}
+}
+
+func TestFakeSession(t *testing.T) {
+	sess := CreateFakeSession()
+
+	// system description
+	sess.SetStr("1.3.6.1.2.1.1.1.0", "my_desc")
+	// device type
+	sess.SetObj("1.3.6.1.2.1.1.2.0", "1.3.6.1.4.1.3375.2.1.3.4.1")
+	// interface description
+	sess.SetStr("1.3.6.1.2.1.2.2.1.2.1", `desc1`)
+	// interface physical address
+	sess.SetByte("1.3.6.1.2.1.2.2.1.6.1", []byte{00, 00, 00, 00, 00, 01})
+	// interface description
+	sess.SetStr("1.3.6.1.2.1.2.2.1.2.2", `desc2`)
+	// interface physical address
+	sess.SetByte("1.3.6.1.2.1.2.2.1.6.2", []byte{00, 00, 00, 00, 00, 01})
+
+	t.Run("Get", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			oids     []string
+			expected *gosnmp.SnmpPacket
+		}{{
+			name: "single",
+			oids: []string{"1.3.6.1.2.1.1.2.0"},
+			expected: Packet(
+				ObjPDU("1.3.6.1.2.1.1.2.0", "1.3.6.1.4.1.3375.2.1.3.4.1"),
+			),
+		}, {
+			name: "multiple",
+			oids: []string{"1.3.6.1.2.1.1.2.0", "1.3.6.1.2.1.1.1.0"},
+			expected: Packet(
+				ObjPDU("1.3.6.1.2.1.1.2.0", "1.3.6.1.4.1.3375.2.1.3.4.1"),
+				StrPDU("1.3.6.1.2.1.1.1.0", "my_desc"),
+			),
+		}, {
+			name: "missing",
+			oids: []string{"1.3.6.1.2.1.1.2.0", "1.3.6.1.2.1.1.10"},
+			expected: Packet(
+				ObjPDU("1.3.6.1.2.1.1.2.0", "1.3.6.1.4.1.3375.2.1.3.4.1"),
+				NoObjPDU("1.3.6.1.2.1.1.10"),
+			),
+		}, {
+			name: "invalid",
+			oids: []string{"1.3.6.1.2.1.1.2.0", "not.an.oid"},
+			expected: Packet(
+				ObjPDU("1.3.6.1.2.1.1.2.0", "1.3.6.1.4.1.3375.2.1.3.4.1"),
+				NoObjPDU("not.an.oid"),
+			),
+		}}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				result, err := sess.Get(tt.oids)
+				assert.Nil(t, err)
+				assert.Equal(t, tt.expected, result)
+			})
+		}
+	})
+
+	t.Run("GetNext", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			oids     []string
+			expected *gosnmp.SnmpPacket
+		}{{
+			name:     "single",
+			oids:     []string{"1.0"},
+			expected: Packet(StrPDU("1.3.6.1.2.1.1.1.0", "my_desc")),
+		}, {
+			name: "multiple",
+			oids: []string{"1.3.6.1.2.1.2.2.1.2.0", "1.3.6.1.2.1.2.2.1.6.0"},
+			expected: Packet(
+				StrPDU("1.3.6.1.2.1.2.2.1.2.1", `desc1`), BytePDU("1.3.6.1.2.1.2.2.1.6.1", []byte{00, 00, 00, 00, 00, 01}),
+			),
+		}, {
+			name: "no-next",
+			oids: []string{"1.3.6.1.2.1.2.2.1.6.2"},
+			expected: Packet(
+				EndOfMibViewPDU("1.3.6.1.2.1.2.2.1.6.2"),
+			),
+		}, {
+			name: "invalid",
+			oids: []string{"not.an.oid"},
+			expected: Packet(
+				EndOfMibViewPDU("not.an.oid"),
+			),
+		}}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				result, err := sess.GetNext(tt.oids)
+				assert.Nil(t, err)
+				assert.Equal(t, tt.expected, result)
+			})
+		}
+	})
+
+	t.Run("GetBulk", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			oids     []string
+			count    uint32
+			expected *gosnmp.SnmpPacket
+		}{{
+			name:  "single",
+			oids:  []string{"1.3.6.1.2.1.2.2.1.2.0"},
+			count: 3,
+			expected: Packet(
+				StrPDU("1.3.6.1.2.1.2.2.1.2.1", `desc1`),
+				StrPDU("1.3.6.1.2.1.2.2.1.2.2", `desc2`),
+				BytePDU("1.3.6.1.2.1.2.2.1.6.1", []byte{00, 00, 00, 00, 00, 01}),
+			),
+		}, {
+			name:  "multiple",
+			oids:  []string{"1.3.6.1.2.1.2.2.1.2.0", "1.3.6.1.2.1.2.2.1.6.0"},
+			count: 3,
+			expected: Packet(
+				StrPDU("1.3.6.1.2.1.2.2.1.2.1", `desc1`),
+				BytePDU("1.3.6.1.2.1.2.2.1.6.1", []byte{00, 00, 00, 00, 00, 01}),
+				StrPDU("1.3.6.1.2.1.2.2.1.2.2", `desc2`),
+				BytePDU("1.3.6.1.2.1.2.2.1.6.2", []byte{00, 00, 00, 00, 00, 01}),
+				BytePDU("1.3.6.1.2.1.2.2.1.6.1", []byte{00, 00, 00, 00, 00, 01}),
+				EndOfMibViewPDU("1.3.6.1.2.1.2.2.1.6.0"),
+			),
+		}, {
+			name:  "no-next",
+			count: 3,
+			oids:  []string{"1.3.6.1.2.1.2.2.1.6.2"},
+			expected: Packet(
+				EndOfMibViewPDU("1.3.6.1.2.1.2.2.1.6.2"),
+				EndOfMibViewPDU("1.3.6.1.2.1.2.2.1.6.2"),
+				EndOfMibViewPDU("1.3.6.1.2.1.2.2.1.6.2"),
+			),
+		}, {
+			name:  "invalid",
+			count: 3,
+			oids:  []string{"not.an.oid"},
+			expected: Packet(
+				EndOfMibViewPDU("not.an.oid"),
+				EndOfMibViewPDU("not.an.oid"),
+				EndOfMibViewPDU("not.an.oid"),
+			),
+		}}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				result, err := sess.GetBulk(tt.oids, tt.count)
+				assert.Nil(t, err)
+				assert.Equal(t, tt.expected, result)
+			})
+		}
+	})
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR adds a `FakeSession` type to `pkg/collector/corechecks/snmp/internal/session`, which implements `Get/GetNext/GetBulk` on top of a static set of PDUs.

### Motivation

I need to expand some existing tests that currently rely on hand-crafted packets registered with a `MockSession`, which requires hard-coding the exact requests that the system will make and makes it difficult to express changing data. This tool will make that much easier. Additionally, it will allow us to shrink the tests noticeably - e.g. the >200 line block linked [here](https://github.com/DataDog/datadog-agent/blob/690fce28878cddf2b23f78e5dfbca261643e9e87/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go#L66-L294) could be replaced with the following 22 lines:

```go
sess.SetStr("1.3.6.1.2.1.1.1.0", "my_desc").
  SetObj("1.3.6.1.2.1.1.2.0", "1.3.6.1.4.1.3375.2.1.3.4.1").
  SetTime("1.3.6.1.2.1.1.3.0", 20).
  SetStr("1.3.6.1.2.1.1.5.0", "foo_sys_name").
  SetInt("1.3.6.1.4.1.3375.2.1.1.2.1.44.0", 30).
  SetInt("1.3.6.1.2.1.2.2.1.13.1", 131).
  SetInt("1.3.6.1.2.1.2.2.1.14.1", 141).
  SetByte("1.3.6.1.2.1.2.2.1.6.1", []byte{00, 00, 00, 00, 00, 01}).
  SetInt("1.3.6.1.2.1.2.2.1.7.1", 1).
  SetInt("1.3.6.1.2.1.2.2.1.8.1", 1).
  SetInt("1.3.6.1.2.1.2.2.1.13.2", 132).
  SetInt("1.3.6.1.2.1.2.2.1.14.2", 142).
  SetByte("1.3.6.1.2.1.2.2.1.6.2", []byte{00, 00, 00, 00, 00, 01}).
  SetInt("1.3.6.1.2.1.2.2.1.7.2", 1).
  SetInt("1.3.6.1.2.1.2.2.1.8.2", 1).
  SetStr("1.3.6.1.2.1.31.1.1.1.1.1", "nameRow1").
  SetStr("1.3.6.1.2.1.31.1.1.1.18.1", "descRow1").
  SetInt("1.3.6.1.2.1.4.20.1.2.10.0.0.1", 1).
  SetIP("1.3.6.1.2.1.4.20.1.3.10.0.0.1", "255.255.255.0").
  SetStr("1.3.6.1.2.1.31.1.1.1.1.2", "nameRow2").
  SetStr("1.3.6.1.2.1.31.1.1.1.18.2", "descRow2").
  SetInt("1.3.6.1.2.1.4.20.1.2.10.0.0.2", 1).
  SetIP("1.3.6.1.2.1.4.20.1.3.10.0.0.2", "255.255.255.0")
```

### Describe how to test/QA your changes

There are tests for `FakeSession` in `testing_utils_test`; this shouldn't require additional QA because it doesn't affect anything on the production path.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
