### PR TITLE
reverting #18844

### DIFF
--- a/pkg/network/protocols/http/protocol.go
+++ b/pkg/network/protocols/http/protocol.go
@@ -99,7 +99,7 @@ func (p *protocol) ConfigureOptions(mgr *manager.Manager, opts *manager.Options)
 	events.Configure(eventStream, mgr, opts)
 }
 
-func (p *protocol) PreStart(mgr *manager.Manager, _ protocols.BuildMode) (err error) {
+func (p *protocol) PreStart(mgr *manager.Manager) (err error) {
 	p.eventsConsumer, err = events.NewConsumer(
 		"http",
 		mgr,

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -142,7 +142,7 @@ func (p *protocol) ConfigureOptions(mgr *manager.Manager, opts *manager.Options)
 	events.Configure(eventStream, mgr, opts)
 }
 
-func (p *protocol) PreStart(mgr *manager.Manager, _ protocols.BuildMode) (err error) {
+func (p *protocol) PreStart(mgr *manager.Manager) (err error) {
 	p.eventsConsumer, err = events.NewConsumer(
 		eventStream,
 		mgr,

--- a/pkg/network/protocols/kafka/protocol.go
+++ b/pkg/network/protocols/kafka/protocol.go
@@ -93,7 +93,7 @@ func (p *protocol) ConfigureOptions(mgr *manager.Manager, opts *manager.Options)
 	utils.EnableOption(opts, "kafka_monitoring_enabled")
 }
 
-func (p *protocol) PreStart(mgr *manager.Manager, _ protocols.BuildMode) error {
+func (p *protocol) PreStart(mgr *manager.Manager) error {
 	var err error
 	p.eventsConsumer, err = events.NewConsumer(
 		eventStreamName,

--- a/pkg/network/protocols/protocols.go
+++ b/pkg/network/protocols/protocols.go
@@ -30,7 +30,7 @@ type Protocol interface {
 	// PreStart is called before the start of the provided eBPF manager.
 	// Additional initialisation steps, such as starting an event consumer,
 	// should be performed here.
-	PreStart(*manager.Manager, BuildMode) error
+	PreStart(*manager.Manager) error
 
 	// PostStart is called after the start of the provided eBPF manager. Final
 	// initialisation steps, such as setting up a map cleaner, should be
@@ -70,14 +70,3 @@ type ProtocolSpec struct {
 	Probes    []*manager.Probe
 	TailCalls []manager.TailCallRoute
 }
-
-// BuildMode represents the way the eBPF code will be built. It used by
-// protocols to check if they are actually compatible with that build mode
-// before starting.
-type BuildMode string
-
-const (
-	Prebuilt        BuildMode = "prebuilt"
-	RuntimeCompiled BuildMode = "runtime-compilation"
-	CORE            BuildMode = "CO-RE"
-)

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -580,10 +580,7 @@ func (s *USMSuite) TestProtocolClassification() {
 		t.Skip("Classification is not supported")
 	}
 
-	if !isPrebuilt(cfg) {
-		cfg.EnableGoTLSSupport = true
-	}
-
+	cfg.EnableGoTLSSupport = true
 	cfg.EnableHTTPSMonitoring = true
 	cfg.EnableHTTPMonitoring = true
 	tr, err := NewTracer(cfg)

--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -119,6 +119,7 @@ type runningBinary struct {
 	processCount int32
 }
 
+// GoTLSProgram contains implementation for go-TLS.
 type GoTLSProgram struct {
 	wg      sync.WaitGroup
 	done    chan struct{}
@@ -194,14 +195,17 @@ func newGoTLSProgram(c *config.Config) *GoTLSProgram {
 	return p
 }
 
+// Name return the program's name.
 func (p *GoTLSProgram) Name() string {
 	return "go-tls"
 }
 
+// IsBuildModeSupported return true if the build mode is supported.
 func (p *GoTLSProgram) IsBuildModeSupported(mode buildMode) bool {
 	return mode == CORE || mode == RuntimeCompiled
 }
 
+// ConfigureManager adds maps to the given manager.
 func (p *GoTLSProgram) ConfigureManager(m *errtelemetry.Manager) {
 	p.manager = m
 	p.manager.Maps = append(p.manager.Maps, []*manager.Map{
@@ -212,6 +216,7 @@ func (p *GoTLSProgram) ConfigureManager(m *errtelemetry.Manager) {
 	// Hooks will be added in runtime for each binary
 }
 
+// ConfigureOptions changes map attributes to the given options.
 func (p *GoTLSProgram) ConfigureOptions(options *manager.Options) {
 	options.MapSpecEditors[connectionTupleByGoTLSMap] = manager.MapSpecEditor{
 		Type:       ebpf.Hash,
@@ -220,6 +225,7 @@ func (p *GoTLSProgram) ConfigureOptions(options *manager.Options) {
 	}
 }
 
+// GetAllUndefinedProbes returns a list of the program's probes.
 func (*GoTLSProgram) GetAllUndefinedProbes() []manager.ProbeIdentificationPair {
 	probeList := make([]manager.ProbeIdentificationPair, 0)
 	for _, probeInfo := range functionToProbes {
@@ -239,6 +245,7 @@ func (*GoTLSProgram) GetAllUndefinedProbes() []manager.ProbeIdentificationPair {
 	return probeList
 }
 
+// Start launches the goTLS main goroutine to handle events.
 func (p *GoTLSProgram) Start() {
 	var err error
 	p.offsetsDataMap, _, err = p.manager.GetMap(offsetsDataMap)
@@ -281,6 +288,7 @@ func (p *GoTLSProgram) Start() {
 	}()
 }
 
+// Stop terminates goTLS main goroutine.
 func (p *GoTLSProgram) Stop() {
 	close(p.done)
 	// Waiting for the main event loop to finish.

--- a/pkg/network/usm/ebpf_javatls.go
+++ b/pkg/network/usm/ebpf_javatls.go
@@ -255,7 +255,7 @@ func (p *javaTLSProgram) newJavaProcess(pid uint32) {
 	}
 }
 
-func (p *javaTLSProgram) PreStart(*manager.Manager, protocols.BuildMode) error {
+func (p *javaTLSProgram) PreStart(*manager.Manager) error {
 	p.cleanupExec = p.processMonitor.SubscribeExec(p.newJavaProcess)
 	return nil
 }

--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -46,16 +46,60 @@ const (
 type ebpfProgram struct {
 	*errtelemetry.Manager
 	cfg                   *config.Config
+	subprograms           []subprogram
+	probesResolvers       []probeResolver
 	tailCallRouter        []manager.TailCallRoute
 	connectionProtocolMap *ebpf.Map
 
 	enabledProtocols  []protocols.Protocol
 	disabledProtocols []*protocols.ProtocolSpec
 
-	buildMode protocols.BuildMode
-
 	// Used for connection_protocol data expiration
 	mapCleaner *ddebpf.MapCleaner
+	buildMode  buildMode
+}
+
+type probeResolver interface {
+	// GetAllUndefinedProbes returns all undefined probes.
+	// Subprogram probes maybe defined in the same ELF file as the probes
+	// of the main program. The cilium loader loads all programs defined
+	// in an ELF file in to the kernel. Therefore, these programs may be
+	// loaded into the kernel, whether the subprogram is activated or not.
+	//
+	// Before the loading can be performed we must associate a function which
+	// performs some fixup in the EBPF bytecode:
+	// https://github.com/DataDog/datadog-agent/blob/main/pkg/ebpf/c/bpf_telemetry.h#L58
+	// If this is not correctly done, the verifier will reject the EBPF bytecode.
+	//
+	// The ebpf telemetry manager
+	// (https://github.com/DataDog/datadog-agent/blob/main/pkg/network/telemetry/telemetry_manager.go#L19)
+	// takes an instance of the Manager managing the main program, to acquire
+	// the list of the probes to patch.
+	// https://github.com/DataDog/datadog-agent/blob/main/pkg/network/telemetry/ebpf_telemetry.go#L256
+	// This Manager may not include the probes of the subprograms. GetAllUndefinedProbes() is,
+	// therefore, necessary for returning the probes of these subprograms so they can be
+	// correctly patched at load-time, when the Manager is being initialized.
+	//
+	// To reiterate, this is necessary due to the fact that the cilium loader loads
+	// all programs defined in an ELF file regardless if they are later attached or not.
+	GetAllUndefinedProbes() []manager.ProbeIdentificationPair
+}
+
+type buildMode string
+
+const (
+	Prebuilt        buildMode = "prebuilt"
+	RuntimeCompiled buildMode = "runtime-compilation"
+	CORE            buildMode = "CO-RE"
+)
+
+type subprogram interface {
+	Name() string
+	IsBuildModeSupported(buildMode) bool
+	ConfigureManager(*errtelemetry.Manager)
+	ConfigureOptions(*manager.Options)
+	Start()
+	Stop()
 }
 
 func newEBPFProgram(c *config.Config, connectionProtocolMap *ebpf.Map, bpfTelemetry *errtelemetry.EBPFTelemetry) (*ebpfProgram, error) {
@@ -92,9 +136,22 @@ func newEBPFProgram(c *config.Config, connectionProtocolMap *ebpf.Map, bpfTeleme
 		},
 	}
 
+	subprogramProbesResolvers := make([]probeResolver, 0, 1)
+	subprograms := make([]subprogram, 0, 1)
+	var tailCalls []manager.TailCallRoute
+
+	goTLSProg := newGoTLSProgram(c)
+	subprogramProbesResolvers = append(subprogramProbesResolvers, goTLSProg)
+	if goTLSProg != nil {
+		subprograms = append(subprograms, goTLSProg)
+	}
+
 	program := &ebpfProgram{
 		Manager:               errtelemetry.NewManager(mgr, bpfTelemetry),
 		cfg:                   c,
+		subprograms:           subprograms,
+		probesResolvers:       subprogramProbesResolvers,
+		tailCallRouter:        tailCalls,
 		connectionProtocolMap: connectionProtocolMap,
 	}
 
@@ -102,21 +159,28 @@ func newEBPFProgram(c *config.Config, connectionProtocolMap *ebpf.Map, bpfTeleme
 }
 
 func (e *ebpfProgram) Init() error {
-	undefinedProbes := make([]manager.ProbeIdentificationPair, 0, len(e.tailCallRouter))
+	var undefinedProbes []manager.ProbeIdentificationPair
 	for _, tc := range e.tailCallRouter {
 		undefinedProbes = append(undefinedProbes, tc.ProbeIdentificationPair)
+	}
+
+	for _, s := range e.probesResolvers {
+		undefinedProbes = append(undefinedProbes, s.GetAllUndefinedProbes()...)
 	}
 
 	e.DumpHandler = e.dumpMapsHandler
 	e.InstructionPatcher = func(m *manager.Manager) error {
 		return errtelemetry.PatchEBPFTelemetry(m, true, undefinedProbes)
 	}
+	for _, s := range e.subprograms {
+		s.ConfigureManager(e.Manager)
+	}
 
 	var err error
 	if e.cfg.EnableCORE {
 		err = e.initCORE()
 		if err == nil {
-			e.buildMode = protocols.CORE
+			e.buildMode = CORE
 			return nil
 		}
 
@@ -129,7 +193,7 @@ func (e *ebpfProgram) Init() error {
 	if e.cfg.EnableRuntimeCompiler || (err != nil && e.cfg.AllowRuntimeCompiledFallback) {
 		err = e.initRuntimeCompiler()
 		if err == nil {
-			e.buildMode = protocols.RuntimeCompiled
+			e.buildMode = RuntimeCompiled
 			return nil
 		}
 
@@ -141,7 +205,7 @@ func (e *ebpfProgram) Init() error {
 
 	err = e.initPrebuilt()
 	if err == nil {
-		e.buildMode = protocols.Prebuilt
+		e.buildMode = Prebuilt
 	}
 	return err
 }
@@ -154,11 +218,28 @@ func (e *ebpfProgram) Start() error {
 		e.mapCleaner = mapCleaner
 	}
 
-	return e.Manager.Start()
+	err = e.Manager.Start()
+	if err != nil {
+		return err
+	}
+
+	for _, s := range e.subprograms {
+		if s.IsBuildModeSupported(e.buildMode) {
+			s.Start()
+			log.Infof("launched %s subprogram", s.Name())
+		} else {
+			log.Infof("%s subprogram does not support %s build mode", s.Name(), e.buildMode)
+		}
+	}
+
+	return nil
 }
 
 func (e *ebpfProgram) Close() error {
 	e.mapCleaner.Stop()
+	for _, s := range e.subprograms {
+		s.Stop()
+	}
 	return e.Stop(manager.CleanAll)
 }
 
@@ -250,6 +331,10 @@ func (e *ebpfProgram) init(buf bytecode.AssetReader, options manager.Options) er
 
 	options.DefaultKprobeAttachMethod = kprobeAttachMethod
 	options.VerifierOptions.Programs.LogSize = 10 * 1024 * 1024
+
+	for _, s := range e.subprograms {
+		s.ConfigureOptions(&options)
+	}
 
 	for _, p := range e.enabledProtocols {
 		p.ConfigureOptions(e.Manager.Manager, &options)

--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -88,9 +88,12 @@ type probeResolver interface {
 type buildMode string
 
 const (
-	Prebuilt        buildMode = "prebuilt"
+	// Prebuilt mode
+	Prebuilt buildMode = "prebuilt"
+	// RuntimeCompiled mode
 	RuntimeCompiled buildMode = "runtime-compilation"
-	CORE            buildMode = "CO-RE"
+	// CORE mode
+	CORE buildMode = "CO-RE"
 )
 
 type subprogram interface {

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -443,7 +443,7 @@ func (o *sslProgram) ConfigureOptions(_ *manager.Manager, options *manager.Optio
 	options.MapEditors[probes.SockByPidFDMap] = o.sockFDMap
 }
 
-func (o *sslProgram) PreStart(*manager.Manager, protocols.BuildMode) error {
+func (o *sslProgram) PreStart(*manager.Manager) error {
 	o.watcher.Start()
 	o.istioMonitor.Start()
 	return nil

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -48,7 +48,6 @@ var (
 		http.Spec,
 		http2.Spec,
 		kafka.Spec,
-		goTLSSpec,
 		javaTLSSpec,
 		// opensslSpec is unique, as we're modifying its factory during runtime to allow getting more parameters in the
 		// factory.
@@ -167,7 +166,7 @@ func (m *Monitor) Start() error {
 	// enabledProtocolsTmp to m.enabledProtocols, we'll use the enabledProtocolsTmp.
 	enabledProtocolsTmp := m.enabledProtocols[:0]
 	for _, protocol := range m.enabledProtocols {
-		startErr := protocol.PreStart(m.ebpfProgram.Manager.Manager, m.ebpfProgram.buildMode)
+		startErr := protocol.PreStart(m.ebpfProgram.Manager.Manager)
 		if startErr != nil {
 			log.Errorf("could not complete pre-start phase of %s monitoring: %s", protocol.Name(), startErr)
 			continue

--- a/pkg/network/usm/monitor_test.go
+++ b/pkg/network/usm/monitor_test.go
@@ -51,10 +51,7 @@ var (
 )
 
 func TestMonitorProtocolFail(t *testing.T) {
-	failingPreStartupMock := func(_ *manager.Manager, _ protocols.BuildMode) error {
-		return fmt.Errorf("mock error")
-	}
-	failingPostStartupMock := func(_ *manager.Manager) error {
+	failingStartupMock := func(_ *manager.Manager) error {
 		return fmt.Errorf("mock error")
 	}
 
@@ -62,8 +59,8 @@ func TestMonitorProtocolFail(t *testing.T) {
 		name string
 		spec protocolMockSpec
 	}{
-		{name: "PreStart fails", spec: protocolMockSpec{preStartFn: failingPreStartupMock}},
-		{name: "PostStart fails", spec: protocolMockSpec{postStartFn: failingPostStartupMock}},
+		{name: "PreStart fails", spec: protocolMockSpec{preStartFn: failingStartupMock}},
+		{name: "PostStart fails", spec: protocolMockSpec{postStartFn: failingStartupMock}},
 	}
 
 	for _, tt := range testCases {

--- a/pkg/network/usm/monitor_testutil.go
+++ b/pkg/network/usm/monitor_testutil.go
@@ -30,7 +30,7 @@ type protocolMock struct {
 type protocolMockSpec struct {
 	// These functions can be set to change the behavior of those methods. If
 	// not set, the methods from the base protocol will be called.
-	preStartFn  func(*manager.Manager, protocols.BuildMode) error
+	preStartFn  func(*manager.Manager) error
 	postStartFn func(*manager.Manager) error
 	stopFn      func(*manager.Manager)
 }
@@ -43,11 +43,11 @@ func (p *protocolMock) ConfigureOptions(m *manager.Manager, opts *manager.Option
 	p.inner.ConfigureOptions(m, opts)
 }
 
-func (p *protocolMock) PreStart(mgr *manager.Manager, mode protocols.BuildMode) (err error) {
+func (p *protocolMock) PreStart(mgr *manager.Manager) (err error) {
 	if p.spec.preStartFn != nil {
-		return p.spec.preStartFn(mgr, mode)
+		return p.spec.preStartFn(mgr)
 	} else {
-		return p.inner.PreStart(mgr, mode)
+		return p.inner.PreStart(mgr)
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Reverting PR #18844 as it had an edge case (enabling goTLS + falling back to prebuilt version) that could prevented USM from being loaded.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. Enabled USM with CO-RE/RUNTIME-COMPILATION and allow fallback to prebuilt, also enable gotls
```
system_probe_config:
  enable_co_re: true
  enable_runtime_compiler: true
  allow_precompiled_fallback: true

service_monitoring_config:
  enabled: true
  enable_go_tls_support: true
```
2. apply the following diff
```
diff --git a/pkg/network/ebpf/c/runtime/usm.c b/pkg/network/ebpf/c/runtime/usm.c
index 198375f11e..b1580927c0 100644
--- a/pkg/network/ebpf/c/runtime/usm.c
+++ b/pkg/network/ebpf/c/runtime/usm.c
@@ -569,10 +569,10 @@ int uprobe__crypto_tls_Conn_Write__return(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u64 pid = pid_tgid >> 32;
     tls_offsets_data_t* od = get_offsets_data();
-    if (od == NULL) {
-        log_debug("[go-tls-write-return] no offsets data in map for pid %d\n", pid);
-        return 0;
-    }
+//    if (od == NULL) {
+//        log_debug("[go-tls-write-return] no offsets data in map for pid %d\n", pid);
+//        return 0;
+//    }
```
3. Build and run USM
4. Expect to see co-re and runtime compilation fails, and the log ` go-tls subprogram does not support prebuilt build mode`
5. Check USM is up and running 
  6. `curl example.com`
  7. `sudo curl --unix /opt/datadog-agent/run/sysprobe.sock http://unix/network_tracer/debug/http_monitoring`


<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
