### PR TITLE
[backport][usm][npm] Revert use of eBPF LRU map

### DIFF
--- a/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
+++ b/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
@@ -7,15 +7,7 @@
 
 // Maps a connection tuple to its classified protocol. Used to reduce redundant
 // classification procedures on the same connection
-#if(defined(COMPILE_RUNTIME) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0))
-// If *runtime compilation is enabled*, but we don't support LRUs, fallback to a HashMap
 BPF_HASH_MAP(connection_protocol, conn_tuple_t, protocol_stack_t, 0)
-#else
-// Otherwise use a LRU map instead. Note that Kernels older than 4.10 will use
-// this map definifition in the context of either pre-built or CO-RE, but in this
-// case we change the map spec during load time from userspace.
-BPF_LRU_MAP(connection_protocol, conn_tuple_t, protocol_stack_t, 0)
-#endif
 
 static __always_inline protocol_stack_t* get_protocol_stack(conn_tuple_t *skb_tup) {
     conn_tuple_t normalized_tup = *skb_tup;

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/features"
 
 	manager "github.com/DataDog/ebpf-manager"
 
@@ -216,14 +215,6 @@ func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer boo
 				EditorFlag: manager.EditType,
 			}
 		}
-	}
-
-	// Replace LRU map type by Hash map if kernel doesn't support it
-	if err := features.HaveMapType(ebpf.LRUHash); err != nil {
-		me := mgrOpts.MapSpecEditors[probes.ConnectionProtocolMap]
-		me.Type = ebpf.Hash
-		me.EditorFlag |= manager.EditType
-		mgrOpts.MapSpecEditors[probes.ConnectionProtocolMap] = me
 	}
 
 	if err := errtelemetry.ActivateBPFTelemetry(m, undefinedProbes); err != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Backport https://github.com/DataDog/datadog-agent/pull/18601

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
