### PR TITLE
pkg/trace/traceutil: Improve perf for large inputs and fix TruncateUTF8

### DIFF
--- a/pkg/trace/traceutil/truncate.go
+++ b/pkg/trace/traceutil/truncate.go
@@ -18,10 +18,19 @@ func TruncateUTF8(s string, limit int) string {
 	// The max length of a valid code point is 4 bytes, therefore if we see all valid
 	// code points in the last 4 bytes we know we have a fully valid utf-8 string
 	// If not we can truncate one byte at a time until the end of the string is valid utf-8
-	for !(len(s) >= 4 && utf8.Valid([]byte(s[len(s)-4:]))) &&
-		!(len(s) >= 3 && utf8.Valid([]byte(s[len(s)-3:]))) &&
-		!(len(s) >= 2 && utf8.Valid([]byte(s[len(s)-2:]))) &&
-		!(len(s) >= 1 && utf8.Valid([]byte(s[len(s)-1:]))) && len(s) >= 1 {
+	for len(s) >= 1 {
+		if len(s) >= 4 && utf8.Valid([]byte(s[len(s)-4:])) {
+			break
+		}
+		if len(s) >= 3 && utf8.Valid([]byte(s[len(s)-3:])) {
+			break
+		}
+		if len(s) >= 2 && utf8.Valid([]byte(s[len(s)-2:])) {
+			break
+		}
+		if len(s) >= 1 && utf8.Valid([]byte(s[len(s)-1:])) {
+			break
+		}
 		s = s[:len(s)-1]
 	}
 	return s

--- a/pkg/trace/traceutil/truncate.go
+++ b/pkg/trace/traceutil/truncate.go
@@ -5,6 +5,8 @@
 
 package traceutil
 
+import "unicode/utf8"
+
 // TruncateUTF8 truncates the given string to make sure it uses less than limit bytes.
 // If the last character is an utf8 character that would be splitten, it removes it
 // entirely to make sure the resulting string is not broken.
@@ -12,12 +14,15 @@ func TruncateUTF8(s string, limit int) string {
 	if len(s) <= limit {
 		return s
 	}
-	var lastValidIndex int
-	for i := range s {
-		if i > limit {
-			return s[:lastValidIndex]
-		}
-		lastValidIndex = i
+	s = s[:limit]
+	// The max length of a valid code point is 4 bytes, therefore if we see all valid
+	// code points in the last 4 bytes we know we have a fully valid utf-8 string
+	// If not we can truncate one byte at a time until the end of the string is valid utf-8
+	for !(len(s) >= 4 && utf8.Valid([]byte(s[len(s)-4:]))) &&
+		!(len(s) >= 3 && utf8.Valid([]byte(s[len(s)-3:]))) &&
+		!(len(s) >= 2 && utf8.Valid([]byte(s[len(s)-2:]))) &&
+		!(len(s) >= 1 && utf8.Valid([]byte(s[len(s)-1:]))) && len(s) >= 1 {
+		s = s[:len(s)-1]
 	}
 	return s
 }

--- a/pkg/trace/traceutil/truncate_test.go
+++ b/pkg/trace/traceutil/truncate_test.go
@@ -6,17 +6,41 @@
 package traceutil
 
 import (
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestTruncateString(t *testing.T) {
 	assert.Equal(t, "", TruncateUTF8("", 5))
-	assert.Equal(t, "télé", TruncateUTF8("télé", 5))
+	assert.Equal(t, "tél", TruncateUTF8("télé", 5))
 	assert.Equal(t, "t", TruncateUTF8("télé", 2))
 	assert.Equal(t, "éé", TruncateUTF8("ééééé", 5))
 	assert.Equal(t, "ééééé", TruncateUTF8("ééééé", 18))
 	assert.Equal(t, "ééééé", TruncateUTF8("ééééé", 10))
 	assert.Equal(t, "ééé", TruncateUTF8("ééééé", 6))
+	assert.Equal(t, "", TruncateUTF8("肋", 2))
+}
+
+func FuzzTruncateString(f *testing.F) {
+	f.Add("télé", 5)
+	f.Fuzz(func(t *testing.T, s string, limit int) {
+		if !utf8.Valid([]byte(s)) || limit <= 0 { // This function previously assumed these invariants so let's keep them for fuzzing.
+			t.Skip()
+		}
+		result := TruncateUTF8(s, limit)
+		if len(result) > limit {
+			t.Errorf("%s was truncated to %s which is %d long. Longer than limit %d", s, result, len(result), limit)
+		}
+		assert.True(t, utf8.Valid([]byte(result)), "%s became invalid utf8 %s", s, result)
+	})
+}
+
+func BenchmarkTruncateString(b *testing.B) {
+	s := strings.Repeat("télé", 100)
+	for i := 0; i < b.N; i++ {
+		TruncateUTF8(s, 100)
+	}
 }

--- a/pkg/trace/traceutil/truncate_test.go
+++ b/pkg/trace/traceutil/truncate_test.go
@@ -22,6 +22,12 @@ func TestTruncateString(t *testing.T) {
 	assert.Equal(t, "ééééé", TruncateUTF8("ééééé", 10))
 	assert.Equal(t, "ééé", TruncateUTF8("ééééé", 6))
 	assert.Equal(t, "", TruncateUTF8("肋", 2))
+	// Testing 4 character split
+	assert.Equal(t, "🠠", TruncateUTF8("🠠a", 4))
+	// Testing 3 character split
+	assert.Equal(t, "⃠⃠", TruncateUTF8("⃠⃠a", 6))
+	// Testing 2 character split
+	assert.Equal(t, "à", TruncateUTF8("àa", 2))
 }
 
 func FuzzTruncateString(f *testing.F) {

--- a/pkg/trace/traceutil/truncate_test.go
+++ b/pkg/trace/traceutil/truncate_test.go
@@ -26,6 +26,7 @@ func TestTruncateString(t *testing.T) {
 
 func FuzzTruncateString(f *testing.F) {
 	f.Add("télé", 5)
+	f.Add("肋", 2)
 	f.Fuzz(func(t *testing.T, s string, limit int) {
 		if !utf8.Valid([]byte(s)) || limit <= 0 { // This function previously assumed these invariants so let's keep them for fuzzing.
 			t.Skip()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Fixes the behavior of TruncateUTF8 so output never is larger than the byte limit. Also improves performance for large inputs.
```
goos: darwin
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/trace/traceutil
                  │   old.out    │               new.out               │
                  │    sec/op    │   sec/op     vs base                │
TruncateString-10   112.60n ± 1%   10.30n ± 0%  -90.85% (p=0.000 n=10)
```
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
While going through trace-agent code I happened across this function which seemed like a possible candidate for performance improvement. When I went to try and improve the performance I noticed that the function was actually wrong. For example: "télé" is 6 bytes long in utf-8, with a limit of 5, the correct output should be "tél" at 4 bytes long. 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
It's possible someone is relying on this "off" nature of Truncation, however they shouldn't be and the function is documented as returning a string that is SMALLER than `limit`. Additionally this new code is a bit harder to read / understand, I think this downside is sufficiently offset by the new fuzz test which should catch any possible mistakes made in future re-writes/refactors etc.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
I fixed the unit tests as well as added a fuzz test to ensure all the invariants hold. It ran successfully for 3 minutes on my machine not finding new code paths and not finding any failures. Therefore I don't believe this needs separate QA.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
