### PR TITLE
[USM] fix http response timestamp

### DIFF
--- a/pkg/network/ebpf/c/protocols/http/http.h
+++ b/pkg/network/ebpf/c/protocols/http/http.h
@@ -140,7 +140,9 @@ static __always_inline void http_process(http_transaction_t *http_stack, skb_inf
 
     http->tags |= tags;
 
-    if (http_responding(http)) {
+    // Only if we have a (L7/application-layer) payload we update the response_last_seen field
+    // This is to prevent things such as keep-alives adding up to the transaction latency
+    if ((buffer[0] != 0) && http_responding(http)) {
         http->response_last_seen = bpf_ktime_get_ns();
     }
 


### PR DESCRIPTION
### What does this PR do?

When the last http response of a connection is added to the `http_in_flight` map we don't enqueue in the batch yet, but will be on the next request or at when we see a end of connection (`tcp_fin/tcp_rst` packet)

This fixing the behavior when a connection is closed late and in the code path we wrongly overwrite the response_last_seen as the response is filled (http_in_flight) but we received the `fin/rst` packet.

Note: TCP RFC page 26 FIN can contain payload
> For sequence number purposes, the SYN is considered to occur before the first actual data octet of the segment in which it occurs, while the FIN is considered to occur after the last actual data octet in a segment in which it occurs.

Here an example of connection with issue, reproduced with k8s load balancer (based on ngnix), the connection is kept alive to the pod with a timeout of 60s) so a single alone request will hit this issue.

![jeu  17 août 2023 11_44_22 CEST](https://github.com/DataDog/datadog-agent/assets/334425/666192ed-0e7c-40a0-9826-55e0ec09775a)

[Deployed on staging](https://ddstaging.datadoghq.com/notebook/6343552/us3-envoy-latency-pr-18864?range=432000000&start=1692273112862&live=false)



### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

[On usm-test max latency per ressource name base vs new](https://dddev.datadoghq.com/s/2CEYN2/3xv-whi-5z4)

![ven  18 août 2023 22_24_22 CEST](https://github.com/DataDog/datadog-agent/assets/334425/7f2e9f71-834e-4ab2-81de-f3cc3512b35a)


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

On a node/host where system-probe is running
* start a http server `python3 -m http.server 8000`
* run the client below `./client.py localhost:8000`
* check system-probe http latency
`curl -s --unix-socket /var/run/sysprobe/sysprobe.sock http://unix/network_tracer/debug/http_monitoring | jq '.[] | select(.Server.Port==8000)'`

If it's working you should have a low latency `FirstLatencySample`
`FirstLatencySample` is measured in nanosecond
```
{
  "Client": {
    "IP": "127.0.0.1",
    "Port": 53616
  },
  "Server": {
    "IP": "127.0.0.1",
    "Port": 8000
  },
  "DNS": "",
  "Path": "/",
  "Method": "GET",
  "ByStatus": {
    "200": {
      "Count": 1,
      "FirstLatencySample": 856064,
      "LatencyP50": 0
    }
  },
  "StaticTags": 0,
  "DynamicTags": null
}
```



```
#!/usr/bin/env python3
import http.client
import time
import sys

print(sys.argv[1])
c = http.client.HTTPConnection(sys.argv[1])
c.request("GET", "/")
r = c.getresponse()
print("Status: {}".format(r.status))
print("connection closing in 5s")
time.sleep(5)
c.close()
print("connection closed")
```



### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
