### PR TITLE
[PRMS-2931] Enable system metrics on EKS fargate

### DIFF
--- a/pkg/util/containers/metrics/system/collector_linux.go
+++ b/pkg/util/containers/metrics/system/collector_linux.go
@@ -52,7 +52,7 @@ func newSystemCollector() (*systemCollector, error) {
 	var err error
 	var hostPrefix string
 
-	if !config.IsHostProcAvailable() || !config.IsHostSysAvailable() {
+	if !config.IsHostProcAvailable() || !config.IsHostSysAvailable() || !config.IsFeaturePresent(config.EKSFargate) {
 		log.Debug("Container metrics system collector not available as host paths not mounted")
 		return nil, provider.ErrPermaFail
 	}

--- a/pkg/util/containers/metrics/system/collector_linux.go
+++ b/pkg/util/containers/metrics/system/collector_linux.go
@@ -52,7 +52,7 @@ func newSystemCollector() (*systemCollector, error) {
 	var err error
 	var hostPrefix string
 
-	if !config.IsHostProcAvailable() || !config.IsHostSysAvailable() || !config.IsFeaturePresent(config.EKSFargate) {
+	if !config.IsFeaturePresent(config.EKSFargate) && (!config.IsHostProcAvailable() || !config.IsHostSysAvailable())  {
 		log.Debug("Container metrics system collector not available as host paths not mounted")
 		return nil, provider.ErrPermaFail
 	}

--- a/pkg/util/containers/metrics/system/collector_linux.go
+++ b/pkg/util/containers/metrics/system/collector_linux.go
@@ -52,7 +52,7 @@ func newSystemCollector() (*systemCollector, error) {
 	var err error
 	var hostPrefix string
 
-	if !config.IsFeaturePresent(config.EKSFargate) && (!config.IsHostProcAvailable() || !config.IsHostSysAvailable())  {
+	if !config.IsFeaturePresent(config.EKSFargate) && (!config.IsHostProcAvailable() || !config.IsHostSysAvailable()) {
 		log.Debug("Container metrics system collector not available as host paths not mounted")
 		return nil, provider.ErrPermaFail
 	}

--- a/releasenotes/notes/eks-fargate-bugfix-01c9116939cfbbb7.yaml
+++ b/releasenotes/notes/eks-fargate-bugfix-01c9116939cfbbb7.yaml
@@ -1,3 +1,3 @@
 ---
 fixes:
-  - Fix bug where system metrics collector does not properly start on eks fargate
+  - Fix bug where system metrics collector does not properly start on EKS Fargate

--- a/releasenotes/notes/eks-fargate-bugfix-01c9116939cfbbb7.yaml
+++ b/releasenotes/notes/eks-fargate-bugfix-01c9116939cfbbb7.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Fix bug where system metrics collector does not properly start on eks fargate


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
This PR fixes a bug where the system metrics collector is not properly registered on EKS fargate.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Bug where container id is not properly mapped to pid

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

Deploy the agent in eks fargate using this script. In live processes, you should see container tags appear.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
