### PR TITLE
Update `smp` and `lading` to their latest releases

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -14,8 +14,8 @@ single-machine-performance-regression_detector:
       - outputs/report.html              # for debugging, also on S3
     when: always
   variables:
-    SMP_VERSION: 0.9.2
-    LADING_VERSION: 0.17.3
+    SMP_VERSION: 0.10.0
+    LADING_VERSION: 0.18.0
     CPUS: 7
     MEMORY: "30g"
   # At present we require two artifacts to exist for the 'baseline' and the


### PR DESCRIPTION
### What does this PR do?

This commit updates the `smp` binary to its latest release, removing a legacy flow with no user-facing change. The latest version of lading has a slightly improved throttle mechanism.

REF SMP-673

