### PR TITLE
fix flaky test in wlm remote process collector

### DIFF
--- a/pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector.go
+++ b/pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector.go
@@ -103,6 +103,7 @@ func (s *stream) Recv() (interface{}, error) {
 
 type streamHandler struct {
 	port int
+	config.Config
 }
 
 func init() {
@@ -113,7 +114,7 @@ func init() {
 	workloadmeta.RegisterCollector(collectorID, func() workloadmeta.Collector {
 		return &remote.GenericCollector{
 			CollectorID:   collectorID,
-			StreamHandler: &streamHandler{},
+			StreamHandler: &streamHandler{Config: config.Datadog},
 			Insecure:      true, // wlm extractor currently does not support TLS
 		}
 	})
@@ -121,7 +122,7 @@ func init() {
 
 func (s *streamHandler) Port() int {
 	if s.port == 0 {
-		return config.Datadog.GetInt("process_config.language_detection.grpc_port")
+		return s.Config.GetInt("process_config.language_detection.grpc_port")
 	}
 	// for test purposes
 	return s.port
@@ -131,7 +132,7 @@ func (s *streamHandler) IsEnabled() bool {
 	if flavor.GetFlavor() != flavor.DefaultAgent {
 		return false
 	}
-	return config.Datadog.GetBool("workloadmeta.remote_process_collector.enabled")
+	return s.Config.GetBool("workloadmeta.remote_process_collector.enabled")
 }
 
 func (s *streamHandler) NewClient(cc grpc.ClientConnInterface) remote.RemoteGrpcClient {

--- a/pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector_test.go
+++ b/pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector_test.go
@@ -261,7 +261,8 @@ func TestCollection(t *testing.T) {
 			// gRPC client (core agent)
 			collector := &remote.GenericCollector{
 				StreamHandler: &streamHandler{
-					port: port,
+					Config: mockConfig,
+					port:   port,
 				},
 				Insecure: true,
 			}

--- a/pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector_test.go
+++ b/pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector_test.go
@@ -230,11 +230,11 @@ func TestCollection(t *testing.T) {
 			errorResponse: true,
 		},
 	}
-	mockConfig := config.Mock(t)
-	mockConfig.Set("workloadmeta.remote_process_collector.enabled", true)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			mockConfig := config.Mock(t)
+			mockConfig.Set("workloadmeta.remote_process_collector.enabled", true)
 
 			// remote process collector server (process agent)
 			server := &mockServer{

--- a/pkg/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta.go
+++ b/pkg/workloadmeta/collectors/internal/remote/workloadmeta/workloadmeta.go
@@ -51,6 +51,7 @@ func (s *stream) Recv() (interface{}, error) {
 
 type streamHandler struct {
 	port int
+	config.Config
 }
 
 func init() {
@@ -59,14 +60,14 @@ func init() {
 	workloadmeta.RegisterRemoteCollector(collectorID, func() workloadmeta.Collector {
 		return &remote.GenericCollector{
 			CollectorID:   collectorID,
-			StreamHandler: &streamHandler{},
+			StreamHandler: &streamHandler{Config: config.Datadog},
 		}
 	})
 }
 
 func (s *streamHandler) Port() int {
 	if s.port == 0 {
-		return config.Datadog.GetInt("cmd_port")
+		return s.Config.GetInt("cmd_port")
 	}
 	// for tests
 	return s.port


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR moves the configuration directly in the given struct.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
(c *GenericCollector) Start(ctx context.Context, store workloadmeta.Store) calls c.Run() at the end in a different goroutine. The code ends up calling security.GetAuthTokenFilepath() which reads the config.
In a different goroutine we have config.Mock() which writes the config in the Cleanup func
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Is it fine to pass the global config in an init function ? As long as we do not read it there I think it should work.
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
All tests should pass. Remote Process Collector should keep working as intended.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
