### PR TITLE
AET-204 Make GetStack clean stack if errors

### DIFF
--- a/test/new-e2e/containers/ecs_test.go
+++ b/test/new-e2e/containers/ecs_test.go
@@ -23,7 +23,7 @@ import (
 	datadog "gopkg.in/zorkian/go-datadog-api.v2"
 )
 
-func TestAgentOnECS(t *testing.T) {
+func TestECSSuite(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 

--- a/test/new-e2e/containers/ecs_test.go
+++ b/test/new-e2e/containers/ecs_test.go
@@ -25,6 +25,7 @@ import (
 
 func TestAgentOnECS(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	// Creating the stack
 	stackConfig := runner.ConfigMap{
@@ -36,6 +37,10 @@ func TestAgentOnECS(t *testing.T) {
 
 	_, stackOutput, err := infra.GetStackManager().GetStack(context.Background(), "ecs-cluster", stackConfig, ecs.Run, false)
 	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		infra.GetStackManager().DeleteStack(ctx, "ecs-cluster")
+	})
 
 	ecsClusterName := stackOutput.Outputs["ecs-cluster-name"].Value.(string)
 	ecsTaskFamily := stackOutput.Outputs["agent-fargate-task-family"].Value.(string)

--- a/test/new-e2e/containers/eks_test.go
+++ b/test/new-e2e/containers/eks_test.go
@@ -38,12 +38,12 @@ func TestEKSSuite(t *testing.T) {
 		"ddtestworkload:deploy": auto.ConfigValue{Value: "true"},
 	}
 
+	_, stackOutput, err := infra.GetStackManager().GetStack(ctx, "eks-cluster", stackConfig, eks.Run, false)
+	require.NoError(t, err)
+
 	t.Cleanup(func() {
 		infra.GetStackManager().DeleteStack(ctx, "eks-cluster")
 	})
-
-	_, stackOutput, err := infra.GetStackManager().GetStack(ctx, "eks-cluster", stackConfig, eks.Run, false)
-	require.NoError(t, err)
 
 	fakeintakeHost := stackOutput.Outputs["fakeintake-host"].Value.(string)
 	kubeconfig, err := json.Marshal(stackOutput.Outputs["kubeconfig"].Value.(map[string]interface{}))

--- a/test/new-e2e/containers/kindvm_test.go
+++ b/test/new-e2e/containers/kindvm_test.go
@@ -37,12 +37,12 @@ func TestKindSuite(t *testing.T) {
 		"ddtestworkload:deploy": auto.ConfigValue{Value: "true"},
 	}
 
+	_, stackOutput, err := infra.GetStackManager().GetStack(ctx, "kind-cluster", stackConfig, kindvm.Run, false)
+	require.NoError(t, err)
+
 	t.Cleanup(func() {
 		infra.GetStackManager().DeleteStack(ctx, "kind-cluster")
 	})
-
-	_, stackOutput, err := infra.GetStackManager().GetStack(ctx, "kind-cluster", stackConfig, kindvm.Run, false)
-	require.NoError(t, err)
 
 	fakeintakeHost := stackOutput.Outputs["fakeintake-host"].Value.(string)
 	kubeconfig := stackOutput.Outputs["kubeconfig"].Value.(string)

--- a/test/new-e2e/utils/infra/stack_manager.go
+++ b/test/new-e2e/utils/infra/stack_manager.go
@@ -113,6 +113,10 @@ func (sm *StackManager) GetStack(ctx context.Context, name string, config runner
 		FlowToPlugins: true,
 		LogLevel:      &loglevel,
 	}))
+
+	if err != nil {
+		sm.DeleteStack(ctx, name)
+	}
 	return stack, upResult, err
 }
 

--- a/test/new-e2e/utils/infra/stack_manager.go
+++ b/test/new-e2e/utils/infra/stack_manager.go
@@ -7,6 +7,7 @@ package infra
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -115,11 +116,14 @@ func (sm *StackManager) GetStack(ctx context.Context, name string, config runner
 	}))
 
 	if err != nil {
-		stack.Destroy(ctx, optdestroy.ProgressStreams(os.Stderr), optdestroy.DebugLogging(debug.LoggingOptions{
+		_, errDestroy := stack.Destroy(ctx, optdestroy.ProgressStreams(os.Stderr), optdestroy.DebugLogging(debug.LoggingOptions{
 			LogToStdErr:   true,
 			FlowToPlugins: true,
 			LogLevel:      &loglevel,
 		}))
+		if errDestroy != nil {
+			return stack, upResult, errors.Join(err, errDestroy)
+		}
 	}
 	return stack, upResult, err
 }

--- a/test/new-e2e/utils/infra/stack_manager.go
+++ b/test/new-e2e/utils/infra/stack_manager.go
@@ -115,7 +115,11 @@ func (sm *StackManager) GetStack(ctx context.Context, name string, config runner
 	}))
 
 	if err != nil {
-		sm.DeleteStack(ctx, name)
+		stack.Destroy(ctx, optdestroy.ProgressStreams(os.Stderr), optdestroy.DebugLogging(debug.LoggingOptions{
+			LogToStdErr:   true,
+			FlowToPlugins: true,
+			LogLevel:      &loglevel,
+		}))
 	}
 	return stack, upResult, err
 }

--- a/test/new-e2e/utils/infra/stack_manager.go
+++ b/test/new-e2e/utils/infra/stack_manager.go
@@ -116,11 +116,7 @@ func (sm *StackManager) GetStack(ctx context.Context, name string, config runner
 	}))
 
 	if err != nil {
-		_, errDestroy := stack.Destroy(ctx, optdestroy.ProgressStreams(os.Stderr), optdestroy.DebugLogging(debug.LoggingOptions{
-			LogToStdErr:   true,
-			FlowToPlugins: true,
-			LogLevel:      &loglevel,
-		}))
+		errDestroy := sm.deleteStack(ctx, name, stack)
 		if errDestroy != nil {
 			return stack, upResult, errors.Join(err, errDestroy)
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

GetStack can now handle errors during runing Pulumi Up, by deleting the stack that has been partially created to avoid leaks.

Rename ECS test suite to match name defined in gitlab-ci jobs.
Add cleanup function to ECS test suite
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Avoid leaking AWS resources
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
