### PR TITLE
[CWS] fix fentry bugs related to dentry resolution and write user path

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/dentry_resolver.h
+++ b/pkg/security/ebpf/c/include/hooks/dentry_resolver.h
@@ -377,6 +377,15 @@ int kprobe_dentry_resolver_segment_erpc_write_user(struct pt_regs *ctx) {
     return dentry_resolver_segment_erpc_write_user(ctx);
 }
 
+#ifdef USE_FENTRY
+
+TAIL_CALL_TARGET("dentry_resolver_segment_erpc_write_user")
+int fentry_dentry_resolver_segment_erpc_write_user(ctx_t *ctx) {
+    return dentry_resolver_segment_erpc_write_user(ctx);
+}
+
+#endif // USE_FENTRY
+
 int __attribute__((always_inline)) dentry_resolver_segment_erpc_mmap(void *ctx) {
     u32 key = 0;
     u32 resolution_err = 0;

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -263,6 +263,9 @@ func AllBPFProbeWriteUserProgramFunctions() []string {
 		"kprobe_dentry_resolver_erpc_write_user",
 		"kprobe_dentry_resolver_parent_erpc_write_user",
 		"kprobe_dentry_resolver_segment_erpc_write_user",
+		"fentry_dentry_resolver_erpc_write_user",
+		"fentry_dentry_resolver_parent_erpc_write_user",
+		"fentry_dentry_resolver_segment_erpc_write_user",
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

The `fentry_dentry_resolver_segment_erpc_write_user` function was missing, and all fentry write user probes were not correctly excluded.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
