### PR TITLE
[corechecks/containers] Add "container.memory.peak" metric

### DIFF
--- a/pkg/collector/corechecks/containers/generic/processor.go
+++ b/pkg/collector/corechecks/containers/generic/processor.go
@@ -169,6 +169,7 @@ func (p *Processor) processContainer(sender sender.Sender, tags []string, contai
 		p.sendMetric(sender.Gauge, "container.memory.working_set", containerStats.Memory.PrivateWorkingSet, tags) // Windows
 		p.sendMetric(sender.Gauge, "container.memory.commit", containerStats.Memory.CommitBytes, tags)
 		p.sendMetric(sender.Gauge, "container.memory.commit.peak", containerStats.Memory.CommitPeakBytes, tags)
+		p.sendMetric(sender.Gauge, "container.memory.peak", containerStats.Memory.Peak, tags)
 		p.sendMetric(sender.Rate, "container.memory.partial_stall", containerStats.Memory.PartialStallTime, tags)
 	}
 

--- a/pkg/collector/corechecks/containers/generic/processor_test.go
+++ b/pkg/collector/corechecks/containers/generic/processor_test.go
@@ -37,7 +37,7 @@ func TestProcessorRunFullStatsLinux(t *testing.T) {
 
 	expectedTags := []string{"runtime:docker"}
 	mockSender.AssertNumberOfCalls(t, "Rate", 20)
-	mockSender.AssertNumberOfCalls(t, "Gauge", 15)
+	mockSender.AssertNumberOfCalls(t, "Gauge", 16)
 
 	mockSender.AssertMetricInRange(t, "Gauge", "container.uptime", 0, 600, "", expectedTags)
 	mockSender.AssertMetric(t, "Rate", "container.cpu.usage", 100, "", expectedTags)
@@ -57,6 +57,7 @@ func TestProcessorRunFullStatsLinux(t *testing.T) {
 	mockSender.AssertMetric(t, "Gauge", "container.memory.working_set", 350, "", expectedTags)
 	mockSender.AssertMetric(t, "Gauge", "container.memory.swap", 0, "", expectedTags)
 	mockSender.AssertMetric(t, "Gauge", "container.memory.oom_events", 10, "", expectedTags)
+	mockSender.AssertMetric(t, "Gauge", "container.memory.peak", 50000, "", expectedTags)
 	mockSender.AssertMetric(t, "Rate", "container.memory.partial_stall", 97000, "", expectedTags)
 
 	mockSender.AssertMetric(t, "Rate", "container.io.partial_stall", 98000, "", expectedTags)

--- a/pkg/util/cgroups/cgroupv1_memory.go
+++ b/pkg/util/cgroups/cgroupv1_memory.go
@@ -88,6 +88,10 @@ func (c *cgroupV1) GetMemoryStats(stats *MemoryStats) error {
 		reportError(err)
 	}
 
+	if err := parseSingleUnsignedStat(c.fr, c.pathFor("memory", "memory.max_usage_in_bytes"), &stats.Peak); err != nil {
+		reportError(err)
+	}
+
 	if err := parseSingleUnsignedStat(c.fr, c.pathFor("memory", "memory.failcnt"), &stats.OOMEvents); err != nil {
 		reportError(err)
 	}

--- a/pkg/util/cgroups/cgroupv1_memory_test.go
+++ b/pkg/util/cgroups/cgroupv1_memory_test.go
@@ -57,6 +57,7 @@ total_unevictable 0`
 	sampleMemoryFailCnt   = "0"
 	sampleMemoryKmemUsage = "4444160"
 	sampleMemorySoftLimit = "9223372036854771712" // No limit
+	sampleMaxUsageInBytes = "400000000"
 )
 
 func createCgroupV1FakeMemoryFiles(cfs *cgroupMemoryFS, cg *cgroupV1) {
@@ -65,6 +66,7 @@ func createCgroupV1FakeMemoryFiles(cfs *cgroupMemoryFS, cg *cgroupV1) {
 	cfs.setCgroupV1File(cg, "memory", "memory.failcnt", sampleMemoryFailCnt)
 	cfs.setCgroupV1File(cg, "memory", "memory.kmem.usage_in_bytes", sampleMemoryKmemUsage)
 	cfs.setCgroupV1File(cg, "memory", "memory.soft_limit_in_bytes", sampleMemorySoftLimit)
+	cfs.setCgroupV1File(cg, "memory", "memory.max_usage_in_bytes", sampleMaxUsageInBytes)
 }
 
 func TestCgroupV1MemoryStats(t *testing.T) {
@@ -84,7 +86,7 @@ func TestCgroupV1MemoryStats(t *testing.T) {
 	cfs.enableControllers("memory")
 	err = cgFoo1.GetMemoryStats(stats)
 	assert.NoError(t, err)
-	assert.Equal(t, len(tr.errors), 5)
+	assert.Equal(t, len(tr.errors), 6)
 	assert.Equal(t, "", cmp.Diff(MemoryStats{}, *stats))
 
 	// Test reading files in memory controller, all files present
@@ -112,5 +114,6 @@ func TestCgroupV1MemoryStats(t *testing.T) {
 		OOMEvents:    pointer.Ptr(uint64(0)),
 		Limit:        pointer.Ptr(uint64(67108864)),
 		KernelMemory: pointer.Ptr(uint64(4444160)),
+		Peak:         pointer.Ptr(uint64(400000000)),
 	}, *stats))
 }

--- a/pkg/util/cgroups/cgroupv2_memory.go
+++ b/pkg/util/cgroups/cgroupv2_memory.go
@@ -94,6 +94,11 @@ func (c *cgroupV2) GetMemoryStats(stats *MemoryStats) error {
 	}
 	nilIfZero(&stats.Limit)
 
+	if err := parseSingleUnsignedStat(c.fr, c.pathFor("memory.peak"), &stats.Peak); err != nil {
+		reportError(err)
+	}
+	nilIfZero(&stats.Peak)
+
 	if err := parseSingleUnsignedStat(c.fr, c.pathFor("memory.swap.current"), &stats.Swap); err != nil {
 		reportError(err)
 	}

--- a/pkg/util/cgroups/cgroupv2_memory_test.go
+++ b/pkg/util/cgroups/cgroupv2_memory_test.go
@@ -61,6 +61,7 @@ thp_collapse_alloc 0`
 	sampleCgroupV2MemoryLow         = "0"
 	sampleCgroupV2MemoryHigh        = "max"
 	sampleCgroupV2MemoryMax         = "max"
+	sampleCgroupV2MemoryPeak        = "7000000"
 	sampleCgroupV2MemorySwapCurrent = "0"
 	sampleCgroupV2MemorySwapHigh    = "max"
 	sampleCgroupV2MemorySwapMax     = "max"
@@ -80,6 +81,7 @@ func createCgroupV2FakeMemoryFiles(cfs *cgroupMemoryFS, cg *cgroupV2) {
 	cfs.setCgroupV2File(cg, "memory.low", sampleCgroupV2MemoryLow)
 	cfs.setCgroupV2File(cg, "memory.high", sampleCgroupV2MemoryHigh)
 	cfs.setCgroupV2File(cg, "memory.max", sampleCgroupV2MemoryMax)
+	cfs.setCgroupV2File(cg, "memory.peak", sampleCgroupV2MemoryPeak)
 	cfs.setCgroupV2File(cg, "memory.swap.current", sampleCgroupV2MemorySwapCurrent)
 	cfs.setCgroupV2File(cg, "memory.swap.high", sampleCgroupV2MemorySwapHigh)
 	cfs.setCgroupV2File(cg, "memory.swap.max", sampleCgroupV2MemorySwapMax)
@@ -104,7 +106,7 @@ func TestCgroupV2MemoryStats(t *testing.T) {
 	cfs.enableControllers("memory")
 	err = cgFoo1.GetMemoryStats(stats)
 	assert.NoError(t, err)
-	assert.Equal(t, len(tr.errors), 11)
+	assert.Equal(t, len(tr.errors), 12)
 	assert.Empty(t, cmp.Diff(MemoryStats{}, *stats))
 
 	// Test reading files in memory controllers, all files present
@@ -130,6 +132,7 @@ func TestCgroupV2MemoryStats(t *testing.T) {
 		KernelMemory:  pointer.Ptr(uint64(49152)),
 		OOMEvents:     pointer.Ptr(uint64(3)),
 		OOMKiilEvents: pointer.Ptr(uint64(0)),
+		Peak:          pointer.Ptr(uint64(7000000)),
 		PSISome: PSIStats{
 			Avg10:  pointer.Ptr(0.0),
 			Avg60:  pointer.Ptr(0.0),

--- a/pkg/util/cgroups/stats.go
+++ b/pkg/util/cgroups/stats.go
@@ -56,6 +56,8 @@ type MemoryStats struct {
 	SwapLimit         *uint64 // Memory+Swap (thus >= Limit)
 	SwapHighThreshold *uint64 // cgroupv2 only
 
+	Peak *uint64 // cgroupv1: mapped to max_usage_in_bytes. cgroupv2: peak.
+
 	PSISome PSIStats
 	PSIFull PSIStats
 }

--- a/pkg/util/containers/metrics/mock/mock_samples.go
+++ b/pkg/util/containers/metrics/mock/mock_samples.go
@@ -52,6 +52,7 @@ func GetFullSampleContainerEntry() ContainerEntry {
 				Swap:             pointer.Ptr(0.0),
 				OOMEvents:        pointer.Ptr(10.0),
 				PartialStallTime: pointer.Ptr(97000.0),
+				Peak:             pointer.Ptr(50000.0),
 			},
 			IO: &metrics.ContainerIOStats{
 				Devices: map[string]metrics.DeviceIOStats{

--- a/pkg/util/containers/metrics/provider/types.go
+++ b/pkg/util/containers/metrics/provider/types.go
@@ -27,6 +27,7 @@ type ContainerMemStats struct {
 	Cache            *float64
 	OOMEvents        *float64 // Number of events where memory allocation failed
 	PartialStallTime *float64 // Correspond to PSI Some total
+	Peak             *float64
 
 	// Windows-only fields
 	PrivateWorkingSet *float64

--- a/pkg/util/containers/metrics/system/collector_linux.go
+++ b/pkg/util/containers/metrics/system/collector_linux.go
@@ -230,6 +230,7 @@ func buildMemoryStats(cgs *cgroups.MemoryStats) *provider.ContainerMemStats {
 	convertField(cgs.Swap, &cs.Swap)
 	convertField(cgs.SwapLimit, &cs.SwapLimit)
 	convertField(cgs.OOMEvents, &cs.OOMEvents)
+	convertField(cgs.Peak, &cs.Peak)
 	convertFieldAndUnit(cgs.PSISome.Total, &cs.PartialStallTime, float64(time.Microsecond))
 
 	// Compute complex fields

--- a/pkg/util/containers/metrics/system/collector_linux_test.go
+++ b/pkg/util/containers/metrics/system/collector_linux_test.go
@@ -67,6 +67,7 @@ func TestBuildContainerMetrics(t *testing.T) {
 					Swap:         pointer.Ptr(uint64(0)),
 					SwapLimit:    pointer.Ptr(uint64(500)),
 					OOMEvents:    pointer.Ptr(uint64(10)),
+					Peak:         pointer.Ptr(uint64(1024)),
 					PSISome: cgroups.PSIStats{
 						Total: pointer.Ptr(uint64(97)),
 					},
@@ -119,6 +120,7 @@ func TestBuildContainerMetrics(t *testing.T) {
 					SwapLimit:        pointer.Ptr(500.0),
 					OOMEvents:        pointer.Ptr(10.0),
 					PartialStallTime: pointer.Ptr(97000.0),
+					Peak:             pointer.Ptr(1024.0),
 				},
 				IO: &provider.ContainerIOStats{
 					ReadBytes:        pointer.Ptr(100.0),

--- a/releasenotes/notes/cgroups-add-memory-peak-e778afb88911bdcb.yaml
+++ b/releasenotes/notes/cgroups-add-memory-peak-e778afb88911bdcb.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added the ``container.memory.peak`` metric to the container check. It shows the maximum memory usage recorded since the container started.


### PR DESCRIPTION
### What does this PR do?

Adds the `container.memory.peak` metric to the container check. It shows the maximum memory usage recorded since the container started.

This metric relies on cgroups. It's `memory.max_usage_in_bytes` in cgroups v1 and `memory.peak` in v2.


### Describe how to test/QA your changes

Check that the `container.memory.peak` metric is reported by the container check.
Needs to be verified in an environment with cgroups v1 and another with v2 (`memory.peak` was added in linux kernel v5.19). I can share details about my test env.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
