### PR TITLE
[CWS] onboard DNS and network probes to fentry

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/network/flow.h
+++ b/pkg/security/ebpf/c/include/hooks/network/flow.h
@@ -47,7 +47,7 @@ int hook_security_sk_classify_flow(ctx_t *ctx) {
     return 0;
 }
 
-__attribute__((always_inline)) int trace_nat_manip_pkt(struct pt_regs *ctx, struct nf_conn *ct) {
+__attribute__((always_inline)) int trace_nat_manip_pkt(struct nf_conn *ct) {
     u32 netns = get_netns_from_nf_conn(ct);
 
     struct nf_conntrack_tuple_hash tuplehash[IP_CT_DIR_MAX];
@@ -77,16 +77,16 @@ __attribute__((always_inline)) int trace_nat_manip_pkt(struct pt_regs *ctx, stru
     return 0;
 }
 
-SEC("kprobe/nf_nat_manip_pkt")
-int kprobe_nf_nat_manip_pkt(struct pt_regs *ctx) {
-    struct nf_conn *ct = (struct nf_conn *)PT_REGS_PARM2(ctx);
-    return trace_nat_manip_pkt(ctx, ct);
+HOOK_ENTRY("nf_nat_manip_pkt")
+int hook_nf_nat_manip_pkt(ctx_t *ctx) {
+    struct nf_conn *ct = (struct nf_conn *)CTX_PARM2(ctx);
+    return trace_nat_manip_pkt(ct);
 }
 
-SEC("kprobe/nf_nat_packet")
-int kprobe_nf_nat_packet(struct pt_regs *ctx) {
-    struct nf_conn *ct = (struct nf_conn *)PT_REGS_PARM1(ctx);
-    return trace_nat_manip_pkt(ctx, ct);
+HOOK_ENTRY("nf_nat_packet")
+int hook_nf_nat_packet(ctx_t *ctx) {
+    struct nf_conn *ct = (struct nf_conn *)CTX_PARM1(ctx);
+    return trace_nat_manip_pkt(ct);
 }
 
 #endif

--- a/pkg/security/ebpf/c/include/hooks/network/flow.h
+++ b/pkg/security/ebpf/c/include/hooks/network/flow.h
@@ -5,10 +5,10 @@
 #include "constants/offsets/netns.h"
 #include "helpers/network.h"
 
-SEC("kprobe/security_sk_classify_flow")
-int kprobe_security_sk_classify_flow(struct pt_regs *ctx) {
-    struct sock *sk = (struct sock *)PT_REGS_PARM1(ctx);
-    struct flowi *fl = (struct flowi *)PT_REGS_PARM2(ctx);
+HOOK_ENTRY("security_sk_classify_flow")
+int hook_security_sk_classify_flow(ctx_t *ctx) {
+    struct sock *sk = (struct sock *)CTX_PARM1(ctx);
+    struct flowi *fl = (struct flowi *)CTX_PARM2(ctx);
     struct pid_route_t key = {};
     union flowi_uli uli;
 

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -15,11 +15,13 @@ import (
 )
 
 // NetworkNFNatSelectors is the list of probes that should be activated if the `nf_nat` module is loaded
-var NetworkNFNatSelectors = []manager.ProbesSelector{
-	&manager.OneOf{Selectors: []manager.ProbesSelector{
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_nf_nat_manip_pkt"}},
-		&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_nf_nat_packet"}},
-	}},
+func NetworkNFNatSelectors(fentry bool) []manager.ProbesSelector {
+	return []manager.ProbesSelector{
+		&manager.OneOf{Selectors: []manager.ProbesSelector{
+			kprobeOrFentry("nf_nat_manip_pkt", fentry),
+			kprobeOrFentry("nf_nat_packet", fentry),
+		}},
+	}
 }
 
 // NetworkVethSelectors is the list of probes that should be activated if the `veth` module is loaded
@@ -446,7 +448,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 	loadedModules, err := utils.FetchLoadedModules()
 	if err == nil {
 		if _, ok := loadedModules["nf_nat"]; ok {
-			selectorsPerEventTypeStore["dns"] = append(selectorsPerEventTypeStore["dns"], NetworkNFNatSelectors...)
+			selectorsPerEventTypeStore["dns"] = append(selectorsPerEventTypeStore["dns"], NetworkNFNatSelectors(fentry)...)
 		}
 	}
 

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -35,7 +35,7 @@ func NetworkSelectors(fentry bool) []manager.ProbesSelector {
 		// flow classification probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
 			kprobeOrFentry("security_socket_bind", fentry),
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_security_sk_classify_flow"}},
+			kprobeOrFentry("security_sk_classify_flow", fentry),
 			kprobeOrFentry("path_get", fentry),
 			kprobeOrFentry("proc_fd_link", fentry),
 		}},

--- a/pkg/security/ebpf/probes/flow.go
+++ b/pkg/security/ebpf/probes/flow.go
@@ -20,13 +20,13 @@ func getFlowProbes() []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe_nf_nat_manip_pkt",
+				EBPFFuncName: "hook_nf_nat_manip_pkt",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe_nf_nat_packet",
+				EBPFFuncName: "hook_nf_nat_packet",
 			},
 		},
 		{

--- a/pkg/security/ebpf/probes/flow.go
+++ b/pkg/security/ebpf/probes/flow.go
@@ -14,7 +14,7 @@ func getFlowProbes() []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe_security_sk_classify_flow",
+				EBPFFuncName: "hook_security_sk_classify_flow",
 			},
 		},
 		{

--- a/pkg/security/ebpf/probes/net_device.go
+++ b/pkg/security/ebpf/probes/net_device.go
@@ -14,61 +14,61 @@ func getNetDeviceProbes() []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe_rtnl_create_link",
+				EBPFFuncName: "hook_rtnl_create_link",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe_register_netdevice",
+				EBPFFuncName: "hook_register_netdevice",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe_dev_get_valid_name",
+				EBPFFuncName: "hook_dev_get_valid_name",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe_dev_new_index",
+				EBPFFuncName: "hook_dev_new_index",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kretprobe_dev_new_index",
+				EBPFFuncName: "rethook_dev_new_index",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe___dev_get_by_index",
+				EBPFFuncName: "hook___dev_get_by_index",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe___dev_get_by_name",
+				EBPFFuncName: "hook___dev_get_by_name",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kretprobe_register_netdevice",
+				EBPFFuncName: "rethook_register_netdevice",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe_dev_change_net_namespace",
+				EBPFFuncName: "hook_dev_change_net_namespace",
 			},
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe___dev_change_net_namespace",
+				EBPFFuncName: "hook___dev_change_net_namespace",
 			},
 		},
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR onboards the DNS and network hooks to the new fentry mechanism.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
