### PR TITLE
[serverless] Fix incorrect creation of a timeout log after a valid timeout

### DIFF
--- a/pkg/serverless/logs/logs_test.go
+++ b/pkg/serverless/logs/logs_test.go
@@ -788,17 +788,17 @@ func TestProcessMultipleLogMessagesTimeoutLogFromReportLog(t *testing.T) {
 	go lc.processLogMessages(logMessages)
 
 	expectedLogs := map[string][]string{
-		"myRequestID-1": []string{
+		"myRequestID-1": {
 			createStringRecordForReportLog(lc.invocationStartTime, lc.invocationEndTime, &reportLogMessageOne),
 			createStringRecordForTimeoutLog(&reportLogMessageOne),
 		},
-		"myRequestID-2": []string{
+		"myRequestID-2": {
 			createStringRecordForReportLog(lc.invocationStartTime, lc.invocationEndTime, &reportLogMessageTwo),
 		},
 	}
 	expectedErrors := map[string][]bool{
-		"myRequestID-1": []bool{false, true},
-		"myRequestID-2": []bool{false},
+		"myRequestID-1": {false, true},
+		"myRequestID-2": {false},
 	}
 
 	for reqId, logsSlice := range expectedLogs {

--- a/pkg/serverless/logs/logs_test.go
+++ b/pkg/serverless/logs/logs_test.go
@@ -729,6 +729,94 @@ func TestProcessLogMessagesTimeoutLogFromReportLog(t *testing.T) {
 	}
 }
 
+func TestProcessMultipleLogMessagesTimeoutLogFromReportLog(t *testing.T) {
+	logChannel := make(chan *config.ChannelMessage)
+	log := fxutil.Test[log.Component](t, log.MockModule)
+	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(log, time.Hour)
+	defer demux.Stop(false)
+
+	mockExecutionContext := &executioncontext.ExecutionContext{}
+	lc := &LambdaLogsCollector{
+		arn:                    "my-arn",
+		lastRequestID:          "myRequestID",
+		logsEnabled:            true,
+		enhancedMetricsEnabled: true,
+		out:                    logChannel,
+		extraTags: &Tags{
+			Tags: []string{"tag0:value0,tag1:value1"},
+		},
+		executionContext:    mockExecutionContext,
+		demux:               demux,
+		invocationStartTime: time.Now(),
+		invocationEndTime:   time.Now().Add(10 * time.Millisecond),
+	}
+
+	reportLogMessageOne := LambdaLogAPIMessage{
+		objectRecord: platformObjectRecord{
+			requestID: "myRequestID-1",
+			reportLogItem: reportLogMetrics{
+				durationMs:       100.00,
+				billedDurationMs: 100,
+				memorySizeMB:     128,
+				maxMemoryUsedMB:  128,
+				initDurationMs:   50.00,
+			},
+			status: timeoutStatus,
+		},
+		logType:      logTypePlatformReport,
+		stringRecord: "contents to be overwritten",
+	}
+	reportLogMessageTwo := LambdaLogAPIMessage{
+		objectRecord: platformObjectRecord{
+			requestID: "myRequestID-2",
+			reportLogItem: reportLogMetrics{
+				durationMs:       100.00,
+				billedDurationMs: 100,
+				memorySizeMB:     128,
+				maxMemoryUsedMB:  128,
+				initDurationMs:   50.00,
+			},
+		},
+		logType:      logTypePlatformReport,
+		stringRecord: "contents to be overwritten",
+	}
+	logMessages := []LambdaLogAPIMessage{
+		reportLogMessageOne,
+		reportLogMessageTwo,
+	}
+
+	go lc.processLogMessages(logMessages)
+
+	expectedLogs := map[string][]string{
+		"myRequestID-1": []string{
+			createStringRecordForReportLog(lc.invocationStartTime, lc.invocationEndTime, &reportLogMessageOne),
+			createStringRecordForTimeoutLog(&reportLogMessageOne),
+		},
+		"myRequestID-2": []string{
+			createStringRecordForReportLog(lc.invocationStartTime, lc.invocationEndTime, &reportLogMessageTwo),
+		},
+	}
+	expectedErrors := map[string][]bool{
+		"myRequestID-1": []bool{false, true},
+		"myRequestID-2": []bool{false},
+	}
+
+	for reqId, logsSlice := range expectedLogs {
+		for i := 0; i < len(logsSlice); i++ {
+			select {
+			case received := <-logChannel:
+				assert.NotNil(t, received)
+				assert.Equal(t, "my-arn", received.Lambda.ARN)
+				assert.Equal(t, reqId, received.Lambda.RequestID)
+				assert.Equal(t, logsSlice[i], string(received.Content))
+				assert.Equal(t, expectedErrors[reqId][i], received.IsError)
+			case <-time.After(100 * time.Millisecond):
+				assert.Fail(t, "We should have received logs")
+			}
+		}
+	}
+}
+
 func TestProcessLogMessagesOutOfMemoryError(t *testing.T) {
 	logChannel := make(chan *config.ChannelMessage)
 	log := fxutil.Test[log.Component](t, log.MockModule)

--- a/pkg/serverless/logs/parse.go
+++ b/pkg/serverless/logs/parse.go
@@ -83,8 +83,6 @@ const (
 	// logTypePlatformInitStart is received when init starts
 	logTypePlatformInitStart = "platform.initStart"
 
-	// success indicates the init or invoke phase was successful
-	successStatus string = "success"
 	// errorStatus indicates the init or invoke phase has errored out
 	errorStatus string = "error"
 	// timeoutStatus indicates the init or invoke phase has timed out


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fixes a bug where a `Task timed out` log would be created _after_ a valid timeout. We were mistakenly storing the timeout state for a Lambda and checking that condition on every invocation, meaning if a valid timeout occurs, every subsequent invocation will create a time out log.

We just need to validate that each invocation's `platform.report` log has a `timeout` status rather than storing the `timeout` status in the logs collector.

Fix doesn't create a timeout log for non-timeout invocations:
<img width="1339" alt="Screenshot 2023-08-09 at 5 54 39 PM" src="https://github.com/DataDog/datadog-agent/assets/25290232/7775398b-332f-4f41-a812-edf985b42c79">

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Issue noticed by support

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
