### PR TITLE
Adds support for sketch origins based on shared metadata field

### DIFF
--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -116,6 +116,8 @@ func (s *TimeSampler) newSketchSeries(ck ckey.ContextKey, points []metrics.Sketc
 		Interval:   s.interval,
 		Points:     points,
 		ContextKey: ck,
+		Source:     ctx.source,
+		NoIndex:    ctx.noIndex,
 	}
 
 	return ss

--- a/pkg/metrics/sketch_series.go
+++ b/pkg/metrics/sketch_series.go
@@ -22,6 +22,8 @@ type SketchSeries struct {
 	Interval   int64                `json:"interval"`
 	Points     []SketchPoint        `json:"points"`
 	ContextKey ckey.ContextKey      `json:"-"`
+	NoIndex    bool                 `json:"-"` // This is only used by api V2
+	Source     MetricSource         `json:"-"` // This is only used by api V2
 }
 
 // String returns the JSON representation of a SketchSeries as a string


### PR DESCRIPTION
### What does this PR do?
Adds support for sketches to send Origin metadata to the ingestion endpoint.
This is in draft until ingestion support is finalized.

### Motivation
Symmetry with series #15935 

### Additional Notes
n/a

### Possible Drawbacks / Trade-offs
n/a

### Describe how to test/QA your changes
TBD

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
