### PR TITLE
[pkg/otlp] Fix ingestion timestamp in logs

### DIFF
--- a/pkg/otlp/internal/logsagentexporter/logs_exporter.go
+++ b/pkg/otlp/internal/logsagentexporter/logs_exporter.go
@@ -68,10 +68,6 @@ func createConsumeLogsFunc(logger *zap.Logger, logSource *sources.LogSource, log
 					if status == "" {
 						status = message.StatusInfo
 					}
-					timestamp, err := time.Parse(time.RFC3339, ddLog.AdditionalProperties["@timestamp"])
-					if err != nil {
-						logger.Error("Error parsing timestamp: " + err.Error())
-					}
 					origin := message.NewOrigin(logSource)
 					origin.SetTags(tags)
 					origin.SetService(service)
@@ -82,7 +78,9 @@ func createConsumeLogsFunc(logger *zap.Logger, logSource *sources.LogSource, log
 						logger.Error("Error parsing log: " + err.Error())
 					}
 
-					message := message.NewMessage(content, origin, status, timestamp.Unix())
+					// ingestionTs is an internal field used for latency tracking on the status page, not the actual log timestamp.
+					ingestionTs := time.Now().UnixNano()
+					message := message.NewMessage(content, origin, status, ingestionTs)
 
 					logsAgentChannel <- message
 				}


### PR DESCRIPTION
### What does this PR do?

Fix ingestion timestamp in OTLP logs population.

### Motivation

Ingestion timestamp is an internal field used for latency tracking on the status page, not the actual log timestamp.

### Additional Notes

Note that the structured JSON logs `ddLog` still have the `@timestamp` field. The intake will prioritize it over the agent set timestamp. Thus no user-facing change is introduced with this PR.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
