### PR TITLE
Prepare v5 metadata migration to FX

### DIFF
--- a/cmd/process-agent/subcommands/status/status_test.go
+++ b/cmd/process-agent/subcommands/status/status_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	hostMetadataUtils "github.com/DataDog/datadog-agent/comp/metadata/host/utils"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
@@ -44,7 +45,7 @@ func TestStatus(t *testing.T) {
 		Date: float64(testTime.UnixNano()),
 		Core: util.CoreStatus{
 			Metadata: host.Payload{
-				Meta: &host.Meta{},
+				Meta: &hostMetadataUtils.Meta{},
 			},
 		},
 		Expvars: util.ProcessExpvars{},

--- a/comp/metadata/host/utils/meta.go
+++ b/comp/metadata/host/utils/meta.go
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
+	"github.com/DataDog/datadog-agent/pkg/util/ec2"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+	"github.com/DataDog/datadog-agent/pkg/util/kubelet"
+)
+
+var (
+	metaCacheKey = cache.BuildAgentKey("host", "utils", "meta")
+)
+
+// Meta is the metadata nested under the meta key
+type Meta struct {
+	SocketHostname string   `json:"socket-hostname"`
+	Timezones      []string `json:"timezones"`
+	SocketFqdn     string   `json:"socket-fqdn"`
+	EC2Hostname    string   `json:"ec2-hostname"`
+	Hostname       string   `json:"hostname"`
+	HostAliases    []string `json:"host_aliases"`
+	InstanceID     string   `json:"instance-id"`
+	AgentHostname  string   `json:"agent-hostname,omitempty"`
+	ClusterName    string   `json:"cluster-name,omitempty"`
+}
+
+// GetMetaFromCache returns the metadata information about the host from the cache and returns it, if the cache is
+// empty, then it queries the information directly
+func GetMetaFromCache(ctx context.Context, conf config.ConfigReader) *Meta {
+	res, _ := cache.Get[*Meta](
+		metaCacheKey,
+		func() (*Meta, error) {
+			return GetMeta(ctx, conf), nil
+		},
+	)
+	return res
+}
+
+// GetMeta returns the metadata information about the host and refreshes the cache
+func GetMeta(ctx context.Context, conf config.ConfigReader) *Meta {
+	osHostname, _ := os.Hostname()
+	tzname, _ := time.Now().Zone()
+	ec2Hostname, _ := ec2.GetHostname(ctx)
+	instanceID, _ := ec2.GetInstanceID(ctx)
+
+	var agentHostname string
+
+	hostnameData, _ := hostname.GetWithProvider(ctx)
+	if conf.GetBool("hostname_force_config_as_canonical") && hostnameData.FromConfiguration() {
+		agentHostname = hostnameData.Hostname
+	}
+
+	m := &Meta{
+		SocketHostname: osHostname,
+		Timezones:      []string{tzname},
+		SocketFqdn:     util.Fqdn(osHostname),
+		EC2Hostname:    ec2Hostname,
+		HostAliases:    cloudproviders.GetHostAliases(ctx),
+		InstanceID:     instanceID,
+		AgentHostname:  agentHostname,
+	}
+
+	if finalClusterName := kubelet.GetMetaClusterNameText(ctx, osHostname); finalClusterName != "" {
+		m.ClusterName = finalClusterName
+	}
+
+	cache.Cache.Set(metaCacheKey, m, cache.NoExpiration)
+	return m
+}

--- a/comp/metadata/host/utils/meta_test.go
+++ b/comp/metadata/host/utils/meta_test.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMeta(t *testing.T) {
+	ctx := context.Background()
+	cfg := fxutil.Test[config.Component](t, config.MockModule)
+
+	meta := GetMeta(ctx, cfg)
+	assert.NotEmpty(t, meta.SocketHostname)
+	assert.NotEmpty(t, meta.Timezones)
+	assert.NotEmpty(t, meta.SocketFqdn)
+}
+
+func TestGetMetaFromCache(t *testing.T) {
+	ctx := context.Background()
+	cfg := fxutil.Test[config.Component](t, config.MockModule)
+
+	cache.Cache.Set(metaCacheKey, &Meta{
+		SocketHostname: "socket_test",
+		Timezones:      []string{"tz_test"},
+	}, cache.NoExpiration)
+
+	m := GetMetaFromCache(ctx, cfg)
+	assert.Equal(t, "socket_test", m.SocketHostname)
+	assert.Equal(t, []string{"tz_test"}, m.Timezones)
+}

--- a/comp/metadata/host/utils/tags_test.go
+++ b/comp/metadata/host/utils/tags_test.go
@@ -3,92 +3,78 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package host
+package utils
 
 import (
 	"context"
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
-func init() {
+func setupTest(t *testing.T) (*config.MockConfig, context.Context) {
 	retrySleepTime = 0
+	t.Cleanup(func() {
+		retrySleepTime = 1 * time.Second
+		getProvidersDefinitionsFunc = getProvidersDefinitions
+	})
+
+	mockConfig := config.Mock(t)
+	mockConfig.Set("autoconfig_from_environment", false)
+	return mockConfig, context.Background()
 }
 
 func TestGetHostTags(t *testing.T) {
-	ctx := context.Background()
-	mockConfig := config.Mock(t)
-	mockConfig.Set("autoconfig_from_environment", false)
-	defer mockConfig.Set("autoconfig_from_environment", true)
-
+	mockConfig, ctx := setupTest(t)
 	mockConfig.Set("tags", []string{"tag1:value1", "tag2", "tag3"})
-	defer mockConfig.Set("tags", nil)
+	mockConfig.Set("tags", []string{"tag1:value1", "tag2", "tag3"})
 
-	hostTags := GetHostTags(ctx, false)
+	hostTags := GetHostTags(ctx, false, mockConfig)
 	assert.NotNil(t, hostTags.System)
 	assert.Equal(t, []string{"tag1:value1", "tag2", "tag3"}, hostTags.System)
 }
 
 func TestGetEmptyHostTags(t *testing.T) {
-	ctx := context.Background()
-
-	mockConfig := config.Mock(t)
-	mockConfig.Set("autoconfig_from_environment", false)
-	defer mockConfig.Set("autoconfig_from_environment", true)
+	mockConfig, ctx := setupTest(t)
 
 	// getHostTags should never return a nil value under System even when there are no host tags
-	hostTags := GetHostTags(ctx, false)
+	hostTags := GetHostTags(ctx, false, mockConfig)
 	assert.NotNil(t, hostTags.System)
 	assert.Equal(t, []string{}, hostTags.System)
 }
 
 func TestGetHostTagsWithSplits(t *testing.T) {
-	ctx := context.Background()
-	mockConfig := config.Mock(t)
-	mockConfig.Set("autoconfig_from_environment", false)
-	defer mockConfig.Set("autoconfig_from_environment", true)
-
+	mockConfig, ctx := setupTest(t)
 	mockConfig.Set("tag_value_split_separator", map[string]string{"kafka_partition": ","})
 	mockConfig.Set("tags", []string{"tag1:value1", "tag2", "tag3", "kafka_partition:0,1,2"})
-	defer mockConfig.Set("tags", nil)
 
-	hostTags := GetHostTags(ctx, false)
+	hostTags := GetHostTags(ctx, false, mockConfig)
 	assert.NotNil(t, hostTags.System)
 	assert.Equal(t, []string{"kafka_partition:0", "kafka_partition:1", "kafka_partition:2", "tag1:value1", "tag2", "tag3"}, hostTags.System)
 }
 
 func TestGetHostTagsWithoutSplits(t *testing.T) {
-	ctx := context.Background()
-	mockConfig := config.Mock(t)
-	mockConfig.Set("autoconfig_from_environment", false)
-	defer mockConfig.Set("autoconfig_from_environment", true)
+	mockConfig, ctx := setupTest(t)
 
 	mockConfig.Set("tag_value_split_separator", map[string]string{"kafka_partition": ";"})
 	mockConfig.Set("tags", []string{"tag1:value1", "tag2", "tag3", "kafka_partition:0,1,2"})
-	defer mockConfig.Set("tags", nil)
 
-	hostTags := GetHostTags(ctx, false)
+	hostTags := GetHostTags(ctx, false, mockConfig)
 	assert.NotNil(t, hostTags.System)
 	assert.Equal(t, []string{"kafka_partition:0,1,2", "tag1:value1", "tag2", "tag3"}, hostTags.System)
 }
 
 func TestGetHostTagsWithEnv(t *testing.T) {
-	ctx := context.Background()
-	mockConfig := config.Mock(t)
-	mockConfig.Set("autoconfig_from_environment", false)
-	defer mockConfig.Set("autoconfig_from_environment", true)
-
+	mockConfig, ctx := setupTest(t)
 	mockConfig.Set("tags", []string{"tag1:value1", "tag2", "tag3", "env:prod"})
 	mockConfig.Set("env", "preprod")
-	defer mockConfig.Set("tags", nil)
-	defer mockConfig.Set("env", "")
 
-	hostTags := GetHostTags(ctx, false)
+	hostTags := GetHostTags(ctx, false, mockConfig)
 	assert.NotNil(t, hostTags.System)
 	assert.Equal(t, []string{"env:preprod", "env:prod", "tag1:value1", "tag2", "tag3"}, hostTags.System)
 }
@@ -100,61 +86,52 @@ func TestMarshalEmptyHostTags(t *testing.T) {
 	}
 
 	marshaled, _ := json.Marshal(tags)
-
 	// `System` should be marshaled as an empty list
 	assert.Equal(t, string(marshaled), `{"system":[]}`)
 }
 
 func TestCombineExtraTags(t *testing.T) {
-	ctx := context.Background()
-	mockConfig := config.Mock(t)
-	mockConfig.Set("autoconfig_from_environment", false)
-	defer mockConfig.Set("autoconfig_from_environment", true)
-
+	mockConfig, ctx := setupTest(t)
 	mockConfig.Set("tags", []string{"tag1:value1", "tag2", "tag4"})
 	mockConfig.Set("extra_tags", []string{"tag1:value2", "tag3", "tag4"})
-	defer mockConfig.Set("tags", nil)
-	defer mockConfig.Set("extra_tags", nil)
 
-	hostTags := GetHostTags(ctx, false)
+	hostTags := GetHostTags(ctx, false, mockConfig)
 	assert.NotNil(t, hostTags.System)
 	assert.Equal(t, []string{"tag1:value1", "tag1:value2", "tag2", "tag3", "tag4"}, hostTags.System)
 }
 
 func TestHostTagsCache(t *testing.T) {
-	ctx := context.Background()
-	mockConfig := config.Mock(t)
-	mockConfig.Set("autoconfig_from_environment", false)
-	defer mockConfig.Set("autoconfig_from_environment", true)
-
+	mockConfig, ctx := setupTest(t)
 	mockConfig.Set("collect_gce_tags", false)
 
 	fooTags := []string{"foo1:value1"}
 	var fooErr error
+	nbCall := 0
 
-	getProvidersDefinitionsFunc = func() map[string]*providerDef {
+	getProvidersDefinitionsFunc = func(config.ConfigReader) map[string]*providerDef {
 		return map[string]*providerDef{
 			"foo": {
-				retries: 1,
+				retries: 2,
 				getTags: func(ctx context.Context) ([]string, error) {
+					nbCall++
 					return fooTags, fooErr
 				},
 			},
 		}
 	}
-	defer func() {
-		getProvidersDefinitionsFunc = getProvidersDefinitions
-	}()
 
 	// First run, all good
-	hostTags := GetHostTags(ctx, false)
+	hostTags := GetHostTags(ctx, false, mockConfig)
 	assert.NotNil(t, hostTags.System)
 	assert.Equal(t, []string{"foo1:value1"}, hostTags.System)
+	assert.Equal(t, 1, nbCall)
 
 	// Second run, provider all fails, we should get cached data
 	fooErr = errors.New("fooerr")
+	nbCall = 0
 
-	hostTags = GetHostTags(ctx, false)
+	hostTags = GetHostTags(ctx, false, mockConfig)
 	assert.NotNil(t, hostTags.System)
 	assert.Equal(t, []string{"foo1:value1"}, hostTags.System)
+	assert.Equal(t, 2, nbCall)
 }

--- a/pkg/cloudfoundry/containertagger/container_tagger.go
+++ b/pkg/cloudfoundry/containertagger/container_tagger.go
@@ -13,8 +13,8 @@ import (
 
 	"code.cloudfoundry.org/garden"
 
+	hostMetadataUtils "github.com/DataDog/datadog-agent/comp/metadata/host/utils"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/cloudfoundry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -96,7 +96,7 @@ func (c *ContainerTagger) processEvent(ctx context.Context, evt workloadmeta.Eve
 		log.Debugf("Processing Event (id %s): %+v", eventID, storeContainer)
 
 		// extract tags
-		hostTags := host.GetHostTags(ctx, true)
+		hostTags := hostMetadataUtils.GetHostTags(ctx, true, config.Datadog)
 		tags := storeContainer.CollectorTags
 		tags = append(tags, hostTags.System...)
 		tags = append(tags, hostTags.GoogleCloudPlatform...)

--- a/pkg/collector/metadata/agentchecks/agentchecks.go
+++ b/pkg/collector/metadata/agentchecks/agentchecks.go
@@ -9,12 +9,13 @@ import (
 	"context"
 	"encoding/json"
 
+	hostMetadataUtils "github.com/DataDog/datadog-agent/comp/metadata/host/utils"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/runner/expvars"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
 	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
-	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -79,7 +80,7 @@ func GetPayload(ctx context.Context) *Payload {
 	}
 
 	// Grab the non agent checks information
-	metaPayload := host.GetMeta(ctx, hostnameData)
+	metaPayload := hostMetadataUtils.GetMetaFromCache(ctx, config.Datadog)
 	metaPayload.Hostname = hostnameData.Hostname
 	cp := common.GetPayload(hostnameData.Hostname)
 	ehp := externalhost.GetPayload()

--- a/pkg/collector/metadata/agentchecks/payload.go
+++ b/pkg/collector/metadata/agentchecks/payload.go
@@ -9,9 +9,9 @@ import (
 	"encoding/json"
 	"fmt"
 
+	hostMetadataUtils "github.com/DataDog/datadog-agent/comp/metadata/host/utils"
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
 	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
-	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 )
 
@@ -25,7 +25,7 @@ type Payload struct {
 
 // MetaPayload wraps Meta from the host package (this is cached)
 type MetaPayload struct {
-	host.Meta `json:"meta"`
+	hostMetadataUtils.Meta `json:"meta"`
 }
 
 // CommonPayload wraps Payload from the common package

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -455,8 +455,7 @@ func Initialize(paths ...string) error {
 	if pyInfo != nil {
 		PythonVersion = strings.Replace(C.GoString(pyInfo.version), "\n", "", -1)
 		// Set python version in the cache
-		key := cache.BuildAgentKey("pythonVersion")
-		cache.Cache.Set(key, PythonVersion, cache.NoExpiration)
+		cache.Cache.Set(pythonInfoCacheKey, PythonVersion, cache.NoExpiration)
 
 		PythonPath = C.GoString(pyInfo.path)
 		C.free_py_info(rtloader, pyInfo)

--- a/pkg/collector/python/version.go
+++ b/pkg/collector/python/version.go
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package python
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+)
+
+var (
+	pythonInfoCacheKey = cache.BuildAgentKey("pythonInfo")
+)
+
+// GetPythonInfo returns the info string as provided by the embedded Python interpreter.
+//
+// Example: '3.10.6 (main, May 29 2023, 11:10:38) [GCC 11.3.0]'
+func GetPythonInfo() string {
+	// retrieve the Python version from the Agent cache
+	if x, found := cache.Cache.Get(pythonInfoCacheKey); found {
+		return x.(string)
+	}
+
+	return "n/a"
+}
+
+// GetPythonVersion returns the embedded python version as provided by the embedded Python interpreter.
+//
+// Example: '3.10.6'
+func GetPythonVersion() string {
+	return strings.SplitN(GetPythonInfo(), " ", 2)[0]
+}

--- a/pkg/collector/python/version_test.go
+++ b/pkg/collector/python/version_test.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package python
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPythonInfo(t *testing.T) {
+	expected := "3.10.6 (main, May 29 2023, 11:10:38) [GCC 11.3.0]"
+	cache.Cache.Set(pythonInfoCacheKey, expected, cache.NoExpiration)
+	defer cache.Cache.Delete(pythonInfoCacheKey)
+	require.Equal(t, expected, GetPythonInfo())
+}
+
+func TestGetPythonInfoNoSet(t *testing.T) {
+	require.Equal(t, "n/a", GetPythonInfo())
+}
+
+func TestGetPythonVersion(t *testing.T) {
+	cache.Cache.Set(pythonInfoCacheKey, "3.10.6 (main, May 29 2023, 11:10:38) [GCC 11.3.0]", cache.NoExpiration)
+	defer cache.Cache.Delete(pythonInfoCacheKey)
+	require.Equal(t, "3.10.6", GetPythonVersion())
+}
+
+func TestGetPythonVersionNotSet(t *testing.T) {
+	require.Equal(t, "n/a", GetPythonVersion())
+}

--- a/pkg/logs/internal/tag/local_provider.go
+++ b/pkg/logs/internal/tag/local_provider.go
@@ -9,9 +9,9 @@ import (
 	"context"
 	"sync"
 
+	hostMetadataUtils "github.com/DataDog/datadog-agent/comp/metadata/host/utils"
 	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
-	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 
 	"github.com/benbjohnson/clock"
 )
@@ -38,7 +38,7 @@ func newLocalProviderWithClock(t []string, clock clock.Clock) Provider {
 	}
 
 	if config.IsExpectedTagsSet() {
-		p.expectedTags = append(p.tags, host.GetHostTags(context.TODO(), false).System...)
+		p.expectedTags = append(p.tags, hostMetadataUtils.GetHostTags(context.TODO(), false, coreConfig.Datadog).System...)
 
 		// expected tags deadline is based on the agent start time, which may have been earlier
 		// than the current time.

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/collector/python"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/logs/status"
@@ -51,7 +52,7 @@ func GetPayload(ctx context.Context, hostnameData hostname.Data) *Payload {
 	p := &Payload{
 		Os:            osName,
 		AgentFlavor:   flavor.GetFlavor(),
-		PythonVersion: GetPythonVersion(),
+		PythonVersion: python.GetPythonInfo(),
 		SystemStats:   getSystemStats(),
 		Meta:          meta,
 		HostTags:      GetHostTags(ctx, false),
@@ -88,17 +89,6 @@ func GetMeta(ctx context.Context, hostnameData hostname.Data) *Meta {
 		return x.(*Meta)
 	}
 	return getMeta(ctx, hostnameData)
-}
-
-// GetPythonVersion returns the version string as provided by the embedded Python
-// interpreter.
-func GetPythonVersion() string {
-	// retrieve the Python version from the Agent cache
-	if x, found := cache.Cache.Get(cache.BuildAgentKey("pythonVersion")); found {
-		return x.(string)
-	}
-
-	return "n/a"
 }
 
 // getMeta grabs the information and refreshes the cache

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -21,14 +21,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metadata/host/container"
 	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 	"github.com/DataDog/datadog-agent/pkg/otlp"
-	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
-	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
-	"github.com/DataDog/datadog-agent/pkg/util/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	yaml "gopkg.in/yaml.v2"
@@ -47,7 +44,7 @@ type installInfo struct {
 // GetPayload builds a metadata payload every time is called.
 // Some data is collected only once, some is cached, some is collected at every call.
 func GetPayload(ctx context.Context, hostnameData hostname.Data) *Payload {
-	meta := getMeta(ctx, hostnameData)
+	meta := hostMetadataUtils.GetMeta(ctx, config.Datadog)
 	meta.Hostname = hostnameData.Hostname
 
 	p := &Payload{
@@ -80,50 +77,6 @@ func GetPayloadFromCache(ctx context.Context, hostnameData hostname.Data) *Paylo
 		return x.(*Payload)
 	}
 	return GetPayload(ctx, hostnameData)
-}
-
-// GetMeta grabs the metadata from the cache and returns it,
-// if the cache is empty, then it queries the information directly
-func GetMeta(ctx context.Context, hostnameData hostname.Data) *Meta {
-	key := buildKey("meta")
-	if x, found := cache.Cache.Get(key); found {
-		return x.(*Meta)
-	}
-	return getMeta(ctx, hostnameData)
-}
-
-// getMeta grabs the information and refreshes the cache
-func getMeta(ctx context.Context, hostnameData hostname.Data) *Meta {
-	osHostname, _ := os.Hostname()
-	tzname, _ := time.Now().Zone()
-	ec2Hostname, _ := ec2.GetHostname(ctx)
-	instanceID, _ := ec2.GetInstanceID(ctx)
-
-	var agentHostname string
-
-	if config.Datadog.GetBool("hostname_force_config_as_canonical") && hostnameData.FromConfiguration() {
-		agentHostname = hostnameData.Hostname
-	}
-
-	m := &Meta{
-		SocketHostname: osHostname,
-		Timezones:      []string{tzname},
-		SocketFqdn:     util.Fqdn(osHostname),
-		EC2Hostname:    ec2Hostname,
-		HostAliases:    cloudproviders.GetHostAliases(ctx),
-		InstanceID:     instanceID,
-		AgentHostname:  agentHostname,
-	}
-
-	if finalClusterName := kubelet.GetMetaClusterNameText(ctx, osHostname); finalClusterName != "" {
-		m.ClusterName = finalClusterName
-	}
-
-	// Cache the metadata for use in other payload
-	key := buildKey("meta")
-	cache.Cache.Set(key, m, cache.NoExpiration)
-
-	return m
 }
 
 func getNetworkMeta(ctx context.Context) *NetworkMeta {

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	hostMetadataUtils "github.com/DataDog/datadog-agent/comp/metadata/host/utils"
 	"github.com/DataDog/datadog-agent/pkg/collector/python"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
@@ -55,7 +56,7 @@ func GetPayload(ctx context.Context, hostnameData hostname.Data) *Payload {
 		PythonVersion: python.GetPythonInfo(),
 		SystemStats:   getSystemStats(),
 		Meta:          meta,
-		HostTags:      GetHostTags(ctx, false),
+		HostTags:      hostMetadataUtils.GetHostTags(ctx, false, config.Datadog),
 		ContainerMeta: getContainerMeta(1 * time.Second),
 		NetworkMeta:   getNetworkMeta(ctx),
 		LogsMeta:      getLogsMeta(),

--- a/pkg/metadata/host/host_notwin.go
+++ b/pkg/metadata/host/host_notwin.go
@@ -9,11 +9,11 @@ package host
 
 import (
 	"runtime"
-	"strings"
 
 	"github.com/shirou/gopsutil/v3/cpu"
 
 	hostMetadataUtils "github.com/DataDog/datadog-agent/comp/metadata/host/utils"
+	"github.com/DataDog/datadog-agent/pkg/collector/python"
 	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -38,7 +38,7 @@ func getSystemStats() *systemStats {
 			Platform:  runtime.GOOS,
 			Processor: cpuInfo.ModelName,
 			CPUCores:  cpuInfo.Cores,
-			Pythonv:   strings.Split(GetPythonVersion(), " ")[0],
+			Pythonv:   python.GetPythonVersion(),
 		}
 
 		// fill the platform dependent bits of info

--- a/pkg/metadata/host/host_test.go
+++ b/pkg/metadata/host/host_test.go
@@ -48,13 +48,6 @@ func TestGetSystemStats(t *testing.T) {
 	assert.Equal(t, fakeStats.Machine, s.Machine)
 }
 
-func TestGetPythonVersion(t *testing.T) {
-	require.Equal(t, "n/a", GetPythonVersion())
-	key := cache.BuildAgentKey("pythonVersion")
-	cache.Cache.Set(key, "Python 2.8", cache.NoExpiration)
-	require.Equal(t, "Python 2.8", GetPythonVersion())
-}
-
 func TestGetCPUInfo(t *testing.T) {
 	assert.NotNil(t, getCPUInfo())
 	fakeInfo := &cpu.InfoStat{Cores: 42}

--- a/pkg/metadata/host/host_test.go
+++ b/pkg/metadata/host/host_test.go
@@ -57,14 +57,6 @@ func TestGetCPUInfo(t *testing.T) {
 	assert.Equal(t, int32(42), info.Cores)
 }
 
-func TestGetMeta(t *testing.T) {
-	ctx := context.Background()
-	meta := getMeta(ctx, hostname.Data{})
-	assert.NotEmpty(t, meta.SocketHostname)
-	assert.NotEmpty(t, meta.Timezones)
-	assert.NotEmpty(t, meta.SocketFqdn)
-}
-
 func TestBuildKey(t *testing.T) {
 	assert.Equal(t, "metadata/host/foo", buildKey("foo"))
 }

--- a/pkg/metadata/host/host_windows.go
+++ b/pkg/metadata/host/host_windows.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	hostMetadataUtils "github.com/DataDog/datadog-agent/comp/metadata/host/utils"
+	"github.com/DataDog/datadog-agent/pkg/collector/python"
 	"github.com/DataDog/datadog-agent/pkg/gohai/cpu"
 	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
@@ -52,7 +53,7 @@ func getSystemStats() *systemStats {
 			Platform:  runtime.GOOS,
 			Processor: modelName,
 			CPUCores:  c32,
-			Pythonv:   strings.Split(GetPythonVersion(), " ")[0],
+			Pythonv:   python.GetPythonVersion(),
 		}
 
 		// fill the platform dependent bits of info

--- a/pkg/metadata/host/payload.go
+++ b/pkg/metadata/host/payload.go
@@ -21,19 +21,6 @@ type systemStats struct {
 	Winver    osVersion `json:"winV"`
 }
 
-// Meta is the metadata nested under the meta key
-type Meta struct {
-	SocketHostname string   `json:"socket-hostname"`
-	Timezones      []string `json:"timezones"`
-	SocketFqdn     string   `json:"socket-fqdn"`
-	EC2Hostname    string   `json:"ec2-hostname"`
-	Hostname       string   `json:"hostname"`
-	HostAliases    []string `json:"host_aliases"`
-	InstanceID     string   `json:"instance-id"`
-	AgentHostname  string   `json:"agent-hostname,omitempty"`
-	ClusterName    string   `json:"cluster-name,omitempty"`
-}
-
 // NetworkMeta is metadata about the host's network
 type NetworkMeta struct {
 	ID         string `json:"network-id"`
@@ -71,7 +58,7 @@ type Payload struct {
 	AgentFlavor   string                  `json:"agent-flavor"`
 	PythonVersion string                  `json:"python"`
 	SystemStats   *systemStats            `json:"systemStats"`
-	Meta          *Meta                   `json:"meta"`
+	Meta          *hostMetadataUtils.Meta `json:"meta"`
 	HostTags      *hostMetadataUtils.Tags `json:"host-tags"`
 	ContainerMeta map[string]string       `json:"container-meta,omitempty"`
 	NetworkMeta   *NetworkMeta            `json:"network"`

--- a/pkg/metadata/host/payload.go
+++ b/pkg/metadata/host/payload.go
@@ -5,6 +5,10 @@
 
 package host
 
+import (
+	hostMetadataUtils "github.com/DataDog/datadog-agent/comp/metadata/host/utils"
+)
+
 type systemStats struct {
 	CPUCores  int32     `json:"cpuCores"`
 	Machine   string    `json:"machine"`
@@ -42,12 +46,6 @@ type LogsMeta struct {
 	AutoMultilineEnabled bool   `json:"auto_multi_line_detection_enabled"`
 }
 
-// Tags contains the detected host tags
-type Tags struct {
-	System              []string `json:"system"`
-	GoogleCloudPlatform []string `json:"google cloud platform,omitempty"`
-}
-
 // InstallMethod is metadata about the agent's installation
 type InstallMethod struct {
 	Tool             *string `json:"tool"`
@@ -69,16 +67,16 @@ type OtlpMeta struct {
 
 // Payload handles the JSON unmarshalling of the metadata payload
 type Payload struct {
-	Os            string            `json:"os"`
-	AgentFlavor   string            `json:"agent-flavor"`
-	PythonVersion string            `json:"python"`
-	SystemStats   *systemStats      `json:"systemStats"`
-	Meta          *Meta             `json:"meta"`
-	HostTags      *Tags             `json:"host-tags"`
-	ContainerMeta map[string]string `json:"container-meta,omitempty"`
-	NetworkMeta   *NetworkMeta      `json:"network"`
-	LogsMeta      *LogsMeta         `json:"logs"`
-	InstallMethod *InstallMethod    `json:"install-method"`
-	ProxyMeta     *ProxyMeta        `json:"proxy-info"`
-	OtlpMeta      *OtlpMeta         `json:"otlp"`
+	Os            string                  `json:"os"`
+	AgentFlavor   string                  `json:"agent-flavor"`
+	PythonVersion string                  `json:"python"`
+	SystemStats   *systemStats            `json:"systemStats"`
+	Meta          *Meta                   `json:"meta"`
+	HostTags      *hostMetadataUtils.Tags `json:"host-tags"`
+	ContainerMeta map[string]string       `json:"container-meta,omitempty"`
+	NetworkMeta   *NetworkMeta            `json:"network"`
+	LogsMeta      *LogsMeta               `json:"logs"`
+	InstallMethod *InstallMethod          `json:"install-method"`
+	ProxyMeta     *ProxyMeta              `json:"proxy-info"`
+	OtlpMeta      *OtlpMeta               `json:"otlp"`
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	checkstats "github.com/DataDog/datadog-agent/pkg/collector/check/stats"
+	"github.com/DataDog/datadog-agent/pkg/collector/python"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/logs"
@@ -56,7 +57,7 @@ func GetStatus(verbose bool) (map[string]interface{}, error) {
 	hostTags = append(hostTags, metadata.HostTags.GoogleCloudPlatform...)
 	stats["hostTags"] = hostTags
 
-	pythonVersion := host.GetPythonVersion()
+	pythonVersion := python.GetPythonVersion()
 	stats["python_version"] = strings.Split(pythonVersion, " ")[0]
 	stats["hostinfo"] = hostMetadataUtils.GetInformation()
 


### PR DESCRIPTION
### What does this PR do?

This PR extract function from `pkg/metadata/host` to `comp/metadata/host/utils`. Those function are used in many places. Making them pure helper function remove the dependencies to the `pkg/metadata/host` making it possible to migrate to FX in the future.

It's easier to review each commit one by one.

### Describe how to test/QA your changes

Sanity check that the "v5" metadata payload is the same than before.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
