### PR TITLE
Allow SNMP profile to change

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -6,7 +6,6 @@
 package checkconfig
 
 import (
-	"fmt"
 	"regexp"
 	"testing"
 	"time"
@@ -278,6 +277,44 @@ workers: 30
 		"127.0.0.8": true,
 		"127.0.0.9": true,
 	}, config.IgnoredIPAddresses)
+}
+
+func TestProfileNormalizeMetrics(t *testing.T) {
+	SetConfdPathAndCleanProfiles()
+
+	// language=yaml
+	rawInstanceConfig := []byte(`
+ip_address: 172.26.0.2
+profile: profile1
+community_string: public
+`)
+	// language=yaml
+	rawInitConfig := []byte(`
+profiles:
+  profile1:
+    definition:
+      metrics:
+        - {OID: 1.3.6.1.2.1.7.1.0, name: IAmACounter32}
+        - {OID: 1.3.6.1.2.1.4.31.1.1.6.1, name: IAmACounter64}
+        - {OID: 1.3.6.1.2.1.4.24.6.0, name: IAmAGauge32}
+        - {OID: 1.3.6.1.2.1.88.1.1.1.0, name: IAmAnInteger}
+`)
+	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
+
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"device_namespace:default", "snmp_device:172.26.0.2"}, config.GetStaticTags())
+	metrics := []MetricsConfig{
+		{Symbol: SymbolConfig{OID: "1.3.6.1.2.1.1.3.0", Name: "sysUpTimeInstance"}},
+		{Symbol: SymbolConfig{OID: "1.3.6.1.2.1.7.1.0", Name: "IAmACounter32"}},
+		{Symbol: SymbolConfig{OID: "1.3.6.1.2.1.4.31.1.1.6.1", Name: "IAmACounter64"}},
+		{Symbol: SymbolConfig{OID: "1.3.6.1.2.1.4.24.6.0", Name: "IAmAGauge32"}},
+		{Symbol: SymbolConfig{OID: "1.3.6.1.2.1.88.1.1.1.0", Name: "IAmAnInteger"}},
+	}
+
+	metricsTags := []MetricTagConfig(nil)
+
+	assert.Equal(t, metrics, config.Metrics)
+	assert.Equal(t, metricsTags, config.MetricTags)
 }
 
 func TestInlineProfileConfiguration(t *testing.T) {
@@ -1007,7 +1044,7 @@ func Test_snmpConfig_getDeviceIDTags(t *testing.T) {
 	assert.Equal(t, expectedTags, actualTags)
 }
 
-func Test_snmpConfig_refreshWithProfile(t *testing.T) {
+func Test_snmpConfig_setProfile(t *testing.T) {
 	metrics := []MetricsConfig{
 		{Symbol: SymbolConfig{OID: "1.2.3.4.5", Name: "someMetric"}},
 		{
@@ -1079,19 +1116,74 @@ func Test_snmpConfig_refreshWithProfile(t *testing.T) {
 		},
 		SysObjectIds: StringArray{"1.3.6.1.4.1.3375.2.1.3.4.*"},
 	}
+	profile2 := profileDefinition{
+		Device:  DeviceMeta{Vendor: "b-vendor"},
+		Metrics: []MetricsConfig{{Symbol: SymbolConfig{OID: "2.3.4.5.6.1", Name: "b-metric"}}},
+		MetricTags: []MetricTagConfig{
+			{Tag: "btag", OID: "2.3.4.5.6.2", Name: "b-tag-name"},
+		},
+		Metadata: MetadataConfig{
+			"device": {
+				Fields: map[string]MetadataField{
+					"b-description": {
+						Symbol: SymbolConfig{
+							OID:  "2.3.4.5.6.3",
+							Name: "sysDescr",
+						},
+					},
+					"b-name": {
+						Symbols: []SymbolConfig{
+							{
+								OID:  "2.3.4.5.6.4",
+								Name: "b-symbol1",
+							},
+							{
+								OID:  "2.3.4.5.6.5",
+								Name: "b-symbol2",
+							},
+						},
+					},
+				},
+			},
+			"interface": {
+				Fields: map[string]MetadataField{
+					"oper_status": {
+						Symbol: SymbolConfig{
+							OID:  "2.3.4.5.6.6",
+							Name: "b-someIfSymbol",
+						},
+					},
+				},
+				IDTags: MetricTagConfigList{
+					{
+						Tag: "b-interface",
+						Column: SymbolConfig{
+							OID:  "2.3.4.5.6.7",
+							Name: "b-ifName",
+						},
+					},
+				},
+			},
+		},
+		SysObjectIds: StringArray{"1.3.6.1.4.1.3375.2.1.3.4.*"},
+	}
+
 	mockProfiles := profileConfigMap{
 		"profile1": profileConfig{
 			Definition: profile1,
+		},
+		"profile2": profileConfig{
+			Definition: profile2,
 		},
 	}
 	c := &CheckConfig{
 		IPAddress: "1.2.3.4",
 		Profiles:  mockProfiles,
 	}
-	err := c.RefreshWithProfile("f5")
+	err := c.SetProfile("f5")
 	assert.EqualError(t, err, "unknown profile `f5`")
 
-	err = c.RefreshWithProfile("profile1")
+	err = c.SetProfile("profile1")
 	assert.NoError(t, err)
 
 	assert.Equal(t, "profile1", c.Profile)
@@ -1112,7 +1204,7 @@ func Test_snmpConfig_refreshWithProfile(t *testing.T) {
 		CollectDeviceMetadata: true,
 		CollectTopology:       false,
 	}
-	err = c.RefreshWithProfile("profile1")
+	err = c.SetProfile("profile1")
 	assert.NoError(t, err)
 	assert.Equal(t, OidConfig{
 		ScalarOids: []string{
@@ -1133,7 +1225,7 @@ func Test_snmpConfig_refreshWithProfile(t *testing.T) {
 
 	// With metadata disabled
 	c.CollectDeviceMetadata = false
-	err = c.RefreshWithProfile("profile1")
+	err = c.SetProfile("profile1")
 	assert.NoError(t, err)
 	assert.Equal(t, OidConfig{
 		ScalarOids: []string{
@@ -1144,6 +1236,57 @@ func Test_snmpConfig_refreshWithProfile(t *testing.T) {
 			"1.2.3.4.7",
 		},
 	}, c.OidConfig)
+
+	c = &CheckConfig{
+		IPAddress:             "1.2.3.4",
+		Profiles:              mockProfiles,
+		CollectDeviceMetadata: true,
+		CollectTopology:       false,
+	}
+	c.RequestedMetrics = append(c.RequestedMetrics,
+		MetricsConfig{Symbol: SymbolConfig{OID: "3.1", Name: "global-metric"}})
+	c.RequestedMetricTags = append(c.RequestedMetricTags,
+		MetricTagConfig{Tag: "global-tag", OID: "3.2", Name: "globalSymbol"})
+	err = c.SetProfile("profile1")
+	assert.NoError(t, err)
+	assert.Equal(t, OidConfig{
+		ScalarOids: []string{
+			"1.2.3.4.5",
+			"1.3.6.1.2.1.1.99.1.0",
+			"1.3.6.1.2.1.1.99.2.0",
+			"1.3.6.1.2.1.1.99.3.0",
+			"3.1",
+			"3.2",
+		},
+		ColumnOids: []string{
+			"1.2.3.4.6",
+			"1.2.3.4.7",
+			"1.3.6.1.2.1.2.2.1.99",
+			"1.3.6.1.2.1.31.1.1.1.1",
+			"1.3.6.1.2.1.4.20.1.2",
+			"1.3.6.1.2.1.4.20.1.3",
+		},
+	}, c.OidConfig)
+	err = c.SetProfile("profile2")
+	assert.NoError(t, err)
+	assert.Equal(t, OidConfig{
+		ScalarOids: []string{
+			"2.3.4.5.6.1",
+			"2.3.4.5.6.2",
+			"2.3.4.5.6.3",
+			"2.3.4.5.6.4",
+			"2.3.4.5.6.5",
+			"3.1",
+			"3.2",
+		},
+		ColumnOids: []string{
+			"1.3.6.1.2.1.4.20.1.2",
+			"1.3.6.1.2.1.4.20.1.3",
+			"2.3.4.5.6.6",
+			"2.3.4.5.6.7",
+		},
+	}, c.OidConfig)
+
 }
 
 func Test_getSubnetFromTags(t *testing.T) {
@@ -1935,13 +2078,6 @@ func TestCheckConfig_DiscoveryDigest(t *testing.T) {
 	}
 }
 
-func assertNotSameButEqualElements(t *testing.T, item1 interface{}, item2 interface{}) {
-	assert.NotEqual(t, fmt.Sprintf("%p", item1), fmt.Sprintf("%p", item2))
-	assert.Equal(t, fmt.Sprintf("%p", item1), fmt.Sprintf("%p", item1))
-	assert.Equal(t, fmt.Sprintf("%p", item2), fmt.Sprintf("%p", item2))
-	assert.ElementsMatch(t, item1, item2)
-}
-
 func TestCheckConfig_Copy(t *testing.T) {
 	config := CheckConfig{
 		Network:         "127.0.0.0/30",
@@ -1960,6 +2096,17 @@ func TestCheckConfig_Copy(t *testing.T) {
 		OidConfig: OidConfig{
 			ScalarOids: []string{"1.2.3"},
 			ColumnOids: []string{"1.2.3", "2.3.4"},
+		},
+		RequestedMetrics: []MetricsConfig{
+			{
+				Symbol: SymbolConfig{
+					OID:  "1.2",
+					Name: "abc",
+				},
+			},
+		},
+		RequestedMetricTags: []MetricTagConfig{
+			{Tag: "my_symbol", OID: "1.2.3", Name: "mySymbol"},
 		},
 		Metrics: []MetricsConfig{
 			{
@@ -1997,42 +2144,16 @@ func TestCheckConfig_Copy(t *testing.T) {
 	}
 	configCopy := config.Copy()
 
-	assert.Equal(t, config.Network, configCopy.Network)
-	assert.Equal(t, config.IPAddress, configCopy.IPAddress)
-	assert.Equal(t, config.Port, configCopy.Port)
-	assert.Equal(t, config.CommunityString, configCopy.CommunityString)
-	assert.Equal(t, config.SnmpVersion, configCopy.SnmpVersion)
-	assert.Equal(t, config.Timeout, configCopy.Timeout)
-	assert.Equal(t, config.Retries, configCopy.Retries)
-	assert.Equal(t, config.User, configCopy.User)
-	assert.Equal(t, config.AuthProtocol, configCopy.AuthProtocol)
-	assert.Equal(t, config.AuthKey, configCopy.AuthKey)
-	assert.Equal(t, config.PrivProtocol, configCopy.PrivProtocol)
-	assert.Equal(t, config.PrivKey, configCopy.PrivKey)
-	assert.Equal(t, config.ContextName, configCopy.ContextName)
-	assert.Equal(t, config.OidConfig, configCopy.OidConfig)
+	assert.Equal(t, &config, configCopy)
 
-	assertNotSameButEqualElements(t, config.Metrics, configCopy.Metrics)
-	assertNotSameButEqualElements(t, config.MetricTags, configCopy.MetricTags)
-
-	assert.Equal(t, config.OidBatchSize, configCopy.OidBatchSize)
-	assert.Equal(t, config.BulkMaxRepetitions, configCopy.BulkMaxRepetitions)
-	assert.Equal(t, config.Profiles, configCopy.Profiles)
-
-	assertNotSameButEqualElements(t, config.ProfileTags, configCopy.ProfileTags)
-
-	assert.Equal(t, config.Profile, configCopy.Profile)
-	assert.Equal(t, config.ProfileDef, configCopy.ProfileDef)
-	assertNotSameButEqualElements(t, config.ExtraTags, configCopy.ExtraTags)
-	assertNotSameButEqualElements(t, config.InstanceTags, configCopy.InstanceTags)
-	assert.Equal(t, config.CollectDeviceMetadata, configCopy.CollectDeviceMetadata)
-	assert.Equal(t, config.CollectTopology, configCopy.CollectTopology)
-	assert.Equal(t, config.UseDeviceIDAsHostname, configCopy.UseDeviceIDAsHostname)
-	assert.Equal(t, config.DeviceID, configCopy.DeviceID)
-	assertNotSameButEqualElements(t, config.DeviceIDTags, configCopy.DeviceIDTags)
-	assert.Equal(t, config.ResolvedSubnetName, configCopy.ResolvedSubnetName)
-	assert.Equal(t, config.AutodetectProfile, configCopy.AutodetectProfile)
-	assert.Equal(t, config.MinCollectionInterval, configCopy.MinCollectionInterval)
+	assert.NotSame(t, config.RequestedMetrics, configCopy.RequestedMetrics)
+	assert.NotSame(t, config.RequestedMetricTags, configCopy.RequestedMetricTags)
+	assert.NotSame(t, config.Metrics, configCopy.Metrics)
+	assert.NotSame(t, config.MetricTags, configCopy.MetricTags)
+	assert.NotSame(t, config.ProfileTags, configCopy.ProfileTags)
+	assert.NotSame(t, config.ExtraTags, configCopy.ExtraTags)
+	assert.NotSame(t, config.InstanceTags, configCopy.InstanceTags)
+	assert.NotSame(t, config.DeviceIDTags, configCopy.DeviceIDTags)
 }
 
 func TestCheckConfig_CopyWithNewIP(t *testing.T) {

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/profile_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/profile_test.go
@@ -171,8 +171,9 @@ func fixtureProfileDefinitionMap() profileConfigMap {
 		},
 		"another_profile": profileConfig{
 			Definition: profileDefinition{
+				SysObjectIds: StringArray{"1.3.6.1.4.1.32473.1.1"},
 				Metrics: []MetricsConfig{
-					{Symbol: SymbolConfig{OID: "1.3.6.1.2.1.1.999.0", Name: "someMetric"}, MetricType: ""},
+					{Symbol: SymbolConfig{OID: "1.3.6.1.2.1.1.999.0", Name: "anotherMetric"}, MetricType: ""},
 				},
 				MetricTags: []MetricTagConfig{
 					{Tag: "snmp_host2", Column: SymbolConfig{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"}},

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -220,25 +220,27 @@ func (d *DeviceCheck) detectMetricsToMonitor(sess session.Session) error {
 
 		detectedMetrics, metricTagConfigs := d.detectAvailableMetrics()
 		log.Debugf("detected metrics: %v", detectedMetrics)
-		d.config.Metrics = []checkconfig.MetricsConfig{}
+		d.config.RequestedMetrics = detectedMetrics
+		d.config.RequestedMetricTags = metricTagConfigs
 		d.config.AddUptimeMetric()
-		d.config.UpdateConfigMetadataMetricsAndTags(nil, detectedMetrics, metricTagConfigs, d.config.CollectTopology)
+		d.config.RebuildMetadataMetricsAndTags()
 	} else if d.config.AutodetectProfile {
 		// detect using sysObjectID
 		sysObjectID, err := session.FetchSysObjectID(sess)
 		if err != nil {
 			return fmt.Errorf("failed to fetch sysobjectid: %s", err)
 		}
-		d.config.AutodetectProfile = false // do not try to auto detect profile next time
-
 		profile, err := checkconfig.GetProfileForSysObjectID(d.config.Profiles, sysObjectID)
 		if err != nil {
 			return fmt.Errorf("failed to get profile sys object id for `%s`: %s", sysObjectID, err)
 		}
-		err = d.config.RefreshWithProfile(profile)
-		if err != nil {
-			// Should not happen since the profile is one of those we matched in GetProfileForSysObjectID
-			return fmt.Errorf("failed to refresh with profile `%s` detected using sysObjectID `%s`: %s", profile, sysObjectID, err)
+		if profile != d.config.Profile {
+			log.Debugf("detected profile change: %s -> %s", d.config.Profile, profile)
+			err = d.config.SetProfile(profile)
+			if err != nil {
+				// Should not happen since the profile is one of those we matched in GetProfileForSysObjectID
+				return fmt.Errorf("failed to refresh with profile `%s` detected using sysObjectID `%s`: %s", profile, sysObjectID, err)
+			}
 		}
 	}
 	return nil

--- a/pkg/collector/corechecks/snmp/internal/test/conf.d/snmp.d/profiles/another_profile.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/conf.d/snmp.d/profiles/another_profile.yaml
@@ -1,9 +1,13 @@
 # Another profile
 #
+sysobjectid:
+  # Example Enterprise Number for Documentation Use (see RFC 5612)
+  - 1.3.6.1.4.1.32473.1.1
+
 metrics:
   - symbol:
       OID: 1.3.6.1.2.1.1.999.0
-      name: someMetric
+      name: anotherMetric
 
 metric_tags:
   - column: # column syntax

--- a/releasenotes/notes/Update-SNMP-profile-when-a-device-changes.-1f43b3fd01664fc5.yaml
+++ b/releasenotes/notes/Update-SNMP-profile-when-a-device-changes.-1f43b3fd01664fc5.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    SNMP profile detection now updates the SNMP profile for a given IP if the device at that IP changes.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This preserves the set of requested SNMP metrics when a device's profile changes, and rechecks the profile on each lookup.

### Motivation

Profile detection is based on the device's reported SysObjID, but devices are identified by IP address; if the network configuration changes so that the IP address is pointing to a different device, we currently continue to use the originally-detected SNMP profile, which may now be the wrong profile for that device (NDM-1420).

### Additional Notes

When `experimental_detect_metrics_enabled` is set, it still overwrites any requested metrics with the detected metrics; this is consistent with current behavior, though it will be changed in a separate PR.

### Possible Drawbacks / Trade-offs

There is a small amount of overhead per check because we now request the SysObjID at the start of every check. A check currently requires multiple SNMP calls anyway, so this additional overhead should be small compared to the runtime of the check.

### Describe how to test/QA your changes

TODO: Can mimic change the type of a device in the middle of a test? If so, that would be how to test this.


You can probably use `ddev env` to test:

1/ Create a new snmprec in `compose/data` like `my-dynamic-device.snmprec` by copying the content of another snmprec like https://github.com/DataDog/integrations-core/blob/8620f81aa3f2b4f4844dcf8d9dc4add9a8ed0313/snmp/tests/compose/data/a10-thunder.snmprec

2/ You can run `ddev env test snmp:py3.9-false`

2/ `ddev env edit snmp py3.9-false` to change the config to target a profile using a specific community_string e.g. `my-dynamic-device`  to target the snmprec.

3/ `ddev env check snmp py3.9-false` to verify that we are correctly using `a10-thunder` profile

4/ Manually update the content of `compose/data/my-dynamic-device.snmprec` with another profile like https://github.com/DataDog/integrations-core/blob/506a139b74c5bf6e3a7ffc3d4b0447563b7dd384/snmp/tests/compose/data/arista-switch.snmprec

5/ Restart the snmpsim simulator using 

```
DATA_DIR=`pwd`/snmp/tests/compose/data/  docker-compose -f snmp/tests/compose/docker-compose.yaml up
```

wait few seconds for it to start

6/ `ddev env check snmp py3.9-false` to verify that we are correctly using `arista-switch` profile now.

Note: we never restarted the Agent, the new feature you implemented should update to the new profile.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
