### PR TITLE
[CWS] cleanup the dentry resolver tail call targets between fentry and kprobe

### DIFF
--- a/pkg/security/ebpf/c/include/constants/custom.h
+++ b/pkg/security/ebpf/c/include/constants/custom.h
@@ -44,9 +44,8 @@ enum MONITOR_KEYS {
 #define DR_MAX_SEGMENT_LENGTH 255
 #define DR_NO_CALLBACK -1
 
-#define DR_KPROBE     1
-#define DR_FENTRY     2
-#define DR_TRACEPOINT 3
+#define DR_KPROBE_OR_FENTRY     1
+#define DR_TRACEPOINT           2
 
 enum DENTRY_RESOLVER_KEYS {
     DR_DENTRY_RESOLVER_KERN_KEY,

--- a/pkg/security/ebpf/c/include/constants/fentry_macro.h
+++ b/pkg/security/ebpf/c/include/constants/fentry_macro.h
@@ -33,8 +33,6 @@ typedef unsigned long long ctx_t;
 #define CTX_PARMRET(ctx, argc) (u64)(ctx[argc])
 #define SYSCALL_PARMRET(ctx) CTX_PARMRET(ctx, 1)
 
-#define DR_KPROBE_OR_FENTRY DR_FENTRY
-
 #else
 
 typedef struct pt_regs ctx_t;
@@ -66,8 +64,6 @@ typedef struct pt_regs ctx_t;
 
 #define CTX_PARMRET(ctx, _argc) PT_REGS_RC(ctx)
 #define SYSCALL_PARMRET(ctx) CTX_PARMRET(ctx, _)
-
-#define DR_KPROBE_OR_FENTRY DR_KPROBE
 
 #endif
 

--- a/pkg/security/ebpf/c/include/helpers/dentry_resolver.h
+++ b/pkg/security/ebpf/c/include/helpers/dentry_resolver.h
@@ -8,11 +8,8 @@
 
 int __attribute__((always_inline)) tail_call_dr_progs(void *ctx, int dr_type, int key) {
     switch (dr_type) {
-    case DR_KPROBE:
-        bpf_tail_call_compat(ctx, &dentry_resolver_kprobe_progs, key);
-        break;
-    case DR_FENTRY:
-        bpf_tail_call_compat(ctx, &dentry_resolver_fentry_progs, key);
+    case DR_KPROBE_OR_FENTRY:
+        bpf_tail_call_compat(ctx, &dentry_resolver_kprobe_or_fentry_progs, key);
         break;
     case DR_TRACEPOINT:
         bpf_tail_call_compat(ctx, &dentry_resolver_tracepoint_progs, key);
@@ -93,8 +90,7 @@ exit:
 
 int __attribute__((always_inline)) select_dr_key(int dr_type, int kprobe_key, int tracepoint_key) {
     switch (dr_type) {
-    case DR_KPROBE:
-    case DR_FENTRY:
+    case DR_KPROBE_OR_FENTRY:
         return kprobe_key;
     default: // DR_TRACEPOINT
         return tracepoint_key;

--- a/pkg/security/ebpf/c/include/hooks/dentry_resolver.h
+++ b/pkg/security/ebpf/c/include/hooks/dentry_resolver.h
@@ -131,7 +131,7 @@ int tracepoint_dentry_resolver_kern(void *ctx) {
 }
 
 TAIL_CALL_TARGET("dentry_resolver_kern")
-int fentry_dentry_resolver_kern(ctx_t *ctx) {
+int tail_call_target_dentry_resolver_kern(ctx_t *ctx) {
     dentry_resolver_kern(ctx, DR_KPROBE_OR_FENTRY);
     return 0;
 }

--- a/pkg/security/ebpf/c/include/hooks/dentry_resolver.h
+++ b/pkg/security/ebpf/c/include/hooks/dentry_resolver.h
@@ -124,27 +124,17 @@ void __attribute__((always_inline)) dentry_resolver_kern(void *ctx, int dr_type)
     }
 }
 
-SEC("kprobe/dentry_resolver_kern")
-int kprobe_dentry_resolver_kern(struct pt_regs *ctx) {
-    dentry_resolver_kern(ctx, DR_KPROBE);
-    return 0;
-}
-
 SEC("tracepoint/dentry_resolver_kern")
 int tracepoint_dentry_resolver_kern(void *ctx) {
     dentry_resolver_kern(ctx, DR_TRACEPOINT);
     return 0;
 }
 
-#ifdef USE_FENTRY
-
 TAIL_CALL_TARGET("dentry_resolver_kern")
 int fentry_dentry_resolver_kern(ctx_t *ctx) {
-    dentry_resolver_kern(ctx, DR_FENTRY);
+    dentry_resolver_kern(ctx, DR_KPROBE_OR_FENTRY);
     return 0;
 }
-
-#endif // USE_FENTRY
 
 int __attribute__((always_inline)) dentry_resolver_erpc_write_user(void *ctx, int dr_type) {
     u32 key = 0;
@@ -219,19 +209,10 @@ exit:
     return 0;
 }
 
-SEC("kprobe/dentry_resolver_erpc_write_user")
-int kprobe_dentry_resolver_erpc_write_user(struct pt_regs *ctx) {
-    return dentry_resolver_erpc_write_user(ctx, DR_KPROBE);
-}
-
-#ifdef USE_FENTRY
-
 TAIL_CALL_TARGET("dentry_resolver_erpc_write_user")
-int fentry_dentry_resolver_erpc_write_user(ctx_t *ctx) {
-    return dentry_resolver_erpc_write_user(ctx, DR_FENTRY);
+int tail_call_target_dentry_resolver_erpc_write_user(ctx_t *ctx) {
+    return dentry_resolver_erpc_write_user(ctx, DR_KPROBE_OR_FENTRY);
 }
-
-#endif // USE_FENTRY
 
 int __attribute__((always_inline)) dentry_resolver_erpc_mmap(void *ctx, int dr_type) {
     u32 key = 0;
@@ -313,19 +294,10 @@ exit:
     return 0;
 }
 
-SEC("kprobe/dentry_resolver_erpc_mmap")
-int kprobe_dentry_resolver_erpc_mmap(struct pt_regs *ctx) {
-    return dentry_resolver_erpc_mmap(ctx, DR_KPROBE);
-}
-
-#ifdef USE_FENTRY
-
 TAIL_CALL_TARGET("dentry_resolver_erpc_mmap")
-int fentry_dentry_resolver_erpc_mmap(ctx_t *ctx) {
-    return dentry_resolver_erpc_mmap(ctx, DR_FENTRY);
+int tail_call_target_dentry_resolver_erpc_mmap(ctx_t *ctx) {
+    return dentry_resolver_erpc_mmap(ctx, DR_KPROBE_OR_FENTRY);
 }
-
-#endif // USE_FENTRY
 
 int __attribute__((always_inline)) dentry_resolver_segment_erpc_write_user(void *ctx) {
     u32 key = 0;
@@ -372,19 +344,10 @@ exit:
     return 0;
 }
 
-SEC("kprobe/dentry_resolver_segment_erpc_write_user")
-int kprobe_dentry_resolver_segment_erpc_write_user(struct pt_regs *ctx) {
-    return dentry_resolver_segment_erpc_write_user(ctx);
-}
-
-#ifdef USE_FENTRY
-
 TAIL_CALL_TARGET("dentry_resolver_segment_erpc_write_user")
-int fentry_dentry_resolver_segment_erpc_write_user(ctx_t *ctx) {
+int tail_call_target_dentry_resolver_segment_erpc_write_user(ctx_t *ctx) {
     return dentry_resolver_segment_erpc_write_user(ctx);
 }
-
-#endif // USE_FENTRY
 
 int __attribute__((always_inline)) dentry_resolver_segment_erpc_mmap(void *ctx) {
     u32 key = 0;
@@ -439,19 +402,10 @@ exit:
     return 0;
 }
 
-SEC("kprobe/dentry_resolver_segment_erpc_mmap")
-int kprobe_dentry_resolver_segment_erpc_mmap(struct pt_regs *ctx) {
-    return dentry_resolver_segment_erpc_mmap(ctx);
-}
-
-#ifdef USE_FENTRY
-
 TAIL_CALL_TARGET("dentry_resolver_segment_erpc_mmap")
-int fentry_dentry_resolver_segment_erpc_mmap(ctx_t *ctx) {
+int tail_call_target_dentry_resolver_segment_erpc_mmap(ctx_t *ctx) {
     return dentry_resolver_segment_erpc_mmap(ctx);
 }
-
-#endif // USE_FENTRY
 
 int __attribute__((always_inline)) dentry_resolver_parent_erpc_write_user(void *ctx) {
     u32 key = 0;
@@ -492,19 +446,10 @@ exit:
     return 0;
 }
 
-SEC("kprobe/dentry_resolver_parent_erpc_write_user")
-int kprobe_dentry_resolver_parent_erpc_write_user(struct pt_regs *ctx) {
-    return dentry_resolver_parent_erpc_write_user(ctx);
-}
-
-#ifdef USE_FENTRY
-
 TAIL_CALL_TARGET("dentry_resolver_parent_erpc_write_user")
-int fentry_dentry_resolver_parent_erpc_write_user(ctx_t *ctx) {
+int tail_call_target_dentry_resolver_parent_erpc_write_user(ctx_t *ctx) {
     return dentry_resolver_parent_erpc_write_user(ctx);
 }
-
-#endif // USE_FENTRY
 
 int __attribute__((always_inline)) dentry_resolver_parent_erpc_mmap(void *ctx) {
     u32 key = 0;
@@ -552,39 +497,13 @@ exit:
     return 0;
 }
 
-SEC("kprobe/dentry_resolver_parent_erpc_mmap")
-int kprobe_dentry_resolver_parent_erpc_mmap(struct pt_regs *ctx) {
-    return dentry_resolver_parent_erpc_mmap(ctx);
-}
-
-#ifdef USE_FENTRY
-
 TAIL_CALL_TARGET("dentry_resolver_parent_erpc_mmap")
-int fentry_dentry_resolver_parent_erpc_mmap(ctx_t *ctx) {
+int tail_call_target_dentry_resolver_parent_erpc_mmap(ctx_t *ctx) {
     return dentry_resolver_parent_erpc_mmap(ctx);
 }
-
-#endif // USE_FENTRY
-
-SEC("kprobe/dentry_resolver_ad_filter")
-int kprobe_dentry_resolver_ad_filter(struct pt_regs *ctx) {
-    struct syscall_cache_t *syscall = peek_syscall(EVENT_ANY);
-    if (!syscall) {
-        return 0;
-    }
-
-    if (is_activity_dump_running(ctx, bpf_get_current_pid_tgid() >> 32, bpf_ktime_get_ns(), syscall->type)) {
-        syscall->resolver.flags |= ACTIVITY_DUMP_RUNNING;
-    }
-
-    tail_call_dr_progs(ctx, DR_KPROBE, DR_DENTRY_RESOLVER_KERN_KEY);
-    return 0;
-}
-
-#ifdef USE_FENTRY
 
 TAIL_CALL_TARGET("dentry_resolver_ad_filter")
-int fentry_dentry_resolver_ad_filter(ctx_t *ctx) {
+int tail_call_target_dentry_resolver_ad_filter(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_ANY);
     if (!syscall) {
         return 0;
@@ -594,11 +513,9 @@ int fentry_dentry_resolver_ad_filter(ctx_t *ctx) {
         syscall->resolver.flags |= ACTIVITY_DUMP_RUNNING;
     }
 
-    tail_call_dr_progs(ctx, DR_FENTRY, DR_DENTRY_RESOLVER_KERN_KEY);
+    tail_call_dr_progs(ctx, DR_KPROBE_OR_FENTRY, DR_DENTRY_RESOLVER_KERN_KEY);
     return 0;
 }
-
-#endif // USE_FENTRY
 
 SEC("tracepoint/dentry_resolver_ad_filter")
 int tracepoint_dentry_resolver_ad_filter(void *ctx) {

--- a/pkg/security/ebpf/c/include/hooks/dentry_resolver.h
+++ b/pkg/security/ebpf/c/include/hooks/dentry_resolver.h
@@ -111,11 +111,8 @@ void __attribute__((always_inline)) dentry_resolver_kern(void *ctx, int dr_type)
 
     if (syscall->resolver.callback >= 0) {
         switch (dr_type) {
-        case DR_KPROBE:
-            bpf_tail_call_compat(ctx, &dentry_resolver_kprobe_callbacks, syscall->resolver.callback);
-            break;
-        case DR_FENTRY:
-            bpf_tail_call_compat(ctx, &dentry_resolver_fentry_callbacks, syscall->resolver.callback);
+        case DR_KPROBE_OR_FENTRY:
+            bpf_tail_call_compat(ctx, &dentry_resolver_kprobe_or_fentry_callbacks, syscall->resolver.callback);
             break;
         case DR_TRACEPOINT:
             bpf_tail_call_compat(ctx, &dentry_resolver_tracepoint_callbacks, syscall->resolver.callback);

--- a/pkg/security/ebpf/c/include/hooks/link.h
+++ b/pkg/security/ebpf/c/include/hooks/link.h
@@ -99,25 +99,8 @@ int hook_vfs_link(ctx_t *ctx) {
     return 0;
 }
 
-SEC("kprobe/dr_link_src_callback")
-int kprobe_dr_link_src_callback(struct pt_regs *ctx) {
-    struct syscall_cache_t *syscall = peek_syscall(EVENT_LINK);
-    if (!syscall) {
-        return 0;
-    }
-
-    if (syscall->resolver.ret == DENTRY_DISCARDED) {
-        monitor_discarded(EVENT_LINK);
-        return mark_as_discarded(syscall);
-    }
-
-    return 0;
-}
-
-#ifdef USE_FENTRY
-
 TAIL_CALL_TARGET("dr_link_src_callback")
-int fentry_dr_link_src_callback(ctx_t *ctx) {
+int tail_call_target_dr_link_src_callback(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_LINK);
     if (!syscall) {
         return 0;
@@ -130,8 +113,6 @@ int fentry_dr_link_src_callback(ctx_t *ctx) {
 
     return 0;
 }
-
-#endif // USE_FENTRY
 
 int __attribute__((always_inline)) sys_link_ret(void *ctx, int retval, int dr_type) {
     if (IS_UNHANDLED_ERROR(retval)) {
@@ -220,19 +201,10 @@ int __attribute__((always_inline)) dr_link_dst_callback(void *ctx) {
     return 0;
 }
 
-SEC("kprobe/dr_link_dst_callback")
-int kprobe_dr_link_dst_callback(struct pt_regs *ctx) {
-    return dr_link_dst_callback(ctx);
-}
-
-#ifdef USE_FENTRY
-
 TAIL_CALL_TARGET("dr_link_dst_callback")
-int fentry_dr_link_dst_callback(ctx_t *ctx) {
+int tail_call_target_dr_link_dst_callback(ctx_t *ctx) {
     return dr_link_dst_callback(ctx);
 }
-
-#endif // USE_FENTRY
 
 SEC("tracepoint/dr_link_dst_callback")
 int tracepoint_dr_link_dst_callback(struct tracepoint_syscalls_sys_exit_t *args) {

--- a/pkg/security/ebpf/c/include/hooks/mkdir.h
+++ b/pkg/security/ebpf/c/include/hooks/mkdir.h
@@ -157,19 +157,10 @@ int __attribute__((always_inline)) dr_mkdir_callback(void *ctx) {
     return 0;
 }
 
-SEC("kprobe/dr_mkdir_callback")
-int kprobe_dr_mkdir_callback(struct pt_regs *ctx) {
-    return dr_mkdir_callback(ctx);
-}
-
-#ifdef USE_FENTRY
-
 TAIL_CALL_TARGET("dr_mkdir_callback")
-int fentry_dr_mkdir_callback(ctx_t *ctx) {
+int tail_call_target_dr_mkdir_callback(ctx_t *ctx) {
     return dr_mkdir_callback(ctx);
 }
-
-#endif // USE_FENTRY
 
 SEC("tracepoint/dr_mkdir_callback")
 int tracepoint_dr_mkdir_callback(struct tracepoint_syscalls_sys_exit_t *args) {

--- a/pkg/security/ebpf/c/include/hooks/mount.h
+++ b/pkg/security/ebpf/c/include/hooks/mount.h
@@ -227,7 +227,7 @@ int tail_call_target_dr_unshare_mntns_stage_one_callback(ctx_t *ctx) {
     syscall->resolver.iteration = 0;
     syscall->resolver.ret = 0;
 
-    resolve_dentry(ctx, DR_FENTRY);
+    resolve_dentry(ctx, DR_KPROBE_OR_FENTRY);
 
     // if the tail call fails, we need to pop the syscall cache entry
     pop_syscall(EVENT_UNSHARE_MNTNS);

--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -304,19 +304,10 @@ int __attribute__((always_inline)) dr_open_callback(void *ctx) {
     return 0;
 }
 
-SEC("kprobe/dr_open_callback")
-int kprobe_dr_open_callback(struct pt_regs *ctx) {
-    return dr_open_callback(ctx);
-}
-
-#ifdef USE_FENTRY
-
 TAIL_CALL_TARGET("dr_open_callback")
-int fentry_dr_open_callback(ctx_t *ctx) {
+int tail_call_target_dr_open_callback(ctx_t *ctx) {
     return dr_open_callback(ctx);
 }
-
-#endif // USE_FENTRY
 
 SEC("tracepoint/dr_open_callback")
 int tracepoint_dr_open_callback(struct tracepoint_syscalls_sys_exit_t *args) {

--- a/pkg/security/ebpf/c/include/hooks/rename.h
+++ b/pkg/security/ebpf/c/include/hooks/rename.h
@@ -215,19 +215,10 @@ int __attribute__((always_inline)) dr_rename_callback(void *ctx) {
     return 0;
 }
 
-SEC("kprobe/dr_rename_callback")
-int kprobe_dr_rename_callback(struct pt_regs *ctx) {
-    return dr_rename_callback(ctx);
-}
-
-#ifdef USE_FENTRY
-
 TAIL_CALL_TARGET("dr_rename_callback")
-int fentry_dr_rename_callback(ctx_t *ctx) {
+int tail_call_target_dr_rename_callback(ctx_t *ctx) {
     return dr_rename_callback(ctx);
 }
-
-#endif // USE_FENTRY
 
 SEC("tracepoint/dr_rename_callback")
 int tracepoint_dr_rename_callback(struct tracepoint_syscalls_sys_exit_t *args) {

--- a/pkg/security/ebpf/c/include/hooks/rmdir.h
+++ b/pkg/security/ebpf/c/include/hooks/rmdir.h
@@ -107,24 +107,8 @@ int hook_security_inode_rmdir(ctx_t *ctx) {
     return 0;
 }
 
-SEC("kprobe/dr_security_inode_rmdir_callback")
-int kprobe_dr_security_inode_rmdir_callback(struct pt_regs *ctx) {
-    struct syscall_cache_t *syscall = peek_syscall_with(rmdir_predicate);
-    if (!syscall) {
-        return 0;
-    }
-
-    if (syscall->resolver.ret == DENTRY_DISCARDED) {
-        monitor_discarded(EVENT_RMDIR);
-        return mark_as_discarded(syscall);
-    }
-    return 0;
-}
-
-#ifdef USE_FENTRY
-
 TAIL_CALL_TARGET("dr_security_inode_rmdir_callback")
-int fentry_dr_security_inode_rmdir_callback(ctx_t *ctx) {
+int tail_call_target_dr_security_inode_rmdir_callback(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(rmdir_predicate);
     if (!syscall) {
         return 0;
@@ -136,8 +120,6 @@ int fentry_dr_security_inode_rmdir_callback(ctx_t *ctx) {
     }
     return 0;
 }
-
-#endif // USE_FENTRY
 
 int __attribute__((always_inline)) sys_rmdir_ret(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall_with(rmdir_predicate);

--- a/pkg/security/ebpf/c/include/hooks/selinux.h
+++ b/pkg/security/ebpf/c/include/hooks/selinux.h
@@ -99,22 +99,12 @@ int __attribute__((always_inline)) dr_selinux_callback(void *ctx, int retval) {
     return 0;
 }
 
-SEC("kprobe/dr_selinux_callback")
-int kprobe_dr_selinux_callback(struct pt_regs *ctx) {
-    int retval = PT_REGS_RC(ctx);
-    return dr_selinux_callback(ctx, retval);
-}
-
-#ifdef USE_FENTRY
-
 TAIL_CALL_TARGET("dr_selinux_callback")
-int fentry_dr_selinux_callback(ctx_t *ctx) {
+int tail_call_target_dr_selinux_callback(ctx_t *ctx) {
     // int retval = PT_REGS_RC(ctx);
     int retval = 0;
     return dr_selinux_callback(ctx, retval);
 }
-
-#endif // USE_FENTRY
 
 #define PROBE_SEL_WRITE_FUNC(func_name, source_event)                       \
     HOOK_ENTRY(#func_name)                                                  \

--- a/pkg/security/ebpf/c/include/hooks/setattr.h
+++ b/pkg/security/ebpf/c/include/hooks/setattr.h
@@ -93,25 +93,8 @@ int hook_security_inode_setattr(ctx_t *ctx) {
     return 0;
 }
 
-SEC("kprobe/dr_setattr_callback")
-int kprobe_dr_setattr_callback(struct pt_regs *ctx) {
-    struct syscall_cache_t *syscall = peek_syscall_with(security_inode_predicate);
-    if (!syscall) {
-        return 0;
-    }
-
-    if (syscall->resolver.ret == DENTRY_DISCARDED) {
-        monitor_discarded(syscall->type);
-        return discard_syscall(syscall);
-    }
-
-    return 0;
-}
-
-#ifdef USE_FENTRY
-
 TAIL_CALL_TARGET("dr_setattr_callback")
-int fentry_dr_setattr_callback(ctx_t *ctx) {
+int tail_call_target_dr_setattr_callback(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(security_inode_predicate);
     if (!syscall) {
         return 0;
@@ -124,7 +107,5 @@ int fentry_dr_setattr_callback(ctx_t *ctx) {
 
     return 0;
 }
-
-#endif // USE_FENTRY
 
 #endif

--- a/pkg/security/ebpf/c/include/hooks/setxattr.h
+++ b/pkg/security/ebpf/c/include/hooks/setxattr.h
@@ -105,25 +105,8 @@ int __attribute__((always_inline)) trace__vfs_setxattr(ctx_t *ctx, u64 event_typ
     return 0;
 }
 
-SEC("kprobe/dr_setxattr_callback")
-int kprobe_dr_setxattr_callback(struct pt_regs *ctx) {
-    struct syscall_cache_t *syscall = peek_syscall_with(xattr_predicate);
-    if (!syscall) {
-        return 0;
-    }
-
-    if (syscall->resolver.ret == DENTRY_DISCARDED) {
-        monitor_discarded(EVENT_SETXATTR);
-        return discard_syscall(syscall);
-    }
-
-    return 0;
-}
-
-#ifdef USE_FENTRY
-
 TAIL_CALL_TARGET("dr_setxattr_callback")
-int fentry_dr_setxattr_callback(ctx_t *ctx) {
+int tail_call_target_dr_setxattr_callback(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(xattr_predicate);
     if (!syscall) {
         return 0;
@@ -136,8 +119,6 @@ int fentry_dr_setxattr_callback(ctx_t *ctx) {
 
     return 0;
 }
-
-#endif // USE_FENTRY
 
 HOOK_ENTRY("vfs_setxattr")
 int hook_vfs_setxattr(ctx_t *ctx) {

--- a/pkg/security/ebpf/c/include/hooks/unlink.h
+++ b/pkg/security/ebpf/c/include/hooks/unlink.h
@@ -88,24 +88,8 @@ int hook_vfs_unlink(ctx_t *ctx) {
     return 0;
 }
 
-SEC("kprobe/dr_unlink_callback")
-int kprobe_dr_unlink_callback(struct pt_regs *ctx) {
-    struct syscall_cache_t *syscall = peek_syscall(EVENT_UNLINK);
-    if (!syscall) {
-        return 0;
-    }
-
-    if (syscall->resolver.ret < 0) {
-        return mark_as_discarded(syscall);
-    }
-
-    return 0;
-}
-
-#ifdef USE_FENTRY
-
 TAIL_CALL_TARGET("dr_unlink_callback")
-int fentry_dr_unlink_callback(ctx_t *ctx) {
+int tail_call_target_dr_unlink_callback(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_UNLINK);
     if (!syscall) {
         return 0;
@@ -117,8 +101,6 @@ int fentry_dr_unlink_callback(ctx_t *ctx) {
 
     return 0;
 }
-
-#endif // USE_FENTRY
 
 int __attribute__((always_inline)) sys_unlink_ret(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_UNLINK);

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -83,11 +83,9 @@ BPF_PERCPU_ARRAY_MAP(selinux_write_buffer, u32, struct selinux_write_buffer_t, 1
 BPF_PERCPU_ARRAY_MAP(is_new_kthread, u32, u32, 1)
 
 BPF_PROG_ARRAY(args_envs_progs, 3)
-BPF_PROG_ARRAY(dentry_resolver_kprobe_callbacks, EVENT_MAX)
-BPF_PROG_ARRAY(dentry_resolver_fentry_callbacks, EVENT_MAX)
+BPF_PROG_ARRAY(dentry_resolver_kprobe_or_fentry_callbacks, EVENT_MAX)
 BPF_PROG_ARRAY(dentry_resolver_tracepoint_callbacks, EVENT_MAX)
-BPF_PROG_ARRAY(dentry_resolver_kprobe_progs, 5)
-BPF_PROG_ARRAY(dentry_resolver_fentry_progs, 5)
+BPF_PROG_ARRAY(dentry_resolver_kprobe_or_fentry_progs, 5)
 BPF_PROG_ARRAY(dentry_resolver_tracepoint_progs, 2)
 BPF_PROG_ARRAY(classifier_router, 100)
 BPF_PROG_ARRAY(sys_exit_progs, 64)

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -243,7 +243,7 @@ func AllTailRoutes(ERPCDentryResolutionEnabled, networkEnabled, supportMmapableM
 	var routes []manager.TailCallRoute
 
 	routes = append(routes, getExecTailCallRoutes()...)
-	routes = append(routes, getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapableMaps, fentry)...)
+	routes = append(routes, getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapableMaps)...)
 	routes = append(routes, getSysExitTailCallRoutes()...)
 	if networkEnabled {
 		routes = append(routes, getTCTailCallRoutes()...)

--- a/pkg/security/ebpf/probes/dentry.go
+++ b/pkg/security/ebpf/probes/dentry.go
@@ -13,15 +13,8 @@ import (
 
 // getDentryResolverTailCallRoutes is the list of routes used during the dentry resolution process
 func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapableMaps bool, fentry bool) []manager.TailCallRoute {
-	var dentryResolverProgs string
-	var dentryCallbackProgs string
-	if fentry {
-		dentryResolverProgs = "dentry_resolver_fentry_progs"
-		dentryCallbackProgs = "dentry_resolver_fentry_callbacks"
-	} else {
-		dentryResolverProgs = "dentry_resolver_kprobe_progs"
-		dentryCallbackProgs = "dentry_resolver_kprobe_callbacks"
-	}
+	dentryResolverProgs := "dentry_resolver_kprobe_or_fentry_progs"
+	dentryCallbackProgs := "dentry_resolver_kprobe_or_fentry_callbacks"
 
 	routes := []manager.TailCallRoute{
 		// activity dump filter programs

--- a/pkg/security/ebpf/probes/dentry.go
+++ b/pkg/security/ebpf/probes/dentry.go
@@ -25,10 +25,10 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 	routes := []manager.TailCallRoute{
 		// activity dump filter programs
 		{
-			ProgArrayName: "dentry_resolver_kprobe_progs",
+			ProgArrayName: dentryResolverProgs,
 			Key:           ActivityDumpFilterKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFFuncName: "kprobe_dentry_resolver_ad_filter",
+				EBPFFuncName: "tail_call_target_dentry_resolver_ad_filter",
 			},
 		},
 		{
@@ -54,18 +54,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 				EBPFFuncName: "tracepoint_dentry_resolver_kern",
 			},
 		},
-	}
-
-	if fentry {
-		routes = append(routes, []manager.TailCallRoute{
-			{
-				ProgArrayName: "dentry_resolver_fentry_progs",
-				Key:           ActivityDumpFilterKey,
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFFuncName: "fentry_dentry_resolver_ad_filter",
-				},
-			},
-		}...)
 	}
 
 	prefixes := []string{"kprobe"}

--- a/pkg/security/ebpf/probes/dentry.go
+++ b/pkg/security/ebpf/probes/dentry.go
@@ -17,9 +17,9 @@ import (
 func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapableMaps bool, fentry bool) []manager.TailCallRoute {
 	var dentryResolverProgs string
 	if fentry {
-		dentryResolverProgs = "dentry_resolver_kprobe_progs"
-	} else {
 		dentryResolverProgs = "dentry_resolver_fentry_progs"
+	} else {
+		dentryResolverProgs = "dentry_resolver_kprobe_progs"
 	}
 
 	routes := []manager.TailCallRoute{

--- a/pkg/security/ebpf/probes/dentry.go
+++ b/pkg/security/ebpf/probes/dentry.go
@@ -15,6 +15,13 @@ import (
 
 // getDentryResolverTailCallRoutes is the list of routes used during the dentry resolution process
 func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapableMaps bool, fentry bool) []manager.TailCallRoute {
+	var dentryResolverProgs string
+	if fentry {
+		dentryResolverProgs = "dentry_resolver_kprobe_progs"
+	} else {
+		dentryResolverProgs = "dentry_resolver_fentry_progs"
+	}
+
 	routes := []manager.TailCallRoute{
 		// activity dump filter programs
 		{
@@ -34,7 +41,7 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 
 		// dentry resolver programs
 		{
-			ProgArrayName: "dentry_resolver_kprobe_progs",
+			ProgArrayName: dentryResolverProgs,
 			Key:           DentryResolverKernKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				EBPFFuncName: "kprobe_dentry_resolver_kern",

--- a/pkg/security/ebpf/probes/dentry.go
+++ b/pkg/security/ebpf/probes/dentry.go
@@ -44,7 +44,7 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 			ProgArrayName: dentryResolverProgs,
 			Key:           DentryResolverKernKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				EBPFFuncName: "kprobe_dentry_resolver_kern",
+				EBPFFuncName: "tail_call_target_dentry_resolver_kern",
 			},
 		},
 		{
@@ -63,13 +63,6 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 				Key:           ActivityDumpFilterKey,
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					EBPFFuncName: "fentry_dentry_resolver_ad_filter",
-				},
-			},
-			{
-				ProgArrayName: "dentry_resolver_fentry_progs",
-				Key:           DentryResolverKernKey,
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFFuncName: "fentry_dentry_resolver_kern",
 				},
 			},
 		}...)
@@ -218,40 +211,36 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 		},
 	}...)
 
-	for _, prefix := range prefixes {
-		// add routes for programs with the bpf_probe_write_user only if necessary
-		if ERPCDentryResolutionEnabled {
-			ebpfSuffix := "_mmap"
-			if !supportMmapableMaps {
-				ebpfSuffix = "_write_user"
-			}
-
-			progArrayName := fmt.Sprintf("dentry_resolver_%s_progs", prefix)
-
-			routes = append(routes, []manager.TailCallRoute{
-				{
-					ProgArrayName: progArrayName,
-					Key:           DentryResolverERPCKey,
-					ProbeIdentificationPair: manager.ProbeIdentificationPair{
-						EBPFFuncName: prefix + "_dentry_resolver_erpc" + ebpfSuffix,
-					},
-				},
-				{
-					ProgArrayName: progArrayName,
-					Key:           DentryResolverParentERPCKey,
-					ProbeIdentificationPair: manager.ProbeIdentificationPair{
-						EBPFFuncName: prefix + "_dentry_resolver_parent_erpc" + ebpfSuffix,
-					},
-				},
-				{
-					ProgArrayName: progArrayName,
-					Key:           DentryResolverSegmentERPCKey,
-					ProbeIdentificationPair: manager.ProbeIdentificationPair{
-						EBPFFuncName: prefix + "_dentry_resolver_segment_erpc" + ebpfSuffix,
-					},
-				},
-			}...)
+	// add routes for programs with the bpf_probe_write_user only if necessary
+	if ERPCDentryResolutionEnabled {
+		ebpfSuffix := "_mmap"
+		if !supportMmapableMaps {
+			ebpfSuffix = "_write_user"
 		}
+
+		routes = append(routes, []manager.TailCallRoute{
+			{
+				ProgArrayName: dentryResolverProgs,
+				Key:           DentryResolverERPCKey,
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					EBPFFuncName: "tail_call_target_dentry_resolver_erpc" + ebpfSuffix,
+				},
+			},
+			{
+				ProgArrayName: dentryResolverProgs,
+				Key:           DentryResolverParentERPCKey,
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					EBPFFuncName: "tail_call_target_dentry_resolver_parent_erpc" + ebpfSuffix,
+				},
+			},
+			{
+				ProgArrayName: dentryResolverProgs,
+				Key:           DentryResolverSegmentERPCKey,
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					EBPFFuncName: "tail_call_target_dentry_resolver_segment_erpc" + ebpfSuffix,
+				},
+			},
+		}...)
 	}
 
 	return routes

--- a/pkg/security/ebpf/probes/dentry.go
+++ b/pkg/security/ebpf/probes/dentry.go
@@ -12,7 +12,7 @@ import (
 )
 
 // getDentryResolverTailCallRoutes is the list of routes used during the dentry resolution process
-func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapableMaps bool, fentry bool) []manager.TailCallRoute {
+func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapableMaps bool) []manager.TailCallRoute {
 	dentryResolverProgs := "dentry_resolver_kprobe_or_fentry_progs"
 	dentryCallbackProgs := "dentry_resolver_kprobe_or_fentry_callbacks"
 

--- a/pkg/security/ebpf/probes/dentry.go
+++ b/pkg/security/ebpf/probes/dentry.go
@@ -8,18 +8,19 @@
 package probes
 
 import (
-	"fmt"
-
 	manager "github.com/DataDog/ebpf-manager"
 )
 
 // getDentryResolverTailCallRoutes is the list of routes used during the dentry resolution process
 func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapableMaps bool, fentry bool) []manager.TailCallRoute {
 	var dentryResolverProgs string
+	var dentryCallbackProgs string
 	if fentry {
 		dentryResolverProgs = "dentry_resolver_fentry_progs"
+		dentryCallbackProgs = "dentry_resolver_fentry_callbacks"
 	} else {
 		dentryResolverProgs = "dentry_resolver_kprobe_progs"
+		dentryCallbackProgs = "dentry_resolver_kprobe_callbacks"
 	}
 
 	routes := []manager.TailCallRoute{
@@ -56,109 +57,100 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled, supportMmapabl
 		},
 	}
 
-	prefixes := []string{"kprobe"}
-	if fentry {
-		prefixes = append(prefixes, "fentry")
-	}
-
-	for _, prefix := range prefixes {
-		progArrayName := fmt.Sprintf("dentry_resolver_%s_callbacks", prefix)
-
-		routes = append(routes, []manager.TailCallRoute{
-			// dentry resolver kprobe callbacks
-			{
-				ProgArrayName: progArrayName,
-				Key:           DentryResolverOpenCallbackKprobeKey,
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFFuncName: prefix + "_dr_open_callback",
-				},
+	routes = append(routes, []manager.TailCallRoute{
+		// dentry resolver kprobe callbacks
+		{
+			ProgArrayName: dentryCallbackProgs,
+			Key:           DentryResolverOpenCallbackKprobeKey,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: "tail_call_target_dr_open_callback",
 			},
-			{
-				ProgArrayName: progArrayName,
-				Key:           DentryResolverSetAttrCallbackKprobeKey,
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFFuncName: prefix + "_dr_setattr_callback",
-				},
+		},
+		{
+			ProgArrayName: dentryCallbackProgs,
+			Key:           DentryResolverSetAttrCallbackKprobeKey,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: "tail_call_target_dr_setattr_callback",
 			},
-			{
-				ProgArrayName: progArrayName,
-				Key:           DentryResolverMkdirCallbackKprobeKey,
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFFuncName: prefix + "_dr_mkdir_callback",
-				},
+		},
+		{
+			ProgArrayName: dentryCallbackProgs,
+			Key:           DentryResolverMkdirCallbackKprobeKey,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: "tail_call_target_dr_mkdir_callback",
 			},
-			{
-				ProgArrayName: progArrayName,
-				Key:           DentryResolverMountCallbackKprobeKey,
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFFuncName: prefix + "_dr_mount_callback",
-				},
+		},
+		{
+			ProgArrayName: dentryCallbackProgs,
+			Key:           DentryResolverMountCallbackKprobeKey,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: "tail_call_target_dr_mount_callback",
 			},
-			{
-				ProgArrayName: progArrayName,
-				Key:           DentryResolverSecurityInodeRmdirCallbackKprobeKey,
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFFuncName: prefix + "_dr_security_inode_rmdir_callback",
-				},
+		},
+		{
+			ProgArrayName: dentryCallbackProgs,
+			Key:           DentryResolverSecurityInodeRmdirCallbackKprobeKey,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: "tail_call_target_dr_security_inode_rmdir_callback",
 			},
-			{
-				ProgArrayName: progArrayName,
-				Key:           DentryResolverSetXAttrCallbackKprobeKey,
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFFuncName: prefix + "_dr_setxattr_callback",
-				},
+		},
+		{
+			ProgArrayName: dentryCallbackProgs,
+			Key:           DentryResolverSetXAttrCallbackKprobeKey,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: "tail_call_target_dr_setxattr_callback",
 			},
-			{
-				ProgArrayName: progArrayName,
-				Key:           DentryResolverUnlinkCallbackKprobeKey,
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFFuncName: prefix + "_dr_unlink_callback",
-				},
+		},
+		{
+			ProgArrayName: dentryCallbackProgs,
+			Key:           DentryResolverUnlinkCallbackKprobeKey,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: "tail_call_target_dr_unlink_callback",
 			},
-			{
-				ProgArrayName: progArrayName,
-				Key:           DentryResolverLinkSrcCallbackKprobeKey,
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFFuncName: prefix + "_dr_link_src_callback",
-				},
+		},
+		{
+			ProgArrayName: dentryCallbackProgs,
+			Key:           DentryResolverLinkSrcCallbackKprobeKey,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: "tail_call_target_dr_link_src_callback",
 			},
-			{
-				ProgArrayName: progArrayName,
-				Key:           DentryResolverLinkDstCallbackKprobeKey,
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFFuncName: prefix + "_dr_link_dst_callback",
-				},
+		},
+		{
+			ProgArrayName: dentryCallbackProgs,
+			Key:           DentryResolverLinkDstCallbackKprobeKey,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: "tail_call_target_dr_link_dst_callback",
 			},
-			{
-				ProgArrayName: progArrayName,
-				Key:           DentryResolverRenameCallbackKprobeKey,
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFFuncName: prefix + "_dr_rename_callback",
-				},
+		},
+		{
+			ProgArrayName: dentryCallbackProgs,
+			Key:           DentryResolverRenameCallbackKprobeKey,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: "tail_call_target_dr_rename_callback",
 			},
-			{
-				ProgArrayName: progArrayName,
-				Key:           DentryResolverSELinuxCallbackKprobeKey,
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFFuncName: prefix + "_dr_selinux_callback",
-				},
+		},
+		{
+			ProgArrayName: dentryCallbackProgs,
+			Key:           DentryResolverSELinuxCallbackKprobeKey,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: "tail_call_target_dr_selinux_callback",
 			},
-			{
-				ProgArrayName: progArrayName,
-				Key:           DentryResolverUnshareMntNSStageOneCallbackKprobeKey,
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFFuncName: prefix + "_dr_unshare_mntns_stage_one_callback",
-				},
+		},
+		{
+			ProgArrayName: dentryCallbackProgs,
+			Key:           DentryResolverUnshareMntNSStageOneCallbackKprobeKey,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: "tail_call_target_dr_unshare_mntns_stage_one_callback",
 			},
-			{
-				ProgArrayName: progArrayName,
-				Key:           DentryResolverUnshareMntNSStageTwoCallbackKprobeKey,
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFFuncName: prefix + "_dr_unshare_mntns_stage_two_callback",
-				},
+		},
+		{
+			ProgArrayName: dentryCallbackProgs,
+			Key:           DentryResolverUnshareMntNSStageTwoCallbackKprobeKey,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: "tail_call_target_dr_unshare_mntns_stage_two_callback",
 			},
-		}...)
-	}
+		},
+	}...)
 
 	routes = append(routes, []manager.TailCallRoute{
 		// dentry resolver tracepoint callbacks


### PR DESCRIPTION
### What does this PR do?

Currently all tail call targets related to the dentry resolver are duplicated in kprobe and fentry versions. This PR merges those, as well as the prog arrays. This simplifies/deduplicate the eBPF code as well as the loading go code.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
