### PR TITLE
usm: process monitor: fix a possible deadlock

### DIFF
--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -239,10 +239,8 @@ func (pm *ProcessMonitor) Initialize() error {
 	pm.initOnce.Do(
 		func() {
 			pm.done = make(chan struct{})
-			pm.callbackRunnersWG = sync.WaitGroup{}
 			pm.initCallbackRunner()
 
-			pm.processMonitorWG = sync.WaitGroup{}
 			pm.processMonitorWG.Add(1)
 			// Setting up the main loop
 			pm.netlinkDoneChannel = make(chan struct{})
@@ -334,6 +332,8 @@ func (pm *ProcessMonitor) Stop() {
 	// As tests are running altogether, initOne and processMonitor are being created only once per compilation unit
 	// thus, the first test works without an issue, but the second test has troubles.
 	pm.initOnce = sync.Once{}
+	pm.processMonitorWG = sync.WaitGroup{}
+	pm.callbackRunnersWG = sync.WaitGroup{}
 	pm.processExecCallbacksMutex.Lock()
 	pm.processExecCallbacks = make(map[*ProcessCallback]struct{})
 	pm.processExecCallbacksMutex.Unlock()

--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -331,9 +331,9 @@ func (pm *ProcessMonitor) Stop() {
 	// that's being done for testing purposes.
 	// As tests are running altogether, initOne and processMonitor are being created only once per compilation unit
 	// thus, the first test works without an issue, but the second test has troubles.
-	pm.initOnce = sync.Once{}
 	pm.processMonitorWG = sync.WaitGroup{}
 	pm.callbackRunnersWG = sync.WaitGroup{}
+	pm.initOnce = sync.Once{}
 	pm.processExecCallbacksMutex.Lock()
 	pm.processExecCallbacks = make(map[*ProcessCallback]struct{})
 	pm.processExecCallbacksMutex.Unlock()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Handles deadlock in the code.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Found a couple of deadlocks in the CI.

```
[4.14.262-200.489.amzn2.x86_64] goroutine 19746 [running]:
       [4.14.262-200.489.amzn2.x86_64] testing.(*M).startAlarm.func1()
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/testing/testing.go:2241 +0x3c5
       [4.14.262-200.489.amzn2.x86_64] created by time.goFunc
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/time/sleep.go:176 +0x32
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 1 [chan receive, 42 minutes]:
       [4.14.262-200.489.amzn2.x86_64] testing.(*T).Run(0xc0007f44e0, {0x25e1b26?, 0x54b805?}, 0x26cf648)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/testing/testing.go:1630 +0x405
       [4.14.262-200.489.amzn2.x86_64] testing.runTests.func1(0x4053480?)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/testing/testing.go:2036 +0x45
       [4.14.262-200.489.amzn2.x86_64] testing.tRunner(0xc0007f44e0, 0xc00055fc18)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/testing/testing.go:1576 +0x10b
       [4.14.262-200.489.amzn2.x86_64] testing.runTests(0xc0003b6dc0?, {0x3f6dd00, 0x14, 0x14}, {0xc0007fc270?, 0x2?, 0x4051d60?})
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/testing/testing.go:2034 +0x489
       [4.14.262-200.489.amzn2.x86_64] testing.(*M).Run(0xc0003b6dc0)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/testing/testing.go:1906 +0x63a
       [4.14.262-200.489.amzn2.x86_64] github.com/DataDog/datadog-agent/pkg/network/tracer.TestMain(0xffffffffffffffff?)
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/network/tracer/tracer_test.go:60 +0x6f
       [4.14.262-200.489.amzn2.x86_64] main.main()
       [4.14.262-200.489.amzn2.x86_64] _testmain.go:93 +0x1d3
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 19 [sync.Cond.Wait, 28 minutes]:
       [4.14.262-200.489.amzn2.x86_64] sync.runtime_notifyListWait(0xc0001a4650, 0x1f)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/runtime/sema.go:527 +0x14c
       [4.14.262-200.489.amzn2.x86_64] sync.(*Cond).Wait(0xc000220000?)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/sync/cond.go:70 +0x8c
       [4.14.262-200.489.amzn2.x86_64] github.com/cihub/seelog.(*asyncLoopLogger).processItem(0xc000220000)
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/cihub/seelog@v0.0.0-20151216151435-d2c6e5aa9fbf/behavior_asynclooplogger.go:50 +0xa5
       [4.14.262-200.489.amzn2.x86_64] github.com/cihub/seelog.(*asyncLoopLogger).processQueue(0xc000220000)
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/cihub/seelog@v0.0.0-20151216151435-d2c6e5aa9fbf/behavior_asynclooplogger.go:63 +0x35
       [4.14.262-200.489.amzn2.x86_64] created by github.com/cihub/seelog.NewAsyncLoopLogger
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/cihub/seelog@v0.0.0-20151216151435-d2c6e5aa9fbf/behavior_asynclooplogger.go:40 +0xca
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 20 [sync.Cond.Wait, 55 minutes]:
       [4.14.262-200.489.amzn2.x86_64] sync.runtime_notifyListWait(0xc0001a47d0, 0x0)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/runtime/sema.go:527 +0x14c
       [4.14.262-200.489.amzn2.x86_64] sync.(*Cond).Wait(0x0?)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/sync/cond.go:70 +0x8c
       [4.14.262-200.489.amzn2.x86_64] github.com/cihub/seelog.(*asyncLoopLogger).processItem(0xc000220120)
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/cihub/seelog@v0.0.0-20151216151435-d2c6e5aa9fbf/behavior_asynclooplogger.go:50 +0xa5
       [4.14.262-200.489.amzn2.x86_64] github.com/cihub/seelog.(*asyncLoopLogger).processQueue(0xc000220120)
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/cihub/seelog@v0.0.0-20151216151435-d2c6e5aa9fbf/behavior_asynclooplogger.go:63 +0x35
       [4.14.262-200.489.amzn2.x86_64] created by github.com/cihub/seelog.NewAsyncLoopLogger
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/cihub/seelog@v0.0.0-20151216151435-d2c6e5aa9fbf/behavior_asynclooplogger.go:40 +0xca
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 37 [select]:
       [4.14.262-200.489.amzn2.x86_64] github.com/patrickmn/go-cache.(*janitor).Run(0xc00011f310, 0xc0001a3800?)
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/patrickmn/go-cache@v2.1.0+incompatible/cache.go:1079 +0x85
       [4.14.262-200.489.amzn2.x86_64] created by github.com/patrickmn/go-cache.runJanitor
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/patrickmn/go-cache@v2.1.0+incompatible/cache.go:1099 +0xed
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 88 [select]:
       [4.14.262-200.489.amzn2.x86_64] github.com/patrickmn/go-cache.(*janitor).Run(0xc00011fec0, 0xc00012c8a0?)
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/patrickmn/go-cache@v2.1.0+incompatible/cache.go:1079 +0x85
       [4.14.262-200.489.amzn2.x86_64] created by github.com/patrickmn/go-cache.runJanitor
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/patrickmn/go-cache@v2.1.0+incompatible/cache.go:1099 +0xed
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 118 [select]:
       [4.14.262-200.489.amzn2.x86_64] go.opencensus.io/stats/view.(*worker).start(0xc0003d7180)
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/go.opencensus.io@v0.24.0/stats/view/worker.go:292 +0xad
       [4.14.262-200.489.amzn2.x86_64] created by go.opencensus.io/stats/view.init.0
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/go.opencensus.io@v0.24.0/stats/view/worker.go:34 +0x96
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 7965 [chan receive, 33 minutes]:
       [4.14.262-200.489.amzn2.x86_64] testing.(*T).Run(0xc000e761a0, {0x25f2956?, 0x599?}, 0xc001337350)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/testing/testing.go:1630 +0x405
       [4.14.262-200.489.amzn2.x86_64] github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest.TestBuildMode(0xf?, {0x2e1b5b8, 0x45cae20}, {0x0, 0x0}, 0x26cf640)
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest/buildmode_linux.go:40 +0xe5
       [4.14.262-200.489.amzn2.x86_64] github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest.TestBuildModes(...)
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest/buildmode_linux.go:35
       [4.14.262-200.489.amzn2.x86_64] github.com/DataDog/datadog-agent/pkg/network/tracer.TestUSMSuite(0xc0014adba0?)
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/network/tracer/tracer_usm_linux_test.go:83 +0xa5
       [4.14.262-200.489.amzn2.x86_64] testing.tRunner(0xc000e761a0, 0x26cf648)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/testing/testing.go:1576 +0x10b
       [4.14.262-200.489.amzn2.x86_64] created by testing.(*T).Run
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/testing/testing.go:1629 +0x3ea
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 19675 [chan receive, 28 minutes]:
       [4.14.262-200.489.amzn2.x86_64] github.com/vishvananda/netlink.ProcEventMonitor.func1()
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/!data!dog/netlink@v1.0.1-0.20230703150631-f11d5ab05838/proc_event_linux.go:151 +0x28
       [4.14.262-200.489.amzn2.x86_64] created by github.com/vishvananda/netlink.ProcEventMonitor
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/!data!dog/netlink@v1.0.1-0.20230703150631-f11d5ab05838/proc_event_linux.go:150 +0x27f
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 17652 [select, 35 minutes]:
       [4.14.262-200.489.amzn2.x86_64] github.com/go-sql-driver/mysql.(*mysqlConn).startWatcher.func1()
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/go-sql-driver/mysql@v1.7.1/connection.go:614 +0xaa
       [4.14.262-200.489.amzn2.x86_64] created by github.com/go-sql-driver/mysql.(*mysqlConn).startWatcher
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/go-sql-driver/mysql@v1.7.1/connection.go:611 +0x10a
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 19652 [semacquire, 28 minutes]:
       [4.14.262-200.489.amzn2.x86_64] sync.runtime_Semacquire(0x198ef9b?)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/runtime/sema.go:62 +0x27
       [4.14.262-200.489.amzn2.x86_64] sync.(*WaitGroup).Wait(0xc000d01500?)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/sync/waitgroup.go:116 +0x4b
       [4.14.262-200.489.amzn2.x86_64] github.com/DataDog/datadog-agent/pkg/network/usm/sharedlibraries.(*Watcher).Stop(0xc0003fb110)
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/network/usm/sharedlibraries/watcher.go:95 +0x45
       [4.14.262-200.489.amzn2.x86_64] github.com/DataDog/datadog-agent/pkg/network/usm.(*sslProgram).Stop(0xc001bea180?, 0xc0016a9e08?)
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/network/usm/ebpf_ssl.go:449 +0x1d
       [4.14.262-200.489.amzn2.x86_64] github.com/DataDog/datadog-agent/pkg/network/usm.(*Monitor).Stop(0xc001122480)
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/network/usm/monitor.go:277 +0x85
       [4.14.262-200.489.amzn2.x86_64] github.com/DataDog/datadog-agent/pkg/network/tracer.(*Tracer).Stop(0xc0012d61a0)
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/network/tracer/tracer.go:355 +0x68
       [4.14.262-200.489.amzn2.x86_64] testing.(*common).Cleanup.func1()
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/testing/testing.go:1150 +0x11f
       [4.14.262-200.489.amzn2.x86_64] testing.(*common).runCleanup(0xc000fd4b60, 0xc0001a1bc8?)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/testing/testing.go:1328 +0xe2
       [4.14.262-200.489.amzn2.x86_64] testing.tRunner.func2()
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/testing/testing.go:1570 +0x29
       [4.14.262-200.489.amzn2.x86_64] testing.tRunner(0xc000fd4b60, 0xc0002b9860)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/testing/testing.go:1582 +0x135
       [4.14.262-200.489.amzn2.x86_64] created by testing.(*T).Run
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/testing/testing.go:1629 +0x3ea
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 19324 [chan receive, 29 minutes]:
       [4.14.262-200.489.amzn2.x86_64] testing.(*T).Run(0xc000e76340, {0x2662659?, 0x0?}, 0xc0002b9860)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/testing/testing.go:1630 +0x405
       [4.14.262-200.489.amzn2.x86_64] github.com/DataDog/datadog-agent/pkg/network/tracer.(*USMSuite).TestJavaInjection(0x0?)
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/network/tracer/tracer_usm_linux_test.go:920 +0x8b3
       [4.14.262-200.489.amzn2.x86_64] reflect.Value.call({0xc000d83780?, 0xc00134aba0?, 0x13?}, {0x25c716a, 0x4}, {0xc000846e70, 0x1, 0x1?})
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/reflect/value.go:586 +0xb0b
       [4.14.262-200.489.amzn2.x86_64] reflect.Value.Call({0xc000d83780?, 0xc00134aba0?, 0xc001368600?}, {0xc00173ee70?, 0x39bceb0?, 0x2f12f87?})
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/reflect/value.go:370 +0xbc
       [4.14.262-200.489.amzn2.x86_64] github.com/stretchr/testify/suite.Run.func1(0xc000e76340)
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/stretchr/testify@v1.8.4/suite/suite.go:197 +0x4b6
       [4.14.262-200.489.amzn2.x86_64] testing.tRunner(0xc000e76340, 0xc000a4d320)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/testing/testing.go:1576 +0x10b
       [4.14.262-200.489.amzn2.x86_64] created by testing.(*T).Run
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/testing/testing.go:1629 +0x3ea
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 19673 [chan receive, 28 minutes]:
       [4.14.262-200.489.amzn2.x86_64] github.com/DataDog/datadog-agent/pkg/process/monitor.(*ProcessMonitor).initCallbackRunner.func1()
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/process/monitor/process_monitor.go:154 +0x7f
       [4.14.262-200.489.amzn2.x86_64] created by github.com/DataDog/datadog-agent/pkg/process/monitor.(*ProcessMonitor).initCallbackRunner
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/process/monitor/process_monitor.go:152 +0x85
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 14854 [select, 36 minutes]:
       [4.14.262-200.489.amzn2.x86_64] github.com/go-sql-driver/mysql.(*mysqlConn).startWatcher.func1()
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/go-sql-driver/mysql@v1.7.1/connection.go:614 +0xaa
       [4.14.262-200.489.amzn2.x86_64] created by github.com/go-sql-driver/mysql.(*mysqlConn).startWatcher
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/go-sql-driver/mysql@v1.7.1/connection.go:611 +0x10a
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 19671 [chan receive, 28 minutes]:
       [4.14.262-200.489.amzn2.x86_64] github.com/DataDog/datadog-agent/pkg/process/monitor.(*ProcessMonitor).initCallbackRunner.func1()
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/process/monitor/process_monitor.go:154 +0x7f
       [4.14.262-200.489.amzn2.x86_64] created by github.com/DataDog/datadog-agent/pkg/process/monitor.(*ProcessMonitor).initCallbackRunner
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/process/monitor/process_monitor.go:152 +0x85
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 19670 [chan receive, 28 minutes]:
       [4.14.262-200.489.amzn2.x86_64] github.com/DataDog/datadog-agent/pkg/process/monitor.(*ProcessMonitor).initCallbackRunner.func1()
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/process/monitor/process_monitor.go:154 +0x7f
       [4.14.262-200.489.amzn2.x86_64] created by github.com/DataDog/datadog-agent/pkg/process/monitor.(*ProcessMonitor).initCallbackRunner
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/process/monitor/process_monitor.go:152 +0x85
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 19723 [syscall, 28 minutes]:
       [4.14.262-200.489.amzn2.x86_64] syscall.Syscall6(0x60?, 0x2500aa0?, 0xc001b8c701?, 0xc0000c8548?, 0x41448a?, 0x8?, 0x4?)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/syscall/syscall_linux.go:91 +0x36
       [4.14.262-200.489.amzn2.x86_64] golang.org/x/sys/unix.EpollWait(0xc0000c8660?, {0xc0006c8840?, 0x0?, 0xc0000c85f0?}, 0xc0000c85f0?)
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/golang.org/x/sys@v0.10.0/unix/zsyscall_linux_amd64.go:56 +0x58
       [4.14.262-200.489.amzn2.x86_64] github.com/cilium/ebpf/internal/unix.EpollWait(...)
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/cilium/ebpf@v0.11.0/internal/unix/types_linux.go:125
       [4.14.262-200.489.amzn2.x86_64] github.com/cilium/ebpf/internal/epoll.(*Poller).Wait(0xc0006c6d80, {0xc0006c8840?, 0xf, 0xf}, {0x7fbe4c1b3dc8?, 0x7fbe7598d5b8?, 0x0?})
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/cilium/ebpf@v0.11.0/internal/epoll/poller.go:145 +0x2b4
       [4.14.262-200.489.amzn2.x86_64] github.com/cilium/ebpf/perf.(*Reader).ReadInto(0xc001ca9bc0, 0xc001b00060?)
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/cilium/ebpf@v0.11.0/perf/reader.go:345 +0x2d6
       [4.14.262-200.489.amzn2.x86_64] github.com/DataDog/ebpf-manager.(*PerfMap).Start.func1()
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/!data!dog/ebpf-manager@v0.2.12/perf.go:120 +0xa5
       [4.14.262-200.489.amzn2.x86_64] created by github.com/DataDog/ebpf-manager.(*PerfMap).Start
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/!data!dog/ebpf-manager@v0.2.12/perf.go:108 +0x125
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 19721 [semacquire, 28 minutes]:
       [4.14.262-200.489.amzn2.x86_64] sync.runtime_Semacquire(0x198b536?)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/runtime/sema.go:62 +0x27
       [4.14.262-200.489.amzn2.x86_64] sync.(*WaitGroup).Wait(0xc0017f2060?)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/sync/waitgroup.go:116 +0x4b
       [4.14.262-200.489.amzn2.x86_64] github.com/DataDog/datadog-agent/pkg/process/monitor.(*ProcessMonitor).Stop(0x40527e0)
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/process/monitor/process_monitor.go:329 +0x91
       [4.14.262-200.489.amzn2.x86_64] github.com/DataDog/datadog-agent/pkg/network/usm/sharedlibraries.(*Watcher).Start.func2.1()
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/network/usm/sharedlibraries/watcher.go:183 +0x50
       [4.14.262-200.489.amzn2.x86_64] github.com/DataDog/datadog-agent/pkg/network/usm/sharedlibraries.(*Watcher).Start.func2()
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/network/usm/sharedlibraries/watcher.go:202 +0x31e
       [4.14.262-200.489.amzn2.x86_64] created by github.com/DataDog/datadog-agent/pkg/network/usm/sharedlibraries.(*Watcher).Start
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/network/usm/sharedlibraries/watcher.go:175 +0x1a5
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 19672 [chan receive, 28 minutes]:
       [4.14.262-200.489.amzn2.x86_64] github.com/DataDog/datadog-agent/pkg/process/monitor.(*ProcessMonitor).initCallbackRunner.func1()
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/process/monitor/process_monitor.go:154 +0x7f
       [4.14.262-200.489.amzn2.x86_64] created by github.com/DataDog/datadog-agent/pkg/process/monitor.(*ProcessMonitor).initCallbackRunner
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/process/monitor/process_monitor.go:152 +0x85
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 18831 [chan receive, 32 minutes]:
       [4.14.262-200.489.amzn2.x86_64] testing.(*T).Run(0xc0008d1d40, {0x1ff0a7e?, 0xc0008d1d40?}, 0xc000a4d320)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/testing/testing.go:1630 +0x405
       [4.14.262-200.489.amzn2.x86_64] github.com/stretchr/testify/suite.runTests({0x2e428d0, 0xc0008d1d40}, {0xc000abe300?, 0x8, 0x8})
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/stretchr/testify@v1.8.4/suite/suite.go:242 +0x112
       [4.14.262-200.489.amzn2.x86_64] github.com/stretchr/testify/suite.Run(0xc0008d1d40, {0x2e1f900, 0xc001368600})
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/stretchr/testify@v1.8.4/suite/suite.go:215 +0x6fe
       [4.14.262-200.489.amzn2.x86_64] github.com/DataDog/datadog-agent/pkg/network/tracer.TestUSMSuite.func1(0xc000bfcf00?)
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/network/tracer/tracer_usm_linux_test.go:84 +0x39
       [4.14.262-200.489.amzn2.x86_64] github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest.TestBuildMode.func1(0xc00061b7d0?)
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest/buildmode_linux.go:47 +0xea
       [4.14.262-200.489.amzn2.x86_64] testing.tRunner(0xc0008d1d40, 0xc001337350)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/testing/testing.go:1576 +0x10b
       [4.14.262-200.489.amzn2.x86_64] created by testing.(*T).Run
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/testing/testing.go:1629 +0x3ea
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 19676 [syscall]:
       [4.14.262-200.489.amzn2.x86_64] syscall.Syscall6(0xc00045ae10?, 0x0?, 0xc000a5ddd8?, 0x460df6?, 0x28?, 0xc000a5ddf8?, 0x41c6ca?)
       [4.14.262-200.489.amzn2.x86_64] /usr/local/go/src/syscall/syscall_linux.go:91 +0x36
       [4.14.262-200.489.amzn2.x86_64] golang.org/x/sys/unix.recvfrom(0x7fbe4c2fad58?, {0xc000a5dec8?, 0x4c?, 0x4c?}, 0xc0008f2640?, 0xc0008f2640?, 0x30000004c?)
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/golang.org/x/sys@v0.10.0/unix/zsyscall_linux_amd64.go:528 +0x70
       [4.14.262-200.489.amzn2.x86_64] golang.org/x/sys/unix.Recvfrom(0xc0008f2640?, {0xc000a5dec8, 0x10000, 0x10000}, 0x0?)
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/golang.org/x/sys@v0.10.0/unix/syscall_unix.go:325 +0x7b
       [4.14.262-200.489.amzn2.x86_64] github.com/vishvananda/netlink/nl.(*NetlinkSocket).Receive(0x30000004c?)
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/!data!dog/netlink@v1.0.1-0.20230703150631-f11d5ab05838/nl/nl_linux.go:762 +0x65
       [4.14.262-200.489.amzn2.x86_64] github.com/vishvananda/netlink.ProcEventMonitor.func2()
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/!data!dog/netlink@v1.0.1-0.20230703150631-f11d5ab05838/proc_event_linux.go:159 +0x9d
       [4.14.262-200.489.amzn2.x86_64] created by github.com/vishvananda/netlink.ProcEventMonitor
       [4.14.262-200.489.amzn2.x86_64] /go/pkg/mod/github.com/!data!dog/netlink@v1.0.1-0.20230703150631-f11d5ab05838/proc_event_linux.go:156 +0x305
       [4.14.262-200.489.amzn2.x86_64] 
       [4.14.262-200.489.amzn2.x86_64] goroutine 19674 [select]:
       [4.14.262-200.489.amzn2.x86_64] github.com/DataDog/datadog-agent/pkg/process/monitor.(*ProcessMonitor).mainEventLoop(0x40527e0)
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/process/monitor/process_monitor.go:180 +0x168
       [4.14.262-200.489.amzn2.x86_64] created by github.com/DataDog/datadog-agent/pkg/process/monitor.(*ProcessMonitor).Initialize.func1
       [4.14.262-200.489.amzn2.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/process/monitor/process_monitor.go:250 +0x165
```

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
