### PR TITLE
Increase fx Start/Stop timeouts

### DIFF
--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	_ "net/http/pprof"
 	"os"
-	"time"
 
 	"go.uber.org/fx"
 
@@ -112,9 +111,6 @@ func runApp(ctx context.Context, globalParams *command.GlobalParams) error {
 		Config config.Component
 	}
 	app := fx.New(
-		// Increase default fx start/stop timeout to account for delays caused by system load.
-		fx.StartTimeout(5*time.Minute),
-		fx.StopTimeout(5*time.Minute),
 		fx.Supply(
 			core.BundleParams{
 				SysprobeConfigParams: sysprobeconfig.NewParams(

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	_ "net/http/pprof"
 	"os"
+	"time"
 
 	"go.uber.org/fx"
 
@@ -111,6 +112,9 @@ func runApp(ctx context.Context, globalParams *command.GlobalParams) error {
 		Config config.Component
 	}
 	app := fx.New(
+		// Increase default fx start/stop timeout to account for delays caused by system load.
+		fx.StartTimeout(5*time.Minute),
+		fx.StopTimeout(5*time.Minute),
 		fx.Supply(
 			core.BundleParams{
 				SysprobeConfigParams: sysprobeconfig.NewParams(

--- a/pkg/util/fxutil/oneshot.go
+++ b/pkg/util/fxutil/oneshot.go
@@ -7,6 +7,7 @@ package fxutil
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/fx"
 )
@@ -37,6 +38,16 @@ func OneShot(oneShotFunc interface{}, opts ...fx.Option) error {
 	opts = append(opts,
 		delayedCall.option(),
 		FxLoggingOption(),
+	)
+	// Increase default fx start/stop timeout to account for delays caused by system load.
+	// Temporarily apply to all fxutil.OneShot calls until we can better characterize our
+	// start time requirements.
+	opts = append(
+		[]fx.Option{
+			fx.StartTimeout(5 * time.Minute),
+			fx.StopTimeout(5 * time.Minute),
+		},
+		opts...,
 	)
 	app := fx.New(opts...)
 

--- a/pkg/util/fxutil/oneshot.go
+++ b/pkg/util/fxutil/oneshot.go
@@ -7,7 +7,6 @@ package fxutil
 
 import (
 	"context"
-	"time"
 
 	"go.uber.org/fx"
 )
@@ -39,14 +38,10 @@ func OneShot(oneShotFunc interface{}, opts ...fx.Option) error {
 		delayedCall.option(),
 		FxLoggingOption(),
 	)
-	// Increase default fx start/stop timeout to account for delays caused by system load.
-	// Temporarily apply to all fxutil.OneShot calls until we can better characterize our
-	// start time requirements.
+	// Temporarily increase timeout for all fxutil.OneShot calls until we can better characterize our
+	// start time requirements. Prepend to opts so individual calls can override the timeout.
 	opts = append(
-		[]fx.Option{
-			fx.StartTimeout(5 * time.Minute),
-			fx.StopTimeout(5 * time.Minute),
-		},
+		[]fx.Option{TemporaryAppTimeouts()},
 		opts...,
 	)
 	app := fx.New(opts...)

--- a/pkg/util/fxutil/run.go
+++ b/pkg/util/fxutil/run.go
@@ -7,6 +7,7 @@ package fxutil
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/fx"
 )
@@ -17,6 +18,16 @@ import (
 // the process.
 func Run(opts ...fx.Option) error {
 	opts = append(opts, FxLoggingOption())
+	// Increase default fx start/stop timeout to account for delays caused by system load.
+	// Temporarily apply to all fxutil.Run calls until we can better characterize our
+	// start time requirements.
+	opts = append(
+		[]fx.Option{
+			fx.StartTimeout(5 * time.Minute),
+			fx.StopTimeout(5 * time.Minute),
+		},
+		opts...,
+	)
 	app := fx.New(opts...)
 
 	startCtx, cancel := context.WithTimeout(context.Background(), app.StartTimeout())

--- a/pkg/util/fxutil/run.go
+++ b/pkg/util/fxutil/run.go
@@ -7,7 +7,6 @@ package fxutil
 
 import (
 	"context"
-	"time"
 
 	"go.uber.org/fx"
 )
@@ -18,14 +17,10 @@ import (
 // the process.
 func Run(opts ...fx.Option) error {
 	opts = append(opts, FxLoggingOption())
-	// Increase default fx start/stop timeout to account for delays caused by system load.
-	// Temporarily apply to all fxutil.Run calls until we can better characterize our
-	// start time requirements.
+	// Temporarily increase timeout for all fxutil.Run calls until we can better characterize our
+	// start time requirements. Prepend to opts so individual calls can override the timeout.
 	opts = append(
-		[]fx.Option{
-			fx.StartTimeout(5 * time.Minute),
-			fx.StopTimeout(5 * time.Minute),
-		},
+		[]fx.Option{TemporaryAppTimeouts()},
 		opts...,
 	)
 	app := fx.New(opts...)

--- a/pkg/util/fxutil/timeout.go
+++ b/pkg/util/fxutil/timeout.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package fxutil
+
+import (
+	"os"
+	"strconv"
+	"time"
+
+	"go.uber.org/fx"
+)
+
+const (
+	envFxStartTimeoutOverride = "DD_FX_START_TIMEOUT_SECONDS"
+	envFxStopTimeoutOverride  = "DD_FX_STOP_TIMEOUT_SECONDS"
+	defaultFxTimeout          = 5 * time.Minute
+)
+
+// TemporaryAppTimeouts returns new fx Start/Stop timeout options, defaulting to 5 minutes.
+//
+// The start timeout can be overriden with the DD_FX_START_TIMEOUT_SECONDS environment variable.
+// The stop timeout can be overriden with the DD_FX_STOP_TIMEOUT_SECONDS environment variable.
+//
+// Before fx the Agent did not have any start/stop timeouts, it would hang indefinitely. As we have
+// have been adding more fx.Hooks we began hitting flaky tests with expired fx timeouts.
+// We use a large timeout value by default to minimize the chance that customers will be impacted by the timeout.
+// We can revisit this once we can better characterize the agent start/stop behavior and be intentional
+// about timeout values
+func TemporaryAppTimeouts() fx.Option {
+	return fx.Options(
+		fx.StartTimeout(timeoutFromEnv(envFxStartTimeoutOverride)),
+		fx.StopTimeout(timeoutFromEnv(envFxStopTimeoutOverride)),
+	)
+}
+
+// timeoutFromEnv reads the environment variable named @envVariable and returns a go duration for that many seconds.
+// Returns defaultFxTimeout (5 minutes) if the environment variable does not exist or is not an integer.
+func timeoutFromEnv(envVariable string) time.Duration {
+	timeString, found := os.LookupEnv(envVariable)
+	if !found {
+		return defaultFxTimeout
+	}
+	timeValue, err := strconv.Atoi(timeString)
+	if err != nil {
+		return defaultFxTimeout
+	}
+	return time.Duration(timeValue) * time.Second
+}

--- a/pkg/util/fxutil/timeout.go
+++ b/pkg/util/fxutil/timeout.go
@@ -21,8 +21,8 @@ const (
 
 // TemporaryAppTimeouts returns new fx Start/Stop timeout options, defaulting to 5 minutes.
 //
-// The start timeout can be overriden with the DD_FX_START_TIMEOUT_SECONDS environment variable.
-// The stop timeout can be overriden with the DD_FX_STOP_TIMEOUT_SECONDS environment variable.
+// The start timeout can be overridden with the DD_FX_START_TIMEOUT_SECONDS environment variable.
+// The stop timeout can be overridden with the DD_FX_STOP_TIMEOUT_SECONDS environment variable.
 //
 // Before fx the Agent did not have any start/stop timeouts, it would hang indefinitely. As we have
 // have been adding more fx.Hooks we began hitting flaky tests with expired fx timeouts.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Increase the fx Start/Stop hook timeouts from the default of 15 seconds to 5 minutes.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
As we've been adding OnStart hooks we started getting flaky tests in CI because the `OnStart` timeout was exceeded. The agent didn't have start/stop timeouts before fx, so we are temporarily setting the timeouts to 5 minutes to give the agent ample time to start/stop, even if there is significant host load.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
The timeout increase was added to our shared helpers, `fxutil.Run` and `fxutil.OneShot`, so that they apply everywhere. It seems unlikely that most agent subcommands will need the increased timeout, and that timeouts on "agent run" should be enough. But until we can characterize the agent's start/stop behavior we should try to closer align to the pre-fx behavior, which was no timeouts.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- Create a VM with 1 CPU and install the agent.
- Stop the agent
- Create significant host load (Windows Search indexer, Windows Defender full scan, etc)
- Ensure the agent starts and reports

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
