### PR TITLE
[SDBM-566] Parse SQL Server query with single dollar identifier $action

### DIFF
--- a/pkg/obfuscate/sql_tokenizer.go
+++ b/pkg/obfuscate/sql_tokenizer.go
@@ -178,6 +178,10 @@ const (
 	DBMSSQLServer = "mssql"
 	// DBMSPostgres is a PostgreSQL Server
 	DBMSPostgres = "postgresql"
+	// DBMSMySQL is a MySQL Server
+	DBMSMySQL = "mysql"
+	// DBMSOracle is an Oracle Server
+	DBMSOracle = "oracle"
 )
 
 const escapeCharacter = '\\'
@@ -475,6 +479,18 @@ func (tkn *SQLTokenizer) Scan() (TokenKind, []byte) {
 				// want to cover for this use-case too (e.g. $1$some text$1$).
 				return tkn.scanPreparedStatement('$')
 			}
+
+			// A special case for a string starts with single $ but does not end with $.
+			// For example in SQLServer, you can have "MG..... OUTPUT $action, inserted.*"
+			// $action in the OUTPUT clause of a MERGE statement is a special identifier
+			// that returns one of three values for each row: 'INSERT', 'UPDATE', or 'DELETE'.
+			// See: https://docs.microsoft.com/en-us/sql/t-sql/statements/merge-transact-sql?view=sql-server-ver15
+			if tkn.cfg.DBMS == DBMSSQLServer && isLetter(tkn.lastChar) {
+				// When the DBMS is SQLServer and the last character is a letter,
+				// we should scan an identifier instead of a string.
+				return tkn.scanIdentifier()
+			}
+
 			kind, tok := tkn.scanDollarQuotedString()
 			if kind == DollarQuotedFunc {
 				// this is considered an embedded query, we should try and

--- a/releasenotes/notes/parse-sqlserver-query-with-dollar-identifier-fea6419a29959053.yaml
+++ b/releasenotes/notes/parse-sqlserver-query-with-dollar-identifier-fea6419a29959053.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Parse SQL Server query with single dollar identifier $action.

--- a/releasenotes/notes/parse-sqlserver-query-with-dollar-identifier-fea6419a29959053.yaml
+++ b/releasenotes/notes/parse-sqlserver-query-with-dollar-identifier-fea6419a29959053.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Parse SQL Server query with single dollar identifier $action.
+    Parse SQL Server query with single dollar identifier ``$action``.

--- a/releasenotes/notes/parse-sqlserver-query-with-dollar-identifier-fea6419a29959053.yaml
+++ b/releasenotes/notes/parse-sqlserver-query-with-dollar-identifier-fea6419a29959053.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Parse SQL Server query with single dollar identifier ``$action``.
+    APM: Parse SQL Server query with single dollar identifier ``$action``.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
The SQL tokenizer previously assumed that any occurrence of the dollar sign `$` was either a prepared statement or the start of a dollar quoted string (`$tag$<string_constant>$tag$`). This assumption caused issues when parsing valid SQL Server queries that contain keywords with a dollar sign, such as `$action`. An unexpected EOF error was raised due to an unmatched `$` sign.

For example, below query will fail in previous implementation.
```SQL
MERGE INTO Employees AS target
USING EmployeeUpdates AS source
ON (target.EmployeeID = source.EmployeeID)
WHEN MATCHED THEN 
    UPDATE SET 
        target.Name = source.Name,
        target.Age = source.Age,
        target.Salary = source.Salary
WHEN NOT MATCHED BY TARGET THEN 
    INSERT (EmployeeID, Name, Age, Salary)
    VALUES (source.EmployeeID, source.Name, source.Age, source.Salary)
WHEN NOT MATCHED BY SOURCE THEN 
    DELETE
OUTPUT $action, inserted.*, deleted.*;
```
For more details about SQL Server `MERGE` and `OUTPUT` clause, refer to https://learn.microsoft.com/en-us/sql/t-sql/statements/merge-transact-sql?view=sql-server-ver15

(A more interesting scenarios is something like `OUTPUT $action, inserted.*, $action, deleted.*;`. The tokenizer will match the open and close `$` sign of `$action, inserted.*, $action` and mark `action, inserted.*, ` between the dollar signs as a tag)

### Proposed Solution
The solution proposed in this PR modifies the tokenizer's handling of `$`. The changes includes:
- For SQL server only: If a `$` is followed by a letter, it is treated as an identifier, addressing cases like `$action`. This could be done because SQL server does not support dollar quoted string. 

### Motivation
https://datadoghq.atlassian.net/browse/SDBM-566
This PR resolves an outstanding bug raised by customer. They're seeing some of their query statements in Datadog without text due to obfuscation error. 

### Additional Notes

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
