### PR TITLE
Explore alternate methods to compute Workload Checks time

### DIFF
--- a/.gitlab/functional_test/workload_checks.yml
+++ b/.gitlab/functional_test/workload_checks.yml
@@ -41,8 +41,6 @@ single-machine-performance-workload-checks:
     # DO NOT MERGE, INTENDED FOR TESTING
     - TARGET_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${CI_COMMIT_SHA}-7-amd64
     # Copy the TARGET_IMAGE to SMP for debugging purposes later
-    - echo -n "${TARGET_IMAGE}" > "target_image"
-    - aws s3 cp --profile "${AWS_NAMED_PROFILE}" --only-show-errors "target_image" "s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/"
     - RUST_LOG="info,aws_config::profile::credentials=error"
     - RUST_LOG_DEBUG="debug,aws_config::profile::credentials=error"
     - RUST_BACKTRACE=1 RUST_LOG="${RUST_LOG_DEBUG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}

--- a/.gitlab/functional_test/workload_checks.yml
+++ b/.gitlab/functional_test/workload_checks.yml
@@ -33,7 +33,7 @@ single-machine-performance-workload-checks:
     # Download smp binary and prepare it for use
     - aws --profile single-machine-performance s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-gnu/smp smp
     - chmod +x smp
-    - TARGET_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:nightly--${CI_COMMIT_SHA}-7-amd64 # double -- intended until PR 18932
+    - TARGET_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:nightly-${CI_COMMIT_BRANCH}-${CI_COMMIT_SHA}-7-amd64
     # Copy the TARGET_IMAGE to SMP for debugging purposes later
     - RUST_LOG="info,aws_config::profile::credentials=error"
     - RUST_LOG_DEBUG="debug,aws_config::profile::credentials=error"

--- a/.gitlab/functional_test/workload_checks.yml
+++ b/.gitlab/functional_test/workload_checks.yml
@@ -49,7 +49,7 @@ single-machine-performance-workload-checks:
             --target-name datadog-agent
             --target-command "/bin/entrypoint.sh"
             --target-environment-variables "DD_HOSTNAME=smp-workload-checks,DD_DD_URL=http://127.0.0.1:9092,DD_API_KEY=00000001"
-            --tags status=experimental,commit_time="${CI_COMMIT_TIME}"
+            --tags status=nightly,commit_time="${CI_COMMIT_TIME}"
             --submission-metadata submission-metadata
     # Wait for job to complete.
     - RUST_BACKTRACE=1 RUST_LOG="${RUST_LOG_DEBUG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}

--- a/.gitlab/functional_test/workload_checks.yml
+++ b/.gitlab/functional_test/workload_checks.yml
@@ -40,6 +40,9 @@ single-machine-performance-workload-checks:
     # - TARGET_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:nightly--${CI_COMMIT_SHA}-7-amd64 # double -- intended
     # DO NOT MERGE, INTENDED FOR TESTING
     - TARGET_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${CI_COMMIT_SHA}-7-amd64
+    # Copy the TARGET_IMAGE to SMP for debugging purposes later
+    - echo -n "${TARGET_IMAGE}" > "target_image"
+    - aws s3 cp --profile "${AWS_NAMED_PROFILE}" --only-show-errors "target_image" "s3://${SMP_AGENT_TEAM_ID}-smp-artifacts/information/"
     - RUST_LOG="info,aws_config::profile::credentials=error"
     - RUST_LOG_DEBUG="debug,aws_config::profile::credentials=error"
     - RUST_BACKTRACE=1 RUST_LOG="${RUST_LOG_DEBUG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
@@ -53,7 +56,7 @@ single-machine-performance-workload-checks:
             --target-config-dir test/workload-checks
             --target-name datadog-agent
             --target-command "/bin/entrypoint.sh"
-            --target-environment-variables "DD_HOSTNAME=smp-regression,DD_DD_URL=http://127.0.0.1:9092,DD_API_KEY=00000001"
+            --target-environment-variables "DD_HOSTNAME=smp-workload-checks,DD_DD_URL=http://127.0.0.1:9092,DD_API_KEY=00000001"
             --tags status=experimental,commit_time="${CI_COMMIT_TIME}"
             --submission-metadata submission-metadata
     # Wait for job to complete.

--- a/.gitlab/functional_test/workload_checks.yml
+++ b/.gitlab/functional_test/workload_checks.yml
@@ -5,16 +5,19 @@ single-machine-performance-workload-checks:
   rules:
     !reference [.on_deploy_nightly_repo_branch_a7]
   needs:
-    - job: single_machine_performance-nightly-amd64-a7
+    - job: single_machine_performance-amd64-a7
       artifacts: false
+    # DO NOT MERGE, INTENDED FOR TESTING
+    # - job: single_machine_performance-nightly-amd64-a7
+    #   artifacts: false
   artifacts:
     expire_in: 1 weeks
     paths:
-      - submission_metadata              # for provenance, debugging
+      - submission_metadata # for provenance, debugging
     when: always
   variables:
-    SMP_VERSION: 0.9.2
-    LADING_VERSION: 0.17.3
+    SMP_VERSION: 0.10.0
+    LADING_VERSION: 0.18.0
     WARMUP_SECONDS: 45
     TOTAL_SAMPLES: 600
     REPLICAS: 5
@@ -33,8 +36,9 @@ single-machine-performance-workload-checks:
     # Download smp binary and prepare it for use
     - aws --profile single-machine-performance s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-gnu/smp smp
     - chmod +x smp
-    # Copy the baseline SHA to SMP for debugging purposes later
-    - TARGET_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:nightly-${CI_COMMIT_SHA}-7-amd64
+    # - TARGET_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:nightly--${CI_COMMIT_SHA}-7-amd64 # double -- intended
+    # DO NOT MERGE, INTENDED FOR TESTING
+    - TARGET_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${CI_COMMIT_SHA}-7-amd64
     - echo "${TARGET_SHA}"
     - RUST_LOG="info,aws_config::profile::credentials=error"
     - RUST_LOG_DEBUG="debug,aws_config::profile::credentials=error"
@@ -50,6 +54,7 @@ single-machine-performance-workload-checks:
             --target-name datadog-agent
             --target-command "/bin/entrypoint.sh"
             --target-environment-variables "DD_HOSTNAME=smp-regression,DD_DD_URL=http://127.0.0.1:9092,DD_API_KEY=00000001"
+            --tags status=experimental,commit_time="${CI_COMMIT_TIME}"
             --submission-metadata submission-metadata
     # Wait for job to complete.
     - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}

--- a/.gitlab/functional_test/workload_checks.yml
+++ b/.gitlab/functional_test/workload_checks.yml
@@ -2,8 +2,9 @@ single-machine-performance-workload-checks:
   stage: functional_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker"]
-  rules:
-    !reference [.on_deploy_nightly_repo_branch_a7]
+  # DO NOT MERGE, INTENDED FOR TESTING
+  # rules:
+  #   !reference [.on_deploy_nightly_repo_branch_a7]
   needs:
     - job: single_machine_performance-amd64-a7
       artifacts: false

--- a/.gitlab/functional_test/workload_checks.yml
+++ b/.gitlab/functional_test/workload_checks.yml
@@ -40,10 +40,9 @@ single-machine-performance-workload-checks:
     # - TARGET_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:nightly--${CI_COMMIT_SHA}-7-amd64 # double -- intended
     # DO NOT MERGE, INTENDED FOR TESTING
     - TARGET_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${CI_COMMIT_SHA}-7-amd64
-    - echo "${TARGET_SHA}"
     - RUST_LOG="info,aws_config::profile::credentials=error"
     - RUST_LOG_DEBUG="debug,aws_config::profile::credentials=error"
-    - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
+    - RUST_BACKTRACE=1 RUST_LOG="${RUST_LOG_DEBUG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
             job submit-workload
             --lading-version ${LADING_VERSION}
             --total-samples ${TOTAL_SAMPLES}
@@ -58,8 +57,8 @@ single-machine-performance-workload-checks:
             --tags status=experimental,commit_time="${CI_COMMIT_TIME}"
             --submission-metadata submission-metadata
     # Wait for job to complete.
-    - RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
-            job status --use-curta
+    - RUST_BACKTRACE=1 RUST_LOG="${RUST_LOG_DEBUG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}
+            job status
             --wait
             --wait-delay-seconds 60
             --submission-metadata submission_metadata

--- a/.gitlab/functional_test/workload_checks.yml
+++ b/.gitlab/functional_test/workload_checks.yml
@@ -61,4 +61,4 @@ single-machine-performance-workload-checks:
             job status
             --wait
             --wait-delay-seconds 60
-            --submission-metadata submission_metadata
+            --submission-metadata submission-metadata

--- a/.gitlab/functional_test/workload_checks.yml
+++ b/.gitlab/functional_test/workload_checks.yml
@@ -2,15 +2,11 @@ single-machine-performance-workload-checks:
   stage: functional_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker"]
-  # DO NOT MERGE, INTENDED FOR TESTING
-  # rules:
-  #   !reference [.on_deploy_nightly_repo_branch_a7]
+  rules:
+    !reference [.on_deploy_nightly_repo_branch_a7]
   needs:
-    - job: single_machine_performance-amd64-a7
+    - job: single_machine_performance-nightly-amd64-a7
       artifacts: false
-    # DO NOT MERGE, INTENDED FOR TESTING
-    # - job: single_machine_performance-nightly-amd64-a7
-    #   artifacts: false
   artifacts:
     expire_in: 1 weeks
     paths:
@@ -37,9 +33,7 @@ single-machine-performance-workload-checks:
     # Download smp binary and prepare it for use
     - aws --profile single-machine-performance s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-gnu/smp smp
     - chmod +x smp
-    # - TARGET_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:nightly--${CI_COMMIT_SHA}-7-amd64 # double -- intended
-    # DO NOT MERGE, INTENDED FOR TESTING
-    - TARGET_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${CI_COMMIT_SHA}-7-amd64
+    - TARGET_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:nightly--${CI_COMMIT_SHA}-7-amd64 # double -- intended until PR 18932
     # Copy the TARGET_IMAGE to SMP for debugging purposes later
     - RUST_LOG="info,aws_config::profile::credentials=error"
     - RUST_LOG_DEBUG="debug,aws_config::profile::credentials=error"

--- a/test/workload-checks/typical/cases/apm_app_server/datadog-agent/datadog.yaml
+++ b/test/workload-checks/typical/cases/apm_app_server/datadog-agent/datadog.yaml
@@ -1,0 +1,33 @@
+api_key: 00000000000000000000000000000000
+auth_token_file_path: /tmp/agent-auth-token
+hostname: smp-regression
+
+dd_url: http://127.0.0.1:9092
+
+confd_path: /etc/datadog-agent/conf.d
+
+# Disable cloud detection. This stops the Agent from poking around the
+# execution environment & network. This is particularly important if the target
+# has network access.
+cloud_provider_metadata: []
+
+dogstatsd_socket: '/tmp/dsd.socket'
+telemetry:
+  enabled: true
+
+process_collection:
+  enabled: true
+
+apm_config:
+  enabled: true
+  apm_dd_url: http://127.0.0.1:9091
+  # set an arbitrarily high sample set
+  max_traces_per_second: 1000000
+  errors_per_second: 1000000
+  max_events_per_second: 1000000
+
+logs_enabled: true
+logs_config:
+  logs_dd_url: 127.0.0.1:9091
+  use_http: true
+  logs_no_ssl: true

--- a/test/workload-checks/typical/cases/app_server/datadog-agent/datadog.yaml
+++ b/test/workload-checks/typical/cases/app_server/datadog-agent/datadog.yaml
@@ -1,0 +1,33 @@
+api_key: 00000000000000000000000000000000
+auth_token_file_path: /tmp/agent-auth-token
+hostname: smp-regression
+
+dd_url: http://127.0.0.1:9092
+
+confd_path: /etc/datadog-agent/conf.d
+
+# Disable cloud detection. This stops the Agent from poking around the
+# execution environment & network. This is particularly important if the target
+# has network access.
+cloud_provider_metadata: []
+
+dogstatsd_socket: '/tmp/dsd.socket'
+telemetry:
+  enabled: true
+
+process_collection:
+  enabled: true
+
+apm_config:
+  enabled: true
+  apm_dd_url: http://127.0.0.1:9092
+  # set an arbitrarily high sample set
+  max_traces_per_second: 1000000
+  errors_per_second: 1000000
+  max_events_per_second: 1000000
+
+logs_enabled: true
+logs_config:
+  logs_dd_url: 127.0.0.1:9091
+  use_http: true
+  logs_no_ssl: true

--- a/test/workload-checks/typical/cases/otel_app_server/datadog-agent/datadog.yaml
+++ b/test/workload-checks/typical/cases/otel_app_server/datadog-agent/datadog.yaml
@@ -1,0 +1,45 @@
+api_key: 00000000000000000000000000000000
+auth_token_file_path: /tmp/agent-auth-token
+hostname: smp-regression
+
+dd_url: http://127.0.0.1:9092
+
+confd_path: /etc/datadog-agent/conf.d
+
+# Disable cloud detection. This stops the Agent from poking around the
+# execution environment & network. This is particularly important if the target
+# has network access.
+cloud_provider_metadata: []
+
+dogstatsd_socket: '/tmp/dsd.socket'
+
+process_collection:
+  enabled: true
+
+apm_config:
+  enabled: true
+  apm_dd_url: http://127.0.0.1:9091
+  # set an arbitrarily high sample set
+  max_traces_per_second: 1000000
+  errors_per_second: 1000000
+  max_events_per_second: 1000000
+
+logs_enabled: true
+logs_config:
+  logs_dd_url: 127.0.0.1:9091
+  use_http: true
+  logs_no_ssl: true
+
+otlp_config:
+  receiver:
+    protocols:
+      http:
+        endpoint: 127.0.0.1:4318
+      grpc:
+        endpoint: 127.0.0.1:4317
+  metrics:
+    enabled: true
+  traces:
+    enabled: true
+  debug:
+    loglevel: info


### PR DESCRIPTION
### What does this PR do?

It turns out that the CI_COMMIT_TIME we introduced on nightly container builds stopped functioning at some point between that introduction and the introduction of the functional check. It always felt brittle and I guess it actually was. This commit is an attempt to compute CI commit time in a manner that doesn't rely on a job definition that is broadly shared but is local to the workflow where that information is needed.

REF SMP-673
