### PR TITLE
Add `gce-container-declaration` to default excluded GCE host tags

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -775,7 +775,7 @@ func InitConfig(config Config) {
 		"kube-env", "kubelet-config", "containerd-configure-sh", "startup-script", "shutdown-script",
 		"configure-sh", "sshKeys", "ssh-keys", "user-data", "cli-cert", "ipsec-cert", "ssl-cert", "google-container-manifest",
 		"bosh_settings", "windows-startup-script-ps1", "common-psm1", "k8s-node-setup-psm1", "serial-port-logging-enable",
-		"enable-oslogin", "disable-address-manager", "disable-legacy-endpoints", "windows-keys", "kubeconfig",
+		"enable-oslogin", "disable-address-manager", "disable-legacy-endpoints", "windows-keys", "kubeconfig", "gce-container-declaration",
 	})
 	config.BindEnvAndSetDefault("gce_send_project_id_tag", false)
 	config.BindEnvAndSetDefault("gce_metadata_timeout", 1000) // value in milliseconds

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -414,26 +414,36 @@ api_key:
 #
 # collect_gce_tags: true
 
-## @param exclude_gce_tags - list of strings - optional - default: ["kube-env", "kubelet-config", "containerd-configure-sh", "startup-script", "shutdown-script", "configure-sh", "sshKeys", "ssh-keys", "user-data", "cli-cert", "ipsec-cert", "ssl-cert", "google-container-manifest", "bosh_settings"]
-## @env DD_EXCLUDE_GCE_TAGS - space separated list of strings - optional - default: kube-env kubelet-config containerd-configure-sh startup-script shutdown-script configure-sh sshKeys ssh-keys user-data cli-cert ipsec-cert ssl-cert google-container-manifest bosh_settings
+## @param exclude_gce_tags - list of strings - optional - default: ["bosh_settings" ,"cli-cert" ,"common-psm1" ,"configure-sh" ,"containerd-configure-sh" ,"disable-address-manager" ,"disable-legacy-endpoints" ,"enable-oslogin" ,"gce-container-declaration" ,"google-container-manifest" ,"ipsec-cert" ,"k8s-node-setup-psm1" ,"kube-env" ,"kubeconfig" ,"kubelet-config" ,"serial-port-logging-enable" ,"shutdown-script" ,"ssh-keys" ,"sshKeys" ,"ssl-cert" ,"startup-script" ,"user-data" ,"windows-keys" ,"windows-startup-script-ps1"]
+## @env DD_EXCLUDE_GCE_TAGS - space separated list of strings - optional - default: bosh_settings cli-cert common-psm1 configure-sh containerd-configure-sh disable-address-manager disable-legacy-endpoints enable-oslogin gce-container-declaration google-container-manifest ipsec-cert k8s-node-setup-psm1 kube-env kubeconfig kubelet-config serial-port-logging-enable shutdown-script ssh-keys sshKeys ssl-cert startup-script user-data windows-keys windows-startup-script-ps1
 ## Google Cloud Engine metadata attribute to exclude from being converted into
 ## host tags -- only applicable when collect_gce_tags is true.
 #
 # exclude_gce_tags:
-#   - "kube-env"
-#   - "kubelet-config"
-#   - "containerd-configure-sh"
-#   - "startup-script"
-#   - "shutdown-script"
-#   - "configure-sh"
-#   - "sshKeys"
-#   - "ssh-keys"
-#   - "user-data"
-#   - "cli-cert"
-#   - "ipsec-cert"
-#   - "ssl-cert"
-#   - "google-container-manifest"
 #   - "bosh_settings"
+#   - "cli-cert"
+#   - "common-psm1"
+#   - "configure-sh"
+#   - "containerd-configure-sh"
+#   - "disable-address-manager"
+#   - "disable-legacy-endpoints"
+#   - "enable-oslogin"
+#   - "gce-container-declaration"
+#   - "google-container-manifest"
+#   - "ipsec-cert"
+#   - "k8s-node-setup-psm1"
+#   - "kube-env"
+#   - "kubeconfig"
+#   - "kubelet-config"
+#   - "serial-port-logging-enable"
+#   - "shutdown-script"
+#   - "ssh-keys"
+#   - "sshKeys"
+#   - "ssl-cert"
+#   - "startup-script"
+#   - "user-data"
+#   - "windows-keys"
+#   - "windows-startup-script-ps1"
 
 ## @param gce_send_project_id_tag - bool - optional - default: false
 ## @env DD_GCE_SEND_PROJECT_ID_TAG - bool - optional - default: false

--- a/releasenotes/notes/exclude_gce_container_declaration_host_tag-395b1829e41ba26b.yaml
+++ b/releasenotes/notes/exclude_gce_container_declaration_host_tag-395b1829e41ba26b.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    Add `gce-container-declaration` to default GCE excluded host tags.
+    Add ``gce-container-declaration`` to default GCE excluded host tags. See ``exclude_gce_tags`` configuration settings for more.

--- a/releasenotes/notes/exclude_gce_container_declaration_host_tag-395b1829e41ba26b.yaml
+++ b/releasenotes/notes/exclude_gce_container_declaration_host_tag-395b1829e41ba26b.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add `gce-container-declaration` to default GCE excluded host tags.


### PR DESCRIPTION
### What does this PR do?

* Updates `config.go` to include `gce-container-declaration` in the list of GCE host tags that are excluded by default
* Updates `config_template.yaml` to reflect the current list of excluded default tags

### Motivation

* Support case where a customer was seeing their logs enriched with this tag since it was a host-level tag, which can contain sensitive data (docker run command, where credentials could be present) : 
> Compute Engine stores your container settings in [instance metadata](https://cloud.google.com/compute/docs/storing-retrieving-metadata) under the gce-container-declaration metadata key.

per https://cloud.google.com/compute/docs/containers/deploying-containers#how_deploying_containers_on_works
<img width="842" alt="Image 2023-08-25 at 1 39 42 PM" src="https://github.com/DataDog/datadog-agent/assets/97530782/a0ece5fb-8afb-4cfe-8cd7-b614f07622ba">
* While doing the PR, I noticed the `config_template.yaml` file was not properly reflecting the current list of excluded tags, so took the opportunity to update it and order it alphabetically

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

1. Deploy a GCE VM with a container optimized OS and a container with a docker run command : https://cloud.google.com/compute/docs/containers/deploying-containers#how_deploying_containers_on_works. Metadata access should be allowed.
2. Deploy the Docker Agent
3. Ensure the metadata GCE tag `gce-container-declaration` is absent from the list of host tags in `agent status` after bashing into the Agent container
4. Verify other GCE excluded tags are absent

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
