### PR TITLE
Adding way to customise tag of "hacky dev image build"

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -346,7 +346,14 @@ def image_build(ctx, arch='amd64', base_dir="omnibus", python_version="2", skip_
 
 @task
 def hacky_dev_image_build(
-    ctx, base_image=None, target_image="agent", process_agent=False, trace_agent=False, push=False, signed_pull=False
+    ctx,
+    base_image=None,
+    target_image="agent",
+    target_tag="latest",
+    process_agent=False,
+    trace_agent=False,
+    push=False,
+    signed_pull=False,
 ):
     os.environ["DELVE"] = "1"
     build(ctx)
@@ -422,13 +429,14 @@ ENV DD_SSLKEYLOGFILE=/tmp/sslkeylog.txt
         )
         dockerfile.flush()
 
+        target_image_name = f'{target_image}:{target_tag}'
         pull_env = {}
         if signed_pull:
             pull_env['DOCKER_CONTENT_TRUST'] = '1'
-        ctx.run(f'docker build -t {target_image} -f {dockerfile.name} .', env=pull_env)
+        ctx.run(f'docker build -t {target_image_name} -f {dockerfile.name} .', env=pull_env)
 
         if push:
-            ctx.run(f'docker push {target_image}')
+            ctx.run(f'docker push {target_image_name}')
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

It allows you specify the tag to use when building the "hacky dev" image locally.

### Motivation

Wanted multiple images without having to retag built images.

### Additional Notes

None.

### Possible Drawbacks / Trade-offs

None.

### Describe how to test/QA your changes

Run `invoke agent.hacky-dev-image-build --target-tag <some tag>` and check you have an image called `agent:<some tag>` after it all builds.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
