### PR TITLE
[CWS] fallback to m6g.xlarge or m7g.xlarge if t4g.xlarge is not available

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -85,7 +85,7 @@ kitchen_test_security_agent_arm64:
   needs: [ "tests_ebpf_arm64", "prepare_ebpf_functional_tests_arm64" ]
   variables:
     KITCHEN_ARCH: arm64
-    KITCHEN_EC2_INSTANCE_TYPE: "t4g.xlarge"
+    KITCHEN_EC2_INSTANCE_TYPE: "[t4g.xlarge, m6g.xlarge, m7g.xlarge]"
     KITCHEN_CI_MOUNT_PATH: "/mnt/ci"
     KITCHEN_CI_ROOT_PATH: "/tmp/ci"
   before_script:


### PR DESCRIPTION
### What does this PR do?

Recently it has been difficult to get some t4g.xlarge spot instances for CWS functional tests. This PR adds a fallback to m6g.xlarge and m7g.xlarge instance types of a similar price point

<img width="1408" alt="image" src="https://github.com/DataDog/datadog-agent/assets/2822037/f0b2b775-91df-42d7-81ac-1f7c2a5569c7">


### Motivation

Fix infra errors in kitchen tests

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
