### PR TITLE
Fix host metadata to correctly reflect running on Windows 11

### DIFF
--- a/pkg/gohai/platform/platform_windows.go
+++ b/pkg/gohai/platform/platform_windows.go
@@ -193,15 +193,13 @@ func fetchOsDescription() (string, error) {
 		if procBrandingFormatString.Find() == nil {
 			// Encode the string "%WINDOWS_LONG%" to UTF-16 and append a null byte for the Windows API
 			magicString := utf16.Encode([]rune("%WINDOWS_LONG%" + "\x00"))
-			os, _, err := procBrandingFormatString.Call(uintptr(unsafe.Pointer(&magicString[0])))
-			if err == ERROR_SUCCESS {
-				// ignore free errors
-				//nolint:errcheck
-				defer windows.LocalFree(windows.Handle(os))
-				// govet complains about possible misuse of unsafe.Pointer here
-				//nolint:govet
-				return windows.UTF16PtrToString((*uint16)(unsafe.Pointer(os))), nil
-			}
+			// Don't check for err, as this API doesn't return an error but just a formatted string.
+			os, _, _ := procBrandingFormatString.Call(uintptr(unsafe.Pointer(&magicString[0])))
+			//nolint:errcheck
+			defer windows.LocalFree(windows.Handle(os))
+			// govet complains about possible misuse of unsafe.Pointer here
+			//nolint:govet
+			return windows.UTF16PtrToString((*uint16)(unsafe.Pointer(os))), nil
 		}
 	}
 

--- a/pkg/gohai/platform/platform_windows.go
+++ b/pkg/gohai/platform/platform_windows.go
@@ -195,11 +195,13 @@ func fetchOsDescription() (string, error) {
 			magicString := utf16.Encode([]rune("%WINDOWS_LONG%" + "\x00"))
 			// Don't check for err, as this API doesn't return an error but just a formatted string.
 			os, _, _ := procBrandingFormatString.Call(uintptr(unsafe.Pointer(&magicString[0])))
-			//nolint:errcheck
-			defer windows.LocalFree(windows.Handle(os))
-			// govet complains about possible misuse of unsafe.Pointer here
-			//nolint:govet
-			return windows.UTF16PtrToString((*uint16)(unsafe.Pointer(os))), nil
+			if os != 0 {
+				//nolint:errcheck
+				defer windows.LocalFree(windows.Handle(os))
+				// govet complains about possible misuse of unsafe.Pointer here
+				//nolint:govet
+				return windows.UTF16PtrToString((*uint16)(unsafe.Pointer(os))), nil
+			}
 		}
 	}
 

--- a/releasenotes/notes/fix-windows-11-host-metadata-06fdf71ccb85e790.yaml
+++ b/releasenotes/notes/fix-windows-11-host-metadata-06fdf71ccb85e790.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    On Windows the host metadata correctly reflects Windows 11 version.

--- a/releasenotes/notes/fix-windows-11-host-metadata-06fdf71ccb85e790.yaml
+++ b/releasenotes/notes/fix-windows-11-host-metadata-06fdf71ccb85e790.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    On Windows the host metadata correctly reflects Windows 11 version.
+    On Windows, the host metadata correctly reflects the Windows 11 version.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR fixes the call to `BrandingFormatString`, previously we were checking for the `err` returned from https://github.com/golang/sys/blob/master/windows/dll_windows.go#L165 but `BrandingFormatString` doesn't return an error, nor sets `LastError`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Correct OS display in Datadog.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Run the Agent on Windows 11 and ensure that in Datadog it displays correctly as Windows 11 and not Windows 10.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
