### PR TITLE
[orchestration] Add Horizontal Pod Autoscalers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/CycloneDX/cyclonedx-go v0.7.1
-	github.com/DataDog/agent-payload/v5 v5.0.92-0.20230814144448-8d190c703f24
+	github.com/DataDog/agent-payload/v5 v5.0.93-0.20230815164829-6b7d89986d56
 	github.com/DataDog/appsec-internal-go v1.0.1-0.20230723140106-7cb513f54ce1
 	github.com/DataDog/datadog-agent/pkg/gohai v0.47.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.47.0-rc.3

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/CycloneDX/cyclonedx-go v0.7.1
-	github.com/DataDog/agent-payload/v5 v5.0.92
+	github.com/DataDog/agent-payload/v5 v5.0.92-0.20230809204249-d8ea2c7fa93d
 	github.com/DataDog/appsec-internal-go v1.0.1-0.20230723140106-7cb513f54ce1
 	github.com/DataDog/datadog-agent/pkg/gohai v0.47.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.47.0-rc.3

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/CycloneDX/cyclonedx-go v0.7.1
-	github.com/DataDog/agent-payload/v5 v5.0.93-0.20230815164829-6b7d89986d56
+	github.com/DataDog/agent-payload/v5 v5.0.93
 	github.com/DataDog/appsec-internal-go v1.0.1-0.20230723140106-7cb513f54ce1
 	github.com/DataDog/datadog-agent/pkg/gohai v0.47.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.47.0-rc.3

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/CycloneDX/cyclonedx-go v0.7.1
-	github.com/DataDog/agent-payload/v5 v5.0.92-0.20230809204249-d8ea2c7fa93d
+	github.com/DataDog/agent-payload/v5 v5.0.92-0.20230814144448-8d190c703f24
 	github.com/DataDog/appsec-internal-go v1.0.1-0.20230723140106-7cb513f54ce1
 	github.com/DataDog/datadog-agent/pkg/gohai v0.47.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.47.0-rc.3

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CycloneDX/cyclonedx-go v0.7.1 h1:5w1SxjGm9MTMNTuRbEPyw21ObdbaagTWF/KfF0qHTRE=
 github.com/CycloneDX/cyclonedx-go v0.7.1/go.mod h1:N/nrdWQI2SIjaACyyDs/u7+ddCkyl/zkNs8xFsHF2Ps=
-github.com/DataDog/agent-payload/v5 v5.0.93-0.20230815164829-6b7d89986d56 h1:Qz40tb7A/i92RWdY5sXTyClPQYQ/Qo7u89oM3tHjr3M=
-github.com/DataDog/agent-payload/v5 v5.0.93-0.20230815164829-6b7d89986d56/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
+github.com/DataDog/agent-payload/v5 v5.0.93 h1:WWTYl0LExXmoLqutF9DjRaZw/pp5Ylear0SXdGuJS/M=
+github.com/DataDog/agent-payload/v5 v5.0.93/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
 github.com/DataDog/appsec-internal-go v1.0.1-0.20230723140106-7cb513f54ce1 h1:vYoZgFDFkHeSRYtDVFGYw6rWbx2wWJxztCj1e9YJdQ0=
 github.com/DataDog/appsec-internal-go v1.0.1-0.20230723140106-7cb513f54ce1/go.mod h1:+Y+4klVWKPOnZx6XESG7QHydOaUGEXyH2j/vSg9JiNM=
 github.com/DataDog/aptly v1.5.2 h1:qnuKf01NDOtpxvs/1H3WVM6HxrHbRuuADVO1gNnelg8=

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CycloneDX/cyclonedx-go v0.7.1 h1:5w1SxjGm9MTMNTuRbEPyw21ObdbaagTWF/KfF0qHTRE=
 github.com/CycloneDX/cyclonedx-go v0.7.1/go.mod h1:N/nrdWQI2SIjaACyyDs/u7+ddCkyl/zkNs8xFsHF2Ps=
-github.com/DataDog/agent-payload/v5 v5.0.92-0.20230809204249-d8ea2c7fa93d h1:9RW2gDrWxQNfjyccUa4HRvirSV1/eoi6taRlO+iLRYc=
-github.com/DataDog/agent-payload/v5 v5.0.92-0.20230809204249-d8ea2c7fa93d/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
+github.com/DataDog/agent-payload/v5 v5.0.92-0.20230814144448-8d190c703f24 h1:SdgHfENZhZyfDZnugfPZPz0fWMgr4TIIvkAs/KNPkd0=
+github.com/DataDog/agent-payload/v5 v5.0.92-0.20230814144448-8d190c703f24/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
 github.com/DataDog/appsec-internal-go v1.0.1-0.20230723140106-7cb513f54ce1 h1:vYoZgFDFkHeSRYtDVFGYw6rWbx2wWJxztCj1e9YJdQ0=
 github.com/DataDog/appsec-internal-go v1.0.1-0.20230723140106-7cb513f54ce1/go.mod h1:+Y+4klVWKPOnZx6XESG7QHydOaUGEXyH2j/vSg9JiNM=
 github.com/DataDog/aptly v1.5.2 h1:qnuKf01NDOtpxvs/1H3WVM6HxrHbRuuADVO1gNnelg8=

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CycloneDX/cyclonedx-go v0.7.1 h1:5w1SxjGm9MTMNTuRbEPyw21ObdbaagTWF/KfF0qHTRE=
 github.com/CycloneDX/cyclonedx-go v0.7.1/go.mod h1:N/nrdWQI2SIjaACyyDs/u7+ddCkyl/zkNs8xFsHF2Ps=
-github.com/DataDog/agent-payload/v5 v5.0.92 h1:LFDVrRzB49J5ARZ4E19kOuixixJt+2cQWx5t6Kgj1os=
-github.com/DataDog/agent-payload/v5 v5.0.92/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
+github.com/DataDog/agent-payload/v5 v5.0.92-0.20230809204249-d8ea2c7fa93d h1:9RW2gDrWxQNfjyccUa4HRvirSV1/eoi6taRlO+iLRYc=
+github.com/DataDog/agent-payload/v5 v5.0.92-0.20230809204249-d8ea2c7fa93d/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
 github.com/DataDog/appsec-internal-go v1.0.1-0.20230723140106-7cb513f54ce1 h1:vYoZgFDFkHeSRYtDVFGYw6rWbx2wWJxztCj1e9YJdQ0=
 github.com/DataDog/appsec-internal-go v1.0.1-0.20230723140106-7cb513f54ce1/go.mod h1:+Y+4klVWKPOnZx6XESG7QHydOaUGEXyH2j/vSg9JiNM=
 github.com/DataDog/aptly v1.5.2 h1:qnuKf01NDOtpxvs/1H3WVM6HxrHbRuuADVO1gNnelg8=

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CycloneDX/cyclonedx-go v0.7.1 h1:5w1SxjGm9MTMNTuRbEPyw21ObdbaagTWF/KfF0qHTRE=
 github.com/CycloneDX/cyclonedx-go v0.7.1/go.mod h1:N/nrdWQI2SIjaACyyDs/u7+ddCkyl/zkNs8xFsHF2Ps=
-github.com/DataDog/agent-payload/v5 v5.0.92-0.20230814144448-8d190c703f24 h1:SdgHfENZhZyfDZnugfPZPz0fWMgr4TIIvkAs/KNPkd0=
-github.com/DataDog/agent-payload/v5 v5.0.92-0.20230814144448-8d190c703f24/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
+github.com/DataDog/agent-payload/v5 v5.0.93-0.20230815164829-6b7d89986d56 h1:Qz40tb7A/i92RWdY5sXTyClPQYQ/Qo7u89oM3tHjr3M=
+github.com/DataDog/agent-payload/v5 v5.0.93-0.20230815164829-6b7d89986d56/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
 github.com/DataDog/appsec-internal-go v1.0.1-0.20230723140106-7cb513f54ce1 h1:vYoZgFDFkHeSRYtDVFGYw6rWbx2wWJxztCj1e9YJdQ0=
 github.com/DataDog/appsec-internal-go v1.0.1-0.20230723140106-7cb513f54ce1/go.mod h1:+Y+4klVWKPOnZx6XESG7QHydOaUGEXyH2j/vSg9JiNM=
 github.com/DataDog/aptly v1.5.2 h1:qnuKf01NDOtpxvs/1H3WVM6HxrHbRuuADVO1gNnelg8=

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory/inventory.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory/inventory.go
@@ -45,6 +45,7 @@ func NewCollectorInventory() *CollectorInventory {
 			k8sCollectors.NewStatefulSetCollectorVersions(),
 			k8sCollectors.NewUnassignedPodCollectorVersions(),
 			k8sCollectors.NewVerticalPodAutoscalerCollectorVersions(),
+			k8sCollectors.NewHorizontalPodAutoscalerCollectorVersions(),
 		},
 	}
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/horizontalpodautoscaler.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/horizontalpodautoscaler.go
@@ -1,0 +1,100 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && orchestrator
+
+package k8s
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
+	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
+	"github.com/DataDog/datadog-agent/pkg/orchestrator"
+
+	v2Informers "k8s.io/client-go/informers/autoscaling/v2"
+	v2Listers "k8s.io/client-go/listers/autoscaling/v2"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
+)
+
+// NewHorizontalPodAutoscalerCollectorVersions builds the group of collector versions.
+func NewHorizontalPodAutoscalerCollectorVersions() collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewHorizontalPodAutoscalerCollector(),
+	)
+}
+
+// HorizontalPodAutoscalerCollector is a collector for Kubernetes HPAs.
+type HorizontalPodAutoscalerCollector struct {
+	informer  v2Informers.HorizontalPodAutoscalerInformer
+	lister    v2Listers.HorizontalPodAutoscalerLister
+	metadata  *collectors.CollectorMetadata
+	processor *processors.Processor
+}
+
+// NewHorizontalPodAutoscalerCollector creates a new collector for the Kubernetes
+// HorizontalPodAutoscaler resource.
+func NewHorizontalPodAutoscalerCollector() *HorizontalPodAutoscalerCollector {
+	return &HorizontalPodAutoscalerCollector{
+		metadata: &collectors.CollectorMetadata{
+			IsDefaultVersion:          true,
+			IsStable:                  true,
+			IsMetadataProducer:        true,
+			IsManifestProducer:        true,
+			SupportsManifestBuffering: true,
+			Name:                      "horizontalpodautoscalers",
+			NodeType:                  orchestrator.K8sHorizontalPodAutoscaler,
+			Version:                   "autoscaling/v2",
+		},
+		processor: processors.NewProcessor(new(k8sProcessors.HorizontalPodAutoscalerHandlers)),
+	}
+}
+
+// Informer returns the shared informer.
+func (c *HorizontalPodAutoscalerCollector) Informer() cache.SharedInformer {
+	return c.informer.Informer()
+}
+
+// Init is used to initialize the collector.
+func (c *HorizontalPodAutoscalerCollector) Init(rcfg *collectors.CollectorRunConfig) {
+	c.informer = rcfg.OrchestratorInformerFactory.InformerFactory.Autoscaling().V2().HorizontalPodAutoscalers()
+	c.lister = c.informer.Lister()
+}
+
+// Metadata is used to access information about the collector.
+func (c *HorizontalPodAutoscalerCollector) Metadata() *collectors.CollectorMetadata {
+	return c.metadata
+}
+
+// Run triggers the hpa collection process.
+func (c *HorizontalPodAutoscalerCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.CollectorRunResult, error) {
+	list, err := c.lister.List(labels.Everything())
+	if err != nil {
+		return nil, collectors.NewListingError(err)
+	}
+
+	ctx := &processors.ProcessorContext{
+		APIClient:  rcfg.APIClient,
+		Cfg:        rcfg.Config,
+		ClusterID:  rcfg.ClusterID,
+		MsgGroupID: rcfg.MsgGroupRef.Inc(),
+		NodeType:   c.metadata.NodeType,
+	}
+
+	processResult, processed := c.processor.Process(ctx, list)
+
+	if processed == -1 {
+		return nil, collectors.ErrProcessingPanic
+	}
+
+	result := &collectors.CollectorRunResult{
+		Result:             processResult,
+		ResourcesListed:    len(list),
+		ResourcesProcessed: processed,
+	}
+
+	return result, nil
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/horizontalpodautoscaler.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/horizontalpodautoscaler.go
@@ -41,7 +41,7 @@ func NewHorizontalPodAutoscalerCollector() *HorizontalPodAutoscalerCollector {
 	return &HorizontalPodAutoscalerCollector{
 		metadata: &collectors.CollectorMetadata{
 			IsDefaultVersion:          true,
-			IsStable:                  true,
+			IsStable:                  false,
 			IsMetadataProducer:        true,
 			IsManifestProducer:        true,
 			SupportsManifestBuffering: true,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/horizontalpodautoscaler.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/horizontalpodautoscaler.go
@@ -1,0 +1,84 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build orchestrator
+
+package k8s
+
+import (
+	model "github.com/DataDog/agent-payload/v5/process"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
+	k8sTransformers "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s"
+	"github.com/DataDog/datadog-agent/pkg/orchestrator/redact"
+	v2 "k8s.io/api/autoscaling/v2"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// HorizontalPodAutoscalerHandlers implements the Handlers interface for Kuberenetes HPAs
+type HorizontalPodAutoscalerHandlers struct {
+	BaseHandlers
+}
+
+// AfterMarshalling is a handler called after resource marshalling.
+func (h *HorizontalPodAutoscalerHandlers) AfterMarshalling(ctx *processors.ProcessorContext, resource, resourceModel interface{}, yaml []byte) (skip bool) {
+	m := resourceModel.(*model.HorizontalPodAutoscaler)
+	m.Yaml = yaml
+	return
+}
+
+// BuildMessageBody is a handler called to build a message body out of a list of
+// extracted resources.
+func (h *HorizontalPodAutoscalerHandlers) BuildMessageBody(ctx *processors.ProcessorContext, resourceModels []interface{}, groupSize int) model.MessageBody {
+	models := make([]*model.HorizontalPodAutoscaler, 0, len(resourceModels))
+
+	for _, m := range resourceModels {
+		models = append(models, m.(*model.HorizontalPodAutoscaler))
+	}
+
+	return &model.CollectorHorizontalPodAutoscaler{
+		ClusterName:              ctx.Cfg.KubeClusterName,
+		ClusterId:                ctx.ClusterID,
+		GroupId:                  ctx.MsgGroupID,
+		GroupSize:                int32(groupSize),
+		HorizontalPodAutoscalers: models,
+		Tags:                     append(ctx.Cfg.ExtraTags, ctx.ApiGroupVersionTag),
+	}
+}
+
+// ExtractResource is a handler called to extract the resource model out of a raw resource.
+func (h *HorizontalPodAutoscalerHandlers) ExtractResource(ctx *processors.ProcessorContext, resource interface{}) (horizontalPodAutoscalerModel interface{}) {
+	r := resource.(*v2.HorizontalPodAutoscaler)
+	return k8sTransformers.ExtractHorizontalPodAutoscaler(r)
+}
+
+// ResourceList is a handler called to convert a list passed as a generic
+// interface to a list of generic interfaces.
+func (h *HorizontalPodAutoscalerHandlers) ResourceList(ctx *processors.ProcessorContext, list interface{}) (resources []interface{}) {
+	resourceList := list.([]*v2.HorizontalPodAutoscaler)
+	resources = make([]interface{}, 0, len(resourceList))
+
+	for _, resource := range resourceList {
+		resources = append(resources, resource)
+	}
+
+	return resources
+}
+
+// ResourceUID is a handler called to retrieve the resource UID.
+func (h *HorizontalPodAutoscalerHandlers) ResourceUID(ctx *processors.ProcessorContext, resource interface{}) types.UID {
+	return resource.(*v2.HorizontalPodAutoscaler).UID
+}
+
+// ResourceVersion is a handler called to retrieve the resource version.
+func (h *HorizontalPodAutoscalerHandlers) ResourceVersion(ctx *processors.ProcessorContext, resource, resourceModel interface{}) string {
+	return resource.(*v2.HorizontalPodAutoscaler).ResourceVersion
+}
+
+// ScrubBeforeExtraction is a handler called to redact the raw resource before
+// it is extracted as an internal resource model.
+func (h *HorizontalPodAutoscalerHandlers) ScrubBeforeExtraction(ctx *processors.ProcessorContext, resource interface{}) {
+	r := resource.(*v2.HorizontalPodAutoscaler)
+	redact.RemoveLastAppliedConfigurationAnnotation(r.Annotations)
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/horizontalpodautoscaler.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/horizontalpodautoscaler.go
@@ -111,13 +111,11 @@ func extractMetricTarget(m v2.MetricTarget) *model.MetricTarget {
 		}
 	case v2.ValueMetricType:
 		if m.Value != nil {
-			v, _ := m.Value.AsInt64()
-			mt.Value = v
+			mt.Value = m.Value.ToDec().MilliValue()
 		}
 	case v2.AverageValueMetricType:
 		if m.AverageValue != nil {
-			v, _ := m.AverageValue.AsInt64()
-			mt.Value = v
+			mt.Value = m.AverageValue.ToDec().MilliValue()
 		}
 	}
 	return &mt
@@ -306,12 +304,10 @@ func extractObjectMetricStatus(s *v2.ObjectMetricStatus) *model.ObjectMetricStat
 	}
 	// ObjectMetric only supports value and AverageValue
 	if s.Current.Value != nil {
-		value, _ := s.Current.Value.AsInt64()
-		m.Current = value
+		m.Current = s.Current.Value.ToDec().MilliValue()
 	}
 	if s.Current.AverageValue != nil {
-		value, _ := s.Current.AverageValue.AsInt64()
-		m.Current = value
+		m.Current = s.Current.AverageValue.ToDec().MilliValue()
 	}
 	return &m
 }
@@ -328,8 +324,7 @@ func extractPodsMetricStatus(s *v2.PodsMetricStatus) *model.PodsMetricStatus {
 
 	// Only AverageValue is supported for PodsMetric
 	if s.Current.AverageValue != nil {
-		value, _ := s.Current.AverageValue.AsInt64()
-		m.Current = value
+		m.Current = s.Current.AverageValue.ToDec().MilliValue()
 	}
 	return &m
 }
@@ -343,10 +338,9 @@ func extractResourceMetricStatus(s *v2.ResourceMetricStatus) *model.ResourceMetr
 	m := model.ResourceMetricStatus{
 		ResourceName: s.Name.String(),
 	}
-	// Only AverageValue and AvertageUtilization is supported for ResourceMetric
+	// Only AverageValue and AverageUtilization is supported for ResourceMetric
 	if s.Current.AverageValue != nil {
-		value, _ := s.Current.AverageValue.AsInt64()
-		m.Current = value
+		m.Current = s.Current.AverageValue.ToDec().MilliValue()
 	}
 	if s.Current.AverageUtilization != nil {
 		m.Current = int64(*s.Current.AverageUtilization)
@@ -381,12 +375,10 @@ func extractExternalMetricStatus(s *v2.ExternalMetricStatus) *model.ExternalMetr
 	}
 	// Only Value and AverageValue is supported for ResourceMetric
 	if s.Current.Value != nil {
-		value, _ := s.Current.Value.AsInt64()
-		m.Current = value
+		m.Current = s.Current.Value.ToDec().MilliValue()
 	}
 	if s.Current.AverageValue != nil {
-		value, _ := s.Current.AverageValue.AsInt64()
-		m.Current = value
+		m.Current = s.Current.AverageValue.ToDec().MilliValue()
 	}
 	return &m
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/horizontalpodautoscaler.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/horizontalpodautoscaler.go
@@ -1,0 +1,422 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build orchestrator
+
+package k8s
+
+import (
+	v2 "k8s.io/api/autoscaling/v2"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers"
+)
+
+// ExtractHorizontalPodAutoscaler returns the protobuf model corresponding to a Kubernetes Horizontal Pod Autoscaler resource.
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L33
+func ExtractHorizontalPodAutoscaler(v *v2.HorizontalPodAutoscaler) *model.HorizontalPodAutoscaler {
+	if v == nil {
+		return &model.HorizontalPodAutoscaler{}
+	}
+
+	m := &model.HorizontalPodAutoscaler{
+		Metadata: extractMetadata(&v.ObjectMeta),
+		Spec:     extractHorizontalPodAutoscalerSpec(&v.Spec),
+		Status:   extractHorizontalPodAutoscalerStatus(&v.Status),
+	}
+
+	if len(v.Status.Conditions) > 0 {
+		hpaConditions, conditionTags := extractHorizontalPodAutoscalerConditions(v)
+		m.Conditions = hpaConditions
+		m.Tags = append(m.Tags, conditionTags...)
+	}
+
+	m.Tags = append(m.Tags, transformers.RetrieveUnifiedServiceTags(v.ObjectMeta.Labels)...)
+	return m
+}
+
+// extractHorizontalPodAutoscalerSpec converts Kubernetes HorizontalPodAutoscalerSpec to our custom one
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L51
+func extractHorizontalPodAutoscalerSpec(s *v2.HorizontalPodAutoscalerSpec) *model.HorizontalPodAutoscalerSpec {
+	spec := model.HorizontalPodAutoscalerSpec{
+		Target: &model.HorizontalPodAutoscalerTarget{
+			Kind: s.ScaleTargetRef.Kind,
+			Name: s.ScaleTargetRef.Name,
+		},
+		MaxReplicas: s.MaxReplicas,
+		Metrics:     extractMetricSpec(s.Metrics),
+		Behavior:    extractHorizontalPodAutoscalerBehavior(s.Behavior),
+	}
+	if s.MinReplicas != nil {
+		spec.MinReplicas = *s.MinReplicas
+	}
+	return &spec
+}
+
+// extractMetricSpec converts Kubernetes MetricSpec to our custom one
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L97
+func extractMetricSpec(ms []v2.MetricSpec) []*model.HorizontalPodAutoscalerMetricSpec {
+	if ms == nil {
+		return []*model.HorizontalPodAutoscalerMetricSpec{}
+	}
+
+	metrics := []*model.HorizontalPodAutoscalerMetricSpec{}
+	for _, m := range ms {
+		metric := &model.HorizontalPodAutoscalerMetricSpec{
+			Type: string(m.Type),
+		}
+		switch m.Type {
+		case v2.ObjectMetricSourceType:
+			metric.Object = extractObjectMetric(m.Object)
+		case v2.PodsMetricSourceType:
+			metric.Pods = extractPodsMetric(m.Pods)
+		case v2.ResourceMetricSourceType:
+			metric.Resource = extractResourceMetric(m.Resource)
+		case v2.ContainerResourceMetricSourceType:
+			metric.ContainerResource = extractContainerResourceMetric(m.ContainerResource)
+		case v2.ExternalMetricSourceType:
+			metric.External = extractExternalMetric(m.External)
+		}
+		metrics = append(metrics, metric)
+	}
+	return metrics
+}
+
+// extractMetricIdentifier converts Kubernetes MetricIdentifier to our custom one
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L310
+func extractMetricIdentifier(m v2.MetricIdentifier) *model.MetricIdentifier {
+	mi := model.MetricIdentifier{
+		Name: m.Name,
+	}
+	// TODO - figure out how we want represent labelSelectors
+	// Leaving as a string for now
+	if m.Selector != nil {
+		mi.LabelSelector = m.Selector.String()
+	}
+	return &mi
+}
+
+// extractMetricTarget converts Kubernetes MetricTarget to our custom one
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L321
+func extractMetricTarget(m v2.MetricTarget) *model.MetricTarget {
+	mt := model.MetricTarget{
+		Type: string(m.Type),
+	}
+
+	switch m.Type {
+	case v2.UtilizationMetricType:
+		if m.AverageUtilization != nil {
+			mt.Value = int64(*m.AverageUtilization)
+		}
+	case v2.ValueMetricType:
+		if m.Value != nil {
+			v, _ := m.Value.AsInt64()
+			mt.Value = v
+		}
+	case v2.AverageValueMetricType:
+		if m.AverageValue != nil {
+			v, _ := m.AverageValue.AsInt64()
+			mt.Value = v
+		}
+	}
+	return &mt
+}
+
+// extractObjectMetric converts Kubernetes ObjectMetricSource to our custom one
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L249
+func extractObjectMetric(s *v2.ObjectMetricSource) *model.ObjectMetricSource {
+	if s == nil {
+		return &model.ObjectMetricSource{}
+	}
+	m := model.ObjectMetricSource{
+		DescribedObject: &model.ObjectReference{
+			Kind:       s.DescribedObject.Kind,
+			Name:       s.DescribedObject.Name,
+			ApiVersion: s.DescribedObject.APIVersion,
+		},
+		Metric: extractMetricIdentifier(s.Metric),
+		Target: extractMetricTarget(s.Target),
+	}
+	return &m
+}
+
+// extractPodsMetric converts Kubernetes PodsMetricSource to our custom one
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L262
+func extractPodsMetric(s *v2.PodsMetricSource) *model.PodsMetricSource {
+	if s == nil {
+		return &model.PodsMetricSource{}
+	}
+	m := model.PodsMetricSource{
+		Metric: extractMetricIdentifier(s.Metric),
+		Target: extractMetricTarget(s.Target),
+	}
+	return &m
+}
+
+// extractResourceMetric converts Kubernetes ResourceMetricSource to our custom one
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L276
+func extractResourceMetric(s *v2.ResourceMetricSource) *model.ResourceMetricSource {
+	if s == nil {
+		return &model.ResourceMetricSource{}
+	}
+	m := model.ResourceMetricSource{
+		ResourceName: s.Name.String(),
+		Target:       extractMetricTarget(s.Target),
+	}
+	return &m
+}
+
+// extractContainerResourceMetric converts Kubernetes ContainerResourceMetricSource to our custom one
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L290
+func extractContainerResourceMetric(s *v2.ContainerResourceMetricSource) *model.ContainerResourceMetricSource {
+	if s == nil {
+		return &model.ContainerResourceMetricSource{}
+	}
+	m := model.ContainerResourceMetricSource{
+		ResourceName: s.Name.String(),
+		Target:       extractMetricTarget(s.Target),
+		Container:    s.Container,
+	}
+	return &m
+}
+
+// extractExternalMetric converts Kubernetes ExternalMetricSource to our custom one
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L302
+func extractExternalMetric(s *v2.ExternalMetricSource) *model.ExternalMetricSource {
+	if s == nil {
+		return &model.ExternalMetricSource{}
+	}
+	m := model.ExternalMetricSource{
+		Metric: extractMetricIdentifier(s.Metric),
+		Target: extractMetricTarget(s.Target),
+	}
+	return &m
+}
+
+// extractHorizontalPodAutoscalerBehavior converts Kubernetes HorizontalPodAutoscalerBehavior to our custom one
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L139
+func extractHorizontalPodAutoscalerBehavior(v *v2.HorizontalPodAutoscalerBehavior) *model.HorizontalPodAutoscalerBehavior {
+	if v == nil {
+		return &model.HorizontalPodAutoscalerBehavior{}
+	}
+
+	b := model.HorizontalPodAutoscalerBehavior{}
+	if v.ScaleUp != nil {
+		b.ScaleUp = extractScalingRules(v.ScaleUp)
+	}
+	if v.ScaleDown != nil {
+		b.ScaleDown = extractScalingRules(v.ScaleDown)
+	}
+
+	return &b
+}
+
+// extractScalingRules converts Kubernetes HPAScalingRules to our custom one
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L173
+func extractScalingRules(sr *v2.HPAScalingRules) *model.HPAScalingRules {
+	if sr == nil {
+		return &model.HPAScalingRules{}
+	}
+
+	r := model.HPAScalingRules{}
+	if sr.StabilizationWindowSeconds != nil {
+		r.StabilizationWindowSeconds = *sr.StabilizationWindowSeconds
+	}
+	if sr.SelectPolicy != nil {
+		r.SelectPolicy = string(*sr.SelectPolicy)
+	}
+	policies := []*model.HPAScalingPolicy{}
+	for _, p := range sr.Policies {
+		p2 := &model.HPAScalingPolicy{
+			Type:          string(p.Type),
+			Value:         p.Value,
+			PeriodSeconds: p.PeriodSeconds,
+		}
+		policies = append(policies, p2)
+	}
+	r.Policies = policies
+	return &r
+}
+
+// extractHorizontalPodAutoscalerStatus converts Kubernetes HorizontalPodAutoscalerStatus to our protobuf model
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L353
+func extractHorizontalPodAutoscalerStatus(s *v2.HorizontalPodAutoscalerStatus) *model.HorizontalPodAutoscalerStatus {
+	if s == nil {
+		return &model.HorizontalPodAutoscalerStatus{}
+	}
+
+	status := model.HorizontalPodAutoscalerStatus{
+		CurrentReplicas: s.CurrentReplicas,
+		DesiredReplicas: s.DesiredReplicas,
+		CurrentMetrics:  extractMetricStatus(s.CurrentMetrics),
+	}
+	if s.ObservedGeneration != nil {
+		status.ObservedGeneration = *s.ObservedGeneration
+	}
+	if s.LastScaleTime != nil {
+		status.LastScaleTime = s.LastScaleTime.Unix()
+	}
+
+	return &status
+}
+
+// extractMetricStatus converts Kubernetes MetricStatus to our custom HorizontalPodAutoscalerMetricSpec model
+// HorizontalPodAutoscalerMetricSpec is being resused since the model is simliar - the only difference is that the type is not used here
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L519
+func extractMetricStatus(ms []v2.MetricStatus) []*model.HorizontalPodAutoscalerMetricStatus {
+	if ms == nil {
+		return []*model.HorizontalPodAutoscalerMetricStatus{}
+	}
+
+	metrics := []*model.HorizontalPodAutoscalerMetricStatus{}
+	for _, m := range ms {
+		metric := &model.HorizontalPodAutoscalerMetricStatus{
+			Type: string(m.Type),
+		}
+		switch m.Type {
+		case v2.ObjectMetricSourceType:
+			metric.Object = extractObjectMetricStatus(m.Object)
+		case v2.PodsMetricSourceType:
+			metric.Pods = extractPodsMetricStatus(m.Pods)
+		case v2.ResourceMetricSourceType:
+			metric.Resource = extractResourceMetricStatus(m.Resource)
+		case v2.ContainerResourceMetricSourceType:
+			metric.ContainerResource = extractContainerResourceMetricStatus(m.ContainerResource)
+		case v2.ExternalMetricSourceType:
+			metric.External = extractExternalMetricStatus(m.External)
+		}
+		metrics = append(metrics, metric)
+	}
+	return metrics
+}
+
+// extractObjectMetricStatus converts Kubernetes ObjectMetricStatus to our custom one
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L249
+func extractObjectMetricStatus(s *v2.ObjectMetricStatus) *model.ObjectMetricStatus {
+	if s == nil {
+		return &model.ObjectMetricStatus{}
+	}
+	m := model.ObjectMetricStatus{
+		DescribedObject: &model.ObjectReference{
+			Kind:       s.DescribedObject.Kind,
+			Name:       s.DescribedObject.Name,
+			ApiVersion: s.DescribedObject.APIVersion,
+		},
+		Metric: extractMetricIdentifier(s.Metric),
+	}
+	// ObjectMetric only supports value and AverageValue
+	if s.Current.Value != nil {
+		value, _ := s.Current.Value.AsInt64()
+		m.Current = value
+	}
+	if s.Current.AverageValue != nil {
+		value, _ := s.Current.AverageValue.AsInt64()
+		m.Current = value
+	}
+	return &m
+}
+
+// extractPodsMetricStatus converts Kubernetes PodsMetricStatus to our custom one
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L262
+func extractPodsMetricStatus(s *v2.PodsMetricStatus) *model.PodsMetricStatus {
+	if s == nil {
+		return &model.PodsMetricStatus{}
+	}
+	m := model.PodsMetricStatus{
+		Metric: extractMetricIdentifier(s.Metric),
+	}
+
+	// Only AverageValue is supported for PodsMetric
+	if s.Current.AverageValue != nil {
+		value, _ := s.Current.AverageValue.AsInt64()
+		m.Current = value
+	}
+	return &m
+}
+
+// extractResourceMetricStatus converts Kubernetes ResourceMetricStatus to our custom one
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L276
+func extractResourceMetricStatus(s *v2.ResourceMetricStatus) *model.ResourceMetricStatus {
+	if s == nil {
+		return &model.ResourceMetricStatus{}
+	}
+	m := model.ResourceMetricStatus{
+		ResourceName: s.Name.String(),
+	}
+	// Only AverageValue and AvertageUtilization is supported for ResourceMetric
+	if s.Current.AverageValue != nil {
+		value, _ := s.Current.AverageValue.AsInt64()
+		m.Current = value
+	}
+	if s.Current.AverageUtilization != nil {
+		m.Current = int64(*s.Current.AverageUtilization)
+	}
+	return &m
+}
+
+// extractContainerResourceMetricStatus converts Kubernetes ContainerResourceMetricStatus to our custom one
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L290
+func extractContainerResourceMetricStatus(s *v2.ContainerResourceMetricStatus) *model.ContainerResourceMetricStatus {
+	if s == nil {
+		return &model.ContainerResourceMetricStatus{}
+	}
+	m := model.ContainerResourceMetricStatus{
+		ResourceName: s.Name.String(),
+		Container:    s.Container,
+	}
+	if s.Current.AverageUtilization != nil {
+		m.Current = int64(*s.Current.AverageUtilization)
+	}
+	return &m
+}
+
+// extractExternalMetric converts Kubernetes ExternalMetricStatus to our custom one
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L302
+func extractExternalMetricStatus(s *v2.ExternalMetricStatus) *model.ExternalMetricStatus {
+	if s == nil {
+		return &model.ExternalMetricStatus{}
+	}
+	m := model.ExternalMetricStatus{
+		Metric: extractMetricIdentifier(s.Metric),
+	}
+	// Only Value and AverageValue is supported for ResourceMetric
+	if s.Current.Value != nil {
+		value, _ := s.Current.Value.AsInt64()
+		m.Current = value
+	}
+	if s.Current.AverageValue != nil {
+		value, _ := s.Current.AverageValue.AsInt64()
+		m.Current = value
+	}
+	return &m
+}
+
+// extractHorizontalPodAutoscalerConditions iterates over hpa conditions and returns:
+// - the payload representation of those conditions
+// - the list of tags that will enable pod filtering by condition
+func extractHorizontalPodAutoscalerConditions(p *v2.HorizontalPodAutoscaler) ([]*model.HorizontalPodAutoscalerCondition, []string) {
+	conditions := make([]*model.HorizontalPodAutoscalerCondition, 0, len(p.Status.Conditions))
+	conditionTags := make([]string, 0, len(p.Status.Conditions))
+
+	for _, condition := range p.Status.Conditions {
+		c := &model.HorizontalPodAutoscalerCondition{
+			Message:         condition.Message,
+			Reason:          condition.Reason,
+			ConditionStatus: string(condition.Status),
+			ConditionType:   string(condition.Type),
+		}
+		if !condition.LastTransitionTime.IsZero() {
+			c.LastTransitionTime = condition.LastTransitionTime.Unix()
+		}
+
+		conditions = append(conditions, c)
+
+		conditionTag := createConditionTag(string(condition.Type), string(condition.Status))
+		conditionTags = append(conditionTags, conditionTag)
+	}
+
+	return conditions, conditionTags
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/horizontalpodautoscaler.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/horizontalpodautoscaler.go
@@ -91,10 +91,8 @@ func extractMetricIdentifier(m v2.MetricIdentifier) *model.MetricIdentifier {
 	mi := model.MetricIdentifier{
 		Name: m.Name,
 	}
-	// TODO - figure out how we want represent labelSelectors
-	// Leaving as a string for now
 	if m.Selector != nil {
-		mi.LabelSelector = m.Selector.String()
+		mi.LabelSelector = extractLabelSelector(m.Selector)
 	}
 	return &mi
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/horizontalpodautoscaler.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/horizontalpodautoscaler.go
@@ -263,8 +263,7 @@ func extractHorizontalPodAutoscalerStatus(s *v2.HorizontalPodAutoscalerStatus) *
 	return &status
 }
 
-// extractMetricStatus converts Kubernetes MetricStatus to our custom HorizontalPodAutoscalerMetricSpec model
-// HorizontalPodAutoscalerMetricSpec is being resused since the model is simliar - the only difference is that the type is not used here
+// extractMetricStatus converts Kubernetes MetricStatus to our custom HorizontalPodAutoscalerMetricStatus model
 // https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L519
 func extractMetricStatus(ms []v2.MetricStatus) []*model.HorizontalPodAutoscalerMetricStatus {
 	if ms == nil {
@@ -294,7 +293,7 @@ func extractMetricStatus(ms []v2.MetricStatus) []*model.HorizontalPodAutoscalerM
 }
 
 // extractObjectMetricStatus converts Kubernetes ObjectMetricStatus to our custom one
-// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L249
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L465
 func extractObjectMetricStatus(s *v2.ObjectMetricStatus) *model.ObjectMetricStatus {
 	if s == nil {
 		return &model.ObjectMetricStatus{}
@@ -320,7 +319,7 @@ func extractObjectMetricStatus(s *v2.ObjectMetricStatus) *model.ObjectMetricStat
 }
 
 // extractPodsMetricStatus converts Kubernetes PodsMetricStatus to our custom one
-// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L262
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L476
 func extractPodsMetricStatus(s *v2.PodsMetricStatus) *model.PodsMetricStatus {
 	if s == nil {
 		return &model.PodsMetricStatus{}
@@ -338,7 +337,7 @@ func extractPodsMetricStatus(s *v2.PodsMetricStatus) *model.PodsMetricStatus {
 }
 
 // extractResourceMetricStatus converts Kubernetes ResourceMetricStatus to our custom one
-// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L276
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L488
 func extractResourceMetricStatus(s *v2.ResourceMetricStatus) *model.ResourceMetricStatus {
 	if s == nil {
 		return &model.ResourceMetricStatus{}
@@ -358,7 +357,7 @@ func extractResourceMetricStatus(s *v2.ResourceMetricStatus) *model.ResourceMetr
 }
 
 // extractContainerResourceMetricStatus converts Kubernetes ContainerResourceMetricStatus to our custom one
-// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L290
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L500
 func extractContainerResourceMetricStatus(s *v2.ContainerResourceMetricStatus) *model.ContainerResourceMetricStatus {
 	if s == nil {
 		return &model.ContainerResourceMetricStatus{}
@@ -373,8 +372,8 @@ func extractContainerResourceMetricStatus(s *v2.ContainerResourceMetricStatus) *
 	return &m
 }
 
-// extractExternalMetric converts Kubernetes ExternalMetricStatus to our custom one
-// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L302
+// extractExternalMetricStatus converts Kubernetes ExternalMetricStatus to our custom one
+// https://github.com/kubernetes/api/blob/v0.23.15/autoscaling/v2/types.go#L511
 func extractExternalMetricStatus(s *v2.ExternalMetricStatus) *model.ExternalMetricStatus {
 	if s == nil {
 		return &model.ExternalMetricStatus{}

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/horizontalpodautoscaler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/horizontalpodautoscaler_test.go
@@ -24,7 +24,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 	exampleTime := metav1.NewTime(time.Date(2021, time.April, 16, 14, 30, 0, 0, time.UTC))
 	minReplicas := new(int32)
 	*minReplicas = 1
-	resourceQuantity := resource.MustParse("5332")
+	resourceQuantity := resource.MustParse("5332m")
 	window := new(int32)
 	*window = 10
 	selectPolicy := v2.MaxChangePolicySelect

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/horizontalpodautoscaler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/horizontalpodautoscaler_test.go
@@ -24,14 +24,14 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 	exampleTime := metav1.NewTime(time.Date(2021, time.April, 16, 14, 30, 0, 0, time.UTC))
 	minReplicas := new(int32)
 	*minReplicas = 1
-	resourceQuantity := resource.MustParse("10")
+	resourceQuantity := resource.MustParse("5332")
 	window := new(int32)
 	*window = 10
 	selectPolicy := v2.MaxChangePolicySelect
 	oberservedGeneration := new(int64)
 	*oberservedGeneration = 1
 	averageUtilization := new(int32)
-	*averageUtilization = 1000
+	*averageUtilization = 60
 
 	tests := map[string]struct {
 		input    v2.HorizontalPodAutoscaler
@@ -228,7 +228,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 									},
 								},
 								Current: v2.MetricValueStatus{
-									AverageValue: &resourceQuantity,
+									Value: &resourceQuantity,
 								},
 							},
 						},
@@ -287,7 +287,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 								},
 								Target: &model.MetricTarget{
 									Type:  "Value",
-									Value: 10,
+									Value: 5332,
 								},
 								Metric: &model.MetricIdentifier{
 									Name: "CPU",
@@ -306,7 +306,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 							Pods: &model.PodsMetricSource{
 								Target: &model.MetricTarget{
 									Type:  "Utilization",
-									Value: 1000,
+									Value: 60,
 								},
 								Metric: &model.MetricIdentifier{
 									Name: "CPU",
@@ -326,7 +326,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 								ResourceName: "CPU",
 								Target: &model.MetricTarget{
 									Type:  "Utilization",
-									Value: 1000,
+									Value: 60,
 								},
 							},
 						},
@@ -336,7 +336,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 								ResourceName: "CPU",
 								Target: &model.MetricTarget{
 									Type:  "Utilization",
-									Value: 1000,
+									Value: 60,
 								},
 								Container: "agent",
 							},
@@ -346,7 +346,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 							External: &model.ExternalMetricSource{
 								Target: &model.MetricTarget{
 									Type:  "Utilization",
-									Value: 1000,
+									Value: 60,
 								},
 								Metric: &model.MetricIdentifier{
 									Name: "CPU",
@@ -389,7 +389,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 									Name:       "agent",
 									ApiVersion: "v1",
 								},
-								Current: 10,
+								Current: 5332,
 								Metric: &model.MetricIdentifier{
 									Name: "CPU",
 									LabelSelector: []*model.LabelSelectorRequirement{
@@ -405,7 +405,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 						{
 							Type: "Pods",
 							Pods: &model.PodsMetricStatus{
-								Current: 10,
+								Current: 5332,
 								Metric: &model.MetricIdentifier{
 									Name: "CPU",
 									LabelSelector: []*model.LabelSelectorRequirement{
@@ -422,21 +422,21 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 							Type: "Resource",
 							Resource: &model.ResourceMetricStatus{
 								ResourceName: "CPU",
-								Current:      1000,
+								Current:      60,
 							},
 						},
 						{
 							Type: "ContainerResource",
 							ContainerResource: &model.ContainerResourceMetricStatus{
 								ResourceName: "CPU",
-								Current:      1000,
+								Current:      60,
 								Container:    "agent",
 							},
 						},
 						{
 							Type: "External",
 							External: &model.ExternalMetricStatus{
-								Current: 10,
+								Current: 5332,
 								Metric: &model.MetricIdentifier{
 									Name: "CPU",
 									LabelSelector: []*model.LabelSelectorRequirement{
@@ -566,7 +566,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 							External: &model.ExternalMetricSource{
 								Target: &model.MetricTarget{
 									Type:  "Utilization",
-									Value: 1000,
+									Value: 60,
 								},
 								Metric: &model.MetricIdentifier{
 									Name: "CPU",
@@ -584,7 +584,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 						{
 							Type: "External",
 							External: &model.ExternalMetricStatus{
-								Current: 10,
+								Current: 5332,
 								Metric: &model.MetricIdentifier{
 									Name: "CPU",
 								},
@@ -772,7 +772,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 								},
 								Target: &model.MetricTarget{
 									Type:  "AverageValue",
-									Value: 10,
+									Value: 5332,
 								},
 								Metric: &model.MetricIdentifier{
 									Name: "CPU",
@@ -791,7 +791,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 							Pods: &model.PodsMetricSource{
 								Target: &model.MetricTarget{
 									Type:  "AverageValue",
-									Value: 10,
+									Value: 5332,
 								},
 								Metric: &model.MetricIdentifier{
 									Name: "CPU",
@@ -833,7 +833,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 									Name:       "agent",
 									ApiVersion: "v1",
 								},
-								Current: 10,
+								Current: 5332,
 								Metric: &model.MetricIdentifier{
 									Name: "CPU",
 									LabelSelector: []*model.LabelSelectorRequirement{
@@ -849,7 +849,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 						{
 							Type: "Pods",
 							Pods: &model.PodsMetricStatus{
-								Current: 10,
+								Current: 5332,
 								Metric: &model.MetricIdentifier{
 									Name: "CPU",
 									LabelSelector: []*model.LabelSelectorRequirement{

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/horizontalpodautoscaler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/horizontalpodautoscaler_test.go
@@ -1,0 +1,853 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build orchestrator
+
+package k8s
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	v2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	model "github.com/DataDog/agent-payload/v5/process"
+)
+
+func TestExtractHorizontalPodAutoscaler(t *testing.T) {
+	exampleTime := metav1.NewTime(time.Date(2021, time.April, 16, 14, 30, 0, 0, time.UTC))
+	minReplicas := new(int32)
+	*minReplicas = 1
+	resourceQuantity := resource.MustParse("10")
+	window := new(int32)
+	*window = 10
+	selectPolicy := v2.MaxChangePolicySelect
+	oberservedGeneration := new(int64)
+	*oberservedGeneration = 1
+	averageUtilization := new(int32)
+	*averageUtilization = 1000
+
+	tests := map[string]struct {
+		input    v2.HorizontalPodAutoscaler
+		expected model.HorizontalPodAutoscaler
+	}{
+		"standard": {
+			input: v2.HorizontalPodAutoscaler{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "HPATest",
+					Namespace:         "Namespace",
+					UID:               "326331f4-77e2-11ed-a1eb-0242ac120002",
+					CreationTimestamp: exampleTime,
+					DeletionTimestamp: &exampleTime,
+					Labels: map[string]string{
+						"app": "my-app",
+					},
+					Annotations: map[string]string{
+						"annotation": "my-annotation",
+					},
+					Finalizers: []string{"final", "izers"},
+				},
+				Spec: v2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: v2.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "agent",
+					},
+					MinReplicas: minReplicas,
+					MaxReplicas: 3,
+					Metrics: []v2.MetricSpec{
+						{
+							Type: "Object",
+							Object: &v2.ObjectMetricSource{
+								DescribedObject: v2.CrossVersionObjectReference{
+									Kind:       "Pod",
+									Name:       "agent",
+									APIVersion: "v1",
+								},
+								Target: v2.MetricTarget{
+									Type:  v2.ValueMetricType,
+									Value: &resourceQuantity,
+								},
+								Metric: v2.MetricIdentifier{
+									Name: "CPU",
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"environment": "production",
+											"service":     "datadog",
+										},
+									},
+								},
+							},
+						},
+						{
+							Type: "Pods",
+							Pods: &v2.PodsMetricSource{
+								Metric: v2.MetricIdentifier{
+									Name: "CPU",
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"environment": "production",
+											"service":     "datadog",
+										},
+									},
+								},
+								Target: v2.MetricTarget{
+									Type:               v2.UtilizationMetricType,
+									AverageUtilization: averageUtilization,
+								},
+							},
+						},
+						{
+							Type: "Resource",
+							Resource: &v2.ResourceMetricSource{
+								Name: "CPU",
+								Target: v2.MetricTarget{
+									Type:               v2.UtilizationMetricType,
+									AverageUtilization: averageUtilization,
+								},
+							},
+						},
+						{
+							Type: "ContainerResource",
+							ContainerResource: &v2.ContainerResourceMetricSource{
+								Name: "CPU",
+								Target: v2.MetricTarget{
+									Type:               v2.UtilizationMetricType,
+									AverageUtilization: averageUtilization,
+								},
+								Container: "agent",
+							},
+						},
+						{
+							Type: "External",
+							External: &v2.ExternalMetricSource{
+								Metric: v2.MetricIdentifier{
+									Name: "CPU",
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"environment": "production",
+											"service":     "datadog",
+										},
+									},
+								},
+								Target: v2.MetricTarget{
+									Type:               v2.UtilizationMetricType,
+									AverageUtilization: averageUtilization,
+								},
+							},
+						},
+					},
+					Behavior: &v2.HorizontalPodAutoscalerBehavior{
+						ScaleUp: &v2.HPAScalingRules{
+							StabilizationWindowSeconds: window,
+							SelectPolicy:               &selectPolicy,
+							Policies: []v2.HPAScalingPolicy{
+								{
+									Type:          v2.PodsScalingPolicy,
+									Value:         4,
+									PeriodSeconds: 60,
+								},
+							},
+						},
+					},
+				},
+				Status: v2.HorizontalPodAutoscalerStatus{
+					ObservedGeneration: oberservedGeneration,
+					LastScaleTime:      &exampleTime,
+					CurrentReplicas:    1,
+					DesiredReplicas:    2,
+					CurrentMetrics: []v2.MetricStatus{
+						{
+							Type: "Object",
+							Object: &v2.ObjectMetricStatus{
+								DescribedObject: v2.CrossVersionObjectReference{
+									Kind:       "Pod",
+									Name:       "agent",
+									APIVersion: "v1",
+								},
+								Current: v2.MetricValueStatus{
+									Value: &resourceQuantity,
+								},
+								Metric: v2.MetricIdentifier{
+									Name: "CPU",
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"environment": "production",
+											"service":     "datadog",
+										},
+									},
+								},
+							},
+						},
+						{
+							Type: "Pods",
+							Pods: &v2.PodsMetricStatus{
+								Metric: v2.MetricIdentifier{
+									Name: "CPU",
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"environment": "production",
+											"service":     "datadog",
+										},
+									},
+								},
+								Current: v2.MetricValueStatus{
+									AverageValue: &resourceQuantity,
+								},
+							},
+						},
+						{
+							Type: "Resource",
+							Resource: &v2.ResourceMetricStatus{
+								Name: "CPU",
+								Current: v2.MetricValueStatus{
+									AverageUtilization: averageUtilization,
+								},
+							},
+						},
+						{
+							Type: "ContainerResource",
+							ContainerResource: &v2.ContainerResourceMetricStatus{
+								Name: "CPU",
+								Current: v2.MetricValueStatus{
+									AverageUtilization: averageUtilization,
+								},
+								Container: "agent",
+							},
+						},
+						{
+							Type: "External",
+							External: &v2.ExternalMetricStatus{
+								Metric: v2.MetricIdentifier{
+									Name: "CPU",
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"environment": "production",
+											"service":     "datadog",
+										},
+									},
+								},
+								Current: v2.MetricValueStatus{
+									AverageValue: &resourceQuantity,
+								},
+							},
+						},
+					},
+					Conditions: []v2.HorizontalPodAutoscalerCondition{
+						{
+							Type:               v2.AbleToScale,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: exampleTime,
+							Reason:             "ReadyForNewScale",
+							Message:            "recommended size matches current size",
+						},
+						{
+							Type:               v2.ScalingActive,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: exampleTime,
+							Reason:             "ValidMetricFound",
+							Message:            "the HPA was able to successfully calculate a replica count from external metric",
+						},
+						{
+							Type:               v2.ScalingLimited,
+							Status:             corev1.ConditionFalse,
+							LastTransitionTime: exampleTime,
+							Reason:             "DesiredWithinRange",
+							Message:            "the desired count is within the acceptable range",
+						},
+					},
+				},
+			},
+			expected: model.HorizontalPodAutoscaler{
+				Metadata: &model.Metadata{
+					Name:              "HPATest",
+					Namespace:         "Namespace",
+					Uid:               "326331f4-77e2-11ed-a1eb-0242ac120002",
+					CreationTimestamp: exampleTime.Unix(),
+					DeletionTimestamp: exampleTime.Unix(),
+					Labels:            []string{"app:my-app"},
+					Annotations:       []string{"annotation:my-annotation"},
+					Finalizers:        []string{"final", "izers"},
+				},
+				Spec: &model.HorizontalPodAutoscalerSpec{
+					Target: &model.HorizontalPodAutoscalerTarget{
+						Kind: "Deployment",
+						Name: "agent",
+					},
+					MinReplicas: 1,
+					MaxReplicas: 3,
+					Metrics: []*model.HorizontalPodAutoscalerMetricSpec{
+						{
+							Type: "Object",
+							Object: &model.ObjectMetricSource{
+								DescribedObject: &model.ObjectReference{
+									Kind:       "Pod",
+									Name:       "agent",
+									ApiVersion: "v1",
+								},
+								Target: &model.MetricTarget{
+									Type:  "Value",
+									Value: 10,
+								},
+								Metric: &model.MetricIdentifier{
+									Name:          "CPU",
+									LabelSelector: "&LabelSelector{MatchLabels:map[string]string{environment: production,service: datadog,},MatchExpressions:[]LabelSelectorRequirement{},}",
+								},
+							},
+						},
+						{
+							Type: "Pods",
+							Pods: &model.PodsMetricSource{
+								Target: &model.MetricTarget{
+									Type:  "Utilization",
+									Value: 1000,
+								},
+								Metric: &model.MetricIdentifier{
+									Name:          "CPU",
+									LabelSelector: "&LabelSelector{MatchLabels:map[string]string{environment: production,service: datadog,},MatchExpressions:[]LabelSelectorRequirement{},}",
+								},
+							},
+						},
+						{
+							Type: "Resource",
+							Resource: &model.ResourceMetricSource{
+								ResourceName: "CPU",
+								Target: &model.MetricTarget{
+									Type:  "Utilization",
+									Value: 1000,
+								},
+							},
+						},
+						{
+							Type: "ContainerResource",
+							ContainerResource: &model.ContainerResourceMetricSource{
+								ResourceName: "CPU",
+								Target: &model.MetricTarget{
+									Type:  "Utilization",
+									Value: 1000,
+								},
+								Container: "agent",
+							},
+						},
+						{
+							Type: "External",
+							External: &model.ExternalMetricSource{
+								Target: &model.MetricTarget{
+									Type:  "Utilization",
+									Value: 1000,
+								},
+								Metric: &model.MetricIdentifier{
+									Name:          "CPU",
+									LabelSelector: "&LabelSelector{MatchLabels:map[string]string{environment: production,service: datadog,},MatchExpressions:[]LabelSelectorRequirement{},}",
+								},
+							},
+						},
+					},
+					Behavior: &model.HorizontalPodAutoscalerBehavior{
+						ScaleUp: &model.HPAScalingRules{
+							StabilizationWindowSeconds: 10,
+							SelectPolicy:               "Max",
+							Policies: []*model.HPAScalingPolicy{
+								{
+									Type:          "Pods",
+									Value:         4,
+									PeriodSeconds: 60,
+								},
+							},
+						},
+					},
+				},
+				Status: &model.HorizontalPodAutoscalerStatus{
+					ObservedGeneration: 1,
+					LastScaleTime:      exampleTime.Unix(),
+					CurrentReplicas:    1,
+					DesiredReplicas:    2,
+					CurrentMetrics: []*model.HorizontalPodAutoscalerMetricStatus{
+						{
+							Type: "Object",
+							Object: &model.ObjectMetricStatus{
+								DescribedObject: &model.ObjectReference{
+									Kind:       "Pod",
+									Name:       "agent",
+									ApiVersion: "v1",
+								},
+								Current: 10,
+								Metric: &model.MetricIdentifier{
+									Name:          "CPU",
+									LabelSelector: "&LabelSelector{MatchLabels:map[string]string{environment: production,service: datadog,},MatchExpressions:[]LabelSelectorRequirement{},}",
+								},
+							},
+						},
+						{
+							Type: "Pods",
+							Pods: &model.PodsMetricStatus{
+								Current: 10,
+								Metric: &model.MetricIdentifier{
+									Name:          "CPU",
+									LabelSelector: "&LabelSelector{MatchLabels:map[string]string{environment: production,service: datadog,},MatchExpressions:[]LabelSelectorRequirement{},}",
+								},
+							},
+						},
+						{
+							Type: "Resource",
+							Resource: &model.ResourceMetricStatus{
+								ResourceName: "CPU",
+								Current:      1000,
+							},
+						},
+						{
+							Type: "ContainerResource",
+							ContainerResource: &model.ContainerResourceMetricStatus{
+								ResourceName: "CPU",
+								Current:      1000,
+								Container:    "agent",
+							},
+						},
+						{
+							Type: "External",
+							External: &model.ExternalMetricStatus{
+								Current: 10,
+								Metric: &model.MetricIdentifier{
+									Name:          "CPU",
+									LabelSelector: "&LabelSelector{MatchLabels:map[string]string{environment: production,service: datadog,},MatchExpressions:[]LabelSelectorRequirement{},}",
+								},
+							},
+						},
+					},
+				},
+				Conditions: []*model.HorizontalPodAutoscalerCondition{
+					{
+						ConditionType:      "AbleToScale",
+						ConditionStatus:    "True",
+						LastTransitionTime: exampleTime.Unix(),
+						Reason:             "ReadyForNewScale",
+						Message:            "recommended size matches current size",
+					},
+					{
+						ConditionType:      "ScalingActive",
+						ConditionStatus:    "True",
+						LastTransitionTime: exampleTime.Unix(),
+						Reason:             "ValidMetricFound",
+						Message:            "the HPA was able to successfully calculate a replica count from external metric",
+					},
+					{
+						ConditionType:      "ScalingLimited",
+						ConditionStatus:    "False",
+						LastTransitionTime: exampleTime.Unix(),
+						Reason:             "DesiredWithinRange",
+						Message:            "the desired count is within the acceptable range",
+					},
+				},
+				Tags: []string{
+					"kube_condition_abletoscale:true",
+					"kube_condition_scalingactive:true",
+					"kube_condition_scalinglimited:false",
+				},
+			},
+		},
+		"minimum-required": {
+			input: v2.HorizontalPodAutoscaler{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "HPATest",
+					Namespace:         "Namespace",
+					UID:               "326331f4-77e2-11ed-a1eb-0242ac120002",
+					CreationTimestamp: exampleTime,
+					DeletionTimestamp: &exampleTime,
+					Labels: map[string]string{
+						"app": "my-app",
+					},
+					Annotations: map[string]string{
+						"annotation": "my-annotation",
+					},
+					Finalizers: []string{"final", "izers"},
+				},
+				Spec: v2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: v2.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "agent",
+					},
+					MinReplicas: nil,
+					Metrics: []v2.MetricSpec{
+						{
+							Type: "External",
+							External: &v2.ExternalMetricSource{
+								Metric: v2.MetricIdentifier{
+									Name:     "CPU",
+									Selector: nil,
+								},
+								Target: v2.MetricTarget{
+									Type:               v2.UtilizationMetricType,
+									AverageUtilization: averageUtilization,
+								},
+							},
+						},
+					},
+					Behavior: &v2.HorizontalPodAutoscalerBehavior{
+						ScaleUp:   nil,
+						ScaleDown: nil,
+					},
+				},
+				Status: v2.HorizontalPodAutoscalerStatus{
+					ObservedGeneration: nil,
+					LastScaleTime:      nil,
+					CurrentMetrics: []v2.MetricStatus{
+						{
+							Type: "External",
+							External: &v2.ExternalMetricStatus{
+								Metric: v2.MetricIdentifier{
+									Name:     "CPU",
+									Selector: nil,
+								},
+								Current: v2.MetricValueStatus{
+									AverageValue: &resourceQuantity,
+								},
+							},
+						},
+					},
+					Conditions: []v2.HorizontalPodAutoscalerCondition{},
+				},
+			},
+			expected: model.HorizontalPodAutoscaler{
+				Metadata: &model.Metadata{
+					Name:              "HPATest",
+					Namespace:         "Namespace",
+					Uid:               "326331f4-77e2-11ed-a1eb-0242ac120002",
+					CreationTimestamp: exampleTime.Unix(),
+					DeletionTimestamp: exampleTime.Unix(),
+					Labels:            []string{"app:my-app"},
+					Annotations:       []string{"annotation:my-annotation"},
+					Finalizers:        []string{"final", "izers"},
+				},
+				Spec: &model.HorizontalPodAutoscalerSpec{
+					Target: &model.HorizontalPodAutoscalerTarget{
+						Kind: "Deployment",
+						Name: "agent",
+					},
+					Metrics: []*model.HorizontalPodAutoscalerMetricSpec{
+						{
+							Type: "External",
+							External: &model.ExternalMetricSource{
+								Target: &model.MetricTarget{
+									Type:  "Utilization",
+									Value: 1000,
+								},
+								Metric: &model.MetricIdentifier{
+									Name: "CPU",
+								},
+							},
+						},
+					},
+					Behavior: &model.HorizontalPodAutoscalerBehavior{
+						ScaleUp:   nil,
+						ScaleDown: nil,
+					},
+				},
+				Status: &model.HorizontalPodAutoscalerStatus{
+					CurrentMetrics: []*model.HorizontalPodAutoscalerMetricStatus{
+						{
+							Type: "External",
+							External: &model.ExternalMetricStatus{
+								Current: 10,
+								Metric: &model.MetricIdentifier{
+									Name: "CPU",
+								},
+							},
+						},
+					},
+				},
+				Conditions: nil,
+			},
+		},
+		"mixed": {
+			input: v2.HorizontalPodAutoscaler{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "HPATest",
+					Namespace:         "Namespace",
+					UID:               "326331f4-77e2-11ed-a1eb-0242ac120002",
+					CreationTimestamp: exampleTime,
+					DeletionTimestamp: &exampleTime,
+					Labels: map[string]string{
+						"app": "my-app",
+					},
+					Annotations: map[string]string{
+						"annotation": "my-annotation",
+					},
+					Finalizers: []string{"final", "izers"},
+				},
+				Spec: v2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: v2.CrossVersionObjectReference{
+						Kind: "Deployment",
+						Name: "agent",
+					},
+					MinReplicas: minReplicas,
+					MaxReplicas: 3,
+					Metrics: []v2.MetricSpec{
+						{
+							Type: "Object",
+							Object: &v2.ObjectMetricSource{
+								DescribedObject: v2.CrossVersionObjectReference{
+									Kind:       "Pod",
+									Name:       "agent",
+									APIVersion: "v1",
+								},
+								Target: v2.MetricTarget{
+									Type:         v2.AverageValueMetricType,
+									AverageValue: &resourceQuantity,
+								},
+								Metric: v2.MetricIdentifier{
+									Name: "CPU",
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"environment": "production",
+											"service":     "datadog",
+										},
+									},
+								},
+							},
+						},
+						{
+							Type: "Pods",
+							Pods: &v2.PodsMetricSource{
+								Metric: v2.MetricIdentifier{
+									Name: "CPU",
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"environment": "production",
+											"service":     "datadog",
+										},
+									},
+								},
+								Target: v2.MetricTarget{
+									Type:         v2.AverageValueMetricType,
+									AverageValue: &resourceQuantity,
+								},
+							},
+						},
+					},
+					Behavior: &v2.HorizontalPodAutoscalerBehavior{
+						ScaleUp: &v2.HPAScalingRules{
+							StabilizationWindowSeconds: window,
+							SelectPolicy:               nil,
+							Policies: []v2.HPAScalingPolicy{
+								{
+									Type:          v2.PodsScalingPolicy,
+									Value:         4,
+									PeriodSeconds: 60,
+								},
+							},
+						},
+					},
+				},
+				Status: v2.HorizontalPodAutoscalerStatus{
+					ObservedGeneration: nil,
+					LastScaleTime:      &exampleTime,
+					CurrentReplicas:    1,
+					DesiredReplicas:    2,
+					CurrentMetrics: []v2.MetricStatus{
+						{
+							Type: "Object",
+							Object: &v2.ObjectMetricStatus{
+								DescribedObject: v2.CrossVersionObjectReference{
+									Kind:       "Pod",
+									Name:       "agent",
+									APIVersion: "v1",
+								},
+								Current: v2.MetricValueStatus{
+									Value: &resourceQuantity,
+								},
+								Metric: v2.MetricIdentifier{
+									Name: "CPU",
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"environment": "production",
+											"service":     "datadog",
+										},
+									},
+								},
+							},
+						},
+						{
+							Type: "Pods",
+							Pods: &v2.PodsMetricStatus{
+								Metric: v2.MetricIdentifier{
+									Name: "CPU",
+									Selector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"environment": "production",
+											"service":     "datadog",
+										},
+									},
+								},
+								Current: v2.MetricValueStatus{
+									AverageValue: &resourceQuantity,
+								},
+							},
+						},
+					},
+					Conditions: []v2.HorizontalPodAutoscalerCondition{
+						{
+							Type:               v2.AbleToScale,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: exampleTime,
+							Reason:             "ReadyForNewScale",
+							Message:            "recommended size matches current size",
+						},
+						{
+							Type:               v2.ScalingActive,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: exampleTime,
+							Reason:             "ValidMetricFound",
+							Message:            "the HPA was able to successfully calculate a replica count from external metric",
+						},
+						{
+							Type:               v2.ScalingLimited,
+							Status:             corev1.ConditionFalse,
+							LastTransitionTime: exampleTime,
+							Reason:             "DesiredWithinRange",
+							Message:            "the desired count is within the acceptable range",
+						},
+					},
+				},
+			},
+			expected: model.HorizontalPodAutoscaler{
+				Metadata: &model.Metadata{
+					Name:              "HPATest",
+					Namespace:         "Namespace",
+					Uid:               "326331f4-77e2-11ed-a1eb-0242ac120002",
+					CreationTimestamp: exampleTime.Unix(),
+					DeletionTimestamp: exampleTime.Unix(),
+					Labels:            []string{"app:my-app"},
+					Annotations:       []string{"annotation:my-annotation"},
+					Finalizers:        []string{"final", "izers"},
+				},
+				Spec: &model.HorizontalPodAutoscalerSpec{
+					Target: &model.HorizontalPodAutoscalerTarget{
+						Kind: "Deployment",
+						Name: "agent",
+					},
+					MinReplicas: 1,
+					MaxReplicas: 3,
+					Metrics: []*model.HorizontalPodAutoscalerMetricSpec{
+						{
+							Type: "Object",
+							Object: &model.ObjectMetricSource{
+								DescribedObject: &model.ObjectReference{
+									Kind:       "Pod",
+									Name:       "agent",
+									ApiVersion: "v1",
+								},
+								Target: &model.MetricTarget{
+									Type:  "AverageValue",
+									Value: 10,
+								},
+								Metric: &model.MetricIdentifier{
+									Name:          "CPU",
+									LabelSelector: "&LabelSelector{MatchLabels:map[string]string{environment: production,service: datadog,},MatchExpressions:[]LabelSelectorRequirement{},}",
+								},
+							},
+						},
+						{
+							Type: "Pods",
+							Pods: &model.PodsMetricSource{
+								Target: &model.MetricTarget{
+									Type:  "AverageValue",
+									Value: 10,
+								},
+								Metric: &model.MetricIdentifier{
+									Name:          "CPU",
+									LabelSelector: "&LabelSelector{MatchLabels:map[string]string{environment: production,service: datadog,},MatchExpressions:[]LabelSelectorRequirement{},}",
+								},
+							},
+						},
+					},
+					Behavior: &model.HorizontalPodAutoscalerBehavior{
+						ScaleUp: &model.HPAScalingRules{
+							StabilizationWindowSeconds: 10,
+							SelectPolicy:               "",
+							Policies: []*model.HPAScalingPolicy{
+								{
+									Type:          "Pods",
+									Value:         4,
+									PeriodSeconds: 60,
+								},
+							},
+						},
+					},
+				},
+				Status: &model.HorizontalPodAutoscalerStatus{
+					LastScaleTime:   exampleTime.Unix(),
+					CurrentReplicas: 1,
+					DesiredReplicas: 2,
+					CurrentMetrics: []*model.HorizontalPodAutoscalerMetricStatus{
+						{
+							Type: "Object",
+							Object: &model.ObjectMetricStatus{
+								DescribedObject: &model.ObjectReference{
+									Kind:       "Pod",
+									Name:       "agent",
+									ApiVersion: "v1",
+								},
+								Current: 10,
+								Metric: &model.MetricIdentifier{
+									Name:          "CPU",
+									LabelSelector: "&LabelSelector{MatchLabels:map[string]string{environment: production,service: datadog,},MatchExpressions:[]LabelSelectorRequirement{},}",
+								},
+							},
+						},
+						{
+							Type: "Pods",
+							Pods: &model.PodsMetricStatus{
+								Current: 10,
+								Metric: &model.MetricIdentifier{
+									Name:          "CPU",
+									LabelSelector: "&LabelSelector{MatchLabels:map[string]string{environment: production,service: datadog,},MatchExpressions:[]LabelSelectorRequirement{},}",
+								},
+							},
+						},
+					},
+				},
+				Conditions: []*model.HorizontalPodAutoscalerCondition{
+					{
+						ConditionType:      "AbleToScale",
+						ConditionStatus:    "True",
+						LastTransitionTime: exampleTime.Unix(),
+						Reason:             "ReadyForNewScale",
+						Message:            "recommended size matches current size",
+					},
+					{
+						ConditionType:      "ScalingActive",
+						ConditionStatus:    "True",
+						LastTransitionTime: exampleTime.Unix(),
+						Reason:             "ValidMetricFound",
+						Message:            "the HPA was able to successfully calculate a replica count from external metric",
+					},
+					{
+						ConditionType:      "ScalingLimited",
+						ConditionStatus:    "False",
+						LastTransitionTime: exampleTime.Unix(),
+						Reason:             "DesiredWithinRange",
+						Message:            "the desired count is within the acceptable range",
+					},
+				},
+				Tags: []string{
+					"kube_condition_abletoscale:true",
+					"kube_condition_scalingactive:true",
+					"kube_condition_scalinglimited:false",
+				},
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, &tc.expected, ExtractHorizontalPodAutoscaler(&tc.input))
+		})
+	}
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/horizontalpodautoscaler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/horizontalpodautoscaler_test.go
@@ -78,8 +78,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 									Name: "CPU",
 									Selector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"environment": "production",
-											"service":     "datadog",
+											"service": "datadog",
 										},
 									},
 								},
@@ -92,8 +91,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 									Name: "CPU",
 									Selector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"environment": "production",
-											"service":     "datadog",
+											"service": "datadog",
 										},
 									},
 								},
@@ -131,8 +129,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 									Name: "CPU",
 									Selector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"environment": "production",
-											"service":     "datadog",
+											"service": "datadog",
 										},
 									},
 								},
@@ -178,8 +175,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 									Name: "CPU",
 									Selector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"environment": "production",
-											"service":     "datadog",
+											"service": "datadog",
 										},
 									},
 								},
@@ -192,8 +188,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 									Name: "CPU",
 									Selector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"environment": "production",
-											"service":     "datadog",
+											"service": "datadog",
 										},
 									},
 								},
@@ -228,8 +223,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 									Name: "CPU",
 									Selector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"environment": "production",
-											"service":     "datadog",
+											"service": "datadog",
 										},
 									},
 								},
@@ -296,8 +290,14 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 									Value: 10,
 								},
 								Metric: &model.MetricIdentifier{
-									Name:          "CPU",
-									LabelSelector: "&LabelSelector{MatchLabels:map[string]string{environment: production,service: datadog,},MatchExpressions:[]LabelSelectorRequirement{},}",
+									Name: "CPU",
+									LabelSelector: []*model.LabelSelectorRequirement{
+										{
+											Key:      "service",
+											Operator: "In",
+											Values:   []string{"datadog"},
+										},
+									},
 								},
 							},
 						},
@@ -309,8 +309,14 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 									Value: 1000,
 								},
 								Metric: &model.MetricIdentifier{
-									Name:          "CPU",
-									LabelSelector: "&LabelSelector{MatchLabels:map[string]string{environment: production,service: datadog,},MatchExpressions:[]LabelSelectorRequirement{},}",
+									Name: "CPU",
+									LabelSelector: []*model.LabelSelectorRequirement{
+										{
+											Key:      "service",
+											Operator: "In",
+											Values:   []string{"datadog"},
+										},
+									},
 								},
 							},
 						},
@@ -343,8 +349,14 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 									Value: 1000,
 								},
 								Metric: &model.MetricIdentifier{
-									Name:          "CPU",
-									LabelSelector: "&LabelSelector{MatchLabels:map[string]string{environment: production,service: datadog,},MatchExpressions:[]LabelSelectorRequirement{},}",
+									Name: "CPU",
+									LabelSelector: []*model.LabelSelectorRequirement{
+										{
+											Key:      "service",
+											Operator: "In",
+											Values:   []string{"datadog"},
+										},
+									},
 								},
 							},
 						},
@@ -379,8 +391,14 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 								},
 								Current: 10,
 								Metric: &model.MetricIdentifier{
-									Name:          "CPU",
-									LabelSelector: "&LabelSelector{MatchLabels:map[string]string{environment: production,service: datadog,},MatchExpressions:[]LabelSelectorRequirement{},}",
+									Name: "CPU",
+									LabelSelector: []*model.LabelSelectorRequirement{
+										{
+											Key:      "service",
+											Operator: "In",
+											Values:   []string{"datadog"},
+										},
+									},
 								},
 							},
 						},
@@ -389,8 +407,14 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 							Pods: &model.PodsMetricStatus{
 								Current: 10,
 								Metric: &model.MetricIdentifier{
-									Name:          "CPU",
-									LabelSelector: "&LabelSelector{MatchLabels:map[string]string{environment: production,service: datadog,},MatchExpressions:[]LabelSelectorRequirement{},}",
+									Name: "CPU",
+									LabelSelector: []*model.LabelSelectorRequirement{
+										{
+											Key:      "service",
+											Operator: "In",
+											Values:   []string{"datadog"},
+										},
+									},
 								},
 							},
 						},
@@ -414,8 +438,14 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 							External: &model.ExternalMetricStatus{
 								Current: 10,
 								Metric: &model.MetricIdentifier{
-									Name:          "CPU",
-									LabelSelector: "&LabelSelector{MatchLabels:map[string]string{environment: production,service: datadog,},MatchExpressions:[]LabelSelectorRequirement{},}",
+									Name: "CPU",
+									LabelSelector: []*model.LabelSelectorRequirement{
+										{
+											Key:      "service",
+											Operator: "In",
+											Values:   []string{"datadog"},
+										},
+									},
 								},
 							},
 						},
@@ -606,8 +636,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 									Name: "CPU",
 									Selector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"environment": "production",
-											"service":     "datadog",
+											"service": "datadog",
 										},
 									},
 								},
@@ -620,8 +649,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 									Name: "CPU",
 									Selector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"environment": "production",
-											"service":     "datadog",
+											"service": "datadog",
 										},
 									},
 								},
@@ -667,8 +695,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 									Name: "CPU",
 									Selector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"environment": "production",
-											"service":     "datadog",
+											"service": "datadog",
 										},
 									},
 								},
@@ -681,8 +708,7 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 									Name: "CPU",
 									Selector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"environment": "production",
-											"service":     "datadog",
+											"service": "datadog",
 										},
 									},
 								},
@@ -749,8 +775,14 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 									Value: 10,
 								},
 								Metric: &model.MetricIdentifier{
-									Name:          "CPU",
-									LabelSelector: "&LabelSelector{MatchLabels:map[string]string{environment: production,service: datadog,},MatchExpressions:[]LabelSelectorRequirement{},}",
+									Name: "CPU",
+									LabelSelector: []*model.LabelSelectorRequirement{
+										{
+											Key:      "service",
+											Operator: "In",
+											Values:   []string{"datadog"},
+										},
+									},
 								},
 							},
 						},
@@ -762,8 +794,14 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 									Value: 10,
 								},
 								Metric: &model.MetricIdentifier{
-									Name:          "CPU",
-									LabelSelector: "&LabelSelector{MatchLabels:map[string]string{environment: production,service: datadog,},MatchExpressions:[]LabelSelectorRequirement{},}",
+									Name: "CPU",
+									LabelSelector: []*model.LabelSelectorRequirement{
+										{
+											Key:      "service",
+											Operator: "In",
+											Values:   []string{"datadog"},
+										},
+									},
 								},
 							},
 						},
@@ -797,8 +835,14 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 								},
 								Current: 10,
 								Metric: &model.MetricIdentifier{
-									Name:          "CPU",
-									LabelSelector: "&LabelSelector{MatchLabels:map[string]string{environment: production,service: datadog,},MatchExpressions:[]LabelSelectorRequirement{},}",
+									Name: "CPU",
+									LabelSelector: []*model.LabelSelectorRequirement{
+										{
+											Key:      "service",
+											Operator: "In",
+											Values:   []string{"datadog"},
+										},
+									},
 								},
 							},
 						},
@@ -807,8 +851,14 @@ func TestExtractHorizontalPodAutoscaler(t *testing.T) {
 							Pods: &model.PodsMetricStatus{
 								Current: 10,
 								Metric: &model.MetricIdentifier{
-									Name:          "CPU",
-									LabelSelector: "&LabelSelector{MatchLabels:map[string]string{environment: production,service: datadog,},MatchExpressions:[]LabelSelectorRequirement{},}",
+									Name: "CPU",
+									LabelSelector: []*model.LabelSelectorRequirement{
+										{
+											Key:      "service",
+											Operator: "In",
+											Values:   []string{"datadog"},
+										},
+									},
 								},
 							},
 						},

--- a/pkg/orchestrator/util.go
+++ b/pkg/orchestrator/util.go
@@ -93,6 +93,7 @@ func NodeTypes() []NodeType {
 		K8sCR,
 		K8sCRD,
 		K8sVerticalPodAutoscaler,
+		K8sHorizontalPodAutoscaler,
 	}
 }
 
@@ -142,6 +143,8 @@ func (n NodeType) String() string {
 		return "CustomResource"
 	case K8sVerticalPodAutoscaler:
 		return "VerticalPodAutoscaler"
+	case K8sHorizontalPodAutoscaler:
+		return "HorizontalPodAutoscaler"
 	case K8sUnsetType:
 		return "UnsetType"
 	default:
@@ -175,6 +178,7 @@ func (n NodeType) Orchestrator() string {
 		K8sCR,
 		K8sNamespace,
 		K8sVerticalPodAutoscaler,
+		K8sHorizontalPodAutoscaler,
 		K8sUnsetType:
 		return "k8s"
 	default:

--- a/pkg/orchestrator/util.go
+++ b/pkg/orchestrator/util.go
@@ -64,6 +64,8 @@ const (
 	K8sCR
 	// K8sVerticalPodAutoscaler represents a Kubernetes VerticalPod Autoscaler
 	K8sVerticalPodAutoscaler
+	// K8sHorizontalPodAutoscaler represents a Kubernetes Horizontal Pod Autoscaler
+	K8sHorizontalPodAutoscaler
 )
 
 // NodeTypes returns the current existing NodesTypes as a slice to iterate over.

--- a/releasenotes-dca/notes/hpa-collection-67eaa6073eaef52c.yaml
+++ b/releasenotes-dca/notes/hpa-collection-67eaa6073eaef52c.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    Add ``VerticalPodAutoscalers`` collection in the orchestrator check.
+    Add ``HorizontalPodAutoscaler`` collection in the orchestrator check.

--- a/releasenotes-dca/notes/hpa-collection-67eaa6073eaef52c.yaml
+++ b/releasenotes-dca/notes/hpa-collection-67eaa6073eaef52c.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add ``VerticalPodAutoscalers`` collection in the orchestrator check.


### PR DESCRIPTION
### What does this PR do?
Start collecting Horizontal Pod Autoscalers from Kubernetes. This PR adds all the needed components to start gathering up information about HPAs and sending them to our backend.

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
