### PR TITLE
[Single Machine Performance] Remove CI_COMMIT_TIME

### DIFF
--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -233,7 +233,7 @@ single_machine_performance-nightly-amd64-a7:
   variables:
     IMG_REGISTRIES: internal-aws-smp
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64
-    IMG_DESTINATIONS: 08450328-agent:nightly-${COMMIT_TIME}-${CI_COMMIT_SHA}-7-amd64
+    IMG_DESTINATIONS: 08450328-agent:nightly-${CI_COMMIT_SHA}-7-amd64
 
 # deploys nightlies to agent-dev
 dev_nightly-dogstatsd:

--- a/.gitlab/docker_common/publish_job_templates.yml
+++ b/.gitlab/docker_common/publish_job_templates.yml
@@ -11,8 +11,6 @@
     <<: *docker_variables
     IMG_VARIABLES: ""
     IMG_SIGNING: ""
-  before_script:
-    - export COMMIT_TIME=$(git show -s --format=%ct $CI_COMMIT_SHA)
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
     - source /root/.bashrc
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)

--- a/.gitlab/functional_test/workload_checks.yml
+++ b/.gitlab/functional_test/workload_checks.yml
@@ -37,7 +37,7 @@ single-machine-performance-workload-checks:
     - aws --profile single-machine-performance s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-gnu/smp smp
     - chmod +x smp
     # Copy the baseline SHA to SMP for debugging purposes later
-    - TARGET_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:nightly-${CI_COMMIT_TIME}-${CI_COMMIT_SHA}-7-amd64
+    - TARGET_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:nightly-${CI_COMMIT_SHA}-7-amd64
     - echo "${TARGET_SHA}"
     - RUST_LOG="info,aws_config::profile::credentials=error"
     - RUST_LOG_DEBUG="debug,aws_config::profile::credentials=error"

--- a/.gitlab/functional_test/workload_checks.yml
+++ b/.gitlab/functional_test/workload_checks.yml
@@ -20,10 +20,7 @@ single-machine-performance-workload-checks:
     REPLICAS: 5
   allow_failure: true
   script:
-    # Compute the commit time from CI_COMMIT_SHA, must match the calculation on
-    # `docker_publish_job_definition`.
     - git fetch origin
-    - CI_COMMIT_TIME=$(git show -s --format=%ct $CI_COMMIT_SHA)
     # Setup AWS credentials for single-machine-performance AWS account
     - AWS_NAMED_PROFILE="single-machine-performance"
     - SMP_ACCOUNT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.single-machine-performance-account-id --with-decryption --query "Parameter.Value" --out text)


### PR DESCRIPTION
### What does this PR do?

While the Workload Checks tool still needs to know the commit time we intend to propagate this information through a tag, passed by our tooling. We believe we no longer require the information to be present in the image name. Experiment to verify ongoing in #18931.

REF SMP-673


