### PR TITLE
usm: http2: Order in the UTs

### DIFF
--- a/pkg/network/protocols/grpc/monitor_test.go
+++ b/pkg/network/protocols/grpc/monitor_test.go
@@ -10,7 +10,7 @@ package grpc
 import (
 	"context"
 	"fmt"
-	"strings"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -31,49 +31,70 @@ const (
 	srvAddr = "127.0.0.1:5050"
 )
 
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func randStringRunes(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}
+
 func TestGRPCScenarios(t *testing.T) {
+	currKernelVersion, err := kernel.HostVersion()
+	require.NoError(t, err)
+	if currKernelVersion < http2.MinimumKernelVersion {
+		t.Skipf("HTTP2 monitoring can not run on kernel before %v", http2.MinimumKernelVersion)
+	}
+
+	rand.Seed(time.Now().UnixNano())
+
 	ebpftest.TestBuildModes(t, []ebpftest.BuildMode{ebpftest.Prebuilt, ebpftest.RuntimeCompiled, ebpftest.CORE}, "", testGRPCScenarios)
+}
+
+func getClientsArray(t *testing.T, size int, options grpc.Options) []*grpc.Client {
+	res := make([]*grpc.Client, size)
+	for i := 0; i < size; i++ {
+		client, err := grpc.NewClient(srvAddr, options)
+		require.NoError(t, err)
+		t.Cleanup(client.Close)
+		res[i] = &client
+	}
+
+	return res
+}
+
+func getClientsIndex(index, totalCount int) int {
+	return index % totalCount
 }
 
 func testGRPCScenarios(t *testing.T) {
 	cfg := config.New()
-	cfg.EnableHTTPMonitoring = true
 	cfg.EnableHTTP2Monitoring = true
-
-	currKernelVersion, err := kernel.HostVersion()
-	require.NoError(t, err)
-	if currKernelVersion < http.MinimumKernelVersion {
-		t.Skipf("USM can not run on kernel before %v", http.MinimumKernelVersion)
-	}
-
-	if currKernelVersion < http2.MinimumKernelVersion {
-		t.Skipf("HTTP2 monitoring can not run on kernel before %v", http2.MinimumKernelVersion)
-	}
 
 	s, err := grpc.NewServer(srvAddr)
 	require.NoError(t, err)
 	s.Run()
 	t.Cleanup(s.Stop)
+	defaultCtx := context.Background()
 
 	// c is a stream endpoint
 	// a + b are unary endpoints
 	tests := []struct {
 		name              string
-		runClients        func(t *testing.T, differentClients bool)
+		runClients        func(t *testing.T, clientsCount int)
 		expectedEndpoints map[http.Key]int
 		expectedError     bool
 	}{
 		{
 			name: "simple unary - multiple requests",
-			runClients: func(t *testing.T, _ bool) {
-				var client1 grpc.Client
-				var err error
-				client1, err = grpc.NewClient(srvAddr, grpc.Options{})
-				require.NoError(t, err)
+			runClients: func(t *testing.T, clientsCount int) {
+				clients := getClientsArray(t, clientsCount, grpc.Options{})
 
-				ctx := context.Background()
 				for i := 0; i < 1000; i++ {
-					require.NoError(t, client1.HandleUnary(ctx, "first"))
+					client := clients[getClientsIndex(i, clientsCount)]
+					require.NoError(t, client.HandleUnary(defaultCtx, "first"))
 				}
 			},
 			expectedEndpoints: map[http.Key]int{
@@ -82,51 +103,15 @@ func testGRPCScenarios(t *testing.T) {
 					Method: http.MethodPost,
 				}: 1000,
 			},
-			expectedError: false,
-		},
-		{
-			name: "unary, a->a->a",
-			runClients: func(t *testing.T, differentClients bool) {
-				var client1, client2 grpc.Client
-				var err error
-				client1, err = grpc.NewClient(srvAddr, grpc.Options{})
-				require.NoError(t, err)
-				client2 = client1
-				if differentClients {
-					client2, err = grpc.NewClient(srvAddr, grpc.Options{})
-					require.NoError(t, err)
-				}
-
-				ctx := context.Background()
-				require.NoError(t, client1.HandleUnary(ctx, "first"))
-				require.NoError(t, client2.HandleUnary(ctx, "second"))
-				require.NoError(t, client1.HandleUnary(ctx, "third"))
-			},
-			expectedEndpoints: map[http.Key]int{
-				{
-					Path:   http.Path{Content: "/helloworld.Greeter/SayHello"},
-					Method: http.MethodPost,
-				}: 3,
-			},
-			expectedError: false,
 		},
 		{
 			name: "unary, a->b->a",
-			runClients: func(t *testing.T, differentClients bool) {
-				var client1, client2 grpc.Client
-				var err error
-				client1, err = grpc.NewClient(srvAddr, grpc.Options{})
-				require.NoError(t, err)
-				client2 = client1
-				if differentClients {
-					client2, err = grpc.NewClient(srvAddr, grpc.Options{})
-					require.NoError(t, err)
-				}
+			runClients: func(t *testing.T, clientsCount int) {
+				clients := getClientsArray(t, clientsCount, grpc.Options{})
 
-				ctx := context.Background()
-				require.NoError(t, client1.HandleUnary(ctx, "first"))
-				require.NoError(t, client2.GetFeature(ctx, -746143763, 407838351))
-				require.NoError(t, client1.HandleUnary(ctx, "first"))
+				require.NoError(t, clients[getClientsIndex(0, clientsCount)].HandleUnary(defaultCtx, "first"))
+				require.NoError(t, clients[getClientsIndex(1, clientsCount)].GetFeature(defaultCtx, -746143763, 407838351))
+				require.NoError(t, clients[getClientsIndex(2, clientsCount)].HandleUnary(defaultCtx, "first"))
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
@@ -138,26 +123,16 @@ func testGRPCScenarios(t *testing.T) {
 					Method: http.MethodPost,
 				}: 1,
 			},
-			expectedError: false,
 		},
 		{
 			name: "unary, a->b->a->b",
-			runClients: func(t *testing.T, differentClients bool) {
-				var client1, client2 grpc.Client
-				var err error
-				client1, err = grpc.NewClient(srvAddr, grpc.Options{})
-				require.NoError(t, err)
-				client2 = client1
-				if differentClients {
-					client2, err = grpc.NewClient(srvAddr, grpc.Options{})
-					require.NoError(t, err)
-				}
+			runClients: func(t *testing.T, clientsCount int) {
+				clients := getClientsArray(t, clientsCount, grpc.Options{})
 
-				ctx := context.Background()
-				require.NoError(t, client1.HandleUnary(ctx, "first"))
-				require.NoError(t, client2.GetFeature(ctx, -746143763, 407838351))
-				require.NoError(t, client1.HandleUnary(ctx, "third"))
-				require.NoError(t, client2.GetFeature(ctx, -743999179, 408122808))
+				require.NoError(t, clients[getClientsIndex(0, clientsCount)].HandleUnary(defaultCtx, "first"))
+				require.NoError(t, clients[getClientsIndex(1, clientsCount)].GetFeature(defaultCtx, -746143763, 407838351))
+				require.NoError(t, clients[getClientsIndex(2, clientsCount)].HandleUnary(defaultCtx, "third"))
+				require.NoError(t, clients[getClientsIndex(3, clientsCount)].GetFeature(defaultCtx, -743999179, 408122808))
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
@@ -169,26 +144,16 @@ func testGRPCScenarios(t *testing.T) {
 					Method: http.MethodPost,
 				}: 2,
 			},
-			expectedError: false,
 		},
 		{
 			name: "unary, a->b->b->a",
-			runClients: func(t *testing.T, differentClients bool) {
-				var client1, client2 grpc.Client
-				var err error
-				client1, err = grpc.NewClient(srvAddr, grpc.Options{})
-				require.NoError(t, err)
-				client2 = client1
-				if differentClients {
-					client2, err = grpc.NewClient(srvAddr, grpc.Options{})
-					require.NoError(t, err)
-				}
+			runClients: func(t *testing.T, clientsCount int) {
+				clients := getClientsArray(t, clientsCount, grpc.Options{})
 
-				ctx := context.Background()
-				require.NoError(t, client1.HandleUnary(ctx, "first"))
-				require.NoError(t, client2.GetFeature(ctx, -746143763, 407838351))
-				require.NoError(t, client1.GetFeature(ctx, -743999179, 408122808))
-				require.NoError(t, client2.HandleUnary(ctx, "third"))
+				require.NoError(t, clients[getClientsIndex(0, clientsCount)].HandleUnary(defaultCtx, "first"))
+				require.NoError(t, clients[getClientsIndex(1, clientsCount)].GetFeature(defaultCtx, -746143763, 407838351))
+				require.NoError(t, clients[getClientsIndex(2, clientsCount)].GetFeature(defaultCtx, -743999179, 408122808))
+				require.NoError(t, clients[getClientsIndex(3, clientsCount)].HandleUnary(defaultCtx, "third"))
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
@@ -200,102 +165,33 @@ func testGRPCScenarios(t *testing.T) {
 					Method: http.MethodPost,
 				}: 2,
 			},
-			expectedError: false,
-		},
-		{
-			name: "unary, a->b->b->a",
-			runClients: func(t *testing.T, differentClients bool) {
-				var client1, client2 grpc.Client
-				var err error
-				client1, err = grpc.NewClient(srvAddr, grpc.Options{})
-				require.NoError(t, err)
-				client2 = client1
-				if differentClients {
-					client2, err = grpc.NewClient(srvAddr, grpc.Options{})
-					require.NoError(t, err)
-				}
-
-				ctx := context.Background()
-				require.NoError(t, client1.HandleUnary(ctx, "first"))
-				require.NoError(t, client2.GetFeature(ctx, -746143763, 407838351))
-				require.NoError(t, client2.GetFeature(ctx, -743999179, 408122808))
-				require.NoError(t, client1.HandleUnary(ctx, "third"))
-			},
-			expectedEndpoints: map[http.Key]int{
-				{
-					Path:   http.Path{Content: "/helloworld.Greeter/SayHello"},
-					Method: http.MethodPost,
-				}: 2,
-				{
-					Path:   http.Path{Content: "/routeguide.RouteGuide/GetFeature"},
-					Method: http.MethodPost,
-				}: 2,
-			},
-			expectedError: false,
 		},
 		{
 			name: "stream, c",
-			runClients: func(t *testing.T, differentClients bool) {
-				var client1 grpc.Client
-				var err error
-				client1, err = grpc.NewClient(srvAddr, grpc.Options{})
-				require.NoError(t, err)
+			runClients: func(t *testing.T, clientsCount int) {
+				clients := getClientsArray(t, clientsCount, grpc.Options{})
 
-				ctx := context.Background()
-				require.NoError(t, client1.HandleStream(ctx, 10))
-			},
-			expectedEndpoints: map[http.Key]int{
-				{
-					Path:   http.Path{Content: "/protobuf.Math/Max"},
-					Method: http.MethodPost,
-				}: 1,
-			},
-			expectedError: false,
-		},
-		{
-			name: "stream, c->c->c",
-			runClients: func(t *testing.T, differentClients bool) {
-				var client1, client2 grpc.Client
-				var err error
-				client1, err = grpc.NewClient(srvAddr, grpc.Options{})
-				require.NoError(t, err)
-				client2 = client1
-				if differentClients {
-					client2, err = grpc.NewClient(srvAddr, grpc.Options{})
-					require.NoError(t, err)
+				for i := 0; i < 25; i++ {
+					client := clients[getClientsIndex(i, clientsCount)]
+					require.NoError(t, client.HandleStream(defaultCtx, 10))
 				}
-
-				ctx := context.Background()
-				require.NoError(t, client1.HandleStream(ctx, 10))
-				require.NoError(t, client2.HandleStream(ctx, 10))
-				require.NoError(t, client1.HandleStream(ctx, 10))
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
 					Path:   http.Path{Content: "/protobuf.Math/Max"},
 					Method: http.MethodPost,
-				}: 3,
+				}: 25,
 			},
-			expectedError: false,
 		},
 		{
 			name: "mixed, c->b->c->b",
-			runClients: func(t *testing.T, differentClients bool) {
-				var client1, client2 grpc.Client
-				var err error
-				client1, err = grpc.NewClient(srvAddr, grpc.Options{})
-				require.NoError(t, err)
-				client2 = client1
-				if differentClients {
-					client2, err = grpc.NewClient(srvAddr, grpc.Options{})
-					require.NoError(t, err)
-				}
+			runClients: func(t *testing.T, clientsCount int) {
+				clients := getClientsArray(t, clientsCount, grpc.Options{})
 
-				ctx := context.Background()
-				require.NoError(t, client1.HandleStream(ctx, 10))
-				require.NoError(t, client2.HandleUnary(ctx, "first"))
-				require.NoError(t, client1.HandleStream(ctx, 10))
-				require.NoError(t, client2.HandleUnary(ctx, "second"))
+				require.NoError(t, clients[getClientsIndex(0, clientsCount)].HandleStream(defaultCtx, 10))
+				require.NoError(t, clients[getClientsIndex(1, clientsCount)].HandleUnary(defaultCtx, "first"))
+				require.NoError(t, clients[getClientsIndex(2, clientsCount)].HandleStream(defaultCtx, 10))
+				require.NoError(t, clients[getClientsIndex(3, clientsCount)].HandleUnary(defaultCtx, "second"))
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
@@ -307,111 +203,37 @@ func testGRPCScenarios(t *testing.T) {
 					Method: http.MethodPost,
 				}: 2,
 			},
-			expectedError: false,
-		},
-		{
-			name: "mixed, c->b->c->b",
-			runClients: func(t *testing.T, differentClients bool) {
-				var client1, client2 grpc.Client
-				var err error
-				client1, err = grpc.NewClient(srvAddr, grpc.Options{})
-				require.NoError(t, err)
-				client2 = client1
-				if differentClients {
-					client2, err = grpc.NewClient(srvAddr, grpc.Options{})
-					require.NoError(t, err)
-				}
-
-				ctx := context.Background()
-				require.NoError(t, client1.HandleStream(ctx, 10))
-				require.NoError(t, client1.HandleUnary(ctx, "first"))
-				require.NoError(t, client2.HandleStream(ctx, 10))
-				require.NoError(t, client2.HandleUnary(ctx, "second"))
-			},
-			expectedEndpoints: map[http.Key]int{
-				{
-					Path:   http.Path{Content: "/protobuf.Math/Max"},
-					Method: http.MethodPost,
-				}: 2,
-				{
-					Path:   http.Path{Content: "/helloworld.Greeter/SayHello"},
-					Method: http.MethodPost,
-				}: 2,
-			},
-			expectedError: false,
 		},
 		{
 			name: "request with large body (1MB)",
-			runClients: func(t *testing.T, differentClients bool) {
-				var client1 grpc.Client
-				var err error
-				client1, err = grpc.NewClient(srvAddr, grpc.Options{})
-				require.NoError(t, err)
+			runClients: func(t *testing.T, clientsCount int) {
+				clients := getClientsArray(t, clientsCount, grpc.Options{})
 
-				longName := strings.Repeat("1", 1024*1024)
-				ctx := context.Background()
-				require.NoError(t, client1.HandleUnary(ctx, longName))
+				for i := 0; i < 5; i++ {
+					longName := randStringRunes(1024 * 1024)
+					ctx := context.Background()
+					require.NoError(t, clients[getClientsIndex(i, clientsCount)].HandleUnary(ctx, longName))
+				}
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
 					Path:   http.Path{Content: "/helloworld.Greeter/SayHello"},
 					Method: http.MethodPost,
-				}: 1,
-			},
-			expectedError: true,
-		},
-
-		{
-			name: "request with large body (1MB) -> b -> request with large body (1MB) -> b",
-			runClients: func(t *testing.T, differentClients bool) {
-				var client1, client2 grpc.Client
-				var err error
-				client1, err = grpc.NewClient(srvAddr, grpc.Options{})
-				require.NoError(t, err)
-				client2 = client1
-				if differentClients {
-					client2, err = grpc.NewClient(srvAddr, grpc.Options{})
-					require.NoError(t, err)
-				}
-
-				longName := strings.Repeat("1", 1024*1024)
-				ctx := context.Background()
-				require.NoError(t, client1.HandleUnary(ctx, longName))
-				require.NoError(t, client2.GetFeature(ctx, -746143763, 407838351))
-				require.NoError(t, client1.HandleUnary(ctx, longName))
-				require.NoError(t, client2.GetFeature(ctx, -743999179, 408122808))
-			},
-			expectedEndpoints: map[http.Key]int{
-				{
-					Path:   http.Path{Content: "/routeguide.RouteGuide/GetFeature"},
-					Method: http.MethodPost,
-				}: 2,
-				{
-					Path:   http.Path{Content: "/helloworld.Greeter/SayHello"},
-					Method: http.MethodPost,
-				}: 2,
+				}: 5,
 			},
 			expectedError: true,
 		},
 		{
 			name: "request with large body (1MB) -> b -> request with large body (1MB) -> b",
-			runClients: func(t *testing.T, differentClients bool) {
-				var client1, client2 grpc.Client
-				var err error
-				client1, err = grpc.NewClient(srvAddr, grpc.Options{})
-				require.NoError(t, err)
-				client2 = client1
-				if differentClients {
-					client2, err = grpc.NewClient(srvAddr, grpc.Options{})
-					require.NoError(t, err)
-				}
+			runClients: func(t *testing.T, clientsCount int) {
+				clients := getClientsArray(t, clientsCount, grpc.Options{})
 
-				longName := strings.Repeat("1", 1024*1024)
-				ctx := context.Background()
-				require.NoError(t, client1.HandleUnary(ctx, longName))
-				require.NoError(t, client2.GetFeature(ctx, -746143763, 407838351))
-				require.NoError(t, client2.HandleUnary(ctx, longName))
-				require.NoError(t, client1.GetFeature(ctx, -743999179, 408122808))
+				longName := randStringRunes(1024 * 1024)
+
+				require.NoError(t, clients[getClientsIndex(0, clientsCount)].HandleUnary(defaultCtx, longName))
+				require.NoError(t, clients[getClientsIndex(1, clientsCount)].GetFeature(defaultCtx, -746143763, 407838351))
+				require.NoError(t, clients[getClientsIndex(2, clientsCount)].HandleUnary(defaultCtx, longName))
+				require.NoError(t, clients[getClientsIndex(3, clientsCount)].GetFeature(defaultCtx, -743999179, 408122808))
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
@@ -427,16 +249,8 @@ func testGRPCScenarios(t *testing.T) {
 		},
 		{
 			name: "500 headers -> b -> 500 headers -> b",
-			runClients: func(t *testing.T, differentClients bool) {
-				var client1, client2 grpc.Client
-				var err error
-				client1, err = grpc.NewClient(srvAddr, grpc.Options{})
-				require.NoError(t, err)
-				client2 = client1
-				if differentClients {
-					client2, err = grpc.NewClient(srvAddr, grpc.Options{})
-					require.NoError(t, err)
-				}
+			runClients: func(t *testing.T, clientsCount int) {
+				clients := getClientsArray(t, clientsCount, grpc.Options{})
 
 				ctxWithoutHeaders := context.Background()
 				ctxWithHeaders := context.Background()
@@ -446,50 +260,11 @@ func testGRPCScenarios(t *testing.T) {
 				}
 				md := metadata.New(headers)
 				ctxWithHeaders = metadata.NewOutgoingContext(ctxWithHeaders, md)
-				longName := strings.Repeat("1", 1024*1024)
-				require.NoError(t, client1.HandleUnary(ctxWithHeaders, longName))
-				require.NoError(t, client2.GetFeature(ctxWithoutHeaders, -746143763, 407838351))
-				require.NoError(t, client1.HandleUnary(ctxWithHeaders, longName))
-				require.NoError(t, client2.GetFeature(ctxWithoutHeaders, -743999179, 408122808))
-			},
-			expectedEndpoints: map[http.Key]int{
-				{
-					Path:   http.Path{Content: "/routeguide.RouteGuide/GetFeature"},
-					Method: http.MethodPost,
-				}: 2,
-				{
-					Path:   http.Path{Content: "/helloworld.Greeter/SayHello"},
-					Method: http.MethodPost,
-				}: 2,
-			},
-			expectedError: true,
-		},
-		{
-			name: "500 headers -> b -> 500 headers -> b",
-			runClients: func(t *testing.T, differentClients bool) {
-				var client1, client2 grpc.Client
-				var err error
-				client1, err = grpc.NewClient(srvAddr, grpc.Options{})
-				require.NoError(t, err)
-				client2 = client1
-				if differentClients {
-					client2, err = grpc.NewClient(srvAddr, grpc.Options{})
-					require.NoError(t, err)
-				}
-
-				ctxWithoutHeaders := context.Background()
-				ctxWithHeaders := context.Background()
-				headers := make(map[string]string, 500)
-				for i := 1; i <= 500; i++ {
-					headers[fmt.Sprintf("header-%d", i)] = fmt.Sprintf("value-%d", i)
-				}
-				md := metadata.New(headers)
-				ctxWithHeaders = metadata.NewOutgoingContext(ctxWithHeaders, md)
-				longName := strings.Repeat("1", 1024*1024)
-				require.NoError(t, client1.HandleUnary(ctxWithHeaders, longName))
-				require.NoError(t, client2.GetFeature(ctxWithoutHeaders, -746143763, 407838351))
-				require.NoError(t, client2.HandleUnary(ctxWithHeaders, longName))
-				require.NoError(t, client1.GetFeature(ctxWithoutHeaders, -743999179, 408122808))
+				longName := randStringRunes(1024 * 1024)
+				require.NoError(t, clients[getClientsIndex(0, clientsCount)].HandleUnary(ctxWithHeaders, longName))
+				require.NoError(t, clients[getClientsIndex(1, clientsCount)].GetFeature(ctxWithoutHeaders, -746143763, 407838351))
+				require.NoError(t, clients[getClientsIndex(2, clientsCount)].HandleUnary(ctxWithHeaders, longName))
+				require.NoError(t, clients[getClientsIndex(3, clientsCount)].GetFeature(ctxWithoutHeaders, -743999179, 408122808))
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
@@ -505,16 +280,8 @@ func testGRPCScenarios(t *testing.T) {
 		},
 		{
 			name: "duplicated headers -> b -> duplicated headers -> b",
-			runClients: func(t *testing.T, differentClients bool) {
-				var client1, client2 grpc.Client
-				var err error
-				client1, err = grpc.NewClient(srvAddr, grpc.Options{})
-				require.NoError(t, err)
-				client2 = client1
-				if differentClients {
-					client2, err = grpc.NewClient(srvAddr, grpc.Options{})
-					require.NoError(t, err)
-				}
+			runClients: func(t *testing.T, clientsCount int) {
+				clients := getClientsArray(t, clientsCount, grpc.Options{})
 
 				ctxWithoutHeaders := context.Background()
 				ctxWithHeaders := context.Background()
@@ -524,50 +291,11 @@ func testGRPCScenarios(t *testing.T) {
 				}
 				md := metadata.New(headers)
 				ctxWithHeaders = metadata.NewOutgoingContext(ctxWithHeaders, md)
-				longName := strings.Repeat("1", 1024*1024)
-				require.NoError(t, client1.HandleUnary(ctxWithHeaders, longName))
-				require.NoError(t, client2.GetFeature(ctxWithoutHeaders, -746143763, 407838351))
-				require.NoError(t, client1.HandleUnary(ctxWithHeaders, longName))
-				require.NoError(t, client2.GetFeature(ctxWithoutHeaders, -743999179, 408122808))
-			},
-			expectedEndpoints: map[http.Key]int{
-				{
-					Path:   http.Path{Content: "/routeguide.RouteGuide/GetFeature"},
-					Method: http.MethodPost,
-				}: 2,
-				{
-					Path:   http.Path{Content: "/helloworld.Greeter/SayHello"},
-					Method: http.MethodPost,
-				}: 2,
-			},
-			expectedError: true,
-		},
-		{
-			name: "duplicated headers -> b -> duplicated headers -> b",
-			runClients: func(t *testing.T, differentClients bool) {
-				var client1, client2 grpc.Client
-				var err error
-				client1, err = grpc.NewClient(srvAddr, grpc.Options{})
-				require.NoError(t, err)
-				client2 = client1
-				if differentClients {
-					client2, err = grpc.NewClient(srvAddr, grpc.Options{})
-					require.NoError(t, err)
-				}
-
-				ctxWithoutHeaders := context.Background()
-				ctxWithHeaders := context.Background()
-				headers := make(map[string]string, 20)
-				for i := 1; i <= 20; i++ {
-					headers[fmt.Sprintf("header-%d", i)] = fmt.Sprintf("value")
-				}
-				md := metadata.New(headers)
-				ctxWithHeaders = metadata.NewOutgoingContext(ctxWithHeaders, md)
-				longName := strings.Repeat("1", 1024*1024)
-				require.NoError(t, client1.HandleUnary(ctxWithHeaders, longName))
-				require.NoError(t, client2.GetFeature(ctxWithoutHeaders, -746143763, 407838351))
-				require.NoError(t, client2.HandleUnary(ctxWithHeaders, longName))
-				require.NoError(t, client1.GetFeature(ctxWithoutHeaders, -743999179, 408122808))
+				longName := randStringRunes(1024 * 1024)
+				require.NoError(t, clients[getClientsIndex(0, clientsCount)].HandleUnary(ctxWithHeaders, longName))
+				require.NoError(t, clients[getClientsIndex(0, clientsCount)].GetFeature(ctxWithoutHeaders, -746143763, 407838351))
+				require.NoError(t, clients[getClientsIndex(0, clientsCount)].HandleUnary(ctxWithHeaders, longName))
+				require.NoError(t, clients[getClientsIndex(0, clientsCount)].GetFeature(ctxWithoutHeaders, -743999179, 408122808))
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
@@ -583,8 +311,8 @@ func testGRPCScenarios(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		for _, val := range []bool{false, true} {
-			testNameSuffix := fmt.Sprintf("-different clients - %v", val)
+		for _, clientCount := range []int{1, 2, 5} {
+			testNameSuffix := fmt.Sprintf("-different clients - %v", clientCount)
 			t.Run(tt.name+testNameSuffix, func(t *testing.T) {
 				// we are currently not supporting some edge cases:
 				// https://datadoghq.atlassian.net/browse/USMO-222
@@ -597,7 +325,7 @@ func testGRPCScenarios(t *testing.T) {
 				require.NoError(t, monitor.Start())
 				defer monitor.Stop()
 
-				tt.runClients(t, val)
+				tt.runClients(t, clientCount)
 
 				res := make(map[http.Key]int)
 				require.Eventually(t, func() bool {

--- a/pkg/network/tracer/testutil/grpc/client.go
+++ b/pkg/network/tracer/testutil/grpc/client.go
@@ -56,7 +56,7 @@ func (c *Client) HandleStream(ctx context.Context, numberOfMessages int32) error
 				sendErr = err
 				return
 			}
-			time.Sleep(time.Millisecond * 200)
+			time.Sleep(time.Millisecond * 10)
 		}
 	}()
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

* Remove redundant UTs for gRPC
* Remove redundant features from the test (http monitoring)
* Make stream handler faster
* Support multiple clients (generic way)
* Close clients

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
