### PR TITLE
observe generation time only for successful scans

### DIFF
--- a/releasenotes/notes/fix-agent-histograms-telemetry-90b12dd2f91a1c58.yaml
+++ b/releasenotes/notes/fix-agent-histograms-telemetry-90b12dd2f91a1c58.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    - Updated ``datadog.agent.sbom_generation_duration`` to only be observed for successful scans.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Updated datadog.agent.sbom_generation_duration to only be observed for successful scans, improving accuracy of the metric.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We see more SBOM generation time than number of generated sboms.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
sbom generation time can still have more counts than the number of SBOMs because images can be scanned multiple times
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Deploy the agent on Kind with sbom collection enabled, container image collection enabled and telemetry:
```
  - name: DD_CONTAINER_IMAGE_ENABLED
    value: "true"
  - name: DD_TELEMETRY_ENABLED
    value: "true"
  - name: DD_RUNTIME_SECURITY_CONFIG_SBOM_ENABLED
    value: "true"
  - name: DD_SBOM_ENABLED
    value: "true"
  - name: DD_SBOM_CONTAINER_IMAGE_ENABLED
    value: "true"
  - name: DD_SBOM_CACHE_ENABLED
    value: "true"
```
The agent should collect some sboms but some scans should fail because kind discards unpacked layers:
```
❯ k -n datadog-agent-helm exec datadog-agent-linux-828fj -- agent workload-list -v | grep -i sbom
Defaulted container "agent" out of: agent, trace-agent, process-agent, system-probe, security-agent, init-volume (init), init-config (init), seccomp-setup (init)
SBOM: not stored
SBOM: not stored
SBOM: stored. Generated in: 0.00 seconds
SBOM: not stored
SBOM: stored. Generated in: 0.00 seconds
SBOM: not stored
SBOM: stored. Generated in: 0.00 seconds
SBOM: stored. Generated in: 0.00 seconds
SBOM: not stored
SBOM: stored. Generated in: 0.00 seconds
SBOM: stored. Generated in: 0.00 seconds
SBOM: stored. Generated in: 0.00 seconds
SBOM: not stored
SBOM: not stored
SBOM: not stored
```
Make sure there are less data points with this change:
```
❯ k -n datadog-agent-helm exec datadog-agent-linux-828fj -- curl -Ls localhost:6000/telemetry | grep -i sbom_generation
Defaulted container "agent" out of: agent, trace-agent, process-agent, system-probe, security-agent, init-volume (init), init-config (init), seccomp-setup (init)
# HELP sbom_generation_duration SBOM generation duration (in seconds)
# TYPE sbom_generation_duration histogram
sbom_generation_duration_bucket{scan_type="daemon",source="containerd",le="10"} 16
sbom_generation_duration_bucket{scan_type="daemon",source="containerd",le="30"} 16
sbom_generation_duration_bucket{scan_type="daemon",source="containerd",le="60"} 16
sbom_generation_duration_bucket{scan_type="daemon",source="containerd",le="120"} 16
sbom_generation_duration_bucket{scan_type="daemon",source="containerd",le="180"} 16
sbom_generation_duration_bucket{scan_type="daemon",source="containerd",le="240"} 16
sbom_generation_duration_bucket{scan_type="daemon",source="containerd",le="300"} 16
sbom_generation_duration_bucket{scan_type="daemon",source="containerd",le="360"} 16
sbom_generation_duration_bucket{scan_type="daemon",source="containerd",le="420"} 16
sbom_generation_duration_bucket{scan_type="daemon",source="containerd",le="480"} 16
sbom_generation_duration_bucket{scan_type="daemon",source="containerd",le="540"} 16
sbom_generation_duration_bucket{scan_type="daemon",source="containerd",le="600"} 16
sbom_generation_duration_bucket{scan_type="daemon",source="containerd",le="+Inf"} 16
sbom_generation_duration_sum{scan_type="daemon",source="containerd"} 0.044100831
sbom_generation_duration_count{scan_type="daemon",source="containerd"} 16
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
