### PR TITLE
[usm] Fix summary message for `Gauge` types

### DIFF
--- a/pkg/network/protocols/telemetry/metric.go
+++ b/pkg/network/protocols/telemetry/metric.go
@@ -38,6 +38,10 @@ func (c *Counter) Add(v int64) {
 	c.value.Add(v)
 }
 
+func (c *Counter) base() *metricBase {
+	return c.metricBase
+}
+
 // Gauge is a metric that represents a numerical value that can arbitrarily go up and down
 type Gauge struct {
 	*metricBase
@@ -60,6 +64,10 @@ func (g *Gauge) Set(v int64) {
 // Add value atomically
 func (g *Gauge) Add(v int64) {
 	g.value.Add(v)
+}
+
+func (g *Gauge) base() *metricBase {
+	return g.metricBase
 }
 
 type metricBase struct {
@@ -90,16 +98,9 @@ func (m *metricBase) Get() int64 {
 	return m.value.Load()
 }
 
-// this method is used to essentially convert the `metric`
-// interface to the underlying `metricBase` in the code
-// that has to deal with both `Counter` and `Gauge` types
-func (m *metricBase) base() *metricBase {
-	return m
-}
-
 // metric is the private interface shared by `Counter` and `Gauge`
 // the base() method simply returns the embedded `*metricBase` struct
-// which is all we need in the internal code
+// which is all we need in the internal code that has to deal with both types
 type metric interface {
 	base() *metricBase
 }

--- a/pkg/network/protocols/telemetry/metric_group.go
+++ b/pkg/network/protocols/telemetry/metric_group.go
@@ -97,12 +97,11 @@ func (mg *MetricGroup) Summary() string {
 
 	valueDeltas := mg.deltas.GetState("")
 	var b strings.Builder
-	for _, metric := range mg.metrics {
-		m := metric.base()
-		_, name := splitName(m)
-		v := valueDeltas.ValueFor(m)
+	for i, metric := range mg.metrics {
+		_, name := splitName(metric)
+		v := valueDeltas.ValueFor(metric)
 
-		uniqueTags := m.tags.Difference(mg.commonTags)
+		uniqueTags := metric.base().tags.Difference(mg.commonTags)
 		if uniqueTags.Len() > 0 {
 			// if the metric has tags print them but excluding the ones that are
 			// common to the metric group
@@ -115,7 +114,10 @@ func (mg *MetricGroup) Summary() string {
 		if _, ok := metric.(*Counter); ok {
 			b.WriteString(fmt.Sprintf("(%.2f/s)", float64(v)/timeDelta))
 		}
-		b.WriteByte(' ')
+
+		if i < len(mg.metrics)-1 {
+			b.WriteByte(' ')
+		}
 	}
 	mg.then = now
 	return b.String()

--- a/pkg/network/protocols/telemetry/metric_group_test.go
+++ b/pkg/network/protocols/telemetry/metric_group_test.go
@@ -39,3 +39,17 @@ func TestMetricGroupSummary(t *testing.T) {
 		metricGroup.Summary(),
 	)
 }
+
+func TestGaugeSummaryRegression(t *testing.T) {
+	Clear()
+
+	metricGroup := NewMetricGroup("foo")
+	gauge := metricGroup.NewGauge("cache_size")
+	gauge.Set(50)
+
+	assert.Equal(t, "cache_size=50", metricGroup.Summary())
+
+	// Assert a second time that the value hasn't changed
+	// (for gauge types we don't want to print the delta, just the actual number)
+	assert.Equal(t, "cache_size=50", metricGroup.Summary())
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix how `*telemetry.Gauge` metrics are reported in the `MetricGroup.Summary()` message.
Prior to this change we were accidentally calculating the delta (which is only desired for Counters) instead of printing the actual value.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

The bug had to do with the fact that we were doing a type assertion over the `metricBase` struct instead of a `Gauge` type.
This happened because both `*Counter`, `*Gauge` and `metricBase` implemented the `metric` interface. This change removes that ambiguity and only `*Counter` and `*Gauge` types implement the aforementioned interface.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
