### PR TITLE
Fetch config option from System Probe instead of regular Agent when creating flare

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -72,7 +72,7 @@ func CompleteFlare(fb flarehelpers.FlareBuilder) error {
 
 	fb.RegisterFilePerm(security.GetAuthTokenFilepath())
 
-	systemProbeConfigBPFDir := config.Datadog.GetString("system_probe_config.bpf_dir")
+	systemProbeConfigBPFDir := config.SystemProbe.GetString("system_probe_config.bpf_dir")
 	if systemProbeConfigBPFDir != "" {
 		fb.RegisterDirPerm(systemProbeConfigBPFDir)
 	}

--- a/pkg/flare/archive_linux.go
+++ b/pkg/flare/archive_linux.go
@@ -22,7 +22,7 @@ import (
 )
 
 func addSystemProbePlatformSpecificEntries(fb flarehelpers.FlareBuilder) {
-	sysprobeSocketLocation := config.Datadog.GetString("system_probe_config.sysprobe_socket")
+	sysprobeSocketLocation := config.SystemProbe.GetString("system_probe_config.sysprobe_socket")
 	if sysprobeSocketLocation != "" {
 		fb.RegisterDirPerm(filepath.Dir(sysprobeSocketLocation))
 	}

--- a/releasenotes/notes/fix-bad-config-lookup-in-flare-b539979674b0a2fd.yaml
+++ b/releasenotes/notes/fix-bad-config-lookup-in-flare-b539979674b0a2fd.yaml
@@ -9,4 +9,4 @@
 fixes:
   - |
     Fixes a bug that prevents the Agent from writing permissions information
-    about system-probe files when creating a flare
+    about system-probe files when creating a flare.

--- a/releasenotes/notes/fix-bad-config-lookup-in-flare-b539979674b0a2fd.yaml
+++ b/releasenotes/notes/fix-bad-config-lookup-in-flare-b539979674b0a2fd.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a bug that prevents the Agent from writing permissions information
+    about system-probe files when creating a flare


### PR DESCRIPTION

### What does this PR do?

The Agent nows search for `system_probe_config.sysprobe_socket` and `system_probe_config.bpf_dir` in the system probe config instead of the regular config.

### Motivation

The above options are defined in the system probe config so it's incorrect to search in the regular Agent config

### Additional Notes



### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

1. Create `/etc/datadog-agent/system-probe.yaml` with the following content
```
system_probe_config.enabled: true
system_probe_config.bpf_dir: /tmp/dummy_system_probe_config_bpf_dir/
system_probe_config.sysprobe_socket: /tmp/dummy_dir/dummy_system_probe_sysprobe_socket
```
2. Ensure that `/tmp/dummy_system_probe_config_bpf_dir/` and `/tmp/dummy_dir/` folders exist
3. Create a flare with the regular Agent `datadog-agent flare`
4. Verify that permissions of `/tmp/dummy_system_probe_config_bpf_dir/` and `/tmp/dummy_dir/` are present in `permissions.log` (in the flare archive)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
