### PR TITLE
Fix NPM manager mutation on fallback

### DIFF
--- a/pkg/network/tracer/connection/fentry/tracer.go
+++ b/pkg/network/tracer/connection/fentry/tracer.go
@@ -33,7 +33,7 @@ func LoadTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *
 		return nil, nil, ErrorNotSupported
 	}
 
-	var m *manager.Manager
+	m := &manager.Manager{}
 	err := ddebpf.LoadCOREAsset(&config.Config, netebpf.ModuleFileName("tracer-fentry", config.BPFDebug), func(ar bytecode.AssetReader, o manager.Options) error {
 		o.RLimit = mgrOpts.RLimit
 		o.MapSpecEditors = mgrOpts.MapSpecEditors

--- a/pkg/network/tracer/connection/fentry/tracer.go
+++ b/pkg/network/tracer/connection/fentry/tracer.go
@@ -13,13 +13,14 @@ import (
 	"os"
 	"syscall"
 
+	manager "github.com/DataDog/ebpf-manager"
+
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	errtelemetry "github.com/DataDog/datadog-agent/pkg/network/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
-	manager "github.com/DataDog/ebpf-manager"
 )
 
 const probeUID = "net"
@@ -27,11 +28,12 @@ const probeUID = "net"
 var ErrorNotSupported = errors.New("fentry tracer is only supported on Fargate")
 
 // LoadTracer loads a new tracer
-func LoadTracer(config *config.Config, m *manager.Manager, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (func(), error) {
+func LoadTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
 	if !fargate.IsFargateInstance() {
-		return nil, ErrorNotSupported
+		return nil, nil, ErrorNotSupported
 	}
 
+	var m *manager.Manager
 	err := ddebpf.LoadCOREAsset(&config.Config, netebpf.ModuleFileName("tracer-fentry", config.BPFDebug), func(ar bytecode.AssetReader, o manager.Options) error {
 		o.RLimit = mgrOpts.RLimit
 		o.MapSpecEditors = mgrOpts.MapSpecEditors
@@ -91,8 +93,8 @@ func LoadTracer(config *config.Config, m *manager.Manager, mgrOpts manager.Optio
 	})
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return nil, nil
+	return m, nil, nil
 }

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -112,7 +112,7 @@ func addBoolConst(options *manager.Options, flag bool, name string) {
 }
 
 // LoadTracer loads the co-re/prebuilt/runtime compiled network tracer, depending on config
-func LoadTracer(cfg *config.Config, m *manager.Manager, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (func(), TracerType, error) {
+func LoadTracer(cfg *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), TracerType, error) {
 	kprobeAttachMethod := manager.AttachKprobeWithPerfEventOpen
 	if cfg.AttachKprobesWithKprobeEventsABI {
 		kprobeAttachMethod = manager.AttachKprobeWithKprobeEvents
@@ -122,18 +122,19 @@ func LoadTracer(cfg *config.Config, m *manager.Manager, mgrOpts manager.Options,
 
 	if cfg.EnableCORE {
 		err := isCORETracerSupported()
-		if err != nil && err != errCORETracerNotSupported {
-			return nil, TracerTypeCORE, fmt.Errorf("error determining if CO-RE tracer is supported: %w", err)
+		if err != nil && !errors.Is(err, errCORETracerNotSupported) {
+			return nil, nil, TracerTypeCORE, fmt.Errorf("error determining if CO-RE tracer is supported: %w", err)
 		}
 
+		var m *manager.Manager
 		var closeFn func()
 		if err == nil {
-			closeFn, err = coreTracerLoader(cfg, m, mgrOpts, perfHandlerTCP)
+			m, closeFn, err = coreTracerLoader(cfg, mgrOpts, perfHandlerTCP)
 			// if it is a verifier error, bail always regardless of
 			// whether a fallback is enabled in config
 			var ve *ebpf.VerifierError
 			if err == nil || errors.As(err, &ve) {
-				return closeFn, TracerTypeCORE, err
+				return m, closeFn, TracerTypeCORE, err
 			}
 			// do not use offset guessing constants with runtime compilation
 			mgrOpts.ConstantEditors = nil
@@ -144,18 +145,18 @@ func LoadTracer(cfg *config.Config, m *manager.Manager, mgrOpts manager.Options,
 		} else if cfg.AllowPrecompiledFallback {
 			log.Warnf("error loading CO-RE network tracer, falling back to pre-compiled: %s", err)
 		} else {
-			return nil, TracerTypeCORE, fmt.Errorf("error loading CO-RE network tracer: %w", err)
+			return nil, nil, TracerTypeCORE, fmt.Errorf("error loading CO-RE network tracer: %w", err)
 		}
 	}
 
 	if cfg.EnableRuntimeCompiler && (!cfg.EnableCORE || cfg.AllowRuntimeCompiledFallback) {
-		closeFn, err := rcTracerLoader(cfg, m, mgrOpts, perfHandlerTCP)
+		m, closeFn, err := rcTracerLoader(cfg, mgrOpts, perfHandlerTCP)
 		if err == nil {
-			return closeFn, TracerTypeRuntimeCompiled, err
+			return m, closeFn, TracerTypeRuntimeCompiled, err
 		}
 
 		if !cfg.AllowPrecompiledFallback {
-			return nil, TracerTypeRuntimeCompiled, fmt.Errorf("error compiling network tracer: %w", err)
+			return nil, nil, TracerTypeRuntimeCompiled, fmt.Errorf("error compiling network tracer: %w", err)
 		}
 
 		log.Warnf("error compiling network tracer, falling back to pre-compiled: %s", err)
@@ -163,18 +164,19 @@ func LoadTracer(cfg *config.Config, m *manager.Manager, mgrOpts manager.Options,
 
 	offsets, err := tracerOffsetGuesserRunner(cfg)
 	if err != nil {
-		return nil, TracerTypePrebuilt, fmt.Errorf("error loading prebuilt tracer: error guessing offsets: %s", err)
+		return nil, nil, TracerTypePrebuilt, fmt.Errorf("error loading prebuilt tracer: error guessing offsets: %s", err)
 	}
 
 	mgrOpts.ConstantEditors = append(mgrOpts.ConstantEditors, offsets...)
 
-	closeFn, err := prebuiltTracerLoader(cfg, m, mgrOpts, perfHandlerTCP)
-	return closeFn, TracerTypePrebuilt, err
+	m, closeFn, err := prebuiltTracerLoader(cfg, mgrOpts, perfHandlerTCP)
+	return m, closeFn, TracerTypePrebuilt, err
 }
 
-func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer bool, config *config.Config, m *manager.Manager, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (func(), error) {
+func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer bool, config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
+	m := &manager.Manager{}
 	if err := initManager(m, config, perfHandlerTCP, runtimeTracer); err != nil {
-		return nil, fmt.Errorf("could not initialize manager: %w", err)
+		return nil, nil, fmt.Errorf("could not initialize manager: %w", err)
 	}
 
 	telemetryMapKeys := errtelemetry.BuildTelemetryKeys(m)
@@ -192,13 +194,13 @@ func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer boo
 			UID:          probeUID,
 		})
 		if socketFilterProbe == nil {
-			return nil, fmt.Errorf("error retrieving protocol classifier socket filter")
+			return nil, nil, fmt.Errorf("error retrieving protocol classifier socket filter")
 		}
 
 		var err error
 		closeProtocolClassifierSocketFilterFn, err = filter.HeadlessSocketFilter(config, socketFilterProbe)
 		if err != nil {
-			return nil, fmt.Errorf("error enabling protocol classifier: %w", err)
+			return nil, nil, fmt.Errorf("error enabling protocol classifier: %w", err)
 		}
 
 		undefinedProbes = append(undefinedProbes, protocolClassificationTailCalls[0].ProbeIdentificationPair)
@@ -217,13 +219,13 @@ func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer boo
 	}
 
 	if err := errtelemetry.ActivateBPFTelemetry(m, undefinedProbes); err != nil {
-		return nil, fmt.Errorf("could not activate ebpf telemetry: %w", err)
+		return nil, nil, fmt.Errorf("could not activate ebpf telemetry: %w", err)
 	}
 
 	// Use the config to determine what kernel probes should be enabled
 	enabledProbes, err := enabledProbes(config, runtimeTracer, coreTracer)
 	if err != nil {
-		return nil, fmt.Errorf("invalid probe configuration: %v", err)
+		return nil, nil, fmt.Errorf("invalid probe configuration: %v", err)
 	}
 
 	// exclude all non-enabled probes to ensure we don't run into problems with unsupported probe types
@@ -258,13 +260,14 @@ func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer boo
 	}
 
 	if err := m.InitWithOptions(buf, mgrOpts); err != nil {
-		return nil, fmt.Errorf("failed to init ebpf manager: %w", err)
+		return nil, nil, fmt.Errorf("failed to init ebpf manager: %w", err)
 	}
 
-	return closeProtocolClassifierSocketFilterFn, nil
+	return m, closeProtocolClassifierSocketFilterFn, nil
 }
 
-func loadCORETracer(config *config.Config, m *manager.Manager, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (func(), error) {
+func loadCORETracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
+	var m *manager.Manager
 	var closeFn func()
 	var err error
 	err = ddebpf.LoadCOREAsset(&config.Config, netebpf.ModuleFileName("tracer", config.BPFDebug), func(ar bytecode.AssetReader, o manager.Options) error {
@@ -272,40 +275,40 @@ func loadCORETracer(config *config.Config, m *manager.Manager, mgrOpts manager.O
 		o.MapSpecEditors = mgrOpts.MapSpecEditors
 		o.ConstantEditors = mgrOpts.ConstantEditors
 		o.DefaultKprobeAttachMethod = mgrOpts.DefaultKprobeAttachMethod
-		closeFn, err = loadTracerFromAsset(ar, false, true, config, m, o, perfHandlerTCP)
+		m, closeFn, err = loadTracerFromAsset(ar, false, true, config, o, perfHandlerTCP)
 		return err
 	})
 
-	return closeFn, err
+	return m, closeFn, err
 }
 
-func loadRuntimeCompiledTracer(config *config.Config, m *manager.Manager, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (func(), error) {
+func loadRuntimeCompiledTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
 	buf, err := getRuntimeCompiledTracer(config)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer buf.Close()
 
-	return loadTracerFromAsset(buf, true, false, config, m, mgrOpts, perfHandlerTCP)
+	return loadTracerFromAsset(buf, true, false, config, mgrOpts, perfHandlerTCP)
 }
 
-func loadPrebuiltTracer(config *config.Config, m *manager.Manager, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (func(), error) {
+func loadPrebuiltTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler) (*manager.Manager, func(), error) {
 	buf, err := netebpf.ReadBPFModule(config.BPFDir, config.BPFDebug)
 	if err != nil {
-		return nil, fmt.Errorf("could not read bpf module: %w", err)
+		return nil, nil, fmt.Errorf("could not read bpf module: %w", err)
 	}
 	defer buf.Close()
 
 	kv, err := kernel.HostVersion()
 	if err != nil {
-		return nil, fmt.Errorf("kernel version: %s", err)
+		return nil, nil, fmt.Errorf("kernel version: %s", err)
 	}
 	// prebuilt on 5.18+ cannot support UDPv6
 	if kv >= kernel.VersionCode(5, 18, 0) {
 		config.CollectUDPv6Conns = false
 	}
 
-	return loadTracerFromAsset(buf, false, false, config, m, mgrOpts, perfHandlerTCP)
+	return loadTracerFromAsset(buf, false, false, config, mgrOpts, perfHandlerTCP)
 }
 
 func isCORETracerSupported() error {

--- a/pkg/network/tracer/connection/tracer.go
+++ b/pkg/network/tracer/connection/tracer.go
@@ -203,7 +203,7 @@ func NewTracer(config *config.Config, bpfTelemetry *nettelemetry.EBPFTelemetry) 
 	var m *manager.Manager
 	var tracerType TracerType = TracerTypeFentry
 	var closeTracerFn func()
-	closeTracerFn, err := fentry.LoadTracer(config, m, mgrOptions, perfHandlerTCP)
+	m, closeTracerFn, err := fentry.LoadTracer(config, mgrOptions, perfHandlerTCP)
 	if err != nil && !errors.Is(err, fentry.ErrorNotSupported) {
 		// failed to load fentry tracer
 		return nil, err
@@ -217,9 +217,9 @@ func NewTracer(config *config.Config, bpfTelemetry *nettelemetry.EBPFTelemetry) 
 		if err != nil {
 			return nil, err
 		}
-		m.DumpHandler = dumpMapsHandler
 		tracerType = TracerType(kprobeTracerType)
 	}
+	m.DumpHandler = dumpMapsHandler
 	ebpfcheck.AddNameMappings(m, "npm_tracer")
 
 	batchMgr, err := newConnBatchManager(m)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Returns a new `*manager.Manager` when loading a tracer, rather than trying to re-use one.

### Motivation

The same `*manager.Manager` instance was being used on fallback, and a duplicate list of `Probe`s were being added. The sanity check in the manager was failing because of this.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
