### PR TITLE
Update config.toml

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -9,7 +9,7 @@ ignored_labels = [
 ]
 
 [teams."Agent Metrics Logs"]
-jira_project = "AML"
+jira_project = "AMLII"
 jira_issue_type = "Task"
 jira_statuses = [
   "To Do",
@@ -67,7 +67,7 @@ github_team = "network-device-monitoring"
 github_labels = ["team/network-device-monitoring"]
 
 [teams."Network Performance Monitoring"]
-jira_project = "NET"
+jira_project = "NPM"
 jira_issue_type = "Task"
 jira_statuses = [
   "Backlog",
@@ -114,7 +114,7 @@ exclude_members = [
 ]
 
 [teams."Platform Integrations"]
-jira_project = "PINT"
+jira_project = "PLINT"
 jira_issue_type = "Task"
 jira_statuses = [
   "To Do",
@@ -242,7 +242,7 @@ github_team = "database-monitoring"
 github_labels = ["team/database-monitoring"]
 
 [teams."Container App"]
-jira_project = "CAP"
+jira_project = "CAP2"
 jira_issue_type = "Task"
 jira_statuses = [
   "💼 To Do",


### PR DESCRIPTION
Due to projects migration to company-based kind, we are changing the projects keys which are used to generate QA cards. This PR updates the already migrated projects.