### PR TITLE
[CWS] Fix crash when trying to save unavailable profile

### DIFF
--- a/pkg/security/security_profile/profile/manager.go
+++ b/pkg/security/security_profile/profile/manager.go
@@ -816,7 +816,7 @@ func (m *SecurityProfileManager) SaveSecurityProfile(params *api.SecurityProfile
 	}
 
 	p := m.GetProfile(selector)
-	if p == nil {
+	if p == nil || p.Status == 0 || p.ActivityTree == nil {
 		return &api.SecurityProfileSaveMessage{
 			Error: "security profile not found",
 		}, nil


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fix this stacktrace:

> goroutine 516 [running]:
> github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree.ActivityTreeToProto(0x0)
> 	/go/src/github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree/activity_tree_proto_enc_v1.go:21 +0x20
> github.com/DataDog/datadog-agent/pkg/security/security_profile/profile.SecurityProfileToProto(0xc002b861c0)
> 	/go/src/github.com/DataDog/datadog-agent/pkg/security/security_profile/profile/profile_proto_enc_v1.go:30 +0xa9
> github.com/DataDog/datadog-agent/pkg/security/security_profile/profile.(*SecurityProfileManager).SaveSecurityProfile(0xc001f08990?, 0x0?)
> 	/go/src/github.com/DataDog/datadog-agent/pkg/security/security_profile/profile/manager.go:824 +0x17b
> github.com/DataDog/datadog-agent/pkg/security/probe.(*SecurityProfileManagers).SaveSecurityProfile(...)
> 	/go/src/github.com/DataDog/datadog-agent/pkg/security/probe/security_profile.go:165
> github.com/DataDog/datadog-agent/pkg/security/module.(*APIServer).SaveSecurityProfile(0x619a120?, {0xc001f08990?, 0x1fb5e86?}, 0x0?)
> 	/go/src/github.com/DataDog/datadog-agent/pkg/security/module/server.go:246 +0x4b
> github.com/DataDog/datadog-agent/pkg/security/proto/api._SecurityModule_SaveSecurityProfile_Handler({0x6385e40?, 0xc002fa8000}, {0x7372150, 0xc001f08960}, 0xc0032a6230, 0x0)
> 	/go/src/github.com/DataDog/datadog-agent/pkg/security/proto/api/api_grpc.pb.go:615 +0x173
> google.golang.org/grpc.(*Server).processUnaryRPC(0xc002d761e0, {0x7386160, 0xc002dcc340}, 0xc0011e1560, 0xc003c376b0, 0x9949c78, 0x0)
> 	/go/pkg/mod/google.golang.org/grpc@v1.56.2/server.go:1337 +0xdf3
> google.golang.org/grpc.(*Server).handleStream(0xc002d761e0, {0x7386160, 0xc002dcc340}, 0xc0011e1560, 0x0)
> 	/go/pkg/mod/google.golang.org/grpc@v1.56.2/server.go:1714 +0xa36
> google.golang.org/grpc.(*Server).serveStreams.func1.1()
> 	/go/pkg/mod/google.golang.org/grpc@v1.56.2/server.go:959 +0x98
> created by google.golang.org/grpc.(*Server).serveStreams.func1
> 	/go/pkg/mod/google.golang.org/grpc@v1.56.2/server.go:957 +0x18c

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
