### PR TITLE
[serverless] add `ruby|go` to the `language` tag regex.

### DIFF
--- a/pkg/serverless/invocationlifecycle/trace.go
+++ b/pkg/serverless/invocationlifecycle/trace.go
@@ -28,7 +28,7 @@ const (
 	functionNameEnvVar = "AWS_LAMBDA_FUNCTION_NAME"
 )
 
-var /* const */ runtimeRegex = regexp.MustCompile(`^(java|dotnet|ruby)\d*$`)
+var /* const */ runtimeRegex = regexp.MustCompile(`^(dotnet|go|java|ruby)(\d+(\.\d+)*|\d+(\.x))$`)
 
 // ExecutionStartInfo is saved information from when an execution span was started
 type ExecutionStartInfo struct {
@@ -120,7 +120,7 @@ func endExecutionSpan(executionContext *ExecutionStartInfo, triggerTags map[stri
 		executionSpan.Meta["proactive_initialization"] = fmt.Sprintf("%t", endDetails.ProactiveInit)
 	}
 	langMatches := runtimeRegex.FindStringSubmatch(endDetails.Runtime)
-	if len(langMatches) == 2 {
+	if len(langMatches) >= 2 {
 		executionSpan.Meta["language"] = langMatches[1]
 	}
 	captureLambdaPayloadEnabled := config.Datadog.GetBool("capture_lambda_payload")

--- a/pkg/serverless/invocationlifecycle/trace.go
+++ b/pkg/serverless/invocationlifecycle/trace.go
@@ -28,7 +28,7 @@ const (
 	functionNameEnvVar = "AWS_LAMBDA_FUNCTION_NAME"
 )
 
-var /* const */ runtimeRegex = regexp.MustCompile(`^(java|dotnet)\d*$`)
+var /* const */ runtimeRegex = regexp.MustCompile(`^(java|dotnet|ruby)\d*$`)
 
 // ExecutionStartInfo is saved information from when an execution span was started
 type ExecutionStartInfo struct {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adds `ruby` and `go` to a regex which adds the `language` tag to `aws.lambda` span.

The new regex: `^(java|dotnet|ruby|go)(\d+(\.\d+)*|\d+(\.x))$`
Gets multiple groups, where the first one will always be the expected runtime, and the second one will be the AWS Lambda version.

`go1.x` => `go`, `1.x`, `.x`,
`dotnet6` => `dotnet`, `6`,
`ruby2.7` => `ruby`, `2.7`, `.7`,
`java11` => `java`, `11`

### Motivation

Ruby is going to introduce inferred spans by using the Datadog Extension. After this changes happens, the `language` tag disappears.

This is highly happening for Go too.

This is needed for runtime metrics too.

### Additional Notes

On the left `language` appears because we are using span generated by the tracer.

On the right, it disappears, because we are using inferred spans generated by the extension.
<img width="1657" alt="Screenshot 2023-08-07 at 3 08 12 PM" src="https://github.com/DataDog/datadog-agent/assets/30836115/84078789-bf1e-43e8-8091-acde633aa81e">

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
