### PR TITLE
[CWS] merge sys fork and `kernel_clone` hooks

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -75,40 +75,13 @@ int __attribute__((always_inline)) handle_interpreted_exec_event(void *ctx, stru
     return 0;
 }
 
-int __attribute__((always_inline)) handle_sys_fork() {
-    struct syscall_cache_t syscall = {
-        .type = EVENT_FORK,
-    };
-
-    cache_syscall(&syscall);
-
-    return 0;
-}
-
-SYSCALL_KPROBE0(fork) {
-    return handle_sys_fork();
-}
-
-HOOK_SYSCALL_ENTRY0(clone) {
-    return handle_sys_fork();
-}
-
-HOOK_SYSCALL_ENTRY0(clone3) {
-    return handle_sys_fork();
-}
-
-SYSCALL_KPROBE0(vfork) {
-    return handle_sys_fork();
-}
-
 #define DO_FORK_STRUCT_INPUT 1
 
 int __attribute__((always_inline)) handle_do_fork(ctx_t *ctx) {
-    struct syscall_cache_t *syscall = peek_syscall(EVENT_FORK);
-    if (!syscall) {
-        return 0;
-    }
-    syscall->fork.is_thread = 1;
+    struct syscall_cache_t syscall = {
+        .type = EVENT_FORK,
+        .fork.is_thread = 1,
+    };
 
     u64 input;
     LOAD_CONSTANT("do_fork_input", input);
@@ -127,6 +100,8 @@ int __attribute__((always_inline)) handle_do_fork(ctx_t *ctx) {
             syscall->fork.is_thread = 0;
         }
     }
+
+    cache_syscall(&syscall);
 
     return 0;
 }

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -92,12 +92,12 @@ int __attribute__((always_inline)) handle_do_fork(ctx_t *ctx) {
         bpf_probe_read(&exit_signal, sizeof(int), (void *)args + 32);
 
         if (exit_signal == SIGCHLD) {
-            syscall->fork.is_thread = 0;
+            syscall.fork.is_thread = 0;
         }
     } else {
         u64 flags = (u64)CTX_PARM1(ctx);
         if ((flags & SIGCHLD) == SIGCHLD) {
-            syscall->fork.is_thread = 0;
+            syscall.fork.is_thread = 0;
         }
     }
 

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -136,10 +136,6 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setresgid", fentry, EntryAndExit|SupportFentry|SupportFexit)},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setresgid16", fentry, EntryAndExit|SupportFentry|SupportFexit)},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "capset", fentry, EntryAndExit|SupportFentry|SupportFexit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fork", fentry, Entry)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "vfork", fentry, Entry)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "clone", fentry, Entry|SupportFentry)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "clone3", fentry, Entry|SupportFentry)},
 
 			// File Attributes
 			kprobeOrFentry("security_inode_setattr", fentry),

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -152,30 +152,6 @@ func getExecProbes(fentry bool) []*manager.Probe {
 		},
 		SyscallFuncName: "execveat",
 	}, fentry, Entry|SupportFentry)...)
-	execProbes = append(execProbes, ExpandSyscallProbes(&manager.Probe{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID: SecurityAgentUID,
-		},
-		SyscallFuncName: "fork",
-	}, fentry, Entry)...)
-	execProbes = append(execProbes, ExpandSyscallProbes(&manager.Probe{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID: SecurityAgentUID,
-		},
-		SyscallFuncName: "vfork",
-	}, fentry, Entry)...)
-	execProbes = append(execProbes, ExpandSyscallProbes(&manager.Probe{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID: SecurityAgentUID,
-		},
-		SyscallFuncName: "clone",
-	}, fentry, Entry|SupportFentry)...)
-	execProbes = append(execProbes, ExpandSyscallProbes(&manager.Probe{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID: SecurityAgentUID,
-		},
-		SyscallFuncName: "clone3",
-	}, fentry, Entry|SupportFentry)...)
 
 	for _, name := range []string{
 		"setuid",


### PR DESCRIPTION
### What does this PR do?

Some systems have some difficulties hooking some kprobes to `sys_fork` and `sys_vfork` syscalls. This PR merges the hooks from the syscall entry and from the `kernel_clone` (the function called directly by the syscall) and does all the work in the `kernel_clone` hook.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
