### PR TITLE
[workloadmeta] Make kubeapiserver collector more generic

### DIFF
--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -53,7 +53,7 @@ func (c *collector) Start(ctx context.Context, wlmetaStore workloadmeta.Store) e
 	for _, storeBuilder := range resourceSpecificGenerator {
 		reflector, store, err := storeBuilder(ctx, wlmetaStore, client)
 		if err != nil {
-			log.Warnf("failed to start reflector:", err)
+			log.Warnf("failed to start reflector: %s", err)
 			continue
 		}
 		objectStores = append(objectStores, store)

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -13,6 +13,7 @@ import (
 
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -30,10 +31,17 @@ const (
 type collector struct{}
 
 // storeGenerator returns a new store specific to a given resource
-type storeGenerator func(context.Context, workloadmeta.Store, kubernetes.Interface) (*cache.Reflector, *reflectorStore, error)
+type storeGenerator func(context.Context, workloadmeta.Store, kubernetes.Interface) (*cache.Reflector, *reflectorStore)
 
-// resourceSpecificGenerator contains a list of stores and functions to create this store
-var resourceSpecificGenerator = make(map[string]storeGenerator)
+func storeGenerators(cfg config.Config) []storeGenerator {
+	generators := []storeGenerator{newNodeStore}
+
+	if cfg.GetBool("cluster_agent.collect_kubernetes_tags") {
+		generators = append(generators, newPodStore)
+	}
+
+	return generators
+}
 
 func init() {
 	workloadmeta.RegisterClusterCollector(collectorID, func() workloadmeta.Collector {
@@ -50,12 +58,8 @@ func (c *collector) Start(ctx context.Context, wlmetaStore workloadmeta.Store) e
 	}
 	client := apiserverClient.Cl
 
-	for _, storeBuilder := range resourceSpecificGenerator {
-		reflector, store, err := storeBuilder(ctx, wlmetaStore, client)
-		if err != nil {
-			log.Warnf("failed to start reflector: %s", err)
-			continue
-		}
+	for _, storeBuilder := range storeGenerators(config.Datadog) {
+		reflector, store := storeBuilder(ctx, wlmetaStore, client)
 		objectStores = append(objectStores, store)
 		go reflector.Run(ctx.Done())
 	}

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/node.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/node.go
@@ -23,10 +23,10 @@ import (
 const nodeStoreName = "node-store"
 
 func init() {
-	objectStoreBuilders[nodeStoreName] = newNodeStore
+	resourceSpecificGenerator[nodeStoreName] = newNodeStore
 }
 
-func newNodeStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.Interface) (*cache.Reflector, error) {
+func newNodeStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.Interface) (*cache.Reflector, *reflectorStore, error) {
 	nodeListerWatcher := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			return client.CoreV1().Nodes().List(ctx, options)
@@ -44,7 +44,7 @@ func newNodeStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes
 		nodeStore,
 		noResync,
 	)
-	return nodeReflector, nil
+	return nodeReflector, nodeStore, nil
 }
 
 func newNodeReflectorStore(wlmetaStore workloadmeta.Store) *reflectorStore {

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/node.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/node.go
@@ -17,16 +17,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
-const nodeStoreName = "node-store"
-
-func init() {
-	resourceSpecificGenerator[nodeStoreName] = newNodeStore
-}
-
-func newNodeStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.Interface) (*cache.Reflector, *reflectorStore, error) {
+func newNodeStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.Interface) (*cache.Reflector, *reflectorStore) {
 	nodeListerWatcher := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			return client.CoreV1().Nodes().List(ctx, options)
@@ -44,7 +39,8 @@ func newNodeStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes
 		nodeStore,
 		noResync,
 	)
-	return nodeReflector, nodeStore, nil
+	log.Debug("node reflector enabled")
+	return nodeReflector, nodeStore
 }
 
 func newNodeReflectorStore(wlmetaStore workloadmeta.Store) *reflectorStore {

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/pod.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/pod.go
@@ -27,12 +27,12 @@ import (
 const podStoreName = "pod-store"
 
 func init() {
-	objectStoreBuilders[podStoreName] = newPodStore
+	resourceSpecificGenerator[podStoreName] = newPodStore
 }
 
-func newPodStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.Interface) (*cache.Reflector, error) {
+func newPodStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.Interface) (*cache.Reflector, *reflectorStore, error) {
 	if config.Datadog.GetBool("cluster_agent.collect_kubernetes_tags") {
-		return nil, fmt.Errorf("cluster_agent.collect_kubernetes_tags is not enabled")
+		return nil, nil, fmt.Errorf("cluster_agent.collect_kubernetes_tags is not enabled")
 	}
 	podListerWatcher := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -51,7 +51,7 @@ func newPodStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.
 		podStore,
 		noResync,
 	)
-	return podReflector, nil
+	return podReflector, podStore, nil
 }
 
 func newPodReflectorStore(wlmetaStore workloadmeta.Store) *reflectorStore {

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/pod.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/pod.go
@@ -8,14 +8,51 @@
 package kubeapiserver
 
 import (
+	"context"
+	"fmt"
 	"regexp"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
+
+const podStoreName = "pod-store"
+
+func init() {
+	objectStoreBuilders[podStoreName] = newPodStore
+}
+
+func newPodStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.Interface) (*cache.Reflector, error) {
+	if config.Datadog.GetBool("cluster_agent.collect_kubernetes_tags") {
+		return nil, fmt.Errorf("cluster_agent.collect_kubernetes_tags is not enabled")
+	}
+	podListerWatcher := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return client.CoreV1().Pods(metav1.NamespaceAll).List(ctx, options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return client.CoreV1().Pods(metav1.NamespaceAll).Watch(ctx, options)
+		},
+	}
+
+	podStore := newPodReflectorStore(wlm)
+	podReflector := cache.NewNamedReflector(
+		componentName,
+		podListerWatcher,
+		&corev1.Pod{},
+		podStore,
+		noResync,
+	)
+	return podReflector, nil
+}
 
 func newPodReflectorStore(wlmetaStore workloadmeta.Store) *reflectorStore {
 	annotationsExclude := config.Datadog.GetStringSlice("cluster_agent.kubernetes_resources_collection.pod_annotations_exclude")

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/pod.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/pod.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 func newPodStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.Interface) (*cache.Reflector, *reflectorStore, error) {
-	if config.Datadog.GetBool("cluster_agent.collect_kubernetes_tags") {
+	if !config.Datadog.GetBool("cluster_agent.collect_kubernetes_tags") {
 		return nil, nil, fmt.Errorf("cluster_agent.collect_kubernetes_tags is not enabled")
 	}
 	podListerWatcher := &cache.ListWatch{

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/pod.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/pod.go
@@ -24,9 +24,6 @@ import (
 )
 
 func newPodStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.Interface) (*cache.Reflector, *reflectorStore) {
-	if !config.Datadog.GetBool("cluster_agent.collect_kubernetes_tags") {
-		return nil, nil
-	}
 	podListerWatcher := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			return client.CoreV1().Pods(metav1.NamespaceAll).List(ctx, options)

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/pod.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/pod.go
@@ -9,7 +9,6 @@ package kubeapiserver
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 
 	corev1 "k8s.io/api/core/v1"
@@ -24,15 +23,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
-const podStoreName = "pod-store"
-
-func init() {
-	resourceSpecificGenerator[podStoreName] = newPodStore
-}
-
-func newPodStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.Interface) (*cache.Reflector, *reflectorStore, error) {
+func newPodStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.Interface) (*cache.Reflector, *reflectorStore) {
 	if !config.Datadog.GetBool("cluster_agent.collect_kubernetes_tags") {
-		return nil, nil, fmt.Errorf("cluster_agent.collect_kubernetes_tags is not enabled")
+		return nil, nil
 	}
 	podListerWatcher := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -51,7 +44,8 @@ func newPodStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.
 		podStore,
 		noResync,
 	)
-	return podReflector, podStore, nil
+	log.Debug("pod reflector enabled")
+	return podReflector, podStore
 }
 
 func newPodReflectorStore(wlmetaStore workloadmeta.Store) *reflectorStore {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR makes the kubeapiserver collector more generic.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The apiserver collector will most likely be extended in the future so it makes sense to make it more generic. 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
None
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Run `agent workload-list -v` on the cluster agent and make sure nodes and pods are still collected. `cluster_agent.collect_kubernetes_tags` needs to be enabled. To do that, you can set the env variable `DD_CLUSTER_AGENT_COLLECT_KUBERNETES_TAGS` to `"true"` in the cluster-agent.
 
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
