### PR TITLE
[CWS] fix signal event on COS

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/signal.h
+++ b/pkg/security/ebpf/c/include/hooks/signal.h
@@ -28,22 +28,22 @@ HOOK_SYSCALL_ENTRY2(kill, int, pid, int, type) {
     return 0;
 }
 
-HOOK_ENTRY("kill_pid_info")
-int hook_kill_pid_info(ctx_t *ctx) {
+HOOK_ENTRY("check_kill_permission")
+int hook_check_kill_permission(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_SIGNAL);
-    if (!syscall || syscall->signal.pid) {
+    if (!syscall) {
         return 0;
     }
 
-    struct pid *pid = (struct pid *)CTX_PARM3(ctx);
-    if (!pid) {
+    struct task_struct *task = (struct task_struct *)CTX_PARM3(ctx);
+    if (!task) {
         return 0;
     }
-    syscall->signal.pid = get_root_nr_from_pid_struct(pid);
+
+    syscall->signal.pid = get_root_nr_from_task_struct(task);
 
     return 0;
 }
-
 
 /* hook here to grab the EPERM retval */
 HOOK_EXIT("check_kill_permission")

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -409,7 +409,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 		"signal": {
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				kretprobeOrFexit("check_kill_permission", fentry),
-				kprobeOrFentry("kill_pid_info", fentry),
+				kprobeOrFentry("check_kill_permission", fentry),
 			}},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "kill", fentry, Entry|SupportFentry)},
 		},

--- a/pkg/security/ebpf/probes/signal.go
+++ b/pkg/security/ebpf/probes/signal.go
@@ -17,6 +17,12 @@ func getSignalProbes(fentry bool) []*manager.Probe {
 				EBPFFuncName: "rethook_check_kill_permission",
 			},
 		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_check_kill_permission",
+			},
+		},
 	}
 
 	signalProbes = append(signalProbes, ExpandSyscallProbes(&manager.Probe{
@@ -25,11 +31,6 @@ func getSignalProbes(fentry bool) []*manager.Probe {
 		},
 		SyscallFuncName: "kill",
 	}, fentry, Entry|SupportFentry)...)
-	signalProbes = append(signalProbes, &manager.Probe{
-		ProbeIdentificationPair: manager.ProbeIdentificationPair{
-			UID:          SecurityAgentUID,
-			EBPFFuncName: "hook_kill_pid_info",
-		},
-	})
+
 	return signalProbes
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR fixes the signal event on OSes that have `kill_pid_info` function inlined in their kill syscall call-path.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
