### PR TITLE
Stop using spot instances for kitchen tests

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -79,7 +79,7 @@ kitchen_test_security_agent_arm64:
   extends:
     - .kitchen_test_security_agent
     - .kitchen_ec2_location_us_east_1
-    - .kitchen_ec2_spot_instances
+    - .kitchen_ec2
   rules:
     !reference [.on_security_agent_changes_or_manual]
   needs: [ "tests_ebpf_arm64", "prepare_ebpf_functional_tests_arm64" ]

--- a/.gitlab/kitchen_common/testing.yml
+++ b/.gitlab/kitchen_common/testing.yml
@@ -65,7 +65,7 @@
     KITCHEN_EC2_INSTANCE_TYPE: "t4g.xlarge"
     CHEF_VERSION: 14.15.6
   extends:
-    - .kitchen_ec2_spot_instances
+    - .kitchen_ec2
 
 # Kitchen: agents
 # ---------------


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Stop using spot instances for kitchen tests
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We cannot get spot instances on kitchen tests for arm since recently, example [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/309134980)
As the test is constantly failing despite our tests, we move out from spot pending a better solution.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
As this is only for ARM the over cost is acceptable (and the savings for t4g was not exceptional neither)
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
Over cost compared to spot
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
