### PR TITLE
Fix flaky test in remote process collector

### DIFF
--- a/pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector_test.go
+++ b/pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector_test.go
@@ -28,6 +28,8 @@ import (
 	"google.golang.org/grpc"
 )
 
+const dummySubscriber = "dummy-subscriber"
+
 type mockServer struct {
 	pbgo.UnimplementedProcessEntityStreamServer
 
@@ -274,10 +276,33 @@ func TestCollection(t *testing.T) {
 			err = collector.Start(ctx, mockStore)
 			require.NoError(t, err)
 
-			// Wait for gRPC calls to be sent
-			time.Sleep(1 * time.Second)
+			ch := mockStore.Subscribe(dummySubscriber, workloadmeta.NormalPriority, nil)
+			doneCh := make(chan struct{})
+
+			numberOfReponse := len(test.serverResponses)
+			if test.errorResponse {
+				numberOfReponse++
+			}
+			go func() {
+				j := 0
+				for i := 0; i < numberOfReponse; i++ {
+					bundle := <-ch
+					close(bundle.Ch)
+					j++
+				}
+				close(doneCh)
+			}()
+
+			<-doneCh
+			mockStore.Unsubscribe(ch)
+
+			// wait that the store gets populated
+			time.Sleep(time.Second)
 
 			cancel()
+
+			// wait that the stream goroutine terminates
+			time.Sleep(time.Second)
 
 			// Verify final state
 			for i := range test.expectedProcesses {


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR adds a subscriber to the remote process collector.
Moreover, it adds a sleep instruction to let the stream goroutine terminate.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Fix flaky test
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
