### PR TITLE
[serverless] Fix blocking on no-requestID logs channel

### DIFF
--- a/pkg/serverless/logs/logs_collector.go
+++ b/pkg/serverless/logs/logs_collector.go
@@ -64,7 +64,7 @@ type LambdaLogsCollector struct {
 func NewLambdaLogCollector(out chan<- *logConfig.ChannelMessage, demux aggregator.Demultiplexer, extraTags *Tags, logsEnabled bool, enhancedMetricsEnabled bool, executionContext *executioncontext.ExecutionContext, handleRuntimeDone func(), lambdaInitMetricChan chan<- *LambdaInitMetric) *LambdaLogsCollector {
 
 	return &LambdaLogsCollector{
-		In:                     make(chan []LambdaLogAPIMessage),
+		In:                     make(chan []LambdaLogAPIMessage, maxBufferedLogs),
 		out:                    out,
 		demux:                  demux,
 		extraTags:              extraTags,

--- a/pkg/serverless/logs/logs_collector.go
+++ b/pkg/serverless/logs/logs_collector.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// The maximum number of logs that will be buffered during the init phase before the first invocation
-	maxBufferedLogs = 2000
+	maxBufferedLogs = 200
 )
 
 // Tags contains the actual array of Tags (useful for passing it via reference)
@@ -116,7 +116,6 @@ func (lc *LambdaLogsCollector) Start() {
 // Shutdown the log collector
 func (lc *LambdaLogsCollector) Shutdown() {
 	close(lc.In)
-	close(lc.orphanLogsChan)
 }
 
 // shouldProcessLog returns whether or not the log should be further processed.

--- a/pkg/serverless/logs/logs_collector.go
+++ b/pkg/serverless/logs/logs_collector.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// The maximum number of logs that will be buffered during the init phase before the first invocation
-	maxBufferedLogs = 200
+	maxBufferedLogs = 2000
 )
 
 // Tags contains the actual array of Tags (useful for passing it via reference)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds a condition to send messages to the orphanLogsChannel only when the slice of log messages without a requestID isn't  empty. This was previously causing an issue where we would _always_ send an empty slice to the channel regardless of whether there were any orphan logs, eventually hitting the maximum buffer size and blocking the channel and the goroutine.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
In reference to https://github.com/DataDog/datadog-agent/pull/18748, the release candidate discovered that metrics and logs were not being sent after _n_ amount of time, due to a blocked goroutine

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
