### PR TITLE
Move cleanup before stack creation to be sure it is called

### DIFF
--- a/test/new-e2e/containers/eks_test.go
+++ b/test/new-e2e/containers/eks_test.go
@@ -39,7 +39,6 @@ func TestEKSSuite(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		fmt.Println("EKS CLEANUP CALLED")
 		infra.GetStackManager().DeleteStack(ctx, "eks-cluster")
 	})
 

--- a/test/new-e2e/containers/eks_test.go
+++ b/test/new-e2e/containers/eks_test.go
@@ -38,12 +38,13 @@ func TestEKSSuite(t *testing.T) {
 		"ddtestworkload:deploy": auto.ConfigValue{Value: "true"},
 	}
 
-	_, stackOutput, err := infra.GetStackManager().GetStack(ctx, "eks-cluster", stackConfig, eks.Run, false)
-	require.NoError(t, err)
-
 	t.Cleanup(func() {
+		fmt.Println("EKS CLEANUP CALLED")
 		infra.GetStackManager().DeleteStack(ctx, "eks-cluster")
 	})
+
+	_, stackOutput, err := infra.GetStackManager().GetStack(ctx, "eks-cluster", stackConfig, eks.Run, false)
+	require.NoError(t, err)
 
 	fakeintakeHost := stackOutput.Outputs["fakeintake-host"].Value.(string)
 	kubeconfig, err := json.Marshal(stackOutput.Outputs["kubeconfig"].Value.(map[string]interface{}))

--- a/test/new-e2e/containers/kindvm_test.go
+++ b/test/new-e2e/containers/kindvm_test.go
@@ -36,13 +36,12 @@ func TestKindSuite(t *testing.T) {
 		"ddagent:fakeintake":    auto.ConfigValue{Value: "true"},
 		"ddtestworkload:deploy": auto.ConfigValue{Value: "true"},
 	}
-
-	_, stackOutput, err := infra.GetStackManager().GetStack(ctx, "kind-cluster", stackConfig, kindvm.Run, false)
-	require.NoError(t, err)
-
 	t.Cleanup(func() {
+		fmt.Println("KIND CLEANUP CALLED")
 		infra.GetStackManager().DeleteStack(ctx, "kind-cluster")
 	})
+	_, stackOutput, err := infra.GetStackManager().GetStack(ctx, "kind-cluster", stackConfig, kindvm.Run, false)
+	require.NoError(t, err)
 
 	fakeintakeHost := stackOutput.Outputs["fakeintake-host"].Value.(string)
 	kubeconfig := stackOutput.Outputs["kubeconfig"].Value.(string)

--- a/test/new-e2e/containers/kindvm_test.go
+++ b/test/new-e2e/containers/kindvm_test.go
@@ -36,10 +36,11 @@ func TestKindSuite(t *testing.T) {
 		"ddagent:fakeintake":    auto.ConfigValue{Value: "true"},
 		"ddtestworkload:deploy": auto.ConfigValue{Value: "true"},
 	}
+
 	t.Cleanup(func() {
-		fmt.Println("KIND CLEANUP CALLED")
 		infra.GetStackManager().DeleteStack(ctx, "kind-cluster")
 	})
+
 	_, stackOutput, err := infra.GetStackManager().GetStack(ctx, "kind-cluster", stackConfig, kindvm.Run, false)
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Call t.cleanUp earlier to ensure it is called even if Pulumi stack creation did not succeed totally
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

For now if Pulumi up fail during creating resources, cleanup will not be called which will cause resources to be leaked

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
