### PR TITLE
[Netflow] Pass dependencies into netflow

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -597,8 +597,8 @@ func startAgent(
 	// Start NetFlow server
 	// This must happen after LoadComponents is set up (via common.LoadComponents).
 	// netflow.StartServer uses AgentDemultiplexer, that uses ContextResolver, that uses the tagger (initialized by LoadComponents)
-	if netflow.IsEnabled() {
-		if err = netflow.StartServer(demux); err != nil {
+	if netflow.IsEnabled(pkgconfig.Datadog) {
+		if err = netflow.StartServer(demux, pkgconfig.Datadog, log); err != nil {
 			log.Errorf("Failed to start NetFlow server: %s", err)
 		}
 	}

--- a/pkg/netflow/config/config.go
+++ b/pkg/netflow/config/config.go
@@ -8,7 +8,7 @@ package config
 import (
 	"fmt"
 
-	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 
 	"github.com/DataDog/datadog-agent/pkg/snmp/utils"
 
@@ -42,10 +42,10 @@ type ListenerConfig struct {
 }
 
 // ReadConfig builds and returns configuration from Agent configuration.
-func ReadConfig() (*NetflowConfig, error) {
+func ReadConfig(conf ddconfig.ConfigReader) (*NetflowConfig, error) {
 	var mainConfig NetflowConfig
 
-	err := coreconfig.Datadog.UnmarshalKey("network_devices.netflow", &mainConfig)
+	err := conf.UnmarshalKey("network_devices.netflow", &mainConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func ReadConfig() (*NetflowConfig, error) {
 			listenerConfig.Workers = 1
 		}
 		if listenerConfig.Namespace == "" {
-			listenerConfig.Namespace = coreconfig.Datadog.GetString("network_devices.namespace")
+			listenerConfig.Namespace = conf.GetString("network_devices.namespace")
 		}
 		normalizedNamespace, err := utils.NormalizeNamespace(listenerConfig.Namespace)
 		if err != nil {

--- a/pkg/netflow/config/config_test.go
+++ b/pkg/netflow/config/config_test.go
@@ -168,7 +168,7 @@ network_devices:
 			err := config.Datadog.ReadConfig(strings.NewReader(tt.configYaml))
 			require.NoError(t, err)
 
-			readConfig, err := ReadConfig()
+			readConfig, err := ReadConfig(config.Datadog)
 			if tt.expectedError != "" {
 				assert.ErrorContains(t, err, tt.expectedError)
 				assert.Nil(t, readConfig)

--- a/pkg/netflow/flowaggregator/aggregator_test.go
+++ b/pkg/netflow/flowaggregator/aggregator_test.go
@@ -26,10 +26,12 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/epforwarder"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	ddlog "github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
 
@@ -157,8 +159,9 @@ func TestAggregator(t *testing.T) {
 
 	epForwarder.EXPECT().SendEventPlatformEventBlocking(&message.Message{Content: compactEvent.Bytes()}, "network-devices-netflow").Return(nil).Times(1)
 	epForwarder.EXPECT().SendEventPlatformEventBlocking(&message.Message{Content: compactMetadataEvent.Bytes()}, "network-devices-metadata").Return(nil).Times(1)
+	logger := fxutil.Test[log.Component](t, log.MockModule)
 
-	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname")
+	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger)
 	aggregator.flushFlowsToSendInterval = 1 * time.Second
 	aggregator.TimeNowFunction = func() time.Time {
 		return flushTime
@@ -257,7 +260,8 @@ func TestAggregator_withMockPayload(t *testing.T) {
 
 	epForwarder.EXPECT().SendEventPlatformEventBlocking(&message.Message{Content: compactMetadataEvent.Bytes()}, "network-devices-metadata").Return(nil).Times(1)
 
-	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname")
+	logger := fxutil.Test[log.Component](t, log.MockModule)
+	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger)
 	aggregator.flushFlowsToSendInterval = 1 * time.Second
 	aggregator.TimeNowFunction = func() time.Time {
 		return flushTime
@@ -274,7 +278,7 @@ func TestAggregator_withMockPayload(t *testing.T) {
 		stoppedFlushLoop <- struct{}{}
 	}()
 
-	flowState, err := goflowlib.StartFlowRoutine(common.TypeNetFlow5, "127.0.0.1", port, 1, "default", aggregator.GetFlowInChan())
+	flowState, err := goflowlib.StartFlowRoutine(common.TypeNetFlow5, "127.0.0.1", port, 1, "default", aggregator.GetFlowInChan(), logger)
 	assert.NoError(t, err)
 
 	time.Sleep(100 * time.Millisecond) // wait to make sure goflow listener is started before sending
@@ -312,12 +316,13 @@ func TestAggregator_withMockPayload(t *testing.T) {
 
 func TestFlowAggregator_flush_submitCollectorMetrics_error(t *testing.T) {
 	// 1/ Arrange
+	logger := fxutil.Test[log.Component](t, log.MockModule)
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 
 	l, err := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
-	assert.Nil(t, err)
-	log.SetupLogger(l, "debug")
+	require.NoError(t, err)
+	ddlog.SetupLogger(l, "debug")
 
 	sender := mocksender.NewMockSender("")
 	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
@@ -344,7 +349,7 @@ func TestFlowAggregator_flush_submitCollectorMetrics_error(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
 
-	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname")
+	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger)
 	aggregator.goflowPrometheusGatherer = prometheus.GathererFunc(func() ([]*promClient.MetricFamily, error) {
 		return nil, fmt.Errorf("some prometheus gatherer error")
 	})
@@ -382,8 +387,9 @@ func TestFlowAggregator_submitCollectorMetrics(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
+	logger := fxutil.Test[log.Component](t, log.MockModule)
 
-	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname")
+	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger)
 	aggregator.goflowPrometheusGatherer = prometheus.GathererFunc(func() ([]*promClient.MetricFamily, error) {
 		return []*promClient.MetricFamily{
 			{
@@ -457,8 +463,9 @@ func TestFlowAggregator_submitCollectorMetrics_error(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
+	logger := fxutil.Test[log.Component](t, log.MockModule)
 
-	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname")
+	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger)
 	aggregator.goflowPrometheusGatherer = prometheus.GathererFunc(func() ([]*promClient.MetricFamily, error) {
 		return nil, fmt.Errorf("some prometheus gatherer error")
 	})
@@ -490,8 +497,9 @@ func TestFlowAggregator_sendExporterMetadata_multiplePayloads(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
+	logger := fxutil.Test[log.Component](t, log.MockModule)
 
-	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname")
+	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger)
 
 	var flows []*common.Flow
 	for i := 1; i <= 250; i++ {
@@ -573,8 +581,9 @@ func TestFlowAggregator_sendExporterMetadata_noPayloads(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
+	logger := fxutil.Test[log.Component](t, log.MockModule)
 
-	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname")
+	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger)
 
 	var flows []*common.Flow
 	now := time.Unix(1681295467, 0)
@@ -605,7 +614,8 @@ func TestFlowAggregator_sendExporterMetadata_invalidIPIgnored(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
 
-	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname")
+	logger := fxutil.Test[log.Component](t, log.MockModule)
+	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger)
 
 	now := time.Unix(1681295467, 0)
 	flows := []*common.Flow{
@@ -688,7 +698,8 @@ func TestFlowAggregator_sendExporterMetadata_multipleNamespaces(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
 
-	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname")
+	logger := fxutil.Test[log.Component](t, log.MockModule)
+	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger)
 
 	now := time.Unix(1681295467, 0)
 	flows := []*common.Flow{
@@ -789,8 +800,9 @@ func TestFlowAggregator_sendExporterMetadata_singleExporterIpWithMultipleFlowTyp
 
 	ctrl := gomock.NewController(t)
 	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
+	logger := fxutil.Test[log.Component](t, log.MockModule)
 
-	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname")
+	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger)
 
 	now := time.Unix(1681295467, 0)
 	flows := []*common.Flow{
@@ -857,6 +869,7 @@ func TestFlowAggregator_sendExporterMetadata_singleExporterIpWithMultipleFlowTyp
 }
 
 func TestFlowAggregator_getSequenceDelta(t *testing.T) {
+	logger := fxutil.Test[log.Component](t, log.MockModule)
 	type round struct {
 		flowsToFlush          []*common.Flow
 		expectedSequenceDelta map[SequenceDeltaKey]SequenceDeltaValue
@@ -1140,7 +1153,7 @@ func TestFlowAggregator_getSequenceDelta(t *testing.T) {
 				AggregatorPortRollupThreshold:          10,
 				AggregatorRollupTrackerRefreshInterval: 3600,
 			}
-			agg := NewFlowAggregator(sender, nil, &conf, "my-hostname")
+			agg := NewFlowAggregator(sender, nil, &conf, "my-hostname", logger)
 			for roundNum, testRound := range tt.rounds {
 				assert.Equal(t, testRound.expectedSequenceDelta, agg.getSequenceDelta(testRound.flowsToFlush), fmt.Sprintf("Test Round %d", roundNum))
 			}

--- a/pkg/netflow/flowaggregator/flowaccumulator_test.go
+++ b/pkg/netflow/flowaggregator/flowaccumulator_test.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/netflow/common"
 	"github.com/DataDog/datadog-agent/pkg/netflow/portrollup"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 // MockTimeNow mocks time.Now
@@ -30,6 +32,7 @@ func setMockTimeNow(newTime time.Time) {
 }
 
 func Test_flowAccumulator_add(t *testing.T) {
+	logger := fxutil.Test[log.Component](t, log.MockModule)
 	synFlag := uint32(2)
 	ackFlag := uint32(16)
 	synAckFlag := synFlag | ackFlag
@@ -79,7 +82,7 @@ func Test_flowAccumulator_add(t *testing.T) {
 	}
 
 	// When
-	acc := newFlowAccumulator(common.DefaultAggregatorFlushInterval, common.DefaultAggregatorFlushInterval, common.DefaultAggregatorPortRollupThreshold, false)
+	acc := newFlowAccumulator(common.DefaultAggregatorFlushInterval, common.DefaultAggregatorFlushInterval, common.DefaultAggregatorPortRollupThreshold, false, logger)
 	acc.add(flowA1)
 	acc.add(flowA2)
 	acc.add(flowB1)
@@ -102,6 +105,7 @@ func Test_flowAccumulator_add(t *testing.T) {
 }
 
 func Test_flowAccumulator_portRollUp(t *testing.T) {
+	logger := fxutil.Test[log.Component](t, log.MockModule)
 	synFlag := uint32(2)
 	ackFlag := uint32(16)
 	synAckFlag := synFlag | ackFlag
@@ -150,7 +154,7 @@ func Test_flowAccumulator_portRollUp(t *testing.T) {
 	}
 
 	// When
-	acc := newFlowAccumulator(common.DefaultAggregatorFlushInterval, common.DefaultAggregatorFlushInterval, 3, false)
+	acc := newFlowAccumulator(common.DefaultAggregatorFlushInterval, common.DefaultAggregatorFlushInterval, 3, false, logger)
 	acc.add(flowA1)
 	acc.add(flowA2)
 
@@ -204,6 +208,7 @@ func Test_flowAccumulator_portRollUp(t *testing.T) {
 }
 
 func Test_flowAccumulator_flush(t *testing.T) {
+	logger := fxutil.Test[log.Component](t, log.MockModule)
 	timeNow = MockTimeNow
 	zeroTime := time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC)
 	flushInterval := 60 * time.Second
@@ -225,7 +230,7 @@ func Test_flowAccumulator_flush(t *testing.T) {
 	}
 
 	// When
-	acc := newFlowAccumulator(flushInterval, flowContextTTL, common.DefaultAggregatorPortRollupThreshold, false)
+	acc := newFlowAccumulator(flushInterval, flowContextTTL, common.DefaultAggregatorPortRollupThreshold, false, logger)
 	acc.add(flow)
 
 	// Then

--- a/pkg/netflow/goflowlib/flowstate.go
+++ b/pkg/netflow/goflowlib/flowstate.go
@@ -13,7 +13,7 @@ import (
 	_ "github.com/netsampler/goflow2/decoders/netflow/templates/memory"
 	"github.com/netsampler/goflow2/utils"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 
 	"github.com/DataDog/datadog-agent/pkg/netflow/common"
 )
@@ -39,11 +39,11 @@ type FlowRunnableState interface {
 }
 
 // StartFlowRoutine starts one of the goflow flow routine depending on the flow type
-func StartFlowRoutine(flowType common.FlowType, hostname string, port uint16, workers int, namespace string, flowInChan chan *common.Flow) (*FlowStateWrapper, error) {
+func StartFlowRoutine(flowType common.FlowType, hostname string, port uint16, workers int, namespace string, flowInChan chan *common.Flow, logger log.Component) (*FlowStateWrapper, error) {
 	var flowState FlowRunnableState
 
 	formatDriver := NewAggregatorFormatDriver(flowInChan, namespace)
-	logger := GetLogrusLevel()
+	logrusLogger := GetLogrusLevel(logger)
 	ctx := context.Background()
 
 	switch flowType {
@@ -56,18 +56,18 @@ func StartFlowRoutine(flowType common.FlowType, hostname string, port uint16, wo
 
 		state := utils.NewStateNetFlow()
 		state.Format = formatDriver
-		state.Logger = logger
+		state.Logger = logrusLogger
 		state.TemplateSystem = templateSystem
 		flowState = state
 	case common.TypeSFlow5:
 		state := utils.NewStateSFlow()
 		state.Format = formatDriver
-		state.Logger = logger
+		state.Logger = logrusLogger
 		flowState = state
 	case common.TypeNetFlow5:
 		state := utils.NewStateNFLegacy()
 		state.Format = formatDriver
-		state.Logger = logger
+		state.Logger = logrusLogger
 		flowState = state
 	default:
 		return nil, fmt.Errorf("unknown flow type: %s", flowType)
@@ -76,7 +76,7 @@ func StartFlowRoutine(flowType common.FlowType, hostname string, port uint16, wo
 	go func() {
 		err := flowState.FlowRoutine(workers, hostname, int(port), reusePort)
 		if err != nil {
-			log.Errorf("Error listening to %s: %s", flowType, err)
+			logger.Errorf("Error listening to %s: %s", flowType, err)
 		}
 	}()
 	return &FlowStateWrapper{

--- a/pkg/netflow/goflowlib/flowstate_test.go
+++ b/pkg/netflow/goflowlib/flowstate_test.go
@@ -10,11 +10,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/netflow/common"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func TestStartFlowRoutine_invalidType(t *testing.T) {
-	state, err := StartFlowRoutine("invalid", "my-hostname", 1234, 1, "my-ns", make(chan *common.Flow))
+	logger := fxutil.Test[log.Component](t, log.MockModule)
+	state, err := StartFlowRoutine("invalid", "my-hostname", 1234, 1, "my-ns", make(chan *common.Flow), logger)
 	assert.EqualError(t, err, "unknown flow type: invalid")
 	assert.Nil(t, state)
 }

--- a/pkg/netflow/goflowlib/logger.go
+++ b/pkg/netflow/goflowlib/logger.go
@@ -6,33 +6,32 @@
 package goflowlib
 
 import (
-	"github.com/cihub/seelog"
 	"github.com/sirupsen/logrus"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 )
 
-var seeLogToLogrusLevel = map[seelog.LogLevel]logrus.Level{
-	seelog.TraceLvl:    logrus.TraceLevel,
-	seelog.DebugLvl:    logrus.DebugLevel,
-	seelog.InfoLvl:     logrus.InfoLevel,
-	seelog.WarnLvl:     logrus.WarnLevel,
-	seelog.ErrorLvl:    logrus.ErrorLevel,
-	seelog.CriticalLvl: logrus.FatalLevel,
+var ddLogToLogrusLevel = map[log.Level]logrus.Level{
+	log.TraceLvl:    logrus.TraceLevel,
+	log.DebugLvl:    logrus.DebugLevel,
+	log.InfoLvl:     logrus.InfoLevel,
+	log.WarnLvl:     logrus.WarnLevel,
+	log.ErrorLvl:    logrus.ErrorLevel,
+	log.CriticalLvl: logrus.FatalLevel,
 }
 
 // GetLogrusLevel returns logrus log level from log.GetLogLevel()
-func GetLogrusLevel() *logrus.Logger {
-	logLevel, err := log.GetLogLevel()
+func GetLogrusLevel(logger log.Component) *logrus.Logger {
+	logLevel, err := logger.GetLogLevel()
 	if err != nil {
-		log.Warnf("error getting log level")
+		logger.Warnf("error getting log level")
 	}
-	logrusLevel, ok := seeLogToLogrusLevel[logLevel]
+	logrusLevel, ok := ddLogToLogrusLevel[logLevel]
 	if !ok {
-		log.Warnf("no matching logrus level for seelog level: %s", logLevel.String())
+		logger.Warnf("no matching logrus level for seelog level: %s", logLevel.String())
 		logrusLevel = logrus.InfoLevel
 	}
-	logger := logrus.StandardLogger()
-	logger.SetLevel(logrusLevel)
-	return logger
+	logrusLogger := logrus.StandardLogger()
+	logrusLogger.SetLevel(logrusLevel)
+	return logrusLogger
 }

--- a/pkg/netflow/goflowlib/logger.go
+++ b/pkg/netflow/goflowlib/logger.go
@@ -6,23 +6,30 @@
 package goflowlib
 
 import (
+	"github.com/cihub/seelog"
 	"github.com/sirupsen/logrus"
 
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	ddlog "github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-var ddLogToLogrusLevel = map[log.Level]logrus.Level{
-	log.TraceLvl:    logrus.TraceLevel,
-	log.DebugLvl:    logrus.DebugLevel,
-	log.InfoLvl:     logrus.InfoLevel,
-	log.WarnLvl:     logrus.WarnLevel,
-	log.ErrorLvl:    logrus.ErrorLevel,
-	log.CriticalLvl: logrus.FatalLevel,
+var ddLogToLogrusLevel = map[seelog.LogLevel]logrus.Level{
+	seelog.TraceLvl:    logrus.TraceLevel,
+	seelog.DebugLvl:    logrus.DebugLevel,
+	seelog.InfoLvl:     logrus.InfoLevel,
+	seelog.WarnLvl:     logrus.WarnLevel,
+	seelog.ErrorLvl:    logrus.ErrorLevel,
+	seelog.CriticalLvl: logrus.FatalLevel,
 }
 
 // GetLogrusLevel returns logrus log level from log.GetLogLevel()
 func GetLogrusLevel(logger log.Component) *logrus.Logger {
-	logLevel, err := logger.GetLogLevel()
+	// TODO: ideally this would be exposed by the log component but there were
+	// some issues getting #19033 merged. Right now this will always be the
+	// datadog log level, even if you pass in a different logger. This problem
+	// will also go away when we upgrade to the latest goflow2, as we will no
+	// longer need to interact with logrus.
+	logLevel, err := ddlog.GetLogLevel()
 	if err != nil {
 		logger.Warnf("error getting log level")
 	}

--- a/pkg/netflow/listener.go
+++ b/pkg/netflow/listener.go
@@ -6,6 +6,7 @@
 package netflow
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/netflow/config"
 	"github.com/DataDog/datadog-agent/pkg/netflow/flowaggregator"
 	"github.com/DataDog/datadog-agent/pkg/netflow/goflowlib"
@@ -23,8 +24,8 @@ func (l *netflowListener) shutdown() {
 	l.flowState.Shutdown()
 }
 
-func startFlowListener(listenerConfig config.ListenerConfig, flowAgg *flowaggregator.FlowAggregator) (*netflowListener, error) {
-	flowState, err := goflowlib.StartFlowRoutine(listenerConfig.FlowType, listenerConfig.BindHost, listenerConfig.Port, listenerConfig.Workers, listenerConfig.Namespace, flowAgg.GetFlowInChan())
+func startFlowListener(listenerConfig config.ListenerConfig, flowAgg *flowaggregator.FlowAggregator, logger log.Component) (*netflowListener, error) {
+	flowState, err := goflowlib.StartFlowRoutine(listenerConfig.FlowType, listenerConfig.BindHost, listenerConfig.Port, listenerConfig.Workers, listenerConfig.Namespace, flowAgg.GetFlowInChan(), logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/netflow/server.go
+++ b/pkg/netflow/server.go
@@ -12,12 +12,12 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
-	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/epforwarder"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/netflow/config"
 	"github.com/DataDog/datadog-agent/pkg/netflow/flowaggregator"
@@ -31,24 +31,25 @@ type Server struct {
 	config    *config.NetflowConfig
 	listeners []*netflowListener
 	flowAgg   *flowaggregator.FlowAggregator
+	logger    log.Component
 }
 
 // NewNetflowServer configures and returns a running SNMP traps server.
-func NewNetflowServer(sender sender.Sender, epForwarder epforwarder.EventPlatformForwarder) (*Server, error) {
+func NewNetflowServer(sender sender.Sender, epForwarder epforwarder.EventPlatformForwarder, ddconf ddconfig.ConfigReader, logger log.Component) (*Server, error) {
 	var listeners []*netflowListener
 
-	mainConfig, err := config.ReadConfig()
+	mainConfig, err := config.ReadConfig(ddconf)
 	if err != nil {
 		return nil, err
 	}
 
 	hostnameDetected, err := hostname.Get(context.TODO())
 	if err != nil {
-		log.Warnf("Error getting the hostname: %v", err)
+		logger.Warnf("Error getting the hostname: %v", err)
 		hostnameDetected = ""
 	}
 
-	flowAgg := flowaggregator.NewFlowAggregator(sender, epForwarder, mainConfig, hostnameDetected)
+	flowAgg := flowaggregator.NewFlowAggregator(sender, epForwarder, mainConfig, hostnameDetected, logger)
 	go flowAgg.Start()
 
 	if mainConfig.PrometheusListenerEnabled {
@@ -57,17 +58,17 @@ func NewNetflowServer(sender sender.Sender, epForwarder epforwarder.EventPlatfor
 			serverMux.Handle("/metrics", promhttp.Handler())
 			err := http.ListenAndServe(mainConfig.PrometheusListenerAddress, serverMux)
 			if err != nil {
-				log.Errorf("error starting prometheus server `%s`", mainConfig.PrometheusListenerAddress)
+				logger.Errorf("error starting prometheus server `%s`", mainConfig.PrometheusListenerAddress)
 			}
 		}()
 	}
 
-	log.Debugf("NetFlow Server configs (aggregator_buffer_size=%d, aggregator_flush_interval=%d, aggregator_flow_context_ttl=%d)", mainConfig.AggregatorBufferSize, mainConfig.AggregatorFlushInterval, mainConfig.AggregatorFlowContextTTL)
+	logger.Debugf("NetFlow Server configs (aggregator_buffer_size=%d, aggregator_flush_interval=%d, aggregator_flow_context_ttl=%d)", mainConfig.AggregatorBufferSize, mainConfig.AggregatorFlushInterval, mainConfig.AggregatorFlowContextTTL)
 	for _, listenerConfig := range mainConfig.Listeners {
-		log.Infof("Starting Netflow listener for flow type %s on %s", listenerConfig.FlowType, listenerConfig.Addr())
-		listener, err := startFlowListener(listenerConfig, flowAgg)
+		logger.Infof("Starting Netflow listener for flow type %s on %s", listenerConfig.FlowType, listenerConfig.Addr())
+		listener, err := startFlowListener(listenerConfig, flowAgg, logger)
 		if err != nil {
-			log.Warnf("Error starting listener for config (flow_type:%s, bind_Host:%s, port:%d): %s", listenerConfig.FlowType, listenerConfig.BindHost, listenerConfig.Port, err)
+			logger.Warnf("Error starting listener for config (flow_type:%s, bind_Host:%s, port:%d): %s", listenerConfig.FlowType, listenerConfig.BindHost, listenerConfig.Port, err)
 			continue
 		}
 		listeners = append(listeners, listener)
@@ -77,12 +78,13 @@ func NewNetflowServer(sender sender.Sender, epForwarder epforwarder.EventPlatfor
 		listeners: listeners,
 		config:    mainConfig,
 		flowAgg:   flowAgg,
+		logger:    logger,
 	}, nil
 }
 
 // Stop stops the Server.
 func (s *Server) stop() {
-	log.Infof("Stop NetFlow Server")
+	s.logger.Infof("Stop NetFlow Server")
 
 	s.flowAgg.Stop()
 
@@ -90,22 +92,22 @@ func (s *Server) stop() {
 		stopped := make(chan interface{})
 
 		go func() {
-			log.Infof("Listener `%s` shutting down", listener.config.Addr())
+			s.logger.Infof("Listener `%s` shutting down", listener.config.Addr())
 			listener.shutdown()
 			close(stopped)
 		}()
 
 		select {
 		case <-stopped:
-			log.Infof("Listener `%s` stopped", listener.config.Addr())
+			s.logger.Infof("Listener `%s` stopped", listener.config.Addr())
 		case <-time.After(time.Duration(s.config.StopTimeout) * time.Second):
-			log.Errorf("Stopping listener `%s`. Timeout after %d seconds", listener.config.Addr(), s.config.StopTimeout)
+			s.logger.Errorf("Stopping listener `%s`. Timeout after %d seconds", listener.config.Addr(), s.config.StopTimeout)
 		}
 	}
 }
 
 // StartServer starts the global NetFlow collector.
-func StartServer(demux aggregator.DemultiplexerWithAggregator) error {
+func StartServer(demux aggregator.DemultiplexerWithAggregator, ddconf ddconfig.ConfigReader, logger log.Component) error {
 	epForwarder, err := demux.GetEventPlatformForwarder()
 	if err != nil {
 		return err
@@ -115,7 +117,7 @@ func StartServer(demux aggregator.DemultiplexerWithAggregator) error {
 	if err != nil {
 		return err
 	}
-	server, err := NewNetflowServer(sender, epForwarder)
+	server, err := NewNetflowServer(sender, epForwarder, ddconf, logger)
 	if err != nil {
 		return err
 	}
@@ -132,6 +134,6 @@ func StopServer() {
 }
 
 // IsEnabled returns whether NetFlow collection is enabled in the Agent configuration.
-func IsEnabled() bool {
-	return coreconfig.Datadog.GetBool("network_devices.netflow.enabled")
+func IsEnabled(ddconf ddconfig.ConfigReader) bool {
+	return ddconf.GetBool("network_devices.netflow.enabled")
 }

--- a/pkg/netflow/server_integration_test.go
+++ b/pkg/netflow/server_integration_test.go
@@ -43,8 +43,8 @@ network_devices:
 	config.Datadog.Set("hostname", "my-hostname")
 
 	// Setup NetFlow Server
-	log := fxutil.Test[log.Component](t, log.MockModule)
-	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(log, 1*time.Millisecond)
+	logger := fxutil.Test[log.Component](t, log.MockModule)
+	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(logger, 1*time.Millisecond)
 	defer demux.Stop(false)
 
 	sender, err := demux.GetDefaultSender()
@@ -52,7 +52,7 @@ network_devices:
 
 	ctrl := gomock.NewController(t)
 	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
-	server, err := NewNetflowServer(sender, epForwarder)
+	server, err := NewNetflowServer(sender, epForwarder, config.Datadog, logger)
 	require.NoError(t, err, "cannot start Netflow Server")
 	assert.NotNil(t, server)
 
@@ -96,8 +96,8 @@ network_devices:
 	config.Datadog.Set("hostname", "my-hostname")
 
 	// Setup NetFlow Server
-	log := fxutil.Test[log.Component](t, log.MockModule)
-	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(log, 1*time.Millisecond)
+	logger := fxutil.Test[log.Component](t, log.MockModule)
+	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(logger, 1*time.Millisecond)
 	defer demux.Stop(false)
 
 	sender, err := demux.GetDefaultSender()
@@ -105,7 +105,7 @@ network_devices:
 
 	ctrl := gomock.NewController(t)
 	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
-	server, err := NewNetflowServer(sender, epForwarder)
+	server, err := NewNetflowServer(sender, epForwarder, config.Datadog, logger)
 	require.NoError(t, err, "cannot start Netflow Server")
 	assert.NotNil(t, server)
 
@@ -143,8 +143,8 @@ network_devices:
 	config.Datadog.Set("hostname", "my-hostname")
 
 	// Setup NetFlow Server
-	log := fxutil.Test[log.Component](t, log.MockModule)
-	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(log, 1*time.Millisecond)
+	logger := fxutil.Test[log.Component](t, log.MockModule)
+	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(logger, 1*time.Millisecond)
 	defer demux.Stop(false)
 
 	sender, err := demux.GetDefaultSender()
@@ -152,7 +152,7 @@ network_devices:
 
 	ctrl := gomock.NewController(t)
 	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
-	server, err := NewNetflowServer(sender, epForwarder)
+	server, err := NewNetflowServer(sender, epForwarder, config.Datadog, logger)
 	require.NoError(t, err, "cannot start Netflow Server")
 	assert.NotNil(t, server)
 

--- a/pkg/netflow/server_test.go
+++ b/pkg/netflow/server_test.go
@@ -23,8 +23,8 @@ import (
 )
 
 func TestStartServerAndStopServer(t *testing.T) {
-	log := fxutil.Test[log.Component](t, log.MockModule)
-	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(log, 10*time.Millisecond)
+	logger := fxutil.Test[log.Component](t, log.MockModule)
+	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(logger, 10*time.Millisecond)
 	defer demux.Stop(false)
 
 	port := testutil.GetFreePort()
@@ -41,8 +41,7 @@ network_devices:
 `, port)))
 	require.NoError(t, err)
 	config.Datadog.Set("hostname", "my-hostname")
-
-	err = StartServer(demux)
+	err = StartServer(demux, config.Datadog, logger)
 	require.NoError(t, err)
 	require.NotNil(t, serverInstance)
 
@@ -53,14 +52,12 @@ network_devices:
 }
 
 func TestIsEnabled(t *testing.T) {
-	saved := config.Datadog.Get("network_devices.netflow.enabled")
-	defer config.Datadog.Set("network_devices.netflow.enabled", saved)
+	conf := config.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+	conf.Set("network_devices.netflow.enabled", true)
+	assert.Equal(t, true, IsEnabled(conf))
 
-	config.Datadog.Set("network_devices.netflow.enabled", true)
-	assert.Equal(t, true, IsEnabled())
-
-	config.Datadog.Set("network_devices.netflow.enabled", false)
-	assert.Equal(t, false, IsEnabled())
+	conf.Set("network_devices.netflow.enabled", false)
+	assert.Equal(t, false, IsEnabled(conf))
 }
 
 func TestServer_Stop(t *testing.T) {
@@ -81,13 +78,13 @@ network_devices:
 	require.NoError(t, err)
 
 	// Setup Netflow Server
-	log := fxutil.Test[log.Component](t, log.MockModule)
-	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(log, 10*time.Millisecond)
+	logger := fxutil.Test[log.Component](t, log.MockModule)
+	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(logger, 10*time.Millisecond)
 	defer demux.Stop(false)
 	sender, err := demux.GetDefaultSender()
 	require.NoError(t, err, "cannot get default sender")
 
-	server, err := NewNetflowServer(sender, nil)
+	server, err := NewNetflowServer(sender, nil, config.Datadog, logger)
 	require.NoError(t, err, "cannot start Netflow Server")
 	assert.NotNil(t, server)
 

--- a/pkg/netflow/testutil/testutil.go
+++ b/pkg/netflow/testutil/testutil.go
@@ -12,12 +12,13 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"net"
+	"testing"
+
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcapgo"
 	"github.com/stretchr/testify/assert"
-	"net"
-	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/epforwarder"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"


### PR DESCRIPTION
### What does this PR do?
This PR refactors netflow in preparation for componentizing it.

It should not change any actual behavior, it just modifies various netflow pieces to receive and/or pass around a `comp/core/config.Component` and a `comp/core/log.Component` rather than reading the global `pkg/util/config` or `pkg/util/log`.

~It depends on #19026 (because we need the log level in order to sync the logrus logger in goflow2 with our own logger).~ I removed the dependence on #19026 because of some issues getting that one merged; instead this will continue to use the global `GetLogLevel` to determine what level to set for `logrus`.

~I also added a config field for the aggregator's FlushToSendInterval so that this can be customized (reducing it to 1s makes the tests much faster).~ Removed this to avoid expanding config; this can be set directly during testing in the componentized version.

### Motivation

This is step one of NDM-2470 to componentize netflow; a followup PR will move the server lifecycle into an actual component.

### Possible Drawbacks / Trade-offs
There are no behavioral changes except that there is a new config variable exposed, but nobody should need to change that except inside our own tests so I don't think it needs to be publicly documented.

### Describe how to test/QA your changes
The standard QA to confirm that the netflow component works should suffice.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
