### PR TITLE
[Linters] Fix type inference error when using a go.work

### DIFF
--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -130,7 +130,7 @@ type SecurityProfileContext struct {
 
 // CanGenerateAnomaliesFor returns true if the current profile can generate anomalies for the provided event type
 func (spc SecurityProfileContext) CanGenerateAnomaliesFor(evtType EventType) bool {
-	return slices.Contains[EventType](spc.AnomalyDetectionEventTypes, evtType)
+	return slices.Contains(spc.AnomalyDetectionEventTypes, evtType)
 }
 
 // IPPortContext is used to hold an IP and Port


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Remove an explicit type annotation which can be inferred by the compiler and causes issues in some setup.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
When using a [go workspaces file](https://go.dev/doc/tutorial/workspaces) in the agent repository, running `inv lint-go` will show the error below.
```
Linter failures:
level=warning msg="[runner] Can't run linter goanalysis_metalinter: buildir: failed to load package model: could not load export data: no export data for \"github.com/DataDog/datadog-agent/pkg/security/secl/model\""
level=error msg="Running error: 1 error occurred:\n\t* can't run linter goanalysis_metalinter: buildir: failed to load package model: could not load export data: no export data for \"github.com/DataDog/datadog-agent/pkg/security/secl/model\"\n\n"
```

This (unexplicit) error is actually due to the following errors:
```
EventType does not satisfy ~[]EventType (EventType missing in ~[]github.com/DataDog/datadog-agent/pkg/security/secl/model.EventType) [pkg/security/secl/model/model.go line 133 column 25]
cannot use spc.AnomalyDetectionEventTypes (variable of type []EventType) as EventType value in argument to slices.Contains[EventType] [pkg/security/secl/model/model.go line 133 column 36]
```

Simply removing the type annotation makes everything work properly. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The root cause is due to `pkg/security/secl` using an older version of `golang.org/x/exp` than the base `go.mod` of the repository (`v0.0.0-20221114191408-850992195362` vs `v0.0.0-20230522175609-2e198f4a06a1`).

I think when using a go workspace file, the same version of the dependency (the most recent of the two) is used for both.

The same error appears when using `v0.0.0-20230522175609-2e198f4a06a1` in `pkg/security/secl` and running `GOWORK=off inv lint-go`, which shows that this is indeed the source of the issue.

I only fixed the symptom because I don't want to be responsible for updating a dependency in that module :)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
