### PR TITLE
Move config creation in wlm remote process collector test

### DIFF
--- a/pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector_test.go
+++ b/pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector_test.go
@@ -233,11 +233,11 @@ func TestCollection(t *testing.T) {
 		},
 	}
 
+	mockConfig := config.Mock(t)
+	mockConfig.Set("language_detection.enabled", true)
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			mockConfig := config.Mock(t)
-			mockConfig.Set("language_detection.enabled", true)
-
 			// remote process collector server (process agent)
 			server := &mockServer{
 				responses:       test.serverResponses,

--- a/pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector_test.go
+++ b/pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector_test.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -233,11 +234,10 @@ func TestCollection(t *testing.T) {
 		},
 	}
 
-	mockConfig := config.Mock(t)
-	mockConfig.Set("language_detection.enabled", true)
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			mockConfig := config.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+			mockConfig.Set("language_detection.enabled", true)
 			// remote process collector server (process agent)
 			server := &mockServer{
 				responses:       test.serverResponses,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR moves config creation out of `t.Run()` in wlm remote process collector test.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
This test is currently flaky. 

```
=== RUN   TestCollection/one_set_one_unset
==================
Write at 0x0000019997e0 by goroutine 5891:
  github.com/DataDog/datadog-agent/pkg/config.Mock.func1()
      /go/src/github.com/DataDog/datadog-agent/pkg/config/mock.go:49 +0x99
  testing.(*common).Cleanup.func1()
      /goroot/src/testing/testing.go:1150 +0x193
  testing.(*common).runCleanup()
      /goroot/src/testing/testing.go:1328 +0x1e9
  testing.tRunner.func2()
      /goroot/src/testing/testing.go:1570 +0x52
  runtime.deferreturn()
      /goroot/src/runtime/panic.go:476 +0x32
  testing.(*T).Run.func1()
      /goroot/src/testing/testing.go:1629 +0x47

Previous read at 0x0000019997e0 by goroutine 5896:
  github.com/DataDog/datadog-agent/pkg/api/security.GetAuthTokenFilepath()
      /go/src/github.com/DataDog/datadog-agent/pkg/api/security/security.go:113 +0xbc
  github.com/DataDog/datadog-agent/pkg/api/security.fetchAuthToken()
      /go/src/github.com/DataDog/datadog-agent/pkg/api/security/security.go:129 +0x3e
  github.com/DataDog/datadog-agent/pkg/api/security.FetchAuthToken()
      /go/src/github.com/DataDog/datadog-agent/pkg/api/security/security.go:119 +0x13b
  github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote.(*GenericCollector).startWorkloadmetaStream.func1()
      /go/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote/generic.go:140 +0x134
  github.com/cenkalti/backoff.RetryNotify()
      /go/pkg/mod/github.com/cenkalti/backoff@v2.2.1+incompatible/retry.go:37 +0x28c
  github.com/cenkalti/backoff.Retry()
      /go/pkg/mod/github.com/cenkalti/backoff@v2.2.1+incompatible/retry.go:24 +0xb3
  github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote.(*GenericCollector).startWorkloadmetaStream()
      /go/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote/generic.go:133 +0x82
  github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote.(*GenericCollector).Run()
      /go/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote/generic.go:178 +0xaa
  github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote.(*GenericCollector).Start.func5()
      /go/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote/generic.go:118 +0x39

Goroutine 5891 (running) created at:
  testing.(*T).Run()
      /goroot/src/testing/testing.go:1629 +0x805
  github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote/process_collector.TestCollection()
      /go/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector_test.go:237 +0x2bab
  testing.tRunner()
      /goroot/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /goroot/src/testing/testing.go:1629 +0x47

Goroutine 5896 (finished) created at:
  github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote.(*GenericCollector).Start()
      /go/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote/generic.go:118 +0x7a5
  github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote/process_collector.TestCollection.func2()
      /go/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector_test.go:277 +0x694
  testing.tRunner()
      /goroot/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /goroot/src/testing/testing.go:1629 +0x47
==================
    testing.go:1446: race detected during execution of test
--- FAIL: TestCollection/one_set_one_unset (2.03s)
```
By moving mock Config creating outside of a goroutine, it should fix the data race.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
`go test -race -count=1 -timeout 30s -tags process,python,docker,zk,podman,kubeapiserver,otlp,systemd,trivy,jetson,ec2,kubelet,containerd,secrets,zlib,apm,etcd,gce,orchestrator,cri,jmx,netcgo,consul,test -run ^TestCollection$ github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote/process_collector`

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
