### PR TITLE
Add kube_pod_tolerations metric to the KSM core check

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -51,6 +51,7 @@ func defaultMetricNamesMapper() map[string]string {
 		"kube_pod_status_scheduled":                                                                "pod.scheduled",
 		"kube_pod_spec_volumes_persistentvolumeclaims_readonly":                                    "pod.volumes.persistentvolumeclaims_readonly",
 		"kube_pod_status_unschedulable":                                                            "pod.unschedulable",
+		"kube_pod_tolerations":                                                                     "pod.tolerations",
 		"kube_poddisruptionbudget_status_current_healthy":                                          "pdb.pods_healthy",
 		"kube_poddisruptionbudget_status_desired_healthy":                                          "pdb.pods_desired",
 		"kube_poddisruptionbudget_status_pod_disruptions_allowed":                                  "pdb.disruptions_allowed",

--- a/releasenotes-dca/notes/Add-pod-tolerations-metric-to-KSM-core-check-1cc56a7c1986dd83.yaml
+++ b/releasenotes-dca/notes/Add-pod-tolerations-metric-to-KSM-core-check-1cc56a7c1986dd83.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Adding kubernetes_state.pod.tolerations metric to KSM core check

--- a/releasenotes-dca/notes/Add-pod-tolerations-metric-to-KSM-core-check-1cc56a7c1986dd83.yaml
+++ b/releasenotes-dca/notes/Add-pod-tolerations-metric-to-KSM-core-check-1cc56a7c1986dd83.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    Adding kubernetes_state.pod.tolerations metric to KSM core check
+    Added the kubernetes_state.pod.tolerations metric to the KSM core check

--- a/releasenotes/notes/Add-pod-tolerations-metric-to-KSM-core-check-737fa165f1b5a963.yaml
+++ b/releasenotes/notes/Add-pod-tolerations-metric-to-KSM-core-check-737fa165f1b5a963.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Adding kubernetes_state.pod.tolerations metric to KSM core check

--- a/releasenotes/notes/Add-pod-tolerations-metric-to-KSM-core-check-737fa165f1b5a963.yaml
+++ b/releasenotes/notes/Add-pod-tolerations-metric-to-KSM-core-check-737fa165f1b5a963.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    Adding kubernetes_state.pod.tolerations metric to KSM core check
+    Added the kubernetes_state.pod.tolerations metric to the KSM core check


### PR DESCRIPTION
### What does this PR do?

This PR exposes the kube_pod_tolerations metric on kube state metrics core check (KSM).

[Ref Jira Card
](https://datadoghq.atlassian.net/jira/software/projects/CONT/boards/167?selectedIssue=CONT-3862)

### Motivation

Being able to monitor what are the toleration set on each pod deployed in my cluster.

Example use case: users might want to know what the ratio is between pods deployed on ARM and AMD even if the application can support both. The choice between ARM or AMD is done by the kube-scheduler depending of the Nodes available to schedule the pod, and so the cluster-autoscaler that increase the number of node depending of the unscheduled pods. 

### Additional Notes
- No unit tests are implemented to test individual metrics for this check, this is why the same pattern is followed in this PR and unit testing for this specific metric wasn't implemented.
- The documentation was updated by adding the new exposed metric to metadata.csv. Check the [corresponding PR](https://github.com/DataDog/integrations-core/pull/15478).

### Describe how to test/QA your changes
The change was tested by the following steps:
- Deploy the cluster agent on a kubernetes cluster (in my case, I deployed it locally on minikube using helm) (refer to [this](https://docs.datadoghq.com/integrations/kubernetes_state_core/?tab=helm) for more information on enabling the check in deployment)
- Create a some pods with tolerations:
    - We created 4 pods with toleration arch=arm
    - We created 3 pods with toleration arch=amd
- Monitor the pods tolerations on Datadog by looking up the `kube_state.pod.tolerations` metric with key=arch and summing by value
- You should get a graph identical to the following:
![image](https://github.com/DataDog/datadog-agent/assets/41540817/737a6ca8-d6d0-45e8-bcef-e13deed2fbe1)


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
