### PR TITLE
[serverless-init] .NET log buffering logic

### DIFF
--- a/cmd/serverless-init/initcontainer/initcontainer.go
+++ b/cmd/serverless-init/initcontainer/initcontainer.go
@@ -52,8 +52,12 @@ func execute(cloudService cloudservice.CloudService, config *serverlessLog.Confi
 
 	cmd := exec.Command(commandName, commandArgs...)
 	cmd.Stdout = &serverlessLog.CustomWriter{
-		LogConfig:    config,
-		LineBuffer:   bytes.Buffer{},
+		LogConfig:  config,
+		LineBuffer: bytes.Buffer{},
+		// Dotnet occasionally writes to stdout in multiple chunks causing log splitting issues.
+		// This happens regardless of logging library (and happens with Console.WriteLine).
+		// ShouldBuffer tells the CustomWriter to buffer all log chunks that don't end in a newline,
+		// fixing log splitting in this scenario.
 		ShouldBuffer: commandName == "dotnet",
 	}
 	cmd.Stderr = &serverlessLog.CustomWriter{

--- a/cmd/serverless-init/initcontainer/initcontainer.go
+++ b/cmd/serverless-init/initcontainer/initcontainer.go
@@ -8,6 +8,7 @@
 package initcontainer
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -51,11 +52,15 @@ func execute(cloudService cloudservice.CloudService, config *serverlessLog.Confi
 
 	cmd := exec.Command(commandName, commandArgs...)
 	cmd.Stdout = &serverlessLog.CustomWriter{
-		LogConfig: config,
+		LogConfig: 	config,
+		LineBuffer: bytes.Buffer{},
+		IsDotnet: 	commandName == "dotnet",
 	}
 	cmd.Stderr = &serverlessLog.CustomWriter{
-		LogConfig: config,
-		IsError:   true,
+		LogConfig: 	config,
+		LineBuffer: bytes.Buffer{},
+		IsDotnet: 	commandName == "dotnet",
+		IsError:   	true,
 	}
 	err := cmd.Start()
 	if err != nil {

--- a/cmd/serverless-init/initcontainer/initcontainer.go
+++ b/cmd/serverless-init/initcontainer/initcontainer.go
@@ -52,15 +52,15 @@ func execute(cloudService cloudservice.CloudService, config *serverlessLog.Confi
 
 	cmd := exec.Command(commandName, commandArgs...)
 	cmd.Stdout = &serverlessLog.CustomWriter{
-		LogConfig: 	config,
+		LogConfig:  config,
 		LineBuffer: bytes.Buffer{},
-		IsDotnet: 	commandName == "dotnet",
+		IsDotnet:   commandName == "dotnet",
 	}
 	cmd.Stderr = &serverlessLog.CustomWriter{
-		LogConfig: 	config,
+		LogConfig:  config,
 		LineBuffer: bytes.Buffer{},
-		IsDotnet: 	commandName == "dotnet",
-		IsError:   	true,
+		IsDotnet:   commandName == "dotnet",
+		IsError:    true,
 	}
 	err := cmd.Start()
 	if err != nil {

--- a/cmd/serverless-init/initcontainer/initcontainer.go
+++ b/cmd/serverless-init/initcontainer/initcontainer.go
@@ -52,15 +52,15 @@ func execute(cloudService cloudservice.CloudService, config *serverlessLog.Confi
 
 	cmd := exec.Command(commandName, commandArgs...)
 	cmd.Stdout = &serverlessLog.CustomWriter{
-		LogConfig:  config,
-		LineBuffer: bytes.Buffer{},
-		IsDotnet:   commandName == "dotnet",
+		LogConfig:    config,
+		LineBuffer:   bytes.Buffer{},
+		ShouldBuffer: commandName == "dotnet",
 	}
 	cmd.Stderr = &serverlessLog.CustomWriter{
-		LogConfig:  config,
-		LineBuffer: bytes.Buffer{},
-		IsDotnet:   commandName == "dotnet",
-		IsError:    true,
+		LogConfig:    config,
+		LineBuffer:   bytes.Buffer{},
+		ShouldBuffer: commandName == "dotnet",
+		IsError:      true,
 	}
 	err := cmd.Start()
 	if err != nil {

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -103,7 +103,7 @@ func (cw *CustomWriter) writeWithMaxBufferSize(p []byte, maxBufferSize int) (n i
 	fmt.Print(string(p))
 
 	if len(p) > maxBufferSize {
-		log.Errorf("Received a log chunk over %d. Truncating", maxBufferSize)
+		log.Errorf("Received a log chunk over %d kb. Truncating", maxBufferSize)
 		p = p[:maxBufferSize]
 	}
 
@@ -115,7 +115,7 @@ func (cw *CustomWriter) writeWithMaxBufferSize(p []byte, maxBufferSize int) (n i
 	// Prevent buffer overflow, flush the buffer if writing the current chunk
 	// will exceed maxBufferSize
 	if cw.LineBuffer.Len()+len(p) > maxBufferSize {
-		log.Errorf("Log buffer exceeds %d. Flushing log buffer\n", maxBufferSize)
+		log.Errorf("Log buffer exceeds %d kb. Flushing log buffer\n", maxBufferSize)
 		Write(cw.LogConfig, getByteArrayClone(cw.LineBuffer.Bytes()), cw.IsError)
 		cw.LineBuffer.Reset()
 	}

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -112,7 +112,7 @@ func (cw *CustomWriter) Write(p []byte) (n int, err error) {
 	// will exceed maxBufferSize
 	if cw.LineBuffer.Len()+len(p) > maxBufferSize {
 		fmt.Print(string(p))
-		Write(cw.LogConfig, []byte(cw.LineBuffer.String()), cw.IsError)
+		Write(cw.LogConfig, getByteArrayClone(cw.LineBuffer.Bytes()), cw.IsError)
 		cw.LineBuffer.Reset()
 	}
 
@@ -126,10 +126,16 @@ func (cw *CustomWriter) Write(p []byte) (n int, err error) {
 	}
 
 	fmt.Println(string(p))
-	Write(cw.LogConfig, []byte(cw.LineBuffer.String()), cw.IsError)
+	Write(cw.LogConfig, getByteArrayClone(cw.LineBuffer.Bytes()), cw.IsError)
 	cw.LineBuffer.Reset()
 
 	return len(p), nil
+}
+
+func getByteArrayClone(src []byte) []byte {
+	clone := make([]byte, len(src))
+	copy(clone, src)
+	return clone
 }
 
 func isEnabled(envValue string) bool {

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -101,7 +101,7 @@ func (cw *CustomWriter) Write(p []byte) (n int, err error) {
 	}
 
 	if !cw.IsDotnet {
-		fmt.Println(string(p))
+		fmt.Print(string(p))
 		Write(cw.LogConfig, p, cw.IsError)
 		return len(p), nil
 	}

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -39,10 +39,10 @@ type Config struct {
 
 // CustomWriter wraps the log config to allow stdout/stderr redirection
 type CustomWriter struct {
-	LogConfig 	*Config
-	LineBuffer 	bytes.Buffer
-	IsDotnet	bool
-	IsError   	bool
+	LogConfig  *Config
+	LineBuffer bytes.Buffer
+	IsDotnet   bool
+	IsError    bool
 }
 
 // CreateConfig builds and returns a log config
@@ -95,7 +95,7 @@ func SetupLog(conf *Config, tags map[string]string) {
 }
 
 func (cw *CustomWriter) Write(p []byte) (n int, err error) {
-	if (!cw.IsDotnet) {
+	if !cw.IsDotnet {
 		fmt.Println(string(p))
 		Write(cw.LogConfig, p, cw.IsError)
 		return len(p), nil
@@ -105,7 +105,7 @@ func (cw *CustomWriter) Write(p []byte) (n int, err error) {
 	// Otherwise, the chunk only represents part of a log. Push it into the buffer and wait
 	// for the rest of the log before flushing.
 	cw.LineBuffer.Write(p)
-	if (string(p[len(p)-1]) != "\n") {
+	if string(p[len(p)-1]) != "\n" {
 		fmt.Print(string(p))
 		return len(p), nil
 	}
@@ -113,7 +113,7 @@ func (cw *CustomWriter) Write(p []byte) (n int, err error) {
 	fmt.Println(string(p))
 	Write(cw.LogConfig, cw.LineBuffer.Bytes(), cw.IsError)
 	cw.LineBuffer.Reset()
-	
+
 	return len(p), nil
 }
 

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -115,7 +115,7 @@ func (cw *CustomWriter) writeWithMaxBufferSize(p []byte, maxBufferSize int) (n i
 	// Prevent buffer overflow, flush the buffer if writing the current chunk
 	// will exceed maxBufferSize
 	if cw.LineBuffer.Len()+len(p) > maxBufferSize {
-		log.Errorf("Log buffer exceeds %d kb. Flushing log buffer\n", maxBufferSize)
+		log.Errorf("Log buffer exceeds %d kb. Flushing log buffer", maxBufferSize)
 		Write(cw.LogConfig, getByteArrayClone(cw.LineBuffer.Bytes()), cw.IsError)
 		cw.LineBuffer.Reset()
 	}

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -40,10 +40,10 @@ type Config struct {
 
 // CustomWriter wraps the log config to allow stdout/stderr redirection
 type CustomWriter struct {
-	LogConfig  *Config
-	LineBuffer bytes.Buffer
-	IsDotnet   bool
-	IsError    bool
+	LogConfig    *Config
+	LineBuffer   bytes.Buffer
+	ShouldBuffer bool
+	IsError      bool
 }
 
 // CreateConfig builds and returns a log config
@@ -100,7 +100,7 @@ func (cw *CustomWriter) Write(p []byte) (n int, err error) {
 		p = p[:maxBufferSize]
 	}
 
-	if !cw.IsDotnet {
+	if !cw.ShouldBuffer {
 		fmt.Print(string(p))
 		Write(cw.LogConfig, p, cw.IsError)
 		return len(p), nil

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -103,6 +103,7 @@ func (cw *CustomWriter) writeWithMaxBufferSize(p []byte, maxBufferSize int) (n i
 	fmt.Print(string(p))
 
 	if len(p) > maxBufferSize {
+		log.Errorf("Received a log chunk over %d. Truncating", maxBufferSize)
 		p = p[:maxBufferSize]
 	}
 
@@ -114,6 +115,7 @@ func (cw *CustomWriter) writeWithMaxBufferSize(p []byte, maxBufferSize int) (n i
 	// Prevent buffer overflow, flush the buffer if writing the current chunk
 	// will exceed maxBufferSize
 	if cw.LineBuffer.Len()+len(p) > maxBufferSize {
+		log.Errorf("Log buffer exceeds %d. Flushing log buffer\n", maxBufferSize)
 		Write(cw.LogConfig, getByteArrayClone(cw.LineBuffer.Bytes()), cw.IsError)
 		cw.LineBuffer.Reset()
 	}

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -96,6 +96,10 @@ func SetupLog(conf *Config, tags map[string]string) {
 }
 
 func (cw *CustomWriter) Write(p []byte) (n int, err error) {
+	if len(p) > maxBufferSize {
+		p = p[:maxBufferSize]
+	}
+
 	if !cw.IsDotnet {
 		fmt.Println(string(p))
 		Write(cw.LogConfig, p, cw.IsError)
@@ -107,8 +111,8 @@ func (cw *CustomWriter) Write(p []byte) (n int, err error) {
 	// Prevent buffer overflow, flush the buffer if writing the current chunk
 	// will exceed maxBufferSize
 	if cw.LineBuffer.Len()+len(p) > maxBufferSize {
-		fmt.Println(string(p))
-		Write(cw.LogConfig, cw.LineBuffer.Bytes(), cw.IsError)
+		fmt.Print(string(p))
+		Write(cw.LogConfig, []byte(cw.LineBuffer.String()), cw.IsError)
 		cw.LineBuffer.Reset()
 	}
 
@@ -122,7 +126,7 @@ func (cw *CustomWriter) Write(p []byte) (n int, err error) {
 	}
 
 	fmt.Println(string(p))
-	Write(cw.LogConfig, cw.LineBuffer.Bytes(), cw.IsError)
+	Write(cw.LogConfig, []byte(cw.LineBuffer.String()), cw.IsError)
 	cw.LineBuffer.Reset()
 
 	return len(p), nil

--- a/cmd/serverless-init/log/log_test.go
+++ b/cmd/serverless-init/log/log_test.go
@@ -110,7 +110,9 @@ func TestCustomWriterShoudBufferOverflow(t *testing.T) {
 }
 
 func TestCustomWriterMaxBufferSize(t *testing.T) {
-	testContent := []byte(strings.Repeat("a", maxBufferSize+1))
+	testMaxBufferSize := 5
+
+	testContent := []byte(strings.Repeat("a", testMaxBufferSize+1))
 	config := &Config{
 		channel:   make(chan *config.ChannelMessage, 2),
 		isEnabled: true,
@@ -118,11 +120,11 @@ func TestCustomWriterMaxBufferSize(t *testing.T) {
 	cw := &CustomWriter{
 		LogConfig: config,
 	}
-	go cw.Write(testContent)
+	go cw.writeWithMaxBufferSize(testContent, testMaxBufferSize)
 	numMessages := 0
 	select {
 	case message := <-config.channel:
-		assert.Equal(t, []byte(strings.Repeat("a", maxBufferSize)), message.Content)
+		assert.Equal(t, []byte(strings.Repeat("a", testMaxBufferSize)), message.Content)
 		numMessages++
 	case <-time.After(100 * time.Millisecond):
 		t.FailNow()

--- a/cmd/serverless-init/log/log_test.go
+++ b/cmd/serverless-init/log/log_test.go
@@ -71,7 +71,7 @@ func TestCustomWriterDotnet(t *testing.T) {
 
 func TestCustomWriterDotnetBufferOverflow(t *testing.T) {
 	// Custom writer should buffer log chunks not ending in a newline when isDotnet: true
-	testContentChunk1 := []byte(strings.Repeat("a", 256*1024))
+	testContentChunk1 := []byte(strings.Repeat("a", maxBufferSize))
 	testContentChunk2 := []byte("b\n")
 	config := &Config{
 		channel:   make(chan *config.ChannelMessage, 2),
@@ -101,12 +101,12 @@ func TestCustomWriterDotnetBufferOverflow(t *testing.T) {
 	}
 
 	assert.Equal(t, 2, len(messages))
-	assert.Equal(t, []byte(strings.Repeat("a", 256*1024)), messages[0])
+	assert.Equal(t, []byte(strings.Repeat("a", maxBufferSize)), messages[0])
 	assert.Equal(t, []byte("b\n"), messages[1])
 }
 
 func TestCustomWriterMaxBufferSize(t *testing.T) {
-	testContent := []byte(strings.Repeat("a", 256*1024+1))
+	testContent := []byte(strings.Repeat("a", maxBufferSize+1))
 	config := &Config{
 		channel:   make(chan *config.ChannelMessage, 2),
 		isEnabled: true,
@@ -118,7 +118,7 @@ func TestCustomWriterMaxBufferSize(t *testing.T) {
 	numMessages := 0
 	select {
 	case message := <-config.channel:
-		assert.Equal(t, []byte(strings.Repeat("a", 256*1024)), message.Content)
+		assert.Equal(t, []byte(strings.Repeat("a", maxBufferSize)), message.Content)
 		numMessages++
 	case <-time.After(100 * time.Millisecond):
 		t.FailNow()

--- a/cmd/serverless-init/log/log_test.go
+++ b/cmd/serverless-init/log/log_test.go
@@ -69,7 +69,7 @@ func TestCustomWriterShouldBuffer(t *testing.T) {
 	assert.Equal(t, 1, numMessages)
 }
 
-func TestCustomWriterShoudBufferOverflow(t *testing.T) {
+func TestCustomWriterPreventBufferOverflow(t *testing.T) {
 	testMaxBufferSize := 5
 
 	testContentChunk1 := []byte(strings.Repeat("a", testMaxBufferSize))
@@ -109,7 +109,7 @@ func TestCustomWriterShoudBufferOverflow(t *testing.T) {
 	assert.Equal(t, []byte("b\n"), messages[1])
 }
 
-func TestCustomWriterMaxBufferSize(t *testing.T) {
+func TestCustomWriterLogChunkTruncation(t *testing.T) {
 	testMaxBufferSize := 5
 
 	testContent := []byte(strings.Repeat("a", testMaxBufferSize+1))

--- a/cmd/serverless-init/log/log_test.go
+++ b/cmd/serverless-init/log/log_test.go
@@ -7,7 +7,6 @@ package log
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -39,7 +38,7 @@ func TestCustomWriterUnbuffered(t *testing.T) {
 	assert.Equal(t, 1, numMessages)
 }
 
-func TestCustomWriterDotnet(t *testing.T) {
+func TestCustomWriterShouldBuffer(t *testing.T) {
 	// Custom writer should buffer log chunks not ending in a newline when isDotnet: true
 	testContentChunk1 := []byte("this is")
 	testContentChunk2 := []byte(" a log line\n")
@@ -48,9 +47,9 @@ func TestCustomWriterDotnet(t *testing.T) {
 		isEnabled: true,
 	}
 	cw := &CustomWriter{
-		LogConfig:  config,
-		LineBuffer: bytes.Buffer{},
-		IsDotnet:   true,
+		LogConfig:    config,
+		LineBuffer:   bytes.Buffer{},
+		ShouldBuffer: true,
 	}
 	go func() {
 		cw.Write(testContentChunk1)
@@ -69,7 +68,7 @@ func TestCustomWriterDotnet(t *testing.T) {
 	assert.Equal(t, 1, numMessages)
 }
 
-func TestCustomWriterDotnetBufferOverflow(t *testing.T) {
+func TestCustomWriterShoudBufferOverflow(t *testing.T) {
 	// Custom writer should buffer log chunks not ending in a newline when isDotnet: true
 	testContentChunk1 := []byte(strings.Repeat("a", maxBufferSize))
 	testContentChunk2 := []byte("b\n")
@@ -78,9 +77,9 @@ func TestCustomWriterDotnetBufferOverflow(t *testing.T) {
 		isEnabled: true,
 	}
 	cw := &CustomWriter{
-		LogConfig:  config,
-		LineBuffer: bytes.Buffer{},
-		IsDotnet:   true,
+		LogConfig:    config,
+		LineBuffer:   bytes.Buffer{},
+		ShouldBuffer: true,
 	}
 
 	go func() {
@@ -95,7 +94,6 @@ func TestCustomWriterDotnetBufferOverflow(t *testing.T) {
 		case message := <-config.channel:
 			messages = append(messages, message.Content)
 		case <-time.After(100 * time.Millisecond):
-			fmt.Println("timeout")
 			t.FailNow()
 		}
 	}

--- a/releasenotes/notes/serverless-init-dotnet-log-buffering-9e2fcf02fcd67c78.yaml
+++ b/releasenotes/notes/serverless-init-dotnet-log-buffering-9e2fcf02fcd67c78.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    Fix logs splitting with serverless-init on dotnet apps.

--- a/releasenotes/notes/serverless-init-dotnet-log-buffering-9e2fcf02fcd67c78.yaml
+++ b/releasenotes/notes/serverless-init-dotnet-log-buffering-9e2fcf02fcd67c78.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix logs splitting with serverless-init on dotnet apps.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Accidentally rebased the previous identical PR, blowing it up with review requests :| (https://github.com/DataDog/datadog-agent/pull/18608)

Re-introduces buffering to the serverless-init logs custom writer. 

For dotnet ONLY, we will buffer all logs that dont end in a newline. This solves the issue where dotnet logs are unintentionally split.

See screenshots:

Previously, JSON structured logs (using dotnet's serilog & RenderedCompactJsonFormatter) would show up like this:
<img width="742" alt="image" src="https://github.com/DataDog/datadog-agent/assets/51187184/4ae103da-3f42-44f0-a009-0bd2e6bf6556">
- The log should show numbers 1-499 in the @m field of the JSON structured log. You can see the log is incomplete/split, with log tag injection further jumbling up the log.
- This is easily reproducible with long logs, though it occasionally appears with shorter ones too.

With the buffering fix:

![image](https://github.com/DataDog/datadog-agent/assets/51187184/9d9fffab-40af-436d-a5ba-545b22bca6a4)
- Logs & injected tags show up in their respective attributes

dotnet stracktraces look like this:
<img width="718" alt="image" src="https://github.com/DataDog/datadog-agent/assets/51187184/7efb3a3e-347f-4737-a555-c52519b541c6">
- Because we buffer ONLY if the last character in the chunk is a newline, stack traces will stay together most of the time.
- A stack trace could be split into chunks directly on a newline, in which case the first chunk isn't buffered and the stack trace shows up split.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

When flushing to stdout, the dotnet runtime will sometimes split messages in two (or more). Under the hood, dotnet makes platform specific system write calls in a loop until all bytes are written. This has resulted in some logs being split in serverless-init instrumented dotnet containers, on Az ContainterApps & Google CloudRun

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.