### PR TITLE
[CI] Refactor pipelines notification Slack message

### DIFF
--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -9,7 +9,7 @@ from .types import FailedJobType, Test
 
 DEFAULT_SLACK_CHANNEL = "#agent-platform"
 DEFAULT_JIRA_PROJECT = "AGENTR"
-DATADOG_AGENT_GITHUB_REPO_URL = "https://github.com/DataDog/datadog-agent"
+DATADOG_AGENT_GITHUB_ORG_URL = "https://github.com/DataDog"
 # Map keys in lowercase
 GITHUB_SLACK_MAP = {
     "@datadog/agent-platform": DEFAULT_SLACK_CHANNEL,
@@ -149,19 +149,24 @@ def find_job_owners(failed_jobs, owners_file=".gitlab/JOBOWNERS"):
 
 
 def base_message(header, state):
-    commit_title=os.getenv("CI_COMMIT_TITLE")
-    pipeline_url=os.getenv("CI_PIPELINE_URL")
-    pipeline_id=os.getenv("CI_PIPELINE_ID")
-    commit_ref_name=os.getenv("CI_COMMIT_REF_NAME")
-    commit_url_gitlab=f"{os.getenv('CI_PROJECT_URL')}/commit/{os.getenv('CI_COMMIT_SHA')}",
-    commit_url_github=f"{DATADOG_AGENT_GITHUB_REPO_URL}/commit/{os.getenv('CI_COMMIT_SHA')}",
-    commit_short_sha=os.getenv("CI_COMMIT_SHORT_SHA")
-    author=get_git_author()
+    project_title = os.getenv("CI_PROJECT_TITLE")
+    commit_title = os.getenv("CI_COMMIT_TITLE")
+    pipeline_url = os.getenv("CI_PIPELINE_URL")
+    pipeline_id = os.getenv("CI_PIPELINE_ID")
+    commit_ref_name = os.getenv("CI_COMMIT_REF_NAME")
+    commit_url_gitlab = f"{os.getenv('CI_PROJECT_URL')}/commit/{os.getenv('CI_COMMIT_SHA')}",
+    commit_url_github = f"{DATADOG_AGENT_GITHUB_ORG_URL}/{project_title}/commit/{os.getenv('CI_COMMIT_SHA')}",
+    commit_short_sha = os.getenv("CI_COMMIT_SHORT_SHA")
+    author = get_git_author()
+
+    # Try to found a PR id (e.g #12345) in the commit title and add a link to it in the message if found.
     parsed_pr_id_found = re.search(r'.*\(#([0-9]*)\)$', commit_title)
+    enhanced_commit_title = commit_title
     if parsed_pr_id_found:
         parsed_pr_id = parsed_pr_id_found.group(1)
-    pr_url_github = f"{DATADOG_AGENT_GITHUB_REPO_URL}/pull/{parsed_pr_id}"
-    enhanced_commit_title = commit_title.replace(f"#{parsed_pr_id}", f"<{pr_url_github} | #{parsed_pr_id}>")
+        pr_url_github = f"{DATADOG_AGENT_GITHUB_ORG_URL}/{project_title}/pull/{parsed_pr_id}"
+        enhanced_commit_title = enhanced_commit_title.replace(f"#{parsed_pr_id}", f"<{pr_url_github} | #{parsed_pr_id}>")
+
     return f"""{header} pipeline <{pipeline_url}|{pipeline_id}> for {commit_ref_name} {state}.
 {enhanced_commit_title} (<{commit_url_gitlab}|{commit_short_sha}>)(:github: <{commit_url_github} | link>) by {author}"""
 

--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -165,9 +165,7 @@ def base_message(header, state):
     if parsed_pr_id_found:
         parsed_pr_id = parsed_pr_id_found.group(1)
         pr_url_github = f"{DATADOG_AGENT_GITHUB_ORG_URL}/{project_title}/pull/{parsed_pr_id}"
-        enhanced_commit_title = enhanced_commit_title.replace(
-            f"#{parsed_pr_id}", f"<{pr_url_github}|#{parsed_pr_id}>"
-        )
+        enhanced_commit_title = enhanced_commit_title.replace(f"#{parsed_pr_id}", f"<{pr_url_github}|#{parsed_pr_id}>")
 
     return f"""{header} pipeline <{pipeline_url}|{pipeline_id}> for {commit_ref_name} {state}.
 {enhanced_commit_title} (<{commit_url_gitlab}|{commit_short_sha}>)(:github: <{commit_url_github}|link>) by {author}"""

--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -1,8 +1,8 @@
 import json
 import os
+import re
 import subprocess
 from collections import defaultdict
-import re
 
 from .common.gitlab import Gitlab, get_gitlab_token
 from .types import FailedJobType, Test

--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -165,10 +165,10 @@ def base_message(header, state):
     if parsed_pr_id_found:
         parsed_pr_id = parsed_pr_id_found.group(1)
         pr_url_github = f"{DATADOG_AGENT_GITHUB_ORG_URL}/{project_title}/pull/{parsed_pr_id}"
-        enhanced_commit_title = enhanced_commit_title.replace(f"#{parsed_pr_id}", f"<{pr_url_github} | #{parsed_pr_id}>")
+        enhanced_commit_title = enhanced_commit_title.replace(f"#{parsed_pr_id}", f"<{pr_url_github}|#{parsed_pr_id}>")
 
     return f"""{header} pipeline <{pipeline_url}|{pipeline_id}> for {commit_ref_name} {state}.
-{enhanced_commit_title} (<{commit_url_gitlab}|{commit_short_sha}>)(:github: <{commit_url_github} | link>) by {author}"""
+{enhanced_commit_title} (<{commit_url_gitlab}|{commit_short_sha}>)(:github: <{commit_url_github}|link>) by {author}"""
 
 
 def get_git_author():

--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -159,7 +159,7 @@ def base_message(header, state):
     commit_short_sha = os.getenv("CI_COMMIT_SHORT_SHA")
     author = get_git_author()
 
-    # Try to found a PR id (e.g #12345) in the commit title and add a link to it in the message if found.
+    # Try to find a PR id (e.g #12345) in the commit title and add a link to it in the message if found.
     parsed_pr_id_found = re.search(r'.*\(#([0-9]*)\)$', commit_title)
     enhanced_commit_title = commit_title
     if parsed_pr_id_found:

--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -165,7 +165,9 @@ def base_message(header, state):
     if parsed_pr_id_found:
         parsed_pr_id = parsed_pr_id_found.group(1)
         pr_url_github = f"{DATADOG_AGENT_GITHUB_ORG_URL}/{project_title}/pull/{parsed_pr_id}"
-        enhanced_commit_title = enhanced_commit_title.replace(f"#{parsed_pr_id}", f"<{pr_url_github}|#{parsed_pr_id}>")
+        enhanced_commit_title = enhanced_commit_title.replace(
+            f"#{parsed_pr_id}", f"<{pr_url_github}|#{parsed_pr_id}>"
+        )
 
     return f"""{header} pipeline <{pipeline_url}|{pipeline_id}> for {commit_ref_name} {state}.
 {enhanced_commit_title} (<{commit_url_gitlab}|{commit_short_sha}>)(:github: <{commit_url_github}|link>) by {author}"""

--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -154,8 +154,8 @@ def base_message(header, state):
     pipeline_url = os.getenv("CI_PIPELINE_URL")
     pipeline_id = os.getenv("CI_PIPELINE_ID")
     commit_ref_name = os.getenv("CI_COMMIT_REF_NAME")
-    commit_url_gitlab = f"{os.getenv('CI_PROJECT_URL')}/commit/{os.getenv('CI_COMMIT_SHA')}",
-    commit_url_github = f"{DATADOG_AGENT_GITHUB_ORG_URL}/{project_title}/commit/{os.getenv('CI_COMMIT_SHA')}",
+    commit_url_gitlab = f"{os.getenv('CI_PROJECT_URL')}/commit/{os.getenv('CI_COMMIT_SHA')}"
+    commit_url_github = f"{DATADOG_AGENT_GITHUB_ORG_URL}/{project_title}/commit/{os.getenv('CI_COMMIT_SHA')}"
     commit_short_sha = os.getenv("CI_COMMIT_SHORT_SHA")
     author = get_git_author()
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR refactors the messages we get when a pipeline fail in the Slack channels.
It adds the PR link and the commit link to Github

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Right now, the PR id is printed but there's no link. Also the commit link is targeting gitlab.
Github is in practice way more used, so I added both PR and commit link to Github.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
