### PR TITLE
ebpf platform: Expose remove program name mapping

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/names.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/names.go
@@ -71,6 +71,15 @@ func AddNameMappingsCollection(coll *ebpf.Collection, module string) {
 	})
 }
 
+// RemoveProgramNameMapping manually removes a program name mapping
+func RemoveProgramNameMapping(progid uint32) {
+	mappingLock.Lock()
+	defer mappingLock.Unlock()
+
+	delete(progNameMapping, progid)
+	delete(progModuleMapping, progid)
+}
+
 // RemoveNameMappings removes the full name mappings for ebpf maps in the manager
 func RemoveNameMappings(mgr *manager.Manager) {
 	maps, err := mgr.GetMaps()

--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -602,6 +602,11 @@ func (p *GoTLSProgram) unhookBinary(bin *runningBinary) {
 
 func (p *GoTLSProgram) detachHooks(probeIDs []manager.ProbeIdentificationPair) {
 	for _, probeID := range probeIDs {
+		probe, ok := p.manager.GetProbe(probeID)
+		if !ok {
+			continue
+		}
+		ebpfcheck.RemoveProgramNameMapping(probe.ID())
 		err := p.manager.DetachHook(probeID)
 		if err != nil {
 			log.Errorf("failed detaching hook %s: %s", probeID.UID, err)

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -558,7 +558,7 @@ func removeHooks(m *manager.Manager, probes []manager.ProbesSelector) func(utils
 				if !found {
 					continue
 				}
-
+				ebpfcheck.RemoveProgramNameMapping(probe.ID())
 				program := probe.Program()
 				err := m.DetachHook(identifier)
 				if err != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Exposes RemoveProgramNameMapping of ebpfcheck, to allow cleanup during hook unloading.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
USM has dynamic modules that attach to binaries (openssl, gotls). During the attachment we're adding program name mapping for to binaries, but they were never cleaned when USM detaches the hook (after process termination). That results in ever-growing maps.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
