### PR TITLE
[pkg/otlp] Default OTLP logs ingestion to disabled

### DIFF
--- a/pkg/config/otlp.go
+++ b/pkg/config/otlp.go
@@ -29,7 +29,7 @@ func SetupOTLP(config Config) {
 	config.BindEnvAndSetDefault(OTLPTracePort, 5003)
 	config.BindEnvAndSetDefault(OTLPMetricsEnabled, true)
 	config.BindEnvAndSetDefault(OTLPTracesEnabled, true)
-	config.BindEnvAndSetDefault(OTLPLogsEnabled, true)
+	config.BindEnvAndSetDefault(OTLPLogsEnabled, false)
 
 	// NOTE: This only partially works.
 	// The environment variable is also manually checked in pkg/otlp/config.go

--- a/pkg/otlp/collector.go
+++ b/pkg/otlp/collector.go
@@ -236,7 +236,7 @@ func NewPipelineFromAgentConfig(cfg config.Config, s serializer.MetricSerializer
 		pipelineError.Store(fmt.Errorf("config error: %w", err))
 		return nil, pipelineError.Load()
 	}
-	if err := checkAndUpdateCfg(cfg, &pcfg, logsAgentChannel); err != nil {
+	if err := checkAndUpdateCfg(pcfg, logsAgentChannel); err != nil {
 		return nil, err
 	}
 

--- a/pkg/otlp/config.go
+++ b/pkg/otlp/config.go
@@ -80,7 +80,7 @@ func FromAgentConfig(cfg config.Config) (PipelineConfig, error) {
 	metricsEnabled := cfg.GetBool(config.OTLPMetricsEnabled)
 	tracesEnabled := cfg.GetBool(config.OTLPTracesEnabled)
 	logsEnabled := cfg.GetBool(config.OTLPLogsEnabled)
-	if !metricsEnabled && !tracesEnabled {
+	if !metricsEnabled && !tracesEnabled && !logsEnabled {
 		errs = append(errs, fmt.Errorf("at least one OTLP signal needs to be enabled"))
 	}
 	metricsConfig := readConfigSection(cfg, config.OTLPMetrics)

--- a/pkg/otlp/config.go
+++ b/pkg/otlp/config.go
@@ -104,11 +104,6 @@ func IsEnabled(cfg config.Config) bool {
 	return hasSection(cfg, config.OTLPReceiverSubSectionKey)
 }
 
-// HasLogsSectionEnabled checks if OTLP logs are explicitly enabled in a given config.
-func HasLogsSectionEnabled(cfg config.Config) bool {
-	return hasSection(cfg, config.OTLPLogsEnabled) && cfg.GetBool(config.OTLPLogsEnabled)
-}
-
 func hasSection(cfg config.Config, section string) bool {
 	// HACK: We want to mark as enabled if the section is present, even if empty, so that we get errors
 	// from unmarshaling/validation done by the Collector code.

--- a/pkg/otlp/config_test.go
+++ b/pkg/otlp/config_test.go
@@ -58,7 +58,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				TracePort:                5003,
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
-				LogsEnabled:              true,
+				LogsEnabled:              false,
 				Metrics: map[string]interface{}{
 					"enabled":         true,
 					"tag_cardinality": "low",
@@ -79,7 +79,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				TracePort:                5003,
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
-				LogsEnabled:              true,
+				LogsEnabled:              false,
 				Metrics: map[string]interface{}{
 					"enabled":         true,
 					"tag_cardinality": "low",
@@ -100,7 +100,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				TracePort:                5003,
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
-				LogsEnabled:              true,
+				LogsEnabled:              false,
 				Metrics: map[string]interface{}{
 					"enabled":         true,
 					"tag_cardinality": "low",
@@ -138,7 +138,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				TracePort:                5003,
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
-				LogsEnabled:              true,
+				LogsEnabled:              false,
 				Metrics: map[string]interface{}{
 					"enabled":         true,
 					"tag_cardinality": "low",
@@ -217,7 +217,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OpenCensusReceiverConfig: map[string]interface{}{},
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
-				LogsEnabled:              true,
+				LogsEnabled:              false,
 				TracePort:                5003,
 				Metrics: map[string]interface{}{
 					"enabled":         true,
@@ -246,7 +246,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OpenCensusReceiverConfig: map[string]interface{}{},
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
-				LogsEnabled:              true,
+				LogsEnabled:              false,
 				TracePort:                5003,
 				Metrics: map[string]interface{}{
 					"enabled":         true,
@@ -278,7 +278,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OpenCensusReceiverConfig: map[string]interface{}{},
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
-				LogsEnabled:              true,
+				LogsEnabled:              false,
 				TracePort:                5003,
 				Metrics: map[string]interface{}{
 					"enabled":                                true,
@@ -309,7 +309,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OpenCensusReceiverConfig: map[string]interface{}{},
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
-				LogsEnabled:              true,
+				LogsEnabled:              false,
 				TracePort:                5003,
 				Metrics: map[string]interface{}{
 					"enabled":         true,
@@ -337,7 +337,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OpenCensusReceiverConfig: map[string]interface{}{},
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
-				LogsEnabled:              true,
+				LogsEnabled:              false,
 				TracePort:                5003,
 				Metrics: map[string]interface{}{
 					"enabled":         true,
@@ -366,7 +366,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OpenCensusReceiverConfig: map[string]interface{}{},
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
-				LogsEnabled:              true,
+				LogsEnabled:              false,
 				TracePort:                5003,
 				Metrics: map[string]interface{}{
 					"enabled":         true,
@@ -393,7 +393,7 @@ func TestFromEnvironmentVariables(t *testing.T) {
 				OpenCensusReceiverConfig: map[string]interface{}{"endpoint": "0.0.0.0:55678"},
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
-				LogsEnabled:              true,
+				LogsEnabled:              false,
 				TracePort:                5003,
 				Metrics: map[string]interface{}{
 					"enabled":         true,
@@ -472,7 +472,7 @@ func TestFromAgentConfigMetrics(t *testing.T) {
 				TracePort:                5003,
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
-				LogsEnabled:              true,
+				LogsEnabled:              false,
 				Metrics: map[string]interface{}{
 					"enabled":                     true,
 					"delta_ttl":                   2400,
@@ -523,7 +523,7 @@ func TestFromAgentConfigDebug(t *testing.T) {
 				TracePort:                5003,
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
-				LogsEnabled:              true,
+				LogsEnabled:              false,
 				Debug:                    map[string]interface{}{},
 				Metrics:                  map[string]interface{}{"enabled": true, "tag_cardinality": "low"},
 			},
@@ -537,7 +537,7 @@ func TestFromAgentConfigDebug(t *testing.T) {
 				TracePort:                5003,
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
-				LogsEnabled:              true,
+				LogsEnabled:              false,
 				Debug:                    map[string]interface{}{"loglevel": "debug"},
 				Metrics:                  map[string]interface{}{"enabled": true, "tag_cardinality": "low"},
 			},
@@ -551,7 +551,7 @@ func TestFromAgentConfigDebug(t *testing.T) {
 				TracePort:                5003,
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
-				LogsEnabled:              true,
+				LogsEnabled:              false,
 				Debug:                    map[string]interface{}{"loglevel": "disabled"},
 				Metrics:                  map[string]interface{}{"enabled": true, "tag_cardinality": "low"},
 			},
@@ -565,7 +565,7 @@ func TestFromAgentConfigDebug(t *testing.T) {
 				TracePort:                5003,
 				MetricsEnabled:           true,
 				TracesEnabled:            true,
-				LogsEnabled:              true,
+				LogsEnabled:              false,
 				Debug:                    map[string]interface{}{"verbosity": "normal"},
 				Metrics:                  map[string]interface{}{"enabled": true, "tag_cardinality": "low"},
 			},

--- a/pkg/otlp/pipeline_validator.go
+++ b/pkg/otlp/pipeline_validator.go
@@ -10,11 +10,10 @@ package otlp
 import (
 	"fmt"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
 
-func checkAndUpdateCfg(cfg config.Config, pcfg *PipelineConfig, logsAgentChannel chan *message.Message) error {
+func checkAndUpdateCfg(pcfg PipelineConfig, logsAgentChannel chan *message.Message) error {
 	if pcfg.LogsEnabled && logsAgentChannel == nil {
 		pipelineError.Store(fmt.Errorf("OTLP logs is enabled but logs agent is not enabled"))
 		return pipelineError.Load()

--- a/pkg/otlp/pipeline_validator_serverless.go
+++ b/pkg/otlp/pipeline_validator_serverless.go
@@ -14,7 +14,7 @@ import (
 )
 
 func checkAndUpdateCfg(pcfg PipelineConfig, logsAgentChannel chan *message.Message) error {
-	if pcfg.LogsEnabled(cfg) {
+	if pcfg.LogsEnabled {
 		pipelineError.Store(fmt.Errorf("Cannot enable OTLP log ingestion for serverless"))
 		return pipelineError.Load()
 	}

--- a/pkg/otlp/pipeline_validator_serverless.go
+++ b/pkg/otlp/pipeline_validator_serverless.go
@@ -10,15 +10,13 @@ package otlp
 import (
 	"fmt"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
 
-func checkAndUpdateCfg(cfg config.Config, pcfg *PipelineConfig, logsAgentChannel chan *message.Message) error {
-	if HasLogsSectionEnabled(cfg) {
+func checkAndUpdateCfg(pcfg PipelineConfig, logsAgentChannel chan *message.Message) error {
+	if pcfg.LogsEnabled(cfg) {
 		pipelineError.Store(fmt.Errorf("Cannot enable OTLP log ingestion for serverless"))
 		return pipelineError.Load()
 	}
-	pcfg.LogsEnabled = false
 	return nil
 }

--- a/pkg/otlp/testdata/logs_disabled.yaml
+++ b/pkg/otlp/testdata/logs_disabled.yaml
@@ -1,3 +1,3 @@
 otlp_config:
   logs:
-    enabled: false
+    enabled:

--- a/pkg/otlp/testdata/logs_enabled.yaml
+++ b/pkg/otlp/testdata/logs_enabled.yaml
@@ -1,2 +1,3 @@
 otlp_config:
   logs:
+    enabled: true

--- a/releasenotes/notes/default_otlp_logs_enabled_false-6d98a23f7a76f153.yaml
+++ b/releasenotes/notes/default_otlp_logs_enabled_false-6d98a23f7a76f153.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    OTLP logs ingestion is now disabled by default, and otlp_config: logs: enabled: true must be specified to enable
+    OTLP logs ingestion is now disabled by default. To enable it, set otlp_config.logs.enabled to true.

--- a/releasenotes/notes/default_otlp_logs_enabled_false-6d98a23f7a76f153.yaml
+++ b/releasenotes/notes/default_otlp_logs_enabled_false-6d98a23f7a76f153.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    OTLP logs ingestion is now disabled by default, and otlp_config: logs: enabled: true must be specified to enable


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Previously, OTLP log ingestion was enabled by default. So, when logs-agent was not enabled as well, the agent would crash (logs-agent needs to be running to use logs ingestion.)

Previously, when `otlp_config: logs: ` was included in the config, logs would be enabled; now `otlp_config: logs: enabled: true` must be specified in full.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Build agent locally, and run it with various settings of `logs_enabled` to verify the following:

1. When logs is not present in otlp_config, does the OTel pipeline start successfully
2. The env var can still enable otlp log ingestion
3. If env is not set, all of `otlp_config: logs: enabled: true` must be included in the yaml to enable logs

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
