### PR TITLE
stop and cleanup tracer on constructor error

### DIFF
--- a/comp/core/telemetry/component.go
+++ b/comp/core/telemetry/component.go
@@ -12,9 +12,10 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/prometheus/client_golang/prometheus"
 	sdk "go.opentelemetry.io/otel/sdk/metric"
+
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 // team: agent-shared-components
@@ -27,6 +28,8 @@ type Component interface {
 	Reset()
 	// RegisterCollector Registers a Collector with the prometheus registry
 	RegisterCollector(c prometheus.Collector)
+	// UnregisterCollector unregisters a Collector with the prometheus registry
+	UnregisterCollector(c prometheus.Collector) bool
 	// Meter returns a new OTEL meter
 	Meter(name string, opts ...metric.MeterOption) metric.Meter
 

--- a/comp/core/telemetry/telemetry.go
+++ b/comp/core/telemetry/telemetry.go
@@ -77,6 +77,11 @@ func (t *telemetryImpl) RegisterCollector(c prometheus.Collector) {
 	registry.MustRegister(c)
 }
 
+// UnregisterCollector unregisters a Collector with the prometheus registry
+func (t *telemetryImpl) UnregisterCollector(c prometheus.Collector) bool {
+	return registry.Unregister(c)
+}
+
 func (t *telemetryImpl) Meter(name string, opts ...metric.MeterOption) metric.Meter {
 	return t.meterProvider.Meter(name, opts...)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent
 
-go 1.18
+go 1.20
 
 // v0.8.0 was tagged long ago, and appared on pkg.go.dev.  We do not want any tagged version
 // to appear there.  The trick to accomplish this is to make a new version (in this case v0.9.0)

--- a/pkg/network/tracer/process_cache.go
+++ b/pkg/network/tracer/process_cache.go
@@ -125,7 +125,7 @@ func newProcessCache(maxProcs int, filteredEnvs []string) (*processCache, error)
 	return pc, nil
 }
 
-func (pc *processCache) handleProcessEvent(entry *smodel.ProcessContext) {
+func (pc *processCache) HandleProcessEvent(entry *smodel.ProcessContext) {
 
 	select {
 	case <-pc.stopped:

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -117,7 +117,7 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 
 // newTracer is an internal function used by tests primarily
 // (and NewTracer above)
-func newTracer(cfg *config.Config) (rettr *Tracer, reterr error) {
+func newTracer(cfg *config.Config) (_ *Tracer, reterr error) {
 	if _, err := tracefs.Root(); err != nil {
 		return nil, fmt.Errorf("system-probe unsupported: %s", err)
 	}

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -99,8 +99,6 @@ type Tracer struct {
 	processCache *processCache
 
 	timeResolver *TimeResolver
-
-	exitTelemetry chan struct{}
 }
 
 // NewTracer creates a Tracer
@@ -119,7 +117,7 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 
 // newTracer is an internal function used by tests primarily
 // (and NewTracer above)
-func newTracer(cfg *config.Config) (*Tracer, error) {
+func newTracer(cfg *config.Config) (rettr *Tracer, reterr error) {
 	if _, err := tracefs.Root(); err != nil {
 		return nil, fmt.Errorf("system-probe unsupported: %s", err)
 	}
@@ -135,12 +133,6 @@ func newTracer(cfg *config.Config) (*Tracer, error) {
 	pre410Kernel := currKernelVersion < kernel.VersionCode(4, 1, 0)
 	if pre410Kernel {
 		log.Infof("detected kernel version %s, will use kprobes from kernel version < 4.1.0", currKernelVersion)
-	}
-
-	var bpfTelemetry *nettelemetry.EBPFTelemetry
-	if nettelemetry.EBPFTelemetrySupported() {
-		bpfTelemetry = nettelemetry.NewEBPFTelemetry()
-		coretelemetry.GetCompatComponent().RegisterCollector(bpfTelemetry)
 	}
 
 	if cfg.ServiceMonitoringEnabled {
@@ -161,48 +153,42 @@ func newTracer(cfg *config.Config) (*Tracer, error) {
 		}
 	}
 
-	ebpfTracer, err := connection.NewTracer(cfg, bpfTelemetry)
+	tr := &Tracer{
+		config:                     cfg,
+		lastCheck:                  atomic.NewInt64(time.Now().Unix()),
+		sysctlUDPConnTimeout:       sysctl.NewInt(cfg.ProcRoot, "net/netfilter/nf_conntrack_udp_timeout", time.Minute),
+		sysctlUDPConnStreamTimeout: sysctl.NewInt(cfg.ProcRoot, "net/netfilter/nf_conntrack_udp_timeout_stream", time.Minute),
+	}
+	defer func() {
+		if reterr != nil {
+			tr.Stop()
+		}
+	}()
+
+	if nettelemetry.EBPFTelemetrySupported() {
+		tr.bpfTelemetry = nettelemetry.NewEBPFTelemetry()
+		coretelemetry.GetCompatComponent().RegisterCollector(tr.bpfTelemetry)
+	}
+
+	tr.ebpfTracer, err = connection.NewTracer(cfg, tr.bpfTelemetry)
 	if err != nil {
 		return nil, err
 	}
-	coretelemetry.GetCompatComponent().RegisterCollector(ebpfTracer)
+	coretelemetry.GetCompatComponent().RegisterCollector(tr.ebpfTracer)
 
-	conntracker, err := newConntracker(cfg, bpfTelemetry)
+	tr.conntracker, err = newConntracker(cfg, tr.bpfTelemetry)
 	if err != nil {
 		return nil, err
 	}
+	coretelemetry.GetCompatComponent().RegisterCollector(tr.conntracker)
 
-	state := network.NewState(
-		cfg.ClientStateExpiry,
-		cfg.MaxClosedConnectionsBuffered,
-		cfg.MaxConnectionsStateBuffered,
-		cfg.MaxDNSStatsBuffered,
-		cfg.MaxHTTPStatsBuffered,
-		cfg.MaxKafkaStatsBuffered,
-	)
-
-	gwLookup := newGatewayLookup(cfg)
-	if gwLookup != nil {
+	tr.gwLookup = newGatewayLookup(cfg)
+	if tr.gwLookup != nil {
 		log.Info("gateway lookup enabled")
 	}
 
-	tr := &Tracer{
-		config:                     cfg,
-		state:                      state,
-		reverseDNS:                 newReverseDNS(cfg),
-		usmMonitor:                 newUSMMonitor(cfg, ebpfTracer, bpfTelemetry),
-		activeBuffer:               network.NewConnectionBuffer(512, 256),
-		conntracker:                conntracker,
-		sourceExcludes:             network.ParseConnectionFilters(cfg.ExcludedSourceConnections),
-		destExcludes:               network.ParseConnectionFilters(cfg.ExcludedDestinationConnections),
-		sysctlUDPConnTimeout:       sysctl.NewInt(cfg.ProcRoot, "net/netfilter/nf_conntrack_udp_timeout", time.Minute),
-		sysctlUDPConnStreamTimeout: sysctl.NewInt(cfg.ProcRoot, "net/netfilter/nf_conntrack_udp_timeout_stream", time.Minute),
-		gwLookup:                   gwLookup,
-		ebpfTracer:                 ebpfTracer,
-		bpfTelemetry:               bpfTelemetry,
-		lastCheck:                  atomic.NewInt64(time.Now().Unix()),
-		exitTelemetry:              make(chan struct{}),
-	}
+	tr.reverseDNS = newReverseDNS(cfg)
+	tr.usmMonitor = newUSMMonitor(cfg, tr.ebpfTracer, tr.bpfTelemetry)
 
 	if cfg.EnableProcessEventMonitoring {
 		if err = events.Init(); err != nil {
@@ -213,13 +199,24 @@ func newTracer(cfg *config.Config) (*Tracer, error) {
 			return nil, fmt.Errorf("could not create process cache; %w", err)
 		}
 		coretelemetry.GetCompatComponent().RegisterCollector(tr.processCache)
-
-		events.RegisterHandler(tr.processCache.handleProcessEvent)
+		events.RegisterHandler(tr.processCache)
 
 		if tr.timeResolver, err = NewTimeResolver(); err != nil {
 			return nil, fmt.Errorf("could not create time resolver: %w", err)
 		}
 	}
+
+	tr.activeBuffer = network.NewConnectionBuffer(512, 256)
+	tr.sourceExcludes = network.ParseConnectionFilters(cfg.ExcludedSourceConnections)
+	tr.destExcludes = network.ParseConnectionFilters(cfg.ExcludedDestinationConnections)
+	tr.state = network.NewState(
+		cfg.ClientStateExpiry,
+		cfg.MaxClosedConnectionsBuffered,
+		cfg.MaxConnectionsStateBuffered,
+		cfg.MaxDNSStatsBuffered,
+		cfg.MaxHTTPStatsBuffered,
+		cfg.MaxKafkaStatsBuffered,
+	)
 
 	return tr, nil
 }
@@ -249,14 +246,12 @@ func newConntracker(cfg *config.Config, bpfTelemetry *nettelemetry.EBPFTelemetry
 	var c netlink.Conntracker
 	var err error
 	if c, err = NewEBPFConntracker(cfg, bpfTelemetry); err == nil {
-		coretelemetry.GetCompatComponent().RegisterCollector(c)
 		return c, nil
 	}
 
 	if cfg.AllowNetlinkConntrackerFallback {
 		log.Warnf("error initializing ebpf conntracker, falling back to netlink version: %s", err)
 		if c, err = netlink.NewConntracker(cfg); err == nil {
-			coretelemetry.GetCompatComponent().RegisterCollector(c)
 			return c, nil
 		}
 	}
@@ -353,13 +348,28 @@ func (t *Tracer) Stop() {
 	if t.gwLookup != nil {
 		t.gwLookup.Close()
 	}
-	t.reverseDNS.Close()
-	t.ebpfTracer.Stop()
-	t.usmMonitor.Stop()
-	t.conntracker.Close()
-	t.processCache.Stop()
-	close(t.exitTelemetry)
-	coretelemetry.GetCompatComponent().Reset()
+	if t.reverseDNS != nil {
+		t.reverseDNS.Close()
+	}
+	if t.ebpfTracer != nil {
+		t.ebpfTracer.Stop()
+		coretelemetry.GetCompatComponent().UnregisterCollector(t.ebpfTracer)
+	}
+	if t.usmMonitor != nil {
+		t.usmMonitor.Stop()
+	}
+	if t.conntracker != nil {
+		t.conntracker.Close()
+		coretelemetry.GetCompatComponent().UnregisterCollector(t.conntracker)
+	}
+	if t.processCache != nil {
+		events.UnregisterHandler(t.processCache)
+		t.processCache.Stop()
+		coretelemetry.GetCompatComponent().UnregisterCollector(t.processCache)
+	}
+	if t.bpfTelemetry != nil {
+		coretelemetry.GetCompatComponent().UnregisterCollector(t.bpfTelemetry)
+	}
 }
 
 // GetActiveConnections returns the delta for connection info from the last time it was called with the same clientID


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Restructures the tracer constructor to cleanup dependencies in case of any error during the function.

### Motivation

One test failure due to some error during this constructor resulted in panics on later tests, due to duplicate collector registration.

### Additional Notes

The events registration was changed from a function to an interface, because functions are not comparable and thus could not be unregistered.

The `go.mod 1.20` change was required for interfaces to be comparable. Once #18874 is merged, I will remove it.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
