### PR TITLE
[bugfix] Fix Go Language Detection when the Process Check is Disabled

### DIFF
--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -256,7 +256,7 @@ func initMisc(deps miscDeps) error {
 	}
 	tagger.SetDefaultTagger(t)
 
-	processCollectionServer := collector.NewProcessCollector(deps.Config)
+	processCollectionServer := collector.NewProcessCollector(deps.Config, deps.Syscfg)
 
 	// appCtx is a context that cancels when the OnStop hook is called
 	appCtx, stopApp := context.WithCancel(context.Background())

--- a/pkg/network/events/monitor.go
+++ b/pkg/network/events/monitor.go
@@ -116,7 +116,7 @@ func (e *eventMonitor) UnregisterHandler(handler ProcessEventHandler) {
 	e.Lock()
 	defer e.Unlock()
 
-	//if idx := slices.Index(e.handlers, handler); idx >= 0 {
-	//	e.handlers = slices.Delete(e.handlers, idx, idx+1)
-	//}
+	if idx := slices.Index(e.handlers, handler); idx >= 0 {
+		e.handlers = slices.Delete(e.handlers, idx, idx+1)
+	}
 }

--- a/pkg/network/events/monitor.go
+++ b/pkg/network/events/monitor.go
@@ -10,11 +10,13 @@ package events
 import (
 	"sync"
 
+	"go.uber.org/atomic"
+	"golang.org/x/exp/slices"
+
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"go.uber.org/atomic"
 )
 
 var theMonitor atomic.Value

--- a/pkg/network/events/monitor.go
+++ b/pkg/network/events/monitor.go
@@ -10,13 +10,11 @@ package events
 import (
 	"sync"
 
-	"go.uber.org/atomic"
-	"golang.org/x/exp/slices"
-
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"go.uber.org/atomic"
 )
 
 var theMonitor atomic.Value
@@ -118,7 +116,7 @@ func (e *eventMonitor) UnregisterHandler(handler ProcessEventHandler) {
 	e.Lock()
 	defer e.Unlock()
 
-	if idx := slices.Index(e.handlers, handler); idx >= 0 {
-		e.handlers = slices.Delete(e.handlers, idx, idx+1)
-	}
+	//if idx := slices.Index(e.handlers, handler); idx >= 0 {
+	//	e.handlers = slices.Delete(e.handlers, idx, idx+1)
+	//}
 }

--- a/pkg/process/metadata/workloadmeta/collector/process.go
+++ b/pkg/process/metadata/workloadmeta/collector/process.go
@@ -19,16 +19,16 @@ import (
 
 const collectorId = "local-process"
 
-func NewProcessCollector(ddConfig config.ConfigReader) *Collector {
-	wlmExtractor := workloadmetaExtractor.NewWorkloadMetaExtractor(ddConfig)
+func NewProcessCollector(coreConfig, sysProbeConfig config.ConfigReader) *Collector {
+	wlmExtractor := workloadmetaExtractor.NewWorkloadMetaExtractor(sysProbeConfig)
 
-	processData := checks.NewProcessData(ddConfig)
+	processData := checks.NewProcessData(coreConfig)
 	processData.Register(wlmExtractor)
 
 	return &Collector{
-		ddConfig:        ddConfig,
+		ddConfig:        coreConfig,
 		wlmExtractor:    wlmExtractor,
-		grpcServer:      workloadmetaExtractor.NewGRPCServer(ddConfig, wlmExtractor),
+		grpcServer:      workloadmetaExtractor.NewGRPCServer(coreConfig, wlmExtractor),
 		processData:     processData,
 		collectionClock: clock.New(),
 		pidToCid:        make(map[int]string),

--- a/pkg/process/metadata/workloadmeta/collector/process.go
+++ b/pkg/process/metadata/workloadmeta/collector/process.go
@@ -19,6 +19,7 @@ import (
 
 const collectorId = "local-process"
 
+// NewProcessCollector creates a new process collector.
 func NewProcessCollector(coreConfig, sysProbeConfig config.ConfigReader) *Collector {
 	wlmExtractor := workloadmetaExtractor.NewWorkloadMetaExtractor(sysProbeConfig)
 
@@ -35,6 +36,8 @@ func NewProcessCollector(coreConfig, sysProbeConfig config.ConfigReader) *Collec
 	}
 }
 
+// Collector collects processes to send to the remote process collector in the core agent.
+// It is only intended to be used when language detection is enabled, and the process check is disabled.
 type Collector struct {
 	ddConfig config.ConfigReader
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR fixes a bug where the language detection module does not query the system probe when using the process collector. This bug occured due to the fact that the core config was passed to the workload meta extractor instead of the system probe config, which the language detection module uses to know whether the system probe's language detection module is enabled.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Bugfix

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
None

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

```yaml
# datadog.yaml
language_detection: { enabled: true }
```
```yaml
# system-probe.yaml
system_probe_config:
  language_detection: { enabled: true } 
```
Using the above config:
1. Run the agent
2. Wait 1 minute for the first process collector run to occur
3. Run `agent workload-list`, and look for at least one go process. The agent is written in go, so it should be able to detect itself.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
