### PR TITLE
Fix agent flare crash caused by diagnose if the flare runs locally (regression)

### DIFF
--- a/pkg/diagnose/check.go
+++ b/pkg/diagnose/check.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 func diagnose(diagCfg diagnosis.Config) []diagnosis.Diagnosis {
-	if diagCfg.RunningInAgentProcess {
+	if diagCfg.RunningInAgentProcess && common.Coll != nil {
 		return diagnoseChecksInAgentProcess()
 	}
 

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -300,10 +300,14 @@ func getProcessChecks(fb flarehelpers.FlareBuilder, getAddressPort func() (url s
 
 func getDiagnoses() ([]byte, error) {
 	fct := func(w io.Writer) error {
+		// Run agent diagnose command to be verbose and remote. If Agent is running small performance hit
+		// since this code will get diagnoses using Agent’s local port listener (instead of calling a
+		// function directly since the caller and callee are in the same process).However, the same code
+		// will continue to work well because agent diagnose command works locally as well (if it cannot
+		// connect to the running Agent).
 		diagCfg := diagnosis.Config{
-			Verbose:               true,
-			RunningInAgentProcess: true,
-			RunLocal:              true,
+			Verbose:  true,
+			RunLocal: false,
 		}
 
 		return diagnose.RunStdOut(w, diagCfg)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Previous [Move agent diagnose execution into agent process context #18792](https://github.com/DataDog/datadog-agent/pull/18792)) PR had optimization to trigger internal Agent function calls because flare and diagnostics run in the same process. However, the code behind agent diagnose command assumes access to the running agent environment. However it is not true in cases when the agent is not running and flare executes locally.

Two fixes are applied. First, always presume that agent diagnose will be executed fully even if the agent is running (meaning to call a local port listener even when the diagnosis code is running inside the running Agent process). Second, add extra validation of internal state before "trusting" passed configuration.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
