### PR TITLE
[CWS] reduce log level of security profile no image provided log

### DIFF
--- a/pkg/security/resolvers/cgroup/model/model.go
+++ b/pkg/security/resolvers/cgroup/model/model.go
@@ -18,6 +18,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
+var (
+	ErrNoImageProvided = errors.New("no image name provided")
+)
+
 // WorkloadSelector is a selector used to uniquely indentify the image of a workload
 type WorkloadSelector struct {
 	Image string
@@ -27,7 +31,7 @@ type WorkloadSelector struct {
 // NewWorkloadSelector returns an initialized instance of a WorkloadSelector
 func NewWorkloadSelector(image string, tag string) (WorkloadSelector, error) {
 	if image == "" {
-		return WorkloadSelector{}, errors.New("no image name provided")
+		return WorkloadSelector{}, ErrNoImageProvided
 	} else if tag == "" {
 		tag = "latest"
 	}

--- a/pkg/security/security_profile/profile/profile_dir.go
+++ b/pkg/security/security_profile/profile/profile_dir.go
@@ -23,7 +23,6 @@ import (
 
 	proto "github.com/DataDog/agent-payload/v5/cws/dumpsv1"
 
-	"github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
@@ -283,7 +282,7 @@ func (dp *DirectoryProvider) onHandleFilesFromWatcher() {
 
 	for file := range dp.newFiles {
 		if err := dp.loadProfile(file); err != nil {
-			if errors.Is(err, model.ErrNoImageProvided) {
+			if errors.Is(err, cgroupModel.ErrNoImageProvided) {
 				seclog.Debugf("couldn't load new profile %s: %v", file, err)
 			} else {
 				seclog.Errorf("couldn't load new profile %s: %v", file, err)

--- a/pkg/security/security_profile/profile/profile_dir.go
+++ b/pkg/security/security_profile/profile/profile_dir.go
@@ -9,6 +9,7 @@ package profile
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -22,6 +23,7 @@ import (
 
 	proto "github.com/DataDog/agent-payload/v5/cws/dumpsv1"
 
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
@@ -281,7 +283,12 @@ func (dp *DirectoryProvider) onHandleFilesFromWatcher() {
 
 	for file := range dp.newFiles {
 		if err := dp.loadProfile(file); err != nil {
-			seclog.Errorf("couldn't load new profile %s: %v", file, err)
+			if errors.Is(err, model.ErrNoImageProvided) {
+				seclog.Debugf("couldn't load new profile %s: %v", file, err)
+			} else {
+				seclog.Errorf("couldn't load new profile %s: %v", file, err)
+			}
+
 			continue
 		}
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This log is super spammy because a lot of workload don't really have the expected `image_name` tag. This PR reduces the log level to debug for this specific error.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
