### PR TITLE
[NPM] Fix process-agent.build-dev-image job

### DIFF
--- a/tools/ebpf/Dockerfiles/Dockerfile-process-agent-dev
+++ b/tools/ebpf/Dockerfiles/Dockerfile-process-agent-dev
@@ -3,7 +3,7 @@ FROM $AGENT_BASE
 ARG CORE_AGENT_DEST
 
 # include some useful dev tools since this will be used or development
-RUN apt-get update -y && apt-get install -y jq conntrack netcat dnsutils iproute2 net-tools
+RUN apt-get update -y && apt-get install -y jq conntrack netcat-openbsd dnsutils iproute2 net-tools
 
 # the core agent has the library path hardcoded, this allows the agent included below to find libs
 ENV LD_LIBRARY_PATH /opt/datadog-agent/embedded/lib


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fix the following error when running `inv process-agent.build-dev-image`:
```
#6 2.985 Reading state information...
#6 2.988 Package netcat is a virtual package provided by:
#6 2.988   netcat-traditional 1.10-47
#6 2.988   netcat-openbsd 1.219-1ubuntu1
#6 2.988 
#6 2.990 E: Package 'netcat' has no installation candidate
#6 ERROR: process "/bin/sh -c apt-get update -y && apt-get install -y jq conntrack netcat dnsutils iproute2 net-tools" did not complete successfully: exit code: 100
------
 > [ 2/11] RUN apt-get update -y && apt-get install -y jq conntrack netcat dnsutils iproute2 net-tools:
1.695 Get:17 http://us-east-1.ec2.archive.ubuntu.com/ubuntu lunar-security/multiverse amd64 Packages [7179 B]
1.695 Get:18 http://us-east-1.ec2.archive.ubuntu.com/ubuntu lunar-security/restricted amd64 Packages [357 kB]
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
