### PR TITLE
[Single Machine Performance] Modify .gitignore for test material

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,5 +201,6 @@ test/fakeintake/build/*
 # dev container
 .devcontainer/
 
-# Allow Regression Detector material to ignore excludes
+# Allow Single Machine Performance material to ignore excludes
 !test/regression/**
+!test/workload-checks/**


### PR DESCRIPTION
### What does this PR do?

This commit is similar in motivation to #16795. Single Machine Performance's test material requires `datadog-agent.yaml` files to be present in-tree and tracked by git. 

### Motivation

This is the root of the problem uncovered in #18931: vital test files were missing and the Workload Checks experiments could not run.

REF SMP-673

