### PR TITLE
[CWS] dynamic probe selection for fentry

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/cgroup.h
+++ b/pkg/security/ebpf/c/include/hooks/cgroup.h
@@ -121,7 +121,6 @@ int hook_cgroup1_procs_write(ctx_t *ctx) {
     return trace__cgroup_write(ctx);
 }
 
-#ifndef USE_FENTRY
 HOOK_ENTRY("cgroup_tasks_write")
 int hook_cgroup_tasks_write(ctx_t *ctx) {
     return trace__cgroup_write(ctx);
@@ -131,6 +130,5 @@ HOOK_ENTRY("cgroup1_tasks_write")
 int hook_cgroup1_tasks_write(ctx_t *ctx) {
     return trace__cgroup_write(ctx);
 }
-#endif
 
 #endif

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -134,7 +134,6 @@ int hook_kernel_clone(ctx_t *ctx) {
     return handle_do_fork(ctx);
 }
 
-#ifndef USE_FENTRY
 HOOK_ENTRY("do_fork")
 int hook_do_fork(ctx_t *ctx) {
     return handle_do_fork(ctx);
@@ -144,7 +143,6 @@ HOOK_ENTRY("_do_fork")
 int hook__do_fork(ctx_t *ctx) {
     return handle_do_fork(ctx);
 }
-#endif
 
 SEC("tracepoint/sched/sched_process_fork")
 int sched_process_fork(struct _tracepoint_sched_process_fork *args) {
@@ -321,12 +319,10 @@ int hook_exit_itimers(ctx_t *ctx) {
     return 0;
 }
 
-#ifndef USE_FENTRY
 HOOK_ENTRY("prepare_binprm")
 int hook_prepare_binprm(ctx_t *ctx) {
     return fill_exec_context();
 }
-#endif
 
 HOOK_ENTRY("bprm_execve")
 int hook_bprm_execve(ctx_t *ctx) {

--- a/pkg/security/ebpf/c/include/hooks/iouring.h
+++ b/pkg/security/ebpf/c/include/hooks/iouring.h
@@ -26,13 +26,11 @@ int hook_io_allocate_scq_urings(ctx_t *ctx) {
     return 0;
 }
 
-#ifndef USE_FENTRY
 HOOK_ENTRY("io_sq_offload_start")
 int hook_io_sq_offload_start(ctx_t *ctx) {
     void *ioctx = (void *)CTX_PARM1(ctx);
     cache_ioctx_pid_tgid(ioctx);
     return 0;
 }
-#endif
 
 #endif

--- a/pkg/security/ebpf/c/include/hooks/module.h
+++ b/pkg/security/ebpf/c/include/hooks/module.h
@@ -75,13 +75,11 @@ int kprobe_parse_args(struct pt_regs *ctx) {
     return 0;
 }
 
-#ifndef USE_FENTRY
 HOOK_ENTRY("security_kernel_module_from_file")
 int hook_security_kernel_module_from_file(ctx_t *ctx) {
     struct file *f = (struct file *)CTX_PARM1(ctx);
     return trace_kernel_file(ctx, f, DR_KPROBE_OR_FENTRY);
 }
-#endif
 
 HOOK_ENTRY("security_kernel_read_file")
 int hook_security_kernel_read_file(ctx_t *ctx) {

--- a/pkg/security/ebpf/c/include/hooks/mount.h
+++ b/pkg/security/ebpf/c/include/hooks/mount.h
@@ -107,13 +107,11 @@ int hook_mnt_want_write_file(ctx_t *ctx) {
     return trace__mnt_want_write_file(ctx);
 }
 
-#ifndef USE_FENTRY
 // mnt_want_write_file_path was used on old kernels (RHEL 7)
 HOOK_ENTRY("mnt_want_write_file_path")
 int hook_mnt_want_write_file_path(ctx_t *ctx) {
     return trace__mnt_want_write_file(ctx);
 }
-#endif
 
 HOOK_SYSCALL_COMPAT_ENTRY3(mount, const char*, source, const char*, target, const char*, fstype) {
     struct syscall_cache_t syscall = {

--- a/pkg/security/ebpf/c/include/hooks/selinux.h
+++ b/pkg/security/ebpf/c/include/hooks/selinux.h
@@ -126,9 +126,7 @@ int fentry_dr_selinux_callback(ctx_t *ctx) {
         return handle_selinux_event(ctx, file, buf, count, (source_event)); \
     }
 
-#ifndef USE_FENTRY
 PROBE_SEL_WRITE_FUNC(sel_write_disable, SELINUX_DISABLE_CHANGE_SOURCE_EVENT)
-#endif // USE_FENTRY
 PROBE_SEL_WRITE_FUNC(sel_write_enforce, SELINUX_ENFORCE_CHANGE_SOURCE_EVENT)
 PROBE_SEL_WRITE_FUNC(sel_write_bool, SELINUX_BOOL_CHANGE_SOURCE_EVENT)
 PROBE_SEL_WRITE_FUNC(sel_commit_bools_write, SELINUX_BOOL_COMMIT_SOURCE_EVENT)

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -28,8 +28,6 @@ const (
 )
 
 var (
-	// allProbes contain the list of all the probes of the runtime security module
-	allProbes []*manager.Probe
 	// EventsPerfRingBufferSize is the buffer size of the perf buffers used for events.
 	// PLEASE NOTE: for the perf ring buffer usage metrics to be accurate, the provided value must have the
 	// following form: (1 + 2^n) * pages. Checkout https://github.com/DataDog/ebpf for more.
@@ -55,10 +53,7 @@ func computeDefaultEventsRingBufferSize() uint32 {
 
 // AllProbes returns the list of all the probes of the runtime security module
 func AllProbes(fentry bool) []*manager.Probe {
-	if len(allProbes) > 0 {
-		return allProbes
-	}
-
+	var allProbes []*manager.Probe
 	allProbes = append(allProbes, getAttrProbes(fentry)...)
 	allProbes = append(allProbes, getExecProbes(fentry)...)
 	allProbes = append(allProbes, getLinkProbe(fentry)...)

--- a/pkg/security/ebpf/probes/attr.go
+++ b/pkg/security/ebpf/probes/attr.go
@@ -9,17 +9,16 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// attrProbes holds the list of probes used to track link events
-var attrProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_security_inode_setattr",
-		},
-	},
-}
-
 func getAttrProbes(fentry bool) []*manager.Probe {
+	var attrProbes = []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_security_inode_setattr",
+			},
+		},
+	}
+
 	// chmod
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{

--- a/pkg/security/ebpf/probes/bind.go
+++ b/pkg/security/ebpf/probes/bind.go
@@ -9,10 +9,8 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// bindProbes holds the list of probes used to track bind events
-var bindProbes []*manager.Probe
-
 func getBindProbes(fentry bool) []*manager.Probe {
+	var bindProbes []*manager.Probe
 	bindProbes = append(bindProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,

--- a/pkg/security/ebpf/probes/bpf.go
+++ b/pkg/security/ebpf/probes/bpf.go
@@ -9,30 +9,29 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// bpfProbes holds the list of probes used to track bpf events
-var bpfProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_security_bpf_map",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_security_bpf_prog",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_check_helper_call",
-		},
-		MatchFuncName: "check_helper_call",
-	},
-}
-
 func getBPFProbes(fentry bool) []*manager.Probe {
+	var bpfProbes = []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_security_bpf_map",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_security_bpf_prog",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_check_helper_call",
+			},
+			MatchFuncName: "check_helper_call",
+		},
+	}
+
 	bpfProbes = append(bpfProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -115,41 +115,36 @@ func getExecProbes(fentry bool) []*manager.Probe {
 				EBPFFuncName: "hook_do_coredump",
 			},
 		},
-	}
-
-	if !fentry {
-		execProbes = append(execProbes, []*manager.Probe{
-			{
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					UID:          SecurityAgentUID,
-					EBPFFuncName: "hook_prepare_binprm",
-				},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_prepare_binprm",
 			},
-			{
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					UID:          SecurityAgentUID,
-					EBPFFuncName: "hook_do_fork",
-				},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_do_fork",
 			},
-			{
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					UID:          SecurityAgentUID,
-					EBPFFuncName: "hook__do_fork",
-				},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook__do_fork",
 			},
-			{
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					UID:          SecurityAgentUID,
-					EBPFFuncName: "hook_cgroup_tasks_write",
-				},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_cgroup_tasks_write",
 			},
-			{
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					UID:          SecurityAgentUID,
-					EBPFFuncName: "hook_cgroup1_tasks_write",
-				},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_cgroup1_tasks_write",
 			},
-		}...)
+		},
 	}
 
 	execProbes = append(execProbes, ExpandSyscallProbes(&manager.Probe{

--- a/pkg/security/ebpf/probes/flow.go
+++ b/pkg/security/ebpf/probes/flow.go
@@ -9,40 +9,37 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// flowProbes holds the list of probes used to track network flows
-var flowProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_security_sk_classify_flow",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_nf_nat_manip_pkt",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_nf_nat_packet",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_path_get",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_proc_fd_link",
-		},
-	},
-}
-
 func getFlowProbes() []*manager.Probe {
-	return flowProbes
+	return []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_security_sk_classify_flow",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_nf_nat_manip_pkt",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_nf_nat_packet",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_path_get",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_proc_fd_link",
+			},
+		},
+	}
 }

--- a/pkg/security/ebpf/probes/ioctl.go
+++ b/pkg/security/ebpf/probes/ioctl.go
@@ -9,16 +9,13 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// ioctlProbes holds the list of probes used to track ioctl events
-var ioctlProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_do_vfs_ioctl",
-		},
-	},
-}
-
 func getIoctlProbes() []*manager.Probe {
-	return ioctlProbes
+	return []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_do_vfs_ioctl",
+			},
+		},
+	}
 }

--- a/pkg/security/ebpf/probes/iouring.go
+++ b/pkg/security/ebpf/probes/iouring.go
@@ -29,15 +29,12 @@ func getIouringProbes(fentry bool) []*manager.Probe {
 				EBPFFuncName: "hook_io_allocate_scq_urings",
 			},
 		},
-	}
-
-	if !fentry {
-		iouringProbes = append(iouringProbes, &manager.Probe{
+		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook_io_sq_offload_start",
 			},
-		})
+		},
 	}
 
 	return iouringProbes

--- a/pkg/security/ebpf/probes/iouring.go
+++ b/pkg/security/ebpf/probes/iouring.go
@@ -11,7 +11,7 @@ import manager "github.com/DataDog/ebpf-manager"
 
 // iouringProbes is the list of probes that are used for iouring monitoring
 func getIouringProbes(fentry bool) []*manager.Probe {
-	iouringProbes := []*manager.Probe{
+	return []*manager.Probe{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
@@ -36,6 +36,4 @@ func getIouringProbes(fentry bool) []*manager.Probe {
 			},
 		},
 	}
-
-	return iouringProbes
 }

--- a/pkg/security/ebpf/probes/link.go
+++ b/pkg/security/ebpf/probes/link.go
@@ -9,29 +9,28 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// linkProbes holds the list of probes used to track link events
-var linkProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_vfs_link",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_do_linkat",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "rethook_do_linkat",
-		},
-	},
-}
-
 func getLinkProbe(fentry bool) []*manager.Probe {
+	var linkProbes = []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_vfs_link",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_do_linkat",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "rethook_do_linkat",
+			},
+		},
+	}
+
 	linkProbes = append(linkProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,

--- a/pkg/security/ebpf/probes/mkdir.go
+++ b/pkg/security/ebpf/probes/mkdir.go
@@ -9,29 +9,28 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// mkdirProbes holds the list of probes used to track mkdir events
-var mkdirProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_vfs_mkdir",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_do_mkdirat",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "rethook_do_mkdirat",
-		},
-	},
-}
-
 func getMkdirProbes(fentry bool) []*manager.Probe {
+	var mkdirProbes = []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_vfs_mkdir",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_do_mkdirat",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "rethook_do_mkdirat",
+			},
+		},
+	}
+
 	mkdirProbes = append(mkdirProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,

--- a/pkg/security/ebpf/probes/mmap.go
+++ b/pkg/security/ebpf/probes/mmap.go
@@ -9,23 +9,22 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// mmapProbes holds the list of probes used to track mmap events
-var mmapProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "rethook_fget",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "tracepoint_syscalls_sys_enter_mmap",
-		},
-	},
-}
-
 func getMMapProbes(fentry bool) []*manager.Probe {
+	var mmapProbes = []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "rethook_fget",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "tracepoint_syscalls_sys_enter_mmap",
+			},
+		},
+	}
+
 	mmapProbes = append(mmapProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,

--- a/pkg/security/ebpf/probes/module.go
+++ b/pkg/security/ebpf/probes/module.go
@@ -31,15 +31,12 @@ func getModuleProbes(fentry bool) []*manager.Probe {
 				EBPFFuncName: "kprobe_parse_args",
 			},
 		},
-	}
-
-	if !fentry {
-		moduleProbes = append(moduleProbes, &manager.Probe{
+		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook_security_kernel_module_from_file",
 			},
-		})
+		},
 	}
 
 	moduleProbes = append(moduleProbes, ExpandSyscallProbes(&manager.Probe{

--- a/pkg/security/ebpf/probes/mount.go
+++ b/pkg/security/ebpf/probes/mount.go
@@ -9,53 +9,52 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// mountProbes holds the list of probes used to track mount points events
-var mountProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_attach_recursive_mnt",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_propagate_mnt",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_security_sb_umount",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_clone_mnt",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook___attach_mnt",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_attach_mnt",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_mnt_set_mountpoint",
-		},
-	},
-}
-
 func getMountProbes(fentry bool) []*manager.Probe {
+	var mountProbes = []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_attach_recursive_mnt",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_propagate_mnt",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_security_sb_umount",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_clone_mnt",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook___attach_mnt",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_attach_mnt",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_mnt_set_mountpoint",
+			},
+		},
+	}
+
 	mountProbes = append(mountProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,

--- a/pkg/security/ebpf/probes/mprotect.go
+++ b/pkg/security/ebpf/probes/mprotect.go
@@ -9,17 +9,16 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// mprotectProbes holds the list of probes used to track mprotect events
-var mprotectProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_security_file_mprotect",
-		},
-	},
-}
-
 func getMProtectProbes(fentry bool) []*manager.Probe {
+	var mprotectProbes = []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_security_file_mprotect",
+			},
+		},
+	}
+
 	mprotectProbes = append(mprotectProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,

--- a/pkg/security/ebpf/probes/net_device.go
+++ b/pkg/security/ebpf/probes/net_device.go
@@ -9,70 +9,67 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// netDeviceProbes holds the list of probes used to track new network devices
-var netDeviceProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_rtnl_create_link",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_register_netdevice",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_dev_get_valid_name",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_dev_new_index",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kretprobe_dev_new_index",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe___dev_get_by_index",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe___dev_get_by_name",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kretprobe_register_netdevice",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe_dev_change_net_namespace",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "kprobe___dev_change_net_namespace",
-		},
-	},
-}
-
 func getNetDeviceProbes() []*manager.Probe {
-	return netDeviceProbes
+	return []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_rtnl_create_link",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_register_netdevice",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_dev_get_valid_name",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_dev_new_index",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kretprobe_dev_new_index",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe___dev_get_by_index",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe___dev_get_by_name",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kretprobe_register_netdevice",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe_dev_change_net_namespace",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "kprobe___dev_change_net_namespace",
+			},
+		},
+	}
 }

--- a/pkg/security/ebpf/probes/open.go
+++ b/pkg/security/ebpf/probes/open.go
@@ -9,53 +9,52 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// openProbes holds the list of probes used to track file open events
-var openProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_vfs_truncate",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_vfs_open",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_do_dentry_open",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_io_openat",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_io_openat2",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "rethook_io_openat2",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_filp_close",
-		},
-	},
-}
-
 func getOpenProbes(fentry bool) []*manager.Probe {
+	var openProbes = []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_vfs_truncate",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_vfs_open",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_do_dentry_open",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_io_openat",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_io_openat2",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "rethook_io_openat2",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_filp_close",
+			},
+		},
+	}
+
 	openProbes = append(openProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,

--- a/pkg/security/ebpf/probes/pipe.go
+++ b/pkg/security/ebpf/probes/pipe.go
@@ -9,16 +9,13 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// pipeProbes holds the list of probes used to track pipe events
-var pipeProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_mntget",
-		},
-	},
-}
-
 func getPipeProbes() []*manager.Probe {
-	return pipeProbes
+	return []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_mntget",
+			},
+		},
+	}
 }

--- a/pkg/security/ebpf/probes/ptrace.go
+++ b/pkg/security/ebpf/probes/ptrace.go
@@ -9,10 +9,8 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// ptraceProbes holds the list of probes used to track ptrace events
-var ptraceProbes []*manager.Probe
-
 func getPTraceProbes(fentry bool) []*manager.Probe {
+	var ptraceProbes []*manager.Probe
 	ptraceProbes = append(ptraceProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,

--- a/pkg/security/ebpf/probes/rename.go
+++ b/pkg/security/ebpf/probes/rename.go
@@ -9,29 +9,28 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// renameProbes holds the list of probes used to track file rename events
-var renameProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_vfs_rename",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_do_renameat2",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "rethook_do_renameat2",
-		},
-	},
-}
-
 func getRenameProbes(fentry bool) []*manager.Probe {
+	var renameProbes = []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_vfs_rename",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_do_renameat2",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "rethook_do_renameat2",
+			},
+		},
+	}
+
 	renameProbes = append(renameProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,

--- a/pkg/security/ebpf/probes/rmdir.go
+++ b/pkg/security/ebpf/probes/rmdir.go
@@ -9,29 +9,28 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// rmdirProbes holds the list of probes used to track file rmdir events
-var rmdirProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_security_inode_rmdir",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_do_rmdir",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "rethook_do_rmdir",
-		},
-	},
-}
-
 func getRmdirProbe(fentry bool) []*manager.Probe {
+	var rmdirProbes = []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_security_inode_rmdir",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_do_rmdir",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "rethook_do_rmdir",
+			},
+		},
+	}
+
 	rmdirProbes = append(rmdirProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,

--- a/pkg/security/ebpf/probes/selinux.go
+++ b/pkg/security/ebpf/probes/selinux.go
@@ -29,15 +29,12 @@ func getSELinuxProbes(fentry bool) []*manager.Probe {
 				EBPFFuncName: "hook_sel_commit_bools_write",
 			},
 		},
-	}
-
-	if !fentry {
-		selinuxProbes = append(selinuxProbes, &manager.Probe{
+		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook_sel_write_disable",
 			},
-		})
+		},
 	}
 
 	return selinuxProbes

--- a/pkg/security/ebpf/probes/shared.go
+++ b/pkg/security/ebpf/probes/shared.go
@@ -11,7 +11,7 @@ import manager "github.com/DataDog/ebpf-manager"
 
 // getSharedProbes returns the list of probes that are shared across multiple events
 func getSharedProbes(fentry bool) []*manager.Probe {
-	probes := []*manager.Probe{
+	return []*manager.Probe{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
@@ -30,16 +30,11 @@ func getSharedProbes(fentry bool) []*manager.Probe {
 				EBPFFuncName: "hook_mnt_want_write_file",
 			},
 		},
-	}
-
-	if !fentry {
-		probes = append(probes, &manager.Probe{
+		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook_mnt_want_write_file_path",
 			},
-		})
+		},
 	}
-
-	return probes
 }

--- a/pkg/security/ebpf/probes/signal.go
+++ b/pkg/security/ebpf/probes/signal.go
@@ -9,17 +9,16 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// signalProbes holds the list of probes used to track signal events
-var signalProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "rethook_check_kill_permission",
-		},
-	},
-}
-
 func getSignalProbes(fentry bool) []*manager.Probe {
+	var signalProbes = []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "rethook_check_kill_permission",
+			},
+		},
+	}
+
 	signalProbes = append(signalProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,

--- a/pkg/security/ebpf/probes/splice.go
+++ b/pkg/security/ebpf/probes/splice.go
@@ -9,23 +9,22 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// spliceProbes holds the list of probes used to track splice events
-var spliceProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "rethook_get_pipe_info",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_get_pipe_info",
-		},
-	},
-}
-
 func getSpliceProbes(fentry bool) []*manager.Probe {
+	var spliceProbes = []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "rethook_get_pipe_info",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_get_pipe_info",
+			},
+		},
+	}
+
 	spliceProbes = append(spliceProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,

--- a/pkg/security/ebpf/probes/syscall_monitor.go
+++ b/pkg/security/ebpf/probes/syscall_monitor.go
@@ -15,17 +15,16 @@ import (
 )
 
 // syscallMonitorProbes holds the list of probes used to track syscall events
-var syscallMonitorProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "sys_enter",
-		},
-	},
-}
 
 func getSyscallMonitorProbes() []*manager.Probe {
-	return syscallMonitorProbes
+	return []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "sys_enter",
+			},
+		},
+	}
 }
 
 func getSyscallTableMap() *manager.Map {

--- a/pkg/security/ebpf/probes/tc.go
+++ b/pkg/security/ebpf/probes/tc.go
@@ -12,31 +12,28 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// tcProbes holds the list of probes used to track network flows
-var tcProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "classifier_ingress",
-		},
-		NetworkDirection: manager.Ingress,
-		TCFilterProtocol: unix.ETH_P_ALL,
-		KeepProgramSpec:  true,
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "classifier_egress",
-		},
-		NetworkDirection: manager.Egress,
-		TCFilterProtocol: unix.ETH_P_ALL,
-		KeepProgramSpec:  true,
-	},
-}
-
 // GetTCProbes returns the list of TCProbes
 func GetTCProbes() []*manager.Probe {
-	return tcProbes
+	return []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "classifier_ingress",
+			},
+			NetworkDirection: manager.Ingress,
+			TCFilterProtocol: unix.ETH_P_ALL,
+			KeepProgramSpec:  true,
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "classifier_egress",
+			},
+			NetworkDirection: manager.Egress,
+			TCFilterProtocol: unix.ETH_P_ALL,
+			KeepProgramSpec:  true,
+		},
+	}
 }
 
 // GetAllTCProgramFunctions returns the list of TC classifier sections

--- a/pkg/security/ebpf/probes/unlink.go
+++ b/pkg/security/ebpf/probes/unlink.go
@@ -9,29 +9,28 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// unlinkProbes holds the list of probes used to track unlink events
-var unlinkProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_vfs_unlink",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_do_unlinkat",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "rethook_do_unlinkat",
-		},
-	},
-}
-
 func getUnlinkProbes(fentry bool) []*manager.Probe {
+	var unlinkProbes = []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_vfs_unlink",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_do_unlinkat",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "rethook_do_unlinkat",
+			},
+		},
+	}
+
 	unlinkProbes = append(unlinkProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,

--- a/pkg/security/ebpf/probes/xattr.go
+++ b/pkg/security/ebpf/probes/xattr.go
@@ -9,23 +9,22 @@ package probes
 
 import manager "github.com/DataDog/ebpf-manager"
 
-// xattrProbes holds the list of probes used to track xattr events
-var xattrProbes = []*manager.Probe{
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_vfs_setxattr",
-		},
-	},
-	{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_vfs_removexattr",
-		},
-	},
-}
-
 func getXattrProbes(fentry bool) []*manager.Probe {
+	var xattrProbes = []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_vfs_setxattr",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_vfs_removexattr",
+			},
+		},
+	}
+
 	xattrProbes = append(xattrProbes, ExpandSyscallProbes(&manager.Probe{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{
 			UID: SecurityAgentUID,

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -1615,6 +1615,13 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 		p.managerOptions.ExcludedFunctions = append(p.managerOptions.ExcludedFunctions, probes.GetAllTCProgramFunctions()...)
 	}
 
+	afBasedExcluder, err := newAvailableFunctionsBasedExcluder()
+	if err != nil {
+		return nil, err
+	}
+
+	p.managerOptions.AdditionalExcludedFunctionCollector = afBasedExcluder
+
 	p.scrubber = procutil.NewDefaultDataScrubber()
 	p.scrubber.AddCustomSensitiveWords(config.Probe.CustomSensitiveWords)
 

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -1615,12 +1615,14 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 		p.managerOptions.ExcludedFunctions = append(p.managerOptions.ExcludedFunctions, probes.GetAllTCProgramFunctions()...)
 	}
 
-	afBasedExcluder, err := newAvailableFunctionsBasedExcluder()
-	if err != nil {
-		return nil, err
-	}
+	if p.useFentry {
+		afBasedExcluder, err := newAvailableFunctionsBasedExcluder()
+		if err != nil {
+			return nil, err
+		}
 
-	p.managerOptions.AdditionalExcludedFunctionCollector = afBasedExcluder
+		p.managerOptions.AdditionalExcludedFunctionCollector = afBasedExcluder
+	}
 
 	p.scrubber = procutil.NewDefaultDataScrubber()
 	p.scrubber.AddCustomSensitiveWords(config.Probe.CustomSensitiveWords)

--- a/pkg/security/probe/stateful_probe_excluder.go
+++ b/pkg/security/probe/stateful_probe_excluder.go
@@ -9,11 +9,11 @@ package probe
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/ebpf-manager/tracefs"
 	"github.com/cilium/ebpf"
 )
@@ -44,7 +44,7 @@ func newAvailableFunctionsBasedExcluder() (*availableFunctionsBasedExcluder, err
 		available[name] = struct{}{}
 	}
 
-	fmt.Printf("size available: %d\n", len(available))
+	seclog.Debugf("available functions excluder: entry count: %d\n", len(available))
 
 	return &availableFunctionsBasedExcluder{
 		available: available,

--- a/pkg/security/probe/stateful_probe_excluder.go
+++ b/pkg/security/probe/stateful_probe_excluder.go
@@ -14,13 +14,19 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
+	manager "github.com/DataDog/ebpf-manager"
 	"github.com/DataDog/ebpf-manager/tracefs"
 	"github.com/cilium/ebpf"
 )
 
+// availableFunctionsBasedExcluder is a FunctionExcluder based on reading entries in
+// `/sys/kernel/{debug,}/tracing/available_filter_functions`, i.e. the list of hookable
+// functions provided by the kernel
 type availableFunctionsBasedExcluder struct {
 	available map[string]struct{}
 }
+
+var _ manager.FunctionExcluder = (*availableFunctionsBasedExcluder)(nil)
 
 func newAvailableFunctionsBasedExcluder() (*availableFunctionsBasedExcluder, error) {
 	tracingRoot, err := tracefs.Root()

--- a/pkg/security/probe/stateful_probe_excluder.go
+++ b/pkg/security/probe/stateful_probe_excluder.go
@@ -11,8 +11,10 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
+	"github.com/DataDog/ebpf-manager/tracefs"
 	"github.com/cilium/ebpf"
 )
 
@@ -21,7 +23,12 @@ type availableFunctionsBasedExcluder struct {
 }
 
 func newAvailableFunctionsBasedExcluder() (*availableFunctionsBasedExcluder, error) {
-	f, err := os.Open("/sys/kernel/debug/tracing/available_filter_functions")
+	tracingRoot, err := tracefs.Root()
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.Open(filepath.Join(tracingRoot, "available_filter_functions"))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/probe/stateful_probe_excluder.go
+++ b/pkg/security/probe/stateful_probe_excluder.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package probe
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/cilium/ebpf"
+)
+
+type availableFunctionsBasedExcluder struct {
+	available map[string]struct{}
+}
+
+func newAvailableFunctionsBasedExcluder() (*availableFunctionsBasedExcluder, error) {
+	f, err := os.Open("/sys/kernel/debug/tracing/available_filter_functions")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Split(bufio.ScanLines)
+
+	available := make(map[string]struct{})
+
+	for scanner.Scan() {
+		name, _, _ := strings.Cut(scanner.Text(), " ")
+		available[name] = struct{}{}
+	}
+
+	fmt.Printf("size available: %d\n", len(available))
+
+	return &availableFunctionsBasedExcluder{
+		available: available,
+	}, nil
+}
+
+func (af *availableFunctionsBasedExcluder) ShouldExcludeFunction(name string, prog *ebpf.ProgramSpec) bool {
+	if af.available == nil {
+		return false
+	}
+
+	if prog.Type != ebpf.Kprobe && prog.Type != ebpf.Tracing {
+		return false
+	}
+
+	if strings.HasPrefix(name, "tail_call") || strings.Contains(name, "dentry_resolver") || strings.Contains(name, "callback") {
+		return false
+	}
+
+	_, ok := af.available[prog.AttachTo]
+	return !ok
+}
+
+func (af *availableFunctionsBasedExcluder) CleanCaches() {
+	af.available = nil
+}


### PR DESCRIPTION
### What does this PR do?

This PR implements a new dynamic probe filter based on entries in `/sys/kernel/tracing/available_filter_functions`. This allows to remove probes that would hook non existant functions, a critical feature for dynamic fentry support.
This dynamic filter is currently only used in fentry mode.

The changes to the `AllProbes` functions are necessary because now that we use dynamic filtering, we need to give ownership of the array to the manager who might modify it. So the changes allow the `AllProbes` to return a fresh new array each time

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
