### PR TITLE
PGA memory leak workaround

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -67,7 +67,8 @@ GROUP BY s.con_id, c.name, force_matching_signature, plan_hash_value
 HAVING MAX (last_active_time) > sysdate - :seconds/24/60/60
 FETCH FIRST :limit ROWS ONLY`
 
-const QUERY_FMS_LAST_ACTIVE = `SELECT /* DD_QM_FMS */ s.con_id con_id, c.name pdb_name, s.force_matching_signature, plan_hash_value, max(dbms_lob.substr(sql_fulltext, 1000, 1)) sql_text, max(length(sql_text)) sql_text_length, sq.sql_id,
+const QUERY_FMS_LAST_ACTIVE = `SELECT /* DD_QM_FMS */ s.con_id con_id, c.name pdb_name, s.force_matching_signature, plan_hash_value, 
+	max(dbms_lob.substr(sql_fulltext, 1000, 1)) sql_text, max(length(sql_text)) sql_text_length, sq.sql_id,
 	sum(parse_calls) as parse_calls,
 	sum(disk_reads) as disk_reads,
 	sum(direct_writes) as direct_writes,
@@ -115,7 +116,8 @@ WHERE s.con_id = c.con_id (+) AND sq.force_matching_signature = s.force_matching
 GROUP BY s.con_id, c.name, s.force_matching_signature, plan_hash_value, sq.sql_id 
 FETCH FIRST :limit ROWS ONLY`
 
-const QUERY_SQLID = `SELECT /* DD_QM_SQLID */ s.con_id con_id, c.name pdb_name, sql_id, plan_hash_value, sql_fulltext sql_text, length (sql_fulltext) sql_text_length, 
+const QUERY_SQLID = `SELECT /* DD_QM_SQLID */ s.con_id con_id, c.name pdb_name, sql_id, plan_hash_value, 
+	dbms_lob.substr(sql_fulltext, 1000, 1) sql_text, length(sql_text) sql_text_length, 
 	parse_calls,
 	disk_reads,
 	direct_writes,
@@ -539,7 +541,7 @@ func (c *Check) StatementMetrics() (int, error) {
 		log.Tracef("number of collected metrics with SQL_ID %+v", len(statementMetrics))
 		statementMetricsAll = append(statementMetricsAll, statementMetrics...)
 		SQLCount = len(statementMetricsAll)
-		sender.Count("dd.oracle.statements_metrics.sql_count", float64(SQLCount), "", c.tags)
+		//sender.Count("dd.oracle.statements_metrics.sql_count", float64(SQLCount), "", c.tags)
 
 		// query metrics cache
 		newCache := make(map[StatementMetricsKeyDB]StatementMetricsMonotonicCountDB)

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -67,6 +67,7 @@ GROUP BY s.con_id, c.name, force_matching_signature, plan_hash_value
 HAVING MAX (last_active_time) > sysdate - :seconds/24/60/60
 FETCH FIRST :limit ROWS ONLY`
 
+// Querying force_matching_signature = 0
 const QUERY_FMS_LAST_ACTIVE = `SELECT /* DD_QM_FMS */ s.con_id con_id, c.name pdb_name, s.force_matching_signature, plan_hash_value, 
 	max(dbms_lob.substr(sql_fulltext, 1000, 1)) sql_text, max(length(sql_text)) sql_text_length, sq.sql_id,
 	sum(parse_calls) as parse_calls,
@@ -116,6 +117,7 @@ WHERE s.con_id = c.con_id (+) AND sq.force_matching_signature = s.force_matching
 GROUP BY s.con_id, c.name, s.force_matching_signature, plan_hash_value, sq.sql_id 
 FETCH FIRST :limit ROWS ONLY`
 
+// Querying force_matching_signature = 0
 const QUERY_SQLID = `SELECT /* DD_QM_SQLID */ s.con_id con_id, c.name pdb_name, sql_id, plan_hash_value, 
 	dbms_lob.substr(sql_fulltext, 1000, 1) sql_text, length(sql_text) sql_text_length, 
 	parse_calls,

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -541,7 +541,6 @@ func (c *Check) StatementMetrics() (int, error) {
 		log.Tracef("number of collected metrics with SQL_ID %+v", len(statementMetrics))
 		statementMetricsAll = append(statementMetricsAll, statementMetrics...)
 		SQLCount = len(statementMetricsAll)
-		//sender.Count("dd.oracle.statements_metrics.sql_count", float64(SQLCount), "", c.tags)
 
 		// query metrics cache
 		newCache := make(map[StatementMetricsKeyDB]StatementMetricsMonotonicCountDB)

--- a/pkg/collector/corechecks/oracle-dbm/statements_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements_test.go
@@ -11,14 +11,24 @@ import (
 	"fmt"
 	"log"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/common"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 )
 
+func TestQueryMetrics(t *testing.T) {
+	initAndStartAgentDemultiplexer(t)
+	chk.dbmEnabled = true
+	chk.statementsLastRun = time.Now().Add(-48 * time.Hour)
+	count, err := chk.StatementMetrics()
+	assert.NoError(t, err, "failed to run query metrics")
+	assert.NotEmpty(t, count, "No statements processed in query metrics")
+}
+
 func TestUInt64Binding(t *testing.T) {
-	initAndStartAgentDemultiplexer()
+	initAndStartAgentDemultiplexer(t)
 
 	chk.dbmEnabled = true
 	chk.config.QueryMetrics.Enabled = true

--- a/releasenotes/notes/oracle-pga-leak-8e8eca3dea738ed0.yaml
+++ b/releasenotes/notes/oracle-pga-leak-8e8eca3dea738ed0.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Workaround for the PGA memory leak.


### PR DESCRIPTION
### What does this PR do?

One of the Oracle Go libraries leaks PGA memory when a LOB column is select with the `db.Select` call. This PR implements the workaround - it converts the LOB column to varchar before returning it to the client. We also added test cases to detect the problem.

### Additional Notes

The root cause will be handled in another ticket.

### Describe how to test/QA your changes

Run repeatedly the following code:

```
begin
  for i in 1..1000
  loop
    execute immediate 'insert into t values (' || i || ')';
  end loop;
end ;
/
```

Check that the total memory consumed by the Agent doesn't exceed 1GB:

```
SELECT 
       sum(p.pga_used_mem)/1024/1024 AS
FROM   v$session s,
       v$process p
WHERE  s.paddr = p.addr AND s.username = 'C##DATADOG'
;
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
