### PR TITLE
[Single Machine Performance] Nightly Workload Checks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -106,6 +106,7 @@
 /.gitlab/benchmarks/benchmarks.yml                   @DataDog/agent-apm
 
 /.gitlab/functional_test/regression_detector.yml     @DataDog/single-machine-performance
+/.gitlab/functional_test/workload_checks.yml         @DataDog/single-machine-performance
 
 /chocolatey/                            @DataDog/windows-agent
 
@@ -438,6 +439,7 @@
 /test/system/dogstatsd/                 @DataDog/agent-metrics-logs
 /test/benchmarks/apm_scripts/           @DataDog/agent-apm
 /test/regression/                       @DataDog/single-machine-performance
+/test/workload-checks/                  @DataDog/single-machine-performance
 
 /tools/                                 @DataDog/agent-platform
 /tools/ebpf/                            @DataDog/ebpf-platform

--- a/.gitlab/functional_test/workload_checks.yml
+++ b/.gitlab/functional_test/workload_checks.yml
@@ -1,0 +1,60 @@
+single-machine-performance-workload-checks:
+  stage: functional_test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["runner:docker"]
+  needs:
+    - job: single_machine_performance-nightly-amd64-a7
+      artifacts: false
+  artifacts:
+    expire_in: 1 weeks
+    paths:
+      - submission_metadata              # for provenance, debugging
+    when: always
+  variables:
+    SMP_VERSION: 0.9.2
+    LADING_VERSION: 0.17.3
+    WARMUP_SECONDS: 45
+    TOTAL_SAMPLES: 600
+    REPLICAS: 5
+  allow_failure: true
+  script:
+    # Compute the commit time from CI_COMMIT_SHA, must match the calculation on
+    # `docker_publish_job_definition`.
+    - git fetch origin
+    - CI_COMMIT_TIME=$(git show -s --format=%ct $CI_COMMIT_SHA)
+    # Setup AWS credentials for single-machine-performance AWS account
+    - AWS_NAMED_PROFILE="single-machine-performance"
+    - SMP_ACCOUNT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-account-id --with-decryption --query "Parameter.Value" --out text)
+    - SMP_ECR_URL=${SMP_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com
+    - SMP_AGENT_TEAM_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-agent-team-id --with-decryption --query "Parameter.Value" --out text)
+    - SMP_API=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-api --with-decryption --query "Parameter.Value" --out text)
+    - aws configure set aws_access_key_id $(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-bot-access-key-id --with-decryption --query "Parameter.Value" --out text) --profile ${AWS_NAMED_PROFILE}
+    - aws configure set aws_secret_access_key $(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-bot-access-key --with-decryption --query "Parameter.Value" --out text) --profile ${AWS_NAMED_PROFILE}
+    - aws configure set region us-west-2 --profile ${AWS_NAMED_PROFILE}
+    # Download smp binary and prepare it for use
+    - aws --profile single-machine-performance s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-gnu/smp smp
+    - chmod +x smp
+    # Copy the baseline SHA to SMP for debugging purposes later
+    - TARGET_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:nightly-${CI_COMMIT_TIME}-${CI_COMMIT_SHA}-7-amd64
+    - echo "${TARGET_SHA}"
+    - RUST_LOG="info,aws_config::profile::credentials=error"
+    - RUST_LOG_DEBUG="debug,aws_config::profile::credentials=error"
+    - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
+            job submit-workload
+            --lading-version ${LADING_VERSION}
+            --total-samples ${TOTAL_SAMPLES}
+            --warmup-seconds ${WARMUP_SECONDS}
+            --replicas ${REPLICAS}
+            --target-image ${TARGET_IMAGE}
+            --target-sha ${CI_COMMIT_SHA}
+            --target-config-dir test/workload-checks
+            --target-name datadog-agent
+            --target-command "/bin/entrypoint.sh"
+            --target-environment-variables "DD_HOSTNAME=smp-regression,DD_DD_URL=http://127.0.0.1:9092,DD_API_KEY=00000001"
+            --submission-metadata submission-metadata
+    # Wait for job to complete.
+    - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
+            job status --use-curta
+            --wait
+            --wait-delay-seconds 60
+            --submission-metadata submission_metadata

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -963,7 +963,7 @@ def lint_filenames(ctx):
     max_length = 255
     for file in files:
         if (
-            not file.startswith(('test/kitchen/', 'tools/windows/DatadogAgentInstaller'))
+            not file.startswith(('test/kitchen/', 'tools/windows/DatadogAgentInstaller', 'test/workload-checks', 'test/regression'))
             and prefix_length + len(file) > max_length
         ):
             print(f"Error: path {file} is too long ({prefix_length + len(file) - max_length} characters too many)")

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -963,7 +963,9 @@ def lint_filenames(ctx):
     max_length = 255
     for file in files:
         if (
-            not file.startswith(('test/kitchen/', 'tools/windows/DatadogAgentInstaller', 'test/workload-checks', 'test/regression'))
+            not file.startswith(
+                ('test/kitchen/', 'tools/windows/DatadogAgentInstaller', 'test/workload-checks', 'test/regression')
+            )
             and prefix_length + len(file) > max_length
         ):
             print(f"Error: path {file} is too long ({prefix_length + len(file) - max_length} characters too many)")

--- a/test/workload-checks/README.md
+++ b/test/workload-checks/README.md
@@ -1,0 +1,37 @@
+# Workload Checks
+
+The Single Machine Performance 'Workload Checks' tool performs a nightly run of
+the Agent and compares that run to a series of 'checks' to determine if the
+Agent is fit for purpose: did we consume too much memory, did we achieve our
+throughput goals etc. This is done relative to a 'machine class', with the
+intention of simulating whether we are fit-for-purpose on a given type of
+machine, for a given type of workload that our customers would run.
+
+## Adding an Experiment
+
+In order for SMP's tooling to properly read a experiment directory please
+adhere to the following structure. Starting at the root:
+
+* `MACHINE_CLASS/` -- __Required__ The directory that contains experiments for
+  each class of machine. Please note that `MACHINE_CLASS` metasyntactic
+  variable. For instance, we have `typical` for a "typical" machine class.
+
+The structure of each machine class is as follows:
+
+* `machine.yaml` -- __Required__ The definition of the machine class, lays out
+  resource limitations.
+* `cases/` -- __Required__ The directory that contains each workload check
+   experiment for the parent machine class.  Each sub-directory is a separate
+   experiment and the name of the directory is the name of the experiment, for
+   instance `tcp_syslog_to_blackhole`. We call these sub-directories 'cases'.
+
+The structure of each case is as follows:
+
+* `lading/lading.yaml` -- __Required__ The [lading] configuration inside its own
+  directory. Directory will be mount read-only in the container built from
+  `Dockerfile` above at `/etc/lading`.
+* `datadog-agent/` -- __Required__ This is the configuration directory of your
+  program. Will be mounted read-only in the container build from `Dockerfile`
+  above at `/etc/datadog-agent`.
+* `experiment.yaml` -- __Optional__ This file can be used to set a
+  single optimization goal for each experiment.

--- a/test/workload-checks/typical/cases/apm_app_server/README.md
+++ b/test/workload-checks/typical/cases/apm_app_server/README.md
@@ -1,0 +1,13 @@
+# Application Server
+
+## Purpose
+
+Demonstrates an Agent configuration typical of one deployed on an application
+server.
+
+## Notes
+
+The purpose above is not quite true. I'm fully guessing at what the 'normal'
+Agent configuration for such a situation would be like. Instead we're
+demonstrating a situation where Agent has two components flipped on and lading
+produces load into both.

--- a/test/workload-checks/typical/cases/apm_app_server/README.md
+++ b/test/workload-checks/typical/cases/apm_app_server/README.md
@@ -1,13 +1,10 @@
-# Application Server
+# APM Application Server
 
 ## Purpose
 
-Demonstrates an Agent configuration typical of one deployed on an application
-server.
-
-## Notes
-
-The purpose above is not quite true. I'm fully guessing at what the 'normal'
-Agent configuration for such a situation would be like. Instead we're
-demonstrating a situation where Agent has two components flipped on and lading
-produces load into both.
+Simulates a relatively busy application server on which DogStatsD metrics, APM
+traces and TCP streamed logs are present on which the client user has mostly
+transitioned to the use of APM over DogStatsD and TCP listener logs, although
+not entirely replacing these sources of metrics and logs. Traces represent the
+majority of load. We make claims about throughput, UDS packet loss and memory,
+CPU resource consumption.

--- a/test/workload-checks/typical/cases/apm_app_server/datadog-agent/conf.d/tcp-listener.d/conf.yaml
+++ b/test/workload-checks/typical/cases/apm_app_server/datadog-agent/conf.d/tcp-listener.d/conf.yaml
@@ -1,0 +1,5 @@
+logs:
+  - type: tcp
+    port: 10000
+    service: "my-service"
+    source: "apache"

--- a/test/workload-checks/typical/cases/apm_app_server/experiment.yaml
+++ b/test/workload-checks/typical/cases/apm_app_server/experiment.yaml
@@ -1,0 +1,72 @@
+description: >
+  Simulates a relatively busy application server on which DogStatsD metrics, APM
+  traces and TCP streamed logs are present on which the client user has mostly
+  transitioned to the use of APM over DogStatsD and TCP listener logs, although
+  not entirely replacing these sources of metrics and logs. Traces represent the
+  majority of load. We make claims about throughput, UDS packet loss and memory,
+  CPU resource consumption.
+
+teams:
+  - agent-core
+
+labels: {}
+
+checks:
+  - name: memory_usage
+    description: "Memory usage"
+    bounds:
+      series: rss_bytes
+      # The machine has 12Gb free.
+      upper_bound: 2.75Gb
+
+  - name: cpu_utilization
+    description: "CPU utilization"
+    bounds:
+      series: cpu_percentage
+      # The machine has 8 cores available.
+      upper_bound: 400
+
+  - name: apm_trace_throughput
+    description: "APM throughput"
+    bounds:
+      series: "rate(bytes_written['traces'])"
+      # Lading is configured to send 64 MB/s on each of two connections. This is
+      # a relatively high priority concern by bounding below close to the
+      # transmission rate.
+      lower_bound: 2Mb
+      upper_bound: 66Mb
+
+  - name: dogstatsd_throughput
+    description: "DogStatsD throughput"
+    bounds:
+      series: "rate(bytes_written['dogstatsd'])"
+      # Lading is configured to send 1 MB/s with one connection. This is a
+      # relatively high priority concern by bounding below close to the
+      # transmission rate.
+      lower_bound: 500Kb
+      upper_bound: 2Mb
+
+  - name: tcp_listener_throughput
+    description: "TCP listener throughput"
+    bounds:
+      series: "rate(bytes_written['tcp_logs'])"
+      # Lading is configured to send 1 MB/s. More throughput than this -- owing
+      # to buffering etc -- is fine but less is not.
+      lower_bound: 500Kb
+      upper_bound: 1Mb
+
+  - name: lost_bytes_uds_dogstatsd
+    description: "Lost UDS DogStatsD bytes"
+    percent_error:
+      expected: "bytes_written['dogstatsd']"
+      actual: "target/dogstatsd-uds/Bytes"
+      threshold: 1.0
+
+environment:
+  DD_TELEMETRY_ENABLED: true
+
+profiling_environment:
+  DD_INTERNAL_PROFILING_ENABLED: true
+  DD_INTERNAL_PROFILING_UNIX_SOCKET: /var/run/datadog/apm.socket
+  DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+  DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true

--- a/test/workload-checks/typical/cases/apm_app_server/experiment.yaml
+++ b/test/workload-checks/typical/cases/apm_app_server/experiment.yaml
@@ -6,8 +6,7 @@ description: >
   majority of load. We make claims about throughput, UDS packet loss and memory,
   CPU resource consumption.
 
-teams:
-  - agent-core
+teams: []
 
 labels: {}
 
@@ -30,9 +29,8 @@ checks:
     description: "APM throughput"
     bounds:
       series: "rate(bytes_written['traces'])"
-      # Lading is configured to send 64 MB/s on each of two connections. This is
-      # a relatively high priority concern by bounding below close to the
-      # transmission rate.
+      # Lading is configured to send 64 MB/s on each of two connections. The
+      # lower bound here is reflective of experimentally determined bounds.
       lower_bound: 2Mb
       upper_bound: 66Mb
 

--- a/test/workload-checks/typical/cases/apm_app_server/lading/lading.yaml
+++ b/test/workload-checks/typical/cases/apm_app_server/lading/lading.yaml
@@ -1,0 +1,69 @@
+generator:
+  - id: tcp_logs
+    tcp:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      addr: "127.0.0.1:10000"
+      variant: "apache_common"
+      bytes_per_second: "1 Mb" # per connection, implicitly one for tcp generator
+      block_sizes: ["0.125Mb", "128Kb", "64Kb", "8Kb", "1Kb"]
+      maximum_prebuild_cache_size_bytes: "8 Mb"
+  - id: traces
+    http:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      headers: {}
+      target_uri: "http://127.0.0.1:8126/"
+      bytes_per_second: "64 Mb" # per connection
+      parallel_connections: 2
+      method:
+        post:
+          maximum_prebuild_cache_size_bytes: "512 Mb"
+          variant:
+            trace_agent: msgpack
+  - id: dogstatsd
+    unix_datagram:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      path: "/tmp/dsd.socket"
+      throttle: stable
+      variant:
+        dogstatsd:
+          metric_names_minimum: 32
+          metric_names_maximum: 128
+          tag_keys_minimum: 0
+          tag_keys_maximum: 512
+          kind_weights:
+            metric: 90
+            event: 5
+            service_check: 5
+          metric_weights:
+            count: 100
+            gauge: 10
+            timer: 0
+            distribution: 50
+            set: 0
+            histogram: 1
+      bytes_per_second: "1 Mb" # per connection
+      parallel_connections: 1
+      block_sizes: ["1Kb", "2Kb", "4Kb", "8Kb", "16Kb", "32Kb"]
+      maximum_prebuild_cache_size_bytes: "8 Mb"
+
+blackhole:
+  - id: api
+    http:
+      binding_addr: "127.0.0.1:9091"
+  - id: traces
+    http:
+      binding_addr: "127.0.0.1:9092"
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:5000/telemetry"
+    # metrics: intentionally left off to collect everything
+  - expvar:
+      uri: "http://127.0.0.1:5000/debug/vars"
+      vars:
+        - "/dogstatsd-uds/Bytes"
+        - "/dogstatsd-uds/Packets"
+        - "/dogstatsd-uds/PacketReadingErrors"

--- a/test/workload-checks/typical/cases/app_server/README.md
+++ b/test/workload-checks/typical/cases/app_server/README.md
@@ -2,12 +2,8 @@
 
 ## Purpose
 
-Demonstrates an Agent configuration typical of one deployed on an application
-server.
-
-## Notes
-
-The purpose above is not quite true. I'm fully guessing at what the 'normal'
-Agent configuration for such a situation would be like. Instead we're
-demonstrating a situation where Agent has two components flipped on and lading
-produces load into both.
+Simulates a relatively busy application server on which DogStatsD metrics,
+traces and TCP streamed logs are present on which the client user is interested
+in OTel but has not made a complete transition. DogStatsD, TCP logs, and APM
+traces make up the load. We make claims about throughput, UDS packet loss and
+memory, CPU resource consumption.

--- a/test/workload-checks/typical/cases/app_server/README.md
+++ b/test/workload-checks/typical/cases/app_server/README.md
@@ -1,0 +1,13 @@
+# Application Server
+
+## Purpose
+
+Demonstrates an Agent configuration typical of one deployed on an application
+server.
+
+## Notes
+
+The purpose above is not quite true. I'm fully guessing at what the 'normal'
+Agent configuration for such a situation would be like. Instead we're
+demonstrating a situation where Agent has two components flipped on and lading
+produces load into both.

--- a/test/workload-checks/typical/cases/app_server/datadog-agent/conf.d/tcp-listener.d/conf.yaml
+++ b/test/workload-checks/typical/cases/app_server/datadog-agent/conf.d/tcp-listener.d/conf.yaml
@@ -1,0 +1,5 @@
+logs:
+  - type: tcp
+    port: 10000
+    service: "my-service"
+    source: "apache"

--- a/test/workload-checks/typical/cases/app_server/experiment.yaml
+++ b/test/workload-checks/typical/cases/app_server/experiment.yaml
@@ -5,8 +5,7 @@ description: >
   and APM traces make up the load. We make claims about throughput, UDS packet
   loss and memory, CPU resource consumption.
 
-teams:
-  - agent-core
+teams: []
 
 labels: {}
 
@@ -39,10 +38,10 @@ checks:
     description: "DogStatsD throughput"
     bounds:
       series: "rate(bytes_written['dogstatsd'])"
-      # Lading is configured to send 32 MB/s. This is a relatively high priority
-      # concern by bounding below close to the transmission rate.
+      # Lading is configured to send 64 MB/s on each of two connections. The
+      # lower bound here is reflective of experimentally determined bounds.
       lower_bound: 0b
-      upper_bound: 34Mb
+      upper_bound: 66Mb
 
   - name: tcp_listener_throughput
     description: "TCP listener throughput"

--- a/test/workload-checks/typical/cases/app_server/experiment.yaml
+++ b/test/workload-checks/typical/cases/app_server/experiment.yaml
@@ -1,0 +1,70 @@
+description: >
+  Simulates a relatively busy application server on which DogStatsD metrics,
+  traces and TCP streamed logs are present on which the client user is
+  interested in OTeL but has not made a complete transition. DogStatsD, TCP logs,
+  and APM traces make up the load. We make claims about throughput, UDS packet
+  loss and memory, CPU resource consumption.
+
+teams:
+  - agent-core
+
+labels: {}
+
+checks:
+  - name: memory_usage
+    description: "Memory usage"
+    bounds:
+      series: rss_bytes
+      # The machine has 12Gb free.
+      upper_bound: 3.5Gb
+
+  - name: cpu_utilization
+    description: "CPU utilization"
+    bounds:
+      series: cpu_percentage
+      # The machine has 8 cores available.
+      upper_bound: 400
+
+  - name: apm_trace_throughput
+    description: "APM throughput"
+    bounds:
+      series: "rate(bytes_written['traces'])"
+      # Lading is configured to send 8 MB/s on each of two connections. This is
+      # a relatively high priority concern by bounding below close to the
+      # transmission rate.
+      lower_bound: 4b
+      upper_bound: 10Mb
+
+  - name: dogstatsd_throughput
+    description: "DogStatsD throughput"
+    bounds:
+      series: "rate(bytes_written['dogstatsd'])"
+      # Lading is configured to send 32 MB/s. This is a relatively high priority
+      # concern by bounding below close to the transmission rate.
+      lower_bound: 0b
+      upper_bound: 34Mb
+
+  - name: tcp_listener_throughput
+    description: "TCP listener throughput"
+    bounds:
+      series: "rate(bytes_written['tcp_logs'])"
+      # Lading is configured to send 10 MB/s. More throughput than this -- owing
+      # to buffering etc -- is fine but less is not.
+      lower_bound: 5Mb
+      upper_bound: 12Mb
+
+  - name: lost_bytes_uds_dogstatsd
+    description: "Lost UDS DogStatsD bytes"
+    percent_error:
+      expected: "bytes_written['dogstatsd']"
+      actual: "target/dogstatsd-uds/Bytes"
+      threshold: 5.0
+
+environment:
+  DD_TELEMETRY_ENABLED: true
+
+profiling_environment:
+  DD_INTERNAL_PROFILING_ENABLED: true
+  DD_INTERNAL_PROFILING_UNIX_SOCKET: /var/run/datadog/apm.socket
+  DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+  DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true

--- a/test/workload-checks/typical/cases/app_server/lading/lading.yaml
+++ b/test/workload-checks/typical/cases/app_server/lading/lading.yaml
@@ -1,0 +1,70 @@
+generator:
+  - id: tcp_logs
+    tcp:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      addr: "127.0.0.1:10000"
+      variant: "apache_common"
+      bytes_per_second: "10 Mb" # per connection, implicitly one for tcp generator
+      block_sizes: ["1Mb", "0.5Mb", "0.25Mb", "0.125Mb", "128Kb", "64Kb", "8Kb", "1Kb"]
+      maximum_prebuild_cache_size_bytes: "128 Mb"
+  - id: traces
+    http:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      headers: {}
+      target_uri: "http://127.0.0.1:8126/"
+      bytes_per_second: "8 Mb" # per connection
+      parallel_connections: 2
+      method:
+        post:
+          maximum_prebuild_cache_size_bytes: "128 Mb"
+          variant:
+            trace_agent: msgpack
+  - id: dogstatsd
+    unix_datagram:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      path: "/tmp/dsd.socket"
+      throttle: stable
+      variant:
+        dogstatsd:
+          metric_names_minimum: 32
+          metric_names_maximum: 128
+          tag_keys_minimum: 0
+          tag_keys_maximum: 512
+          kind_weights:
+            metric: 90
+            event: 5
+            service_check: 5
+          metric_weights:
+            count: 100
+            gauge: 10
+            timer: 0
+            distribution: 50
+            set: 0
+            histogram: 1
+      bytes_per_second: "32 Mb" # per connection
+      parallel_connections: 1
+      block_sizes: ["1Kb", "2Kb", "4Kb", "8Kb", "16Kb", "32Kb"]
+      maximum_prebuild_cache_size_bytes: "128 Mb"
+
+blackhole:
+  - id: api
+    http:
+      binding_addr: "127.0.0.1:9091"
+
+  - id: traces
+    http:
+      binding_addr: "127.0.0.1:9092"
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:5000/telemetry"
+    # metrics: intentionally left off to collect everything
+  - expvar:
+      uri: "http://127.0.0.1:5000/debug/vars"
+      vars:
+        - "/dogstatsd-uds/Bytes"
+        - "/dogstatsd-uds/Packets"
+        - "/dogstatsd-uds/PacketReadingErrors"

--- a/test/workload-checks/typical/cases/otel_app_server/README.md
+++ b/test/workload-checks/typical/cases/otel_app_server/README.md
@@ -1,13 +1,10 @@
-# Application Server
+# OTel Application Server
 
 ## Purpose
 
-Demonstrates an Agent configuration typical of one deployed on an application
-server.
-
-## Notes
-
-The purpose above is not quite true. I'm fully guessing at what the 'normal'
-Agent configuration for such a situation would be like. Instead we're
-demonstrating a situation where Agent has two components flipped on and lading
-produces load into both.
+Simulates a relatively busy application server on which DogStatsD metrics, OTel
+traces and TCP streamed logs are present on which the client user has mostly
+transitioned to the use of OTeL over DogStatsD and TCP listener logs, although
+not entirely replacing these sources of metrics and logs. Traces represent the
+majority of load. We make claims about throughput, UDS packet loss and memory,
+CPU resource consumption.

--- a/test/workload-checks/typical/cases/otel_app_server/README.md
+++ b/test/workload-checks/typical/cases/otel_app_server/README.md
@@ -1,0 +1,13 @@
+# Application Server
+
+## Purpose
+
+Demonstrates an Agent configuration typical of one deployed on an application
+server.
+
+## Notes
+
+The purpose above is not quite true. I'm fully guessing at what the 'normal'
+Agent configuration for such a situation would be like. Instead we're
+demonstrating a situation where Agent has two components flipped on and lading
+produces load into both.

--- a/test/workload-checks/typical/cases/otel_app_server/datadog-agent/conf.d/tcp-listener.d/conf.yaml
+++ b/test/workload-checks/typical/cases/otel_app_server/datadog-agent/conf.d/tcp-listener.d/conf.yaml
@@ -1,0 +1,5 @@
+logs:
+  - type: tcp
+    port: 10000
+    service: "my-service"
+    source: "apache"

--- a/test/workload-checks/typical/cases/otel_app_server/experiment.yaml
+++ b/test/workload-checks/typical/cases/otel_app_server/experiment.yaml
@@ -6,8 +6,7 @@ description: >
   represent the majority of load. We make claims about throughput, UDS packet
   loss and memory, CPU resource consumption.
 
-teams:
-  - agent-core
+teams: []
 
 labels: {}
 
@@ -30,9 +29,8 @@ checks:
     description: "OTeL throughput"
     bounds:
       series: "rate(bytes_written['traces'])"
-      # Lading is configured to send 64 MB/s on each of two connections. This is
-      # a relatively high priority concern by bounding below close to the
-      # transmission rate.
+      # Lading is configured to send 64 MB/s on each of two connections. The
+      # lower bound here is reflective of experimentally determined bounds.
       lower_bound: 1Mb
       upper_bound: 66Mb
 

--- a/test/workload-checks/typical/cases/otel_app_server/experiment.yaml
+++ b/test/workload-checks/typical/cases/otel_app_server/experiment.yaml
@@ -1,0 +1,72 @@
+description: >
+  Simulates a relatively busy application server on which DogStatsD metrics,
+  OTeL traces and TCP streamed logs are present on which the client user has
+  mostly transitioned to the use of OTeL over DogStatsD and TCP listener logs,
+  although not entirely replacing these sources of metrics and logs. Traces
+  represent the majority of load. We make claims about throughput, UDS packet
+  loss and memory, CPU resource consumption.
+
+teams:
+  - agent-core
+
+labels: {}
+
+checks:
+  - name: memory_usage
+    description: "Memory usage"
+    bounds:
+      series: rss_bytes
+      # The machine has 12Gb free.
+      upper_bound: 2.75Gb
+
+  - name: cpu_utilization
+    description: "CPU utilization"
+    bounds:
+      series: cpu_percentage
+      # The machine has 8 cores available.
+      upper_bound: 400
+
+  - name: otel_traces_throughput
+    description: "OTeL throughput"
+    bounds:
+      series: "rate(bytes_written['traces'])"
+      # Lading is configured to send 64 MB/s on each of two connections. This is
+      # a relatively high priority concern by bounding below close to the
+      # transmission rate.
+      lower_bound: 1Mb
+      upper_bound: 66Mb
+
+  - name: dogstatsd_throughput
+    description: "DogStatsD throughput"
+    bounds:
+      series: "rate(bytes_written['dogstatsd'])"
+      # Lading is configured to send 1 MB/s on one connection. This is a
+      # relatively high priority concern by bounding below close to the
+      # transmission rate.
+      lower_bound: 500Kb
+      upper_bound: 2Mb
+
+  - name: tcp_listener_throughput
+    description: "TCP listener throughput"
+    bounds:
+      series: "rate(bytes_written['tcp_logs'])"
+      # Lading is configured to send 1 MB/s. More throughput than this -- owing
+      # to buffering etc -- is fine but less is not.
+      lower_bound: 500Kb
+      upper_bound: 1Mb
+
+  - name: lost_bytes_uds_dogstatsd
+    description: "Lost UDS DogStatsD bytes"
+    percent_error:
+      expected: "bytes_written['dogstatsd']"
+      actual: "target/dogstatsd-uds/Bytes"
+      threshold: 1.0
+
+environment:
+  DD_TELEMETRY_ENABLED: true
+
+profiling_environment:
+  DD_INTERNAL_PROFILING_ENABLED: true
+  DD_INTERNAL_PROFILING_UNIX_SOCKET: /var/run/datadog/apm.socket
+  DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+  DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true

--- a/test/workload-checks/typical/cases/otel_app_server/lading/lading.yaml
+++ b/test/workload-checks/typical/cases/otel_app_server/lading/lading.yaml
@@ -1,0 +1,66 @@
+generator:
+  - id: tcp_logs
+    tcp:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      addr: "127.0.0.1:10000"
+      variant: "apache_common"
+      bytes_per_second: "1 Mb" # per connection, implicitly one for tcp generator
+      block_sizes: ["0.125Mb", "128Kb", "64Kb", "8Kb", "1Kb"]
+      maximum_prebuild_cache_size_bytes: "8 Mb"
+  - id: traces
+    http:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      headers:
+        content-type: "application/x-protobuf"
+      target_uri: "http://127.0.0.1:4318/v1/traces"
+      bytes_per_second: "64 Mb" # per connection
+      parallel_connections: 2
+      method:
+        post:
+          maximum_prebuild_cache_size_bytes: "512 Mb"
+          variant: "opentelemetry_traces"
+  - id: dogstatsd
+    unix_datagram:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      path: "/tmp/dsd.socket"
+      throttle: stable
+      variant:
+        dogstatsd:
+          metric_names_minimum: 32
+          metric_names_maximum: 128
+          tag_keys_minimum: 0
+          tag_keys_maximum: 512
+          kind_weights:
+            metric: 90
+            event: 5
+            service_check: 5
+          metric_weights:
+            count: 100
+            gauge: 10
+            timer: 0
+            distribution: 50
+            set: 0
+            histogram: 1
+      bytes_per_second: "1 Mb" # per connection
+      parallel_connections: 1
+      block_sizes: ["1Kb", "2Kb", "4Kb", "8Kb", "16Kb", "32Kb"]
+      maximum_prebuild_cache_size_bytes: "8 Mb"
+
+blackhole:
+  - id: api
+    http:
+      binding_addr: "127.0.0.1:9091"
+  - id: traces
+    http:
+      binding_addr: "127.0.0.1:9092"
+
+target_metrics:
+  - expvar:
+      uri: "http://127.0.0.1:5000/debug/vars"
+      vars:
+        - "/dogstatsd-uds/Bytes"
+        - "/dogstatsd-uds/Packets"
+        - "/dogstatsd-uds/PacketReadingErrors"

--- a/test/workload-checks/typical/machine.yaml
+++ b/test/workload-checks/typical/machine.yaml
@@ -1,0 +1,7 @@
+description: >
+  An ‘average’ customer server on which the agent runs alongside user
+  software. This is equivalent to an AWS c5.2xlarge with 4Gb of system memory
+  held back for system processes.
+name: typical
+cpu: 8
+memory: 12Gb


### PR DESCRIPTION
### What does this PR do?

This commit introduces the functional test that drives Workload Checks in the Agent project. Tests for a 'typical' machine and its workloads are also added.

### Motivation 

Single Machine Performance intend to do historical analysis of the Agent's fitness. The Workload Checks tool achieves that, with regard to customer-like machine configurations and Agent setup. Please see [this document](https://datadoghq.atlassian.net/wiki/spaces/SMP/pages/2983952861/Workload+Checks) and its children for more details.

REF SMP-673

