### PR TITLE
Fix linter error by differentiating test suite structs

### DIFF
--- a/test/new-e2e/agent-subcommands/configcheck_test.go
+++ b/test/new-e2e/agent-subcommands/configcheck_test.go
@@ -15,12 +15,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type agentSuite struct {
+type agentConfigCheckSuite struct {
 	e2e.Suite[e2e.AgentEnv]
 }
 
 func TestAgentConfigCheckSuite(t *testing.T) {
-	e2e.Run(t, &agentSuite{}, e2e.AgentStackDef(nil))
+	e2e.Run(t, &agentConfigCheckSuite{}, e2e.AgentStackDef(nil))
 }
 
 type CheckConfigOutput struct {
@@ -57,7 +57,7 @@ func MatchCheckToTemplate(checkname, input string) (*CheckConfigOutput, error) {
 	}, nil
 }
 
-func (v *agentSuite) TestMatchToTemplateHelper() {
+func (v *agentConfigCheckSuite) TestMatchToTemplateHelper() {
 	sampleCheck := `=== uptime check ===
 Configuration provider: file
 Configuration source: file:/etc/datadog-agent/conf.d/uptime.d/conf.yaml.default
@@ -103,7 +103,7 @@ Config for instance ID: cpu:e331d61ed1323219
 }
 
 // cpu, disk, file_handle, io, load, memory, network, ntp, uptime
-func (v *agentSuite) TestDefaultInstalledChecks() {
+func (v *agentConfigCheckSuite) TestDefaultInstalledChecks() {
 	v.UpdateEnv(e2e.AgentStackDef(nil))
 
 	testChecks := []CheckConfigOutput{
@@ -178,7 +178,7 @@ func (v *agentSuite) TestDefaultInstalledChecks() {
 	}
 }
 
-func (v *agentSuite) TestWithBadConfigCheck() {
+func (v *agentConfigCheckSuite) TestWithBadConfigCheck() {
 	// invalid config because of tabspace
 	config := `instances:
 	- name: bad yaml formatting via tab
@@ -191,7 +191,7 @@ func (v *agentSuite) TestWithBadConfigCheck() {
 	assert.Contains(v.T(), output, "http_check: yaml: line 2: found character that cannot start any token")
 }
 
-func (v *agentSuite) TestWithAddedIntegrationsCheck() {
+func (v *agentConfigCheckSuite) TestWithAddedIntegrationsCheck() {
 	config := `instances:
   - name: My First Service
     url: http://some.url.example.com

--- a/test/new-e2e/agent-subcommands/hostname_ec2_test.go
+++ b/test/new-e2e/agent-subcommands/hostname_ec2_test.go
@@ -15,16 +15,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type agentSuite struct {
+type agentHostnameSuite struct {
 	e2e.Suite[e2e.AgentEnv]
 }
 
 func TestAgentHostnameEC2Suite(t *testing.T) {
-	e2e.Run(t, &agentSuite{}, e2e.AgentStackDef(nil))
+	e2e.Run(t, &agentHostnameSuite{}, e2e.AgentStackDef(nil))
 }
 
 // https://github.com/DataDog/datadog-agent/blob/main/pkg/util/hostname/README.md#the-current-logic
-func (v *agentSuite) TestAgentHostnameDefaultsToResourceId() {
+func (v *agentHostnameSuite) TestAgentHostnameDefaultsToResourceId() {
 	v.UpdateEnv(e2e.AgentStackDef(nil, agentparams.WithAgentConfig("")))
 
 	metadata := client.NewEC2Metadata(v.Env().VM)
@@ -35,14 +35,14 @@ func (v *agentSuite) TestAgentHostnameDefaultsToResourceId() {
 	assert.Equal(v.T(), hostname, resourceId)
 }
 
-func (v *agentSuite) TestAgentConfigHostnameVarOverride() {
+func (v *agentHostnameSuite) TestAgentConfigHostnameVarOverride() {
 	v.UpdateEnv(e2e.AgentStackDef(nil, agentparams.WithAgentConfig("hostname: hostname.from.var")))
 
 	hostname := v.Env().Agent.Hostname()
 	assert.Equal(v.T(), hostname, "hostname.from.var")
 }
 
-func (v *agentSuite) TestAgentConfigHostnameFileOverride() {
+func (v *agentHostnameSuite) TestAgentConfigHostnameFileOverride() {
 	fileContent := "hostname.from.file"
 	v.Env().VM.Execute(fmt.Sprintf(`echo "%s" | tee /tmp/hostname`, fileContent))
 	v.UpdateEnv(e2e.AgentStackDef(nil, agentparams.WithAgentConfig("hostname_file: /tmp/hostname")))
@@ -52,7 +52,7 @@ func (v *agentSuite) TestAgentConfigHostnameFileOverride() {
 }
 
 // hostname_force_config_as_canonical stops throwing a warning but doesn't change behavior
-func (v *agentSuite) TestAgentConfigHostnameForceAsCanonical() {
+func (v *agentHostnameSuite) TestAgentConfigHostnameForceAsCanonical() {
 	config := `hostname: ip-172-29-113-35.ec2.internal
 hostname_force_config_as_canonical: true`
 	v.UpdateEnv(e2e.AgentStackDef(nil, agentparams.WithAgentConfig(config)))
@@ -61,7 +61,7 @@ hostname_force_config_as_canonical: true`
 	assert.Equal(v.T(), hostname, "ip-172-29-113-35.ec2.internal")
 }
 
-func (v *agentSuite) TestAgentConfigPrioritizeEC2Id() {
+func (v *agentHostnameSuite) TestAgentConfigPrioritizeEC2Id() {
 	// ec2_prioritize_instance_id_as_hostname doesn't override higher priority providers
 	config := `hostname: hostname.from.var
 ec2_prioritize_instance_id_as_hostname: true`
@@ -71,7 +71,7 @@ ec2_prioritize_instance_id_as_hostname: true`
 	assert.Equal(v.T(), hostname, "hostname.from.var")
 }
 
-func (v *agentSuite) TestAgentConfigPreferImdsv2() {
+func (v *agentHostnameSuite) TestAgentConfigPreferImdsv2() {
 	v.UpdateEnv(e2e.AgentStackDef(nil, agentparams.WithAgentConfig("ec2_prefer_imdsv2: true")))
 	// e2e metadata provider already uses IMDSv2
 	metadata := client.NewEC2Metadata(v.Env().VM)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fixes a [linter error](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/307094112) for reused type name introduced in https://github.com/DataDog/datadog-agent/pull/18290

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
