### PR TITLE
Add CI job to calculate changes in Go imports

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -15,6 +15,9 @@ prepare_ebpf_functional_tests*       @DataDog/ebpf-platform
 
 # Golang dependency list generation (currently disabled)
 golang_deps_generate                 @DataDog/agent-shared-components
+# Golang dependency diff generation
+golang_deps_diff                     @DataDog/ebpf-platform
+golang_deps_commenter                @DataDog/ebpf-platform
 
 # Binary build
 build_system-probe*                  @DataDog/ebpf-platform

--- a/.gitlab/source_test.yml
+++ b/.gitlab/source_test.yml
@@ -10,3 +10,4 @@ include:
   - /.gitlab/source_test/windows.yml
   - /.gitlab/source_test/go_generate_check.yml
   - /.gitlab/source_test/slack.yml
+  - /.gitlab/source_test/golang_deps_diff.yml

--- a/.gitlab/source_test/golang_deps_diff.yml
+++ b/.gitlab/source_test/golang_deps_diff.yml
@@ -1,0 +1,26 @@
+---
+# golang_deps_diff stage
+# Contains the step to generate diff of go imports for each binary/build
+golang_deps_diff:
+  stage: source_test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs: ["go_deps"]
+  before_script:
+    - source /root/.bashrc
+    - !reference [.retrieve_linux_go_deps]
+  script:
+    - inv -e diff.go-deps --report-file=deps-report.md
+  artifacts:
+    paths:
+      - deps-report.md
+    expire_in: 2 weeks
+
+golang_deps_commenter:
+  stage: source_test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/pr-commenter:2
+  tags: ["arch:amd64"]
+  needs: ["golang_deps_diff"]
+  script:
+    - echo "${CI_COMMIT_REF_NAME}"
+    - pr-commenter --for-pr="${CI_COMMIT_REF_NAME}" --header="Go Package Import Differences" --infile deps-report.md

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -12,6 +12,7 @@ from . import (
     cluster_agent_cloudfoundry,
     components,
     customaction,
+    diff,
     docker_tasks,
     dogstatsd,
     epforwarder,
@@ -135,6 +136,7 @@ ns.add_collection(security_agent)
 ns.add_collection(vscode)
 ns.add_collection(new_e2e_tests)
 ns.add_collection(kmt)
+ns.add_collection(diff)
 ns.configure(
     {
         'run': {

--- a/tasks/diff.py
+++ b/tasks/diff.py
@@ -1,0 +1,189 @@
+"""
+Diffing tasks
+"""
+
+import os
+import tempfile
+
+from invoke import task
+from invoke.exceptions import Exit
+
+from .build_tags import get_default_build_tags
+from .flavor import AgentFlavor
+from .go import GOARCH_MAPPING, GOOS_MAPPING
+from .libs.common.color import color_message
+from .release import _get_release_json_value
+from .utils import check_uncommitted_changes
+
+
+@task
+def go_deps(ctx, baseline_ref=None, report_file=None):
+    if check_uncommitted_changes(ctx):
+        raise Exit(
+            color_message(
+                "There are uncomitted changes in your repository. Please commit or stash them before trying again.",
+                "red",
+            ),
+            code=1,
+        )
+    current_branch = ctx.run("git rev-parse --abbrev-ref HEAD", hide=True).stdout.strip()
+    commit_sha = os.getenv("CI_COMMIT_SHA")
+    if commit_sha is None:
+        commit_sha = ctx.run("git rev-parse HEAD", hide=True).stdout.strip()
+
+    if not baseline_ref:
+        base_branch = _get_release_json_value("base_branch")
+        baseline_ref = ctx.run(f"git merge-base {commit_sha} origin/{base_branch}", hide=True).stdout.strip()
+
+    # platforms are the agent task recognized os/platform and arch values, not Go-specific values
+    binaries = {
+        "agent": {
+            "entrypoint": "cmd/agent",
+            "platforms": ["linux/x64", "linux/arm64", "win32/x64", "win32/x86", "darwin/x64", "darwin/arm64"],
+        },
+        "iot-agent": {
+            "build": "agent",
+            "entrypoint": "cmd/agent",
+            "flavor": AgentFlavor.iot,
+            "platforms": ["linux/x64", "linux/arm64"],
+        },
+        "heroku-agent": {
+            "build": "agent",
+            "entrypoint": "cmd/agent",
+            "flavor": AgentFlavor.heroku,
+            "platforms": ["linux/x64"],
+        },
+        "cluster-agent": {"entrypoint": "cmd/cluster-agent", "platforms": ["linux/x64", "linux/arm64"]},
+        "cluster-agent-cloudfoundry": {
+            "entrypoint": "cmd/cluster-agent-cloudfoundry",
+            "platforms": ["linux/x64", "linux/arm64"],
+        },
+        "dogstatsd": {"entrypoint": "cmd/dogstatsd", "platforms": ["linux/x64", "linux/arm64"]},
+        "process-agent": {
+            "entrypoint": "cmd/process-agent",
+            "platforms": ["linux/x64", "linux/arm64", "win32/x64", "darwin/x64", "darwin/arm64"],
+        },
+        "heroku-process-agent": {
+            "build": "process-agent",
+            "entrypoint": "cmd/process-agent",
+            "flavor": AgentFlavor.heroku,
+            "platforms": ["linux/x64"],
+        },
+        "security-agent": {
+            "entrypoint": "cmd/security-agent",
+            "platforms": ["linux/x64", "linux/arm64"],
+        },
+        "serverless": {"entrypoint": "cmd/serverless", "platforms": ["linux/x64", "linux/arm64"]},
+        "system-probe": {"entrypoint": "cmd/system-probe", "platforms": ["linux/x64", "linux/arm64", "win32/x64"]},
+        "trace-agent": {
+            "entrypoint": "cmd/trace-agent",
+            "platforms": ["linux/x64", "linux/arm64", "win32/x64", "win32/x86", "darwin/x64", "darwin/arm64"],
+        },
+        "heroku-trace-agent": {
+            "build": "trace-agent",
+            "entrypoint": "cmd/trace-agent",
+            "flavor": AgentFlavor.heroku,
+            "platforms": ["linux/x64"],
+        },
+    }
+    diffs = {}
+    dep_cmd = "go list -f '{{ range .Deps }}{{ printf \"%s\\n\" . }}{{end}}'"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        try:
+            # generate list of imports for each target+branch combo
+            branches = {"current": None, "main": baseline_ref}
+            for branch_name, branch_ref in branches.items():
+                if branch_ref:
+                    ctx.run(f"git checkout -q {branch_ref}")
+
+                for binary, details in binaries.items():
+                    with ctx.cd(details.get("entrypoint")):
+                        for combo in details.get("platforms"):
+                            platform, arch = combo.split("/")
+                            goos, goarch = GOOS_MAPPING.get(platform), GOARCH_MAPPING.get(arch)
+                            target = f"{binary}-{goos}-{goarch}"
+
+                            depsfile = os.path.join(tmpdir, f"{target}-{branch_name}")
+                            flavor = details.get("flavor", AgentFlavor.base)
+                            build = details.get("build", binary)
+                            build_tags = get_default_build_tags(
+                                build=build, arch=arch, platform=platform, flavor=flavor
+                            )
+                            env = {"GOOS": goos, "GOARCH": goarch}
+                            ctx.run(f"{dep_cmd} -tags \"{' '.join(build_tags)}\" > {depsfile}", env=env)
+        finally:
+            ctx.run(f"git checkout -q {current_branch}")
+
+        # compute diffs for each target
+        for binary, details in binaries.items():
+            for combo in details.get("platforms"):
+                platform, arch = combo.split("/")
+                goos, goarch = GOOS_MAPPING.get(platform), GOARCH_MAPPING.get(arch)
+                target = f"{binary}-{goos}-{goarch}"
+
+                prdeps = os.path.join(tmpdir, f"{target}-current")
+                maindeps = os.path.join(tmpdir, f"{target}-main")
+                res = ctx.run(
+                    f"diff -u0 {maindeps} {prdeps} | grep -v '^@@' | grep -v '^[+-][+-]'", hide=True, warn=True
+                )
+                if len(res.stdout) > 0:
+                    diffs[target] = res.stdout.strip()
+
+        # output, also to file if requested
+        if len(diffs) > 0:
+            pr_comment = [
+                f"Baseline: {baseline_ref}",
+                f"Comparison: {commit_sha}\n",
+            ]
+            for binary, details in binaries.items():
+                for combo in details.get("platforms"):
+                    platform, arch = combo.split("/")
+                    goos, goarch = GOOS_MAPPING.get(platform), GOARCH_MAPPING.get(arch)
+                    target = f"{binary}-{goos}-{goarch}"
+                    prettytarget = f"{binary} {goos}/{goarch}"
+
+                    if target in diffs:
+                        targetdiffs = diffs[target]
+                        add, remove = patch_summary(targetdiffs)
+                        color_add = color_message(f"+{add}", "green")
+                        color_remove = color_message(f"-{remove}", "red")
+                        print(f"== {prettytarget} {color_add}, {color_remove} ==")
+                        print(f"{color_patch(targetdiffs)}\n")
+
+                        summary = f"<summary>{prettytarget} +{add}, -{remove}</summary>"
+                        diff_block = f"\n```diff\n{targetdiffs}\n```\n"
+                        pr_comment.append(f"<details>{summary}\n{diff_block}</details>\n")
+                    else:
+                        print(f"== {prettytarget} ==\nno changes\n")
+
+            if report_file:
+                with open(report_file, 'w') as f:
+                    f.write("\n".join(pr_comment))
+        else:
+            print("no changes for all binaries")
+            if report_file:
+                # touch file
+                open(report_file, 'w').close()
+
+
+def color_patch(diff):
+    out = []
+    for line in diff.splitlines():
+        if line.startswith("+"):
+            out.append(color_message(line, 'green'))
+        elif line.startswith("-"):
+            out.append(color_message(line, 'red'))
+        else:
+            out.append(line)
+    return "\n".join(out)
+
+
+def patch_summary(diff):
+    add_count, remove_count = 0, 0
+    for line in diff.splitlines():
+        if line.startswith("+"):
+            add_count += 1
+        elif line.startswith("-"):
+            remove_count += 1
+    return add_count, remove_count

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -17,6 +17,17 @@ from .licenses import get_licenses_list
 from .modules import DEFAULT_MODULES, generate_dummy_package
 from .utils import get_build_flags
 
+GOOS_MAPPING = {
+    "win32": "windows",
+    "linux": "linux",
+    "darwin": "darwin",
+}
+GOARCH_MAPPING = {
+    "x64": "amd64",
+    "x86": "386",
+    "arm64": "arm64",
+}
+
 
 def run_golangci_lint(ctx, targets, rtloader_root=None, build_tags=None, build="test", arch="x64", concurrency=None):
     if isinstance(targets, str):

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1270,6 +1270,11 @@ def build_rc(ctx, major_versions="6,7", patch_version=False):
 
 @task(help={'key': "Path to the release.json key, separated with double colons, eg. 'last_stable::6'"})
 def get_release_json_value(_, key):
+    release_json = _get_release_json_value(key)
+    print(release_json)
+
+
+def _get_release_json_value(key):
     release_json = _load_release_json()
 
     path = key.split('::')
@@ -1280,7 +1285,7 @@ def get_release_json_value(_, key):
 
         release_json = release_json.get(element)
 
-    print(release_json)
+    return release_json
 
 
 def create_release_branch(ctx, repo, release_branch, base_directory="~/dd", upstream="origin"):

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -18,7 +18,6 @@ from .go import golangci_lint
 from .libs.ninja_syntax import NinjaWriter
 from .system_probe import (
     CURRENT_ARCH,
-    SBOM_TAG,
     build_cws_object_files,
     check_for_ninja,
     ninja_define_ebpf_compiler,
@@ -292,7 +291,7 @@ def build_functional_tests(
 
     build_tags = build_tags.split(",")
     build_tags.append("linux_bpf")
-    build_tags.append(SBOM_TAG)
+    build_tags.append("trivy")
     build_tags.append("containerd")
 
     if bundle_ebpf:

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -28,7 +28,6 @@ BIN_PATH = os.path.join(BIN_DIR, bin_name("system-probe"))
 BPF_TAG = "linux_bpf"
 BUNDLE_TAG = "ebpf_bindata"
 NPM_TAG = "npm"
-SBOM_TAG = "trivy"
 
 KITCHEN_DIR = os.getenv('DD_AGENT_TESTING_DIR') or os.path.normpath(os.path.join(os.getcwd(), "test", "kitchen"))
 KITCHEN_ARTIFACT_DIR = os.path.join(KITCHEN_DIR, "site-cookbooks", "dd-system-probe-check", "files", "default", "tests")
@@ -487,7 +486,6 @@ def build(
     strip_object_files=False,
     strip_binary=False,
     with_unit_test=False,
-    sbom=True,
 ):
     """
     Build the system-probe
@@ -513,7 +511,6 @@ def build(
         race=race,
         incremental_build=incremental_build,
         strip_binary=strip_binary,
-        sbom=sbom,
     )
 
 
@@ -541,7 +538,6 @@ def build_sysprobe_binary(
     arch=CURRENT_ARCH,
     bundle_ebpf=False,
     strip_binary=False,
-    sbom=True,
 ):
     ldflags, gcflags, env = get_build_flags(
         ctx,
@@ -552,9 +548,6 @@ def build_sysprobe_binary(
     build_tags = get_default_build_tags(build="system-probe", arch=arch)
     if bundle_ebpf:
         build_tags.append(BUNDLE_TAG)
-    if sbom:
-        build_tags.append(SBOM_TAG)
-
     if strip_binary:
         ldflags += ' -s -w'
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adds a CI job that calculates Go import differences made by the branch. It comments on the PR with the binary + os/arch for any that have changes. If there are no changes, no comment is made.

### Motivation

It is easy to accidentally transitively import a bunch of Go deps and cause unexpected binary size changes.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
