### PR TITLE
Force remove stack using the automation API

### DIFF
--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -282,8 +282,6 @@ kernel_matrix_testing_setup_env:
     - pulumi login $(cat $STACK_DIR | tr -d '\n')
     - inv -e system-probe.start-microvms --instance-type-x86=$EC2_X86_INSTANCE_TYPE --instance-type-arm=$EC2_ARM_INSTANCE_TYPE --x86-ami-id=$X86_AMI_ID --arm-ami-id=$ARM_AMI_ID --ssh-key-name=$AWS_EC2_SSH_KEY_NAME --ssh-key-path=$AWS_EC2_SSH_KEY_FILE --infra-env=$INFRA_ENV --stack-name=kernel-matrix-testing-$CI_PIPELINE_ID
     - cat $CI_PROJECT_DIR/stack.outputs
-    # Force remove pulumi stack files so the infra cleaner does not fail trying to remove stale stacks
-    - pulumi stack rm -y --force $(pulumi stack ls -a | grep kernel-matrix-testing-$CI_PIPELINE_ID | cut -d ' ' -f 1)
     - pulumi logout
   artifacts:
     when: always

--- a/test/new-e2e/scenarios/system-probe/main.go
+++ b/test/new-e2e/scenarios/system-probe/main.go
@@ -34,7 +34,7 @@ func run(envName, x86InstanceType, armInstanceType string, destroy bool, opts *s
 	fmt.Println(systemProbeEnv.ARM64InstanceIP)
 	fmt.Println(systemProbeEnv.X86_64InstanceIP)
 
-	return nil
+	return systemProbeEnv.RemoveStack()
 }
 
 func main() {

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -244,5 +244,5 @@ func Destroy(name string) error {
 }
 
 func (env *TestEnv) RemoveStack() error {
-	return infra.GetStackManager().ForceRemoveStack(env.context, env.name)
+	return infra.GetStackManager().ForceRemoveStackConfiguration(env.context, env.name)
 }

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -242,3 +242,7 @@ func NewTestEnv(name, x86InstanceType, armInstanceType string, opts *SystemProbe
 func Destroy(name string) error {
 	return infra.GetStackManager().DeleteStack(context.Background(), name)
 }
+
+func (env *TestEnv) RemoveStack() error {
+	return infra.GetStackManager().ForceRemoveStack(env.context)
+}

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -244,5 +244,5 @@ func Destroy(name string) error {
 }
 
 func (env *TestEnv) RemoveStack() error {
-	return infra.GetStackManager().ForceRemoveStack(env.context)
+	return infra.GetStackManager().ForceRemoveStack(env.context, env.name)
 }

--- a/test/new-e2e/utils/infra/stack_manager.go
+++ b/test/new-e2e/utils/infra/stack_manager.go
@@ -158,7 +158,7 @@ func (sm *StackManager) ForceRemoveStackConfiguration(ctx context.Context, name 
 
 	stack, ok := sm.stacks[name]
 	if !ok {
-		return fmt.Errorf("stack %s is not present", name)
+		return fmt.Errorf("unable to remove stack %s: stack not present", name)
 	}
 
 	deleteContext, cancel := context.WithTimeout(ctx, stackDeleteTimeout)

--- a/test/new-e2e/utils/infra/stack_manager.go
+++ b/test/new-e2e/utils/infra/stack_manager.go
@@ -16,10 +16,10 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/runner"
-	"github.com/pulumi/pulumi/sdk/v3/go/auto/optremove"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/debug"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optdestroy"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/optremove"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optup"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"

--- a/test/new-e2e/utils/infra/stack_manager.go
+++ b/test/new-e2e/utils/infra/stack_manager.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/runner"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/optremove"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/debug"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optdestroy"
@@ -147,6 +148,17 @@ func (sm *StackManager) DeleteStack(ctx context.Context, name string) error {
 	}
 
 	return sm.deleteStack(ctx, name, stack)
+}
+
+func (sm *StackManager) ForceRemoveStack(ctx context.Context, name string) error {
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
+
+	stack := sm.stacks[name]
+
+	deleteContext, cancel := context.WithTimeout(ctx, stackDeleteTimeout)
+	defer cancel()
+	return stack.WorkSpace().RemoveStack(ctx, stack.Name(), optremove.Force())
 }
 
 func (sm *StackManager) Cleanup(ctx context.Context) []error {

--- a/test/new-e2e/utils/infra/stack_manager.go
+++ b/test/new-e2e/utils/infra/stack_manager.go
@@ -154,7 +154,10 @@ func (sm *StackManager) ForceRemoveStack(ctx context.Context, name string) error
 	sm.lock.Lock()
 	defer sm.lock.Unlock()
 
-	stack := sm.stacks[name]
+	stack, ok := sm.stacks[name]
+	if !ok {
+		return fmt.Errorf("stack %s is not present", name)
+	}
 
 	deleteContext, cancel := context.WithTimeout(ctx, stackDeleteTimeout)
 	defer cancel()

--- a/test/new-e2e/utils/infra/stack_manager.go
+++ b/test/new-e2e/utils/infra/stack_manager.go
@@ -158,7 +158,7 @@ func (sm *StackManager) ForceRemoveStack(ctx context.Context, name string) error
 
 	deleteContext, cancel := context.WithTimeout(ctx, stackDeleteTimeout)
 	defer cancel()
-	return stack.WorkSpace().RemoveStack(ctx, stack.Name(), optremove.Force())
+	return stack.Workspace().RemoveStack(deleteContext, stack.Name(), optremove.Force())
 }
 
 func (sm *StackManager) Cleanup(ctx context.Context) []error {

--- a/test/new-e2e/utils/infra/stack_manager.go
+++ b/test/new-e2e/utils/infra/stack_manager.go
@@ -150,7 +150,9 @@ func (sm *StackManager) DeleteStack(ctx context.Context, name string) error {
 	return sm.deleteStack(ctx, name, stack)
 }
 
-func (sm *StackManager) ForceRemoveStack(ctx context.Context, name string) error {
+// ForceRemoveStackConfiguration removes the configuration files pulumi creates for managing a stack.
+// It DOES NOT perform any cleanup of the resources created by the stack. Call `DeleteStack` for correct cleanup.
+func (sm *StackManager) ForceRemoveStackConfiguration(ctx context.Context, name string) error {
 	sm.lock.Lock()
 	defer sm.lock.Unlock()
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Using `pulumi stack ls` can fail when stacks are simultaneously being deleted. By using the automation API we do not need to list all stacks to get the name of the `stack` we want to target. This is because the code is already aware of the name of the `stack` it is targetting.

[Example failure.](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/310275565)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
