### PR TITLE
allow skip to count as pass for re-runs

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1517,7 +1517,7 @@ def print_failed_tests(_, output_dir):
                             package = json_test['Package']
                             action = json_test["Action"]
 
-                            if action == "pass" or action == "fail":
+                            if action == "pass" or action == "fail" or action == "skip":
                                 test_key = f"{package}.{name}"
                                 res = test_results.get(test_key)
                                 if res is None:
@@ -1526,7 +1526,7 @@ def print_failed_tests(_, output_dir):
 
                                 if res == "fail":
                                     print(f"re-ran [{test_platform}] {package} {name}: {action}")
-                                if action == "pass" and res == "fail":
+                                if (action == "pass" or action == "skip") and res == "fail":
                                     test_results[test_key] = action
 
         for key, res in test_results.items():


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Allows a result of `skip` to count as passing for test re-runs

### Motivation

It seems for subtests, Go may report `skip` for parents of the the subtests that actually re-ran. We should count those as passing, since the actual test did re-run and did pass.

```
re-ran [platform] pkg/network/tracer TestUSMSuite/prebuilt/TestProtocolClassification/without_nat/edge_cases/mixed_protocols: pass
re-ran [platform] pkg/network/tracer TestUSMSuite/prebuilt/TestProtocolClassification/without_nat/edge_cases: pass
re-ran [platform] pkg/network/tracer TestUSMSuite/prebuilt/TestProtocolClassification/without_nat: skip
re-ran [platform] pkg/network/tracer TestUSMSuite/prebuilt/TestProtocolClassification: pass
re-ran [platform] pkg/network/tracer TestUSMSuite/prebuilt: pass
re-ran [platform] pkg/network/tracer TestUSMSuite: pass
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
