### PR TITLE
[CSPM] Allow compliance checks to execute cross-container resolving

### DIFF
--- a/pkg/compliance/data.go
+++ b/pkg/compliance/data.go
@@ -54,6 +54,14 @@ type CheckStatus struct {
 	LastEvent   *CheckEvent
 }
 
+// CheckContainerMeta holds metadata related to the container that has been checked.
+type CheckContainerMeta struct {
+	ContainerID string `json:"container_id"`
+	ImageID     string `json:"image_id"`
+	ImageName   string `json:"image_name"`
+	ImageTag    string `json:"image_tag"`
+}
+
 // CheckEvent is the data structure sent to the backend as a result of a rule
 // evaluation.
 type CheckEvent struct {
@@ -66,6 +74,7 @@ type CheckEvent struct {
 	Result       CheckResult            `json:"result,omitempty"`
 	ResourceType string                 `json:"resource_type,omitempty"`
 	ResourceID   string                 `json:"resource_id,omitempty"`
+	Container    *CheckContainerMeta    `json:"container,omitempty"`
 	Tags         []string               `json:"tags"`
 	Data         map[string]interface{} `json:"data"`
 

--- a/pkg/compliance/evaluator_rego.go
+++ b/pkg/compliance/evaluator_rego.go
@@ -139,10 +139,27 @@ func newCheckEventFromRegoResult(data interface{}, rule *Rule, resolvedInputs Re
 	eventData, _ := m["data"].(map[string]interface{})
 	resourceID, _ := m["resource_id"].(string)
 	resourceType, _ := m["resource_type"].(string)
+
+	var event *CheckEvent
 	if errReason != nil {
-		return NewCheckError(RegoEvaluator, errReason, resourceID, resourceType, rule, benchmark)
+		event = NewCheckError(RegoEvaluator, errReason, resourceID, resourceType, rule, benchmark)
+	} else {
+		event = NewCheckEvent(RegoEvaluator, result, eventData, resourceID, resourceType, rule, benchmark)
 	}
-	return NewCheckEvent(RegoEvaluator, result, eventData, resourceID, resourceType, rule, benchmark)
+
+	if containerID, _ := m["container_id"].(string); containerID != "" {
+		imageID, _ := m["image_id"].(string)
+		imageName, _ := m["image_name"].(string)
+		imageTag, _ := m["image_tag"].(string)
+		event.Container = &CheckContainerMeta{
+			ContainerID: containerID,
+			ImageID: imageID,
+			ImageName: imageName,
+			ImageTag: imageTag,
+		}
+	}
+
+	return event
 }
 
 func buildRegoModules(rootDir string, rule *Rule) (map[string]string, error) {
@@ -177,6 +194,10 @@ raw_finding(status, resource_type, resource_id, event_data) = f {
 		"status": status,
 		"resource_type": resource_type,
 		"resource_id": resource_id,
+		"image_id": input.context.image_id,
+		"image_name": input.context.image_name,
+		"image_tag": input.context.image_tag,
+		"container_id": input.context.container_id,
 		"data": event_data,
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Add a `eligible_processes` field for benchmark to be able to tell the compliance runner to select these benchmarks only if we detect running processes with the given name.

As we detect these processes, we also try to detect whether or not they actually run inside a container. In which case we also modify the root path of the resolver to be able to run these benchmarks against the filesystem of said container.

Some changes to how tags can be associated with check logs is also part of the commit. Required to associates some container / image metadata along with the check log.

### Motivation

Being able to execute cross-container compliance checks.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
