### PR TITLE
[task] deprecate golangci-lint task

### DIFF
--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -51,9 +51,9 @@
   script:
     - inv -e install-tools
     - inv -e system-probe.object-files
-    - invoke -e golangci-lint --build system-probe-unit-tests --concurrency 4 ./pkg
+    - invoke -e lint-go --build system-probe-unit-tests --cpus 4 --targets ./pkg
     - invoke -e security-agent.run-ebpf-unit-tests --verbose
-    - invoke -e golangci-lint --targets=./pkg/security/tests --concurrency 4 --build-tags="functionaltests stresstests trivy containerd linux_bpf ebpf_bindata" --arch=$TASK_ARCH
+    - invoke -e lint-go --targets=./pkg/security/tests --cpus 4 --build-tags="functionaltests stresstests trivy containerd linux_bpf ebpf_bindata" --arch=$TASK_ARCH
   variables:
     KUBERNETES_MEMORY_LIMIT: "8Gi"
 

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -197,7 +197,11 @@ build_tags = {
 
 
 def compute_build_tags_for_flavor(
-    build: str, arch: str, build_include: List[str], build_exclude: List[str], flavor: AgentFlavor = AgentFlavor.base
+    build: str,
+    arch: str,
+    build_include: List[str],
+    build_exclude: List[str],
+    flavor: AgentFlavor = AgentFlavor.base,
 ):
     """
     Given a flavor, an architecture, a list of tags to include and exclude, get the final list

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -37,7 +37,7 @@ def run_golangci_lint(ctx, targets, rtloader_root=None, build_tags=None, build="
     for target in targets:
         print(f"running golangci on {target}")
         concurrency_arg = "" if concurrency is None else f"--concurrency {concurrency}"
-        tags_arg = " ".join(set(tags))
+        tags_arg = " ".join(sorted(set(tags)))
         result = ctx.run(
             f'golangci-lint run --timeout 20m0s {concurrency_arg} --build-tags "{tags_arg}" {target}/...',
             env=env,
@@ -55,19 +55,11 @@ def golangci_lint(ctx, targets, rtloader_root=None, build_tags=None, build="test
 
     Example invocation:
         inv golangci-lint --targets=./pkg/collector/check,./pkg/aggregator
+    DEPRECATED
+    Please use inv lint-go instead
     """
-    results = run_golangci_lint(ctx, targets, rtloader_root, build_tags, build, arch, concurrency)
-
-    should_fail = False
-    for result in results:
-        # golangci exits with status 1 when it finds an issue
-        if result.exited != 0:
-            should_fail = True
-
-    if should_fail:
-        raise Exit(code=1)
-    else:
-        print("golangci-lint found no issues")
+    print("WARNING: golangci-lint task is deprecated, please migrate to lint-go task")
+    raise Exit(code=1)
 
 
 @task
@@ -318,7 +310,7 @@ def generate_protobuf(ctx):
 
     # generate messagepack marshallers
     for pkg, files in msgp_targets.items():
-        for (src, io_gen) in files:
+        for src, io_gen in files:
             dst = os.path.splitext(os.path.basename(src))[0]  # .go
             dst = os.path.splitext(dst)[0]  # .pb
             ctx.run(f"msgp -file {pbgo_dir}/{pkg}/{src} -o={pbgo_dir}/{pkg}/{dst}_gen.go -io={io_gen}")

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -49,7 +49,9 @@ def run_golangci_lint(ctx, targets, rtloader_root=None, build_tags=None, build="
 
 
 @task
-def golangci_lint(ctx, targets, rtloader_root=None, build_tags=None, build="test", arch="x64", concurrency=None):
+def golangci_lint(
+    ctx, targets, rtloader_root=None, build_tags=None, build="test", arch="x64", concurrency=None  # noqa: U100
+):
     """
     Run golangci-lint on targets using .golangci.yml configuration.
 

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -562,15 +562,15 @@ def test(
 
     if not skip_linters:
         modules_results_per_phase["lint"] = run_lint_go(
-            ctx,
-            module,
-            targets,
-            flavors,
-            build_include,
-            build_exclude,
-            rtloader_root,
-            arch,
-            cpus,
+            ctx=ctx,
+            module=module,
+            targets=targets,
+            flavors=flavors,
+            build_include=build_include,
+            build_exclude=build_exclude,
+            rtloader_root=rtloader_root,
+            arch=arch,
+            cpus=cpus,
         )
 
     # Process input arguments
@@ -726,6 +726,8 @@ def run_lint_go(
     module=None,
     targets=None,
     flavors=None,
+    build="lint",
+    build_tags=None,
     build_include=None,
     build_exclude=None,
     rtloader_root=None,
@@ -735,8 +737,9 @@ def run_lint_go(
     modules, flavors = process_input_args(module, targets, flavors)
 
     linter_tags = {
-        f: compute_build_tags_for_flavor(
-            flavor=f, build="lint", arch=arch, build_include=build_include, build_exclude=build_exclude
+        f: build_tags
+        or compute_build_tags_for_flavor(
+            flavor=f, build=build, arch=arch, build_include=build_include, build_exclude=build_exclude
         )
         for f in flavors
     }
@@ -765,6 +768,8 @@ def lint_go(
     module=None,
     targets=None,
     flavors=None,
+    build="lint",
+    build_tags=None,
     build_include=None,
     build_exclude=None,
     rtloader_root=None,
@@ -796,15 +801,17 @@ def lint_go(
     modules_results_per_phase = defaultdict(dict)
 
     modules_results_per_phase["lint"] = run_lint_go(
-        ctx,
-        module,
-        targets,
-        flavors,
-        build_include,
-        build_exclude,
-        rtloader_root,
-        arch,
-        cpus,
+        ctx=ctx,
+        module=module,
+        targets=targets,
+        flavors=flavors,
+        build=build,
+        build_tags=build_tags,
+        build_include=build_include,
+        build_exclude=build_exclude,
+        rtloader_root=rtloader_root,
+        arch=arch,
+        cpus=cpus,
     )
 
     success = process_module_results(modules_results_per_phase)

--- a/tasks/winbuildscripts/sysprobe.ps1
+++ b/tasks/winbuildscripts/sysprobe.ps1
@@ -25,10 +25,10 @@ if ($Env:TARGET_ARCH -eq "x86") {
 }
 & .\tasks\winbuildscripts\pre-go-build.ps1 -Architecture "$archflag" -PythonRuntimes "$Env:PY_RUNTIMES"
 
-& inv -e golangci-lint --build system-probe-unit-tests .\pkg
+& inv -e lint-go --build system-probe-unit-tests --targets .\pkg
 $err = $LASTEXITCODE
 if ($err -ne 0) {
-    Write-Host -ForegroundColor Red "golangci-lint failed $err"
+    Write-Host -ForegroundColor Red "lint-go failed $err"
     [Environment]::Exit($err)
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

* Mark `golangci-lint` as deprecated
* Move usage of deprecated task to the official lint task
* Add missing feature to `lint-go` task to override build tasks

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

`lint-go` covers golanci-lint command, `golangci-lint` task is deprecated and will be removed. Jobs and local calls to invoke task should use `lint-go` instead of `golangci-lint`


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

I tested the equivalence of old and new invoke tasks locally, build tags are correctly computed and forwarded to `golangci-lint` command.

I will follow up to see if we can have a new AgentFlavour to cover security lint tags. 

Note: `arch` parameter has no effect when `build_tags` is defined, as `arch` is used by the tag builder function, which is not called when `build_tags` is defined

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
