### PR TITLE
usm: javatls: Fix path creation

### DIFF
--- a/pkg/network/protocols/tls/java/hotspot.go
+++ b/pkg/network/protocols/tls/java/hotspot.go
@@ -104,7 +104,7 @@ func getPathOwner(path string) (uint32, uint32, error) {
 //	o dstPath is path to the copy of agent-usm.jar (from container perspective), this would be pass to the hotspot command
 //	o cleanup must be called to remove the created file
 func (h *Hotspot) copyAgent(agent string, uid int, gid int) (dstPath string, cleanup func(), err error) {
-	dstPath = h.cwd + "/" + filepath.Base(agent)
+	dstPath = filepath.Join(h.cwd, filepath.Base(agent))
 	// path from the host point of view pointing to the process root namespace (/proc/pid/root/usr/...)
 	nsDstPath := h.root + dstPath
 	if dst, err := os.Stat(nsDstPath); err == nil {
@@ -189,7 +189,7 @@ func (h *Hotspot) connect(withCredential bool) (close func(), err error) {
 		return nil, err
 	}
 
-	if err := conn.SetDeadline(time.Now().Add(3 * time.Second)); err != nil {
+	if err := conn.SetDeadline(time.Now().Add(30 * time.Second)); err != nil {
 		conn.Close()
 		return nil, err
 	}

--- a/pkg/network/protocols/tls/java/hotspot.go
+++ b/pkg/network/protocols/tls/java/hotspot.go
@@ -189,7 +189,7 @@ func (h *Hotspot) connect(withCredential bool) (close func(), err error) {
 		return nil, err
 	}
 
-	if err := conn.SetDeadline(time.Now().Add(30 * time.Second)); err != nil {
+	if err := conn.SetDeadline(time.Now().Add(3 * time.Second)); err != nil {
 		conn.Close()
 		return nil, err
 	}

--- a/pkg/network/protocols/tls/java/hotspot.go
+++ b/pkg/network/protocols/tls/java/hotspot.go
@@ -104,7 +104,7 @@ func getPathOwner(path string) (uint32, uint32, error) {
 //	o dstPath is path to the copy of agent-usm.jar (from container perspective), this would be pass to the hotspot command
 //	o cleanup must be called to remove the created file
 func (h *Hotspot) copyAgent(agent string, uid int, gid int) (string, func(), error) {
-	dstPath = filepath.Join(h.cwd, filepath.Base(agent))
+	dstPath := filepath.Join(h.cwd, filepath.Base(agent))
 	// path from the host point of view pointing to the process root namespace (/proc/pid/root/usr/...)
 	nsDstPath := h.root + dstPath
 	if dst, err := os.Stat(nsDstPath); err == nil {

--- a/pkg/network/protocols/tls/java/hotspot.go
+++ b/pkg/network/protocols/tls/java/hotspot.go
@@ -32,7 +32,7 @@ import (
 //	o touch .attach_pid<pid-of-java>
 //	o kill -SIGQUIT <pid-of-java>
 //	o java process check if .attach_pid<his-pid> exit
-//	o then create an unix socket .java_pid<his-pid>
+//	o then create a unix socket .java_pid<his-pid>
 //	o we can write command through the unix socket
 //	<pid-of-java> refers to the namespaced pid of the process.
 //
@@ -103,7 +103,7 @@ func getPathOwner(path string) (uint32, uint32, error) {
 //
 //	o dstPath is path to the copy of agent-usm.jar (from container perspective), this would be pass to the hotspot command
 //	o cleanup must be called to remove the created file
-func (h *Hotspot) copyAgent(agent string, uid int, gid int) (dstPath string, cleanup func(), err error) {
+func (h *Hotspot) copyAgent(agent string, uid int, gid int) (string, func(), error) {
 	dstPath = filepath.Join(h.cwd, filepath.Base(agent))
 	// path from the host point of view pointing to the process root namespace (/proc/pid/root/usr/...)
 	nsDstPath := h.root + dstPath
@@ -132,9 +132,9 @@ func (h *Hotspot) copyAgent(agent string, uid int, gid int) (dstPath string, cle
 	if err != nil {
 		return "", nil, err
 	}
-	_, err = io.Copy(dst, srcAgent)
-	dst.Close() // we are closing the file here as Chown will be call just after on the same path
-	if err != nil {
+	_, copyErr := io.Copy(dst, srcAgent)
+	dst.Close() // we are closing the file here as Chown will be called just after on the same path
+	if copyErr != nil {
 		return "", nil, err
 	}
 	if err := syscall.Chown(nsDstPath, uid, gid); err != nil {
@@ -178,7 +178,7 @@ func (h *Hotspot) dialunix(raddr *net.UnixAddr, withCredential bool) (*net.UnixC
 
 // connect to the previously created hotspot unix socket
 // return close function must be call when finished
-func (h *Hotspot) connect(withCredential bool) (close func(), err error) {
+func (h *Hotspot) connect(withCredential bool) (func(), error) {
 	h.conn = nil
 	addr, err := net.ResolveUnixAddr("unix", h.socketPath)
 	if err != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixes java tls path creation on the target namespace.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fix bugs found during testing.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
