### PR TITLE
fix typo in comment

### DIFF
--- a/pkg/trace/traceutil/trace.go
+++ b/pkg/trace/traceutil/trace.go
@@ -79,7 +79,7 @@ func GetRoot(t pb.Trace) *pb.Span {
 		log.Debugf("Didn't reliably find the root span for traceID:%v", t[0].TraceID)
 	}
 
-	// Have a safe bahavior if that's not the case
+	// Have a safe behavior if that's not the case
 	// Pick the first span without its parent
 	for parentID := range parentIDToChild {
 		return parentIDToChild[parentID]


### PR DESCRIPTION
### What does this PR do?
It fixes a typo in a code comment.

### Reviewer's Checklist
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
