### PR TITLE
[CWS] make use of device for the mount resolution

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/filesystem.h
+++ b/pkg/security/ebpf/c/include/helpers/filesystem.h
@@ -121,16 +121,18 @@ void __attribute__((always_inline)) fill_resolver_mnt(void *ctx, struct syscall_
     pop_syscall(syscall->type);
 }
 
-void __attribute__((always_inline)) fill_file_metadata(struct dentry* dentry, struct file_metadata_t* file) {
+void __attribute__((always_inline)) fill_file(struct dentry* dentry, struct file_t* file) {
     struct inode *d_inode = get_dentry_inode(dentry);
 
-    bpf_probe_read(&file->nlink, sizeof(file->nlink), (void *)&d_inode->i_nlink);
-    bpf_probe_read(&file->mode, sizeof(file->mode), &d_inode->i_mode);
-    bpf_probe_read(&file->uid, sizeof(file->uid), &d_inode->i_uid);
-    bpf_probe_read(&file->gid, sizeof(file->gid), &d_inode->i_gid);
+    file->dev = get_dentry_dev(dentry);
 
-    bpf_probe_read(&file->ctime, sizeof(file->ctime), &d_inode->i_ctime);
-    bpf_probe_read(&file->mtime, sizeof(file->mtime), &d_inode->i_mtime);
+    bpf_probe_read(&file->metadata.nlink, sizeof(file->metadata.nlink), (void *)&d_inode->i_nlink);
+    bpf_probe_read(&file->metadata.mode, sizeof(file->metadata.mode), &d_inode->i_mode);
+    bpf_probe_read(&file->metadata.uid, sizeof(file->metadata.uid), &d_inode->i_uid);
+    bpf_probe_read(&file->metadata.gid, sizeof(file->metadata.gid), &d_inode->i_gid);
+
+    bpf_probe_read(&file->metadata.ctime, sizeof(file->metadata.ctime), &d_inode->i_ctime);
+    bpf_probe_read(&file->metadata.mtime, sizeof(file->metadata.mtime), &d_inode->i_mtime);
 }
 
 #define get_dentry_key_path(dentry, path) (struct path_key_t) { .ino = get_dentry_ino(dentry), .mount_id = get_path_mount_id(path) }

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -627,7 +627,7 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
         },
         .container = {},
     };
-    fill_file_metadata(syscall->exec.dentry, &pc.entry.executable.metadata);
+    fill_file(syscall->exec.dentry, &pc.entry.executable);
     bpf_get_current_comm(&pc.entry.comm, sizeof(pc.entry.comm));
 
     // select the previous cookie entry in cache of the current process

--- a/pkg/security/ebpf/c/include/hooks/link.h
+++ b/pkg/security/ebpf/c/include/hooks/link.h
@@ -74,7 +74,7 @@ int hook_vfs_link(ctx_t *ctx) {
         return mark_as_discarded(syscall);
     }
 
-    fill_file_metadata(src_dentry, &syscall->link.src_file.metadata);
+    fill_file(src_dentry, &syscall->link.src_file);
     syscall->link.target_file.metadata = syscall->link.src_file.metadata;
 
     // we generate a fake target key as the inode is the same

--- a/pkg/security/ebpf/c/include/hooks/mkdir.h
+++ b/pkg/security/ebpf/c/include/hooks/mkdir.h
@@ -148,7 +148,7 @@ int __attribute__((always_inline)) dr_mkdir_callback(void *ctx) {
         .mode = syscall->mkdir.mode,
     };
 
-    fill_file_metadata(syscall->mkdir.dentry, &event.file.metadata);
+    fill_file(syscall->mkdir.dentry, &event.file);
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);
     fill_span_context(&event.span);

--- a/pkg/security/ebpf/c/include/hooks/mmap.h
+++ b/pkg/security/ebpf/c/include/hooks/mmap.h
@@ -58,7 +58,7 @@ int __attribute__((always_inline)) sys_mmap_ret(void *ctx, int retval, u64 addr)
     };
 
     if (syscall->mmap.dentry != NULL) {
-        fill_file_metadata(syscall->mmap.dentry, &event.file.metadata);
+        fill_file(syscall->mmap.dentry, &event.file);
     }
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);

--- a/pkg/security/ebpf/c/include/hooks/module.h
+++ b/pkg/security/ebpf/c/include/hooks/module.h
@@ -120,7 +120,7 @@ int __attribute__((always_inline)) trace_init_module_ret(void *ctx, int retval, 
     }
 
     if (syscall->init_module.dentry != NULL) {
-        fill_file_metadata(syscall->init_module.dentry, &event.file.metadata);
+        fill_file(syscall->init_module.dentry, &event.file);
     }
 
     struct proc_cache_t *entry = fill_process_context(&event.process);

--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -300,7 +300,7 @@ int __attribute__((always_inline)) dr_open_callback(void *ctx) {
         .mode = syscall->open.mode,
     };
 
-    fill_file_metadata(syscall->open.dentry, &event.file.metadata);
+    fill_file(syscall->open.dentry, &event.file);
     struct proc_cache_t *entry;
     if (syscall->open.pid_tgid != 0) {
         entry = fill_process_context_with_pid_tgid(&event.process, syscall->open.pid_tgid);

--- a/pkg/security/ebpf/c/include/hooks/procfs.h
+++ b/pkg/security/ebpf/c/include/hooks/procfs.h
@@ -45,7 +45,7 @@ int hook_security_inode_getattr(ctx_t *ctx) {
         .flags = flags,
     };
 
-    fill_file_metadata(dentry, &entry.metadata);
+    fill_file(dentry, &entry);
 
     bpf_map_update_elem(&exec_file_cache, &inode, &entry, BPF_NOEXIST);
 

--- a/pkg/security/ebpf/c/include/hooks/rename.h
+++ b/pkg/security/ebpf/c/include/hooks/rename.h
@@ -67,7 +67,7 @@ int hook_vfs_rename(ctx_t *ctx) {
     syscall->rename.src_dentry = src_dentry;
     syscall->rename.target_dentry = target_dentry;
 
-    fill_file_metadata(src_dentry, &syscall->rename.src_file.metadata);
+    fill_file(src_dentry, &syscall->rename.src_file);
     syscall->rename.target_file.metadata = syscall->rename.src_file.metadata;
     if (is_overlayfs(src_dentry)) {
         syscall->rename.target_file.flags |= UPPER_LAYER;

--- a/pkg/security/ebpf/c/include/hooks/rmdir.h
+++ b/pkg/security/ebpf/c/include/hooks/rmdir.h
@@ -52,7 +52,7 @@ int hook_security_inode_rmdir(ctx_t *ctx) {
             // we resolve all the information before the file is actually removed
             dentry = (struct dentry *)CTX_PARM2(ctx);
             set_file_inode(dentry, &syscall->rmdir.file, 1);
-            fill_file_metadata(dentry, &syscall->rmdir.file.metadata);
+            fill_file(dentry, &syscall->rmdir.file);
 
             // the mount id of path_key is resolved by kprobe/mnt_want_write. It is already set by the time we reach this probe.
             key = syscall->rmdir.file.path_key;
@@ -71,7 +71,7 @@ int hook_security_inode_rmdir(ctx_t *ctx) {
             // we resolve all the information before the file is actually removed
             dentry = (struct dentry *) CTX_PARM2(ctx);
             set_file_inode(dentry, &syscall->unlink.file, 1);
-            fill_file_metadata(dentry, &syscall->unlink.file.metadata);
+            fill_file(dentry, &syscall->unlink.file);
 
             // the mount id of path_key is resolved by kprobe/mnt_want_write. It is already set by the time we reach this probe.
             key = syscall->unlink.file.path_key;

--- a/pkg/security/ebpf/c/include/hooks/selinux.h
+++ b/pkg/security/ebpf/c/include/hooks/selinux.h
@@ -50,7 +50,7 @@ int __attribute__((always_inline)) handle_selinux_event(void *ctx, struct file *
     }
     // otherwise let's keep the value = error state.
 
-    fill_file_metadata(syscall.selinux.dentry, &syscall.selinux.file.metadata);
+    fill_file(syscall.selinux.dentry, &syscall.selinux.file);
     set_file_inode(syscall.selinux.dentry, &syscall.selinux.file, 0);
 
     syscall.resolver.key = syscall.selinux.file.path_key;

--- a/pkg/security/ebpf/c/include/hooks/setattr.h
+++ b/pkg/security/ebpf/c/include/hooks/setattr.h
@@ -28,7 +28,7 @@ int hook_security_inode_setattr(ctx_t *ctx) {
         iattr = (struct iattr *)param2;
     }
 
-    fill_file_metadata(dentry, &syscall->setattr.file.metadata);
+    fill_file(dentry, &syscall->setattr.file);
 
     if (iattr != NULL) {
         int valid;

--- a/pkg/security/ebpf/c/include/hooks/setxattr.h
+++ b/pkg/security/ebpf/c/include/hooks/setxattr.h
@@ -150,7 +150,7 @@ int __attribute__((always_inline)) sys_xattr_ret(void *ctx, int retval, u64 even
 
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);
-    fill_file_metadata(syscall->xattr.dentry, &event.file.metadata);
+    fill_file(syscall->xattr.dentry, &event.file);
     fill_span_context(&event.span);
 
     send_event(ctx, event_type, event);

--- a/pkg/security/ebpf/c/include/hooks/splice.h
+++ b/pkg/security/ebpf/c/include/hooks/splice.h
@@ -100,7 +100,7 @@ int __attribute__((always_inline)) sys_splice_ret(void *ctx, int retval) {
         .pipe_entry_flag = syscall->splice.pipe_entry_flag,
         .pipe_exit_flag = syscall->splice.pipe_exit_flag,
     };
-    fill_file_metadata(syscall->splice.dentry, &event.file.metadata);
+    fill_file(syscall->splice.dentry, &event.file);
 
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);

--- a/pkg/security/ebpf/c/include/hooks/unlink.h
+++ b/pkg/security/ebpf/c/include/hooks/unlink.h
@@ -62,7 +62,7 @@ int hook_vfs_unlink(ctx_t *ctx) {
     // we resolve all the information before the file is actually removed
     syscall->unlink.dentry = dentry;
     set_file_inode(dentry, &syscall->unlink.file, 1);
-    fill_file_metadata(dentry, &syscall->unlink.file.metadata);
+    fill_file(dentry, &syscall->unlink.file);
 
     if (filter_syscall(syscall, unlink_approvers)) {
         return mark_as_discarded(syscall);

--- a/pkg/security/ebpf/c/include/structs/events_context.h
+++ b/pkg/security/ebpf/c/include/structs/events_context.h
@@ -50,8 +50,8 @@ struct file_metadata_t {
 
 struct file_t {
     struct path_key_t path_key;
+    u32 dev;
     u32 flags;
-    u32 padding;
     struct file_metadata_t metadata;
 };
 

--- a/pkg/security/probe/field_handlers_linux.go
+++ b/pkg/security/probe/field_handlers_linux.go
@@ -48,7 +48,7 @@ func (fh *FieldHandlers) ResolveFileFilesystem(ev *model.Event, f *model.FileEve
 		if f.IsFileless() {
 			f.Filesystem = model.TmpFS
 		} else {
-			fs, err := fh.resolvers.MountResolver.ResolveFilesystem(f.FileFields.MountID, ev.PIDContext.Pid, ev.ContainerContext.ID)
+			fs, err := fh.resolvers.MountResolver.ResolveFilesystem(f.FileFields.MountID, f.FileFields.Device, ev.PIDContext.Pid, ev.ContainerContext.ID)
 			if err != nil {
 				ev.SetPathResolutionError(f, err)
 			}
@@ -85,7 +85,7 @@ func (fh *FieldHandlers) ResolveXAttrNamespace(ev *model.Event, e *model.SetXAtt
 // ResolveMountPointPath resolves a mount point path
 func (fh *FieldHandlers) ResolveMountPointPath(ev *model.Event, e *model.MountEvent) string {
 	if len(e.MountPointPath) == 0 {
-		mountPointPath, err := fh.resolvers.MountResolver.ResolveMountPath(e.MountID, ev.PIDContext.Pid, ev.ContainerContext.ID)
+		mountPointPath, err := fh.resolvers.MountResolver.ResolveMountPath(e.MountID, e.Device, ev.PIDContext.Pid, ev.ContainerContext.ID)
 		if err != nil {
 			e.MountPointPathResolutionError = err
 			return ""
@@ -98,7 +98,7 @@ func (fh *FieldHandlers) ResolveMountPointPath(ev *model.Event, e *model.MountEv
 // ResolveMountSourcePath resolves a mount source path
 func (fh *FieldHandlers) ResolveMountSourcePath(ev *model.Event, e *model.MountEvent) string {
 	if e.BindSrcMountID != 0 && len(e.MountSourcePath) == 0 {
-		bindSourceMountPath, err := fh.resolvers.MountResolver.ResolveMountPath(e.BindSrcMountID, ev.PIDContext.Pid, ev.ContainerContext.ID)
+		bindSourceMountPath, err := fh.resolvers.MountResolver.ResolveMountPath(e.BindSrcMountID, e.Device, ev.PIDContext.Pid, ev.ContainerContext.ID)
 		if err != nil {
 			e.MountSourcePathResolutionError = err
 			return ""

--- a/pkg/security/probe/field_handlers_linux.go
+++ b/pkg/security/probe/field_handlers_linux.go
@@ -85,7 +85,7 @@ func (fh *FieldHandlers) ResolveXAttrNamespace(ev *model.Event, e *model.SetXAtt
 // ResolveMountPointPath resolves a mount point path
 func (fh *FieldHandlers) ResolveMountPointPath(ev *model.Event, e *model.MountEvent) string {
 	if len(e.MountPointPath) == 0 {
-		mountPointPath, err := fh.resolvers.MountResolver.ResolveMountPath(e.MountID, e.Device, ev.PIDContext.Pid, ev.ContainerContext.ID)
+		mountPointPath, err := fh.resolvers.MountResolver.ResolveMountPath(e.MountID, 0, ev.PIDContext.Pid, ev.ContainerContext.ID)
 		if err != nil {
 			e.MountPointPathResolutionError = err
 			return ""
@@ -98,7 +98,7 @@ func (fh *FieldHandlers) ResolveMountPointPath(ev *model.Event, e *model.MountEv
 // ResolveMountSourcePath resolves a mount source path
 func (fh *FieldHandlers) ResolveMountSourcePath(ev *model.Event, e *model.MountEvent) string {
 	if e.BindSrcMountID != 0 && len(e.MountSourcePath) == 0 {
-		bindSourceMountPath, err := fh.resolvers.MountResolver.ResolveMountPath(e.BindSrcMountID, e.Device, ev.PIDContext.Pid, ev.ContainerContext.ID)
+		bindSourceMountPath, err := fh.resolvers.MountResolver.ResolveMountPath(e.BindSrcMountID, 0, ev.PIDContext.Pid, ev.ContainerContext.ID)
 		if err != nil {
 			e.MountSourcePathResolutionError = err
 			return ""

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -581,7 +581,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		// TODO: this should be moved in the resolver itself in order to handle the fallbacks
 		if event.Mount.GetFSType() == "nsfs" {
 			nsid := uint32(event.Mount.RootPathKey.Inode)
-			mountPath, err := p.resolvers.MountResolver.ResolveMountPath(event.Mount.MountID, event.PIDContext.Pid, event.ContainerContext.ID)
+			mountPath, err := p.resolvers.MountResolver.ResolveMountPath(event.Mount.MountID, event.Mount.Device, event.PIDContext.Pid, event.ContainerContext.ID)
 			if err != nil {
 				seclog.Debugf("failed to get mount path: %v", err)
 			} else {
@@ -597,7 +597,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		}
 
 		// we can skip this error as this is for the umount only and there is no impact on the filepath resolution
-		mount, _ := p.resolvers.MountResolver.ResolveMount(event.Umount.MountID, event.PIDContext.Pid, event.ContainerContext.ID)
+		mount, _ := p.resolvers.MountResolver.ResolveMount(event.Umount.MountID, 0, event.PIDContext.Pid, event.ContainerContext.ID)
 		if mount != nil && mount.GetFSType() == "nsfs" {
 			nsid := uint32(mount.RootPathKey.Inode)
 			if namespace := p.resolvers.NamespaceResolver.ResolveNetworkNamespace(nsid); namespace != nil {
@@ -711,6 +711,9 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		// The pid_cache kernel map has the exit_time but it's only accessed if there's a local miss
 		event.ProcessCacheEntry.Process.ExitTime = p.fieldHandlers.ResolveEventTime(event)
 		event.Exit.Process = &event.ProcessCacheEntry.Process
+
+		// update mount pid mapping
+		p.resolvers.MountResolver.DelPid(event.Exit.Pid)
 	case model.SetuidEventType:
 		if _, err = event.SetUID.UnmarshalBinary(data[offset:]); err != nil {
 			seclog.Errorf("failed to decode setuid event: %s (offset %d, len %d)", err, offset, len(data))
@@ -1300,7 +1303,7 @@ func (p *Probe) handleNewMount(ev *model.Event, m *model.Mount) error {
 	}
 
 	// Insert new mount point in cache, passing it a copy of the mount that we got from the event
-	if err := p.resolvers.MountResolver.Insert(*m); err != nil {
+	if err := p.resolvers.MountResolver.Insert(*m, 0); err != nil {
 		seclog.Errorf("failed to insert mount event: %v", err)
 		return err
 	}

--- a/pkg/security/resolvers/mount/resolver_test.go
+++ b/pkg/security/resolvers/mount/resolver_test.go
@@ -11,6 +11,7 @@ package mount
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -450,7 +451,10 @@ func TestMountResolver(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					mr.finalize(mount)
+					mr.delete(mount)
+
+					// wait end of remption
+					time.Sleep(redemptionTime)
 				}
 			}
 

--- a/pkg/security/resolvers/mount/resolver_test.go
+++ b/pkg/security/resolvers/mount/resolver_test.go
@@ -22,6 +22,7 @@ func TestMountResolver(t *testing.T) {
 	// Prepare test cases
 	type testCase struct {
 		mountID           uint32
+		device            uint32
 		expectedMountPath string
 		expectedError     error
 	}
@@ -44,7 +45,6 @@ func TestMountResolver(t *testing.T) {
 				[]event{
 					{
 						mount: &model.MountEvent{
-							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID: 27,
 								Device:  1,
@@ -61,35 +61,7 @@ func TestMountResolver(t *testing.T) {
 				[]testCase{
 					{
 						27,
-						"/",
-						nil,
-					},
-				},
-			},
-		},
-		{
-			"insert_root",
-			args{
-				[]event{
-					{
-						mount: &model.MountEvent{
-							SyscallEvent: model.SyscallEvent{},
-							Mount: model.Mount{
-								MountID: 27,
-								Device:  1,
-								ParentPathKey: model.PathKey{
-									MountID: 1,
-								},
-								FSType:        "ext4",
-								MountPointStr: "/",
-								RootStr:       "",
-							},
-						},
-					},
-				},
-				[]testCase{
-					{
-						27,
+						1,
 						"/",
 						nil,
 					},
@@ -102,7 +74,6 @@ func TestMountResolver(t *testing.T) {
 				[]event{
 					{
 						mount: &model.MountEvent{
-							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID: 127,
 								Device:  52,
@@ -119,18 +90,49 @@ func TestMountResolver(t *testing.T) {
 				[]testCase{
 					{
 						127,
+						0,
 						"/var/lib/docker/overlay2/f44b5a1fe134f57a31da79fa2e76ea09f8659a34edfa0fa2c3b4f52adbd91963/merged",
 						nil,
 					},
 					{
+						0,
 						0,
 						"",
 						ErrMountUndefined,
 					},
 					{
 						22,
+						0,
 						"",
 						&ErrMountNotFound{MountID: 22},
+					},
+				},
+			},
+		},
+		{
+			"insert_device",
+			args{
+				[]event{
+					{
+						mount: &model.MountEvent{
+							Mount: model.Mount{
+								MountID: 458,
+								Device:  44,
+								ParentPathKey: model.PathKey{
+									MountID: 27,
+								},
+								MountPointStr: "/usr",
+								RootStr:       "",
+							},
+						},
+					},
+				},
+				[]testCase{
+					{
+						459,
+						44,
+						"/usr",
+						nil,
 					},
 				},
 			},
@@ -141,14 +143,14 @@ func TestMountResolver(t *testing.T) {
 				[]event{
 					{
 						umount: &model.UmountEvent{
-							SyscallEvent: model.SyscallEvent{},
-							MountID:      127,
+							MountID: 127,
 						},
 					},
 				},
 				[]testCase{
 					{
 						127,
+						0,
 						"",
 						&ErrMountNotFound{MountID: 127},
 					},
@@ -161,7 +163,6 @@ func TestMountResolver(t *testing.T) {
 				[]event{
 					{
 						mount: &model.MountEvent{
-							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID: 27,
 								Device:  1,
@@ -176,7 +177,6 @@ func TestMountResolver(t *testing.T) {
 					},
 					{
 						mount: &model.MountEvent{
-							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID: 22,
 								Device:  21,
@@ -191,7 +191,6 @@ func TestMountResolver(t *testing.T) {
 					},
 					{
 						mount: &model.MountEvent{
-							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID: 31,
 								Device:  26,
@@ -208,16 +207,19 @@ func TestMountResolver(t *testing.T) {
 				[]testCase{
 					{
 						27,
+						0,
 						"/",
 						nil,
 					},
 					{
 						22,
+						0,
 						"/sys",
 						nil,
 					},
 					{
 						31,
+						0,
 						"/sys/fs/cgroup",
 						nil,
 					},
@@ -230,24 +232,26 @@ func TestMountResolver(t *testing.T) {
 				[]event{
 					{
 						umount: &model.UmountEvent{
-							SyscallEvent: model.SyscallEvent{},
-							MountID:      27,
+							MountID: 27,
 						},
 					},
 				},
 				[]testCase{
 					{
 						27,
+						0,
 						"",
 						&ErrMountNotFound{MountID: 27},
 					},
 					{
 						22,
+						0,
 						"",
 						&ErrMountNotFound{MountID: 22},
 					},
 					{
 						31,
+						0,
 						"",
 						&ErrMountNotFound{MountID: 31},
 					},
@@ -260,7 +264,6 @@ func TestMountResolver(t *testing.T) {
 				[]event{
 					{
 						mount: &model.MountEvent{
-							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID: 27,
 								Device:  1,
@@ -275,7 +278,6 @@ func TestMountResolver(t *testing.T) {
 					},
 					{
 						mount: &model.MountEvent{
-							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID: 176,
 								Device:  52,
@@ -290,10 +292,9 @@ func TestMountResolver(t *testing.T) {
 					},
 					{
 						mount: &model.MountEvent{
-							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID: 638,
-								Device:  52,
+								Device:  53,
 								ParentPathKey: model.PathKey{
 									MountID: 635,
 								},
@@ -305,7 +306,6 @@ func TestMountResolver(t *testing.T) {
 					},
 					{
 						mount: &model.MountEvent{
-							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID: 639,
 								Device:  54,
@@ -322,6 +322,7 @@ func TestMountResolver(t *testing.T) {
 				[]testCase{
 					{
 						639,
+						0,
 						"/proc",
 						nil,
 					},
@@ -334,24 +335,31 @@ func TestMountResolver(t *testing.T) {
 				[]event{
 					{
 						umount: &model.UmountEvent{
-							SyscallEvent: model.SyscallEvent{},
-							MountID:      176,
+							MountID: 176,
+						},
+					},
+					{
+						umount: &model.UmountEvent{
+							MountID: 638,
 						},
 					},
 				},
 				[]testCase{
 					{
 						176,
+						0,
 						"",
 						&ErrMountNotFound{MountID: 176},
 					},
 					{
 						638,
+						0,
 						"",
 						&ErrMountNotFound{MountID: 638},
 					},
 					{
 						639,
+						0,
 						"",
 						&ErrMountNotFound{MountID: 639},
 					},
@@ -364,9 +372,9 @@ func TestMountResolver(t *testing.T) {
 				[]event{
 					{
 						mount: &model.MountEvent{
-							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID: 32,
+								Device:  97,
 								ParentPathKey: model.PathKey{
 									MountID: 638,
 								},
@@ -376,9 +384,9 @@ func TestMountResolver(t *testing.T) {
 					},
 					{
 						mount: &model.MountEvent{
-							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID: 41,
+								Device:  98,
 								ParentPathKey: model.PathKey{
 									MountID: 32,
 								},
@@ -388,9 +396,9 @@ func TestMountResolver(t *testing.T) {
 					},
 					{
 						mount: &model.MountEvent{
-							SyscallEvent: model.SyscallEvent{},
 							Mount: model.Mount{
 								MountID: 42,
+								Device:  99,
 								ParentPathKey: model.PathKey{
 									MountID: 41,
 								},
@@ -402,16 +410,19 @@ func TestMountResolver(t *testing.T) {
 				[]testCase{
 					{
 						32,
+						0,
 						"/",
 						nil,
 					},
 					{
 						41,
+						0,
 						"/tmp",
 						nil,
 					},
 					{
 						42,
+						0,
 						"/tmp/tmp",
 						nil,
 					},
@@ -420,8 +431,9 @@ func TestMountResolver(t *testing.T) {
 		},
 	}
 
-	// use pid 1 for the tests
-	var pid uint32 = 1
+	var (
+		pid uint32 = 1
+	)
 
 	cr, _ := cgroup.NewResolver(nil)
 
@@ -431,10 +443,10 @@ func TestMountResolver(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			for _, evt := range tt.args.events {
 				if evt.mount != nil {
-					mr.insert(&evt.mount.Mount)
+					mr.insert(&evt.mount.Mount, pid)
 				}
 				if evt.umount != nil {
-					mount, err := mr.ResolveMount(evt.umount.MountID, pid, "")
+					mount, err := mr.ResolveMount(evt.umount.MountID, 0, pid, "")
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -443,7 +455,7 @@ func TestMountResolver(t *testing.T) {
 			}
 
 			for _, testC := range tt.args.cases {
-				p, err := mr.ResolveMountPath(testC.mountID, pid, "")
+				p, err := mr.ResolveMountPath(testC.mountID, testC.device, pid, "")
 				if err != nil {
 					if testC.expectedError != nil {
 						assert.Equal(t, testC.expectedError.Error(), err.Error())
@@ -489,7 +501,7 @@ func TestMountGetParentPath(t *testing.T) {
 		},
 	}
 
-	parentPath, err := mr.getMountPath(4)
+	parentPath, err := mr.getMountPath(4, 44, 1)
 	assert.NoError(t, err)
 	assert.Equal(t, "/a/b/c", parentPath)
 }
@@ -525,7 +537,7 @@ func TestMountLoop(t *testing.T) {
 		},
 	}
 
-	parentPath, err := mr.getMountPath(3)
+	parentPath, err := mr.getMountPath(3, 44, 1)
 	assert.Equal(t, ErrMountLoop, err)
 	assert.Equal(t, "", parentPath)
 }
@@ -552,6 +564,6 @@ func BenchmarkGetParentPath(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = mr.getMountPath(100)
+		_, _ = mr.getMountPath(100, 44, 1)
 	}
 }

--- a/pkg/security/resolvers/path/resolver.go
+++ b/pkg/security/resolvers/path/resolver.go
@@ -97,11 +97,6 @@ func (r *Resolver) ResolveFileFieldsPath(e *model.FileFields, pidCtx *model.PIDC
 		if _, err := r.mountResolver.IsMountIDValid(e.MountID); errors.Is(err, mount.ErrMountKernelID) {
 			return pathStr, &ErrPathResolutionNotCritical{Err: fmt.Errorf("mount ID(%d) invalid: %w", e.MountID, err)}
 		}
-
-		if e.Device == 265289732 {
-			fmt.Printf("KO ? : %s/%s\n", mountPath, pathStr)
-		}
-
 		return pathStr, &ErrPathResolution{Err: err}
 	}
 

--- a/pkg/security/resolvers/resolvers_linux.go
+++ b/pkg/security/resolvers/resolvers_linux.go
@@ -252,6 +252,7 @@ func (r *Resolvers) snapshot() error {
 			if !os.IsNotExist(err) {
 				log.Debugf("snapshot failed for %d: couldn't sync mount points: %s", proc.Pid, err)
 			}
+			continue
 		}
 
 		// Sync the process cache

--- a/pkg/security/resolvers/resolvers_linux.go
+++ b/pkg/security/resolvers/resolvers_linux.go
@@ -116,7 +116,7 @@ func NewResolvers(config *config.Config, manager *manager.Manager, statsdClient 
 
 	// Force the use of redemption for now, as it seems that the kernel reference counter on mounts used to remove mounts is not working properly.
 	// This means that we can remove mount entries that are still in use.
-	mountResolver, err := mount.NewResolver(statsdClient, cgroupsResolver, mount.ResolverOpts{UseProcFS: true, UseRedemption: true})
+	mountResolver, err := mount.NewResolver(statsdClient, cgroupsResolver, mount.ResolverOpts{UseProcFS: true})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -356,6 +356,8 @@ type FileFields struct {
 	MTime uint64 `field:"modification_time"`                             // SECLDoc[modification_time] Definition:`Modification time (mtime) of the file`
 
 	PathKey
+	Device uint32 `field:"-"`
+
 	InUpperLayer bool `field:"in_upper_layer,handler:ResolveFileFieldsInUpperLayer"` // SECLDoc[in_upper_layer] Definition:`Indicator of the file layer, for example, in an OverlayFS`
 
 	NLink uint32 `field:"-" json:"-"`

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -338,16 +338,14 @@ func (e *FileFields) UnmarshalBinary(data []byte) (int, error) {
 	}
 	data = data[n:]
 
-	e.Flags = int32(ByteOrder.Uint32(data[0:4]))
+	e.Device = ByteOrder.Uint32(data[0:4])
 
-	// +4 for padding
+	e.Flags = int32(ByteOrder.Uint32(data[4:8]))
 
 	e.UID = ByteOrder.Uint32(data[8:12])
 	e.GID = ByteOrder.Uint32(data[12:16])
 	e.NLink = ByteOrder.Uint32(data[16:20])
 	e.Mode = ByteOrder.Uint16(data[20:22])
-
-	// +2 for padding
 
 	timeSec := ByteOrder.Uint64(data[24:32])
 	timeNsec := ByteOrder.Uint64(data[32:40])

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -334,17 +334,19 @@ func TestMountSnapshot(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	checkSnapshotAndModelMatch := func(mntInfo *mountinfo.Info) {
-		mount, err := mountResolver.ResolveMount(uint32(mntInfo.ID), pid, "")
+		dev := utils.Mkdev(uint32(mntInfo.Major), uint32(mntInfo.Minor))
+
+		mount, err := mountResolver.ResolveMount(uint32(mntInfo.ID), dev, pid, "")
 		if err != nil {
 			t.Errorf(err.Error())
 			return
 		}
 		assert.Equal(t, uint32(mntInfo.ID), mount.MountID, "snapshot and model mount ID mismatch")
 		assert.Equal(t, uint32(mntInfo.Parent), mount.ParentPathKey.MountID, "snapshot and model parent mount ID mismatch")
-		assert.Equal(t, uint32(unix.Mkdev(uint32(mntInfo.Major), uint32(mntInfo.Minor))), mount.Device, "snapshot and model device mismatch")
+		assert.Equal(t, dev, mount.Device, "snapshot and model device mismatch")
 		assert.Equal(t, mntInfo.FSType, mount.FSType, "snapshot and model fstype mismatch")
 		assert.Equal(t, mntInfo.Root, mount.RootStr, "snapshot and model root mismatch")
-		mountPointPath, err := mountResolver.ResolveMountPath(mount.MountID, pid, "")
+		mountPointPath, err := mountResolver.ResolveMountPath(mount.MountID, dev, pid, "")
 		if err != nil {
 			t.Errorf("failed to resolve mountpoint path of mountpoint with id %d", mount.MountID)
 		}

--- a/pkg/security/utils/dev.go
+++ b/pkg/security/utils/dev.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package utils
+
+// Mkdev returns the representation of a device
+// use the kernel algorithm, the golang unix.Mkdev function bring inconsistency between representations of device
+// https://elixir.bootlin.com/linux/v6.4.9/source/include/linux/kdev_t.h#L12
+func Mkdev(major uint32, minor uint32) uint32 {
+	const minorBits = 20
+	return (major << minorBits) | minor
+}

--- a/pkg/security/utils/endpoint.go
+++ b/pkg/security/utils/endpoint.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
-
 // Package utils holds utils related files
 package utils
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR makes use of the device as a fallback for the mount resolution.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
