### PR TITLE
[DDQA] Update @DataDog/agent-shared-components JIRA project ID

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -21,7 +21,7 @@ github_labels = ["team/agent-metrics-logs"]
 exclude_members = ["olivielpeau"]
 
 [teams."Agent Shared Components"]
-jira_project = "ASC"
+jira_project = "ASCII"
 jira_issue_type = "QA"
 jira_statuses = [
   "To Do",


### PR DESCRIPTION
### What does this PR do?

Changes ddqa team name of @DataDog/agent-shared-components  from `ASC` to `ASCII`

### Motivation

@DataDog/agent-shared-components team's JIRA project ID changed from `ASC` to `ASCII` and this change ensures that QA cards are sent to the right place.

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

Next QA cycle should check the change

### Reviewer's Checklist


- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
