### PR TITLE
[clusteragent/clusterchecks/dispatcher] Pick random node for new checks when advanced dispatching is enabled

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -147,7 +147,7 @@ func (d *dispatcher) reschedule(configs []integration.Config) {
 
 // add stores and delegates a given configuration
 func (d *dispatcher) add(config integration.Config) {
-	target := d.getLeastBusyNode()
+	target := d.getNodeToScheduleCheck()
 	if target == "" {
 		// If no node is found, store it in the danglingConfigs map for retrying later.
 		log.Warnf("No available node to dispatch %s:%s on, will retry later", config.Name, config.Digest())

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -231,26 +231,26 @@ func TestProcessNodeStatus(t *testing.T) {
 	requireNotLocked(t, dispatcher.store)
 }
 
-func TestGetLeastBusyNode(t *testing.T) {
+func TestGetNodeWithLessChecks(t *testing.T) {
 	dispatcher := newDispatcher()
 
 	// No node registered -> empty string
-	assert.Equal(t, "", dispatcher.getLeastBusyNode())
+	assert.Equal(t, "", dispatcher.getNodeWithLessChecks())
 
 	// 1 config on node1, 2 on node2
 	dispatcher.addConfig(generateIntegration("A"), "node1")
 	dispatcher.addConfig(generateIntegration("B"), "node2")
 	dispatcher.addConfig(generateIntegration("C"), "node2")
-	assert.Equal(t, "node1", dispatcher.getLeastBusyNode())
+	assert.Equal(t, "node1", dispatcher.getNodeWithLessChecks())
 
 	// 3 configs on node1, 2 on node2
 	dispatcher.addConfig(generateIntegration("D"), "node1")
 	dispatcher.addConfig(generateIntegration("E"), "node1")
-	assert.Equal(t, "node2", dispatcher.getLeastBusyNode())
+	assert.Equal(t, "node2", dispatcher.getNodeWithLessChecks())
 
 	// Add an empty node3
 	dispatcher.processNodeStatus("node3", "10.0.0.3", types.NodeStatus{})
-	assert.Equal(t, "node3", dispatcher.getLeastBusyNode())
+	assert.Equal(t, "node3", dispatcher.getNodeWithLessChecks())
 
 	requireNotLocked(t, dispatcher.store)
 }

--- a/releasenotes-dca/notes/schedule-to-random-when-using-advance-dispatching-03915e197be5ad36.yaml
+++ b/releasenotes-dca/notes/schedule-to-random-when-using-advance-dispatching-03915e197be5ad36.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a bug in the advanced dispatching of cluster checks. All the checks
+    scheduled since the last rebalance were being scheduled in the same node.
+    Now they should be distributed among the available nodes.


### PR DESCRIPTION

### What does this PR do?

Improves checks scheduling when advanced dispatching is enabled (`cluster_checks.advanced_dispatching_enabled=true`).

When advanced dispatching is enabled, the cluster-agent schedules a new check in the least busy or least utilized node. But that doesn't seem to be a good idea because  advanced dispatching relies on the check stats fetched from the cluster check runners API to distribute the checks and those stats are only updated when the checks are rebalanced. They are not updated every time a check is scheduled. That's why it's not a good idea to pick the least busy node. Rebalance happens every few minutes, so all the checks added during that time would get scheduled to the same node. It's a better solution to pick a random node and rely on rebalancing to distribute when needed.

### Describe how to test/QA your changes

Deploy with advanced dispatching enabled (`cluster_checks.advanced_dispatching_enabled=true`) and at least 2 runner pods replicas. 

Try to deploy several cluster checks between 2 rebalances and verify that not all of the checks go to the same runner. Run `agent clusterchecks` from the datadog cluster agent to check this.

Note that the first rebalances happens 2 minutes after start, the next one after 5 minutes, and the rest every 10 minutes. You can check the logs to know when the cluster agent is trying to rebalance the checks.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
