### PR TITLE
Add pga_over_allocation_count metric to Oracle check

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -78,6 +78,7 @@ type Check struct {
 	connectedToPdb                          bool
 	fqtEmitted                              *cache.Cache
 	planEmitted                             *cache.Cache
+	previousAllocationCount                 float64
 }
 
 func handleServiceCheck(c *Check, err error) {

--- a/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
+++ b/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
@@ -155,6 +155,17 @@ func (c *Check) SysMetrics() error {
 		}
 	}
 
+	var overAllocationCount float64
+	err = c.db.Get(&overAllocationCount, "SELECT value FROM v$pgastat WHERE name = 'over allocation count'")
+	if err != nil {
+		return fmt.Errorf("failed to get PGA over allocation count: %w", err)
+	}
+	if c.previousAllocationCount != 0 {
+		v := overAllocationCount - c.previousAllocationCount
+		sender.Gauge(fmt.Sprintf("%s.%s", common.IntegrationName, "pga_over_allocation_count"), v, "", c.tags)
+	}
+	c.previousAllocationCount = overAllocationCount
+
 	sender.Commit()
 	return nil
 }

--- a/releasenotes/notes/oracle-over-allocation-count-14f4cdb0716d18d5.yaml
+++ b/releasenotes/notes/oracle-over-allocation-count-14f4cdb0716d18d5.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Add Oracle pga_over_allocation_count_metric.
+    Add Oracle ``pga_over_allocation_count_metric``.

--- a/releasenotes/notes/oracle-over-allocation-count-14f4cdb0716d18d5.yaml
+++ b/releasenotes/notes/oracle-over-allocation-count-14f4cdb0716d18d5.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add Oracle pga_over_allocation_count_metric.


### PR DESCRIPTION
### What does this PR do?

Adding `oracle.pga_over_allocation_count` metric.

### Motivation

The metric measures the number of times that the allocations exceeded `pga_target`. It can be useful for detecting undersized PGA. It was requested by Haven.

### Describe how to test/QA your changes

Generate the load and check if the metric `oracle.pga_over_allocation_count` is being emitted.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
