### PR TITLE
default to stripping eBPF object files

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -484,7 +484,7 @@ def build(
     bundle_ebpf=False,
     kernel_release=None,
     debug=False,
-    strip_object_files=False,
+    strip_object_files=True,
     strip_binary=False,
     with_unit_test=False,
     sbom=True,
@@ -1251,7 +1251,7 @@ def build_object_files(
     arch=CURRENT_ARCH,
     kernel_release=None,
     debug=False,
-    strip_object_files=False,
+    strip_object_files=True,
     with_unit_test=False,
 ):
     build_dir = os.path.join("pkg", "ebpf", "bytecode", "build")
@@ -1336,8 +1336,10 @@ def build_cws_object_files(
 
 
 @task
-def object_files(ctx, kernel_release=None, with_unit_test=False):
-    build_object_files(ctx, kernel_release=kernel_release, with_unit_test=with_unit_test)
+def object_files(ctx, kernel_release=None, with_unit_test=False, strip_object_files=True):
+    build_object_files(
+        ctx, kernel_release=kernel_release, with_unit_test=with_unit_test, strip_object_files=strip_object_files
+    )
 
 
 def clean_object_files(


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Uses `llvm-strip -g` to strip eBPF object files of unnecessary DWARF information.

### Motivation

potentially save 36MiB in package size, due to smaller object files. (77MiB before - 41MiB after)

### Additional Notes

debian 10 failing, waiting for #19030 

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
