### PR TITLE
configurable jmxfetch telemetry check 

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -835,6 +835,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("jmx_check_period", int(defaults.DefaultCheckInterval/time.Millisecond))
 	config.BindEnvAndSetDefault("jmx_reconnection_timeout", 60)
 	config.BindEnvAndSetDefault("jmx_statsd_telemetry_enabled", false)
+	config.BindEnvAndSetDefault("jmx_instance_telemetry_enabled", false)
 	// The following jmx_statsd_client-* options are internal and will not be documented
 	// the queue size is the no. of elements (metrics, event, service checks) it can hold.
 	config.BindEnvAndSetDefault("jmx_statsd_client_queue_size", 4096)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -835,7 +835,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("jmx_check_period", int(defaults.DefaultCheckInterval/time.Millisecond))
 	config.BindEnvAndSetDefault("jmx_reconnection_timeout", 60)
 	config.BindEnvAndSetDefault("jmx_statsd_telemetry_enabled", false)
-	config.BindEnvAndSetDefault("jmx_instance_telemetry_enabled", false)
+	config.BindEnvAndSetDefault("jmx_telemetry_enabled", false)
 	// The following jmx_statsd_client-* options are internal and will not be documented
 	// the queue size is the no. of elements (metrics, event, service checks) it can hold.
 	config.BindEnvAndSetDefault("jmx_statsd_client_queue_size", 4096)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2357,6 +2357,12 @@ api_key:
 #
 # jmx_statsd_telemetry_enabled: false
 
+## @param jmx_instance_telemetry_enabled - boolean - optional - default: false
+## @env DD_JMX_INSTANCE_TELEMETRY_ENABLED - boolean - optional - default: false
+## Specifies whether the JMXFetch instance telemetry is enabled.
+#
+# jmx_instance_telemetry_enabled: false
+
 {{ end -}}
 {{- if .Logging }}
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2357,11 +2357,11 @@ api_key:
 #
 # jmx_statsd_telemetry_enabled: false
 
-## @param jmx_instance_telemetry_enabled - boolean - optional - default: false
-## @env DD_JMX_INSTANCE_TELEMETRY_ENABLED - boolean - optional - default: false
-## Specifies whether the JMXFetch instance telemetry is enabled.
+## @param jmx_telemetry_enabled - boolean - optional - default: false
+## @env DD_JMX_TELEMETRY_ENABLED - boolean - optional - default: false
+## Specifies whether additional JMXFetch telemetry is enabled.
 #
-# jmx_instance_telemetry_enabled: false
+# jmx_telemetry_enabled: false
 
 {{ end -}}
 {{- if .Logging }}

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -297,8 +297,8 @@ func (j *JMXFetch) Start(manage bool) error {
 		subprocessArgs = append(subprocessArgs, "--statsd_telemetry")
 	}
 
-	if config.Datadog.GetBool("jmx_instance_telemetry_enabled") {
-		subprocessArgs = append(subprocessArgs, "--instance_telemetry")
+	if config.Datadog.GetBool("jmx_telemetry_enabled") {
+		subprocessArgs = append(subprocessArgs, "--jmxfetch_telemetry")
 	}
 
 	if config.Datadog.GetBool("jmx_statsd_client_use_non_blocking") {

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -297,6 +297,10 @@ func (j *JMXFetch) Start(manage bool) error {
 		subprocessArgs = append(subprocessArgs, "--statsd_telemetry")
 	}
 
+	if config.Datadog.GetBool("jmx_instance_telemetry_enabled") {
+		subprocessArgs = append(subprocessArgs, "--instance_telemetry")
+	}
+
 	if config.Datadog.GetBool("jmx_statsd_client_use_non_blocking") {
 		subprocessArgs = append(subprocessArgs, "--statsd_nonblocking")
 	}

--- a/releasenotes/notes/jmxfetch-configurable-jmxfetch-telemetry-check-1234346b60e6ce93.yaml
+++ b/releasenotes/notes/jmxfetch-configurable-jmxfetch-telemetry-check-1234346b60e6ce93.yaml
@@ -1,0 +1,6 @@
+features:
+  - |
+    Adds a configurable jmxfetch telemetry check that collects more data on the
+    running jmxfetch JVM in addition to data about the JVMs jmxfetch is monitoring.
+    It can be configured by enabling the jmx_telemetry_enabled option in the agent.
+

--- a/releasenotes/notes/jmxfetch-configurable-jmxfetch-telemetry-check-1234346b60e6ce93.yaml
+++ b/releasenotes/notes/jmxfetch-configurable-jmxfetch-telemetry-check-1234346b60e6ce93.yaml
@@ -1,6 +1,6 @@
 features:
   - |
-    Adds a configurable jmxfetch telemetry check that collects more data on the
+    Adds a configurable jmxfetch telemetry check that collects additional data on the
     running jmxfetch JVM in addition to data about the JVMs jmxfetch is monitoring.
-    It can be configured by enabling the jmx_telemetry_enabled option in the agent.
+    The check can be configured by enabling the jmx_telemetry_enabled option in the Agent.
 


### PR DESCRIPTION
### What does this PR do?
Adds a new config option to allow users to enable extra telemetry to be reported from their JMXFetch instances.
This utilizes a [new JMXFetch feature](https://github.com/DataDog/jmxfetch/pull/475) and reports these metrics back to datadog. 

### Motivation
This is intended to be used in debugging scenarios, this is not something that is useful enough to enable by default.

### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
