### PR TITLE
tasks: test: skip generating coverage report when a package has no test

### DIFF
--- a/tasks/test.py
+++ b/tasks/test.py
@@ -367,6 +367,14 @@ def test_flavor(
 
         if res.exited is None or res.exited > 0:
             module_result.failed = True
+        else:
+            lines = res.stdout.splitlines()
+            if lines is not None and 'DONE 0 tests' in lines[-1]:
+                print(color_message("No tests were run, skipping coverage report", "orange"))
+                cov_path = os.path.join(module.full_path(), PROFILE_COV)
+                if os.path.exists(cov_path):
+                    os.remove(cov_path)
+                return
 
         if save_result_json:
             with open(save_result_json, 'ab') as json_file, open(module_result.result_json_path, 'rb') as module_file:


### PR DESCRIPTION
This will prevent an "unusable report" message in codecov

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR skips the generation/sending of a coverage report for a package which doesn't have any test.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

When processing a coverage report package without test, we send an "empty" report (it only contains the files that are present in the repo). This displays a warning in codecov, and would likely trigger suspicions, while the report is just meaningless since no tests were run (see AP-2374)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

The approach is probably a bit naive, and will fail if the `go test` output is internationalized. However, I didn't found a practical way of querying the number of tests from a package.
An alternatives could be to run `go test -list .` from all packages and extract the number of tests as a property of our `GoModule` object, and ignore testing such packages

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
