### PR TITLE
[CI] Remove go linters for `rpm`, `amd64` and `arm64`.

### DIFF
--- a/.gitlab/binary_build/linux.yml
+++ b/.gitlab/binary_build/linux.yml
@@ -6,7 +6,7 @@ build_dogstatsd_static-binary_x64:
     !reference [.on_a7]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs: ["lint_deb-x64", "tests_deb-x64-py3", "go_deps"]
+  needs: ["lint_linux-x64", "tests_deb-x64-py3", "go_deps"]
   variables:
     ARCH: amd64
   before_script:
@@ -23,7 +23,7 @@ build_dogstatsd_static-binary_arm64:
     !reference [.on_a7]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
-  needs: ["lint_deb-arm64", "tests_deb-arm64-py3", "go_deps"]
+  needs: ["lint_linux-arm64", "tests_deb-arm64-py3", "go_deps"]
   variables:
     ARCH: arm64
   before_script:
@@ -40,7 +40,7 @@ build_dogstatsd-binary_x64:
     !reference [.on_a7]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs: ["lint_deb-x64", "tests_deb-x64-py3", "go_deps"]
+  needs: ["lint_linux-x64", "tests_deb-x64-py3", "go_deps"]
   before_script:
     - source /root/.bashrc
     - !reference [.retrieve_linux_go_deps]
@@ -55,7 +55,7 @@ build_dogstatsd-binary_arm64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["arch:arm64"]
-  needs: ["lint_deb-arm64", "tests_deb-arm64-py3", "go_deps"]
+  needs: ["lint_linux-arm64", "tests_deb-arm64-py3", "go_deps"]
   variables:
     ARCH: arm64
   before_script:
@@ -73,7 +73,7 @@ build_iot_agent-binary_x64:
     !reference [.on_a7]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
-  needs: ["lint_deb-x64", "tests_deb-x64-py3", "go_deps"]
+  needs: ["lint_linux-x64", "tests_deb-x64-py3", "go_deps"]
   before_script:
     - !reference [.retrieve_linux_go_deps]
   script:
@@ -88,7 +88,7 @@ build_iot_agent-binary_arm64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:arm64"]
-  needs: ["lint_deb-arm64", "tests_deb-arm64-py3", "go_deps"]
+  needs: ["lint_linux-arm64", "tests_deb-arm64-py3", "go_deps"]
   variables:
     ARCH: arm64
   before_script:

--- a/.gitlab/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy.yml
@@ -144,7 +144,7 @@ deploy_rpm_testing-a6_x64:
     !reference [.on_kitchen_tests_a6]
   extends:
     - .deploy_rpm_testing-a6
-  needs: ["agent_rpm-x64-a6", "tests_rpm-x64-py2", "lint_rpm-x64", "tests_rpm-x64-py3"]
+  needs: ["agent_rpm-x64-a6", "tests_rpm-x64-py2", "lint_deb-x64", "tests_rpm-x64-py3"]
   script:
     - *setup_rpm_signing_key
     - set +x
@@ -155,7 +155,7 @@ deploy_rpm_testing-a6_arm64:
     !reference [.on_all_kitchen_builds_a6]
   extends:
     - .deploy_rpm_testing-a6
-  needs: ["agent_rpm-arm64-a6", "tests_rpm-arm64-py2", "lint_rpm-arm64", "tests_rpm-arm64-py3"]
+  needs: ["agent_rpm-arm64-a6", "tests_rpm-arm64-py2", "lint_deb-arm64", "tests_rpm-arm64-py3"]
   script:
     - *setup_rpm_signing_key
     - set +x
@@ -176,7 +176,7 @@ deploy_rpm_testing-a7_x64:
     !reference [.on_default_kitchen_tests_a7]
   extends:
     - .deploy_rpm_testing-a7
-  needs: ["agent_rpm-x64-a7", "iot_agent_rpm-x64", "dogstatsd_rpm-x64", "lint_rpm-x64", "tests_rpm-x64-py3"]
+  needs: ["agent_rpm-x64-a7", "iot_agent_rpm-x64", "dogstatsd_rpm-x64", "lint_deb-x64", "tests_rpm-x64-py3"]
   script:
     - *setup_rpm_signing_key
     - set +x
@@ -187,7 +187,7 @@ deploy_rpm_testing-a7_arm64:
     !reference [.on_all_kitchen_builds_a7]
   extends:
     - .deploy_rpm_testing-a7
-  needs: ["agent_rpm-arm64-a7", "lint_rpm-arm64", "tests_rpm-arm64-py3"]
+  needs: ["agent_rpm-arm64-a7", "lint_deb-arm64", "tests_rpm-arm64-py3"]
   script:
     - *setup_rpm_signing_key
     - set +x
@@ -199,7 +199,7 @@ deploy_suse_rpm_testing-a6:
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["arch:amd64"]
-  needs: ["agent_suse-x64-a6", "tests_rpm-x64-py2", "lint_rpm-x64", "tests_rpm-x64-py3"]
+  needs: ["agent_suse-x64-a6", "tests_rpm-x64-py2", "lint_deb-x64", "tests_rpm-x64-py3"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
   before_script:
@@ -216,7 +216,7 @@ deploy_suse_rpm_testing-a7:
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["arch:amd64"]
-  needs: ["agent_suse-x64-a7", "iot_agent_suse-x64", "dogstatsd_suse-x64", "lint_rpm-x64", "tests_rpm-x64-py3"]
+  needs: ["agent_suse-x64-a7", "iot_agent_suse-x64", "dogstatsd_suse-x64", "lint_deb-x64", "tests_rpm-x64-py3"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
   before_script:

--- a/.gitlab/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy.yml
@@ -59,7 +59,7 @@ deploy_deb_testing-a6_x64:
     !reference [.on_kitchen_tests_a6]
   extends:
     - .deploy_deb_testing-a6
-  needs: ["agent_deb-x64-a6", "agent_heroku_deb-x64-a6", "tests_deb-x64-py2", "lint_deb-x64", "tests_deb-x64-py3"]
+  needs: ["agent_deb-x64-a6", "agent_heroku_deb-x64-a6", "tests_deb-x64-py2", "lint_linux-x64", "tests_deb-x64-py3"]
   script:
     - *setup_apt_signing_key
     - set +x  # make sure we don't output the creds to the build log
@@ -102,7 +102,7 @@ deploy_deb_testing-a7_x64:
     !reference [.on_default_kitchen_tests_a7]
   extends:
     - .deploy_deb_testing-a7
-  needs: ["agent_deb-x64-a7", "agent_heroku_deb-x64-a7", "iot_agent_deb-x64", "dogstatsd_deb-x64", "lint_deb-x64", "tests_deb-x64-py3"]
+  needs: ["agent_deb-x64-a7", "agent_heroku_deb-x64-a7", "iot_agent_deb-x64", "dogstatsd_deb-x64", "lint_linux-x64", "tests_deb-x64-py3"]
   script:
     - *setup_apt_signing_key
     - set +x  # make sure we don't output the creds to the build log
@@ -119,7 +119,7 @@ deploy_deb_testing-a7_arm64:
     !reference [.on_all_kitchen_builds_a7]
   extends:
     - .deploy_deb_testing-a7
-  needs: ["agent_deb-arm64-a7", "lint_deb-arm64", "tests_deb-arm64-py3"]
+  needs: ["agent_deb-arm64-a7", "lint_linux-arm64", "tests_deb-arm64-py3"]
   script:
     - *setup_apt_signing_key
     - set +x  # make sure we don't output the creds to the build log
@@ -144,7 +144,7 @@ deploy_rpm_testing-a6_x64:
     !reference [.on_kitchen_tests_a6]
   extends:
     - .deploy_rpm_testing-a6
-  needs: ["agent_rpm-x64-a6", "tests_rpm-x64-py2", "lint_deb-x64", "tests_rpm-x64-py3"]
+  needs: ["agent_rpm-x64-a6", "tests_rpm-x64-py2", "lint_linux-x64", "tests_rpm-x64-py3"]
   script:
     - *setup_rpm_signing_key
     - set +x
@@ -155,7 +155,7 @@ deploy_rpm_testing-a6_arm64:
     !reference [.on_all_kitchen_builds_a6]
   extends:
     - .deploy_rpm_testing-a6
-  needs: ["agent_rpm-arm64-a6", "tests_rpm-arm64-py2", "lint_deb-arm64", "tests_rpm-arm64-py3"]
+  needs: ["agent_rpm-arm64-a6", "tests_rpm-arm64-py2", "lint_linux-arm64", "tests_rpm-arm64-py3"]
   script:
     - *setup_rpm_signing_key
     - set +x
@@ -176,7 +176,7 @@ deploy_rpm_testing-a7_x64:
     !reference [.on_default_kitchen_tests_a7]
   extends:
     - .deploy_rpm_testing-a7
-  needs: ["agent_rpm-x64-a7", "iot_agent_rpm-x64", "dogstatsd_rpm-x64", "lint_deb-x64", "tests_rpm-x64-py3"]
+  needs: ["agent_rpm-x64-a7", "iot_agent_rpm-x64", "dogstatsd_rpm-x64", "lint_linux-x64", "tests_rpm-x64-py3"]
   script:
     - *setup_rpm_signing_key
     - set +x
@@ -187,7 +187,7 @@ deploy_rpm_testing-a7_arm64:
     !reference [.on_all_kitchen_builds_a7]
   extends:
     - .deploy_rpm_testing-a7
-  needs: ["agent_rpm-arm64-a7", "lint_deb-arm64", "tests_rpm-arm64-py3"]
+  needs: ["agent_rpm-arm64-a7", "lint_linux-arm64", "tests_rpm-arm64-py3"]
   script:
     - *setup_rpm_signing_key
     - set +x
@@ -199,7 +199,7 @@ deploy_suse_rpm_testing-a6:
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["arch:amd64"]
-  needs: ["agent_suse-x64-a6", "tests_rpm-x64-py2", "lint_deb-x64", "tests_rpm-x64-py3"]
+  needs: ["agent_suse-x64-a6", "tests_rpm-x64-py2", "lint_linux-x64", "tests_rpm-x64-py3"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
   before_script:
@@ -216,7 +216,7 @@ deploy_suse_rpm_testing-a7:
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["arch:amd64"]
-  needs: ["agent_suse-x64-a7", "iot_agent_suse-x64", "dogstatsd_suse-x64", "lint_deb-x64", "tests_rpm-x64-py3"]
+  needs: ["agent_suse-x64-a7", "iot_agent_suse-x64", "dogstatsd_suse-x64", "lint_linux-x64", "tests_rpm-x64-py3"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
   before_script:

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -73,7 +73,7 @@ tests_deb-x64-py3:
     PYTHON_RUNTIMES: '3'
     CONDA_ENV: ddpy3
 
-lint_deb-x64:
+lint_linux-x64:
   extends:
     - .linux_lint
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -92,7 +92,7 @@ tests_flavor_iot_deb-x64:
     CONDA_ENV: ddpy3
     FLAVORS: '--flavors iot'
 
-lint_flavor_iot_deb-x64:
+lint_flavor_iot_linux-x64:
   extends:
     - .linux_lint
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -113,7 +113,7 @@ tests_flavor_dogstatsd_deb-x64:
     CONDA_ENV: ddpy3
     FLAVORS: '--flavors dogstatsd'
 
-lint_flavor_dogstatsd_deb-x64:
+lint_flavor_dogstatsd_linux-x64:
   extends:
     - .linux_lint
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -134,7 +134,7 @@ tests_flavor_heroku_deb-x64:
     CONDA_ENV: ddpy3
     FLAVORS: '--flavors heroku'
 
-lint_flavor_heroku_deb-x64:
+lint_flavor_heroku_linux-x64:
   extends:
     - .linux_lint
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
@@ -193,7 +193,7 @@ tests_deb-arm64-py3:
     PYTHON_RUNTIMES: '3'
     CONDA_ENV: ddpy3
 
-lint_deb-arm64:
+lint_linux-arm64:
   extends:
     - .linux_lint
   needs: ["go_deps", "go_tools_deps"]

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -170,14 +170,6 @@ tests_rpm-x64-py3:
     CONDA_ENV: ddpy3
     EXTRA_OPTS: '--build-exclude=systemd'
 
-lint_rpm-x64:
-  extends:
-    - .linux_lint
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["arch:amd64"]
-  needs: ["go_deps", "go_tools_deps"]
-  variables:
-    EXTRA_OPTS: '--build-exclude=systemd'
 
 tests_deb-arm64-py2:
   extends: .rtloader_tests
@@ -229,13 +221,6 @@ tests_rpm-arm64-py3:
   variables:
     PYTHON_RUNTIMES: '3'
     CONDA_ENV: ddpy3
-
-lint_rpm-arm64:
-  extends:
-    - .linux_lint
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["arch:arm64"]
-  needs: ["go_deps", "go_tools_deps"]
 
 # Check consistency of go.mod file with project imports
 go_mod_tidy_check:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR removes the linter for `rpm`, `amd64` and `arm64`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The linters are already run for `deb`, `amd64` and `arm64`. Both are linux so it doesn't seem useful to run both linters.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
