### PR TITLE
[Gohai][ASC-670] Fix revive lint warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -96,3 +96,7 @@ linters-settings:
           - github.com/DataDog/datadog-agent/pkg/util/log.Printf
           - github.com/DataDog/datadog-agent/pkg/util/log.Warnf
           - github.com/DataDog/datadog-agent/pkg/util/log.Errorf
+  revive:
+    rules:
+      - name: package-comments
+        disabled: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -96,7 +96,3 @@ linters-settings:
           - github.com/DataDog/datadog-agent/pkg/util/log.Printf
           - github.com/DataDog/datadog-agent/pkg/util/log.Warnf
           - github.com/DataDog/datadog-agent/pkg/util/log.Errorf
-  revive:
-    rules:
-      - name: package-comments
-        disabled: true

--- a/pkg/gohai/cpu/cpu.go
+++ b/pkg/gohai/cpu/cpu.go
@@ -49,7 +49,7 @@ func CollectInfo() *Info {
 	return getCPUInfo()
 }
 
-// Returns an interface which can be marshalled to a JSON and contains the value of non-errored fields.
+// AsJSON returns an interface which can be marshalled to a JSON and contains the value of non-errored fields.
 func (info *Info) AsJSON() (interface{}, []string, error) {
 	return utils.AsJSON(info, false)
 }

--- a/pkg/gohai/cpu/cpu_linux_arm64.go
+++ b/pkg/gohai/cpu/cpu_linux_arm64.go
@@ -78,7 +78,7 @@ func (cpuInfo *Info) fillFirstCPUInfo(firstCPU map[string]string) {
 }
 
 func (cpuInfo *Info) fillProcCPUInfo() {
-	procCPU, err := readProcCpuInfo()
+	procCPU, err := readProcCPUInfo()
 	if err != nil {
 		cpuInfo.fillProcCPUErr(err)
 		return
@@ -101,18 +101,18 @@ func (cpuInfo *Info) fillProcCPUInfo() {
 			continue
 		}
 
-		if coreID, ok := sysCpuInt(fmt.Sprintf("cpu%d/topology/core_id", procID)); ok {
+		if coreID, ok := sysCPUInt(fmt.Sprintf("cpu%d/topology/core_id", procID)); ok {
 			cores[coreID] = struct{}{}
 		}
 
-		if pkgID, ok := sysCpuInt(fmt.Sprintf("cpu%d/topology/physical_package_id", procID)); ok {
+		if pkgID, ok := sysCPUInt(fmt.Sprintf("cpu%d/topology/physical_package_id", procID)); ok {
 			packages[pkgID] = struct{}{}
 		}
 
 		// iterate over each cache this CPU can use
 		i := 0
 		for {
-			if sharedList, ok := sysCpuList(fmt.Sprintf("cpu%d/cache/index%d/shared_cpu_list", procID, i)); ok {
+			if sharedList, ok := sysCPUList(fmt.Sprintf("cpu%d/cache/index%d/shared_cpu_list", procID, i)); ok {
 				// we are scanning CPUs in order, so only count this cache if it's not shared with a
 				// CPU that has already been scanned
 				shared := false
@@ -124,8 +124,8 @@ func (cpuInfo *Info) fillProcCPUInfo() {
 				}
 
 				if !shared {
-					if level, ok := sysCpuInt(fmt.Sprintf("cpu%d/cache/index%d/level", procID, i)); ok {
-						if size, ok := sysCpuSize(fmt.Sprintf("cpu%d/cache/index%d/size", procID, i)); ok {
+					if level, ok := sysCPUInt(fmt.Sprintf("cpu%d/cache/index%d/level", procID, i)); ok {
+						if size, ok := sysCPUSize(fmt.Sprintf("cpu%d/cache/index%d/size", procID, i)); ok {
 							cacheSizes[level] += size
 						}
 					}

--- a/pkg/gohai/cpu/util_linux.go
+++ b/pkg/gohai/cpu/util_linux.go
@@ -17,8 +17,8 @@ import (
 var prefix = "" // only used for testing
 var listRangeRegex = regexp.MustCompile("([0-9]+)-([0-9]+)$")
 
-// sysCpuInt reads an integer from a file in /sys/devices/system/cpu
-func sysCpuInt(path string) (uint64, bool) {
+// sysCPUInt reads an integer from a file in /sys/devices/system/cpu
+func sysCPUInt(path string) (uint64, bool) {
 	content, err := ioutil.ReadFile(prefix + "/sys/devices/system/cpu/" + path)
 	if err != nil {
 		return 0, false
@@ -32,8 +32,8 @@ func sysCpuInt(path string) (uint64, bool) {
 	return value, true
 }
 
-// sysCpuSize reads an value with a K/M/G suffix from a file in /sys/devices/system/cpu
-func sysCpuSize(path string) (uint64, bool) {
+// sysCPUSize reads an value with a K/M/G suffix from a file in /sys/devices/system/cpu
+func sysCPUSize(path string) (uint64, bool) {
 	content, err := ioutil.ReadFile(prefix + "/sys/devices/system/cpu/" + path)
 	if err != nil {
 		return 0, false
@@ -61,11 +61,11 @@ func sysCpuSize(path string) (uint64, bool) {
 	return value * mult, true
 }
 
-// sysCpuList reads a list of integers, comma-seprated with ranges (`0-5,7-11`)
+// sysCPUList reads a list of integers, comma-seprated with ranges (`0-5,7-11`)
 // from a file in /sys/devices/system/cpu.  The return value is the set of
 // integers included in the list (for the example above, {0, 1, 2, 3, 4, 5, 7,
 // 8, 9, 10, 11}).
-func sysCpuList(path string) (map[uint64]struct{}, bool) {
+func sysCPUList(path string) (map[uint64]struct{}, bool) {
 	content, err := ioutil.ReadFile(prefix + "/sys/devices/system/cpu/" + path)
 	if err != nil {
 		return nil, false
@@ -104,10 +104,10 @@ func sysCpuList(path string) (map[uint64]struct{}, bool) {
 	return result, true
 }
 
-// readProcCpuInfo reads /proc/cpuinfo.  The file is structured as a set of
+// readProcCPUInfo reads /proc/cpuinfo.  The file is structured as a set of
 // blank-line-separated stanzas, and each stanza is a map of string to string,
 // with whitespace stripped.
-func readProcCpuInfo() ([]map[string]string, error) {
+func readProcCPUInfo() ([]map[string]string, error) {
 	file, err := os.Open(prefix + "/proc/cpuinfo")
 	if err != nil {
 		return nil, err

--- a/pkg/gohai/cpu/util_linux_test.go
+++ b/pkg/gohai/cpu/util_linux_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSysCpuInt(t *testing.T) {
+func TestSysCPUInt(t *testing.T) {
 	prefix = t.TempDir()
 	defer func() { prefix = "" }()
 	os.MkdirAll(filepath.Join(prefix, filepath.FromSlash("sys/devices/system/cpu")), 0o777)
@@ -22,38 +22,38 @@ func TestSysCpuInt(t *testing.T) {
 
 	t.Run("zero", func(t *testing.T) {
 		ioutil.WriteFile(path, []byte("0\n"), 0o666)
-		got, ok := sysCpuInt("somefile")
+		got, ok := sysCPUInt("somefile")
 		require.True(t, ok)
 		require.Equal(t, uint64(0), got)
 	})
 
 	t.Run("dec", func(t *testing.T) {
 		ioutil.WriteFile(path, []byte("20\n"), 0o666)
-		got, ok := sysCpuInt("somefile")
+		got, ok := sysCPUInt("somefile")
 		require.True(t, ok)
 		require.Equal(t, uint64(20), got)
 	})
 
 	t.Run("hex", func(t *testing.T) {
 		ioutil.WriteFile(path, []byte("0x20\n"), 0o666)
-		got, ok := sysCpuInt("somefile")
+		got, ok := sysCPUInt("somefile")
 		require.True(t, ok)
 		require.Equal(t, uint64(32), got)
 	})
 
 	t.Run("invalid", func(t *testing.T) {
 		ioutil.WriteFile(path, []byte("eleventy"), 0o666)
-		_, ok := sysCpuInt("somefile")
+		_, ok := sysCPUInt("somefile")
 		require.False(t, ok)
 	})
 
 	t.Run("missing", func(t *testing.T) {
-		_, ok := sysCpuInt("nonexistent")
+		_, ok := sysCPUInt("nonexistent")
 		require.False(t, ok)
 	})
 }
 
-func TestSysCpuSize(t *testing.T) {
+func TestSysCPUSize(t *testing.T) {
 	prefix = t.TempDir()
 	defer func() { prefix = "" }()
 	os.MkdirAll(filepath.Join(prefix, filepath.FromSlash("sys/devices/system/cpu")), 0o777)
@@ -61,52 +61,52 @@ func TestSysCpuSize(t *testing.T) {
 
 	t.Run("zero", func(t *testing.T) {
 		ioutil.WriteFile(path, []byte("0\n"), 0o666)
-		got, ok := sysCpuSize("somefile")
+		got, ok := sysCPUSize("somefile")
 		require.True(t, ok)
 		require.Equal(t, uint64(0), got)
 	})
 
 	t.Run("no-suffix", func(t *testing.T) {
 		ioutil.WriteFile(path, []byte("20\n"), 0o666)
-		got, ok := sysCpuSize("somefile")
+		got, ok := sysCPUSize("somefile")
 		require.True(t, ok)
 		require.Equal(t, uint64(20), got)
 	})
 
 	t.Run("K", func(t *testing.T) {
 		ioutil.WriteFile(path, []byte("20K\n"), 0o666)
-		got, ok := sysCpuSize("somefile")
+		got, ok := sysCPUSize("somefile")
 		require.True(t, ok)
 		require.Equal(t, uint64(20*1024), got)
 	})
 
 	t.Run("M", func(t *testing.T) {
 		ioutil.WriteFile(path, []byte("20M"), 0o666)
-		got, ok := sysCpuSize("somefile")
+		got, ok := sysCPUSize("somefile")
 		require.True(t, ok)
 		require.Equal(t, uint64(20*1024*1024), got)
 	})
 
 	t.Run("G", func(t *testing.T) {
 		ioutil.WriteFile(path, []byte("20G"), 0o666)
-		got, ok := sysCpuSize("somefile")
+		got, ok := sysCPUSize("somefile")
 		require.True(t, ok)
 		require.Equal(t, uint64(20*1024*1024*1024), got)
 	})
 
 	t.Run("invalid", func(t *testing.T) {
 		ioutil.WriteFile(path, []byte("eleventy"), 0o666)
-		_, ok := sysCpuSize("somefile")
+		_, ok := sysCPUSize("somefile")
 		require.False(t, ok)
 	})
 
 	t.Run("missing", func(t *testing.T) {
-		_, ok := sysCpuSize("nonexistent")
+		_, ok := sysCPUSize("nonexistent")
 		require.False(t, ok)
 	})
 }
 
-func TestSysCpuList(t *testing.T) {
+func TestSysCPUList(t *testing.T) {
 	prefix = t.TempDir()
 	defer func() { prefix = "" }()
 	os.MkdirAll(filepath.Join(prefix, filepath.FromSlash("sys/devices/system/cpu")), 0o777)
@@ -114,21 +114,21 @@ func TestSysCpuList(t *testing.T) {
 
 	t.Run("empty", func(t *testing.T) {
 		ioutil.WriteFile(path, []byte("\n"), 0o666)
-		got, ok := sysCpuList("somefile")
+		got, ok := sysCPUList("somefile")
 		require.True(t, ok)
 		require.Equal(t, map[uint64]struct{}{}, got)
 	})
 
 	t.Run("single", func(t *testing.T) {
 		ioutil.WriteFile(path, []byte("20\n"), 0o666)
-		got, ok := sysCpuList("somefile")
+		got, ok := sysCPUList("somefile")
 		require.True(t, ok)
 		require.Equal(t, map[uint64]struct{}{20: {}}, got)
 	})
 
 	t.Run("range", func(t *testing.T) {
 		ioutil.WriteFile(path, []byte("5-8\n"), 0o666)
-		got, ok := sysCpuList("somefile")
+		got, ok := sysCPUList("somefile")
 		require.True(t, ok)
 		require.Equal(t, map[uint64]struct{}{
 			5: {},
@@ -140,7 +140,7 @@ func TestSysCpuList(t *testing.T) {
 
 	t.Run("combo", func(t *testing.T) {
 		ioutil.WriteFile(path, []byte("1,5-8,10\n"), 0o666)
-		got, ok := sysCpuList("somefile")
+		got, ok := sysCPUList("somefile")
 		require.True(t, ok)
 		require.Equal(t, map[uint64]struct{}{
 			1:  {},
@@ -154,17 +154,17 @@ func TestSysCpuList(t *testing.T) {
 
 	t.Run("invalid", func(t *testing.T) {
 		ioutil.WriteFile(path, []byte("eleventy"), 0o666)
-		_, ok := sysCpuList("somefile")
+		_, ok := sysCPUList("somefile")
 		require.False(t, ok)
 	})
 
 	t.Run("missing", func(t *testing.T) {
-		_, ok := sysCpuList("nonexistent")
+		_, ok := sysCPUList("nonexistent")
 		require.False(t, ok)
 	})
 }
 
-func TestReadProcCpuInfo(t *testing.T) {
+func TestReadProcCPUInfo(t *testing.T) {
 	prefix = t.TempDir()
 	defer func() { prefix = "" }()
 	os.MkdirAll(filepath.Join(prefix, filepath.FromSlash("proc")), 0o777)
@@ -176,7 +176,7 @@ processor:	0
 
 processor:	1
 `), 0o777)
-		info, err := readProcCpuInfo()
+		info, err := readProcCPUInfo()
 		require.NoError(t, err)
 		require.Equal(t, []map[string]string{
 			{"processor": "0"},
@@ -203,7 +203,7 @@ beside the white
 chickens
 	-- William Carlos Williams
 `), 0o777)
-		info, err := readProcCpuInfo()
+		info, err := readProcCPUInfo()
 		require.NoError(t, err)
 		require.Equal(t, []map[string]string{
 			{"processor": "0"},

--- a/pkg/gohai/memory/memory.go
+++ b/pkg/gohai/memory/memory.go
@@ -26,7 +26,7 @@ func CollectInfo() *Info {
 	return info
 }
 
-// Returns an interface which can be marshalled to a JSON and contains the value of non-errored fields.
+// AsJSON returns an interface which can be marshalled to a JSON and contains the value of non-errored fields.
 func (info *Info) AsJSON() (interface{}, []string, error) {
 	return utils.AsJSON(info, false)
 }

--- a/pkg/gohai/platform/platform.go
+++ b/pkg/gohai/platform/platform.go
@@ -59,7 +59,7 @@ func CollectInfo() *Info {
 	return info
 }
 
-// Returns an interface which can be marshalled to a JSON and contains the value of non-errored fields.
+// AsJSON returns an interface which can be marshalled to a JSON and contains the value of non-errored fields.
 func (info *Info) AsJSON() (interface{}, []string, error) {
 	return utils.AsJSON(info, false)
 }

--- a/pkg/gohai/utils/common.go
+++ b/pkg/gohai/utils/common.go
@@ -11,13 +11,22 @@ import (
 	"runtime"
 )
 
-var ErrNoFieldCollected = errors.New("no field was collected")
-var ErrArgNotStruct = errors.New("argument is not a struct")
-var ErrNotCollectable = fmt.Errorf("cannot be collected on %s %s", runtime.GOOS, runtime.GOARCH)
-var ErrNotExported = errors.New("field not exported by the struct")
-var ErrCannotRender = errors.New("field inner type cannot be rendered")
-var ErrNoValueMethod = errors.New("field doesn't have the expected Value method")
-var ErrNoJSONTag = errors.New("field doesn't have a json tag")
+var (
+	// ErrNoFieldCollected means no field could be collected
+	ErrNoFieldCollected = errors.New("no field was collected")
+	// ErrArgNotStruct means the argument should be a struct but wasn't
+	ErrArgNotStruct = errors.New("argument is not a struct")
+	// ErrNotCollectable means the value can't be collected on the given platform
+	ErrNotCollectable = fmt.Errorf("cannot be collected on %s %s", runtime.GOOS, runtime.GOARCH)
+	// ErrNotExported means the struct has an unexported field
+	ErrNotExported = errors.New("field not exported by the struct")
+	// ErrCannotRender means a field which cannot be rendered
+	ErrCannotRender = errors.New("field inner type cannot be rendered")
+	// ErrNoValueMethod means a field doesn't have a Value method
+	ErrNoValueMethod = errors.New("field doesn't have the expected Value method")
+	// ErrNoJSONTag means a field doesn't have a json tag
+	ErrNoJSONTag = errors.New("field doesn't have a json tag")
+)
 
 // canBeRendered returns whether the given type can be converted to a string properly
 func canBeRendered(ty reflect.Kind) bool {

--- a/pkg/gohai/utils/value.go
+++ b/pkg/gohai/utils/value.go
@@ -53,10 +53,10 @@ func NewErrorValue[T any](err error) Value[T] {
 func (value *Value[T]) Value() (T, error) {
 	if value.initialized {
 		return value.value, value.err
-	} else {
-		var def T
-		return def, errors.New("value not initialized")
 	}
+
+	var def T
+	return def, errors.New("value not initialized")
 }
 
 // Error returns the error stored in the Value[T], or nil if it doesn't contain an error.
@@ -71,8 +71,8 @@ func (value *Value[T]) ValueOrDefault() T {
 	val, err := value.Value()
 	if err == nil {
 		return val
-	} else {
-		var def T
-		return def
 	}
+
+	var def T
+	return def
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fix `revive` lint warnings in `pkg/gohai`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Have a cleaner code and have less things to fix when the linter is re-enabled.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

There should be no functional change.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
