### PR TITLE
pkg/trace/info: remove references to the rate limiter.

### DIFF
--- a/cmd/agent/gui/views/private/js/apm.js
+++ b/cmd/agent/gui/views/private/js/apm.js
@@ -40,9 +40,6 @@ var apmTemplate = '' +
 '                <% } else { %>' +
 '                    Priority sampling rate for \'<%= prop[0] %>\': <% prop[1].toFixed(2)*100 %>%' +
 '                <% } %>' +
-'                <% if (ratelimiter.TargetRate > 1.0) { %>' +
-'                    <br>WARNING: Rate-limiter keep percentage: <% ratelimiter.TargetRate.toFixed(2)*100 %>%<br>' +
-'                <% } %>' +
 '            <% }); %>' +
 '        <% } %>' +
 '    </span>' +

--- a/pkg/status/templates/trace-agent.tmpl
+++ b/pkg/status/templates/trace-agent.tmpl
@@ -42,9 +42,6 @@ APM Agent
     Priority sampling rate for '{{ $key }}': {{percent $value}}%
     {{- end}}
     {{- end }}
-    {{- if lt .ratelimiter.TargetRate 1.0}}
-    WARNING: Rate-limiter keep percentage: {{percent .ratelimiter.TargetRate}}%
-    {{- end}}
 
   Writer (previous minute)
   ========================

--- a/pkg/trace/info/info.go
+++ b/pkg/trace/info/info.go
@@ -38,7 +38,6 @@ var (
 	rateByService map[string]float64
 	// The rates by service with empty env values removed (As they are confusing to view for customers)
 	rateByServiceFiltered map[string]float64
-	rateLimiterStats      RateLimiterStats
 	start                 = time.Now()
 	once                  sync.Once
 	infoTmpl              *template.Template
@@ -76,9 +75,6 @@ const (
   {{ range $key, $value := .Status.RateByService }}
   Priority sampling rate for '{{ $key }}': {{percent $value}} %
   {{ end }}
-  {{if lt .Status.RateLimiter.TargetRate 1.0}}
-  WARNING: Rate-limiter keep percentage: {{percent .Status.RateLimiter.TargetRate}} %
-  {{end}}
 
   --- Writer stats (1 min) ---
 
@@ -177,32 +173,6 @@ func publishWatchdogInfo() interface{} {
 	return watchdogInfo
 }
 
-// RateLimiterStats contains rate limiting data. The public content
-// might be interesting for statistics, logging.
-type RateLimiterStats struct {
-	// TargetRate is the rate limiting rate that we are aiming for.
-	TargetRate float64
-	// RecentPayloadsSeen is the number of payloads that passed by.
-	RecentPayloadsSeen float64
-	// RecentTracesSeen is the number of traces that passed by.
-	RecentTracesSeen float64
-	// RecentTracesDropped is the number of traces that were dropped.
-	RecentTracesDropped float64
-}
-
-// UpdateRateLimiter updates internal stats about the rate limiting.
-func UpdateRateLimiter(ss RateLimiterStats) {
-	infoMu.Lock()
-	defer infoMu.Unlock()
-	rateLimiterStats = ss
-}
-
-func publishRateLimiterStats() interface{} {
-	infoMu.RLock()
-	defer infoMu.RUnlock()
-	return rateLimiterStats
-}
-
 func publishUptime() interface{} {
 	return int(time.Since(start) / time.Second)
 }
@@ -242,7 +212,6 @@ type StatusInfo struct {
 	TraceWriter   TraceWriterInfo    `json:"trace_writer"`
 	StatsWriter   StatsWriterInfo    `json:"stats_writer"`
 	Watchdog      watchdog.Info      `json:"watchdog"`
-	RateLimiter   RateLimiterStats   `json:"ratelimiter"`
 	Config        config.AgentConfig `json:"config"`
 }
 
@@ -360,7 +329,6 @@ func initInfo(conf *config.AgentConfig) error {
 	expvar.Publish("ratebyservice", expvar.Func(publishRateByService))
 	expvar.Publish("ratebyservice_filtered", expvar.Func(publishRateByServiceFiltered))
 	expvar.Publish("watchdog", expvar.Func(publishWatchdogInfo))
-	expvar.Publish("ratelimiter", expvar.Func(publishRateLimiterStats))
 
 	// copy the config to ensure we don't expose sensitive data such as API keys
 	c := *conf

--- a/pkg/trace/info/info_test.go
+++ b/pkg/trace/info/info_test.go
@@ -535,18 +535,6 @@ func TestPublishWatchdogInfo(t *testing.T) {
 		})
 }
 
-func TestPublishRateLimiterStats(t *testing.T) {
-	rateLimiterStats = RateLimiterStats{1.0, 2.0, 3.0, 4.0}
-
-	testExpvarPublish(t, publishRateLimiterStats,
-		map[string]interface{}{
-			"TargetRate":          1.0,
-			"RecentPayloadsSeen":  2.0,
-			"RecentTracesSeen":    3.0,
-			"RecentTracesDropped": 4.0,
-		})
-}
-
 func TestScrubCreds(t *testing.T) {
 	assert := assert.New(t)
 	conf := testInit(t)

--- a/pkg/trace/info/testdata/warning.info
+++ b/pkg/trace/info/testdata/warning.info
@@ -18,7 +18,6 @@ Trace Agent (v 0.99.0)
     Spans received: 984
     WARNING: traces_dropped(empty_trace:3), spans_malformed(span_name_empty:3, type_truncate:2)
 
-  WARNING: Rate-limiter keep percentage: 42.1 %
 
   --- Writer stats (1 min) ---
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This removes references to the rate limiter from the pkg/trace/info package.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The rate limiter was removed in #17917 but we still referenced it in the expvars and in the info. 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

`agent status` shouldn't print a warning in the APM section.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
