### PR TITLE
[CWS][SEC-9396] namespaced pid PoC 

### DIFF
--- a/pkg/security/ebpf/c/include/constants/custom.h
+++ b/pkg/security/ebpf/c/include/constants/custom.h
@@ -2,6 +2,7 @@
 #define _CONSTANTS_CUSTOM_H
 
 #include "macros.h"
+#include "helpers/pid_tgid.h"
 
 #define TTY_NAME_LEN 64
 #define CONTAINER_ID_LEN 64
@@ -147,7 +148,7 @@ static __attribute__((always_inline)) int is_runtime_request() {
     u64 pid;
     LOAD_CONSTANT("runtime_pid", pid);
 
-    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = get_ns_current_pid_tgid();
     return pid_tgid >> 32 == pid;
 }
 

--- a/pkg/security/ebpf/c/include/helpers/bpf.h
+++ b/pkg/security/ebpf/c/include/helpers/bpf.h
@@ -7,7 +7,7 @@
 
 __attribute__((always_inline)) void save_obj_fd(struct syscall_cache_t *syscall) {
     struct bpf_tgid_fd_t key = {
-        .tgid = bpf_get_current_pid_tgid() >> 32,
+        .tgid = get_ns_current_pid_tgid() >> 32,
         .fd = syscall->bpf.retval,
     };
 
@@ -29,7 +29,7 @@ __attribute__((always_inline)) void save_obj_fd(struct syscall_cache_t *syscall)
 
 __attribute__((always_inline)) u32 fetch_map_id(int fd) {
     struct bpf_tgid_fd_t key = {
-        .tgid = bpf_get_current_pid_tgid() >> 32,
+        .tgid = get_ns_current_pid_tgid() >> 32,
         .fd = fd,
     };
 
@@ -42,7 +42,7 @@ __attribute__((always_inline)) u32 fetch_map_id(int fd) {
 
 __attribute__((always_inline)) u32 fetch_prog_id(int fd) {
     struct bpf_tgid_fd_t key = {
-        .tgid = bpf_get_current_pid_tgid() >> 32,
+        .tgid = get_ns_current_pid_tgid() >> 32,
         .fd = fd,
     };
 

--- a/pkg/security/ebpf/c/include/helpers/discarders.h
+++ b/pkg/security/ebpf/c/include/helpers/discarders.h
@@ -353,7 +353,7 @@ int __attribute__((always_inline)) is_discarded_by_pid(u64 event_type, u32 tgid)
 }
 
 int __attribute__((always_inline)) is_discarded_by_process(const char mode, u64 event_type) {
-    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = get_ns_current_pid_tgid();
     u32 tgid = pid_tgid >> 32;
 
     if (is_runtime_discarded() && is_runtime_request()) {

--- a/pkg/security/ebpf/c/include/helpers/iouring.h
+++ b/pkg/security/ebpf/c/include/helpers/iouring.h
@@ -5,7 +5,7 @@
 #include "maps.h"
 
 void __attribute__((always_inline)) cache_ioctx_pid_tgid(void *ioctx) {
-    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = get_ns_current_pid_tgid();
 #ifdef DEBUG
     bpf_printk("pid = %d", (u32)pid_tgid);
     bpf_printk("tgid = %d", pid_tgid >> 32);

--- a/pkg/security/ebpf/c/include/helpers/pid_tgid.h
+++ b/pkg/security/ebpf/c/include/helpers/pid_tgid.h
@@ -1,0 +1,19 @@
+#ifndef _HELPERS_PIDTGID_H_
+#define _HELPERS_PIDTGID_H_
+
+#include "constants/macros.h"
+
+u64 __attribute__((always_inline)) __attribute__((pure)) get_ns_current_pid_tgid() {
+    u64 dev, ino;
+    LOAD_CONSTANT("pid_namespace_device", dev);
+    LOAD_CONSTANT("pid_namespace_inode", ino);
+
+    struct bpf_pidns_info info;
+    if (bpf_get_ns_current_pid_tgid(dev, ino, &info, sizeof(info)) != 0) {
+        return -1;
+    }
+
+    return (u64)info.tgid << 32 | (u64)info.pid;
+}
+
+#endif // _HELPERS_PIDTGID_H_

--- a/pkg/security/ebpf/c/include/helpers/process.h
+++ b/pkg/security/ebpf/c/include/helpers/process.h
@@ -88,7 +88,7 @@ static struct proc_cache_t * __attribute__((always_inline)) fill_process_context
 }
 
 static struct proc_cache_t * __attribute__((always_inline)) fill_process_context(struct process_context_t *data) {
-    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = get_ns_current_pid_tgid();
     return fill_process_context_with_pid_tgid(data, pid_tgid);
 }
 

--- a/pkg/security/ebpf/c/include/helpers/span.h
+++ b/pkg/security/ebpf/c/include/helpers/span.h
@@ -9,7 +9,7 @@ int __attribute__((always_inline)) handle_register_span_memory(void *data) {
    struct span_tls_t tls = {};
    bpf_probe_read(&tls, sizeof(tls), data);
 
-   u64 pid_tgid = bpf_get_current_pid_tgid();
+   u64 pid_tgid = get_ns_current_pid_tgid();
    u32 tgid = pid_tgid >> 32;
 
    bpf_map_update_elem(&span_tls, &tgid, &tls, BPF_NOEXIST);
@@ -18,7 +18,7 @@ int __attribute__((always_inline)) handle_register_span_memory(void *data) {
 }
 
 int __attribute__((always_inline)) unregister_span_memory() {
-   u64 pid_tgid = bpf_get_current_pid_tgid();
+   u64 pid_tgid = get_ns_current_pid_tgid();
    u32 tgid = pid_tgid >> 32;
 
    bpf_map_delete_elem(&span_tls, &tgid);
@@ -27,7 +27,7 @@ int __attribute__((always_inline)) unregister_span_memory() {
 }
 
 void __attribute__((always_inline)) fill_span_context(struct span_context_t *span) {
-   u64 pid_tgid = bpf_get_current_pid_tgid();
+   u64 pid_tgid = get_ns_current_pid_tgid();
    u32 tgid = pid_tgid >> 32;
 
    struct span_tls_t *tls = bpf_map_lookup_elem(&span_tls, &tgid);

--- a/pkg/security/ebpf/c/include/hooks/commit_creds.h
+++ b/pkg/security/ebpf/c/include/hooks/commit_creds.h
@@ -24,7 +24,7 @@ int __attribute__((always_inline)) credentials_update_ret(void *ctx, int retval)
         return 0;
     }
 
-    u32 pid = bpf_get_current_pid_tgid() >> 32;
+    u32 pid = get_ns_current_pid_tgid() >> 32;
     struct pid_cache_t *pid_entry = (struct pid_cache_t *)bpf_map_lookup_elem(&pid_cache, &pid);
     if (!pid_entry) {
         return 0;
@@ -254,7 +254,7 @@ int hook_commit_creds(ctx_t *ctx) {
     struct pid_cache_t new_pid_entry = {};
 
     // update pid_cache entry for the current process
-    u32 pid = bpf_get_current_pid_tgid() >> 32;
+    u32 pid = get_ns_current_pid_tgid() >> 32;
     u8 new_entry = 0;
     struct pid_cache_t *pid_entry = (struct pid_cache_t *)bpf_map_lookup_elem(&pid_cache, &pid);
     if (!pid_entry) {

--- a/pkg/security/ebpf/c/include/hooks/dentry_resolver.h
+++ b/pkg/security/ebpf/c/include/hooks/dentry_resolver.h
@@ -573,7 +573,7 @@ int kprobe_dentry_resolver_ad_filter(struct pt_regs *ctx) {
         return 0;
     }
 
-    if (is_activity_dump_running(ctx, bpf_get_current_pid_tgid() >> 32, bpf_ktime_get_ns(), syscall->type)) {
+    if (is_activity_dump_running(ctx, get_ns_current_pid_tgid() >> 32, bpf_ktime_get_ns(), syscall->type)) {
         syscall->resolver.flags |= ACTIVITY_DUMP_RUNNING;
     }
 
@@ -590,7 +590,7 @@ int fentry_dentry_resolver_ad_filter(ctx_t *ctx) {
         return 0;
     }
 
-    if (is_activity_dump_running(ctx, bpf_get_current_pid_tgid() >> 32, bpf_ktime_get_ns(), syscall->type)) {
+    if (is_activity_dump_running(ctx, get_ns_current_pid_tgid() >> 32, bpf_ktime_get_ns(), syscall->type)) {
         syscall->resolver.flags |= ACTIVITY_DUMP_RUNNING;
     }
 
@@ -607,7 +607,7 @@ int tracepoint_dentry_resolver_ad_filter(void *ctx) {
         return 0;
     }
 
-    if (is_activity_dump_running(ctx, bpf_get_current_pid_tgid() >> 32, bpf_ktime_get_ns(), syscall->type)) {
+    if (is_activity_dump_running(ctx, get_ns_current_pid_tgid() >> 32, bpf_ktime_get_ns(), syscall->type)) {
         syscall->resolver.flags |= ACTIVITY_DUMP_RUNNING;
     }
 

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -21,7 +21,7 @@ int __attribute__((always_inline)) trace__sys_execveat(ctx_t *ctx, const char **
     };
     cache_syscall(&syscall);
 
-    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = get_ns_current_pid_tgid();
     u32 tgid = pid_tgid >> 32;
     u32 pid = pid_tgid;
     // exec is called from a non leader thread:
@@ -234,7 +234,7 @@ int sched_process_fork(struct _tracepoint_sched_process_fork *args) {
 
 HOOK_ENTRY("do_coredump")
 int hook_do_coredump(ctx_t *ctx) {
-    u64 key = bpf_get_current_pid_tgid();
+    u64 key = get_ns_current_pid_tgid();
     u8 in_coredump = 1;
 
     bpf_map_update_elem(&tasks_in_coredump, &key, &in_coredump, BPF_ANY);
@@ -244,7 +244,7 @@ int hook_do_coredump(ctx_t *ctx) {
 
 HOOK_ENTRY("do_exit")
 int hook_do_exit(ctx_t *ctx) {
-    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = get_ns_current_pid_tgid();
     u32 tgid = pid_tgid >> 32;
     u32 pid = pid_tgid;
 
@@ -298,7 +298,7 @@ HOOK_ENTRY("exit_itimers")
 int hook_exit_itimers(ctx_t *ctx) {
     void *signal = (void *)CTX_PARM1(ctx);
 
-    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = get_ns_current_pid_tgid();
     u32 tgid = pid_tgid >> 32;
 
     struct proc_cache_t *pc = get_proc_cache(tgid);
@@ -604,7 +604,7 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
     }
 
     // check if this is a thread first
-    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = get_ns_current_pid_tgid();
     u64 now = bpf_ktime_get_ns();
     u32 tgid = pid_tgid >> 32;
 

--- a/pkg/security/ebpf/c/include/hooks/module.h
+++ b/pkg/security/ebpf/c/include/hooks/module.h
@@ -124,7 +124,7 @@ int __attribute__((always_inline)) trace_init_module_ret(void *ctx, int retval, 
 SEC("tracepoint/module/module_load")
 int module_load(struct tracepoint_module_module_load_t *args) {
     // check if the tracepoint is hit by a kworker
-    u32 pid = bpf_get_current_pid_tgid();
+    u32 pid = get_ns_current_pid_tgid();
     u32 *is_kworker = bpf_map_lookup_elem(&pid_ignored, &pid);
     if (!is_kworker) {
         return 0;

--- a/pkg/security/ebpf/c/include/hooks/namespaces.h
+++ b/pkg/security/ebpf/c/include/hooks/namespaces.h
@@ -18,7 +18,7 @@ int hook_switch_task_namespaces(ctx_t *ctx) {
     }
 
     u32 netns = get_netns_from_net(net);
-    u32 tid = bpf_get_current_pid_tgid();
+    u32 tid = get_ns_current_pid_tgid();
     bpf_map_update_elem(&netns_cache, &tid, &netns, BPF_ANY);
     return 0;
 }

--- a/pkg/security/ebpf/c/include/hooks/network/bind.h
+++ b/pkg/security/ebpf/c/include/hooks/network/bind.h
@@ -99,7 +99,7 @@ int hook_security_socket_bind(ctx_t *ctx) {
 
     // Register service PID
     if (key.port != 0) {
-        u64 id = bpf_get_current_pid_tgid();
+        u64 id = get_ns_current_pid_tgid();
         u32 tid = (u32) id;
 
         // add netns information

--- a/pkg/security/ebpf/c/include/hooks/network/flow.h
+++ b/pkg/security/ebpf/c/include/hooks/network/flow.h
@@ -27,7 +27,7 @@ int kprobe_security_sk_classify_flow(struct pt_regs *ctx) {
 
     // Register service PID
     if (key.port != 0) {
-        u64 id = bpf_get_current_pid_tgid();
+        u64 id = get_ns_current_pid_tgid();
         u32 tid = (u32)id;
         u32 pid = id >> 32;
 

--- a/pkg/security/ebpf/c/include/hooks/network/net_device.h
+++ b/pkg/security/ebpf/c/include/hooks/network/net_device.h
@@ -9,7 +9,7 @@
 #include "perf_ring.h"
 
 int __attribute__((always_inline)) start_veth_state_machine() {
-    u64 id = bpf_get_current_pid_tgid();
+    u64 id = get_ns_current_pid_tgid();
     struct veth_state_t state = {
         .state = STATE_NEWLINK,
     };
@@ -43,7 +43,7 @@ int kprobe_rtnl_create_link(struct pt_regs *ctx) {
 
 SEC("kprobe/register_netdevice")
 int kprobe_register_netdevice(struct pt_regs *ctx) {
-    u64 id = bpf_get_current_pid_tgid();
+    u64 id = get_ns_current_pid_tgid();
     struct register_netdevice_cache_t entry = {
         .device = (struct net_device *)PT_REGS_PARM1(ctx),
     };
@@ -53,7 +53,7 @@ int kprobe_register_netdevice(struct pt_regs *ctx) {
 
 SEC("kprobe/dev_get_valid_name")
 int kprobe_dev_get_valid_name(struct pt_regs *ctx) {
-    u64 id = bpf_get_current_pid_tgid();
+    u64 id = get_ns_current_pid_tgid();
     struct register_netdevice_cache_t *entry = bpf_map_lookup_elem(&register_netdevice_cache, &id);
     if (entry != NULL) {
         struct net *net = (struct net *)PT_REGS_PARM1(ctx);
@@ -64,7 +64,7 @@ int kprobe_dev_get_valid_name(struct pt_regs *ctx) {
 
 SEC("kprobe/dev_new_index")
 int kprobe_dev_new_index(struct pt_regs *ctx) {
-    u64 id = bpf_get_current_pid_tgid();
+    u64 id = get_ns_current_pid_tgid();
 
     struct register_netdevice_cache_t *entry = bpf_map_lookup_elem(&register_netdevice_cache, &id);
     if (entry != NULL) {
@@ -76,7 +76,7 @@ int kprobe_dev_new_index(struct pt_regs *ctx) {
 
 SEC("kretprobe/dev_new_index")
 int kretprobe_dev_new_index(struct pt_regs *ctx) {
-    u64 id = bpf_get_current_pid_tgid();
+    u64 id = get_ns_current_pid_tgid();
 
     struct register_netdevice_cache_t *entry = bpf_map_lookup_elem(&register_netdevice_cache, &id);
     if (entry != NULL) {
@@ -87,7 +87,7 @@ int kretprobe_dev_new_index(struct pt_regs *ctx) {
 
 SEC("kprobe/__dev_get_by_index")
 int kprobe___dev_get_by_index(struct pt_regs *ctx) {
-    u64 id = bpf_get_current_pid_tgid();
+    u64 id = get_ns_current_pid_tgid();
     struct net *net = (struct net *)PT_REGS_PARM1(ctx);
 
     struct device_ifindex_t entry = {
@@ -106,7 +106,7 @@ int kprobe___dev_get_by_index(struct pt_regs *ctx) {
 
 SEC("kprobe/__dev_get_by_name")
 int kprobe___dev_get_by_name(struct pt_regs *ctx) {
-    u64 id = bpf_get_current_pid_tgid();
+    u64 id = get_ns_current_pid_tgid();
     struct net *net = (struct net *)PT_REGS_PARM1(ctx);
 
     struct device_name_t name = {
@@ -130,7 +130,7 @@ int kprobe___dev_get_by_name(struct pt_regs *ctx) {
 
 SEC("kretprobe/register_netdevice")
 int kretprobe_register_netdevice(struct pt_regs *ctx) {
-    u64 id = bpf_get_current_pid_tgid();
+    u64 id = get_ns_current_pid_tgid();
     int ret = PT_REGS_RC(ctx);
     if (ret != 0) {
         // interface registration failed, remove cache entry
@@ -231,7 +231,7 @@ int kretprobe_register_netdevice(struct pt_regs *ctx) {
 };
 
 __attribute__((always_inline)) int trace_dev_change_net_namespace(struct pt_regs *ctx) {
-    u64 id = bpf_get_current_pid_tgid();
+    u64 id = get_ns_current_pid_tgid();
     struct net *net = (struct net *)PT_REGS_PARM2(ctx);
 
     // lookup cache

--- a/pkg/security/ebpf/c/include/hooks/raw_syscalls.h
+++ b/pkg/security/ebpf/c/include/hooks/raw_syscalls.h
@@ -9,7 +9,7 @@
 SEC("tracepoint/raw_syscalls/sys_enter")
 int sys_enter(struct _tracepoint_raw_syscalls_sys_enter *args) {
     struct syscall_monitor_entry_t zero = {};
-    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = get_ns_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
     u64 now = bpf_ktime_get_ns();
     struct syscall_monitor_event_t event = {};

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -214,6 +214,7 @@ var (
 	logTags          stringSlice
 	logStatusMetrics bool
 	withProfile      bool
+	hostStdOnly      bool
 )
 
 const (
@@ -872,7 +873,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 	}
 
 	var cmdWrapper cmdWrapper
-	if testEnvironment == DockerEnvironment {
+	if testEnvironment == DockerEnvironment || hostStdOnly {
 		cmdWrapper = newStdCmdWrapper()
 	} else {
 		wrapper, err := newDockerCmdWrapper(st.Root(), st.Root(), "ubuntu")
@@ -1756,6 +1757,7 @@ func init() {
 	flag.Var(&logTags, "logtag", "List of log tag")
 	flag.BoolVar(&logStatusMetrics, "status-metrics", false, "display status metrics")
 	flag.BoolVar(&withProfile, "with-profile", false, "enable profile per test")
+	flag.BoolVar(&hostStdOnly, "host-std-only", false, "disable docker test in host env")
 
 	rand.Seed(time.Now().UnixNano())
 

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -1758,6 +1758,10 @@ func TestProcessExit(t *testing.T) {
 }
 
 func TestProcessBusybox(t *testing.T) {
+	if hostStdOnly {
+		t.Skip("docker is disabled in host env")
+	}
+
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_busybox_1",


### PR DESCRIPTION
### What does this PR do?

The main issue currently faced is that the namespaced helper only work in the direct namespace, i.e. not in a child one

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
