### PR TITLE
[CWS] display evaluated events in timeout errors in tests

### DIFF
--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -446,6 +446,10 @@ func (e *RuleEngine) HandleEvent(event *model.Event) {
 	}
 }
 
+func (e *RuleEngine) StopEventCollector() []rules.CollectedEvent {
+	return e.GetRuleSet().StopEventCollector()
+}
+
 func logLoadingErrors(msg string, m *multierror.Error) {
 	var errorLevel bool
 	for _, err := range m.Errors {

--- a/pkg/security/secl/rules/collected_events.go
+++ b/pkg/security/secl/rules/collected_events.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package rules
+
+type CollectedEvent struct {
+	Type       string
+	EvalResult bool
+	Fields     map[string]interface{}
+}

--- a/pkg/security/secl/rules/collected_events_functests.go
+++ b/pkg/security/secl/rules/collected_events_functests.go
@@ -7,13 +7,21 @@
 
 package rules
 
-import "github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+import (
+	"sync"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+)
 
 type EventCollector struct {
+	sync.Mutex
 	eventsCollected []CollectedEvent
 }
 
 func (ec *EventCollector) CollectEvent(rs *RuleSet, event eval.Event, result bool) {
+	ec.Lock()
+	defer ec.Unlock()
+
 	eventType := event.GetType()
 	collectedEvent := CollectedEvent{
 		Type:       eventType,
@@ -44,6 +52,9 @@ func (ec *EventCollector) CollectEvent(rs *RuleSet, event eval.Event, result boo
 }
 
 func (ec *EventCollector) Stop() []CollectedEvent {
+	ec.Lock()
+	defer ec.Unlock()
+
 	collected := ec.eventsCollected
 	ec.eventsCollected = nil
 	return collected

--- a/pkg/security/secl/rules/collected_events_functests.go
+++ b/pkg/security/secl/rules/collected_events_functests.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build functionaltests
+
+package rules
+
+import "github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+
+type CollectedEvent struct {
+	Type       string
+	EvalResult bool
+	Fields     map[string]interface{}
+}
+
+type EventCollector struct {
+	eventsCollected []CollectedEvent
+}
+
+func (ec *EventCollector) CollectEvent(rs *RuleSet, event eval.Event, result bool) {
+	collectedEvent := CollectedEvent{
+		Type:       event.GetType(),
+		EvalResult: result,
+		Fields:     make(map[string]interface{}, len(rs.fields)),
+	}
+
+	for _, field := range rs.fields {
+		value, err := event.GetFieldValue(field)
+		if err != nil {
+			rs.logger.Errorf("failed to get value for %s: %v", field, err)
+			continue
+		}
+
+		collectedEvent.Fields[field] = value
+	}
+
+	ec.eventsCollected = append(ec.eventsCollected, collectedEvent)
+}
+
+func (ec *EventCollector) Stop() []CollectedEvent {
+	collected := ec.eventsCollected
+	ec.eventsCollected = nil
+	return collected
+}

--- a/pkg/security/secl/rules/collected_events_functests.go
+++ b/pkg/security/secl/rules/collected_events_functests.go
@@ -9,12 +9,6 @@ package rules
 
 import "github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 
-type CollectedEvent struct {
-	Type       string
-	EvalResult bool
-	Fields     map[string]interface{}
-}
-
 type EventCollector struct {
 	eventsCollected []CollectedEvent
 }

--- a/pkg/security/secl/rules/collected_events_regular.go
+++ b/pkg/security/secl/rules/collected_events_regular.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !functionaltests
+
+package rules
+
+import "github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+
+type CollectedEvent struct {
+}
+
+type EventCollector struct {
+}
+
+func (ec *EventCollector) CollectEvent(rs *RuleSet, event eval.Event, result bool) {
+	// no-op
+}
+
+func (ec *EventCollector) Stop() []CollectedEvent {
+	return nil
+}

--- a/pkg/security/secl/rules/collected_events_regular.go
+++ b/pkg/security/secl/rules/collected_events_regular.go
@@ -9,9 +9,6 @@ package rules
 
 import "github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 
-type CollectedEvent struct {
-}
-
 type EventCollector struct {
 }
 

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -678,6 +678,8 @@ func (rs *RuleSet) Evaluate(event eval.Event) bool {
 		}
 	}
 
+	// no-op in the general case, only used to collect events in functional tests
+	// for debugging purposes
 	rs.eventCollector.CollectEvent(rs, event, result)
 
 	return result

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -181,6 +181,9 @@ type RuleSet struct {
 	fields []string
 	logger log.Logger
 	pool   *eval.ContextPool
+
+	// event collector, used for tests
+	eventCollector EventCollector
 }
 
 // ListRuleIDs returns the list of RuleIDs from the ruleset
@@ -646,6 +649,7 @@ func (rs *RuleSet) Evaluate(event eval.Event) bool {
 	defer rs.pool.Put(ctx)
 
 	eventType := event.GetType()
+
 	bucket, exists := rs.eventRuleBuckets[eventType]
 	if !exists {
 		return false
@@ -673,6 +677,8 @@ func (rs *RuleSet) Evaluate(event eval.Event) bool {
 			}
 		}
 	}
+
+	rs.eventCollector.CollectEvent(rs, event, result)
 
 	return result
 }
@@ -740,6 +746,10 @@ func (rs *RuleSet) generatePartials() error {
 		}
 	}
 	return nil
+}
+
+func (rs *RuleSet) StopEventCollector() []CollectedEvent {
+	return rs.eventCollector.Stop()
 }
 
 // NewEvent returns a new event using the embedded constructor

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -1207,7 +1207,7 @@ func (tm *testModule) NewTimeoutError() ErrTimeout {
 		for _, event := range events {
 			msg.WriteString(fmt.Sprintf("%s (eval=%v) {\n", event.Type, event.EvalResult))
 			for field, value := range event.Fields {
-				msg.WriteString(fmt.Sprintf("\t%s = %v\n", field, value))
+				msg.WriteString(fmt.Sprintf("\t%s=%v,\n", field, value))
 			}
 			msg.WriteString("}\n")
 		}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -1124,7 +1124,7 @@ func (tm *testModule) GetEventDiscarder(tb testing.TB, action func() error, cb o
 
 	select {
 	case <-time.After(getEventTimeout):
-		return NewTimeoutError(tm.probe)
+		return tm.NewTimeoutError()
 	case <-ctx.Done():
 		return nil
 	}
@@ -1193,10 +1193,28 @@ func (et ErrTimeout) Error() string {
 }
 
 // NewTimeoutError returns a new timeout error with the metrics collected during the test
-func NewTimeoutError(probe *sprobe.Probe) ErrTimeout {
-	return ErrTimeout{
-		fmt.Sprintf("timeout, details: %s, probe stats: %+v", GetStatusMetrics(probe), spew.Sdump(ddebpf.GetProbeStats())),
+func (tm *testModule) NewTimeoutError() ErrTimeout {
+	err := ErrTimeout{
+		"timeout, details: ",
 	}
+
+	err.msg += GetStatusMetrics(tm.probe)
+	err.msg += spew.Sdump(ddebpf.GetProbeStats())
+
+	events := tm.ruleEngine.StopEventCollector()
+	if len(events) != 0 {
+		err.msg += "\nevents evaluated:\n"
+
+		for _, event := range events {
+			err.msg += fmt.Sprintf("%s (eval=%v) {\n", event.Type, event.EvalResult)
+			for field, value := range event.Fields {
+				err.msg += fmt.Sprintf("\t%s = %v\n", field, value)
+			}
+			err.msg += "}\n"
+		}
+	}
+
+	return err
 }
 
 // ActionMessage is used to send a message from an action function to its callback
@@ -1272,7 +1290,7 @@ func (tm *testModule) GetSignal(tb testing.TB, action func() error, cb onRuleHan
 		tb.FailNow()
 		return nil
 	case <-time.After(getEventTimeout):
-		return NewTimeoutError(tm.probe)
+		return tm.NewTimeoutError()
 	case <-ctx.Done():
 		return nil
 	}
@@ -1322,7 +1340,7 @@ func (tm *testModule) GetCustomEventSent(tb testing.TB, action func() error, cb 
 
 	select {
 	case <-time.After(timeout):
-		return NewTimeoutError(tm.probe)
+		return tm.NewTimeoutError()
 	case <-ctx.Done():
 		return nil
 	}
@@ -1390,7 +1408,7 @@ func (tm *testModule) GetProbeEvent(action func() error, cb func(event *model.Ev
 
 	select {
 	case <-time.After(timeout):
-		return NewTimeoutError(tm.probe)
+		return tm.NewTimeoutError()
 	case <-ctx.Done():
 		return nil
 	}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -1194,27 +1194,26 @@ func (et ErrTimeout) Error() string {
 
 // NewTimeoutError returns a new timeout error with the metrics collected during the test
 func (tm *testModule) NewTimeoutError() ErrTimeout {
-	err := ErrTimeout{
-		"timeout, details: ",
-	}
+	var msg strings.Builder
 
-	err.msg += GetStatusMetrics(tm.probe)
-	err.msg += spew.Sdump(ddebpf.GetProbeStats())
+	msg.WriteString("timeout, details: ")
+	msg.WriteString(GetStatusMetrics(tm.probe))
+	msg.WriteString(spew.Sdump(ddebpf.GetProbeStats()))
 
 	events := tm.ruleEngine.StopEventCollector()
 	if len(events) != 0 {
-		err.msg += "\nevents evaluated:\n"
+		msg.WriteString("\nevents evaluated:\n")
 
 		for _, event := range events {
-			err.msg += fmt.Sprintf("%s (eval=%v) {\n", event.Type, event.EvalResult)
+			msg.WriteString(fmt.Sprintf("%s (eval=%v) {\n", event.Type, event.EvalResult))
 			for field, value := range event.Fields {
-				err.msg += fmt.Sprintf("\t%s = %v\n", field, value)
+				msg.WriteString(fmt.Sprintf("\t%s = %v\n", field, value))
 			}
-			err.msg += "}\n"
+			msg.WriteString("}\n")
 		}
 	}
 
-	return err
+	return ErrTimeout{msg.String()}
 }
 
 // ActionMessage is used to send a message from an action function to its callback


### PR DESCRIPTION
### What does this PR do?

The goal of this PR is to collect events going through the current ruleset, and displaying them when a test fails because of a timeout. This will help investigation of flaky tests by showing for example events that should have matched but whose fields are broken, not what is expected.

This feature is enabled only if the `functionaltests` build tag is enabled so that it doesn't impact the actual system probe build.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
