### PR TITLE
Split http malformed metric to more specific metrics

### DIFF
--- a/pkg/network/protocols/http/statkeeper.go
+++ b/pkg/network/protocols/http/statkeeper.go
@@ -85,7 +85,7 @@ func (h *StatKeeper) Close() {
 func (h *StatKeeper) add(tx Transaction) {
 	rawPath, fullPath := tx.Path(h.buffer)
 	if rawPath == nil {
-		h.telemetry.malformed.Add(1)
+		h.telemetry.emptyPath.Add(1)
 		return
 	}
 	path, rejected := h.processHTTPPath(tx, rawPath)
@@ -94,7 +94,7 @@ func (h *StatKeeper) add(tx Transaction) {
 	}
 
 	if tx.Method() == MethodUnknown {
-		h.telemetry.malformed.Add(1)
+		h.telemetry.unknownMethod.Add(1)
 		if h.oversizedLogLimit.ShouldLog() {
 			log.Warnf("method should never be unknown: %s", tx.String())
 		}
@@ -103,7 +103,7 @@ func (h *StatKeeper) add(tx Transaction) {
 
 	latency := tx.RequestLatency()
 	if latency <= 0 {
-		h.telemetry.malformed.Add(1)
+		h.telemetry.invalidLatency.Add(1)
 		if h.oversizedLogLimit.ShouldLog() {
 			log.Warnf("latency should never be equal to 0: %s", tx.String())
 		}
@@ -166,7 +166,7 @@ func (h *StatKeeper) processHTTPPath(tx Transaction, path []byte) (pathStr strin
 		if h.oversizedLogLimit.ShouldLog() {
 			log.Debugf("http path malformed: %+v %s", h.newKey(tx, "", false).ConnectionKey, tx.String())
 		}
-		h.telemetry.malformed.Add(1)
+		h.telemetry.nonPrintableCharacters.Add(1)
 		return "", true
 	}
 	return h.intern(path), false

--- a/pkg/network/protocols/http/telemetry.go
+++ b/pkg/network/protocols/http/telemetry.go
@@ -22,11 +22,11 @@ type Telemetry struct {
 
 	hits1XX, hits2XX, hits3XX, hits4XX, hits5XX *libtelemetry.Counter
 
-	totalHits    *libtelemetry.Counter
-	dropped      *libtelemetry.Counter // this happens when statKeeper reaches capacity
-	rejected     *libtelemetry.Counter // this happens when an user-defined reject-filter matches a request
-	malformed    *libtelemetry.Counter // this happens when the request doesn't have the expected format
-	aggregations *libtelemetry.Counter
+	totalHits                                                        *libtelemetry.Counter
+	dropped                                                          *libtelemetry.Counter // this happens when statKeeper reaches capacity
+	rejected                                                         *libtelemetry.Counter // this happens when an user-defined reject-filter matches a request
+	emptyPath, unknownMethod, invalidLatency, nonPrintableCharacters *libtelemetry.Counter // this happens when the request doesn't have the expected format
+	aggregations                                                     *libtelemetry.Counter
 }
 
 func NewTelemetry(protocol string) *Telemetry {
@@ -44,10 +44,13 @@ func NewTelemetry(protocol string) *Telemetry {
 		aggregations: metricGroup.NewCounter("aggregations", libtelemetry.OptPrometheus),
 
 		// these metrics are also exported as statsd metrics
-		totalHits: metricGroup.NewCounter("total_hits", libtelemetry.OptStatsd, libtelemetry.OptPayloadTelemetry),
-		dropped:   metricGroup.NewCounter("dropped", libtelemetry.OptStatsd),
-		rejected:  metricGroup.NewCounter("rejected", libtelemetry.OptStatsd),
-		malformed: metricGroup.NewCounter("malformed", libtelemetry.OptStatsd),
+		totalHits:              metricGroup.NewCounter("total_hits", libtelemetry.OptStatsd, libtelemetry.OptPayloadTelemetry),
+		dropped:                metricGroup.NewCounter("dropped", libtelemetry.OptStatsd),
+		rejected:               metricGroup.NewCounter("rejected", libtelemetry.OptStatsd),
+		emptyPath:              metricGroup.NewCounter("malformed", "type:empty-path", libtelemetry.OptStatsd),
+		unknownMethod:          metricGroup.NewCounter("malformed", "type:unknown-method", libtelemetry.OptStatsd),
+		invalidLatency:         metricGroup.NewCounter("malformed", "type:invalid-latency", libtelemetry.OptStatsd),
+		nonPrintableCharacters: metricGroup.NewCounter("malformed", "type:non-printable-char", libtelemetry.OptStatsd),
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Split the malformed metric into 4 different metrics:
1. Empty request path
2. Unknown request method
3. Invalid request latency
4. Request path contains non printable characters

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
To effectively distinguish between various errors, we require a more detailed examination of the malformed metric, offering a more granular perspective

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
