### PR TITLE
remove outdated version section in eBPF

### DIFF
--- a/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern.c
@@ -73,5 +73,4 @@ int BPF_KPROBE(kprobe__oom_kill_process, struct oom_control *oc) {
     return 0;
 }
 
-__u32 _version SEC("version") = 0xFFFFFFFE;
 char _license[] SEC("license") = "GPL";

--- a/pkg/collector/corechecks/ebpf/c/runtime/tcp-queue-length-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/tcp-queue-length-kern.c
@@ -113,5 +113,4 @@ int BPF_KRETPROBE(kretprobe__tcp_sendmsg) {
     return 0;
 }
 
-__u32 _version SEC("version") = 0xFFFFFFFE;
 char _license[] SEC("license") = "GPL";

--- a/pkg/network/ebpf/c/co-re/tracer-fentry.c
+++ b/pkg/network/ebpf/c/co-re/tracer-fentry.c
@@ -655,7 +655,4 @@ int BPF_PROG(sockfd_lookup_light_exit, int fd, int *err, int *fput_needed, struc
     return 0;
 }
 
-// This number will be interpreted by elf-loader to set the current running kernel version
-__u32 _version SEC("version") = 0xFFFFFFFE; // NOLINT(bugprone-reserved-identifier)
-
-char _license[] SEC("license") = "GPL"; // NOLINT(bugprone-reserved-identifier)
+char _license[] SEC("license") = "GPL";

--- a/pkg/network/ebpf/c/prebuilt/conntrack.c
+++ b/pkg/network/ebpf/c/prebuilt/conntrack.c
@@ -63,7 +63,4 @@ int kprobe_ctnetlink_fill_info(struct pt_regs* ctx) {
     return 0;
 }
 
-// This number will be interpreted by elf-loader to set the current running kernel version
-__u32 _version SEC("version") = 0xFFFFFFFE; // NOLINT(bugprone-reserved-identifier)
-
-char _license[] SEC("license") = "GPL"; // NOLINT(bugprone-reserved-identifier)
+char _license[] SEC("license") = "GPL";

--- a/pkg/network/ebpf/c/prebuilt/dns.c
+++ b/pkg/network/ebpf/c/prebuilt/dns.c
@@ -24,7 +24,4 @@ int socket__dns_filter(struct __sk_buff* skb) {
     return -1;
 }
 
-// This number will be interpreted by elf-loader to set the current running kernel version
-__u32 _version SEC("version") = 0xFFFFFFFE; // NOLINT(bugprone-reserved-identifier)
-
-char _license[] SEC("license") = "GPL"; // NOLINT(bugprone-reserved-identifier)
+char _license[] SEC("license") = "GPL";

--- a/pkg/network/ebpf/c/prebuilt/offset-guess.c
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.c
@@ -460,7 +460,4 @@ int kprobe___nf_conntrack_hash_insert(struct pt_regs* ctx) {
 }
 
 
-// This number will be interpreted by elf-loader to set the current running kernel version
-__u32 _version SEC("version") = 0xFFFFFFFE; // NOLINT(bugprone-reserved-identifier)
-
-char _license[] SEC("license") = "GPL"; // NOLINT(bugprone-reserved-identifier)
+char _license[] SEC("license") = "GPL";

--- a/pkg/network/ebpf/c/prebuilt/usm.c
+++ b/pkg/network/ebpf/c/prebuilt/usm.c
@@ -516,7 +516,4 @@ int kprobe__do_vfs_ioctl(struct pt_regs *ctx) {
     return 0;
 }
 
-// This number will be interpreted by elf-loader to set the current running kernel version
-__u32 _version SEC("version") = 0xFFFFFFFE; // NOLINT(bugprone-reserved-identifier)
-
-char _license[] SEC("license") = "GPL"; // NOLINT(bugprone-reserved-identifier)
+char _license[] SEC("license") = "GPL";

--- a/pkg/network/ebpf/c/prebuilt/usm_events_test.c
+++ b/pkg/network/ebpf/c/prebuilt/usm_events_test.c
@@ -50,5 +50,4 @@ int tracepoint__syscalls__sys_enter_write(struct syscalls_enter_write_args *ctx)
     return 0;
 }
 
-__u32 _version SEC("version") = 0xFFFFFFFE; // NOLINT(bugprone-reserved-identifier)
-char _license[] SEC("license") = "GPL"; // NOLINT(bugprone-reserved-identifier)
+char _license[] SEC("license") = "GPL";

--- a/pkg/network/ebpf/c/runtime/conntrack.c
+++ b/pkg/network/ebpf/c/runtime/conntrack.c
@@ -75,7 +75,4 @@ int kprobe_ctnetlink_fill_info(struct pt_regs* ctx) {
     return 0;
 }
 
-// This number will be interpreted by elf-loader to set the current running kernel version
-__u32 _version SEC("version") = 0xFFFFFFFE; // NOLINT(bugprone-reserved-identifier)
-
-char _license[] SEC("license") = "GPL"; // NOLINT(bugprone-reserved-identifier)
+char _license[] SEC("license") = "GPL";

--- a/pkg/network/ebpf/c/runtime/offsetguess-test.c
+++ b/pkg/network/ebpf/c/runtime/offsetguess-test.c
@@ -173,7 +173,4 @@ int kprobe__tcp_getsockopt(struct pt_regs* ctx) {
     return 0;
 }
 
-// This number will be interpreted by elf-loader to set the current running kernel version
-__u32 _version SEC("version") = 0xFFFFFFFE; // NOLINT(bugprone-reserved-identifier)
-
-char _license[] SEC("license") = "GPL"; // NOLINT(bugprone-reserved-identifier)
+char _license[] SEC("license") = "GPL";

--- a/pkg/network/ebpf/c/runtime/usm.c
+++ b/pkg/network/ebpf/c/runtime/usm.c
@@ -800,7 +800,4 @@ static __always_inline void* get_tls_base(struct task_struct* task) {
 #endif
 }
 
-// This number will be interpreted by elf-loader to set the current running kernel version
-__u32 _version SEC("version") = 0xFFFFFFFE; // NOLINT(bugprone-reserved-identifier)
-
-char _license[] SEC("license") = "GPL"; // NOLINT(bugprone-reserved-identifier)
+char _license[] SEC("license") = "GPL";

--- a/pkg/network/ebpf/c/tracer.c
+++ b/pkg/network/ebpf/c/tracer.c
@@ -1150,7 +1150,4 @@ int tracepoint__net__net_dev_queue(struct net_dev_queue_ctx* ctx) {
     return 0;
 }
 
-// This number will be interpreted by elf-loader to set the current running kernel version
-__u32 _version SEC("version") = 0xFFFFFFFE; // NOLINT(bugprone-reserved-identifier)
-
-char _license[] SEC("license") = "GPL"; // NOLINT(bugprone-reserved-identifier)
+char _license[] SEC("license") = "GPL";

--- a/pkg/security/ebpf/c/prebuilt/offset-guesser.c
+++ b/pkg/security/ebpf/c/prebuilt/offset-guesser.c
@@ -26,6 +26,4 @@ BPF_ARRAY_MAP(guessed_offsets, u32, 2)
 
 #pragma clang diagnostic pop
 
-__u32 _version SEC("version") = 0xFFFFFFFE;
-
 char LICENSE[] SEC("license") = "GPL";

--- a/pkg/security/ebpf/c/prebuilt/probe.c
+++ b/pkg/security/ebpf/c/prebuilt/probe.c
@@ -41,6 +41,4 @@
 #include "tests/tests.h"
 #endif
 
-__u32 _version SEC("version") = 0xFFFFFFFE;
-
 char LICENSE[] SEC("license") = "GPL";

--- a/pkg/security/tests/syscall_tester/c/ebpf_probe.c
+++ b/pkg/security/tests/syscall_tester/c/ebpf_probe.c
@@ -31,4 +31,3 @@ int kprobe_vfs_open(void *ctx) {
 }
 
 char _license[] SEC("license") = "GPL";
-__u32 _version SEC("version") = 0xFFFFFFFE;


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Removes `version` section from eBPF ELF files. `0` or a missing `version` section is treated the same as the magic value now.

### Motivation

Simpler eBPF code.

### Additional Notes

Also removed CLion-specific comment `// NOLINT(bugprone-reserved-identifier)`

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
