### PR TITLE
usm: fix incomplete buffer timestamp parameter

### DIFF
--- a/pkg/network/protocols/http/incomplete_stats.go
+++ b/pkg/network/protocols/http/incomplete_stats.go
@@ -109,11 +109,10 @@ func (b *incompleteBuffer) Add(tx Transaction) {
 	}
 }
 
-func (b *incompleteBuffer) Flush(now time.Time) []Transaction {
+func (b *incompleteBuffer) Flush(nowNano int64) []Transaction {
 	var (
 		joined   []Transaction
 		previous = b.data
-		nowUnix  = now.UnixNano()
 	)
 
 	b.data = make(map[types.ConnectionKey]*txParts)
@@ -146,7 +145,7 @@ func (b *incompleteBuffer) Flush(now time.Time) []Transaction {
 		// now that we have finished matching requests and responses
 		// we check if we should keep orphan requests a little longer
 		for i < len(parts.requests) {
-			if b.shouldKeep(parts.requests[i], nowUnix) {
+			if b.shouldKeep(parts.requests[i], nowNano) {
 				keep := parts.requests[i:]
 				parts := newTXParts()
 				parts.requests = append(parts.requests, keep...)

--- a/pkg/network/protocols/http/incomplete_stats_test.go
+++ b/pkg/network/protocols/http/incomplete_stats_test.go
@@ -19,23 +19,23 @@ import (
 
 func TestOrphanEntries(t *testing.T) {
 	t.Run("orphan entries can be joined even after flushing", func(t *testing.T) {
-		now := time.Now()
+		nowTS := time.Now()
 		tel := NewTelemetry("http")
 		buffer := newIncompleteBuffer(config.New(), tel)
 		request := &EbpfTx{
 			Request_fragment: requestFragment([]byte("GET /foo/bar")),
-			Request_started:  uint64(now.UnixNano()),
+			Request_started:  uint64(nowTS.UnixNano()),
 		}
 		request.Tup.Sport = 60000
 
 		buffer.Add(request)
-		now = now.Add(5 * time.Second)
+		now := nowTS.Add(5 * time.Second).UnixNano()
 		complete := buffer.Flush(now)
 		assert.Len(t, complete, 0)
 
 		response := &EbpfTx{
 			Response_status_code: 200,
-			Response_last_seen:   uint64(now.UnixNano()),
+			Response_last_seen:   uint64(now),
 		}
 		response.Tup.Sport = 60000
 		buffer.Add(response)
@@ -51,18 +51,18 @@ func TestOrphanEntries(t *testing.T) {
 	t.Run("orphan entries are not kept indefinitely", func(t *testing.T) {
 		tel := NewTelemetry("http")
 		buffer := newIncompleteBuffer(config.New(), tel)
-		now := time.Now()
+		nowTS := time.Now()
 		buffer.minAgeNano = (30 * time.Second).Nanoseconds()
 		request := &EbpfTx{
 			Request_fragment: requestFragment([]byte("GET /foo/bar")),
-			Request_started:  uint64(now.UnixNano()),
+			Request_started:  uint64(nowTS.UnixNano()),
 		}
 		buffer.Add(request)
-		_ = buffer.Flush(now)
+		_ = buffer.Flush(nowTS.UnixNano())
 
 		assert.True(t, len(buffer.data) > 0)
-		now = now.Add(35 * time.Second)
-		_ = buffer.Flush(now)
+		nowTS = nowTS.Add(35 * time.Second)
+		_ = buffer.Flush(nowTS.UnixNano())
 		assert.True(t, len(buffer.data) == 0)
 	})
 }

--- a/pkg/network/protocols/http/incomplete_stats_windows.go
+++ b/pkg/network/protocols/http/incomplete_stats_windows.go
@@ -8,8 +8,6 @@
 package http
 
 import (
-	"time"
-
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 )
 
@@ -21,5 +19,5 @@ func newIncompleteBuffer(c *config.Config, telemetry *Telemetry) *incompleteBuff
 	return &incompleteBuffer{}
 }
 
-func (b *incompleteBuffer) Add(tx Transaction)                {}
-func (b *incompleteBuffer) Flush(now time.Time) []Transaction { return nil }
+func (b *incompleteBuffer) Add(tx Transaction)            {}
+func (b *incompleteBuffer) Flush(now int64) []Transaction { return nil }

--- a/pkg/network/protocols/http/statkeeper.go
+++ b/pkg/network/protocols/http/statkeeper.go
@@ -8,6 +8,7 @@
 package http
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"strconv"
 	"sync"
 	"time"
@@ -68,7 +69,12 @@ func (h *StatKeeper) GetAndResetAllStats() map[Key]*RequestStats {
 	h.mux.Lock()
 	defer h.mux.Unlock()
 
-	for _, tx := range h.incomplete.Flush(time.Now()) {
+	now, err := ebpf.NowNanoseconds()
+	if err != nil {
+		log.Warnf("couldn't get monotonic clock, using realtime clock instead: %s", err)
+		now = time.Now().UnixNano()
+	}
+	for _, tx := range h.incomplete.Flush(now) {
 		h.add(tx)
 	}
 

--- a/pkg/network/protocols/http/statkeeper.go
+++ b/pkg/network/protocols/http/statkeeper.go
@@ -8,11 +8,11 @@
 package http
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"strconv"
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"

--- a/pkg/network/protocols/http/statkeeper.go
+++ b/pkg/network/protocols/http/statkeeper.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -69,12 +68,7 @@ func (h *StatKeeper) GetAndResetAllStats() map[Key]*RequestStats {
 	h.mux.Lock()
 	defer h.mux.Unlock()
 
-	now, err := ebpf.NowNanoseconds()
-	if err != nil {
-		log.Warnf("couldn't get monotonic clock, using realtime clock instead: %s", err)
-		now = time.Now().UnixNano()
-	}
-	for _, tx := range h.incomplete.Flush(now) {
+	for _, tx := range h.incomplete.Flush(getCurrentNanoSeconds()) {
 		h.add(tx)
 	}
 

--- a/pkg/network/protocols/http/statkeeper_linux.go
+++ b/pkg/network/protocols/http/statkeeper_linux.go
@@ -8,9 +8,22 @@
 package http
 
 import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func getPathBufferSize(c *config.Config) int {
 	return int(BufferSize)
+}
+
+func getCurrentNanoSeconds() int64 {
+	now, err := ebpf.NowNanoseconds()
+	if err != nil {
+		log.Warnf("couldn't get monotonic clock, using realtime clock instead: %s", err)
+		now = time.Now().UnixNano()
+	}
+	return now
 }

--- a/pkg/network/protocols/http/statkeeper_windows.go
+++ b/pkg/network/protocols/http/statkeeper_windows.go
@@ -8,9 +8,15 @@
 package http
 
 import (
+	"time"
+
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 )
 
 func getPathBufferSize(c *config.Config) int {
 	return int(c.HTTPMaxRequestFragment)
+}
+
+func getCurrentNanoSeconds() int64 {
+	return time.Now().UnixNano()
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Incomplete buffer `Flush` method is now getting monotonic time instead of real time.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
`Flush` is comparing the input timestamp (previously, relatime clock) with monotonic clock (request's start and end timestamps)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
