### PR TITLE
[omnibus] Consider cgroup when determining memory usage in OpenSCAP

### DIFF
--- a/omnibus/config/patches/openscap/memusage_cgroup.patch
+++ b/omnibus/config/patches/openscap/memusage_cgroup.patch
@@ -1,0 +1,106 @@
+commit 66af35b1f05d73ed10cb30099ada463b99709058
+Author: David du Colombier <djc@datadoghq.com>
+Date:   Thu Jul 20 13:40:38 2023 +0200
+
+    Consider cgroup when determining memory usage
+    
+    This change modifies the oscap_sys_memusage function
+    to take into account the memory constraints of the
+    cgroup. Both cgroup and cgroup2 are supported.
+
+diff --git a/src/common/memusage.c b/src/common/memusage.c
+index f6baca329..6baa16e3d 100644
+--- a/src/common/memusage.c
++++ b/src/common/memusage.c
+@@ -48,9 +48,9 @@
+ #define GET_VM_FREE_PAGE_COUNT  "vm.stats.vm.v_free_count"
+ #define GET_VM_INACT_PAGE_COUNT "vm.stats.vm.v_inactive_count"
+ #define GET_VM_ACT_PAGE_COUNT   "vm.stats.vm.v_active_count"
++#endif
+ 
+ #define BYTES_TO_KIB(x) (x >> 10)
+-#endif
+ 
+ #include "debug_priv.h"
+ #include "memusage.h"
+@@ -173,6 +173,26 @@ static int read_status(const char *source, void *base, struct stat_parser *spt,
+ 	return processed == spt_size ? 0 : 1;
+ }
+ 
++static size_t get_sys_value(const char *source)
++{
++	FILE *f;
++	size_t v;
++
++	f = fopen(source, "r");
++	if (f == NULL) {
++		return (size_t)-1;
++	}
++
++	if (fscanf(f, "%zu", &v) != 1) {
++		fclose(f);
++		return (size_t)-1;
++	}
++
++	fclose(f);
++
++	return v;
++}
++
+ #define stat_sizet_field(name, stype, sfield)                           \
+ 	{ (name), &read_common_sizet, (ptrdiff_t)offsetof(stype, sfield) }
+ 
+@@ -294,14 +314,31 @@ int oscap_sys_memusage(struct sys_memusage *mu)
+ 	if (mu == NULL)
+ 		return -1;
+ #if defined(OS_LINUX)
+-	if (read_status(MEMUSAGE_LINUX_SYS_STATUS,
+-	                mu, __sys_stat_ptable,
+-	                (sizeof __sys_stat_ptable)/sizeof(struct stat_parser)) != 0)
+-	{
+-		return -1;
++	// cgroup
++	size_t cgroup_memory_usage = get_sys_value(MEMUSAGE_LINUX_SYS_CGROUP_USAGE);
++	size_t cgroup_memory_limit = get_sys_value(MEMUSAGE_LINUX_SYS_CGROUP_LIMIT);
++	if (cgroup_memory_usage != (size_t)-1 && cgroup_memory_limit != (size_t)-1) {
++		mu->mu_total = BYTES_TO_KIB(cgroup_memory_limit);
++		mu->mu_realfree = BYTES_TO_KIB(cgroup_memory_limit) - BYTES_TO_KIB(cgroup_memory_usage);
++	} else {
++		// cgroup2
++		size_t cgroup_memory_current = get_sys_value(MEMUSAGE_LINUX_SYS_CGROUP2_CURRENT);
++		size_t cgroup_memory_max = get_sys_value(MEMUSAGE_LINUX_SYS_CGROUP2_MAX);
++		if (cgroup_memory_current != (size_t)-1 && cgroup_memory_max != (size_t)-1) {
++			mu->mu_total = BYTES_TO_KIB(cgroup_memory_max);
++			mu->mu_realfree = BYTES_TO_KIB(cgroup_memory_max) - BYTES_TO_KIB(cgroup_memory_current);
++		} else {
++			if (read_status(MEMUSAGE_LINUX_SYS_STATUS,
++			                mu, __sys_stat_ptable,
++			                (sizeof __sys_stat_ptable)/sizeof(struct stat_parser)) != 0)
++			{
++				return -1;
++			}
++
++			mu->mu_realfree = mu->mu_free + mu->mu_cached + mu->mu_buffers;
++		}
+ 	}
+ 
+-	mu->mu_realfree = mu->mu_free + mu->mu_cached + mu->mu_buffers;
+ #elif defined(OS_FREEBSD)
+ 	if (freebsd_sys_memusage(mu))
+ 		return -1;
+diff --git a/src/common/memusage.h b/src/common/memusage.h
+index daa29fe57..aa8b9c9f0 100644
+--- a/src/common/memusage.h
++++ b/src/common/memusage.h
+@@ -8,6 +8,11 @@
+ # define MEMUSAGE_LINUX_PROC_ENV    "MEMUSAGE_PROC_STATUS"
+ # define MEMUSAGE_LINUX_SYS_STATUS "/proc/meminfo"
+ # define MEMUSAGE_LINUX_SYS_ENV "MEMUSAGE_SYS_STATUS"
++# define MEMUSAGE_LINUX_SYS_CGROUP_USAGE "/sys/fs/cgroup/memory/memory.usage_in_bytes"
++# define MEMUSAGE_LINUX_SYS_CGROUP_LIMIT "/sys/fs/cgroup/memory/memory.limit_in_bytes"
++# define MEMUSAGE_LINUX_SYS_CGROUP2_CURRENT "/sys/fs/cgroup/memory.current"
++# define MEMUSAGE_LINUX_SYS_CGROUP2_MAX "/sys/fs/cgroup/memory.max"
++
+ #endif /* OS_LINUX */
+ 
+ struct proc_memusage {

--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -53,6 +53,7 @@ build do
   patch source: "systemd-dbus-address.patch", env: env # fix dbus address in systemd probe
   patch source: "rpm-verbosity-err.patch", env: env # decrease rpmlog verbosity level to ERR
   patch source: "session-print-syschar.patch", env: env # add a function to print system characteristics
+  patch source: "memusage-cgroup.patch", env: env # consider cgroup when determining memory usage
 
   patch source: "oscap-io.patch", env: env # add new oscap-io tool
 


### PR DESCRIPTION
### What does this PR do?

This change adds a patch to OpenSCAP which modifies the
oscap_sys_memusage function to take into account the memory
constraints of the cgroup. Both cgroup and cgroup2 are supported.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
