### PR TITLE
[CWS] implement new kthread detection

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -121,6 +121,14 @@ int hook_kernel_thread(ctx_t *ctx) {
     return 0;
 }
 
+HOOK_ENTRY("user_mode_thread")
+int hook_user_mode_thread(ctx_t *ctx) {
+    u32 index = 0;
+    u32 value = 1;
+    bpf_map_update_elem(&is_new_kthread, &index, &value, BPF_ANY);
+    return 0;
+}
+
 HOOK_ENTRY("kernel_clone")
 int hook_kernel_clone(ctx_t *ctx) {
     return handle_do_fork(ctx);

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -83,6 +83,12 @@ int __attribute__((always_inline)) handle_do_fork(ctx_t *ctx) {
         .fork.is_thread = 1,
     };
 
+    u32 kthread_key = 0;
+    u32 *is_kthread = bpf_map_lookup_elem(&is_new_kthread, &kthread_key);
+    if (is_kthread) {
+        syscall.fork.is_kthread = *is_kthread;
+    }
+
     u64 input;
     LOAD_CONSTANT("do_fork_input", input);
 
@@ -103,6 +109,14 @@ int __attribute__((always_inline)) handle_do_fork(ctx_t *ctx) {
 
     cache_syscall(&syscall);
 
+    return 0;
+}
+
+HOOK_ENTRY("kernel_thread")
+int hook_kernel_thread(ctx_t *ctx) {
+    u32 index = 0;
+    u32 value = 1;
+    bpf_map_update_elem(&is_new_kthread, &index, &value, BPF_ANY);
     return 0;
 }
 
@@ -131,7 +145,7 @@ int sched_process_fork(struct _tracepoint_sched_process_fork *args) {
 
     // ignore the rest if kworker
     struct syscall_cache_t *syscall = peek_syscall(EVENT_FORK);
-    if (!syscall) {
+    if (!syscall || syscall->fork.is_kthread) {
         u32 value = 1;
         // mark as ignored fork not from syscall, ex: kworkers
         bpf_map_update_elem(&pid_ignored, &pid, &value, BPF_ANY);

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -87,6 +87,7 @@ int __attribute__((always_inline)) handle_do_fork(ctx_t *ctx) {
     u32 *is_kthread = bpf_map_lookup_elem(&is_new_kthread, &kthread_key);
     if (is_kthread) {
         syscall.fork.is_kthread = *is_kthread;
+        *is_kthread = 0;
     }
 
     u64 input;

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -80,6 +80,7 @@ BPF_PERCPU_ARRAY_MAP(is_discarded_by_inode_gen, u32, struct is_discarded_by_inod
 BPF_PERCPU_ARRAY_MAP(dns_event, u32, struct dns_event_t, 1)
 BPF_PERCPU_ARRAY_MAP(packets, u32, struct packet_t, 1)
 BPF_PERCPU_ARRAY_MAP(selinux_write_buffer, u32, struct selinux_write_buffer_t, 1)
+BPF_PERCPU_ARRAY_MAP(is_new_kthread, u32, u32, 1)
 
 BPF_PROG_ARRAY(args_envs_progs, 3)
 BPF_PROG_ARRAY(dentry_resolver_kprobe_callbacks, EVENT_MAX)

--- a/pkg/security/ebpf/c/include/structs/syscalls.h
+++ b/pkg/security/ebpf/c/include/structs/syscalls.h
@@ -121,6 +121,7 @@ struct syscall_cache_t {
 
         struct {
             u32 is_thread;
+            u32 is_kthread;
         } fork;
 
         struct {

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -112,6 +112,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				kprobeOrFentry("_do_fork", fentry, withSkipIfFentry(true)),
 				kprobeOrFentry("do_fork", fentry, withSkipIfFentry(true)),
 				kprobeOrFentry("kernel_clone", fentry),
+				kprobeOrFentry("kernel_thread", fentry),
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
 				kprobeOrFentry("cgroup_tasks_write", fentry, withSkipIfFentry(true)),

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -113,6 +113,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				kprobeOrFentry("do_fork", fentry, withSkipIfFentry(true)),
 				kprobeOrFentry("kernel_clone", fentry),
 				kprobeOrFentry("kernel_thread", fentry),
+				kprobeOrFentry("user_mode_thread", fentry),
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
 				kprobeOrFentry("cgroup_tasks_write", fentry, withSkipIfFentry(true)),

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -52,6 +52,12 @@ func getExecProbes(fentry bool) []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_user_mode_thread",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook_cgroup_procs_write",
 			},
 		},

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -46,6 +46,12 @@ func getExecProbes(fentry bool) []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_kernel_thread",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook_cgroup_procs_write",
 			},
 		},

--- a/pkg/security/tests/kernel_module_test.go
+++ b/pkg/security/tests/kernel_module_test.go
@@ -101,6 +101,58 @@ func getModulePath(modulePathFmt string, t *testing.T) (string, bool) {
 	return modulePath, wasCompressed
 }
 
+func TestKworker(t *testing.T) {
+	if testEnvironment == DockerEnvironment {
+		t.Skip("skipping kernel module test in docker")
+	}
+
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "test_load_module_kworker",
+			Expression: `load_module.name == "xt_LED" && process.is_kworker`,
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	_ = unix.DeleteModule("xt_LED", 0)
+
+	cmd := exec.Command("modprobe", "xt_LED")
+	if err := cmd.Run(); err != nil {
+		t.Skip("required kernel module not available")
+	}
+
+	defer func() {
+		cmd := exec.Command("iptables", "-D", "INPUT", "-p", "tcp", "--dport", "2222", "-j", "LED", "--led-trigger-id", "123")
+		if err := cmd.Run(); err != nil {
+			t.Error(err)
+		}
+
+		if err := retry.Do(func() error { return unix.DeleteModule("xt_LED", 0) }); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	test.WaitSignal(t, func() error {
+		if err := unix.DeleteModule("xt_LED", 0); err != nil {
+			return err
+		}
+
+		cmd := exec.Command("iptables", "-A", "INPUT", "-p", "tcp", "--dport", "2222", "-j", "LED", "--led-trigger-id", "123")
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+
+		return nil
+	}, func(event *model.Event, r *rules.Rule) {
+		assert.Equal(t, "test_load_module_kworker", r.ID, "invalid rule triggered")
+	})
+}
+
 func TestLoadModule(t *testing.T) {
 	if os.Getenv("CI") == "true" {
 		t.Skip("TestLoadModule is known to be flaky")
@@ -135,10 +187,6 @@ func TestLoadModule(t *testing.T) {
 		{
 			ID:         "test_load_module",
 			Expression: fmt.Sprintf(`load_module.name == "%s" && load_module.file.path == "%s" && load_module.loaded_from_memory == false && load_module.args == "" && !process.is_kworker`, testModuleName, modulePath),
-		},
-		{
-			ID:         "test_load_module_kworker",
-			Expression: `load_module.name == "xt_LED" && process.is_kworker`,
 		},
 		{
 			ID:         "test_load_module_with_params",
@@ -204,41 +252,6 @@ func TestLoadModule(t *testing.T) {
 			assert.Equal(t, "test_load_module", r.ID, "invalid rule triggered")
 
 			test.validateLoadModuleSchema(t, event)
-		})
-	})
-
-	t.Run("kworker", func(t *testing.T) {
-		_ = unix.DeleteModule("xt_LED", 0)
-
-		cmd := exec.Command("modprobe", "xt_LED")
-		if err := cmd.Run(); err != nil {
-			t.Skip("required kernel module not available")
-		}
-
-		defer func() {
-			cmd := exec.Command("iptables", "-D", "INPUT", "-p", "tcp", "--dport", "2222", "-j", "LED", "--led-trigger-id", "123")
-			if err := cmd.Run(); err != nil {
-				t.Error(err)
-			}
-
-			if err := retry.Do(func() error { return unix.DeleteModule("xt_LED", 0) }); err != nil {
-				t.Error(err)
-			}
-		}()
-
-		test.WaitSignal(t, func() error {
-			if err := unix.DeleteModule("xt_LED", 0); err != nil {
-				return err
-			}
-
-			cmd := exec.Command("iptables", "-A", "INPUT", "-p", "tcp", "--dport", "2222", "-j", "LED", "--led-trigger-id", "123")
-			if err := cmd.Run(); err != nil {
-				return err
-			}
-
-			return nil
-		}, func(event *model.Event, r *rules.Rule) {
-			assert.Equal(t, "test_load_module_kworker", r.ID, "invalid rule triggered")
 		})
 	})
 


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/datadog-agent/pull/18710 broke the `kthread` detection mechanism, because the hook in `tracepoint/sched/sched_process_fork` checks if there is something in the `syscalls` cache for the fork event:
- if there is it means it's a user process
- if there is non it means it's a kernel thread
This is no longer working because we are not caching the syscall entry in the syscall hooks but in the `kernel_clone` hook which is common to both user and kernel thread.

This PR implements a new solution to this issue by hooking `kernel_thread` (available since before 3.10), setting to `true` in a per-cpu array map, and using this boolean to compute if we are in a kthread instead.

This fix has the advantage to not be susceptible to `syscalls` LRU eviction.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
