### PR TITLE
[NPM] Remove tracer internal stats from module stats

### DIFF
--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -446,7 +446,7 @@ func (t *Tracer) getConnTelemetry(mapSize int) map[network.ConnTelemetryType]int
 		network.MonotonicConnsClosed:      tracerTelemetry.closedConns.Load(),
 	}
 
-	stats, err := t.getStats(conntrackStats, dnsStats, epbfStats, httpStats, stateStats, kafkaStats)
+	stats, err := t.getStats(stateStats)
 	if err != nil {
 		return nil
 	}
@@ -664,7 +664,11 @@ func (t *Tracer) getStats(comps ...statsComp) (map[string]interface{}, error) {
 
 // GetStats returns a map of statistics about the current tracer's internal state
 func (t *Tracer) GetStats() (map[string]interface{}, error) {
-	return t.getStats()
+	return map[string]interface{}{
+		"tracer": map[string]interface{}{
+			"last_check": t.lastCheck.Load(),
+		},
+	}, nil
 }
 
 // DebugNetworkState returns a map with the current tracer's internal state, for debugging

--- a/pkg/network/tracer/tracer_classification_linux_test.go
+++ b/pkg/network/tracer/tracer_classification_linux_test.go
@@ -8,7 +8,6 @@
 package tracer
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -31,35 +30,6 @@ func testProtocolClassificationInner(t *testing.T, params protocolClassification
 	if params.preTracerSetup != nil {
 		params.preTracerSetup(t, params.context)
 	}
-
-	var kStatsPre map[string]int64
-	if m, _ := tr.getStats(kprobesStats); m != nil {
-		if m := m["kprobes"]; m != nil {
-			kStatsPre = m.(map[string]int64)
-		}
-	}
-
-	t.Cleanup(func() {
-		if kStatsPre != nil && t.Failed() {
-			var kStatsPost map[string]int64
-			if m, _ := tr.getStats(kprobesStats); m != nil {
-				if m := m["kprobes"]; m != nil {
-					kStatsPost = m.(map[string]int64)
-				}
-				if kStatsPost == nil {
-					return
-				}
-				for k, pre := range kStatsPre {
-					if !strings.HasSuffix(k, "_misses") {
-						continue
-					}
-					if post, ok := kStatsPost[k]; ok && pre != post {
-						t.Logf("kprobe stat %s differs pre=%v post=%v", k, pre, post)
-					}
-				}
-			}
-		}
-	})
 
 	tr.removeClient(clientID)
 	initTracerState(t, tr)

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1846,7 +1846,7 @@ func (s *TracerSuite) TestGetMapsTelemetry() {
 	err := exec.Command(cmd[0], cmd[1:]...).Run()
 	require.NoError(t, err)
 
-	stats, err := tr.GetStats()
+	stats, err := tr.getStats(bpfMapStats)
 	require.NoError(t, err)
 
 	mapsTelemetry, ok := stats[telemetry.EBPFMapTelemetryNS].(map[string]interface{})
@@ -1904,7 +1904,7 @@ func (s *TracerSuite) TestGetHelpersTelemetry() {
 		syscall.Syscall(syscall.SYS_MUNMAP, uintptr(addr), uintptr(syscall.Getpagesize()), 0)
 	})
 
-	stats, err := tr.GetStats()
+	stats, err := tr.getStats(bpfHelperStats)
 	require.NoError(t, err)
 
 	helperTelemetry, ok := stats[telemetry.EBPFHelperTelemetryNS].(map[string]interface{})

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -132,7 +132,7 @@ func (s *TracerSuite) TestGetStats() {
 			<-time.After(time.Second)
 
 			getConnections(t, tr)
-			actual, _ := tr.GetStats()
+			actual, _ := tr.getStats()
 
 			for section, entries := range expected {
 				if section == "usm" && !httpSupported {

--- a/pkg/network/tracer/tracer_windows.go
+++ b/pkg/network/tracer/tracer_windows.go
@@ -211,12 +211,16 @@ func (t *Tracer) getConnTelemetry() map[network.ConnTelemetryType]int64 {
 	}
 }
 
-// GetStats returns a map of statistics about the current tracer's internal state
-func (t *Tracer) GetStats() (map[string]interface{}, error) {
+func (t *Tracer) getStats() (map[string]interface{}, error) {
 	stats := map[string]interface{}{
 		"state": t.state.GetStats(),
 	}
 	return stats, nil
+}
+
+// GetStats returns a map of statistics about the current tracer's internal state
+func (t *Tracer) GetStats() (map[string]interface{}, error) {
+	return t.getStats()
 }
 
 // DebugNetworkState returns a map with the current tracer's internal state, for debugging


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Removes internal stats from getting reported as module stats. This also removes them from expvar reporting and from the `/debug/stats` endpoint. We are already reporting these in the `/telemetry` endpoint and they get picked up by the openmetrics/prometheus check in the agent.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
