### PR TITLE
[CSM] make `utils.GetHostname` a bit more resilient to slow core agent startup

### DIFF
--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -44,6 +44,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger/remote"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -204,7 +205,11 @@ func RunAgent(ctx context.Context, log log.Component, config config.Component, t
 
 	hostnameDetected, err := utils.GetHostname()
 	if err != nil {
-		return log.Errorf("Error while getting hostname, exiting: %v", err)
+		log.Warnf("Could not resolve hostname from core-agent: %v", err)
+		hostnameDetected, err = hostname.Get(ctx)
+		if err != nil {
+			return log.Errorf("Error while getting hostname, exiting: %v", err)
+		}
 	}
 	log.Infof("Hostname is: %s", hostnameDetected)
 

--- a/pkg/security/utils/hostname.go
+++ b/pkg/security/utils/hostname.go
@@ -16,6 +16,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+const (
+	// maxAttempts is the maximum number of times we try to get the hostname
+	// from the core-agent before bailing out.
+	maxAttempts = 6
+)
+
 // GetHostname attempts to acquire a hostname by connecting to the core agent's
 // gRPC endpoints
 func GetHostname() (string, error) {
@@ -38,6 +44,6 @@ func GetHostname() (string, error) {
 
 		hostname = reply.Hostname
 		return nil
-	}, retry.LastErrorOnly(true), retry.Attempts(6))
+	}, retry.LastErrorOnly(true), retry.Attempts(maxAttempts))
 	return hostname, err
 }

--- a/pkg/security/utils/hostname.go
+++ b/pkg/security/utils/hostname.go
@@ -21,7 +21,7 @@ import (
 func GetHostname() (string, error) {
 	var hostname string
 	err := retry.Do(func() error {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 
 		client, err := grpc.GetDDAgentClient(ctx)
@@ -38,6 +38,6 @@ func GetHostname() (string, error) {
 
 		hostname = reply.Hostname
 		return nil
-	}, retry.LastErrorOnly(true))
+	}, retry.LastErrorOnly(true), retry.Attempts(6))
 	return hostname, err
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

In case the security agent starts faster than the core agent the gRPC communication to fetch the hostname can fail. This PR makes this process a bit more resilient by retrying the fetching multiple times and falling back to a local method if it failed.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
