### PR TITLE
Fix print-failed-tests by splitting only once

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1545,7 +1545,7 @@ def print_failed_tests(_, output_dir):
 
         for key, res in test_results.items():
             if res == "fail":
-                package, name = key.split(".")
+                package, name = key.split(".", maxsplit=1)
                 print(color_message(f"FAIL: [{test_platform}] {package} {name}", "red"))
                 fail_count += 1
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fix print-failed-tests by splitting only once

### Motivation

The test name can contain `.` too, so ensure we are only splitting between the package and test name.

### Additional Notes

Original error:
```
$ inv system-probe.print-failed-tests --output-dir $DD_AGENT_TESTING_DIR/testjson
Traceback (most recent call last):
  File "/usr/local/bin/inv", line 8, in <module>
    sys.exit(program.run())
  File "/usr/local/lib/python3.9/dist-packages/invoke/program.py", line 398, in run
    self.execute()
  File "/usr/local/lib/python3.9/dist-packages/invoke/program.py", line 583, in execute
    executor.execute(*self.tasks)
  File "/usr/local/lib/python3.9/dist-packages/invoke/executor.py", line 140, in execute
    result = call.task(*args, **call.kwargs)
  File "/usr/local/lib/python3.9/dist-packages/invoke/tasks.py", line 138, in __call__
    result = self.body(*args, **kwargs)
  File "/go/src/github.com/DataDog/datadog-agent/tasks/system_probe.py", line 1534, in print_failed_tests
    package, name = key.split(".")
ValueError: too many values to unpack (expected 2)
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
