### PR TITLE
usm: Fixed payload size calculation

### DIFF
--- a/pkg/network/ebpf/c/ip.h
+++ b/pkg/network/ebpf/c/ip.h
@@ -120,6 +120,7 @@ static __always_inline void read_ipv4_skb(struct __sk_buff *skb, __u64 off, __u6
 // that manipulates a `__sk_buff` object.
 typedef struct {
     __u32 data_off;
+    __u32 data_end;
     __u32 tcp_seq;
     __u8 tcp_flags;
 } skb_info_t;
@@ -131,11 +132,13 @@ __maybe_unused static __always_inline __u64 read_conn_tuple_skb(struct __sk_buff
     info->data_off = ETH_HLEN;
 
     __u16 l3_proto = __load_half(skb, offsetof(struct ethhdr, h_proto));
+    info->data_end = ETH_HLEN;
     __u8 l4_proto = 0;
     switch (l3_proto) {
     case ETH_P_IP:
     {
         __u8 ipv4_hdr_len = (__load_byte(skb, info->data_off) & 0x0f) << 2;
+        info->data_end += __load_half(skb, info->data_off + offsetof(struct iphdr, tot_len));
         if (ipv4_hdr_len < sizeof(struct iphdr)) {
             return 0;
         }
@@ -147,6 +150,7 @@ __maybe_unused static __always_inline __u64 read_conn_tuple_skb(struct __sk_buff
         break;
     }
     case ETH_P_IPV6:
+        info->data_end += sizeof(struct ipv6hdr) + __load_half(skb, info->data_off + offsetof(struct ipv6hdr, payload_len));
         l4_proto = __load_byte(skb, info->data_off + offsetof(struct ipv6hdr, nexthdr));
         tup->metadata |= CONN_V6;
         read_ipv6_skb(skb, info->data_off + offsetof(struct ipv6hdr, saddr), &tup->saddr_l, &tup->saddr_h);
@@ -178,7 +182,7 @@ __maybe_unused static __always_inline __u64 read_conn_tuple_skb(struct __sk_buff
         return 0;
     }
 
-    if ((skb->len - info->data_off) < 0) {
+    if ((info->data_end - info->data_off) < 0) {
         return 0;
     }
 

--- a/pkg/network/ebpf/c/protocols/classification/common.h
+++ b/pkg/network/ebpf/c/protocols/classification/common.h
@@ -26,8 +26,8 @@ static __always_inline bool is_tcp(conn_tuple_t *tup) {
 }
 
 // Returns true if the payload is empty.
-static __always_inline bool is_payload_empty(struct __sk_buff *skb, skb_info_t *skb_info) {
-    return skb_info->data_off == skb->len;
+static __always_inline bool is_payload_empty(skb_info_t *skb_info) {
+    return skb_info->data_off == skb_info->data_end;
 }
 
 READ_INTO_BUFFER(for_classification, CLASSIFICATION_MAX_BUFFER, BLK_SIZE)

--- a/pkg/network/ebpf/c/protocols/classification/dispatcher-helpers.h
+++ b/pkg/network/ebpf/c/protocols/classification/dispatcher-helpers.h
@@ -98,7 +98,7 @@ static __always_inline void protocol_dispatcher_entrypoint(struct __sk_buff *skb
 
     bool tcp_termination = is_tcp_termination(&skb_info);
     // We don't process non tcp packets, nor empty tcp packets which are not tcp termination packets.
-    if (!is_tcp(&skb_tup) || (is_payload_empty(skb, &skb_info) && !tcp_termination)) {
+    if (!is_tcp(&skb_tup) || (is_payload_empty(&skb_info) && !tcp_termination)) {
         return;
     }
 
@@ -135,7 +135,7 @@ static __always_inline void protocol_dispatcher_entrypoint(struct __sk_buff *skb
         char request_fragment[CLASSIFICATION_MAX_BUFFER];
         bpf_memset(request_fragment, 0, sizeof(request_fragment));
         read_into_buffer_for_classification((char *)request_fragment, skb, skb_info.data_off);
-        const size_t payload_length = skb->len - skb_info.data_off;
+        const size_t payload_length = skb_info.data_end - skb_info.data_off;
         const size_t final_fragment_size = payload_length < CLASSIFICATION_MAX_BUFFER ? payload_length : CLASSIFICATION_MAX_BUFFER;
         classify_protocol_for_dispatcher(&cur_fragment_protocol, &skb_tup, request_fragment, final_fragment_size);
         if (is_kafka_monitoring_enabled() && cur_fragment_protocol == PROTOCOL_UNKNOWN) {
@@ -176,7 +176,7 @@ static __always_inline void dispatch_kafka(struct __sk_buff *skb) {
     char request_fragment[CLASSIFICATION_MAX_BUFFER];
     bpf_memset(request_fragment, 0, sizeof(request_fragment));
     read_into_buffer_for_classification((char *)request_fragment, skb, skb_info.data_off);
-    const size_t payload_length = skb->len - skb_info.data_off;
+    const size_t payload_length = skb_info.data_end - skb_info.data_off;
     const size_t final_fragment_size = payload_length < CLASSIFICATION_MAX_BUFFER ? payload_length : CLASSIFICATION_MAX_BUFFER;
     protocol_t cur_fragment_protocol = PROTOCOL_UNKNOWN;
     if (is_kafka(skb, &skb_info, request_fragment, final_fragment_size)) {

--- a/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
+++ b/pkg/network/ebpf/c/protocols/classification/protocol-classification.h
@@ -144,7 +144,7 @@ __maybe_unused static __always_inline void protocol_classifier_entrypoint(struct
     }
 
     // We support non empty TCP payloads for classification at the moment.
-    if (!is_tcp(&skb_tup) || is_payload_empty(skb, &skb_info)) {
+    if (!is_tcp(&skb_tup) || is_payload_empty(&skb_info)) {
         return;
     }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Calculating the payload's real size instead of relying on `skb->len`
Currently fixing a limited scope of functions, as `is_payload_empty` and the calculation of payload length in the protocol dispatcher.
This is meant to fix a bug introduced by removing the check of `is_ack` by #18673 


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The problem is caused by TCP padding, we experienced the same issue as described [here](https://ask.wireshark.org/question/11194/tcp-ack-shows-only-54-bytes-in-wireshark/)
While the `skb->len` correctly points to 60 bytes, the actual tcp payload is empty.
Thus we are getting an ACK packet which should be empty (with padding), but our code does not treat it as an empty ACK packet, but as an ACK with 6 bytes.
We're trying to process it, and while we do, we're caching the tcp sequence as seen.
Later we get an actual packet with tcp payload (for example http response), but we're not processing the packet (and the data) as we have already processed that tcp sequence.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. Run system probe with usm enabled (http monitoring)
2. Run `curl example.com`
3. Pull the http payloads `sudo curl --unix /opt/datadog-agent/run/sysprobe.sock http://unix/network_tracer/debug/http_monitoring` expect to see the request from above

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
