### PR TITLE
[CWS] use real options for kernel module tests

### DIFF
--- a/pkg/security/tests/kernel_module_test.go
+++ b/pkg/security/tests/kernel_module_test.go
@@ -152,10 +152,6 @@ func TestKworker(t *testing.T) {
 }
 
 func TestLoadModule(t *testing.T) {
-	if os.Getenv("CI") == "true" {
-		t.Skip("TestLoadModule is known to be flaky")
-	}
-
 	if testEnvironment == DockerEnvironment {
 		t.Skip("skipping kernel module test in docker")
 	}
@@ -188,15 +184,15 @@ func TestLoadModule(t *testing.T) {
 		},
 		{
 			ID:         "test_load_module_with_params",
-			Expression: fmt.Sprintf(`load_module.name == "%s" && load_module.argv in ["toto=1"]`, testModuleName),
+			Expression: fmt.Sprintf(`load_module.name == "%s" && load_module.argv in ["cifs_max_pending=2"]`, testModuleName),
 		},
 		{
 			ID:         "test_load_module_with_truncated_params",
-			Expression: fmt.Sprintf(`load_module.name == "%s" && load_module.argv in ["Lorem"]`, testModuleName),
+			Expression: fmt.Sprintf(`load_module.name == "%s" && load_module.argv in [r"CIFSMaxBufSize=.*"]`, testModuleName),
 		},
 		{
 			ID:         "test_load_module_with_params_from_memory",
-			Expression: fmt.Sprintf(`load_module.name == "%s" && load_module.argv in ["toto=5"] && load_module.loaded_from_memory == true`, testModuleName),
+			Expression: fmt.Sprintf(`load_module.name == "%s" && load_module.argv in ["cifs_min_rcv=6"] && load_module.loaded_from_memory == true`, testModuleName),
 		},
 	}
 
@@ -261,13 +257,13 @@ func TestLoadModule(t *testing.T) {
 			}
 			defer f.Close()
 
-			if err = unix.FinitModule(int(f.Fd()), "toto=1 toto=2 toto=3", 0); err != nil {
+			if err = unix.FinitModule(int(f.Fd()), "cifs_max_pending=2 cifs_min_small=2", 0); err != nil {
 				return fmt.Errorf("couldn't insert module: %w", err)
 			}
 			return unix.DeleteModule(testModuleName, 0)
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "test_load_module_with_params", r.ID, "wrong rule triggered")
-			assertFieldEqual(t, event, "load_module.args", "toto=1 toto=2 toto=3")
+			assertFieldEqual(t, event, "load_module.args", "cifs_max_pending=2 cifs_min_small=2")
 			assertFieldEqual(t, event, "load_module.loaded_from_memory", false)
 			assertFieldEqual(t, event, "load_module.args_truncated", false)
 			test.validateLoadModuleSchema(t, event)
@@ -281,14 +277,14 @@ func TestLoadModule(t *testing.T) {
 				return fmt.Errorf("couldn't load module content: %w", err)
 			}
 
-			if err = unix.InitModule(module, "toto=5"); err != nil {
+			if err = unix.InitModule(module, "cifs_min_rcv=6"); err != nil {
 				return fmt.Errorf("couldn't insert module: %w", err)
 			}
 
 			return unix.DeleteModule(testModuleName, 0)
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "test_load_module_with_params_from_memory", r.ID, "wrong rule triggered")
-			assertFieldEqual(t, event, "load_module.argv", []string{"toto=5"})
+			assertFieldEqual(t, event, "load_module.argv", []string{"cifs_min_rcv=6"})
 			assertFieldEqual(t, event, "load_module.loaded_from_memory", true)
 			assertFieldEqual(t, event, "load_module.args_truncated", false)
 			test.validateLoadModuleSchema(t, event)
@@ -296,21 +292,26 @@ func TestLoadModule(t *testing.T) {
 	})
 
 	t.Run("load_module_with_truncated_params", func(t *testing.T) {
+		var args []string
+		for i := 0; i != 10; i++ {
+			args = append(args, fmt.Sprintf("CIFSMaxBufSize=%d", 8192+i))
+		}
+
 		test.WaitSignal(t, func() error {
 			module, err := os.ReadFile(modulePath)
 			if err != nil {
 				return fmt.Errorf("couldn't load module content: %w", err)
 			}
 
-			if err = unix.InitModule(module, "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis in luctus quam. Nam purus risus, varius non massa bibendum, sollicitudin"); err != nil {
+			if err = unix.InitModule(module, strings.Join(args, " ")); err != nil {
 				return fmt.Errorf("couldn't insert module: %w", err)
 			}
 
 			return unix.DeleteModule(testModuleName, 0)
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "test_load_module_with_truncated_params", r.ID, "wrong rule triggered")
-			assertFieldEqual(t, event, "load_module.argv", []string{"Lorem", "ipsum", "dolor", "sit", "amet,", "consectetur", "adipiscing", "elit.", "Duis", "in", "luctus", "quam.", "Nam", "purus", "risus,", "varius", "non", "massa", "bibendum,"})
-			assertFieldEqual(t, event, "load_module.args", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis in luctus quam. Nam purus risus, varius non massa bibendum,")
+			assertFieldEqual(t, event, "load_module.argv", args[0:6])
+			assertFieldEqual(t, event, "load_module.args", strings.Join(args[0:6], " "))
 			assertFieldEqual(t, event, "load_module.loaded_from_memory", true)
 			assertFieldEqual(t, event, "load_module.args_truncated", true)
 			test.validateLoadModuleSchema(t, event)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
