### PR TITLE
Expose log level from logging component.

### DIFF
--- a/cmd/serverless-init/log.go
+++ b/cmd/serverless-init/log.go
@@ -8,7 +8,10 @@
 // nolint
 package main
 
-import "github.com/DataDog/datadog-agent/pkg/util/log"
+import (
+	logcomp "github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
 
 // Stack depth of 3 since the `corelogger` struct adds a layer above the logger
 const stackDepth = 3
@@ -65,3 +68,9 @@ func (corelogger) Criticalf(format string, params ...interface{}) error {
 
 // Flush implements Logger.
 func (corelogger) Flush() { log.Flush() }
+
+// GetLogLevel implements Logger.
+func (corelogger) GetLogLevel() (logcomp.Level, error) {
+	lvl, err := log.GetLogLevel()
+	return logcomp.Level(lvl), err
+}

--- a/cmd/trace-agent/subcommands/run/run.go
+++ b/cmd/trace-agent/subcommands/run/run.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/manager"
 	remotecfg "github.com/DataDog/datadog-agent/cmd/trace-agent/config/remote"
+	logcomp "github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/trace/config"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	rc "github.com/DataDog/datadog-agent/pkg/config/remote"
@@ -316,6 +317,12 @@ func (corelogger) Criticalf(format string, params ...interface{}) error {
 
 // Flush implements Logger.
 func (corelogger) Flush() { log.Flush() }
+
+// GetLogLevel implements Logger
+func (corelogger) GetLogLevel() (logcomp.Level, error) {
+	lvl, err := log.GetLogLevel()
+	return logcomp.Level(lvl), err
+}
 
 func profilingConfig(tracecfg *tracecfg.AgentConfig) *profiling.Settings {
 	if !coreconfig.Datadog.GetBool("apm_config.internal_profiling.enabled") {

--- a/comp/core/log/component.go
+++ b/comp/core/log/component.go
@@ -60,6 +60,9 @@ type Component interface {
 	// an error containing the message.
 	Criticalf(format string, params ...interface{}) error
 
+	// GetLogLevel returns the current log level
+	GetLogLevel() (Level, error)
+
 	// Flush will flush the contents of the logs to the sinks
 	Flush()
 }

--- a/comp/core/log/logger.go
+++ b/comp/core/log/logger.go
@@ -24,6 +24,24 @@ type logger struct {
 	// pkg/util/log, and uses globals in that package.
 }
 
+// Level is the type for log levels.
+type Level seelog.LogLevel
+
+// Log levels
+const (
+	TraceLvl    Level = seelog.TraceLvl
+	DebugLvl    Level = seelog.DebugLvl
+	InfoLvl     Level = seelog.InfoLvl
+	WarnLvl     Level = seelog.WarnLvl
+	ErrorLvl    Level = seelog.ErrorLvl
+	CriticalLvl Level = seelog.CriticalLvl
+	Off         Level = seelog.Off
+)
+
+func (l Level) String() string {
+	return seelog.LogLevel(l).String()
+}
+
 // NewTemporaryLogger returns a logger component instance. It assumes the logger has already been
 // initialized beforehand.
 //
@@ -137,6 +155,12 @@ func (*logger) Criticalf(format string, params ...interface{}) error {
 	// no need to check the current log level since Sprintf will be called in all case to generate the returned
 	// error
 	return log.CriticalStackDepth(2, fmt.Sprintf(format, params...))
+}
+
+// GetLogLevel implements Component#GetLogLevel.
+func (*logger) GetLogLevel() (Level, error) {
+	lvl, err := log.GetLogLevel()
+	return Level(lvl), err
 }
 
 // Flush implements Component#Flush.

--- a/comp/core/log/logger_test.go
+++ b/comp/core/log/logger_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLogging(t *testing.T) {
@@ -21,4 +22,7 @@ func TestLogging(t *testing.T) {
 		Module,
 	))
 	log.Debugf("hello, world. %s", "hi")
+	if lvl, err := log.GetLogLevel(); assert.NoError(t, err) {
+		assert.Equal(t, DebugLvl, lvl)
+	}
 }

--- a/pkg/trace/log/buflogger.go
+++ b/pkg/trace/log/buflogger.go
@@ -9,6 +9,8 @@ import (
 	"bytes"
 	"fmt"
 	"sync"
+
+	"github.com/DataDog/datadog-agent/comp/core/log"
 )
 
 var _ Logger = (*buflogger)(nil)
@@ -93,3 +95,8 @@ func (b *buflogger) Criticalf(format string, params ...interface{}) error {
 
 // Flush implements Logger.
 func (b *buflogger) Flush() {}
+
+// GetLogLevel implements Logger.
+func (b *buflogger) GetLogLevel() (log.Level, error) {
+	return log.DebugLvl, nil
+}

--- a/pkg/trace/log/logger.go
+++ b/pkg/trace/log/logger.go
@@ -7,6 +7,8 @@ package log
 
 import (
 	"sync"
+
+	"github.com/DataDog/datadog-agent/comp/core/log"
 )
 
 var (
@@ -31,21 +33,7 @@ func IsSet() bool {
 }
 
 // Logger implements the core logger interface.
-type Logger interface {
-	Trace(v ...interface{})
-	Tracef(format string, params ...interface{})
-	Debug(v ...interface{})
-	Debugf(format string, params ...interface{})
-	Info(v ...interface{})
-	Infof(format string, params ...interface{})
-	Warn(v ...interface{}) error
-	Warnf(format string, params ...interface{}) error
-	Error(v ...interface{}) error
-	Errorf(format string, params ...interface{}) error
-	Critical(v ...interface{}) error
-	Criticalf(format string, params ...interface{}) error
-	Flush()
-}
+type Logger = log.Component
 
 // Trace formats message using the default formats for its operands
 // and writes to log with level = Trace
@@ -193,3 +181,6 @@ func (noopLogger) Criticalf(format string, params ...interface{}) error { return
 
 // Flush implements Logger.
 func (noopLogger) Flush() {}
+
+// GetLogLevel implements Logger.
+func (noopLogger) GetLogLevel() (log.Level, error) { return log.Off, nil }


### PR DESCRIPTION
### What does this PR do?
This PR exposes the log level from the logging component. It reexports seelog.LogLevel as log.Level to avoid having the interface explicitly rely on seelog.

This PR also modifies the trace package and the serverless init command, because both define loggers that need to adhere to the log component specification, so I added GetLogLevel() methods to them.

### Motivation
We need this for componentizing netflow - we use a third-party library that uses a different logging library, and as part of connecting those logs to ours we need to set their logging level to match ours.

### Describe how to test/QA your changes
A unit test is already provided for the single function this adds.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
