### PR TITLE
[backport] Fix support for Read-Only domain controllers in NG installer (#18977)

### DIFF
--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/ProcessUserCustomActionsDomainControllerTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/ProcessUserCustomActionsDomainControllerTests.cs
@@ -53,6 +53,84 @@ namespace CustomActions.Tests.ProcessUserCustomActions
 
         [Theory]
         [AutoData]
+        public void ProcessDdAgentUserCredentials_Fails_With_Creating_DomainUser_On_ReadOnly_Domain_Controllers(
+            string ddAgentUserName,
+            string ddAgentUserPassword)
+        {
+            Test.WithReadOnlyDomainController();
+
+            Test.Session
+                .Setup(session => session["DDAGENTUSER_NAME"]).Returns($"{Domain}\\{ddAgentUserName}");
+            Test.Session
+                .Setup(session => session["DDAGENTUSER_PASSWORD"]).Returns(ddAgentUserPassword);
+
+            Test.Create()
+                .ProcessDdAgentUserCredentials()
+                .Should()
+                .Be(ActionResult.Failure);
+
+            Test.Properties.Should()
+                .OnlyContain(kvp => (kvp.Key == "DDAGENTUSER_FOUND" && kvp.Value == "false") ||
+                                    (kvp.Key == "DDAGENTUSER_SID" && string.IsNullOrEmpty(kvp.Value)));
+        }
+
+        [Theory]
+        [AutoData]
+        public void ProcessDdAgentUserCredentials_Fails_With_Creating_DomainUser_On_ReadOnly_Domain_Controllers_Sanity(
+            string ddAgentUserName,
+            string ddAgentUserPassword)
+        {
+            // Sanity check logic when IsDomainController() returns false and IsReadOnlyDomainController() returns true.
+            // This should never happen but we should make sure we still treat the host as a read-only domain controller.
+            Test.NativeMethods.Setup(n => n.IsDomainController()).Returns(false);
+            Test.NativeMethods.Setup(n => n.IsReadOnlyDomainController()).Returns(true);
+
+            Test.Session
+                .Setup(session => session["DDAGENTUSER_NAME"]).Returns($"{Domain}\\{ddAgentUserName}");
+            Test.Session
+                .Setup(session => session["DDAGENTUSER_PASSWORD"]).Returns(ddAgentUserPassword);
+
+            Test.Create()
+                .ProcessDdAgentUserCredentials()
+                .Should()
+                .Be(ActionResult.Failure);
+
+            Test.Properties.Should()
+                .OnlyContain(kvp => (kvp.Key == "DDAGENTUSER_FOUND" && kvp.Value == "false") ||
+                                    (kvp.Key == "DDAGENTUSER_SID" && string.IsNullOrEmpty(kvp.Value)));
+        }
+
+        [Theory]
+        [AutoData]
+        public void ProcessDdAgentUserCredentials_Succeeds_With_Existing_DomainUser_On_ReadOnly_Domain_Controllers(
+            string ddAgentUserName,
+            string ddAgentUserPassword)
+        {
+            Test.WithReadOnlyDomainController();
+            Test.WithDomainUser(ddAgentUserName);
+
+            Test.Session
+                .Setup(session => session["DDAGENTUSER_NAME"]).Returns($"{Domain}\\{ddAgentUserName}");
+            Test.Session
+                .Setup(session => session["DDAGENTUSER_PASSWORD"]).Returns(ddAgentUserPassword);
+
+            Test.Create()
+                .ProcessDdAgentUserCredentials()
+                .Should()
+                .Be(ActionResult.Success);
+
+            Test.Properties.Should()
+                .Contain("DDAGENTUSER_FOUND", "true").And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_SID" && !string.IsNullOrEmpty(kvp.Value)).And
+                .Contain("DDAGENTUSER_PROCESSED_NAME", ddAgentUserName).And
+                .Contain("DDAGENTUSER_PROCESSED_DOMAIN", Domain).And
+                .Contain("DDAGENTUSER_PROCESSED_FQ_NAME", $"{Domain}\\{ddAgentUserName}").And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_RESET_PASSWORD" && string.IsNullOrEmpty(kvp.Value)).And
+                .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" && !string.IsNullOrEmpty(kvp.Value));
+        }
+
+        [Theory]
+        [AutoData]
         public void ProcessDdAgentUserCredentials_Succeeds_With_Existing_DomainUser_On_Domain_Controllers(
             string ddAgentUserName,
             string ddAgentUserPassword)

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/ProcessUserCustomActionsTestSetup.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/ProcessUserCustomActionsTestSetup.cs
@@ -21,6 +21,7 @@ namespace CustomActions.Tests.ProcessUserCustomActions
             
             // By default computers are not domain-joined
             NativeMethods.Setup(n => n.IsDomainController()).Returns(false);
+            NativeMethods.Setup(n => n.IsReadOnlyDomainController()).Returns(false);
             NativeMethods.Setup(n => n.GetComputerDomain()).Throws<ActiveDirectoryObjectNotFoundException>();
             ServiceController.SetupGet(s => s.Services).Returns(new WindowsService[] { });
         }
@@ -81,6 +82,18 @@ namespace CustomActions.Tests.ProcessUserCustomActions
             domain ??= _fixture.Create<string>();
 
             NativeMethods.Setup(n => n.IsDomainController()).Returns(true);
+            NativeMethods.Setup(n => n.IsReadOnlyDomainController()).Returns(false);
+            NativeMethods.Setup(n => n.GetComputerDomain()).Returns(domain);
+
+            return this;
+        }
+
+        public ProcessUserCustomActionsTestSetup WithReadOnlyDomainController(string domain = null)
+        {
+            domain ??= _fixture.Create<string>();
+
+            NativeMethods.Setup(n => n.IsDomainController()).Returns(true);
+            NativeMethods.Setup(n => n.IsReadOnlyDomainController()).Returns(true);
             NativeMethods.Setup(n => n.GetComputerDomain()).Returns(domain);
 
             return this;

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
@@ -91,6 +91,13 @@ namespace Datadog.CustomActions
         /// </summary>
         private void ConfigureUserGroups()
         {
+            if (_nativeMethods.IsReadOnlyDomainController())
+            {
+                _session.Log("Host is a Read-Only Domain controller, user cannot be added to groups by the installer." +
+                             " Install will continue, agent may not function properly if user has not been added to these groups.");
+                return;
+            }
+
             _nativeMethods.AddToGroup(_ddAgentUserSID, WellKnownSidType.BuiltinPerformanceMonitoringUsersSid);
             // Builtin\Event Log Readers
             _nativeMethods.AddToGroup(_ddAgentUserSID, new SecurityIdentifier("S-1-5-32-573"));

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Interfaces/INativeMethods.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Interfaces/INativeMethods.cs
@@ -27,6 +27,8 @@ namespace Datadog.CustomActions.Interfaces
 
         bool IsDomainController();
 
+        bool IsReadOnlyDomainController();
+
         /// <summary>
         /// 
         /// </summary>

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/NativeMethods.cs
@@ -68,6 +68,7 @@ namespace Datadog.CustomActions.Native
 
             // One or more of the members specified were already members of the local group. No new members were added.
             ERROR_MEMBER_IN_ALIAS = 1378,
+            ERROR_MEMBER_IN_GROUP = 1320,
 
             // One or more of the members specified do not exist. Therefore, no new members were added.
             ERROR_NO_SUCH_MEMBER = 1387,
@@ -395,6 +396,52 @@ namespace Datadog.CustomActions.Native
         string lpdwTagId, string lpDependencies, string lpServiceStartName, string lpPassword,
         string lpDisplayName);
 
+        [StructLayout(LayoutKind.Sequential)]
+        public class GuidClass
+        {
+            public Guid TheGuid;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        struct DOMAIN_CONTROLLER_INFO
+        {
+            [MarshalAs(UnmanagedType.LPTStr)]
+            public string DomainControllerName;
+            [MarshalAs(UnmanagedType.LPTStr)]
+            public string DomainControllerAddress;
+            public uint DomainControllerAddressType;
+            public Guid DomainGuid;
+            [MarshalAs(UnmanagedType.LPTStr)]
+            public string DomainName;
+            [MarshalAs(UnmanagedType.LPTStr)]
+            public string DnsForestName;
+            public DS_FLAG Flags;
+            [MarshalAs(UnmanagedType.LPTStr)]
+            public string DcSiteName;
+            [MarshalAs(UnmanagedType.LPTStr)]
+            public string ClientSiteName;
+        }
+
+        [Flags]
+        public enum DS_FLAG : uint
+        {
+            DS_WRITABLE_FLAG = 0x00000100,
+        }
+
+        [DllImport("Netapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        static extern int DsGetDcName
+        (
+            [MarshalAs(UnmanagedType.LPTStr)]
+            string ComputerName,
+            [MarshalAs(UnmanagedType.LPTStr)]
+            string DomainName,
+            [In] GuidClass DomainGuid,
+            [MarshalAs(UnmanagedType.LPTStr)]
+            string SiteName,
+            int Flags,
+            out IntPtr pDOMAIN_CONTROLLER_INFO
+        );
+
         #endregion
         #region Public interface
 
@@ -461,7 +508,9 @@ namespace Datadog.CustomActions.Native
                 Marshal.Copy(sid, 0, info.pSID, sid.Length);
 
                 err = (ReturnCodes)NetLocalGroupAddMembers(null, groupName, 0, ref info, 1);
-                if (err == ReturnCodes.NO_ERROR || err == ReturnCodes.ERROR_MEMBER_IN_ALIAS)
+                if (err == ReturnCodes.NO_ERROR ||
+                    err == ReturnCodes.ERROR_MEMBER_IN_ALIAS ||
+                    err == ReturnCodes.ERROR_MEMBER_IN_GROUP)
                 {
                     return;
                 }
@@ -543,12 +592,41 @@ namespace Datadog.CustomActions.Native
             return false;
         }
 
+        public bool IsReadOnlyDomainController()
+        {
+            if (!IsDomainController())
+            {
+                return false;
+            }
+
+            IntPtr pDCI = IntPtr.Zero;
+            try
+            {
+                var result = DsGetDcName(null, null, null, null, 0, out pDCI);
+                if (result != 0)
+                {
+                    throw new Exception("unexpected error getting domain controller information",
+                        new Win32Exception((int)result));
+                }
+
+                var domainInfo = (DOMAIN_CONTROLLER_INFO)Marshal.PtrToStructure(pDCI, typeof(DOMAIN_CONTROLLER_INFO));
+                var isWritable = domainInfo.Flags.HasFlag(DS_FLAG.DS_WRITABLE_FLAG);
+                return !isWritable;
+            }
+            finally
+            {
+                if (pDCI != IntPtr.Zero)
+                {
+                    NetApiBufferFree(pDCI);
+                }
+            }
+        }
+
         public string GetComputerDomain()
         {
             // Computer is a DC, default to domain name
             return Domain.GetComputerDomain().Name;
         }
-
 
         /// <summary>
         /// Checks whether or not a user account belongs to a domain or is a local account.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

backport of: Fix support for Read-Only domain controllers in NG installer (#18977) https://github.com/DataDog/datadog-agent/commit/9d57c10a9eeb3916e661d35dbd23c6e36395a99d

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
