### PR TITLE
Convert OTLP span links to the expected datadog format

### DIFF
--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -423,12 +423,12 @@ func marshalLinks(links ptrace.SpanLinkSlice) string {
 		if i > 0 {
 			str.WriteString(",")
 		}
-		t := l.TraceID()
+		t := [16]byte(l.TraceID())
 		str.WriteString(`{"trace_id":"`)
-		str.WriteString(hex.EncodeToString(t[:]))
+		str.WriteString(strconv.FormatUint(traceIDToUint64(t), 10))
 		s := l.SpanID()
 		str.WriteString(`","span_id":"`)
-		str.WriteString(hex.EncodeToString(s[:]))
+		str.WriteString(strconv.FormatUint(spanIDToUint64(s), 10))
 		str.WriteString(`"`)
 		if ts := l.TraceState().AsRaw(); len(ts) > 0 {
 			str.WriteString(`,"trace_state":"`)

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -33,6 +33,9 @@ import (
 	semconv "go.opentelemetry.io/collector/semconv/v1.6.1"
 )
 
+var hexLinkedTraceID = "fedcba98765432100123456789abcdef"
+var hexLinkedSpanID = "abcdef0123456789"
+
 var otlpTestSpanConfig = &testutil.OTLPSpan{
 	TraceState: "state",
 	Name:       "/path",
@@ -65,8 +68,8 @@ var otlpTestSpanConfig = &testutil.OTLPSpan{
 	},
 	Links: []testutil.OTLPSpanLink{
 		{
-			TraceID:    "fedcba98765432100123456789abcdef",
-			SpanID:     "abcdef0123456789",
+			TraceID:    convertHexToBytes16(hexLinkedTraceID),
+			SpanID:     convertHexToBytes8(hexLinkedSpanID),
 			TraceState: "dd=asdf256,ee=jkl;128",
 			Attributes: map[string]interface{}{
 				"a1": "v1",
@@ -75,8 +78,8 @@ var otlpTestSpanConfig = &testutil.OTLPSpan{
 			Dropped: 24,
 		},
 		{
-			TraceID:    "abcdef0123456789abcdef0123456789",
-			SpanID:     "fedcba9876543210",
+			TraceID:    convertHexToBytes16("abcdef0123456789abcdef0123456789"),
+			SpanID:     convertHexToBytes8("fedcba9876543210"),
 			TraceState: "",
 			Attributes: map[string]interface{}{
 				"a3": "v2",
@@ -85,15 +88,15 @@ var otlpTestSpanConfig = &testutil.OTLPSpan{
 			Dropped: 0,
 		},
 		{
-			TraceID:    "abcdef0123456789abcdef0123456789",
-			SpanID:     "fedcba9876543210",
+			TraceID:    convertHexToBytes16("abcdef0123456789abcdef0123456789"),
+			SpanID:     convertHexToBytes8("fedcba9876543210"),
 			TraceState: "",
 			Attributes: map[string]interface{}{},
 			Dropped:    2,
 		},
 		{
-			TraceID:    "abcdef0123456789abcdef0123456789",
-			SpanID:     "fedcba9876543210",
+			TraceID:    convertHexToBytes16("abcdef0123456789abcdef0123456789"),
+			SpanID:     convertHexToBytes8("fedcba9876543210"),
 			TraceState: "",
 			Attributes: map[string]interface{}{},
 			Dropped:    0,
@@ -906,6 +909,26 @@ func TestOTLPHelpers(t *testing.T) {
 	})
 }
 
+func convertHexToBytes16(in string) [16]byte {
+	out, err := hex.DecodeString(in)
+	if err != nil {
+		panic(err)
+	}
+	var out16 [16]byte
+	copy(out16[:], out)
+	return out16
+}
+
+func convertHexToBytes8(in string) [8]byte {
+	out, err := hex.DecodeString(in)
+	if err != nil {
+		panic(err)
+	}
+	var out8 [8]byte
+	copy(out8[:], out)
+	return out8
+}
+
 func TestOTLPConvertSpan(t *testing.T) {
 	now := uint64(otlpTestSpan.StartTimestamp())
 	cfg := config.New()
@@ -1010,8 +1033,8 @@ func TestOTLPConvertSpan(t *testing.T) {
 				},
 				Links: []testutil.OTLPSpanLink{
 					{
-						TraceID:    "fedcba98765432100123456789abcdef",
-						SpanID:     "abcdef0123456789",
+						TraceID:    convertHexToBytes16(hexLinkedTraceID),
+						SpanID:     convertHexToBytes8(hexLinkedSpanID),
 						TraceState: "dd=asdf256,ee=jkl;128",
 						Attributes: map[string]interface{}{
 							"a1": "v1",
@@ -1020,8 +1043,8 @@ func TestOTLPConvertSpan(t *testing.T) {
 						Dropped: 24,
 					},
 					{
-						TraceID:    "abcdef0123456789abcdef0123456789",
-						SpanID:     "fedcba9876543210",
+						TraceID:    convertHexToBytes16("abcdef0123456789abcdef0123456789"),
+						SpanID:     convertHexToBytes8("fedcba9876543210"),
 						TraceState: "",
 						Attributes: map[string]interface{}{
 							"a3": "v2",
@@ -1030,15 +1053,15 @@ func TestOTLPConvertSpan(t *testing.T) {
 						Dropped: 0,
 					},
 					{
-						TraceID:    "abcdef0123456789abcdef0123456789",
-						SpanID:     "fedcba9876543210",
+						TraceID:    convertHexToBytes16("abcdef0123456789abcdef0123456789"),
+						SpanID:     convertHexToBytes8("fedcba9876543210"),
 						TraceState: "",
 						Attributes: map[string]interface{}{},
 						Dropped:    2,
 					},
 					{
-						TraceID:    "abcdef0123456789abcdef0123456789",
-						SpanID:     "fedcba9876543210",
+						TraceID:    convertHexToBytes16("abcdef0123456789abcdef0123456789"),
+						SpanID:     convertHexToBytes8("fedcba9876543210"),
 						TraceState: "",
 						Attributes: map[string]interface{}{},
 						Dropped:    0,
@@ -1134,8 +1157,8 @@ func TestOTLPConvertSpan(t *testing.T) {
 				},
 				Links: []testutil.OTLPSpanLink{
 					{
-						TraceID:    "fedcba98765432100123456789abcdef",
-						SpanID:     "abcdef0123456789",
+						TraceID:    convertHexToBytes16(hexLinkedTraceID),
+						SpanID:     convertHexToBytes8(hexLinkedSpanID),
 						TraceState: "dd=asdf256,ee=jkl;128",
 						Attributes: map[string]interface{}{
 							"a1": "v1",
@@ -1144,8 +1167,8 @@ func TestOTLPConvertSpan(t *testing.T) {
 						Dropped: 24,
 					},
 					{
-						TraceID:    "abcdef0123456789abcdef0123456789",
-						SpanID:     "fedcba9876543210",
+						TraceID:    convertHexToBytes16("abcdef0123456789abcdef0123456789"),
+						SpanID:     convertHexToBytes8("fedcba9876543210"),
 						TraceState: "",
 						Attributes: map[string]interface{}{
 							"a3": "v2",
@@ -1154,15 +1177,15 @@ func TestOTLPConvertSpan(t *testing.T) {
 						Dropped: 0,
 					},
 					{
-						TraceID:    "abcdef0123456789abcdef0123456789",
-						SpanID:     "fedcba9876543210",
+						TraceID:    convertHexToBytes16("abcdef0123456789abcdef0123456789"),
+						SpanID:     convertHexToBytes8("fedcba9876543210"),
 						TraceState: "",
 						Attributes: map[string]interface{}{},
 						Dropped:    2,
 					},
 					{
-						TraceID:    "abcdef0123456789abcdef0123456789",
-						SpanID:     "fedcba9876543210",
+						TraceID:    convertHexToBytes16("abcdef0123456789abcdef0123456789"),
+						SpanID:     convertHexToBytes8("fedcba9876543210"),
 						TraceState: "",
 						Attributes: map[string]interface{}{},
 						Dropped:    0,
@@ -1898,7 +1921,7 @@ func makeSpanLinkSlice(t *testing.T, traceId, spanId, traceState string, attrs m
 }
 
 func TestMakeSpanLinkSlice(t *testing.T) {
-	in := makeSpanLinkSlice(t, "fedcba98765432100123456789abcdef", "abcdef1234567890", "dd=asdf256", map[string]string{"k1": "v1", "k2": "v2"}, 42)
+	in := makeSpanLinkSlice(t, hexLinkedTraceID, hexLinkedSpanID, "dd=asdf256", map[string]string{"k1": "v1", "k2": "v2"}, 42)
 
 	out := ptrace.NewSpanLinkSlice()
 	l := out.AppendEmpty()
@@ -1907,7 +1930,7 @@ func TestMakeSpanLinkSlice(t *testing.T) {
 	binary.BigEndian.PutUint64(bh, 0xfedcba9876543210)
 	binary.BigEndian.PutUint64(bl, 0x0123456789abcdef)
 	l.SetTraceID(*(*pcommon.TraceID)(append(bh, bl...)))
-	binary.BigEndian.PutUint64(bl, 0xabcdef1234567890)
+	binary.BigEndian.PutUint64(bl, 0xabcdef0123456789)
 	l.SetSpanID(*(*pcommon.SpanID)(bl))
 	l.TraceState().FromRaw("dd=asdf256")
 	l.Attributes().PutStr("k1", "v1")
@@ -1924,73 +1947,73 @@ func TestMarshalSpanLinks(t *testing.T) {
 	}{
 
 		{
-			in: makeSpanLinkSlice(t, "fedcba98765432100123456789abcdef", "abcdef0123456789", "", map[string]string{}, 0),
+			in: makeSpanLinkSlice(t, hexLinkedTraceID, hexLinkedSpanID, "", map[string]string{}, 0),
 			out: `[{
-					"trace_id": "fedcba98765432100123456789abcdef",
-					"span_id":  "abcdef0123456789"
+					"trace_id": "81985529216486895",
+					"span_id":  "12379813738877118345"
 				}]`,
 		}, {
-			in: makeSpanLinkSlice(t, "fedcba98765432100123456789abcdef", "abcdef0123456789", "dd=asdf256", map[string]string{}, 0),
+			in: makeSpanLinkSlice(t, hexLinkedTraceID, hexLinkedSpanID, "dd=asdf256", map[string]string{}, 0),
 			out: `[{
-					"trace_id":    "fedcba98765432100123456789abcdef",
-					"span_id":     "abcdef0123456789",
+					"trace_id":    "81985529216486895",
+					"span_id":     "12379813738877118345",
 					"trace_state": "dd=asdf256"
 				}]`,
 		}, {
-			in: makeSpanLinkSlice(t, "fedcba98765432100123456789abcdef", "abcdef0123456789", "dd=asdf256", map[string]string{"k1": "v1"}, 0),
+			in: makeSpanLinkSlice(t, hexLinkedTraceID, hexLinkedSpanID, "dd=asdf256", map[string]string{"k1": "v1"}, 0),
 			out: `[{
-					"trace_id":    "fedcba98765432100123456789abcdef",
-					"span_id":     "abcdef0123456789",
+					"trace_id":    "81985529216486895",
+					"span_id":     "12379813738877118345",
 					"trace_state": "dd=asdf256",
 					"attributes":  {"k1": "v1"}
 				}]`,
 		}, {
-			in: makeSpanLinkSlice(t, "fedcba98765432100123456789abcdef", "abcdef0123456789", "dd=asdf256", map[string]string{}, 42),
+			in: makeSpanLinkSlice(t, hexLinkedTraceID, hexLinkedSpanID, "dd=asdf256", map[string]string{}, 42),
 			out: `[{
-					"trace_id":                 "fedcba98765432100123456789abcdef",
-					"span_id":                  "abcdef0123456789",
+					"trace_id":                 "81985529216486895",
+					"span_id":                  "12379813738877118345",
 					"trace_state":              "dd=asdf256",
 					"dropped_attributes_count": 42
 				}]`,
 		}, {
-			in: makeSpanLinkSlice(t, "fedcba98765432100123456789abcdef", "abcdef0123456789", "dd=asdf256", map[string]string{"k1": "v1"}, 42),
+			in: makeSpanLinkSlice(t, hexLinkedTraceID, hexLinkedSpanID, "dd=asdf256", map[string]string{"k1": "v1"}, 42),
 			out: `[{
-					"trace_id":                 "fedcba98765432100123456789abcdef",
-					"span_id":                  "abcdef0123456789",
+					"trace_id":                 "81985529216486895",
+					"span_id":                  "12379813738877118345",
 					"trace_state":              "dd=asdf256",
 					"attributes":               {"k1": "v1"},
 					"dropped_attributes_count": 42
 				}]`,
 		}, {
-			in: makeSpanLinkSlice(t, "fedcba98765432100123456789abcdef", "abcdef0123456789", "", map[string]string{"k1": "v1"}, 0),
+			in: makeSpanLinkSlice(t, hexLinkedTraceID, hexLinkedSpanID, "", map[string]string{"k1": "v1"}, 0),
 			out: `[{
-					"trace_id":   "fedcba98765432100123456789abcdef",
-					"span_id":    "abcdef0123456789",
+					"trace_id":   "81985529216486895",
+					"span_id":    "12379813738877118345",
 					"attributes": {"k1": "v1"}
 				}]`,
 		}, {
-			in: makeSpanLinkSlice(t, "fedcba98765432100123456789abcdef", "abcdef0123456789", "", map[string]string{"k1": "v1"}, 42),
+			in: makeSpanLinkSlice(t, hexLinkedTraceID, hexLinkedSpanID, "", map[string]string{"k1": "v1"}, 42),
 			out: `[{
-					"trace_id":                 "fedcba98765432100123456789abcdef",
-					"span_id":                  "abcdef0123456789",
+					"trace_id":                 "81985529216486895",
+					"span_id":                  "12379813738877118345",
 					"attributes":               {"k1": "v1"},
 					"dropped_attributes_count": 42
 				}]`,
 		}, {
-			in: makeSpanLinkSlice(t, "fedcba98765432100123456789abcdef", "abcdef0123456789", "", map[string]string{}, 42),
+			in: makeSpanLinkSlice(t, hexLinkedTraceID, hexLinkedSpanID, "", map[string]string{}, 42),
 			out: `[{
-					"trace_id":                 "fedcba98765432100123456789abcdef",
-					"span_id":                  "abcdef0123456789",
+					"trace_id":                 "81985529216486895",
+					"span_id":                  "12379813738877118345",
 					"dropped_attributes_count": 42
 				}]`,
 		}, {
-			in: makeSpanLinkSlice(t, "fedcba98765432100123456789abcdef", "abcdef0123456789", "dd=asdf256,ee=jkl;128", map[string]string{
+			in: makeSpanLinkSlice(t, hexLinkedTraceID, hexLinkedSpanID, "dd=asdf256,ee=jkl;128", map[string]string{
 				"k1": "v1",
 				"k2": "v2",
 			}, 57),
 			out: `[{
-					"trace_id":                 "fedcba98765432100123456789abcdef",
-					"span_id":                  "abcdef0123456789",
+					"trace_id":                 "81985529216486895",
+					"span_id":                  "12379813738877118345",
 					"trace_state":              "dd=asdf256,ee=jkl;128",
 					"attributes":               {"k1": "v1", "k2": "v2"},
 					"dropped_attributes_count": 57
@@ -1998,20 +2021,20 @@ func TestMarshalSpanLinks(t *testing.T) {
 		}, {
 
 			in: (func() ptrace.SpanLinkSlice {
-				s1 := makeSpanLinkSlice(t, "fedcba98765432100123456789abcdef", "0123456789abcdef", "dd=asdf256,ee=jkl;128", map[string]string{"k1": "v1"}, 611187)
+				s1 := makeSpanLinkSlice(t, hexLinkedTraceID, hexLinkedSpanID, "dd=asdf256,ee=jkl;128", map[string]string{"k1": "v1"}, 611187)
 				s2 := makeSpanLinkSlice(t, "abcdef01234567899876543210fedcba", "fedcba9876543210", "", map[string]string{"k1": "v10", "k2": "v20"}, 0)
 				s2.MoveAndAppendTo(s1)
 				return s1
 			})(),
 			out: `[{
-					"trace_id":                 "fedcba98765432100123456789abcdef",
-					"span_id":                  "0123456789abcdef",
+					"trace_id":                 "81985529216486895",
+					"span_id":                  "12379813738877118345",
 					"trace_state":              "dd=asdf256,ee=jkl;128",
 					"attributes":               {"k1": "v1"},
 					"dropped_attributes_count": 611187
 			       }, {
-					"trace_id":                 "abcdef01234567899876543210fedcba",
-					"span_id":                  "fedcba9876543210",
+					"trace_id":                 "10986060915027139770",
+					"span_id":                  "18364758544493064720",
 					"attributes":               {"k1": "v10", "k2": "v20"}
 			       }]`,
 		},

--- a/pkg/trace/testutil/otlp.go
+++ b/pkg/trace/testutil/otlp.go
@@ -6,7 +6,6 @@
 package testutil
 
 import (
-	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -32,11 +31,11 @@ type OTLPSpanEvent struct {
 
 // OTLPSpanLink defines an OTLP test span link.
 type OTLPSpanLink struct {
-	TraceID    string                 `json:"trace_id"`
-	SpanID     string                 `json:"span_id"`
-	TraceState string                 `json:"trace_state"`
-	Attributes map[string]interface{} `json:"attributes"`
-	Dropped    uint32                 `json:"dropped_attributes_count"`
+	TraceID    [16]byte
+	SpanID     [8]byte
+	TraceState string
+	Attributes map[string]interface{}
+	Dropped    uint32
 }
 
 // OTLPSpan defines an OTLP test span.
@@ -101,16 +100,8 @@ func setOTLPSpan(span ptrace.Span, s *OTLPSpan) {
 	ls := span.Links()
 	for _, l := range s.Links {
 		li := ls.AppendEmpty()
-		buf, err := hex.DecodeString(l.TraceID)
-		if err != nil {
-			panic(err)
-		}
-		li.SetTraceID(*(*pcommon.TraceID)(buf))
-		buf, err = hex.DecodeString(l.SpanID)
-		if err != nil {
-			panic(err)
-		}
-		li.SetSpanID(*(*pcommon.SpanID)(buf))
+		li.SetTraceID(pcommon.TraceID(l.TraceID))
+		li.SetSpanID(pcommon.SpanID(l.SpanID))
 		li.TraceState().FromRaw(l.TraceState)
 		insertAttributes(li.Attributes(), l.Attributes)
 		li.SetDroppedAttributesCount(l.Dropped)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fixes the implementation of OTLP links. The previous attempt assumed that links' `SpanID` and `TraceID` would come as strings, but the are actually `[]byte`.

### Motivation

Have correct span links for OTLP traces

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Send OTLP traces to the agent containing span links

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
