### PR TITLE
Configure SecurityContext on APM auto-instrumentation init container

### DIFF
--- a/pkg/clusteragent/admission/mutate/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation.go
@@ -333,6 +333,8 @@ func injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo) error {
 
 func injectLibInitContainer(pod *corev1.Pod, image string, lang language) error {
 	initCtrName := initContainerName(lang)
+	initCtrRunAsUser := int64(10000)
+	initCtrRunAsGroup := int64(10000)
 	log.Debugf("Injecting init container named %q with image %q into pod %s", initCtrName, image, podString(pod))
 	initContainer := corev1.Container{
 		Name:    initCtrName,
@@ -343,6 +345,10 @@ func injectLibInitContainer(pod *corev1.Pod, image string, lang language) error 
 				Name:      volumeName,
 				MountPath: mountPath,
 			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:  &initCtrRunAsUser,
+			RunAsGroup: &initCtrRunAsGroup,
 		},
 	}
 	resources, hasResources, err := initResources()

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
@@ -256,6 +256,12 @@ func assertLibReq(t *testing.T, pod *corev1.Pod, lang language, image, envKey, e
 			require.Equal(t, []string{"sh", "copy-lib.sh", "/datadog-lib"}, container.Command)
 			require.Equal(t, "datadog-auto-instrumentation", container.VolumeMounts[0].Name)
 			require.Equal(t, "/datadog-lib", container.VolumeMounts[0].MountPath)
+
+			securityContext := container.SecurityContext
+			require.NotNil(t, securityContext)
+			require.Equal(t, *securityContext.RunAsUser, int64(10000))
+			require.Equal(t, *securityContext.RunAsGroup, int64(10000))
+
 			initContainerFound = true
 			break
 		}

--- a/releasenotes/notes/securitycontext-on-auto-instrumentation-init-container-302976a9bf1bb629.yaml
+++ b/releasenotes/notes/securitycontext-on-auto-instrumentation-init-container-302976a9bf1bb629.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Configure the SecurityContext on the APM auto-instrumentation init container to
+    ensure the container runs as the intended user.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

In our environment we run pods with a podSecurityContext that sets runAsUser=1000 and have found that this causes the python init-container to run as this user which causes the following errors:

```
cp: can't open 'ddtrace_pkgs/site-packages-ddtrace-py3.8-musllinux_1_1/protobuf-4.23.4.dist-info/WHEEL': Permission denied
cp: can't open 'ddtrace_pkgs/site-packages-ddtrace-py3.8-musllinux_1_1/protobuf-4.23.4.dist-info/RECORD': Permission denied
cp: can't open 'ddtrace_pkgs/site-packages-ddtrace-py3.8-musllinux_1_1/protobuf-4.23.4.dist-info/METADATA': Permission denied
cp: can't open 'ddtrace_pkgs/site-packages-ddtrace-py3.7-musllinux_1_1/protobuf-4.23.4.dist-info/WHEEL': Permission denied
...
...
```

After some digging it looks like the init container itself runs as user=10000 https://github.com/DataDog/dd-trace-py/blob/b00afa39a0cdc8e277b442fdae7bfc6a421e9250/lib-injection/Dockerfile#L28

This PR changes things so that the init container explicitly specifies runAsUser and runAsGroup which should ensure the init container runs as the user it expects to run as.

### Motivation

The motivation here is to ensure the init container will work when the pods security context specifies to run as a user other than 10000.

### Additional Notes

https://github.com/DataDog/dd-trace-py/pull/6569 currently has a fix for Python, however as discussed with @Kyle-Verhoog offline it is probably a good idea to be explicit with runAsUser/runAsGroup for the init container anyway.

### Possible Drawbacks / Trade-offs

The main issue would present if the lib-injection container did not run as UID=GID=10000 however looking at all current implementations they are using this value.

### Describe how to test/QA your changes

Will need to run a pod that specifies a podSecurityContext with a value for runAsUser/runAsGroup != 10000

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
