### PR TITLE
usm: npm: performance improvement in encoding 

### DIFF
--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -896,12 +896,12 @@ func TestUSMPayloadTelemetry(t *testing.T) {
 
 func BenchmarkModeling(b *testing.B) {
 	marshaler := GetMarshaler(encoding.ContentTypeProtobuf)
+	conns := GenerateBenchMarkPayload(360, 360)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		conns := GenerateBenchMarkPayload(100, 100)
 
 		_, err := marshaler.Marshal(&conns)
 		require.NoError(b, err)

--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/process/encoding"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
 
@@ -891,4 +892,18 @@ func TestUSMPayloadTelemetry(t *testing.T) {
 	payloadTelemetry := result.ConnTelemetryMap
 	assert.Equal(t, int64(10), payloadTelemetry["usm.http.total_hits"])
 	assert.NotContains(t, payloadTelemetry, "foobar")
+}
+
+func BenchmarkModeling(b *testing.B) {
+	marshaler := GetMarshaler(encoding.ContentTypeProtobuf)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		conns := GenerateBenchMarkPayload(100, 100)
+
+		_, err := marshaler.Marshal(&conns)
+		require.NoError(b, err)
+	}
 }

--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -902,7 +902,6 @@ func BenchmarkModeling(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-
 		_, err := marshaler.Marshal(&conns)
 		require.NoError(b, err)
 	}

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -38,6 +38,12 @@ var formatIPTrans = sync.Pool{
 	},
 }
 
+var formatProtocolSt = sync.Pool{
+	New: func() interface{} {
+		return new(model.ProtocolStack)
+	},
+}
+
 // RouteIdx stores the route and the index into the route collection for a route
 type RouteIdx struct {
 	Idx   int32
@@ -168,6 +174,10 @@ func returnToPool(c *model.Connections) {
 			}
 			if c.Raddr != nil {
 				modelAddressPool.Put(c.Raddr)
+			}
+
+			if c.Protocol != nil {
+				formatProtocolSt.Put(c.Protocol)
 			}
 
 			c.Reset()

--- a/pkg/network/encoding/http_test.go
+++ b/pkg/network/encoding/http_test.go
@@ -371,7 +371,7 @@ func verifyQuantile(t *testing.T, sketch *ddsketch.DDSketch, q float64, expected
 	assert.True(t, val <= expectedValue+acceptableError)
 }
 
-func GenerateBenchMarkPayload(sourcePortsMax, destPortsMax uint16) network.Connections {
+func GenerateBenchMarkPayload(sourcePortsMax, destPortsMax uint32) network.Connections {
 	localhost := util.AddressFromString("127.0.0.1")
 
 	payload := network.Connections{
@@ -388,28 +388,28 @@ func GenerateBenchMarkPayload(sourcePortsMax, destPortsMax uint16) network.Conne
 	httpStats.AddRequest(400, 10, 0, nil)
 	httpStats.AddRequest(500, 10, 0, nil)
 
-	for sport := uint16(0); sport < sourcePortsMax; sport++ {
-		for dport := uint16(0); dport < destPortsMax; dport++ {
+	for sport := uint32(0); sport < sourcePortsMax; sport++ {
+		for dport := uint32(0); dport < destPortsMax; dport++ {
 			index := sport*sourcePortsMax + dport
 
 			payload.Conns[index].Dest = localhost
 			payload.Conns[index].Source = localhost
-			payload.Conns[index].DPort = dport + 1
-			payload.Conns[index].SPort = sport + 1
+			payload.Conns[index].DPort = uint16(dport + 1)
+			payload.Conns[index].SPort = uint16(sport + 1)
 			if index%2 == 0 {
 				payload.Conns[index].IPTranslation = &network.IPTranslation{
 					ReplSrcIP:   localhost,
 					ReplDstIP:   localhost,
-					ReplSrcPort: dport + 1,
-					ReplDstPort: sport + 1,
+					ReplSrcPort: uint16(dport + 1),
+					ReplDstPort: uint16(sport + 1),
 				}
 			}
 
 			payload.HTTP[http.NewKey(
 				localhost,
 				localhost,
-				sport+1,
-				dport+1,
+				uint16(sport+1),
+				uint16(dport+1),
 				fmt.Sprintf("/api/%d-%d", sport+1, dport+1),
 				true,
 				http.MethodGet,
@@ -420,7 +420,7 @@ func GenerateBenchMarkPayload(sourcePortsMax, destPortsMax uint16) network.Conne
 	return payload
 }
 
-func commonBenchmarkHTTPEncoder(b *testing.B, numberOfPorts uint16) {
+func commonBenchmarkHTTPEncoder(b *testing.B, numberOfPorts uint32) {
 	payload := GenerateBenchMarkPayload(numberOfPorts, numberOfPorts)
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/pkg/network/encoding/http_test.go
+++ b/pkg/network/encoding/http_test.go
@@ -371,7 +371,7 @@ func verifyQuantile(t *testing.T, sketch *ddsketch.DDSketch, q float64, expected
 	assert.True(t, val <= expectedValue+acceptableError)
 }
 
-func generateBenchMarkPayload(sourcePortsMax, destPortsMax uint16) network.Connections {
+func GenerateBenchMarkPayload(sourcePortsMax, destPortsMax uint16) network.Connections {
 	localhost := util.AddressFromString("127.0.0.1")
 
 	payload := network.Connections{
@@ -421,7 +421,7 @@ func generateBenchMarkPayload(sourcePortsMax, destPortsMax uint16) network.Conne
 }
 
 func commonBenchmarkHTTPEncoder(b *testing.B, numberOfPorts uint16) {
-	payload := generateBenchMarkPayload(numberOfPorts, numberOfPorts)
+	payload := GenerateBenchMarkPayload(numberOfPorts, numberOfPorts)
 	b.ResetTimer()
 	b.ReportAllocs()
 	var h *httpEncoder

--- a/pkg/network/encoding/protocols.go
+++ b/pkg/network/encoding/protocols.go
@@ -43,9 +43,10 @@ func formatProtocolStack(originalStack protocols.Stack, staticTags uint64) *mode
 		stack = addProtocol(stack, originalStack.Application)
 	}
 
-	return &model.ProtocolStack{
-		Stack: stack,
-	}
+	fps := formatProtocolSt.Get().(*model.ProtocolStack)
+	fps.Stack = stack
+
+	return fps
 }
 
 func addProtocol(stack []model.ProtocolType, proto protocols.ProtocolType) []model.ProtocolType {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Utilizes pooling in modeling areas, which reduces the number of allocations and memory usage.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Benchmarks results:

```
before:   	       4	 266342332 ns/op	154495978 B/op	 1138851 allocs/op
after:  	       4	 263562289 ns/op	144782216 B/op	  798797 allocs/op
```
Allocations reduction of 30%
Reduction of 6%
Runtime - no change

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
