### PR TITLE
Revert "[CWS] do not report failure of arm64 functional tests"

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -83,7 +83,6 @@ kitchen_test_security_agent_arm64:
   rules:
     !reference [.on_security_agent_changes_or_manual]
   needs: [ "tests_ebpf_arm64", "prepare_ebpf_functional_tests_arm64" ]
-  allow_failure: true
   variables:
     KITCHEN_ARCH: arm64
     KITCHEN_EC2_INSTANCE_TYPE: "t4g.xlarge"


### PR DESCRIPTION
Reverts DataDog/datadog-agent#18705

Now that the spot instance issue is fixed, let's revert this