### PR TITLE
gitlab: source /etc/profile instead of ~/.bashrc

### DIFF
--- a/.gitlab/binary_build/cluster_agent.yml
+++ b/.gitlab/binary_build/cluster_agent.yml
@@ -19,7 +19,7 @@ cluster_agent-build_amd64:
   variables:
     ARCH: amd64
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - !reference [.retrieve_linux_go_deps]
 
 cluster_agent-build_arm64:
@@ -32,5 +32,5 @@ cluster_agent-build_arm64:
   variables:
     ARCH: arm64
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - !reference [.retrieve_linux_go_deps]

--- a/.gitlab/binary_build/cluster_agent_cloudfoundry.yml
+++ b/.gitlab/binary_build/cluster_agent_cloudfoundry.yml
@@ -13,7 +13,7 @@ cluster_agent_cloudfoundry-build_amd64:
   variables:
     ARCH: amd64
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - !reference [.retrieve_linux_go_deps]
   script:
     - inv check-go-version

--- a/.gitlab/binary_build/linux.yml
+++ b/.gitlab/binary_build/linux.yml
@@ -10,7 +10,7 @@ build_dogstatsd_static-binary_x64:
   variables:
     ARCH: amd64
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - !reference [.retrieve_linux_go_deps]
   script:
     - inv check-go-version
@@ -27,7 +27,7 @@ build_dogstatsd_static-binary_arm64:
   variables:
     ARCH: arm64
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - !reference [.retrieve_linux_go_deps]
   script:
     - inv check-go-version
@@ -42,7 +42,7 @@ build_dogstatsd-binary_x64:
   tags: ["arch:amd64"]
   needs: ["lint_deb-x64", "tests_deb-x64-py3", "go_deps"]
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - !reference [.retrieve_linux_go_deps]
   script:
     - inv check-go-version
@@ -59,7 +59,7 @@ build_dogstatsd-binary_arm64:
   variables:
     ARCH: arm64
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - !reference [.retrieve_linux_go_deps]
   script:
     - inv check-go-version
@@ -77,7 +77,7 @@ build_iot_agent-binary_x64:
   before_script:
     - !reference [.retrieve_linux_go_deps]
   script:
-    - source /root/.bashrc
+    - source /etc/profile
     - inv check-go-version
     - inv -e agent.build --flavor iot --major-version 7
     - $S3_CP_CMD $CI_PROJECT_DIR/$AGENT_BINARIES_DIR/agent $S3_ARTIFACTS_URI/iot/agent
@@ -94,6 +94,6 @@ build_iot_agent-binary_arm64:
   before_script:
     - !reference [.retrieve_linux_go_deps]
   script:
-    - source /root/.bashrc
+    - source /etc/profile
     - inv check-go-version
     - inv -e agent.build --flavor iot --major-version 7

--- a/.gitlab/binary_build/serverless.yml
+++ b/.gitlab/binary_build/serverless.yml
@@ -2,7 +2,7 @@
 .build_serverless_common:
   stage: binary_build
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - !reference [.retrieve_linux_go_deps]
   script:
     - inv check-go-version

--- a/.gitlab/deploy_containers.yml
+++ b/.gitlab/deploy_containers.yml
@@ -20,7 +20,7 @@
   stage: deploy_containers
   dependencies: []
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv agent.version --major-version 6 --url-safe)"; fi
     - export IMG_SOURCES="${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6${JMX}-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6${JMX}-arm64"
     - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}${JMX}"
@@ -70,7 +70,7 @@ deploy_containers_latest-a6:
   stage: deploy_containers
   dependencies: []
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv agent.version --major-version 7 --url-safe)"; fi
     - export IMG_BASE_SRC="${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
     - export IMG_LINUX_SOURCES="${IMG_BASE_SRC}-7${JMX}-amd64,${IMG_BASE_SRC}-7${JMX}-arm64"
@@ -113,7 +113,7 @@ deploy_containers-dogstatsd:
     !reference [.on_deploy_a7_manual_auto_on_rc]
   dependencies: []
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - export VERSION="$(inv agent.version --major-version 7 --url-safe)"
     - export IMG_SOURCES="${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64"
     - export IMG_DESTINATIONS="${DSD_REPOSITORY}:${VERSION}"

--- a/.gitlab/deploy_dca.yml
+++ b/.gitlab/deploy_dca.yml
@@ -14,7 +14,7 @@
   stage: deploy_dca
   dependencies: []
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv agent.version --major-version 7 --url-safe)"; fi
     - if [[ "$CLUSTER_AGENT_REPOSITORY" == "" ]]; then export CLUSTER_AGENT_REPOSITORY="cluster-agent"; fi
     - export IMG_BASE_SRC="${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"

--- a/.gitlab/deps_fetch.yml
+++ b/.gitlab/deps_fetch.yml
@@ -17,7 +17,7 @@ go_deps:
   tags: ["arch:amd64"]
   needs: ["setup_agent_version"]
   script:
-    - source /root/.bashrc
+    - source /etc/profile
     - inv -e deps --verbose
     - cd $GOPATH/pkg/mod/ && tar czf $CI_PROJECT_DIR/modcache.tar.gz .
   artifacts:
@@ -32,7 +32,7 @@ go_tools_deps:
   tags: ["arch:amd64"]
   needs: ["setup_agent_version"]
   script:
-    - source /root/.bashrc
+    - source /etc/profile
     - inv -e download-tools
     - cd $GOPATH/pkg/mod/ && tar czf $CI_PROJECT_DIR/modcache_tools.tar.gz .
   artifacts:

--- a/.gitlab/docker_common/publish_job_templates.yml
+++ b/.gitlab/docker_common/publish_job_templates.yml
@@ -14,7 +14,7 @@
   before_script:
     - export COMMIT_TIME=$(git show -s --format=%ct $CI_COMMIT_SHA)
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
-    - source /root/.bashrc
+    - source /etc/profile
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
     - ECR_RELEASE_SUFFIX="${CI_COMMIT_TAG+-release}"
     - IMG_VARIABLES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_VARIABLES")"

--- a/.gitlab/install_script_testing.yml
+++ b/.gitlab/install_script_testing.yml
@@ -4,7 +4,7 @@ test_install_script:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   script:
-    - source /root/.bashrc
+    - source /etc/profile
     - set +x
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
     - export APT_URL=$DEB_TESTING_S3_BUCKET

--- a/.gitlab/integration_test.yml
+++ b/.gitlab/integration_test.yml
@@ -10,7 +10,7 @@ dogstatsd_x64_size_test:
   tags: ["arch:amd64"]
   needs: ["build_dogstatsd_static-binary_x64"]
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - mkdir -p $STATIC_BINARIES_DIR
     - $S3_CP_CMD $S3_ARTIFACTS_URI/static/dogstatsd.amd64 $STATIC_BINARIES_DIR/dogstatsd
   script:

--- a/.gitlab/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy.yml
@@ -23,7 +23,7 @@ docker_trigger_internal:
     TMPL_SRC_REPO: ci/datadog-agent/agent
     RELEASE_STAGING: "true"
   script:
-    - source /root/.bashrc
+    - source /etc/profile
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
     - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_SRC_REPO="${TMPL_SRC_REPO}-release"; fi
     - if [ "$BUCKET_BRANCH" = "nightly" ]; then RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi
@@ -52,7 +52,7 @@ docker_trigger_cluster_agent_internal:
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"
   script:
-    - source /root/.bashrc
+    - source /etc/profile
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
     - if [ "$BUCKET_BRANCH" = "beta" ] || [ "$BUCKET_BRANCH" = "stable" ]; then TMPL_SRC_REPO="${TMPL_SRC_REPO}-release"; fi
     - if [ "$BUCKET_BRANCH" = "nightly" ]; then RELEASE_TAG="${RELEASE_TAG}-${CI_COMMIT_SHORT_SHA}"; fi

--- a/.gitlab/internal_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy.yml
@@ -27,6 +27,6 @@ internal_kubernetes_deploy_experimental:
     WORKFLOW: "agents"
     FILTER: "cluster.env == 'experimental' and cluster.shortName == 'snowver'"
   script:
-    - source /root/.bashrc
+    - source /etc/profile
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/k8s-datadog-agent-ops" --git-ref "main" --variables "OPTION_AUTOMATIC_ROLLOUT,WORKFLOW,OPTION_PRE_SCRIPT,FILTER,SKIP_PLAN_CHECK"

--- a/.gitlab/notify.yml
+++ b/.gitlab/notify.yml
@@ -48,7 +48,7 @@ send_pipeline_stats:
   when: always
   dependencies: []
   script:
-    - source /root/.bashrc
+    - source /etc/profile
     - set +x
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_read_api_token --with-decryption --query "Parameter.Value" --out text)
     - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -8,7 +8,7 @@
 
 .agent_build_common_deb:
   script:
-    - source /root/.bashrc
+    - source /etc/profile
     - !reference [.setup_ruby_mirror_linux]
     - !reference [.setup_python_mirror_linux]
     - !reference [.retrieve_linux_go_deps]
@@ -143,7 +143,7 @@ agent_deb-arm64-a7:
 
 .iot_agent_build_common_deb:
   script:
-    - source /root/.bashrc
+    - source /etc/profile
     - !reference [.setup_ruby_mirror_linux]
     - !reference [.setup_python_mirror_linux]
     - !reference [.retrieve_linux_go_deps]
@@ -216,7 +216,7 @@ dogstatsd_deb-x64:
   needs: ["go_mod_tidy_check", "build_dogstatsd-binary_x64", "go_deps"]
   variables:
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - !reference [.retrieve_linux_go_deps]
   script:
     # remove artifacts from previous pipelines that may come from the cache
@@ -243,7 +243,7 @@ dogstatsd_deb-arm64:
   tags: ["arch:arm64"]
   needs: ["go_mod_tidy_check", "build_dogstatsd-binary_arm64", "go_deps"]
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - !reference [.retrieve_linux_go_deps]
   script:
     # remove artifacts from previous pipelines that may come from the cache

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -32,5 +32,5 @@ agent_dmg-x64-a7:
     AGENT_MAJOR_VERSION: 7
     PYTHON_RUNTIMES: '3'
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - export RELEASE_VERSION=$RELEASE_VERSION_7

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -82,7 +82,7 @@ agent_rpm-x64-a6:
     PYTHON_RUNTIMES: '2,3'
     PACKAGE_ARCH: amd64
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - export RELEASE_VERSION=$RELEASE_VERSION_6
 
 # build Agent package for rpm-x64
@@ -99,7 +99,7 @@ agent_rpm-x64-a7:
     PYTHON_RUNTIMES: '3'
     PACKAGE_ARCH: amd64
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - export RELEASE_VERSION=$RELEASE_VERSION_7
 
 # build Agent package for rpm-arm64
@@ -116,7 +116,7 @@ agent_rpm-arm64-a6:
     PYTHON_RUNTIMES: '2,3'
     PACKAGE_ARCH: arm64
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - export RELEASE_VERSION=$RELEASE_VERSION_6
 
 # build Agent package for rpm-arm64
@@ -133,13 +133,13 @@ agent_rpm-arm64-a7:
     PYTHON_RUNTIMES: '3'
     PACKAGE_ARCH: arm64
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - export RELEASE_VERSION=$RELEASE_VERSION_7
 
 .iot_agent_build_common_rpm:
   script:
     - echo "About to build iot agent for $RELEASE_VERSION_7"
-    - source /root/.bashrc
+    - source /etc/profile
     - !reference [.setup_ruby_mirror_linux]
     - !reference [.setup_python_mirror_linux]
     - !reference [.retrieve_linux_go_deps]
@@ -208,7 +208,7 @@ dogstatsd_rpm-x64:
   needs: ["go_mod_tidy_check", "build_dogstatsd-binary_x64", "go_deps"]
   variables:
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - !reference [.retrieve_linux_go_deps]
   script:
     # remove artifacts from previous pipelines that may come from the cache

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -84,7 +84,7 @@ agent_suse-x64-a6:
     PYTHON_RUNTIMES: '2,3'
     PACKAGE_ARCH: amd64
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - export RELEASE_VERSION=$RELEASE_VERSION_6
 
 # build Agent package for suse-x64
@@ -101,7 +101,7 @@ agent_suse-x64-a7:
     PYTHON_RUNTIMES: '3'
     PACKAGE_ARCH: amd64
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - export RELEASE_VERSION=$RELEASE_VERSION_7
 
 iot_agent_suse-x64:
@@ -112,7 +112,7 @@ iot_agent_suse-x64:
   tags: ["arch:amd64"]
   needs: ["go_mod_tidy_check", "go_deps"]
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
   script:
     - echo "About to build iot agent for $RELEASE_VERSION_7"
     - !reference [.setup_ruby_mirror_linux]
@@ -150,7 +150,7 @@ dogstatsd_suse-x64:
   needs: ["go_mod_tidy_check", "build_dogstatsd-binary_x64", "go_deps"]
   variables:
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - !reference [.retrieve_linux_go_deps]
   script:
     # remove artifacts from previous pipelines that may come from the cache

--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -51,7 +51,7 @@ send_pkg_size-a6:
     - ls -l $OMNIBUS_PACKAGE_DIR
     - ls -l $OMNIBUS_PACKAGE_DIR_SUSE
   script:
-    - source /root/.bashrc
+    - source /etc/profile
     - mkdir -p /tmp/deb/amd64-agent
     - mkdir -p /tmp/deb/arm64-agent
     - mkdir -p /tmp/rpm/amd64-agent
@@ -119,10 +119,10 @@ send_pkg_size-a7:
     - ls -l $OMNIBUS_PACKAGE_DIR
     - ls -l $OMNIBUS_PACKAGE_DIR_SUSE
   script:
-    - source /root/.bashrc
+    - source /etc/profile
     - !reference [.add_metric_func, script]
 
-    - source /root/.bashrc
+    - source /etc/profile
     - mkdir -p /tmp/amd64-deb/agent /tmp/amd64-deb/dogstatsd /tmp/amd64-deb/iot-agent /tmp/amd64-deb/heroku-agent
     - mkdir -p /tmp/arm64-deb/agent /tmp/arm64-deb/dogstatsd /tmp/arm64-deb/iot-agent
     - mkdir -p /tmp/amd64-rpm/agent /tmp/amd64-rpm/dogstatsd /tmp/amd64-rpm/iot-agent
@@ -194,13 +194,13 @@ send_pkg_size-a7:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   script:
-    - source /root/.bashrc
+    - source /etc/profile
     - !reference [.add_metric_func, script]
 
     - ls -l $OMNIBUS_PACKAGE_DIR
     - if [[ "${ARCH}" == "amd64" ]]; then ls -l $OMNIBUS_PACKAGE_DIR_SUSE; fi
 
-    - source /root/.bashrc
+    - source /etc/profile
     - export failures=0
     - export last_stable=$(inv release.get-release-json-value "last_stable::${MAJOR_VERSION}")
     # Get stable packages from S3 buckets, send new package sizes & compare stable and new package sizes

--- a/.gitlab/setup/setup.yml
+++ b/.gitlab/setup/setup.yml
@@ -4,7 +4,7 @@ setup_agent_version:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   script:
-    - source /root/.bashrc
+    - source /etc/profile
     - inv -e agent.version --version-cached
     - $S3_CP_CMD $CI_PROJECT_DIR/agent-version.cache $S3_ARTIFACTS_URI/agent-version.cache
 

--- a/.gitlab/source_test/golang_deps_generate.yml
+++ b/.gitlab/source_test/golang_deps_generate.yml
@@ -9,7 +9,7 @@ golang_deps_generate:
   tags: ["arch:amd64"]
   needs: ["go_deps"]
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - !reference [.retrieve_linux_go_deps]
   script:
     - inv agent.build-dep-tree

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -2,7 +2,7 @@
 .rtloader_tests:
   stage: source_test
   before_script:
-    - source /root/.bashrc && conda activate $CONDA_ENV
+    - source /etc/profile && conda activate $CONDA_ENV
     - !reference [.retrieve_linux_go_deps]
     - inv -e rtloader.make --install-prefix=$CI_PROJECT_DIR/dev --python-runtimes "$PYTHON_RUNTIMES"
     - inv -e rtloader.install
@@ -45,7 +45,7 @@
   script:
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
-    - source /root/.bashrc && conda activate ddpy3
+    - source /etc/profile && conda activate ddpy3
     - inv -e rtloader.make --install-prefix=$CI_PROJECT_DIR/dev --python-runtimes "3"
     - inv -e rtloader.install
     - inv -e install-tools
@@ -244,7 +244,7 @@ go_mod_tidy_check:
   tags: ["arch:amd64"]
   needs: ["go_deps"]
   before_script:
-    - source /root/.bashrc
+    - source /etc/profile
     - !reference [.retrieve_linux_go_deps]
   script:
     - inv -e check-mod-tidy

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -8,7 +8,7 @@ tests_macos:
   variables:
     PYTHON_RUNTIMES: '3'
   script:
-    - source /root/.bashrc
+    - source /etc/profile
     - export GITHUB_KEY_B64=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_key_b64 --with-decryption --query "Parameter.Value" --out text)
     - export GITHUB_APP_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_app_id --with-decryption --query "Parameter.Value" --out text)
     - export GITHUB_INSTALLATION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_installation_id --with-decryption --query "Parameter.Value" --out text)

--- a/.gitlab/source_test/slack.yml
+++ b/.gitlab/source_test/slack.yml
@@ -6,7 +6,7 @@ slack_teams_channels_check:
   tags: ["arch:amd64"]
   needs: []
   script:
-    - source /root/.bashrc
+    - source /etc/profile
     - python3 -m pip install codeowners
     - inv -e pipeline.check-notify-teams
 

--- a/.gitlab/trigger_release.yml
+++ b/.gitlab/trigger_release.yml
@@ -18,7 +18,7 @@
   script:
     # agent-release-management creates pipeline for both Agent 6 and Agent 7
     # when triggered with major version 7
-    - source /root/.bashrc
+    - source /etc/profile
     - export RELEASE_VERSION=$(inv agent.version --major-version 7 --url-safe --omnibus-format)-1
     - inv pipeline.trigger-child-pipeline --no-follow --project-name "DataDog/agent-release-management" --git-ref "main" --variables "ACTION,AUTO_RELEASE,BUILD_PIPELINE_ID,RELEASE_PRODUCT,RELEASE_VERSION,TARGET_REPO,TARGET_REPO_BRANCH"
   dependencies: []


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR sources `/etc/profile` instead of `/root/.bashrc` for jobs runnings on k8s

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

/etc/profile will source the user's .bashrc as well, and will in addition source /etc/profile.d/*.sh
In most cases it doesn't make much difference, but RVM puts its configuration in /etc/profile.d, causing k8s runners not to be able to find ruby tools (as they ignore entrypoints, which was executing the commands through a login shell, which sources /etc/profile automatically)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
