### PR TITLE
[CWS] make the test version of our statsd client more resiliant to interface change

### DIFF
--- a/pkg/security/tests/statsdclient/statsd_client.go
+++ b/pkg/security/tests/statsdclient/statsd_client.go
@@ -8,7 +8,6 @@ package statsdclient
 import (
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 )
@@ -17,6 +16,7 @@ var _ statsd.ClientInterface = &StatsdClient{}
 
 // StatsdClient is a statsd client for used for tests
 type StatsdClient struct {
+	statsd.NoOpClient
 	lock   sync.RWMutex
 	counts map[string]int64
 }
@@ -82,66 +82,6 @@ func (s *StatsdClient) Count(name string, value int64, tags []string, rate float
 	return nil
 }
 
-// Histogram does nothing and returns nil
-func (s *StatsdClient) Histogram(name string, value float64, tags []string, rate float64) error {
-	return nil
-}
-
-// Distribution does nothing and returns nil
-func (s *StatsdClient) Distribution(name string, value float64, tags []string, rate float64) error {
-	return nil
-}
-
-// Decr does nothing and returns nil
-func (s *StatsdClient) Decr(name string, tags []string, rate float64) error {
-	return nil
-}
-
-// Incr does nothing and returns nil
-func (s *StatsdClient) Incr(name string, tags []string, rate float64) error {
-	return nil
-}
-
-// Set does nothing and returns nil
-func (s *StatsdClient) Set(name string, value string, tags []string, rate float64) error {
-	return nil
-}
-
-// Timing does nothing and returns nil
-func (s *StatsdClient) Timing(name string, value time.Duration, tags []string, rate float64) error {
-	return nil
-}
-
-// TimeInMilliseconds does nothing and returns nil
-func (s *StatsdClient) TimeInMilliseconds(name string, value float64, tags []string, rate float64) error {
-	return nil
-}
-
-// Event does nothing and returns nil
-func (s *StatsdClient) Event(e *statsd.Event) error {
-	return nil
-}
-
-// SimpleEvent does nothing and returns nil
-func (s *StatsdClient) SimpleEvent(title, text string) error {
-	return nil
-}
-
-// ServiceCheck does nothing and returns nil
-func (s *StatsdClient) ServiceCheck(sc *statsd.ServiceCheck) error {
-	return nil
-}
-
-// SimpleServiceCheck does nothing and returns nil
-func (s *StatsdClient) SimpleServiceCheck(name string, status statsd.ServiceCheckStatus) error {
-	return nil
-}
-
-// Close does nothing and returns nil
-func (s *StatsdClient) Close() error {
-	return nil
-}
-
 // Flush does nothing and returns nil
 func (s *StatsdClient) Flush() error {
 	s.lock.Lock()
@@ -149,14 +89,4 @@ func (s *StatsdClient) Flush() error {
 
 	s.counts = make(map[string]int64)
 	return nil
-}
-
-// IsClosed does nothing and return false
-func (s *StatsdClient) IsClosed() bool {
-	return false
-}
-
-// GetTelemetry does nothing and returns an empty Telemetry
-func (s *StatsdClient) GetTelemetry() statsd.Telemetry {
-	return statsd.Telemetry{}
 }

--- a/pkg/security/tests/statsdclient/statsd_client.go
+++ b/pkg/security/tests/statsdclient/statsd_client.go
@@ -17,7 +17,7 @@ var _ statsd.ClientInterface = &StatsdClient{}
 
 // StatsdClient is a statsd client for used for tests
 type StatsdClient struct {
-	sync.RWMutex
+	lock   sync.RWMutex
 	counts map[string]int64
 }
 
@@ -30,8 +30,8 @@ func NewStatsdClient() *StatsdClient {
 
 // Get return the count
 func (s *StatsdClient) Get(key string) int64 {
-	s.RLock()
-	defer s.RUnlock()
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 	return s.counts[key]
 }
 
@@ -39,8 +39,8 @@ func (s *StatsdClient) Get(key string) int64 {
 func (s *StatsdClient) GetByPrefix(prefix string) map[string]int64 {
 	result := make(map[string]int64)
 
-	s.RLock()
-	defer s.RUnlock()
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 
 	for key, value := range s.counts {
 		if strings.HasPrefix(key, prefix) {
@@ -54,8 +54,8 @@ func (s *StatsdClient) GetByPrefix(prefix string) map[string]int64 {
 
 // Gauge does nothing and returns nil
 func (s *StatsdClient) Gauge(name string, value float64, tags []string, rate float64) error {
-	s.Lock()
-	defer s.Unlock()
+	s.lock.Lock()
+	defer s.lock.Unlock()
 
 	if len(tags) == 0 {
 		s.counts[name] = int64(value)
@@ -69,8 +69,8 @@ func (s *StatsdClient) Gauge(name string, value float64, tags []string, rate flo
 
 // Count does nothing and returns nil
 func (s *StatsdClient) Count(name string, value int64, tags []string, rate float64) error {
-	s.Lock()
-	defer s.Unlock()
+	s.lock.Lock()
+	defer s.lock.Unlock()
 
 	if len(tags) == 0 {
 		s.counts[name] += value
@@ -144,8 +144,8 @@ func (s *StatsdClient) Close() error {
 
 // Flush does nothing and returns nil
 func (s *StatsdClient) Flush() error {
-	s.Lock()
-	defer s.Unlock()
+	s.lock.Lock()
+	defer s.lock.Unlock()
 
 	s.counts = make(map[string]int64)
 	return nil


### PR DESCRIPTION
### What does this PR do?

When the `ClientInterface` changes our "mocks/test" implementation of the statsd client can prevent the simple bump of the `datadog-go/v5` library.

This PR fixes this by embedding a `NoOpClient`, that should handle the default implementation for all functions except the ones we "override".

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
