### PR TITLE
[CWS] fix display of open flags `O_RDONLY`

### DIFF
--- a/pkg/security/secl/model/consts_common.go
+++ b/pkg/security/secl/model/consts_common.go
@@ -997,21 +997,26 @@ func (f OpenFlags) String() string {
 
 // StringArray returns the open flags as an array of strings
 func (f OpenFlags) StringArray() []string {
-	rdWriteBits := int(f) & 0b11
+	// open flags are actually composed of 2 sets of flags
+	// the lowest 2 bits manage the read/write access modes
+	readWriteBits := int(f) & 0b11
+	// the other bits manage the general purpose flags (like O_CLOEXEC, or O_TRUNC)
 	flagsBits := int(f) & ^0b11
 
-	rdWrite := bitmaskToStringArray(rdWriteBits, openFlagsStrings)
+	// in order to default to O_RDONLY even if other bits are set we convert
+	// both bitmask separately
+	readWrite := bitmaskToStringArray(readWriteBits, openFlagsStrings)
 	flags := bitmaskToStringArray(flagsBits, openFlagsStrings)
 
-	if len(rdWrite) == 0 {
-		rdWrite = []string{openFlagsStrings[syscall.O_RDONLY]}
+	if len(readWrite) == 0 {
+		readWrite = []string{openFlagsStrings[syscall.O_RDONLY]}
 	}
 
 	if len(flags) == 0 {
-		return rdWrite
+		return readWrite
 	}
 
-	return append(rdWrite, flags...)
+	return append(readWrite, flags...)
 }
 
 // FileMode represents a file mode bitmask value

--- a/pkg/security/secl/model/consts_common.go
+++ b/pkg/security/secl/model/consts_common.go
@@ -992,18 +992,26 @@ func bitmaskU64ToString(bitmask uint64, intToStrMap map[uint64]string) string {
 type OpenFlags int
 
 func (f OpenFlags) String() string {
-	if int(f) == syscall.O_RDONLY {
-		return openFlagsStrings[syscall.O_RDONLY]
-	}
-	return bitmaskToString(int(f), openFlagsStrings)
+	return strings.Join(f.StringArray(), " | ")
 }
 
 // StringArray returns the open flags as an array of strings
 func (f OpenFlags) StringArray() []string {
-	if int(f) == syscall.O_RDONLY {
-		return []string{openFlagsStrings[syscall.O_RDONLY]}
+	rdWriteBits := int(f) & 0b11
+	flagsBits := int(f) & ^0b11
+
+	rdWrite := bitmaskToStringArray(rdWriteBits, openFlagsStrings)
+	flags := bitmaskToStringArray(flagsBits, openFlagsStrings)
+
+	if len(rdWrite) == 0 {
+		rdWrite = []string{openFlagsStrings[syscall.O_RDONLY]}
 	}
-	return bitmaskToStringArray(int(f), openFlagsStrings)
+
+	if len(flags) == 0 {
+		return rdWrite
+	}
+
+	return append(rdWrite, flags...)
 }
 
 // FileMode represents a file mode bitmask value

--- a/pkg/security/secl/model/consts_test.go
+++ b/pkg/security/secl/model/consts_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestFlagsToString(t *testing.T) {
 	str := OpenFlags(syscall.O_EXCL | syscall.O_TRUNC).String()
-	if str != "O_EXCL | O_TRUNC" {
+	if str != "O_RDONLY | O_EXCL | O_TRUNC" {
 		t.Errorf("expected flags not found, got: %s", str)
 	}
 
@@ -25,12 +25,22 @@ func TestFlagsToString(t *testing.T) {
 	}
 
 	str = OpenFlags(syscall.O_EXCL | syscall.O_TRUNC | 1<<32).String()
-	if str != fmt.Sprintf("%d | O_EXCL | O_TRUNC", 1<<32) {
+	if str != fmt.Sprintf("O_RDONLY | %d | O_EXCL | O_TRUNC", 1<<32) {
 		t.Errorf("expected flags not found, got: %s", str)
 	}
 
 	str = OpenFlags(syscall.O_RDONLY).String()
 	if str != "O_RDONLY" {
+		t.Errorf("expected flags not found, got: %s", str)
+	}
+
+	str = OpenFlags(syscall.O_RDONLY | syscall.O_RDWR).String()
+	if str != "O_RDWR" {
+		t.Errorf("expected flags not found, got: %s", str)
+	}
+
+	str = OpenFlags(syscall.O_RDONLY | syscall.O_CLOEXEC).String()
+	if str != "O_RDONLY | O_CLOEXEC" {
 		t.Errorf("expected flags not found, got: %s", str)
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR improves (some would say fixes) the way we display `O_RDONLY` in open flags.

The way this was done before is that we would default to `O_RDONLY` only if flags were otherwise empty/0. This does not match what strace for example is doing, defaulting to `O_RDONLY` for the R/W bits event if some other flags (like `O_CLOEXEC` or others are set).

To match the behavior of strace this PR splits the bits between the R/W bits and the other flags and compute the result for each separately before defaulting and concatenating. The test suite is updated to match the new behavior as well.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
