### PR TITLE
[util/cgroups/pid_mapper] Fix cgroup file parser

### DIFF
--- a/pkg/util/cgroups/pid_mapper.go
+++ b/pkg/util/cgroups/pid_mapper.go
@@ -25,7 +25,7 @@ func IdentiferFromCgroupReferences(procPath, pid, baseCgroupController string, f
 	err := parseFile(defaultFileReader, filepath.Join(procPath, pid, procCgroupFile), func(s string) error {
 		var err error
 
-		parts := strings.Split(s, ":")
+		parts := strings.SplitN(s, ":", 3)
 		// Skip potentially malformed lines
 		if len(parts) != 3 {
 			return nil

--- a/pkg/util/cgroups/pid_mapper_test.go
+++ b/pkg/util/cgroups/pid_mapper_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var sampleCgroupProcs = `1142219
@@ -64,6 +65,23 @@ var cgroupV1ProcCgroup = `12:rdma:/
 2:pids:/kubepods/burstable/pod15513b48-e7a5-48fc-b9e3-92f713f36504/a51a9f7d073f848e7fc59e56e8f11524f330a2175a4ed26327da2dfe0d28015f
 1:name=systemd:/kubepods/burstable/pod15513b48-e7a5-48fc-b9e3-92f713f36504/a51a9f7d073f848e7fc59e56e8f11524f330a2175a4ed26327da2dfe0d28015f
 0::/system.slice/containerd.service`
+
+// Notice that in this example the paths contain ":"
+var cgroupV1ProcCgroupWithColons = `13:misc:/kubepods-burstable-pod5be537b8_3a4e_4607_af71_31598b3a4fd3.slice:cri-containerd:1c8f503430973935b7d8a80c4f58c0946b052a021e6855b358e5ec38601af120
+12:perf_event:/kubepods-burstable-pod5be537b8_3a4e_4607_af71_31598b3a4fd3.slice:cri-containerd:1c8f503430973935b7d8a80c4f58c0946b052a021e6855b358e5ec38601af120
+11:freezer:/kubepods-burstable-pod5be537b8_3a4e_4607_af71_31598b3a4fd3.slice:cri-containerd:1c8f503430973935b7d8a80c4f58c0946b052a021e6855b358e5ec38601af120
+10:pids:/kuberuntime.slice/containerd.service/kubepods-burstable-pod5be537b8_3a4e_4607_af71_31598b3a4fd3.slice:cri-containerd:1c8f503430973935b7d8a80c4f58c0946b052a021e6855b358e5ec38601af120
+9:cpuset:/kubepods-burstable-pod5be537b8_3a4e_4607_af71_31598b3a4fd3.slice:cri-containerd:1c8f503430973935b7d8a80c4f58c0946b052a021e6855b358e5ec38601af120
+8:memory:/kuberuntime.slice/containerd.service/kubepods-burstable-pod5be537b8_3a4e_4607_af71_31598b3a4fd3.slice:cri-containerd:1c8f503430973935b7d8a80c4f58c0946b052a021e6855b358e5ec38601af120
+7:rdma:/kubepods-burstable-pod5be537b8_3a4e_4607_af71_31598b3a4fd3.slice:cri-containerd:1c8f503430973935b7d8a80c4f58c0946b052a021e6855b358e5ec38601af120
+6:blkio:/kuberuntime.slice/containerd.service/kubepods-burstable-pod5be537b8_3a4e_4607_af71_31598b3a4fd3.slice:cri-containerd:1c8f503430973935b7d8a80c4f58c0946b052a021e6855b358e5ec38601af120
+5:devices:/kuberuntime.slice/containerd.service/kubepods-burstable-pod5be537b8_3a4e_4607_af71_31598b3a4fd3.slice:cri-containerd:1c8f503430973935b7d8a80c4f58c0946b052a021e6855b358e5ec38601af120
+4:net_cls,net_prio:/kubepods-burstable-pod5be537b8_3a4e_4607_af71_31598b3a4fd3.slice:cri-containerd:1c8f503430973935b7d8a80c4f58c0946b052a021e6855b358e5ec38601af120
+3:hugetlb:/kubepods-burstable-pod5be537b8_3a4e_4607_af71_31598b3a4fd3.slice:cri-containerd:1c8f503430973935b7d8a80c4f58c0946b052a021e6855b358e5ec38601af120
+2:cpu,cpuacct:/kuberuntime.slice/containerd.service/kubepods-burstable-pod5be537b8_3a4e_4607_af71_31598b3a4fd3.slice:cri-containerd:1c8f503430973935b7d8a80c4f58c0946b052a021e6855b358e5ec38601af120
+1:name=systemd:/kuberuntime.slice/containerd.service/kubepods-burstable-pod5be537b8_3a4e_4607_af71_31598b3a4fd3.slice:cri-containerd:1c8f503430973935b7d8a80c4f58c0946b052a021e6855b358e5ec38601af120
+0::/
+`
 
 var dindProcCgroup = `14:name=systemd:/docker/88ea268ece65a02d68b169fd74bcbcb427eb7f28900db0e3b906fb2eeb7341df/kubelet/kubepods/burstable/poda5ea884f-9e60-4912-bd62-fef9a31db47a/a51a9f7d073f848e7fc59e56e8f11524f330a2175a4ed26327da2dfe0d28015e
 13:rdma:/
@@ -158,4 +176,42 @@ func TestProcPidMapperCgroupV2(t *testing.T) {
 	pids, err := cgFooV2.GetPIDs(0)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []int{420, 430}, pids)
+}
+
+func TestIdentiferFromCgroupReferences(t *testing.T) {
+	tests := []struct {
+		name        string
+		fileContent string
+		expectedID  string
+	}{
+		{
+			name:        "cgroup v1",
+			fileContent: cgroupV1ProcCgroup,
+			expectedID:  "a51a9f7d073f848e7fc59e56e8f11524f330a2175a4ed26327da2dfe0d28015f",
+		},
+		{
+			name:        "cgroup v1 with colons",
+			fileContent: cgroupV1ProcCgroupWithColons,
+			expectedID:  "1c8f503430973935b7d8a80c4f58c0946b052a021e6855b358e5ec38601af120",
+		},
+		{
+			name:        "docker in docker",
+			fileContent: dindProcCgroup,
+			expectedID:  "a51a9f7d073f848e7fc59e56e8f11524f330a2175a4ed26327da2dfe0d28015e",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fakeFsPath := t.TempDir()
+			procPath := filepath.Join(fakeFsPath, "proc")
+			procPIDPath := filepath.Join(procPath, "123")
+			require.NoErrorf(t, os.MkdirAll(procPIDPath, 0o750), "impossible to create temp directory '%s'", procPath)
+			require.NoError(t, os.WriteFile(filepath.Join(procPIDPath, "cgroup"), []byte(test.fileContent), 0o640))
+
+			id, err := IdentiferFromCgroupReferences(procPath, "123", defaultBaseController, ContainerFilter)
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedID, id)
+		})
+	}
 }

--- a/releasenotes/notes/fix-cgroup-file-parser-f742864679aaca7c.yaml
+++ b/releasenotes/notes/fix-cgroup-file-parser-f742864679aaca7c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a bug that causes the Agent to report the ``datadog.agent_name.running`` metric with missing tags in some environments with cgroups v1.


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the cgroups v1 parser.

The bug causes the agent to report the `datadog.agent.running` metric with missing tags in some environments with cgroups v1.


### Describe how to test/QA your changes

Verify that the `datadog.agent.running` metric is reported with all the tags in the cluster where we noticed the issue.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
