### PR TITLE
Add ruby language detection

### DIFF
--- a/pkg/languagedetection/cli_detector.go
+++ b/pkg/languagedetection/cli_detector.go
@@ -6,6 +6,7 @@
 package languagedetection
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
@@ -17,6 +18,9 @@ type languageFromCLI struct {
 	validator func(exe string) bool
 }
 
+// rubyPattern is a regexp validator for the ruby prefix
+var rubyPattern = regexp.MustCompile(`^ruby\d+\.\d+$`)
+
 // knownPrefixes maps languages names to their prefix
 var knownPrefixes = map[string]languageFromCLI{
 	"python": {name: languagemodels.Python},
@@ -25,6 +29,9 @@ var knownPrefixes = map[string]languageFromCLI{
 			return false
 		}
 		return true
+	}},
+	"ruby": {name: languagemodels.Ruby, validator: func(exe string) bool {
+		return rubyPattern.MatchString(exe)
 	}},
 }
 
@@ -39,20 +46,21 @@ var exactMatches = map[string]languageFromCLI{
 	"node": {name: languagemodels.Node},
 
 	"dotnet": {name: languagemodels.Dotnet},
+
+	"ruby":  {name: languagemodels.Ruby},
+	"rubyw": {name: languagemodels.Ruby},
 }
 
-func languageNameFromCommandLine(cmdline []string) languagemodels.LanguageName {
-	exe := getExe(cmdline)
-
+func languageNameFromCommand(command string) languagemodels.LanguageName {
 	// First check to see if there is an exact match
-	if lang, ok := exactMatches[exe]; ok {
+	if lang, ok := exactMatches[command]; ok {
 		return lang.name
 	}
 
 	for prefix, language := range knownPrefixes {
-		if strings.HasPrefix(exe, prefix) {
+		if strings.HasPrefix(command, prefix) {
 			if language.validator != nil {
-				isValidResult := language.validator(exe)
+				isValidResult := language.validator(command)
 				if !isValidResult {
 					continue
 				}
@@ -68,7 +76,11 @@ func languageNameFromCommandLine(cmdline []string) languagemodels.LanguageName {
 func DetectLanguage(procs []*procutil.Process) []*languagemodels.Language {
 	langs := make([]*languagemodels.Language, len(procs))
 	for i, proc := range procs {
-		languageName := languageNameFromCommandLine(proc.Cmdline)
+		exe := getExe(proc.Cmdline)
+		languageName := languageNameFromCommand(exe)
+		if languageName == languagemodels.Unknown {
+			languageName = languageNameFromCommand(proc.Comm)
+		}
 		langs[i] = &languagemodels.Language{Name: languageName}
 	}
 	return langs

--- a/pkg/languagedetection/detector_nix_test.go
+++ b/pkg/languagedetection/detector_nix_test.go
@@ -8,7 +8,6 @@
 package languagedetection
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,77 +16,102 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
-func makeProcess(cmdline []string) *procutil.Process {
-	return &procutil.Process{
-		Pid:     rand.Int31(),
-		Cmdline: cmdline,
-	}
-}
-
-func TestLanguageFromCommandline(t *testing.T) {
+func TestDetectLanguage(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		cmdline  []string
+		comm     string
 		expected languagemodels.LanguageName
 	}{
 		{
 			name:     "python2",
 			cmdline:  []string{"/opt/Python/2.7.11/bin/python2.7", "/opt/foo/bar/baz", "--config=asdf"},
+			comm:     "baz",
 			expected: languagemodels.Python,
 		},
 		{
 			name:     "Java",
 			cmdline:  []string{"/usr/bin/Java", "-Xfoo=true", "org.elasticsearch.bootstrap.Elasticsearch"},
+			comm:     "java",
 			expected: languagemodels.Java,
 		},
 		{
 			name:     "Unknown",
 			cmdline:  []string{"mine-bitcoins", "--all"},
+			comm:     "mine-bitcoins",
 			expected: languagemodels.Unknown,
 		},
 		{
 			name:     "Python with space and special chars in path",
 			cmdline:  []string{"//..//path/\"\\ to/Python", "asdf"},
+			comm:     "asdf",
 			expected: languagemodels.Python,
 		},
 		{
 			name:     "args in first element",
 			cmdline:  []string{"/usr/bin/Python myapp.py --config=/etc/mycfg.yaml"},
+			comm:     "myapp.py",
 			expected: languagemodels.Python,
 		},
 		{
 			name:     "javac is not Java",
 			cmdline:  []string{"javac", "main.Java"},
+			comm:     "javac",
 			expected: languagemodels.Unknown,
 		},
 		{
 			name:     "py is Python",
 			cmdline:  []string{"py", "test.py"},
+			comm:     "test.py",
 			expected: languagemodels.Python,
 		},
 		{
 			name:     "py is not a prefix",
 			cmdline:  []string{"pyret", "main.pyret"},
+			comm:     "pyret",
 			expected: languagemodels.Unknown,
 		},
 		{
 			name:     "node",
 			cmdline:  []string{"node", "/etc/app/index.js"},
+			comm:     "node",
 			expected: languagemodels.Node,
 		},
 		{
 			name:     "npm",
 			cmdline:  []string{"npm", "start"},
+			comm:     "npm",
 			expected: languagemodels.Node,
 		},
 		{
 			name:     "dotnet",
 			cmdline:  []string{"dotnet", "myApp"},
+			comm:     "dotnet",
 			expected: languagemodels.Dotnet,
+		},
+		{
+			name:     "ruby",
+			cmdline:  []string{"ruby", "prog.rb"},
+			comm:     "ruby",
+			expected: languagemodels.Ruby,
+		},
+		{
+			name:     "rails",
+			cmdline:  []string{"puma", "5.6.6", "(tcp://localhost:3000)", "[app]"},
+			comm:     "ruby",
+			expected: languagemodels.Ruby,
+		},
+		{
+			name:     "irb",
+			cmdline:  []string{"irb"},
+			comm:     "ruby2.7",
+			expected: languagemodels.Ruby,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, languageNameFromCommandLine(tc.cmdline))
+			process := []*procutil.Process{makeProcess(tc.cmdline, tc.comm)}
+			expected := []*languagemodels.Language{{Name: tc.expected}}
+			assert.Equal(t, expected, DetectLanguage(process))
 		})
 	}
 }
@@ -138,29 +162,95 @@ func TestGetExe(t *testing.T) {
 }
 
 func BenchmarkDetectLanguage(b *testing.B) {
-	commands := [][]string{
-		{"Python", "--version"},
-		{"python3", "--version"},
-		{"py", "--version"},
-		{"Python", "-c", "import platform; print(platform.python_version())"},
-		{"python3", "-c", "import platform; print(platform.python_version())"},
-		{"py", "-c", "import platform; print(platform.python_version())"},
-		{"Python", "-c", "import sys; print(sys.version)"},
-		{"python3", "-c", "import sys; print(sys.version)"},
-		{"py", "-c", "import sys; print(sys.version)"},
-		{"Python", "-c", "print('Python')"},
-		{"python3", "-c", "print('Python')"},
-		{"py", "-c", "print('Python')"},
-		{"Java", "-version"},
-		{"Java", "-jar", "myapp.jar"},
-		{"Java", "-cp", ".", "MyClass"},
-		{"javac", "MyClass.Java"},
-		{"javap", "-c", "MyClass"},
+	commands := []struct {
+		cmdline []string
+		comm    string
+	}{
+		{
+			cmdline: []string{"Python", "--version"},
+			comm:    "",
+		},
+		{
+			cmdline: []string{"python3", "--version"},
+			comm:    "",
+		},
+		{
+			cmdline: []string{"py", "--version"},
+			comm:    "",
+		},
+		{
+			cmdline: []string{"Python", "-c", "import platform; print(platform.python_version())"},
+			comm:    "",
+		},
+		{
+			cmdline: []string{"python3", "-c", "import platform; print(platform.python_version())"},
+			comm:    "",
+		},
+		{
+			cmdline: []string{"py", "-c", "import platform; print(platform.python_version())"},
+			comm:    "",
+		},
+		{
+			cmdline: []string{"Python", "-c", "import sys; print(sys.version)"},
+			comm:    "",
+		},
+		{
+			cmdline: []string{"python3", "-c", "import sys; print(sys.version)"},
+			comm:    "",
+		},
+		{
+			cmdline: []string{"py", "-c", "import sys; print(sys.version)"},
+			comm:    "",
+		},
+		{
+			cmdline: []string{"Python", "-c", "print('Python')"},
+			comm:    "",
+		},
+		{
+			cmdline: []string{"python3", "-c", "print('Python')"},
+			comm:    "",
+		},
+		{
+			cmdline: []string{"py", "-c", "print('Python')"},
+			comm:    "",
+		},
+		{
+			cmdline: []string{"Java", "-version"},
+			comm:    "",
+		},
+		{
+			cmdline: []string{"Java", "-jar", "myapp.jar"},
+			comm:    "",
+		},
+		{
+			cmdline: []string{"Java", "-cp", ".", "MyClass"},
+			comm:    "",
+		},
+		{
+			cmdline: []string{"javac", "MyClass.Java"},
+			comm:    "",
+		},
+		{
+			cmdline: []string{"javap", "-c", "MyClass"},
+			comm:    "",
+		},
+		{
+			cmdline: []string{"ruby", "prog.rb"},
+			comm:    "ruby",
+		},
+		{
+			cmdline: []string{"puma", "5.6.6", "(tcp://localhost:3000)", "[app]"},
+			comm:    "ruby",
+		},
+		{
+			cmdline: []string{"irb"},
+			comm:    "ruby2.7",
+		},
 	}
 
 	var procs []*procutil.Process
 	for _, command := range commands {
-		procs = append(procs, makeProcess(command))
+		procs = append(procs, makeProcess(command.cmdline, command.comm))
 	}
 
 	b.StartTimer()

--- a/pkg/languagedetection/detector_nix_test.go
+++ b/pkg/languagedetection/detector_nix_test.go
@@ -107,6 +107,12 @@ func TestDetectLanguage(t *testing.T) {
 			comm:     "ruby2.7",
 			expected: languagemodels.Ruby,
 		},
+		{
+			name:     "jruby",
+			cmdline:  []string{"java", "-Djruby.home=/usr/share/jruby", "-Djruby.lib=/usr/share/jruby/lib", "org.jruby.Main", "prog.rb"},
+			comm:     "java",
+			expected: languagemodels.Java, // TODO: not yet implemented
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			process := []*procutil.Process{makeProcess(tc.cmdline, tc.comm)}

--- a/pkg/languagedetection/detector_test.go
+++ b/pkg/languagedetection/detector_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 package languagedetection
 
 import (

--- a/pkg/languagedetection/detector_test.go
+++ b/pkg/languagedetection/detector_test.go
@@ -1,0 +1,15 @@
+package languagedetection
+
+import (
+	"math/rand"
+
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
+)
+
+func makeProcess(cmdline []string, comm string) *procutil.Process {
+	return &procutil.Process{
+		Pid:     rand.Int31(),
+		Cmdline: cmdline,
+		Comm:    comm,
+	}
+}

--- a/pkg/languagedetection/detector_windows_test.go
+++ b/pkg/languagedetection/detector_windows_test.go
@@ -13,9 +13,10 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
-func TestLanguageFromCommandline(t *testing.T) {
+func TestDetectLanguage(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		cmdline  []string
@@ -42,9 +43,16 @@ func TestLanguageFromCommandline(t *testing.T) {
 			cmdline:  []string{"dotnet", "BankApp.dll"},
 			expected: languagemodels.Dotnet,
 		},
+		{
+			name:     "rubyw",
+			cmdline:  []string{"C:\\Users\\AppData\\bin\\rubyw.exe", "prog.rb"},
+			expected: languagemodels.Ruby,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, languageNameFromCommandLine(tc.cmdline))
+			process := []*procutil.Process{makeProcess(tc.cmdline, "")}
+			expected := []*languagemodels.Language{{Name: tc.expected}}
+			assert.Equal(t, expected, DetectLanguage(process))
 		})
 	}
 }

--- a/pkg/languagedetection/languagemodels/types.go
+++ b/pkg/languagedetection/languagemodels/types.go
@@ -14,6 +14,7 @@ const (
 	Dotnet  LanguageName = "dotnet"
 	Python  LanguageName = "python"
 	Java    LanguageName = "java"
+	Ruby    LanguageName = "ruby"
 	Unknown LanguageName = ""
 )
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add Ruby language detection. No changelog as this code is still dormant.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Set the following config:

```
log_level: trace
process_config:
  process_collection:
    enabled: true
  language_detection:
    enabled: true
```

Run a ruby process (e.g. a long-running `ruby foo.rb` or an [empty `rails` server](https://guides.rubyonrails.org/getting_started.html)) and verify that the process is detected as Ruby by looking for the following log line:

```
detected language ruby for pid <pid>
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
