### PR TITLE
[corechecks/ksm] Support HPA v2beta2 again

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/customresources/hpa.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/hpa.go
@@ -10,14 +10,15 @@ package customresources
 // This file has most of its logic copied from the KSM hpa metric family
 // generators available at
 // https://github.com/kubernetes/kube-state-metrics/blob/release-2.4/internal/store/horizontalpodautoscaler.go
-// It exists here to provide backwards compatibility with k8s >1.25, as KSM 2.4
-// uses API v2beta2 instead of v2.
+// It exists here to provide backwards compatibility with kubernetes versions
+// that use autoscaling/v2beta2, as the KSM version that we depend on uses API
+// v2 instead of v2beta2.
 
 import (
 	"context"
 
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
-	autoscaling "k8s.io/api/autoscaling/v2"
+	autoscaling "k8s.io/api/autoscaling/v2beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -54,9 +55,9 @@ var (
 	targetMetricLabels = []string{"metric_name", "metric_target_type"}
 )
 
-// NewHorizontalPodAutoscalerV2Factory returns a new HorizontalPodAutoscaler
-// metric family generator factory.
-func NewHorizontalPodAutoscalerV2Factory(client *apiserver.APIClient) customresource.RegistryFactory {
+// NewHorizontalPodAutoscalerV2Beta2Factory returns a new
+// HorizontalPodAutoscaler metric family generator factory.
+func NewHorizontalPodAutoscalerV2Beta2Factory(client *apiserver.APIClient) customresource.RegistryFactory {
 	return &hpav2Factory{
 		client: client.Cl,
 	}
@@ -363,11 +364,11 @@ func (f *hpav2Factory) ListWatch(customResourceClient interface{}, ns string, fi
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			opts.FieldSelector = fieldSelector
-			return client.AutoscalingV2().HorizontalPodAutoscalers(ns).List(context.TODO(), opts)
+			return client.AutoscalingV2beta2().HorizontalPodAutoscalers(ns).List(context.TODO(), opts)
 		},
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
 			opts.FieldSelector = fieldSelector
-			return client.AutoscalingV2().HorizontalPodAutoscalers(ns).Watch(context.TODO(), opts)
+			return client.AutoscalingV2beta2().HorizontalPodAutoscalers(ns).Watch(context.TODO(), opts)
 		},
 	}
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -431,11 +431,8 @@ func manageResourcesReplacement(c *apiserver.APIClient, factories []customresour
 		"policy/v1": {
 			"PodDisruptionBudget": customresources.NewPodDisruptionBudgetV1Beta1Factory,
 		},
-
-		// support for newer k8s versions where the newer resources are
-		// not yet supported by KSM
-		"autoscaling/v2beta2": {
-			"HorizontalPodAutoscaler": customresources.NewHorizontalPodAutoscalerV2Factory,
+		"autoscaling/v2": {
+			"HorizontalPodAutoscaler": customresources.NewHorizontalPodAutoscalerV2Beta2Factory,
 		},
 	}
 

--- a/releasenotes-dca/ksm-support-hpa-v2beta2-e745b1d2519a7d6c.yaml
+++ b/releasenotes-dca/ksm-support-hpa-v2beta2-e745b1d2519a7d6c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes the KSM check to support HPA v2beta2 again. This stopped working in agent v7.44.0.

--- a/releasenotes-dca/ksm-support-hpa-v2beta2-e745b1d2519a7d6c.yaml
+++ b/releasenotes-dca/ksm-support-hpa-v2beta2-e745b1d2519a7d6c.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fixes the KSM check to support HPA v2beta2 again. This stopped working in agent v7.44.0.
+    Fixes the KSM check to support HPA v2beta2 again. This stopped working in Agent v7.44.0.

--- a/releasenotes/notes/ksm-support-hpa-v2beta2-e745b1d2519a7d6c.yaml
+++ b/releasenotes/notes/ksm-support-hpa-v2beta2-e745b1d2519a7d6c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes the KSM check to support HPA v2beta2 again. This stopped working in agent v7.44.0.

--- a/releasenotes/notes/ksm-support-hpa-v2beta2-e745b1d2519a7d6c.yaml
+++ b/releasenotes/notes/ksm-support-hpa-v2beta2-e745b1d2519a7d6c.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fixes the KSM check to support HPA v2beta2 again. This stopped working in agent v7.44.0.
+    Fixes the KSM check to support HPA v2beta2 again. This stopped working in Agent v7.44.0.


### PR DESCRIPTION
### What does this PR do?

Fixes the KSM check to support HPA v2beta2 again.

Support for HPA v2beta2 was broken in agent v7.44 when the kube-state-metrics dependency was upgraded (https://github.com/DataDog/datadog-agent/pull/15623)

The old kube-state-metrics version that we used only supported HPA v2beta2, so we added some custom code to also support HPA v2. The kube-state-metrics version that we're using now only support v2, so this time we need to add some custom code to support HPA v2beta2.

Fixes https://github.com/DataDog/datadog-agent/issues/17843

### Describe how to test/QA your changes

Deploy the agent with the kubernetes state metrics check enabled. Deploy an HPA. Verify that the `kubernetes_state.hpa.*` metrics are reported both in a recent version of kubernetes (>= 1.23) with HPA v2 and an older version of kubernetes (< 1.23) with HPA v2beta2.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
