### PR TITLE
[CWS] Fix DNS hostnames resolution

### DIFF
--- a/pkg/security/secl/model/dns_helpers.go
+++ b/pkg/security/secl/model/dns_helpers.go
@@ -80,19 +80,20 @@ LOOP:
 }
 
 func validateDNSName(dns string) error {
-	if len(dns) < 3 { // check the minimun length, ie "a.b"
-		return ErrDNSNameMalformatted
-	} else if len(dns) > 253 { // check the max full domain name length
+	// Maximum length of the DNS name field in the DNS protocol is 255 bytes:
+	//
+	//                  <------------- 255 --------------->
+	//                  | X | ... | Y | ... | Z | ... | 0 |
+	//
+	// If you remove the trailing 0 and the first X (which isn't turned into a `.` in the string representation), you
+	// get a maximum printable characters length of 253.
+	if len(dns) > 253 {
 		return ErrDNSNameMalformatted
 	}
-	domains := strings.Split(dns, ".")
-	if len(domains) < 2 {
-		return ErrDNSNameMalformatted
-	}
-	for _, sub := range domains {
-		if len(sub) < 1 {
-			return ErrDNSNameMalformatted
-		} else if len(sub) > 63 {
+
+	// Check that each label isn't empty and at most 63 characters.
+	for _, sub := range strings.Split(dns, ".") {
+		if n := len(sub); n < 1 || n > 63 {
 			return ErrDNSNameMalformatted
 		}
 	}

--- a/pkg/security/secl/model/dns_helpers_test.go
+++ b/pkg/security/secl/model/dns_helpers_test.go
@@ -45,18 +45,18 @@ func TestDnsHelpers_validateDNSName(t *testing.T) {
 			dnsName:  "012345678901234567890123456789012345678901234567890123456789012.com",
 			isValid:  true,
 		},
+		{
+			testName: "test_ok_single_char",
+			dnsName:  "a",
+			isValid:  true,
+		},
+		{
+			testName: "test_ok_hostname",
+			dnsName:  "localhost",
+			isValid:  true,
+		},
 
 		// test invalid dns names
-		{
-			testName: "test_ko_0",
-			dnsName:  "a",
-			isValid:  false,
-		},
-		{
-			testName: "test_ko_1",
-			dnsName:  "abc",
-			isValid:  false,
-		},
 		{
 			testName: "test_ko_2",
 			dnsName:  "a.b.",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR fixes the logic in the `validateDNSName` helper function so that it validates the resolution DNS hostnames.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Hostnames resolution requests are valid DNS requests, regardless of internal business logic for Security Profiles and Anomaly Detections. Additionally, they showcase network activity that can be used to resolve remote addresses, they are not limited to localhost and it is up to the sysadmin to decide (or not) to add remote IPs to `/etc/hosts`. Last but not least, they are valuable piece of context to label local IP addresses.

### How to QA this change ?

Write a rule on "localhost" and resolve "localhost". A CWS event should be generated.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
