### PR TITLE
usm: openssl: Removed leftovers from migration PR

### DIFF
--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -133,8 +133,8 @@ func newEBPFProgram(c *config.Config, connectionProtocolMap *ebpf.Map, bpfTeleme
 		},
 	}
 
-	subprogramProbesResolvers := make([]probeResolver, 0, 3)
-	subprograms := make([]subprogram, 0, 3)
+	subprogramProbesResolvers := make([]probeResolver, 0, 1)
+	subprograms := make([]subprogram, 0, 1)
 	var tailCalls []manager.TailCallRoute
 
 	goTLSProg := newGoTLSProgram(c)

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -424,7 +424,6 @@ func (o *sslProgram) Name() string {
 
 func (o *sslProgram) ConfigureOptions(_ *manager.Manager, options *manager.Options) {
 	options.MapSpecEditors[sslSockByCtxMap] = manager.MapSpecEditor{
-		Type:       ebpf.Hash,
 		MaxEntries: o.cfg.MaxTrackedConnections,
 		EditorFlag: manager.EditMaxEntries,
 	}
@@ -585,20 +584,4 @@ func removeHooks(m *manager.Manager, probes []manager.ProbesSelector) func(utils
 // functionName is variable but with a minimum guarantee of 10 chars
 func getUID(lib utils.PathIdentifier) string {
 	return lib.Key()[:5]
-}
-
-func (*sslProgram) GetAllUndefinedProbes() []manager.ProbeIdentificationPair {
-	var probeList []manager.ProbeIdentificationPair
-
-	for _, sslProbeList := range [][]manager.ProbesSelector{openSSLProbes, cryptoProbes, gnuTLSProbes} {
-		for _, singleProbe := range sslProbeList {
-			for _, identifier := range singleProbe.GetProbesIdentificationPairList() {
-				probeList = append(probeList, manager.ProbeIdentificationPair{
-					EBPFFuncName: identifier.EBPFFuncName,
-				})
-			}
-		}
-	}
-
-	return probeList
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Remove leftovers from the migration of openssl from usm subprogram to the new format:
1. `GetAllUndefinedProbes` implementation (not used anymore)
2. The size of `subprogramProbesResolvers` and `subprograms` arrays to 1

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Code cleanup
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
