### PR TITLE
e2e: fix ami check

### DIFF
--- a/test/e2e/scripts/setup-instance/00-entrypoint-gitlab.sh
+++ b/test/e2e/scripts/setup-instance/00-entrypoint-gitlab.sh
@@ -14,7 +14,7 @@ IGNITION_BASE64=$(base64 -w 0 ignition.json)
 
 REGION="${REGION:-us-east-1}"
 UPDATE_STREAM="${UPDATE_STREAM:-stable}"
-if [ -z "$AMI"]; then
+if [ -z "${AMI+x}" ]; then
   AMI="$(curl "https://builds.coreos.fedoraproject.org/streams/${UPDATE_STREAM}.json" | jq -r ".architectures.x86_64.images.aws.regions.\"$REGION\".image")"
 fi
 ARGO_WORKFLOW=${ARGO_WORKFLOW:-''}


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/datadog-agent/pull/18984 fixed the issue encountered by the CWS tests but broke the case where the AMI is not defined and thus the other tests.. This PR fixes the new issue

Here is an example of a failing job that this PR fixes https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/317827118

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
