### PR TITLE
[collector/worker] Add utilization to the telemetry

### DIFF
--- a/pkg/collector/worker/worker.go
+++ b/pkg/collector/worker/worker.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/runner/tracker"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -27,6 +28,17 @@ const (
 
 	// Variables for the utilization expvars
 	pollingInterval = 15 * time.Second
+)
+
+// The worker utilization is also reported via expvars, but it emits one metric
+// for each worker, which is a bit inconvenient to use because the number of
+// workers might be different on every Agent. With telemetry, we can use a
+// single metric and put the worker name in a tag.
+var workerUtilization = telemetry.NewGauge(
+	"collector",
+	"worker_utilization",
+	[]string{"worker_name"},
+	"Worker utilization. It's a value between 0 and 1 that represents the share of time that the check runner worker is running checks",
 )
 
 // Worker is an object that encapsulates the logic to manage a loop of processing
@@ -113,7 +125,7 @@ func (w *Worker) Run() {
 	utilizationTracker := NewUtilizationTracker(w.Name, w.utilizationTickInterval)
 	defer utilizationTracker.Stop()
 
-	startExpvarUpdater(w.Name, utilizationTracker)
+	startUtilizationUpdater(w.Name, utilizationTracker)
 	cancel := startTrackerTicker(utilizationTracker, w.utilizationTickInterval)
 	defer cancel()
 
@@ -199,16 +211,20 @@ func (w *Worker) Run() {
 	log.Debugf("Runner %d, worker %d: Finished processing checks.", w.runnerID, w.ID)
 }
 
-func startExpvarUpdater(name string, ut *UtilizationTracker) {
+func startUtilizationUpdater(name string, ut *UtilizationTracker) {
 	expvars.SetWorkerStats(name, &expvars.WorkerStats{
 		Utilization: 0.0,
 	})
+
+	workerUtilization.Set(0, name)
 
 	go func() {
 		for value := range ut.Output {
 			expvars.SetWorkerStats(name, &expvars.WorkerStats{
 				Utilization: value,
 			})
+
+			workerUtilization.Set(value, name)
 		}
 		expvars.DeleteWorkerStats(name)
 	}()

--- a/releasenotes/notes/worker-utilization-in-telemetry-15708e06cd138ea7.yaml
+++ b/releasenotes/notes/worker-utilization-in-telemetry-15708e06cd138ea7.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added ``collector.worker_utilization`` to the telemetry. This metric represents the amount of time that a runner worker has been running checks.


### PR DESCRIPTION
### What does this PR do?

Adds `collector.worker_utilization` to the telemetry. This metric represents the amount of time that a runner worker has been running checks.

### Motivation

This metric is already exposed via expvars, but it emits one metric for each worker, which is a bit inconvenient to use because the number of workers might be different on every Agent. It makes it difficult to build dashboards that show the metric, for example. With telemetry, we can use a single metric and put the worker name in a tag.

### Describe how to test/QA your changes

Run the agent with `DD_TELEMETRY_ENABLED` set to true and verify that the new metric is reported in the telemetry endpoint.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
