### PR TITLE
[clusteragent/clusterchecks] Add new rebalance based on the workers utilization

### DIFF
--- a/pkg/clusteragent/clusterchecks/checks_distribution.go
+++ b/pkg/clusteragent/clusterchecks/checks_distribution.go
@@ -1,0 +1,213 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build clusterchecks
+
+package clusterchecks
+
+import (
+	"math"
+	"sort"
+)
+
+type CheckStatus struct {
+	WorkersNeeded float64
+	Runner        string
+}
+
+type RunnerStatus struct {
+	Workers     int
+	WorkersUsed float64
+	NumChecks   int
+}
+
+func (ns RunnerStatus) utilization() float64 {
+	if ns.Workers == 0 {
+		return 0
+	}
+
+	return ns.WorkersUsed / (float64)(ns.Workers)
+}
+
+// checksDistribution represents the placement of cluster checks across the
+// different runners of a cluster
+type checksDistribution struct {
+	Checks  map[string]*CheckStatus
+	Runners map[string]*RunnerStatus
+}
+
+func newChecksDistribution(workersPerRunner map[string]int) checksDistribution {
+	runners := map[string]*RunnerStatus{}
+	for runnerName, runnerWorkers := range workersPerRunner {
+		runners[runnerName] = &RunnerStatus{
+			Workers:     runnerWorkers,
+			WorkersUsed: 0.0,
+			NumChecks:   0,
+		}
+	}
+
+	return checksDistribution{
+		Checks:  map[string]*CheckStatus{},
+		Runners: runners,
+	}
+}
+
+// leastBusyRunner returns the runner with the lowest utilization. If there are
+// several options, it gives preference to preferredRunner. If preferredRunner
+// is not among the runners with the lowest utilization, it gives precedence to
+// the runner with the lowest number of checks deployed.
+func (distribution *checksDistribution) leastBusyRunner(preferredRunner string) string {
+	leastBusyRunner := ""
+	minUtilization := 0.0
+	numChecksLeastBusyRunner := 0
+
+	for runnerName, runnerStatus := range distribution.Runners {
+		runnerUtilization := runnerStatus.utilization()
+		runnerNumChecks := runnerStatus.NumChecks
+
+		selectRunner := leastBusyRunner == "" ||
+			runnerUtilization < minUtilization ||
+			runnerUtilization == minUtilization && runnerName == preferredRunner ||
+			runnerUtilization == minUtilization && runnerNumChecks < numChecksLeastBusyRunner
+
+		if selectRunner {
+			leastBusyRunner = runnerName
+			minUtilization = runnerUtilization
+			numChecksLeastBusyRunner = runnerNumChecks
+		}
+	}
+
+	return leastBusyRunner
+}
+
+func (distribution *checksDistribution) addToLeastBusy(checkID string, workersNeeded float64, preferredRunner string) {
+	leastBusy := distribution.leastBusyRunner(preferredRunner)
+	if leastBusy == "" {
+		return
+	}
+
+	distribution.addCheck(checkID, workersNeeded, leastBusy)
+}
+
+func (distribution *checksDistribution) addCheck(checkID string, workersNeeded float64, runner string) {
+	distribution.Checks[checkID] = &CheckStatus{
+		WorkersNeeded: workersNeeded,
+		Runner:        runner,
+	}
+
+	runnerInfo, runnerExists := distribution.Runners[runner]
+	if runnerExists {
+		runnerInfo.WorkersUsed += workersNeeded
+		runnerInfo.NumChecks += 1
+	} else {
+		distribution.Runners[runner] = &RunnerStatus{
+			WorkersUsed: workersNeeded,
+			NumChecks:   1,
+		}
+	}
+}
+
+func (distribution *checksDistribution) runnerWorkers() map[string]int {
+	res := map[string]int{}
+
+	for runnerName, runnerStatus := range distribution.Runners {
+		res[runnerName] = runnerStatus.Workers
+	}
+
+	return res
+}
+
+func (distribution *checksDistribution) runnerForCheck(checkID string) string {
+	if checkInfo, found := distribution.Checks[checkID]; found {
+		return checkInfo.Runner
+	}
+
+	return ""
+}
+
+func (distribution *checksDistribution) workersNeededForCheck(checkID string) float64 {
+	if checkInfo, found := distribution.Checks[checkID]; found {
+		return checkInfo.WorkersNeeded
+	}
+
+	return 0
+}
+
+// Note: if there are several checks with the same number of workers needed,
+// they are returned in alphabetical order.
+// When distributing the checks, having the same order will help in minimizing
+// the number of re-schedules.
+func (distribution *checksDistribution) checksSortedByWorkersNeeded() []string {
+	var checks []struct {
+		checkID       string
+		workersNeeded float64
+	}
+
+	for checkID, checkStatus := range distribution.Checks {
+		checks = append(checks, struct {
+			checkID       string
+			workersNeeded float64
+		}{
+			checkID:       checkID,
+			workersNeeded: checkStatus.WorkersNeeded,
+		})
+	}
+
+	sort.Slice(checks, func(i, j int) bool {
+		if checks[i].workersNeeded == checks[j].workersNeeded {
+			return checks[i].checkID < checks[j].checkID
+		}
+
+		return checks[i].workersNeeded > checks[j].workersNeeded
+	})
+
+	var res []string
+	for _, check := range checks {
+		res = append(res, check.checkID)
+	}
+	return res
+}
+
+func (distribution *checksDistribution) numEmptyRunners() int {
+	empty := 0
+
+	for _, runnerStatus := range distribution.Runners {
+		if runnerStatus.NumChecks == 0 {
+			empty += 1
+		}
+	}
+
+	return empty
+}
+
+func (distribution *checksDistribution) numRunnersWithHighUtilization() int {
+	withHighUtilization := 0
+
+	for _, runnerStatus := range distribution.Runners {
+		if runnerStatus.utilization() > 0.8 {
+			withHighUtilization += 1
+		}
+	}
+
+	return withHighUtilization
+}
+
+func (distribution *checksDistribution) utilizationStdDev() float64 {
+	totalUtilization := 0.0
+	for _, runnerStatus := range distribution.Runners {
+		totalUtilization += runnerStatus.utilization()
+	}
+
+	avgUtilization := totalUtilization / float64(len(distribution.Runners))
+
+	sumSquaredDeviations := 0.0
+	for _, runnerStatus := range distribution.Runners {
+		sumSquaredDeviations += math.Pow(runnerStatus.utilization()-avgUtilization, 2)
+	}
+
+	variance := sumSquaredDeviations / float64(len(distribution.Runners))
+
+	return math.Sqrt(variance)
+}

--- a/pkg/clusteragent/clusterchecks/checks_distribution_test.go
+++ b/pkg/clusteragent/clusterchecks/checks_distribution_test.go
@@ -1,0 +1,233 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build clusterchecks
+
+package clusterchecks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUtilization(t *testing.T) {
+	tests := []struct {
+		name                string
+		runnerStatus        RunnerStatus
+		expectedUtilization float64
+	}{
+		{
+			name: "standard case",
+			runnerStatus: RunnerStatus{
+				Workers:     4,
+				WorkersUsed: 1,
+				NumChecks:   1,
+			},
+			expectedUtilization: 0.25,
+		},
+		{
+			name: "0 workers used",
+			runnerStatus: RunnerStatus{
+				Workers:     4,
+				WorkersUsed: 0,
+				NumChecks:   0,
+			},
+			expectedUtilization: 0,
+		},
+		{
+			name: "0 workers",
+			runnerStatus: RunnerStatus{
+				Workers:     0,
+				WorkersUsed: 0,
+				NumChecks:   0,
+			},
+			expectedUtilization: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.InDelta(t, test.expectedUtilization, test.runnerStatus.utilization(), 0.05)
+		})
+	}
+}
+
+func TestAddToLeastBusy(t *testing.T) {
+	tests := []struct {
+		name              string
+		existingRunners   map[string]int
+		existingChecks    map[string]CheckStatus
+		preferredRunner   string
+		expectedPlacement string
+	}{
+		{
+			name: "standard case",
+			existingRunners: map[string]int{
+				"runner1": 4,
+				"runner2": 4,
+				"runner3": 4,
+			},
+			existingChecks: map[string]CheckStatus{
+				"check1": {WorkersNeeded: 3, Runner: "runner1"},
+				"check2": {WorkersNeeded: 1, Runner: "runner2"},
+				"check3": {WorkersNeeded: 2, Runner: "runner3"},
+			},
+			preferredRunner:   "",
+			expectedPlacement: "runner2",
+		},
+		{
+			name: "2 least busy runners. Add to preferred",
+			existingRunners: map[string]int{
+				"runner1": 4,
+				"runner2": 4,
+				"runner3": 4,
+			},
+			existingChecks: map[string]CheckStatus{
+				"check1": {WorkersNeeded: 3, Runner: "runner1"},
+				"check2": {WorkersNeeded: 1, Runner: "runner2"},
+				"check3": {WorkersNeeded: 1, Runner: "runner3"},
+			},
+			preferredRunner:   "runner2",
+			expectedPlacement: "runner2",
+		},
+		{
+			name: "2 least busy runners. Add to the one with less checks",
+			existingRunners: map[string]int{
+				"runner1": 4,
+				"runner2": 4,
+				"runner3": 4,
+			},
+			existingChecks: map[string]CheckStatus{
+				"check1": {WorkersNeeded: 3, Runner: "runner1"},
+				"check2": {WorkersNeeded: 2, Runner: "runner2"},
+				"check3": {WorkersNeeded: 1, Runner: "runner3"},
+				"check4": {WorkersNeeded: 1, Runner: "runner3"},
+			},
+			preferredRunner:   "",
+			expectedPlacement: "runner2",
+		},
+		{
+			name: "only one runner",
+			existingRunners: map[string]int{
+				"runner1": 4,
+			},
+			existingChecks: map[string]CheckStatus{
+				"check1": {WorkersNeeded: 3, Runner: "runner1"},
+			},
+			preferredRunner:   "",
+			expectedPlacement: "runner1",
+		},
+		{
+			name:              "no runners",
+			existingRunners:   map[string]int{},
+			existingChecks:    map[string]CheckStatus{},
+			preferredRunner:   "",
+			expectedPlacement: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			distribution := newChecksDistribution(test.existingRunners)
+
+			for checkID, checkStatus := range test.existingChecks {
+				distribution.addCheck(checkID, checkStatus.WorkersNeeded, checkStatus.Runner)
+			}
+
+			distribution.addToLeastBusy("newCheck", 10, test.preferredRunner)
+
+			assert.Equal(t, test.expectedPlacement, distribution.runnerForCheck("newCheck"))
+		})
+	}
+}
+
+func TestAddCheck(t *testing.T) {
+	distribution := newChecksDistribution(map[string]int{
+		"runner1": 4,
+	})
+
+	distribution.addCheck("check1", 3, "runner1")
+	assert.Equal(t, "runner1", distribution.runnerForCheck("check1"))
+	assert.Equal(t, 3.0, distribution.workersNeededForCheck("check1"))
+}
+
+func TestChecksSortedByWorkersNeeded(t *testing.T) {
+	// Standard case
+	distribution := newChecksDistribution(map[string]int{
+		"runner1": 4,
+		"runner2": 4,
+		"runner3": 4,
+	})
+
+	distribution.addCheck("check1", 3, "runner1")
+	distribution.addCheck("check2", 1, "runner1")
+	distribution.addCheck("check3", 4, "runner2")
+	distribution.addCheck("check4", 2, "runner3")
+
+	assert.Equal(t, []string{"check3", "check1", "check4", "check2"}, distribution.checksSortedByWorkersNeeded())
+
+	// Sorted alphabetically when the number of workers is the same
+	distribution = newChecksDistribution(map[string]int{
+		"runner1": 4,
+		"runner2": 4,
+	})
+
+	distribution.addCheck("check_B", 1, "runner1")
+	distribution.addCheck("check_A", 1, "runner2")
+	distribution.addCheck("check_C", 1, "runner1")
+	distribution.addCheck("check_Z", 2, "runner2")
+
+	assert.Equal(t, []string{"check_Z", "check_A", "check_B", "check_C"}, distribution.checksSortedByWorkersNeeded())
+}
+
+func TestNumEmptyRunners(t *testing.T) {
+	distribution := newChecksDistribution(map[string]int{
+		"runner1": 4,
+		"runner2": 2,
+	})
+	assert.Equal(t, 2, distribution.numEmptyRunners())
+
+	distribution.addCheck("check1", 1, "runner1")
+	assert.Equal(t, 1, distribution.numEmptyRunners())
+
+	distribution.addCheck("check2", 1, "runner2")
+	assert.Equal(t, 0, distribution.numEmptyRunners())
+}
+
+func TestNumRunnersWithHighUtilization(t *testing.T) {
+	distribution := newChecksDistribution(map[string]int{
+		"runner1": 4,
+		"runner2": 2,
+	})
+	assert.Equal(t, 0, distribution.numRunnersWithHighUtilization())
+
+	distribution.addCheck("check1", 1, "runner1") // runner 1 at 25%
+	assert.Equal(t, 0, distribution.numRunnersWithHighUtilization())
+
+	distribution.addCheck("check2", 2.5, "runner1") // runner 1 at 3.5/4=0.875, above threshold
+	assert.Equal(t, 1, distribution.numRunnersWithHighUtilization())
+
+	distribution.addCheck("check3", 2, "runner2") // runner 2 at 100%
+	assert.Equal(t, 2, distribution.numRunnersWithHighUtilization())
+}
+
+func TestUtilizationStdDev(t *testing.T) {
+	// Define runner1 with 3 workers needed, runner2 with 5, runner3 with 8, and runner4 with 0
+	distribution := newChecksDistribution(map[string]int{
+		"runner1": 4,
+		"runner2": 4,
+		"runner3": 4,
+	})
+	distribution.addCheck("check1", 1, "runner1")
+	distribution.addCheck("check2", 2, "runner1")
+	distribution.addCheck("check3", 2, "runner2")
+	distribution.addCheck("check4", 4, "runner3")
+
+	// The avg utilization is (0.75 + 0.5 + 1)/3 = 0.75
+	// The variance is ((0.75-0.75)^2 + (0.5-0.75)^2 + (1-0.75)^2)/3 = 0.125/3
+	// The stddev is sqrt(0.125/3) = 0.204
+	assert.InDelta(t, 0.204, distribution.utilizationStdDev(), 0.05)
+}

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
@@ -8,11 +8,18 @@
 package clusterchecks
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"time"
 
+	"gopkg.in/yaml.v2"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
+	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	le "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -164,9 +171,17 @@ func (d *dispatcher) moveCheck(src, dest, checkID string) error {
 	return nil
 }
 
-// rebalance tries to optimize the checks repartition on cluster level check
-// runners with less possible check moves based on the runner stats.
 func (d *dispatcher) rebalance() []types.RebalanceResponse {
+	if config.Datadog.GetBool("cluster_checks.rebalance_with_utilization") {
+		return d.rebalanceUsingUtilization()
+	}
+
+	return d.rebalanceUsingBusyness()
+}
+
+// rebalanceUsingBusyness tries to optimize the checks repartition on cluster
+// level check runners with less possible check moves based on the runner stats.
+func (d *dispatcher) rebalanceUsingBusyness() []types.RebalanceResponse {
 	// Collect CLC runners stats and update cache before rebalancing
 	d.updateRunnersStats()
 
@@ -233,4 +248,194 @@ func (d *dispatcher) rebalance() []types.RebalanceResponse {
 	}
 
 	return checksMoved
+}
+
+// rebalanceUsingUtilization rebalances the cluster checks deployed in a cluster
+// by taking into account the workers utilization of each runner instead of
+// using the busyness function as the rebalanceUsingBusyness function.
+//
+// When all the workers of a runner are busy running checks (utilization = 1),
+// they are not able to accept any new requests to run other checks. If other
+// checks need to be run, the agent will be marked as unhealthy and the runner
+// pod will be restarted shortly after. What we're trying to achieve is to avoid
+// that situation by balancing the checks in a way that all the runners are at
+// similar utilization level and none of them approaches a utilization of 1, if
+// there's enough capacity in other runners.
+//
+// The implementation is a classical greedy algorithm. It sorts in descending
+// order all the cluster checks by the number of workers that we think that they
+// are going to require, and it goes one by one placing them in the runner with
+// the lowest utilization. When there are several candidate runners, first, if
+// the current node is among the candidates, it leaves the check there to avoid
+// unnecessary check schedules and unschedules. If the current runner is not
+// among the candidates, it chooses the runner that contains fewer checks.
+//
+// The algorithm used by rebalanceUsingBusyness has 2 limitations that this one
+// does not have:
+// - It does not try to move checks from runners where the busyness is below
+// average.
+// - It tries to move checks from a runner trying the ones with the highest
+// busyness first. It stops when it cannot move one, even if ones with a lower
+// busyness could be moved.
+//
+// To apply this algorithm we need the number of workers of each runner and the
+// predicted number of workers that each check deployed in the cluster is going
+// to require. The number of workers for each runner is fetched from the CLC
+// API. The predicted number of workers of a check is calculated as follows:
+// avg_execution_time / interval_execution_time. This means that a check that on
+// average takes 3 seconds to run and needs to run every 15 seconds, is going to
+// require 3/15=0.20 workers approximately. A check that takes longer to run
+// than its defined interval, will be running all the time (approx.), so we
+// consider that it requires a whole worker.
+//
+// Limitations and assumptions:
+// - This function does not try to find the optimal solution, but in most cases
+// it should find one that's good enough for our use case.
+// - It assumes that the execution time of a check is more or less stable and
+// can be predicted according to the average execution time of the last few
+// runs.
+// - It assumes that the checks running on the runners that are not cluster
+// checks are not very costly. They're ignored by this function.
+// - It can't predict the execution time of checks that are running for the
+// first time. This could become a problem for checks that take too long.
+func (d *dispatcher) rebalanceUsingUtilization() []types.RebalanceResponse {
+	// Collect CLC runners stats and update cache before rebalancing
+	d.updateRunnersStats()
+
+	start := time.Now()
+	defer func() {
+		rebalancingDuration.Set(time.Since(start).Seconds(), le.JoinLeaderValue)
+	}()
+
+	currentChecksDistribution := d.currentDistribution()
+
+	proposedDistribution := newChecksDistribution(currentChecksDistribution.runnerWorkers())
+	for _, checkID := range currentChecksDistribution.checksSortedByWorkersNeeded() {
+		proposedDistribution.addToLeastBusy(
+			checkID,
+			currentChecksDistribution.workersNeededForCheck(checkID),
+			currentChecksDistribution.runnerForCheck(checkID),
+		)
+	}
+
+	// We don't calculate the optimal distribution, so it might be worse than
+	// the current one or not good enough so that it's worth it to schedule and
+	// unschedule checks. When that's the case, return without moving any
+	// checks.
+	currentUtilizationStdDev := currentChecksDistribution.utilizationStdDev()
+	proposedUtilizationStdDev := proposedDistribution.utilizationStdDev()
+	minPercImprovement := config.Datadog.GetInt("cluster_checks.rebalance_min_percentage_improvement")
+	if !rebalanceIsWorthIt(currentChecksDistribution, proposedDistribution, minPercImprovement) {
+		log.Debugf("Didn't find a distribution better enough so that rescheduling checks is worth it (current utilization stddev: %.3f, found utilization stddev: %.3f)",
+			currentUtilizationStdDev, proposedUtilizationStdDev)
+		setPredictedUtilization(currentChecksDistribution)
+		return nil
+	}
+
+	jsonDistribution, _ := json.Marshal(proposedDistribution)
+	log.Infof("Found a better distribution for the cluster checks. Utilization stdDev of proposed distribution: %.3f. StdDev of current distribution: %.3f. Proposed distribution: %s",
+		proposedUtilizationStdDev, currentUtilizationStdDev, jsonDistribution)
+
+	setPredictedUtilization(proposedDistribution)
+
+	return d.applyDistribution(proposedDistribution, currentChecksDistribution)
+}
+
+func (d *dispatcher) currentDistribution() checksDistribution {
+	currentWorkersPerRunner := map[string]int{}
+
+	d.store.Lock()
+	defer d.store.Unlock()
+
+	for nodeName, nodeInfo := range d.store.nodes {
+		currentWorkersPerRunner[nodeName] = nodeInfo.workers
+	}
+
+	distribution := newChecksDistribution(currentWorkersPerRunner)
+
+	for nodeName, nodeStoreInfo := range d.store.nodes {
+		for checkID, stats := range nodeStoreInfo.clcRunnerStats {
+			digest, found := d.store.idToDigest[checkid.ID(checkID)]
+			if !found { // Not a cluster check
+				continue
+			}
+
+			minCollectionInterval := defaults.DefaultCheckInterval
+
+			conf := d.store.digestToConfig[digest]
+
+			if len(conf.Instances) > 0 {
+				commonOptions := integration.CommonInstanceConfig{}
+				err := yaml.Unmarshal(conf.Instances[0], &commonOptions)
+				if err != nil {
+					// Assume default
+					log.Errorf("error getting min collection interval for check ID %s: %v", checkID, err)
+				} else if commonOptions.MinCollectionInterval != 0 {
+					minCollectionInterval = time.Duration(commonOptions.MinCollectionInterval) * time.Second
+				}
+			}
+
+			workersNeeded := (float64)(stats.AverageExecutionTime) / (float64)(minCollectionInterval.Milliseconds())
+			if workersNeeded > 1 {
+				workersNeeded = 1
+			}
+
+			distribution.addCheck(checkID, workersNeeded, nodeName)
+		}
+	}
+
+	return distribution
+}
+
+func (d *dispatcher) applyDistribution(proposedDistribution checksDistribution, currentDistribution checksDistribution) []types.RebalanceResponse {
+	var checksMoved []types.RebalanceResponse
+
+	for checkID, checkStatus := range proposedDistribution.Checks {
+		currentNode := currentDistribution.runnerForCheck(checkID)
+		proposedNode := checkStatus.Runner
+
+		if proposedNode == currentNode {
+			continue
+		}
+
+		rebalancingDecisions.Inc(le.JoinLeaderValue)
+
+		err := d.moveCheck(currentNode, proposedNode, checkID)
+		if err != nil {
+			log.Warnf("Cannot move check %s: %v", checkID, err)
+			continue
+		}
+
+		successfulRebalancing.Inc(le.JoinLeaderValue)
+
+		checksMoved = append(
+			checksMoved,
+			types.RebalanceResponse{
+				CheckID:        checkID,
+				SourceNodeName: currentNode,
+				DestNodeName:   proposedNode,
+			},
+		)
+	}
+
+	return checksMoved
+}
+
+func setPredictedUtilization(distribution checksDistribution) {
+	for runnerName, runnerStatus := range distribution.Runners {
+		predictedUtilization.Set(runnerStatus.utilization(), runnerName, le.JoinLeaderValue)
+	}
+}
+
+func rebalanceIsWorthIt(currentDistribution checksDistribution, proposedDistribution checksDistribution, minPercImprovement int) bool {
+	// If the current utilization stddev is already good enough, consider that
+	// rescheduling checks is not worth it, unless the new distribution has
+	// fewer runners with a high utilization or leaves fewer runners empty.
+	if currentDistribution.utilizationStdDev() < 0.1 {
+		return proposedDistribution.numRunnersWithHighUtilization() < currentDistribution.numRunnersWithHighUtilization() ||
+			proposedDistribution.numEmptyRunners() < currentDistribution.numEmptyRunners()
+	}
+
+	maxStdDevAccepted := currentDistribution.utilizationStdDev() * ((100 - float64(minPercImprovement)) / 100)
+	return proposedDistribution.utilizationStdDev() < maxStdDevAccepted
 }

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -11,12 +11,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 func TestRebalance(t *testing.T) {
@@ -1507,4 +1508,123 @@ func TestCalculateAvg(t *testing.T) {
 	avg, err := testDispatcher.calculateAvg()
 	require.NoError(t, err)
 	assert.Equal(t, 5, avg)
+}
+
+func TestRebalanceUsingUtilization(t *testing.T) {
+	// To simplify the test:
+	//   - Fill the store manually to avoid having to fetch the information from
+	//   the API exposed by the check runners.
+	//   - Use basic example with only 3 checks and 2 runners because there are
+	//   other tests specific for the checksDistribution struct that test more
+	//   complex scenarios.
+
+	testDispatcher := newDispatcher()
+
+	testDispatcher.store.active = true
+	testDispatcher.store.nodes["node1"] = newNodeStore("node1", "")
+	testDispatcher.store.nodes["node1"].workers = config.DefaultNumWorkers
+	testDispatcher.store.nodes["node2"] = newNodeStore("node2", "")
+	testDispatcher.store.nodes["node2"].workers = config.DefaultNumWorkers
+
+	testDispatcher.store.nodes["node1"].clcRunnerStats = map[string]types.CLCRunnerStats{
+		// This is the check with the highest utilization. The code will try to
+		// place this one first, but it'll give precedence to the node where the
+		// check is already running, so the check won't move.
+		"check1": {
+			AverageExecutionTime: 3000,
+			IsClusterCheck:       true,
+		},
+		// This check should be moved.
+		"check2": {
+			AverageExecutionTime: 2000,
+			IsClusterCheck:       true,
+		},
+		// This check is not a cluster check, so it won't be moved.
+		"check3": {
+			AverageExecutionTime: 1000,
+			IsClusterCheck:       false,
+		},
+	}
+
+	// check3 not included because it's a cluster check.
+	testDispatcher.store.idToDigest = map[checkid.ID]string{
+		"check1": "digest1",
+		"check2": "digest2",
+	}
+	testDispatcher.store.digestToConfig = map[string]integration.Config{
+		"digest1": {},
+		"digest2": {},
+	}
+	testDispatcher.store.digestToNode = map[string]string{
+		"digest1": "node1",
+		"digest2": "node1",
+	}
+
+	checksMoved := testDispatcher.rebalanceUsingUtilization()
+
+	requireNotLocked(t, testDispatcher.store)
+
+	// Check that the internal state has been updated
+	expectedStatsNode1 := types.CLCRunnersStats{
+		"check1": {
+			AverageExecutionTime: 3000,
+			IsClusterCheck:       true,
+		},
+		"check3": {
+			AverageExecutionTime: 1000,
+			IsClusterCheck:       false,
+		},
+	}
+	expectedStatsNode2 := types.CLCRunnersStats{
+		"check2": {
+			AverageExecutionTime: 2000,
+			IsClusterCheck:       true,
+		},
+	}
+	assert.Equal(t, expectedStatsNode1, testDispatcher.store.nodes["node1"].clcRunnerStats)
+	assert.Equal(t, expectedStatsNode2, testDispatcher.store.nodes["node2"].clcRunnerStats)
+
+	// Check response
+	require.Len(t, checksMoved, 1)
+	assert.Equal(t, "check2", checksMoved[0].CheckID)
+	assert.Equal(t, "node1", checksMoved[0].SourceNodeName)
+	assert.Equal(t, "node2", checksMoved[0].DestNodeName)
+
+	// The next rebalance should not move anything because there were not any
+	// changes in the checks stats.
+	checksMoved = testDispatcher.rebalanceUsingUtilization()
+	assert.Empty(t, checksMoved)
+}
+
+func TestRebalanceIsWorthIt(t *testing.T) {
+	workersPerRunner := map[string]int{
+		"runner1": 3,
+		"runner2": 3,
+		"runner3": 3,
+	}
+
+	// The proposed solution is worth it if it leaves less unused runners
+
+	currentDistribution := newChecksDistribution(workersPerRunner)
+	currentDistribution.addCheck("check1", 1, "runner1")
+	currentDistribution.addCheck("check2", 1, "runner1")
+
+	proposedDistribution := newChecksDistribution(workersPerRunner)
+	proposedDistribution.addCheck("check1", 1, "runner1")
+	proposedDistribution.addCheck("check2", 1, "runner2")
+
+	assert.True(t, rebalanceIsWorthIt(currentDistribution, proposedDistribution, 10))
+
+	// The proposed	solution is worth it if it has fewer runners with a high utilization
+	currentDistribution = newChecksDistribution(workersPerRunner)
+	currentDistribution.addCheck("check1", 1, "runner1")
+	currentDistribution.addCheck("check2", 1, "runner1")
+	currentDistribution.addCheck("check3", 1, "runner1")
+
+	proposedDistribution = newChecksDistribution(workersPerRunner)
+	proposedDistribution.addCheck("check1", 1, "runner1")
+	proposedDistribution.addCheck("check2", 1, "runner2")
+	proposedDistribution.addCheck("check3", 1, "runner3")
+
+	assert.True(t, rebalanceIsWorthIt(currentDistribution, proposedDistribution, 10))
 }

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -570,7 +570,36 @@ func (d *dummyClientStruct) GetRunnerStats(IP string) (types.CLCRunnersStats, er
 	return stats[IP], nil
 }
 
+func (d *dummyClientStruct) GetRunnerWorkers(IP string) (types.Workers, error) {
+	workers := map[string]types.Workers{
+		"10.0.0.1": {
+			Count: 1,
+			Instances: map[string]types.WorkerInfo{
+				"worker_1": {
+					Utilization: 0.1,
+				},
+			},
+		},
+		"10.0.0.2": {
+			Count: 2,
+			Instances: map[string]types.WorkerInfo{
+				"worker_1": {
+					Utilization: 0.1,
+				},
+				"worker_2": {
+					Utilization: 0.2,
+				},
+			},
+		},
+	}
+
+	return workers[IP], nil
+}
+
 func TestUpdateRunnersStats(t *testing.T) {
+	mockConfig := config.Mock(t)
+	mockConfig.Set("cluster_checks.rebalance_with_utilization", true)
+
 	dispatcher := newDispatcher()
 	status := types.NodeStatus{LastChange: 10}
 	dispatcher.store.active = true
@@ -598,11 +627,13 @@ func TestUpdateRunnersStats(t *testing.T) {
 	assert.True(t, found)
 	assert.EqualValues(t, "10.0.0.1", node1.clientIP)
 	assert.EqualValues(t, types.CLCRunnersStats{}, node1.clcRunnerStats)
+	assert.Zero(t, node1.workers)
 
 	node2, found := dispatcher.store.getNodeStore("node2")
 	assert.True(t, found)
 	assert.EqualValues(t, "10.0.0.2", node2.clientIP)
 	assert.EqualValues(t, types.CLCRunnersStats{}, node2.clcRunnerStats)
+	assert.Zero(t, node2.workers)
 
 	dispatcher.updateRunnersStats()
 
@@ -610,11 +641,13 @@ func TestUpdateRunnersStats(t *testing.T) {
 	assert.True(t, found)
 	assert.EqualValues(t, "10.0.0.1", node1.clientIP)
 	assert.EqualValues(t, stats1, node1.clcRunnerStats)
+	assert.Equal(t, 1, node1.workers)
 
 	node2, found = dispatcher.store.getNodeStore("node2")
 	assert.True(t, found)
 	assert.EqualValues(t, "10.0.0.2", node2.clientIP)
 	assert.EqualValues(t, stats2, node2.clcRunnerStats)
+	assert.Equal(t, 2, node2.workers)
 
 	// Switch node1 and node2 stats
 	_ = dispatcher.processNodeStatus("node2", "10.0.0.1", status)

--- a/pkg/clusteragent/clusterchecks/metrics.go
+++ b/pkg/clusteragent/clusterchecks/metrics.go
@@ -45,6 +45,8 @@ var (
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 	configsInfo = telemetry.NewGaugeWithOpts("cluster_checks", "configs_info",
 		[]string{"node", "check_id", le.JoinLeaderLabel}, "Information about the dispatched checks (node, check ID)",
-		telemetry.Options{NoDoubleUnderscoreSep: true},
-	)
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	predictedUtilization = telemetry.NewGaugeWithOpts("cluster_checks", "predicted_utilization",
+		[]string{"node", le.JoinLeaderLabel}, "Utilization predicted by the rebalance algorithm",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
 )

--- a/pkg/clusteragent/clusterchecks/stores.go
+++ b/pkg/clusteragent/clusterchecks/stores.go
@@ -88,6 +88,7 @@ type nodeStore struct {
 	clientIP         string
 	clcRunnerStats   types.CLCRunnersStats
 	busyness         int
+	workers          int
 }
 
 func newNodeStore(name, clientIP string) *nodeStore {

--- a/pkg/clusteragent/clusterchecks/types/types.go
+++ b/pkg/clusteragent/clusterchecks/types/types.go
@@ -89,3 +89,12 @@ type CLCRunnerStats struct {
 	IsClusterCheck       bool `json:"IsClusterCheck"`
 	LastExecFailed       bool `json:"LastExecFailed"`
 }
+
+type Workers struct {
+	Count     int                   `json:"Count"`
+	Instances map[string]WorkerInfo `json:"Instances"`
+}
+
+type WorkerInfo struct {
+	Utilization float64 `json:"Utilization"`
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1015,7 +1015,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cluster_checks.cluster_tag_name", "cluster_name")
 	config.BindEnvAndSetDefault("cluster_checks.extra_tags", []string{})
 	config.BindEnvAndSetDefault("cluster_checks.advanced_dispatching_enabled", false)
-	config.BindEnvAndSetDefault("cluster_checks.rebalance_with_utilization", false) // Experimental. Subject to change. Uses the runners utilization to balance.
+	config.BindEnvAndSetDefault("cluster_checks.rebalance_with_utilization", false)        // Experimental. Subject to change. Uses the runners utilization to balance.
+	config.BindEnvAndSetDefault("cluster_checks.rebalance_min_percentage_improvement", 10) // Experimental. Subject to change. Rebalance only if the distribution found improves the current one by this.
 	config.BindEnvAndSetDefault("cluster_checks.clc_runners_port", 5005)
 	config.BindEnvAndSetDefault("cluster_checks.exclude_checks", []string{})
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1015,6 +1015,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cluster_checks.cluster_tag_name", "cluster_name")
 	config.BindEnvAndSetDefault("cluster_checks.extra_tags", []string{})
 	config.BindEnvAndSetDefault("cluster_checks.advanced_dispatching_enabled", false)
+	config.BindEnvAndSetDefault("cluster_checks.rebalance_with_utilization", false) // Experimental. Subject to change. Uses the runners utilization to balance.
 	config.BindEnvAndSetDefault("cluster_checks.clc_runners_port", 5005)
 	config.BindEnvAndSetDefault("cluster_checks.exclude_checks", []string{})
 

--- a/pkg/status/types.go
+++ b/pkg/status/types.go
@@ -7,12 +7,14 @@ package status
 
 import (
 	"encoding/json"
+
 	"github.com/DataDog/datadog-agent/pkg/collector/check/stats"
 )
 
 // CLCChecks is used to unmarshall the runner expvar payload for CLC Runner
 type CLCChecks struct {
-	Checks map[string]map[string]CLCStats `json:"Checks"`
+	Checks  map[string]map[string]CLCStats `json:"Checks"`
+	Workers Workers                        `json:"Workers"`
 }
 
 // CLCStats is used to unmarshall the stats needed from the runner expvar payload
@@ -22,6 +24,17 @@ type CLCStats struct {
 	HistogramBuckets     int  `json:"HistogramBuckets"`
 	Events               int  `json:"Events"`
 	LastExecFailed       bool `json:"LastExecFailed"`
+}
+
+// Workers is used to unmarshall the workers info needed from the runner expvar payload
+type Workers struct {
+	Count     int                   `json:"Count"`
+	Instances map[string]WorkerInfo `json:"Instances"`
+}
+
+// WorkerInfo is used to unmarshall the workers info needed from the runner expvar payload
+type WorkerInfo struct {
+	Utilization float64 `json:"Utilization"`
 }
 
 // UnmarshalJSON overwrites the unmarshall method for CLCStats

--- a/pkg/util/clusteragent/clcrunner_test.go
+++ b/pkg/util/clusteragent/clcrunner_test.go
@@ -46,6 +46,7 @@ func newDummyCLCRunner() (*dummyCLCRunner, error) {
 		rawResponses: map[string]string{
 			"/api/v1/clcrunner/version": `{"Major":0, "Minor":0, "Patch":0, "Pre":"test", "Meta":"test", "Commit":"1337"}`,
 			"/api/v1/clcrunner/stats":   `{"http_check:My Nginx Service:b0041608e66d20ba":{"AverageExecutionTime":241,"MetricSamples":3},"kube_apiserver_metrics:c5d2d20ccb4bb880":{"AverageExecutionTime":858,"MetricSamples":1562},"":{"AverageExecutionTime":100,"MetricSamples":10}}`,
+			"/api/v1/clcrunner/workers": `{"Count":2,"Instances":{"worker_1":{"Utilization":0.1},"worker_2":{"Utilization":0.2}}}`,
 		},
 		token:    config.Datadog.GetString("cluster_agent.auth_token"),
 		requests: make(chan *http.Request, 100),
@@ -182,6 +183,38 @@ func (suite *clcRunnerSuite) TestGetCLCRunnerVersion() {
 
 		require.Nil(t, err, fmt.Sprintf("%v", err))
 		assert.Equal(t, expected, version)
+	})
+}
+
+func (suite *clcRunnerSuite) TestGetRunnerWorkers() {
+	clcRunner, err := newDummyCLCRunner()
+	require.NoError(suite.T(), err)
+
+	ts, p, err := clcRunner.StartTLS()
+	require.NoError(suite.T(), err)
+	defer ts.Close()
+
+	c, err := GetCLCRunnerClient()
+	require.NoError(suite.T(), err)
+
+	c.(*CLCRunnerClient).clcRunnerPort = p
+
+	expected := types.Workers{
+		Count: 2,
+		Instances: map[string]types.WorkerInfo{
+			"worker_1": {
+				Utilization: 0.1,
+			},
+			"worker_2": {
+				Utilization: 0.2,
+			},
+		},
+	}
+
+	suite.T().Run("", func(t *testing.T) {
+		workers, err := c.GetRunnerWorkers("127.0.0.1")
+		require.NoError(suite.T(), err)
+		assert.Equal(t, expected, workers)
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds a new rebalance algorithm for the cluster checks. It takes into account the workers utilization of each runner pod instead of the busyness function that we're currently using.

This is enabled with a config option `cluster_checks.rebalance_with_utilization`. It should still be considered subject to change until we run more tests. It's disabled by default.

When all the workers of a runner are busy running checks (utilization = 1), they are not able to accept any new requests to run other checks. If other checks need to be run, the agent will be marked as unhealthy and the runner pod will be restarted shortly after. What we're trying to achieve is to avoid that situation by balancing the checks in a way that all the runners are at similar utilization level and none of them approaches a utilization of 1, if there's enough capacity in other runners.

I have included more details about how this works and its limitations in the documentation of the `rebalanceUsingUtilization` function.


### Describe how to test/QA your changes

Try on a Kubernetes cluster with the new option enabled `cluster_checks.rebalance_with_utilization`. It also needs `cluster_checks.advanced_dispatching_enabled` set to true.

This needs to be tested in clusters with many cluster checks deployed. The idea would be to check that the utilization among the workers is well balanced (there's a new metric in 7.48: `collector.worker_utilization`). Also, there should be no or at least less pod restarts than before cause by a worker_utilization of 1. We should also check that this doesn't try to move too many checks when the distribution is already good.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
