### PR TITLE
Convert Oracle PDB and CDB tags to lowecase

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -261,7 +261,7 @@ func (c *Check) Connect() (*sqlx.DB, error) {
 	db.SetMaxOpenConns(MAX_OPEN_CONNECTIONS)
 
 	if c.cdbName == "" {
-		row := db.QueryRow("SELECT /* DD */ name FROM v$database")
+		row := db.QueryRow("SELECT /* DD */ lower(name) FROM v$database")
 		err = row.Scan(&c.cdbName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to query db name: %w", err)
@@ -461,7 +461,7 @@ func appendPDBTag(tags []string, pdb sql.NullString) []string {
 	if !pdb.Valid {
 		return tags
 	}
-	return append(tags, "pdb:"+pdb.String)
+	return append(tags, "pdb:"+strings.ToLower(pdb.String))
 }
 
 func selectWrapper[T any](c *Check, s T, sql string, binds ...interface{}) error {

--- a/releasenotes/notes/oracle-duplicate-uppercase-tags-d3548c99c3139903.yaml
+++ b/releasenotes/notes/oracle-duplicate-uppercase-tags-d3548c99c3139903.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Eliminate duplicate upper case cdb and pdb tags.

--- a/releasenotes/notes/oracle-duplicate-uppercase-tags-d3548c99c3139903.yaml
+++ b/releasenotes/notes/oracle-duplicate-uppercase-tags-d3548c99c3139903.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Eliminate duplicate upper case cdb and pdb tags.
+    Eliminate duplicate upper case ``cdb`` and ``pdb`` tags.


### PR DESCRIPTION
### What does this PR do?

Converting the PDB and CDB tags to lowercase.

### Motivation

Originally, the tags were sent in uppercase. The CDB and PDB names are stored in uppercase in the database. This caused problems, because outside the agent a new lowercase was created. Duplicate tags were being showed in the metrics dashboard.

### Additional Notes

It should be investigated which component exactly duplicates the tags, and why this happens.

### Describe how to test/QA your changes

Verify in dashboard if the duplication still happens.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
