### PR TITLE
[CI] Add Debian 12 to the kitchen tested platforms

### DIFF
--- a/.gitlab/kitchen_testing/debian.yml
+++ b/.gitlab/kitchen_testing/debian.yml
@@ -21,7 +21,7 @@
 
 .kitchen_scenario_debian_a6_x64:
   variables:
-    KITCHEN_OSVERS: "debian-9,debian-10,debian-11"
+    KITCHEN_OSVERS: "debian-9,debian-10,debian-11,debian-12"
     KITCHEN_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
     DEFAULT_KITCHEN_OSVERS: "debian-11"
   extends:
@@ -32,7 +32,7 @@
 
 .kitchen_scenario_debian_a7_x64:
   variables:
-    KITCHEN_OSVERS: "debian-9,debian-10,debian-11"
+    KITCHEN_OSVERS: "debian-9,debian-10,debian-11,debian-12"
     KITCHEN_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
     DEFAULT_KITCHEN_OSVERS: "debian-11"
   extends:

--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -113,7 +113,7 @@ platforms:
       # Check if we should use an ed25519 key, an rsa key or the default key
       # Some newer platforms don't support rsa, while some older platforms don't support ed25519
       # In Azure, ed25519 is not supported, but the default key created by the driver works
-      default_key_platforms = ["ubuntu-22-04", "rhel-91"]
+      default_key_platforms = ["ubuntu-22-04", "rhel-91", "debian-12"]
       use_default_key = default_key_platforms.any? { |p| platform_name.include?(p) }
 
       ed25519_platforms = []

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -42,12 +42,12 @@
             "x86_64": {
                 "debian-10": "ami-09c5dc3046df4741f",
                 "debian-11": "ami-09e24b0cfe072ecef",
-                "debian-12": "ami-06db4d78cb1d3bbf9"
+                "debian-12": "ami-0076a5c1d029e906a"
             },
             "arm64": {
                 "debian-10": "ami-0d35a4c5725fd0da7",
                 "debian-11": "ami-03ea090ddd75eb738",
-                "debian-12": "ami-0d3eda47adff3e44b"
+                "debian-12": "ami-02aab8d5301cb8d68"
             }
         }
     },

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -42,12 +42,12 @@
             "x86_64": {
                 "debian-10": "ami-09c5dc3046df4741f",
                 "debian-11": "ami-09e24b0cfe072ecef",
-                "debian-12": "ami-0076a5c1d029e906a"
+                "debian-12": "ami-06db4d78cb1d3bbf9"
             },
             "arm64": {
                 "debian-10": "ami-0d35a4c5725fd0da7",
                 "debian-11": "ami-03ea090ddd75eb738",
-                "debian-12": "ami-02aab8d5301cb8d68"
+                "debian-12": "ami-0d3eda47adff3e44b"
             }
         }
     },

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -35,7 +35,8 @@
                 "debian-9": "urn,credativ:Debian:9:9.20200722.0",
                 "debian-10": "urn,Debian:debian-10:10:0.20230222.1299",
                 "debian-10-daily": "urn,Debian:debian-10-daily:10:0.20230727.1454",
-                "debian-11": "urn,Debian:debian-11:11:0.20230501.1367"
+                "debian-11": "urn,Debian:debian-11:11:0.20230501.1367",
+                "debian-12": "urn,Debian:debian-12:12:0.20230802.1460"
             }
         },
         "ec2": {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR adds Debian 12 to the kitchen tested platforms (AP-2384).

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Have a better test coverage.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
