### PR TITLE
[Single Machine Performance] Avoid APM intake drops

### DIFF
--- a/test/regression/cases/otel_to_otel_logs/datadog-agent/datadog.yaml
+++ b/test/regression/cases/otel_to_otel_logs/datadog-agent/datadog.yaml
@@ -10,11 +10,10 @@ cloud_provider_metadata: []
 apm_config:
   enabled: true
   apm_dd_url: http://127.0.0.1:9091
-
-  # disable ingest sampling
-  max_traces_per_second: 0
-  errors_per_second: 0
-  max_events_per_second: 0
+  # set an arbitrarily high sample set
+  max_traces_per_second: 1000000
+  errors_per_second: 1000000
+  max_events_per_second: 1000000
 
 logs_enabled: true
 logs_config:

--- a/test/regression/cases/trace_agent_json/datadog-agent/datadog.yaml
+++ b/test/regression/cases/trace_agent_json/datadog-agent/datadog.yaml
@@ -14,8 +14,7 @@ cloud_provider_metadata: []
 apm_config:
   enabled: true
   apm_dd_url: http://127.0.0.1:9091
-
-  # disable ingest sampling
-  max_traces_per_second: 0
-  errors_per_second: 0
-  max_events_per_second: 0
+  # set an arbitrarily high sample set
+  max_traces_per_second: 1000000
+  errors_per_second: 1000000
+  max_events_per_second: 1000000

--- a/test/regression/cases/trace_agent_msgpack/datadog-agent/datadog.yaml
+++ b/test/regression/cases/trace_agent_msgpack/datadog-agent/datadog.yaml
@@ -14,8 +14,7 @@ cloud_provider_metadata: []
 apm_config:
   enabled: true
   apm_dd_url: http://127.0.0.1:9091
-
-  # disable ingest sampling
-  max_traces_per_second: 0
-  errors_per_second: 0
-  max_events_per_second: 0
+  # set an arbitrarily high sample set
+  max_traces_per_second: 1000000
+  errors_per_second: 1000000
+  max_events_per_second: 1000000


### PR DESCRIPTION
### What does this PR do?

When we initially configured the regression detector experiments for APM the interpretion of `max_traces_per_second` disabled sampling. This is no longer the case and gives an incorrect understanding of the trace-agent's performance: we're dropping all load, almost.

REF SMP-673
