### PR TITLE
Dogstatsd traffic capture fixes

### DIFF
--- a/comp/dogstatsd/replay/capture.go
+++ b/comp/dogstatsd/replay/capture.go
@@ -89,7 +89,8 @@ func (tc *trafficCapture) Start(p string, d time.Duration, compressed bool) (str
 		return "", err
 	}
 
-	go tc.writer.Capture(target, d, compressed)
+	destinationName := target.Name()
+	go tc.writer.Capture(target, d, compressed, destinationName)
 
 	return path, nil
 

--- a/comp/dogstatsd/replay/writer_test.go
+++ b/comp/dogstatsd/replay/writer_test.go
@@ -92,7 +92,7 @@ func writerTest(t *testing.T, z bool) {
 		defer wg.Done()
 
 		close(start)
-		writer.Capture(file, testDuration, z)
+		writer.Capture(file, testDuration, z, path)
 	}(&wg)
 
 	wgc := make(chan struct{})


### PR DESCRIPTION
### What does this PR do?
Fixes two bugs found in the dogstatsd traffic capture functionality:
1. The first dogstatsd msg after enabling a capture is missed 
2. A traffic-capture instance would be permanently closed after one recording completed

### Motivation
The incorrect check on `is traffic capture ongoing` in the UDS codepath can result in a panic.
I have only seen this panic a handful of times, and cannot reproduce reliably :(

Imagine a scenario where traffic capture is enabled, expires, and we then close that capture (which [closes the channel](https://github.com/DataDog/datadog-agent/blob/0f8dfce1dfd60eb30a43541004647a71fd4c82d5/comp/dogstatsd/replay/writer.go#L260)). Next, we enable a new traffic capture which runs `TrafficCaptureWriter::Capture` and as this function executes, it first sets `ongoing=true`, then enters into the blocking channel read selector.
This is the window of time where the race is possible.
The [read on the closed channel](https://github.com/DataDog/datadog-agent/blob/0f8dfce1dfd60eb30a43541004647a71fd4c82d5/comp/dogstatsd/replay/writer.go#L217) will return immediately, and this function sets `ongoing=false` as it exits.

During this brief window of time where `ongoing=true` (during the execution of `TrafficCaptureWriter::Capture`) if we enter the dogstatsd read loop, [this block](https://github.com/DataDog/datadog-agent/blob/0f8dfce1dfd60eb30a43541004647a71fd4c82d5/comp/dogstatsd/listeners/uds_common.go#L171) executes **and `IsOngoing` returns true**. So now capBuff is now pointing to a valid buffer. Now the traffic capture ends, but we still have a valid capBuff, so we still enqueue it [here](https://github.com/DataDog/datadog-agent/blob/0f8dfce1dfd60eb30a43541004647a71fd4c82d5/comp/dogstatsd/listeners/uds_common.go#L250). This enqueue succeeds because `Capture` only sets `ongoing` to false, not `accepting` to false.
We now try to send this on the channel and hit the panic.



```
2023-08-23T20:59:40Z | CORE | WARN | (comp/dogstatsd/replay/writer.go:230 in Capture) | Wrote 8 bytes for capture tagger state
panic: send on closed channel

goroutine 432 [running]:
github.com/DataDog/datadog-agent/comp/dogstatsd/replay.(*TrafficCaptureWriter).Enqueue(0x4001967e28?, 0x4002304000)
        /home/lima.linux/dev/datadog-agent/comp/dogstatsd/replay/writer.go:280 +0xbc
github.com/DataDog/datadog-agent/comp/dogstatsd/replay.(*trafficCapture).Enqueue(0x4000dcdd18?, 0x4002302000?)
        /home/lima.linux/dev/datadog-agent/comp/dogstatsd/replay/capture.go:127 +0xb4
github.com/DataDog/datadog-agent/comp/dogstatsd/listeners.(*UDSListener).Listen(0x4000b38690)
        /home/lima.linux/dev/datadog-agent/comp/dogstatsd/listeners/uds_common.go:250 +0x9e4
created by github.com/DataDog/datadog-agent/comp/dogstatsd/server.(*server).handleMessages
        /home/lima.linux/dev/datadog-agent/comp/dogstatsd/server/server.go:446 +0xe0
```

### Additional Notes
I cannot repro this panic on demand and wasn't able to find a good way to express this in the unit tests.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
1. Set a dogstatsd_socket_path to enable UDS in the agent
2. Start a dogstatsd capture: `agent dogstatsd-capture --compressed=false -d 15s --path /tmp/`
3. Send some uds traffic, eg `echo "statsd.other.metric:3|c|@1.000000|#environment:dev\nstatsd.other.metric:8|c|@1.000000|#environment:dev\nstatsd.other.metric:7|c|@1.000000|#environment:dev" | nc -w0 -uU /tmp/dsd.sock`
4. Once 15s have passed and the capture is complete, give the resulting traffic capture a sanity check by inspecting the file with `xxd` and ensure in the ASCII output you can see the metric you sent.
5. Repeat steps 2-4 once more to ensure that a second capture works.

(Note this QA is just a basic sanity check that the capture mechanism still works, as noted above I don't have reliable instructions for repro'ing the panic)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
