### PR TITLE
Fix YAML serialization error for the configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -173,25 +173,25 @@ func (l *Listeners) IsProviderEnabled(provider string) bool {
 
 // MappingProfile represent a group of mappings
 type MappingProfile struct {
-	Name     string          `mapstructure:"name" json:"name"`
-	Prefix   string          `mapstructure:"prefix" json:"prefix"`
-	Mappings []MetricMapping `mapstructure:"mappings" json:"mappings"`
+	Name     string          `mapstructure:"name" json:"name" yaml:"name"`
+	Prefix   string          `mapstructure:"prefix" json:"prefix" yaml:"prefix"`
+	Mappings []MetricMapping `mapstructure:"mappings" json:"mappings" yaml:"mappings"`
 }
 
 // MetricMapping represent one mapping rule
 type MetricMapping struct {
-	Match     string            `mapstructure:"match" json:"match"`
-	MatchType string            `mapstructure:"match_type" json:"match_type"`
-	Name      string            `mapstructure:"name" json:"name"`
-	Tags      map[string]string `mapstructure:"tags" json:"tags"`
+	Match     string            `mapstructure:"match" json:"match" yaml:"match"`
+	MatchType string            `mapstructure:"match_type" json:"match_type" yaml:"match_type"`
+	Name      string            `mapstructure:"name" json:"name" yaml:"name"`
+	Tags      map[string]string `mapstructure:"tags" json:"tags" yaml:"tags"`
 }
 
 // Endpoint represent a datadog endpoint
 type Endpoint struct {
-	Site   string `mapstructure:"site" json:"site"`
-	URL    string `mapstructure:"url" json:"url"`
-	APIKey string `mapstructure:"api_key" json:"api_key"`
-	APPKey string `mapstructure:"app_key" json:"app_key" `
+	Site   string `mapstructure:"site" json:"site" yaml:"site"`
+	URL    string `mapstructure:"url" json:"url" yaml:"url"`
+	APIKey string `mapstructure:"api_key" json:"api_key" yaml:"api_key"`
+	APPKey string `mapstructure:"app_key" json:"app_key" yaml:"app_key"`
 }
 
 // Warnings represent the warnings in the config

--- a/releasenotes/notes/fix-conf-serialization-to-yaml-9b967fd375bbecdf.yaml
+++ b/releasenotes/notes/fix-conf-serialization-to-yaml-9b967fd375bbecdf.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix ``dogstatsd_mapper_profiles`` wrong serialization when displaying the configuration (for example ``match_type``
+    was shown as ``matchtype``). This also fixes a bug in which the secret management feature was incompatible with
+    ``dogstatsd_mapper_profiles`` due to the renaming of the ``match_type`` key in the YAML data.


### PR DESCRIPTION
### What does this PR do?

We serialize the configuration to YAML when displaying it through the CLI or when using the secrets management feature. Some keys were wrongly named as YAML remove underscores by default (ie: 'matchtype' instead of `match_type`).

### Describe how to test/QA your changes

1. Set a `secret_backend_command` to anything but an empty string (doesn't has to be valid).
2. Configure `dogstatsd_mapper_profiles`.
3. Test that the profile are loaded without error and working.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
