### PR TITLE
[Orchestrator] skip resources missing RBACs

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -8,6 +8,7 @@
 package orchestrator
 
 import (
+	"expvar"
 	"strings"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/discovery"
 	"github.com/DataDog/datadog-agent/pkg/orchestrator"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -25,6 +27,13 @@ import (
 const (
 	defaultExtraSyncTimeout = 60 * time.Second
 	defaultMaximumCRDs      = 100
+)
+
+var (
+	skippedResourcesExpVars = expvar.NewMap("orchestrator-skipped-resources")
+	skippedResources        = map[string]*expvar.String{}
+
+	tlmSkippedResources = telemetry.NewCounter("orchestrator", "skipped_resources", []string{"name"}, "Skipped resources in orchestrator check")
 )
 
 // CollectorBundle is a container for a group of collectors. It provides a way
@@ -263,11 +272,17 @@ func (cb *CollectorBundle) Initialize() error {
 	informerSynced := map[cache.SharedInformer]struct{}{}
 
 	for _, collector := range cb.collectors {
+		collectorFullName := collector.Metadata().FullName()
+
+		// init metrics
+		skippedResources[collectorFullName] = &expvar.String{}
+		skippedResourcesExpVars.Set(collectorFullName, skippedResources[collectorFullName])
+
 		collector.Init(cb.runCfg)
 		informer := collector.Informer()
 
 		if _, found := informerSynced[informer]; !found {
-			informersToSync[apiserver.InformerName(collector.Metadata().FullName())] = informer
+			informersToSync[apiserver.InformerName(collectorFullName)] = informer
 			informerSynced[informer] = struct{}{}
 			// we run each enabled informer individually, because starting them through the factory
 			// would prevent us from restarting them again if the check is unscheduled/rescheduled
@@ -277,7 +292,29 @@ func (cb *CollectorBundle) Initialize() error {
 		}
 	}
 
-	return apiserver.SyncInformers(informersToSync, cb.extraSyncTimeout)
+	errors := apiserver.SyncInformersReturnErrors(informersToSync, cb.extraSyncTimeout)
+
+	for informerName, err := range errors {
+		if err != nil {
+			cb.skipCollector(informerName, err)
+		}
+	}
+
+	return nil
+}
+
+func (cb *CollectorBundle) skipCollector(informerName apiserver.InformerName, err error) {
+	for _, collector := range cb.collectors {
+		collectorFullName := collector.Metadata().FullName()
+		if apiserver.InformerName(collectorFullName) == informerName {
+			collector.Metadata().IsSkipped = true
+			collector.Metadata().SkippedReason = err.Error()
+
+			// emit metrics
+			skippedResources[collectorFullName].Set(err.Error())
+			tlmSkippedResources.Inc(collectorFullName)
+		}
+	}
 }
 
 // Run is used to sequentially run all collectors in the bundle.
@@ -290,6 +327,11 @@ func (cb *CollectorBundle) Run(sender sender.Sender) {
 	}
 
 	for _, collector := range cb.collectors {
+		if collector.Metadata().IsSkipped {
+			log.Warnf("Collector %s is skipped: %s", collector.Metadata().FullName(), collector.Metadata().SkippedReason)
+			continue
+		}
+
 		runStartTime := time.Now()
 
 		result, err := collector.Run(cb.runCfg)

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/collector.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/collector.go
@@ -9,18 +9,18 @@ package collectors
 
 import (
 	"fmt"
+
+	"go.uber.org/atomic"
 	"k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	vpai "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/informers/externalversions"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
 	"github.com/DataDog/datadog-agent/pkg/orchestrator"
 	"github.com/DataDog/datadog-agent/pkg/orchestrator/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
-
-	"go.uber.org/atomic"
-	"k8s.io/client-go/tools/cache"
 )
 
 // Collector is an interface that represents the collection process for a
@@ -75,6 +75,8 @@ type CollectorMetadata struct {
 	Name                      string
 	NodeType                  orchestrator.NodeType
 	Version                   string
+	IsSkipped                 bool
+	SkippedReason             string
 }
 
 // FullName returns a string that contains the collector name and version.

--- a/pkg/status/templates/orchestrator.tmpl
+++ b/pkg/status/templates/orchestrator.tmpl
@@ -58,9 +58,9 @@ Orchestrator Explorer
       Last Run: (Hits: {{$element.CacheHits}} Miss: {{$element.CacheMiss}}) | Total: (Hits: {{$element.TotalHits}} Miss: {{$element.TotalMiss}})
 {{end}}
 {{- if .SkippedResources }}
-  ===========
+  =================
   Skipped Resources
-  ===========
+  =================
   {{- range $name, $reason := .SkippedResources}}
     {{$name}} : {{$reason}}
   {{- end}}

--- a/pkg/status/templates/orchestrator.tmpl
+++ b/pkg/status/templates/orchestrator.tmpl
@@ -57,6 +57,14 @@ Orchestrator Explorer
     {{ $element.NodeType }}
       Last Run: (Hits: {{$element.CacheHits}} Miss: {{$element.CacheMiss}}) | Total: (Hits: {{$element.TotalHits}} Miss: {{$element.TotalMiss}})
 {{end}}
+{{- if .SkippedResources }}
+  ===========
+  Skipped Resources
+  ===========
+  {{- range $name, $reason := .SkippedResources}}
+    {{$name}} : {{$reason}}
+  {{- end}}
+{{- end}}
 {{- if .ManifestCollection }}
   =====================
   Manifest Buffer Stats

--- a/pkg/util/kubernetes/apiserver/util.go
+++ b/pkg/util/kubernetes/apiserver/util.go
@@ -51,6 +51,53 @@ func SyncInformers(informers map[InformerName]cache.SharedInformer, extraWait ti
 	return g.Wait()
 }
 
+type syncInformerResult struct {
+	informerName InformerName
+	err          error
+}
+
+// SyncInformersReturnErrors does the same thing as SyncInformers except it returns a map of InformerName and error
+func SyncInformersReturnErrors(informers map[InformerName]cache.SharedInformer, extraWait time.Duration) map[InformerName]error {
+	resultChan := make(chan syncInformerResult)
+	errors := make(map[InformerName]error, len(informers))
+	timeoutConfig := config.Datadog.GetDuration("kube_cache_sync_timeout_seconds") * time.Second
+	// syncTimeout can be used to wait for the kubernetes client-go cache to sync.
+	// It cannot be retrieved at the package-level due to the package being imported before configs are loaded.
+	syncTimeout := timeoutConfig + extraWait
+	for name := range informers {
+		name := name // https://golang.org/doc/faq#closures_and_goroutines
+		go (func() {
+			ctx, cancel := context.WithTimeout(context.Background(), syncTimeout)
+			defer cancel()
+			start := time.Now()
+			if !cache.WaitForCacheSync(ctx.Done(), informers[name].HasSynced) {
+				end := time.Now()
+				cacheSyncTimeouts.Inc()
+				log.Warnf("couldn't sync informer %s in %v (kube_cache_sync_timeout_seconds: %v)", name, end.Sub(start), timeoutConfig)
+				resultChan <- syncInformerResult{
+					informerName: name,
+					err:          fmt.Errorf("couldn't sync informer %s in %v", name, end.Sub(start)),
+				}
+				return
+			}
+			log.Debugf("Sync done for informer %s in %v, last resource version: %s", name, time.Since(start), informers[name].LastSyncResourceVersion())
+			resultChan <- syncInformerResult{
+				informerName: name,
+				err:          nil,
+			}
+		})()
+	}
+
+	for r := range resultChan {
+		errors[r.informerName] = r.err
+		if len(errors) == len(informers) {
+			break
+		}
+	}
+
+	return errors
+}
+
 // UnstructuredIntoWPA converts an unstructured into a WPA
 func UnstructuredIntoWPA(obj interface{}, structDest *v1alpha1.WatermarkPodAutoscaler) error {
 	unstrObj, ok := obj.(*unstructured.Unstructured)

--- a/releasenotes-dca/notes/skip-resource-missing-rbacs-0101d8050b268712.yaml
+++ b/releasenotes-dca/notes/skip-resource-missing-rbacs-0101d8050b268712.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Skip collections for resources missing RBACs in orchestrator check


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Skipping resources missing RBACs and continuing other collections in Orchestrator check

Logs

```
2023-08-22 08:17:44 PDT | CLUSTER | WARN | (pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go:331 in Run) | Collector crd.projectcalico.org/v1/clusterinformations is skipped: couldn't sync informer crd.projectcalico.org/v1/clusterinformations in 5.000056921s
2023-08-22 08:17:44 PDT | CLUSTER | WARN | (pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go:331 in Run) | Collector rbac.authorization.k8s.io/v1/rolebindings is skipped: couldn't sync informer rbac.authorization.k8s.io/v1/rolebindings in 4.999977922s
2023-08-22 08:17:44 PDT | CLUSTER | WARN | (pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go:331 in Run) | Collector v1/namespaces is skipped: couldn't sync informer v1/namespaces in 5.000087464s
```

Agent Flare
```
  ===========
  Skipped Resources
  ===========
    crd.projectcalico.org/v1/clusterinformations : couldn't sync informer crd.projectcalico.org/v1/clusterinformations in 5.000056921s
    rbac.authorization.k8s.io/v1/rolebindings : couldn't sync informer rbac.authorization.k8s.io/v1/rolebindings in 4.999977922s
    v1/namespaces : couldn't sync informer v1/namespaces in 5.000087464s
  =====================

```


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
