### PR TITLE
[CWS] fix hardlink for exec in overlayfs

### DIFF
--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -156,6 +156,15 @@ struct dentry* __attribute__((always_inline)) get_file_dentry(struct file *file)
     return file_dentry;
 }
 
+u32  __attribute__((always_inline)) get_dentry_nlink(struct dentry* dentry) {
+    struct inode *d_inode = get_dentry_inode(dentry);
+
+    int nlink = 0;
+    bpf_probe_read(&nlink, sizeof(nlink), (void *)&d_inode->i_nlink);
+
+    return nlink;
+}
+
 struct dentry* __attribute__((always_inline)) get_path_dentry(struct path *path) {
     struct dentry *dentry;
     bpf_probe_read(&dentry, sizeof(dentry), &path->dentry);

--- a/pkg/security/ebpf/c/include/helpers/exec.h
+++ b/pkg/security/ebpf/c/include/helpers/exec.h
@@ -8,6 +8,14 @@
 
 int __attribute__((always_inline)) handle_exec_event(ctx_t *ctx, struct syscall_cache_t *syscall, struct file *file, struct path *path, struct inode *inode) {
     if (syscall->exec.is_parsed) {
+        // handle nlink that needs to be collected in the second pass
+        struct dentry *dentry  = get_file_dentry(file);
+        if (dentry) {
+            u32 nlink = get_dentry_nlink(dentry);
+            if (nlink > syscall->exec.file.metadata.nlink) {
+                syscall->exec.file.metadata.nlink = nlink;
+            }
+        }
         return 0;
     }
     syscall->exec.is_parsed = 1;

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -630,7 +630,7 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
         },
         .container = {},
     };
-    fill_file_metadata(syscall->exec.dentry, &pc.entry.executable.metadata);
+    fill_file_metadata(syscall->exec.dentry, &pc.entry.executable.metadata, &syscall->exec.file);
     bpf_get_current_comm(&pc.entry.comm, sizeof(pc.entry.comm));
 
     // select the previous cookie entry in cache of the current process

--- a/pkg/security/ebpf/c/include/hooks/link.h
+++ b/pkg/security/ebpf/c/include/hooks/link.h
@@ -74,7 +74,7 @@ int hook_vfs_link(ctx_t *ctx) {
         return mark_as_discarded(syscall);
     }
 
-    fill_file_metadata(src_dentry, &syscall->link.src_file.metadata);
+    fill_file_metadata(src_dentry, &syscall->link.src_file.metadata, NULL);
     syscall->link.target_file.metadata = syscall->link.src_file.metadata;
 
     // we generate a fake target key as the inode is the same

--- a/pkg/security/ebpf/c/include/hooks/mkdir.h
+++ b/pkg/security/ebpf/c/include/hooks/mkdir.h
@@ -148,7 +148,7 @@ int __attribute__((always_inline)) dr_mkdir_callback(void *ctx) {
         .mode = syscall->mkdir.mode,
     };
 
-    fill_file_metadata(syscall->mkdir.dentry, &event.file.metadata);
+    fill_file_metadata(syscall->mkdir.dentry, &event.file.metadata, NULL);
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);
     fill_span_context(&event.span);

--- a/pkg/security/ebpf/c/include/hooks/mmap.h
+++ b/pkg/security/ebpf/c/include/hooks/mmap.h
@@ -58,7 +58,7 @@ int __attribute__((always_inline)) sys_mmap_ret(void *ctx, int retval, u64 addr)
     };
 
     if (syscall->mmap.dentry != NULL) {
-        fill_file_metadata(syscall->mmap.dentry, &event.file.metadata);
+        fill_file_metadata(syscall->mmap.dentry, &event.file.metadata, NULL);
     }
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);

--- a/pkg/security/ebpf/c/include/hooks/module.h
+++ b/pkg/security/ebpf/c/include/hooks/module.h
@@ -111,7 +111,7 @@ int __attribute__((always_inline)) trace_init_module_ret(void *ctx, int retval, 
     }
 
     if (syscall->init_module.dentry != NULL) {
-        fill_file_metadata(syscall->init_module.dentry, &event.file.metadata);
+        fill_file_metadata(syscall->init_module.dentry, &event.file.metadata, NULL);
     }
 
     struct proc_cache_t *entry = fill_process_context(&event.process);

--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -290,7 +290,7 @@ int __attribute__((always_inline)) dr_open_callback(void *ctx) {
         .mode = syscall->open.mode,
     };
 
-    fill_file_metadata(syscall->open.dentry, &event.file.metadata);
+    fill_file_metadata(syscall->open.dentry, &event.file.metadata, NULL);
     struct proc_cache_t *entry;
     if (syscall->open.pid_tgid != 0) {
         entry = fill_process_context_with_pid_tgid(&event.process, syscall->open.pid_tgid);

--- a/pkg/security/ebpf/c/include/hooks/procfs.h
+++ b/pkg/security/ebpf/c/include/hooks/procfs.h
@@ -45,7 +45,7 @@ int hook_security_inode_getattr(ctx_t *ctx) {
         .flags = flags,
     };
 
-    fill_file_metadata(dentry, &entry.metadata);
+    fill_file_metadata(dentry, &entry.metadata, NULL);
 
     bpf_map_update_elem(&exec_file_cache, &inode, &entry, BPF_NOEXIST);
 

--- a/pkg/security/ebpf/c/include/hooks/rename.h
+++ b/pkg/security/ebpf/c/include/hooks/rename.h
@@ -67,7 +67,7 @@ int hook_vfs_rename(ctx_t *ctx) {
     syscall->rename.src_dentry = src_dentry;
     syscall->rename.target_dentry = target_dentry;
 
-    fill_file_metadata(src_dentry, &syscall->rename.src_file.metadata);
+    fill_file_metadata(src_dentry, &syscall->rename.src_file.metadata, NULL);
     syscall->rename.target_file.metadata = syscall->rename.src_file.metadata;
     if (is_overlayfs(src_dentry)) {
         syscall->rename.target_file.flags |= UPPER_LAYER;

--- a/pkg/security/ebpf/c/include/hooks/rmdir.h
+++ b/pkg/security/ebpf/c/include/hooks/rmdir.h
@@ -52,7 +52,7 @@ int hook_security_inode_rmdir(ctx_t *ctx) {
             // we resolve all the information before the file is actually removed
             dentry = (struct dentry *)CTX_PARM2(ctx);
             set_file_inode(dentry, &syscall->rmdir.file, 1);
-            fill_file_metadata(dentry, &syscall->rmdir.file.metadata);
+            fill_file_metadata(dentry, &syscall->rmdir.file.metadata, NULL);
 
             // the mount id of path_key is resolved by kprobe/mnt_want_write. It is already set by the time we reach this probe.
             key = syscall->rmdir.file.path_key;
@@ -71,7 +71,7 @@ int hook_security_inode_rmdir(ctx_t *ctx) {
             // we resolve all the information before the file is actually removed
             dentry = (struct dentry *) CTX_PARM2(ctx);
             set_file_inode(dentry, &syscall->unlink.file, 1);
-            fill_file_metadata(dentry, &syscall->unlink.file.metadata);
+            fill_file_metadata(dentry, &syscall->unlink.file.metadata, NULL);
 
             // the mount id of path_key is resolved by kprobe/mnt_want_write. It is already set by the time we reach this probe.
             key = syscall->unlink.file.path_key;

--- a/pkg/security/ebpf/c/include/hooks/selinux.h
+++ b/pkg/security/ebpf/c/include/hooks/selinux.h
@@ -50,7 +50,7 @@ int __attribute__((always_inline)) handle_selinux_event(void *ctx, struct file *
     }
     // otherwise let's keep the value = error state.
 
-    fill_file_metadata(syscall.selinux.dentry, &syscall.selinux.file.metadata);
+    fill_file_metadata(syscall.selinux.dentry, &syscall.selinux.file.metadata, NULL);
     set_file_inode(syscall.selinux.dentry, &syscall.selinux.file, 0);
 
     syscall.resolver.key = syscall.selinux.file.path_key;

--- a/pkg/security/ebpf/c/include/hooks/setattr.h
+++ b/pkg/security/ebpf/c/include/hooks/setattr.h
@@ -29,7 +29,7 @@ int hook_security_inode_setattr(ctx_t *ctx) {
         iattr = (struct iattr *)param2;
     }
 
-    fill_file_metadata(dentry, &syscall->setattr.file.metadata);
+    fill_file_metadata(dentry, &syscall->setattr.file.metadata, NULL);
 
     if (iattr != NULL) {
         int valid;

--- a/pkg/security/ebpf/c/include/hooks/setxattr.h
+++ b/pkg/security/ebpf/c/include/hooks/setxattr.h
@@ -169,7 +169,7 @@ int __attribute__((always_inline)) sys_xattr_ret(void *ctx, int retval, u64 even
 
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);
-    fill_file_metadata(syscall->xattr.dentry, &event.file.metadata);
+    fill_file_metadata(syscall->xattr.dentry, &event.file.metadata, NULL);
     fill_span_context(&event.span);
 
     send_event(ctx, event_type, event);

--- a/pkg/security/ebpf/c/include/hooks/splice.h
+++ b/pkg/security/ebpf/c/include/hooks/splice.h
@@ -100,7 +100,7 @@ int __attribute__((always_inline)) sys_splice_ret(void *ctx, int retval) {
         .pipe_entry_flag = syscall->splice.pipe_entry_flag,
         .pipe_exit_flag = syscall->splice.pipe_exit_flag,
     };
-    fill_file_metadata(syscall->splice.dentry, &event.file.metadata);
+    fill_file_metadata(syscall->splice.dentry, &event.file.metadata, NULL);
 
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);

--- a/pkg/security/ebpf/c/include/hooks/unlink.h
+++ b/pkg/security/ebpf/c/include/hooks/unlink.h
@@ -62,7 +62,7 @@ int hook_vfs_unlink(ctx_t *ctx) {
     // we resolve all the information before the file is actually removed
     syscall->unlink.dentry = dentry;
     set_file_inode(dentry, &syscall->unlink.file, 1);
-    fill_file_metadata(dentry, &syscall->unlink.file.metadata);
+    fill_file_metadata(dentry, &syscall->unlink.file.metadata, NULL);
 
     if (filter_syscall(syscall, unlink_approvers)) {
         return mark_as_discarded(syscall);

--- a/pkg/security/tests/cmdwrapper.go
+++ b/pkg/security/tests/cmdwrapper.go
@@ -35,7 +35,11 @@ var dockerImageLibrary = map[string][]string{
 	},
 	"alpine": {
 		"alpine",
-		"public.ecr.aws/docker/library/alpine:latest",
+		"public.ecr.aws/docker/library/alpine:3.18.2", // before changing the version make sure that the new version behaves as previously (hardlink vs symlink)
+	},
+	"busybox": {
+		"busybox",
+		"public.ecr.aws/docker/library/busybox:1.36.1", // before changing the version make sure that the new version behaves as previously (hardlink vs symlink)
 	},
 }
 

--- a/pkg/security/tests/hardlink_test.go
+++ b/pkg/security/tests/hardlink_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"gotest.tools/assert"
 )
 
 func runHardlinkTests(t *testing.T, opts testOpts) {
@@ -53,6 +54,7 @@ func runHardlinkTests(t *testing.T, opts testOpts) {
 			return cmd.Run()
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_orig")
+			assert.Equal(t, event.Exec.FileEvent.NLink, uint32(1), "wrong nlink")
 		})
 
 		testNewExecutable, _, err := test.Path("my-touch")
@@ -71,6 +73,7 @@ func runHardlinkTests(t *testing.T, opts testOpts) {
 			return cmd.Run()
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_link")
+			assert.Equal(t, event.Exec.FileEvent.NLink, uint32(2), "wrong nlink")
 		})
 	})
 
@@ -91,6 +94,7 @@ func runHardlinkTests(t *testing.T, opts testOpts) {
 			return cmd.Run()
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_orig")
+			assert.Equal(t, event.Exec.FileEvent.NLink, uint32(2), "wrong nlink")
 		})
 
 		test.WaitSignal(t, func() error {
@@ -98,6 +102,7 @@ func runHardlinkTests(t *testing.T, opts testOpts) {
 			return cmd.Run()
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_link")
+			assert.Equal(t, event.Exec.FileEvent.NLink, uint32(2), "wrong nlink")
 		})
 	})
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR fixes the Nlink value of files for exec events in overlayfs. This value is used during the path resolution in order to determine if the cache has to be used or not. Before this PR exec events in busybox container, using hardlink, were having path resolution issue. The first entry in the cache for a busybox binary was used for all the subsequent resolutions whatever the command used.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
