### PR TITLE
Fix image size in containerd

### DIFF
--- a/pkg/workloadmeta/collectors/internal/containerd/image.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image.go
@@ -297,7 +297,7 @@ func (c *collector) notifyEventForImage(ctx context.Context, namespace string, i
 		}
 	}
 
-	var totalSizeBytes int64 = 0
+	totalSizeBytes := manifest.Config.Size
 	for _, layer := range manifest.Layers {
 		totalSizeBytes += layer.Size
 	}

--- a/releasenotes/notes/fix-image-size-containerd-700037b6589e2464.yaml
+++ b/releasenotes/notes/fix-image-size-containerd-700037b6589e2464.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Corrected a bug in calculating the total size of a container image, now accounting for the configuration file size.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR includes the size of the configuration file when calculating the size of a container image.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Do not miss some data / have the same result as container registries
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
None
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Deploy the agent with container image collection enabled. Run `agent workload-list -v`, make sure that the size of the image respects the size reported by docker or containerd.
It is possible to retrieve this size, either by using a docker inspect or with `ctr -n k8s.io content get...`.

Here is an example of an image manifest to understand the problem:

```shell
ctr -n k8s.io content get sha256:mysha | jq
```
```json
{
  "schemaVersion": X,
  "mediaType": "X",
  "config": {
    "mediaType": "application/vnd.oci.image.config.v1+json",
    "digest": "X",
    "size": 2323
  },
  "layers": [
    {
      "mediaType": "X",
      "digest": "X",
      "size": 35732217,
      "annotations": {
        "X": "Y",
      }
    },
    {
      "mediaType": "X",
      "digest": "X",
      "size": 35732217
  ],
  "annotations": {
    "X": "Y" 
 }
}
```
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
