### PR TITLE
[usm][npm] Revert use of eBPF LRU map

### DIFF
--- a/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
+++ b/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
@@ -7,15 +7,7 @@
 
 // Maps a connection tuple to its classified protocol. Used to reduce redundant
 // classification procedures on the same connection
-#if(defined(COMPILE_RUNTIME) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0))
-// If *runtime compilation is enabled*, but we don't support LRUs, fallback to a HashMap
 BPF_HASH_MAP(connection_protocol, conn_tuple_t, protocol_stack_t, 0)
-#else
-// Otherwise use a LRU map instead. Note that Kernels older than 4.10 will use
-// this map definifition in the context of either pre-built or CO-RE, but in this
-// case we change the map spec during load time from userspace.
-BPF_LRU_MAP(connection_protocol, conn_tuple_t, protocol_stack_t, 0)
-#endif
 
 static __always_inline protocol_stack_t* get_protocol_stack(conn_tuple_t *skb_tup) {
     conn_tuple_t normalized_tup = *skb_tup;

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/features"
 
 	manager "github.com/DataDog/ebpf-manager"
 
@@ -216,14 +215,6 @@ func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer boo
 				EditorFlag: manager.EditType,
 			}
 		}
-	}
-
-	// Replace LRU map type by Hash map if kernel doesn't support it
-	if err := features.HaveMapType(ebpf.LRUHash); err != nil {
-		me := mgrOpts.MapSpecEditors[probes.ConnectionProtocolMap]
-		me.Type = ebpf.Hash
-		me.EditorFlag |= manager.EditType
-		mgrOpts.MapSpecEditors[probes.ConnectionProtocolMap] = me
 	}
 
 	if err := errtelemetry.ActivateBPFTelemetry(m, undefinedProbes); err != nil {


### PR DESCRIPTION
### What does this PR do?

Revert https://github.com/DataDog/datadog-agent/pull/17839

### Motivation

We have established that this particular map is causing CPU contention in some of our production workloads, which is is translating into many issues such as elevated error rates for some of our network-edge services.

### Additional Notes

The underlying map leak that motivated the transition to a LRU map was tackled in a separate change (https://github.com/DataDog/datadog-agent/pull/17972) which obviates the need for this type of map since we no longer rely on evictions.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
