### PR TITLE
[DRAFT] Componentize netflow

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -600,8 +600,8 @@ func startAgent(
 	// Start NetFlow server
 	// This must happen after LoadComponents is set up (via common.LoadComponents).
 	// netflow.StartServer uses AgentDemultiplexer, that uses ContextResolver, that uses the tagger (initialized by LoadComponents)
-	if netflow.IsEnabled() {
-		if err = netflow.StartServer(demux); err != nil {
+	if netflow.IsEnabled(pkgconfig.Datadog) {
+		if err = netflow.StartServer(demux, pkgconfig.Datadog, log); err != nil {
 			log.Errorf("Failed to start NetFlow server: %s", err)
 		}
 	}

--- a/comp/netflow/bundle.go
+++ b/comp/netflow/bundle.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package netflow implements the "netflow" bundle
+package netflow
+
+import (
+	"github.com/DataDog/datadog-agent/comp/netflow/server"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: network-device-monitoring
+
+// Bundle defines the fx options for this bundle.
+var Bundle = fxutil.Bundle(
+	server.Module,
+)

--- a/comp/netflow/server/component.go
+++ b/comp/netflow/server/component.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package server implements a component that runs the netflow observation server.
+package server
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/netflow"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: network-device-monitoring
+
+// Component is the component type.
+type Component interface {
+	Start() error
+	Stop()
+}
+
+// Module defines the fx options for this component.
+var Module = fxutil.Component(
+	fx.Provide(newServer),
+)
+
+// Mock implements mock-specific methods.
+type Mock interface {
+	Component
+}
+
+type dependencies struct {
+	fx.In
+	Config config.Component
+	Logger log.Component
+	Demux  aggregator.DemultiplexerWithAggregator
+}
+
+func newServer(dep dependencies) (Component, error) {
+	epForwarder, err := dep.Demux.GetEventPlatformForwarder()
+	if err != nil {
+		return nil, err
+	}
+
+	sender, err := dep.Demux.GetDefaultSender()
+	if err != nil {
+		return nil, err
+	}
+	return netflow.NewNetflowServer(sender, epForwarder, dep.Config, dep.Logger)
+}

--- a/pkg/netflow/config/config.go
+++ b/pkg/netflow/config/config.go
@@ -9,7 +9,7 @@ package config
 import (
 	"fmt"
 
-	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 
 	"github.com/DataDog/datadog-agent/pkg/snmp/utils"
 
@@ -43,10 +43,10 @@ type ListenerConfig struct {
 }
 
 // ReadConfig builds and returns configuration from Agent configuration.
-func ReadConfig() (*NetflowConfig, error) {
+func ReadConfig(conf ddconfig.ConfigReader) (*NetflowConfig, error) {
 	var mainConfig NetflowConfig
 
-	err := coreconfig.Datadog.UnmarshalKey("network_devices.netflow", &mainConfig)
+	err := conf.UnmarshalKey("network_devices.netflow", &mainConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func ReadConfig() (*NetflowConfig, error) {
 			listenerConfig.Workers = 1
 		}
 		if listenerConfig.Namespace == "" {
-			listenerConfig.Namespace = coreconfig.Datadog.GetString("network_devices.namespace")
+			listenerConfig.Namespace = conf.GetString("network_devices.namespace")
 		}
 		normalizedNamespace, err := utils.NormalizeNamespace(listenerConfig.Namespace)
 		if err != nil {

--- a/pkg/netflow/config/config.go
+++ b/pkg/netflow/config/config.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2020-present Datadog, Inc.
 
+// Package config defines the configuration for the netflow component
 package config
 
 import (

--- a/pkg/netflow/config/config_test.go
+++ b/pkg/netflow/config/config_test.go
@@ -168,7 +168,7 @@ network_devices:
 			err := config.Datadog.ReadConfig(strings.NewReader(tt.configYaml))
 			require.NoError(t, err)
 
-			readConfig, err := ReadConfig()
+			readConfig, err := ReadConfig(config.Datadog)
 			if tt.expectedError != "" {
 				assert.ErrorContains(t, err, tt.expectedError)
 				assert.Nil(t, readConfig)

--- a/pkg/netflow/flowaggregator/flowaccumulator_test.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator_test.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/netflow/common"
 	"github.com/DataDog/datadog-agent/pkg/netflow/portrollup"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 // MockTimeNow mocks time.Now
@@ -30,6 +32,7 @@ func setMockTimeNow(newTime time.Time) {
 }
 
 func Test_flowAccumulator_add(t *testing.T) {
+	logger := fxutil.Test[log.Component](t, log.MockModule)
 	synFlag := uint32(2)
 	ackFlag := uint32(16)
 	synAckFlag := synFlag | ackFlag
@@ -79,7 +82,7 @@ func Test_flowAccumulator_add(t *testing.T) {
 	}
 
 	// When
-	acc := newFlowAccumulator(common.DefaultAggregatorFlushInterval, common.DefaultAggregatorFlushInterval, common.DefaultAggregatorPortRollupThreshold, false)
+	acc := newFlowAccumulator(common.DefaultAggregatorFlushInterval, common.DefaultAggregatorFlushInterval, common.DefaultAggregatorPortRollupThreshold, false, logger)
 	acc.add(flowA1)
 	acc.add(flowA2)
 	acc.add(flowB1)
@@ -102,6 +105,7 @@ func Test_flowAccumulator_add(t *testing.T) {
 }
 
 func Test_flowAccumulator_portRollUp(t *testing.T) {
+	logger := fxutil.Test[log.Component](t, log.MockModule)
 	synFlag := uint32(2)
 	ackFlag := uint32(16)
 	synAckFlag := synFlag | ackFlag
@@ -150,7 +154,7 @@ func Test_flowAccumulator_portRollUp(t *testing.T) {
 	}
 
 	// When
-	acc := newFlowAccumulator(common.DefaultAggregatorFlushInterval, common.DefaultAggregatorFlushInterval, 3, false)
+	acc := newFlowAccumulator(common.DefaultAggregatorFlushInterval, common.DefaultAggregatorFlushInterval, 3, false, logger)
 	acc.add(flowA1)
 	acc.add(flowA2)
 
@@ -204,6 +208,7 @@ func Test_flowAccumulator_portRollUp(t *testing.T) {
 }
 
 func Test_flowAccumulator_flush(t *testing.T) {
+	logger := fxutil.Test[log.Component](t, log.MockModule)
 	timeNow = MockTimeNow
 	zeroTime := time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC)
 	flushInterval := 60 * time.Second
@@ -225,7 +230,7 @@ func Test_flowAccumulator_flush(t *testing.T) {
 	}
 
 	// When
-	acc := newFlowAccumulator(flushInterval, flowContextTTL, common.DefaultAggregatorPortRollupThreshold, false)
+	acc := newFlowAccumulator(flushInterval, flowContextTTL, common.DefaultAggregatorPortRollupThreshold, false, logger)
 	acc.add(flow)
 
 	// Then

--- a/pkg/netflow/goflowlib/flowstate_test.go
+++ b/pkg/netflow/goflowlib/flowstate_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestStartFlowRoutine_invalidType(t *testing.T) {
-	state, err := StartFlowRoutine("invalid", "my-hostname", 1234, 1, "my-ns", make(chan *common.Flow))
+	state, err := StartFlowRoutine("invalid", "my-hostname", 1234, 1, "my-ns", make(chan *common.Flow), nil)
 	assert.EqualError(t, err, "unknown flow type: invalid")
 	assert.Nil(t, state)
 }

--- a/pkg/netflow/goflowlib/logger.go
+++ b/pkg/netflow/goflowlib/logger.go
@@ -23,6 +23,7 @@ var seeLogToLogrusLevel = map[seelog.LogLevel]logrus.Level{
 
 // GetLogrusLevel returns logrus log level from log.GetLogLevel()
 func GetLogrusLevel() *logrus.Logger {
+	// TODO this should come from the logger component instead, but it doesn't expose this function yet.
 	logLevel, err := log.GetLogLevel()
 	if err != nil {
 		log.Warnf("error getting log level")

--- a/pkg/netflow/listener.go
+++ b/pkg/netflow/listener.go
@@ -6,6 +6,7 @@
 package netflow
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/netflow/config"
 	"github.com/DataDog/datadog-agent/pkg/netflow/flowaggregator"
 	"github.com/DataDog/datadog-agent/pkg/netflow/goflowlib"
@@ -23,8 +24,8 @@ func (l *netflowListener) shutdown() {
 	l.flowState.Shutdown()
 }
 
-func startFlowListener(listenerConfig config.ListenerConfig, flowAgg *flowaggregator.FlowAggregator) (*netflowListener, error) {
-	flowState, err := goflowlib.StartFlowRoutine(listenerConfig.FlowType, listenerConfig.BindHost, listenerConfig.Port, listenerConfig.Workers, listenerConfig.Namespace, flowAgg.GetFlowInChan())
+func startFlowListener(listenerConfig config.ListenerConfig, flowAgg *flowaggregator.FlowAggregator, logger log.Component) (*netflowListener, error) {
+	flowState, err := goflowlib.StartFlowRoutine(listenerConfig.FlowType, listenerConfig.BindHost, listenerConfig.Port, listenerConfig.Workers, listenerConfig.Namespace, flowAgg.GetFlowInChan(), logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/netflow/server.go
+++ b/pkg/netflow/server.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2020-present Datadog, Inc.
 
+// Package netflow defines listeners that parse metrics and events from netflow traffic
 package netflow
 
 import (

--- a/pkg/netflow/server.go
+++ b/pkg/netflow/server.go
@@ -63,6 +63,7 @@ func NewNetflowServer(sender sender.Sender, epForwarder epforwarder.EventPlatfor
 
 }
 
+// Start starts the server running
 func (s *Server) Start() error {
 	if s.started {
 		return errors.New("server already started")

--- a/pkg/netflow/server_integration_test.go
+++ b/pkg/netflow/server_integration_test.go
@@ -53,6 +53,9 @@ network_devices:
 	ctrl := gomock.NewController(t)
 	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
 	server, err := NewNetflowServer(sender, epForwarder, config.Datadog, logger)
+	if err == nil {
+		err = server.Start()
+	}
 	require.NoError(t, err, "cannot start Netflow Server")
 	assert.NotNil(t, server)
 
@@ -106,6 +109,9 @@ network_devices:
 	ctrl := gomock.NewController(t)
 	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
 	server, err := NewNetflowServer(sender, epForwarder, config.Datadog, logger)
+	if err == nil {
+		err = server.Start()
+	}
 	require.NoError(t, err, "cannot start Netflow Server")
 	assert.NotNil(t, server)
 
@@ -153,6 +159,9 @@ network_devices:
 	ctrl := gomock.NewController(t)
 	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
 	server, err := NewNetflowServer(sender, epForwarder, config.Datadog, logger)
+	if err == nil {
+		err = server.Start()
+	}
 	require.NoError(t, err, "cannot start Netflow Server")
 	assert.NotNil(t, server)
 

--- a/pkg/netflow/server_integration_test.go
+++ b/pkg/netflow/server_integration_test.go
@@ -43,8 +43,8 @@ network_devices:
 	config.Datadog.Set("hostname", "my-hostname")
 
 	// Setup NetFlow Server
-	log := fxutil.Test[log.Component](t, log.MockModule)
-	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(log, 1*time.Millisecond)
+	logger := fxutil.Test[log.Component](t, log.MockModule)
+	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(logger, 1*time.Millisecond)
 	defer demux.Stop(false)
 
 	sender, err := demux.GetDefaultSender()
@@ -52,7 +52,7 @@ network_devices:
 
 	ctrl := gomock.NewController(t)
 	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
-	server, err := NewNetflowServer(sender, epForwarder)
+	server, err := NewNetflowServer(sender, epForwarder, config.Datadog, logger)
 	require.NoError(t, err, "cannot start Netflow Server")
 	assert.NotNil(t, server)
 
@@ -96,8 +96,8 @@ network_devices:
 	config.Datadog.Set("hostname", "my-hostname")
 
 	// Setup NetFlow Server
-	log := fxutil.Test[log.Component](t, log.MockModule)
-	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(log, 1*time.Millisecond)
+	logger := fxutil.Test[log.Component](t, log.MockModule)
+	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(logger, 1*time.Millisecond)
 	defer demux.Stop(false)
 
 	sender, err := demux.GetDefaultSender()
@@ -105,7 +105,7 @@ network_devices:
 
 	ctrl := gomock.NewController(t)
 	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
-	server, err := NewNetflowServer(sender, epForwarder)
+	server, err := NewNetflowServer(sender, epForwarder, config.Datadog, logger)
 	require.NoError(t, err, "cannot start Netflow Server")
 	assert.NotNil(t, server)
 
@@ -143,8 +143,8 @@ network_devices:
 	config.Datadog.Set("hostname", "my-hostname")
 
 	// Setup NetFlow Server
-	log := fxutil.Test[log.Component](t, log.MockModule)
-	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(log, 1*time.Millisecond)
+	logger := fxutil.Test[log.Component](t, log.MockModule)
+	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(logger, 1*time.Millisecond)
 	defer demux.Stop(false)
 
 	sender, err := demux.GetDefaultSender()
@@ -152,7 +152,7 @@ network_devices:
 
 	ctrl := gomock.NewController(t)
 	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
-	server, err := NewNetflowServer(sender, epForwarder)
+	server, err := NewNetflowServer(sender, epForwarder, config.Datadog, logger)
 	require.NoError(t, err, "cannot start Netflow Server")
 	assert.NotNil(t, server)
 

--- a/pkg/netflow/server_test.go
+++ b/pkg/netflow/server_test.go
@@ -23,8 +23,8 @@ import (
 )
 
 func TestStartServerAndStopServer(t *testing.T) {
-	log := fxutil.Test[log.Component](t, log.MockModule)
-	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(log, 10*time.Millisecond)
+	logger := fxutil.Test[log.Component](t, log.MockModule)
+	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(logger, 10*time.Millisecond)
 	defer demux.Stop(false)
 
 	port := testutil.GetFreePort()
@@ -41,8 +41,7 @@ network_devices:
 `, port)))
 	require.NoError(t, err)
 	config.Datadog.Set("hostname", "my-hostname")
-
-	err = StartServer(demux)
+	err = StartServer(demux, config.Datadog, logger)
 	require.NoError(t, err)
 	require.NotNil(t, serverInstance)
 
@@ -53,14 +52,12 @@ network_devices:
 }
 
 func TestIsEnabled(t *testing.T) {
-	saved := config.Datadog.Get("network_devices.netflow.enabled")
-	defer config.Datadog.Set("network_devices.netflow.enabled", saved)
+	conf := config.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+	conf.Set("network_devices.netflow.enabled", true)
+	assert.Equal(t, true, IsEnabled(conf))
 
-	config.Datadog.Set("network_devices.netflow.enabled", true)
-	assert.Equal(t, true, IsEnabled())
-
-	config.Datadog.Set("network_devices.netflow.enabled", false)
-	assert.Equal(t, false, IsEnabled())
+	conf.Set("network_devices.netflow.enabled", false)
+	assert.Equal(t, false, IsEnabled(conf))
 }
 
 func TestServer_Stop(t *testing.T) {
@@ -81,13 +78,13 @@ network_devices:
 	require.NoError(t, err)
 
 	// Setup Netflow Server
-	log := fxutil.Test[log.Component](t, log.MockModule)
-	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(log, 10*time.Millisecond)
+	logger := fxutil.Test[log.Component](t, log.MockModule)
+	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(logger, 10*time.Millisecond)
 	defer demux.Stop(false)
 	sender, err := demux.GetDefaultSender()
 	require.NoError(t, err, "cannot get default sender")
 
-	server, err := NewNetflowServer(sender, nil)
+	server, err := NewNetflowServer(sender, nil, config.Datadog, logger)
 	require.NoError(t, err, "cannot start Netflow Server")
 	assert.NotNil(t, server)
 

--- a/pkg/netflow/server_test.go
+++ b/pkg/netflow/server_test.go
@@ -85,13 +85,16 @@ network_devices:
 	require.NoError(t, err, "cannot get default sender")
 
 	server, err := NewNetflowServer(sender, nil, config.Datadog, logger)
+	if err == nil {
+		err = server.Start()
+	}
 	require.NoError(t, err, "cannot start Netflow Server")
 	assert.NotNil(t, server)
 
 	flowProcessor := replaceWithDummyFlowProcessor(server, port)
 
 	// Stops server
-	server.stop()
+	server.Stop()
 
 	// Assert logs present
 	assert.Equal(t, flowProcessor.stopped, true)

--- a/pkg/netflow/testutil/testutil.go
+++ b/pkg/netflow/testutil/testutil.go
@@ -12,12 +12,13 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"net"
+	"testing"
+
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcapgo"
 	"github.com/stretchr/testify/assert"
-	"net"
-	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/epforwarder"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This is a work-in-progress for componentizing the netflow trace agent.

Things to do
 - [x] Replace all references to `pkg/util/config` with a passed-in `comp/core/config.Component`
 - [x] Replace all references to `pkg/util/log` with a passed-in `comp/core/log.Component`
   - Note that `goflowlib/logger` still uses the global log - the component doesn't expose `GetLogLevel()`. This problem would go away if we upgraded to `goflow2@2.0`, which no longer generates log messages (instead a running checker exposes a channel where it will publish errors if it encounters any).
 - [x] Separate server creation from server startup so they can happen at different times.
 - [x] Stub out a component that just calls the server creation functions
 - [ ] Replace the dependency on the root config with a dependency on the `NetflowConfig` type, and register a provider that pulls the netflow config from the root config.
 - [ ]  Figure out what to do about `hostname.Get()` - can this be exposed via `fx`?
 - [ ] Do we need to run the prometheus metrics server ourselves? Can we use the `telemetry` component instead?
 - [ ] Can we inject the EPForwarder and the Sender, instead of injecting a demux just to pull those two off of it? That would make testing easier, in cases where we don't care about one or the other.
 - [ ] Rewrite tests to use injector for all dependencies where applicable.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
