### PR TITLE
[Netflow] Create Netflow Component

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -201,6 +201,7 @@
 /comp/forwarder @DataDog/agent-shared-components
 /comp/logs @DataDog/agent-metrics-logs
 /comp/metadata @DataDog/agent-shared-components
+/comp/netflow @DataDog/network-device-monitoring
 /comp/process @DataDog/processes
 /comp/remote-config @DataDog/remote-config
 /comp/systray @DataDog/windows-agent

--- a/comp/README.md
+++ b/comp/README.md
@@ -88,6 +88,19 @@ Package runner implements a component to generate the 'resources' metadata paylo
 
 Package runner implements a component to generate metadata payload at the right interval.
 
+## [comp/netflow](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/netflow) (Component Bundle)
+
+*Datadog Team*: network-device-monitoring
+
+Package netflow implements the "netflow" bundle
+
+### [comp/netflow/server](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/netflow/server)
+
+Package server implements a component that runs the netflow server.
+When running, it listens for network traffic according to configured
+listeners and aggregates traffic data to send to the backend.
+It does not expose any public methods.
+
 ## [comp/process](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/process) (Component Bundle)
 
 *Datadog Team*: processes

--- a/comp/netflow/bundle.go
+++ b/comp/netflow/bundle.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package netflow implements the "netflow" bundle
+package netflow
+
+import (
+	"github.com/DataDog/datadog-agent/comp/netflow/server"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: network-device-monitoring
+
+// Bundle defines the fx options for this bundle.
+var Bundle = fxutil.Bundle(
+	server.Module,
+)

--- a/comp/netflow/server/component.go
+++ b/comp/netflow/server/component.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package server implements a component that runs the netflow server.
+// When running, it listens for network traffic according to configured
+// listeners and aggregates traffic data to send to the backend.
+// It does not expose any public methods.
+package server
+
+import (
+	"go.uber.org/fx"
+
+	nfconfig "github.com/DataDog/datadog-agent/pkg/netflow/config"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: network-device-monitoring
+
+// Component is the component type.
+type Component interface{}
+
+// Module defines the fx options for this component.
+var Module = fxutil.Component(
+	fx.Provide(newServer),
+	fx.Provide(getNetflowForwarder),
+	fx.Provide(getNetflowSender),
+	fx.Provide(getHostname),
+	fx.Provide(nfconfig.ReadConfig),
+)

--- a/comp/netflow/server/integration_test.go
+++ b/comp/netflow/server/integration_test.go
@@ -1,0 +1,148 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+//go:build test
+
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/pkg/epforwarder"
+	"github.com/DataDog/datadog-agent/pkg/netflow/common"
+	nfconfig "github.com/DataDog/datadog-agent/pkg/netflow/config"
+	"github.com/DataDog/datadog-agent/pkg/netflow/flowaggregator"
+	"github.com/DataDog/datadog-agent/pkg/netflow/testutil"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func singleListenerConfig(flowType common.FlowType, port uint16) *nfconfig.NetflowConfig {
+	return &nfconfig.NetflowConfig{
+		AggregatorFlushInterval: 1,
+		Listeners: []nfconfig.ListenerConfig{{
+			FlowType: flowType,
+			BindHost: "127.0.0.1",
+			Port:     port,
+		}},
+	}
+}
+
+func TestNetFlow_IntegrationTest_NetFlow5(t *testing.T) {
+	port := testutil.GetFreePort()
+	ctrl := gomock.NewController(t)
+	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
+	srv := fxutil.Test[Component](t, fx.Options(
+		log.MockModule,
+		testModule,
+		fx.Replace(
+			fx.Annotate(epForwarder, fx.As(new(netflowEPForwarder))),
+			singleListenerConfig("netflow5", port),
+		),
+	)).(*Server)
+
+	flushTime, _ := time.Parse(time.RFC3339, "2019-02-18T16:00:06Z")
+
+	// Setup NetFlow Server
+	srv.FlowAgg.TimeNowFunction = func() time.Time {
+		return flushTime
+	}
+
+	// Send netflowV5Data twice to test aggregator
+	// Flows will have 2x bytes/packets after aggregation
+	time.Sleep(100 * time.Millisecond) // wait to make sure goflow listener is started before sending
+
+	packetData, err := testutil.GetNetFlow5Packet()
+	require.NoError(t, err, "error getting packet")
+	err = testutil.SendUDPPacket(port, packetData)
+	require.NoError(t, err, "error sending udp packet")
+
+	testutil.ExpectNetflow5Payloads(t, epForwarder)
+
+	epForwarder.EXPECT().SendEventPlatformEventBlocking(gomock.Any(), "network-devices-metadata").Return(nil).Times(1)
+
+	netflowEvents, err := flowaggregator.WaitForFlowsToBeFlushed(srv.FlowAgg, time.Second, 2)
+	assert.Equal(t, uint64(2), netflowEvents)
+	assert.NoError(t, err)
+}
+
+func TestNetFlow_IntegrationTest_NetFlow9(t *testing.T) {
+	port := testutil.GetFreePort()
+	ctrl := gomock.NewController(t)
+	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
+	srv := fxutil.Test[Component](t, fx.Options(
+		log.MockModule,
+		testModule,
+		fx.Replace(
+			fx.Annotate(epForwarder, fx.As(new(netflowEPForwarder))),
+			singleListenerConfig("netflow9", port),
+		),
+	)).(*Server)
+
+	flushTime, _ := time.Parse(time.RFC3339, "2019-02-18T16:00:06Z")
+
+	// Setup NetFlow Server
+	srv.FlowAgg.TimeNowFunction = func() time.Time {
+		return flushTime
+	}
+
+	time.Sleep(100 * time.Millisecond) // wait to make sure goflow listener is started before sending
+
+	packetData, err := testutil.GetNetFlow9Packet()
+	require.NoError(t, err, "error getting packet")
+	err = testutil.SendUDPPacket(port, packetData)
+	require.NoError(t, err, "error sending udp packet")
+
+	// Test later content of payloads if needed for more precise test.
+	epForwarder.EXPECT().SendEventPlatformEventBlocking(gomock.Any(), epforwarder.EventTypeNetworkDevicesNetFlow).Return(nil).Times(29)
+	epForwarder.EXPECT().SendEventPlatformEventBlocking(gomock.Any(), "network-devices-metadata").Return(nil).Times(1)
+
+	netflowEvents, err := flowaggregator.WaitForFlowsToBeFlushed(srv.FlowAgg, time.Second, 6)
+	assert.Equal(t, uint64(29), netflowEvents)
+	assert.NoError(t, err)
+}
+
+func TestNetFlow_IntegrationTest_SFlow5(t *testing.T) {
+	port := testutil.GetFreePort()
+	ctrl := gomock.NewController(t)
+	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
+	srv := fxutil.Test[Component](t, fx.Options(
+		log.MockModule,
+		testModule,
+		fx.Replace(
+			fx.Annotate(epForwarder, fx.As(new(netflowEPForwarder))),
+			singleListenerConfig("sflow5", port),
+		),
+	)).(*Server)
+
+	flushTime, _ := time.Parse(time.RFC3339, "2019-02-18T16:00:06Z")
+
+	// Setup NetFlow Server
+	srv.FlowAgg.TimeNowFunction = func() time.Time {
+		return flushTime
+	}
+
+	time.Sleep(100 * time.Millisecond) // wait to make sure goflow listener is started before sending
+
+	data, err := testutil.GetSFlow5Packet()
+	require.NoError(t, err, "error getting sflow data")
+
+	err = testutil.SendUDPPacket(port, data)
+	require.NoError(t, err, "error sending udp packet")
+
+	// Test later content of payloads if needed for more precise test.
+	epForwarder.EXPECT().SendEventPlatformEventBlocking(gomock.Any(), epforwarder.EventTypeNetworkDevicesNetFlow).Return(nil).Times(7)
+	epForwarder.EXPECT().SendEventPlatformEventBlocking(gomock.Any(), "network-devices-metadata").Return(nil).Times(1)
+
+	netflowEvents, err := flowaggregator.WaitForFlowsToBeFlushed(srv.FlowAgg, time.Second, 6)
+	assert.Equal(t, uint64(7), netflowEvents)
+	assert.NoError(t, err)
+}

--- a/comp/netflow/server/listener.go
+++ b/comp/netflow/server/listener.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package server
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/pkg/netflow/config"
+	"github.com/DataDog/datadog-agent/pkg/netflow/flowaggregator"
+	"github.com/DataDog/datadog-agent/pkg/netflow/goflowlib"
+)
+
+// netflowListener contains state of goflow listener and the related netflow config
+// flowState can be of type *utils.StateNetFlow/StateSFlow/StateNFLegacy
+type netflowListener struct {
+	flowState *goflowlib.FlowStateWrapper
+	config    config.ListenerConfig
+}
+
+// Shutdown will close the goflow listener state
+func (l *netflowListener) shutdown() {
+	l.flowState.Shutdown()
+}
+
+func startFlowListener(listenerConfig config.ListenerConfig, flowAgg *flowaggregator.FlowAggregator, logger log.Component) (*netflowListener, error) {
+	flowState, err := goflowlib.StartFlowRoutine(listenerConfig.FlowType, listenerConfig.BindHost, listenerConfig.Port, listenerConfig.Workers, listenerConfig.Namespace, flowAgg.GetFlowInChan(), logger)
+	if err != nil {
+		return nil, err
+	}
+	return &netflowListener{
+		flowState: flowState,
+		config:    listenerConfig,
+	}, nil
+}

--- a/comp/netflow/server/server.go
+++ b/comp/netflow/server/server.go
@@ -1,0 +1,151 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/epforwarder"
+	"github.com/DataDog/datadog-agent/pkg/netflow/config"
+	"github.com/DataDog/datadog-agent/pkg/netflow/flowaggregator"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.uber.org/fx"
+)
+
+// We expose these types internally in order to inject them; if they are ever componentized separately we will use the true componentized versions.
+type netflowHostname string
+type netflowEPForwarder epforwarder.EventPlatformForwarder
+type netflowSender sender.Sender
+
+func getHostname(logger log.Component) netflowHostname {
+	host, err := hostname.Get(context.Background())
+	if err != nil {
+		logger.Warnf("Error getting the hostname: %v", err)
+		return ""
+	}
+	return netflowHostname(host)
+}
+
+func getNetflowSender(agg aggregator.DemultiplexerWithAggregator) (netflowSender, error) {
+	return agg.GetDefaultSender()
+}
+
+func getNetflowForwarder(agg aggregator.DemultiplexerWithAggregator) (netflowEPForwarder, error) {
+	return agg.GetEventPlatformForwarder()
+}
+
+type dependencies struct {
+	fx.In
+	Config      *config.NetflowConfig
+	Logger      log.Component
+	EPForwarder netflowEPForwarder
+	Sender      netflowSender
+	Hostname    netflowHostname
+}
+
+func newServer(lc fx.Lifecycle, dep dependencies) (Component, error) {
+	server, err := NewServer(dep.Sender, dep.EPForwarder, dep.Config, dep.Logger, string(dep.Hostname))
+	if err != nil {
+		return nil, err
+	}
+	lc.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			return server.Start()
+		},
+		OnStop: func(context.Context) error {
+			server.Stop()
+			return nil
+		},
+	})
+	return server, nil
+}
+
+// Server manages netflow listeners.
+type Server struct {
+	Addr      string
+	config    *config.NetflowConfig
+	listeners []*netflowListener
+	FlowAgg   *flowaggregator.FlowAggregator
+	logger    log.Component
+	started   bool
+}
+
+// NewServer configures and returns a netflow server.
+func NewServer(sender sender.Sender, epForwarder epforwarder.EventPlatformForwarder, conf *config.NetflowConfig, logger log.Component, hostname string) (*Server, error) {
+	var listeners []*netflowListener
+
+	flowAgg := flowaggregator.NewFlowAggregator(sender, epForwarder, conf, hostname, logger)
+
+	return &Server{
+		listeners: listeners,
+		config:    conf,
+		FlowAgg:   flowAgg,
+		logger:    logger,
+	}, nil
+
+}
+
+// Start starts the server running
+func (s *Server) Start() error {
+	if s.started {
+		return errors.New("server already started")
+	}
+	s.started = true
+	go s.FlowAgg.Start()
+
+	if s.config.PrometheusListenerEnabled {
+		go func() {
+			serverMux := http.NewServeMux()
+			serverMux.Handle("/metrics", promhttp.Handler())
+			err := http.ListenAndServe(s.config.PrometheusListenerAddress, serverMux)
+			if err != nil {
+				s.logger.Errorf("error starting prometheus server `%s`", s.config.PrometheusListenerAddress)
+			}
+		}()
+	}
+	s.logger.Debugf("NetFlow Server configs (aggregator_buffer_size=%d, aggregator_flush_interval=%d, aggregator_flow_context_ttl=%d)", s.config.AggregatorBufferSize, s.config.AggregatorFlushInterval, s.config.AggregatorFlowContextTTL)
+	for _, listenerConfig := range s.config.Listeners {
+		s.logger.Infof("Starting Netflow listener for flow type %s on %s", listenerConfig.FlowType, listenerConfig.Addr())
+		listener, err := startFlowListener(listenerConfig, s.FlowAgg, s.logger)
+		if err != nil {
+			s.logger.Warnf("Error starting listener for config (flow_type:%s, bind_Host:%s, port:%d): %s", listenerConfig.FlowType, listenerConfig.BindHost, listenerConfig.Port, err)
+			continue
+		}
+		s.listeners = append(s.listeners, listener)
+	}
+	return nil
+}
+
+// Stop stops the Server.
+func (s *Server) Stop() {
+	s.logger.Infof("Stop NetFlow Server")
+
+	s.FlowAgg.Stop()
+
+	for _, listener := range s.listeners {
+		stopped := make(chan interface{})
+
+		go func() {
+			s.logger.Infof("Listener `%s` shutting down", listener.config.Addr())
+			listener.shutdown()
+			close(stopped)
+		}()
+
+		select {
+		case <-stopped:
+			s.logger.Infof("Listener `%s` stopped", listener.config.Addr())
+		case <-time.After(time.Duration(s.config.StopTimeout) * time.Second):
+			s.logger.Errorf("Stopping listener `%s`. Timeout after %d seconds", listener.config.Addr(), s.config.StopTimeout)
+		}
+	}
+}

--- a/comp/netflow/server/server_test.go
+++ b/comp/netflow/server/server_test.go
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+//go:build test
+
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	nfconfig "github.com/DataDog/datadog-agent/pkg/netflow/config"
+	"github.com/DataDog/datadog-agent/pkg/netflow/testutil"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func getAggregator(logger log.Component, lc fx.Lifecycle) aggregator.DemultiplexerWithAggregator {
+	agg := aggregator.InitTestAgentDemultiplexerWithFlushInterval(logger, 10*time.Millisecond)
+	lc.Append(fx.Hook{OnStop: func(context.Context) error {
+		agg.Stop(false)
+		return nil
+	}})
+	return agg
+}
+
+// testModule is an fx module of common dependencies for all tests
+var testModule = fx.Module(
+	"ServerTestModule",
+	// Provide the test demux/aggregator
+	fx.Provide(
+		getAggregator,
+	),
+	// Set the hostname to my-hostname
+	fx.Replace(netflowHostname("my-hostname")),
+	// Set the internal flush frequency to a small number so tests don't take forever
+	fx.Decorate(
+		// Allow tests to inject incomplete config and have defaults set automatically
+		func(conf *nfconfig.NetflowConfig) (*nfconfig.NetflowConfig, error) {
+			return conf, conf.SetDefaults("default")
+		},
+	),
+	fx.Invoke(func(c Component) {
+		c.(*Server).FlowAgg.FlushFlowsToSendInterval = 100 * time.Millisecond
+	}),
+	Module,
+)
+
+func TestStartServerAndStopServer(t *testing.T) {
+	port := testutil.GetFreePort()
+
+	server := fxutil.Test[Component](t, fx.Options(
+		log.MockModule,
+		testModule,
+		fx.Replace(
+			&nfconfig.NetflowConfig{
+				Listeners: []nfconfig.ListenerConfig{{
+					FlowType: "netflow5",
+					BindHost: "127.0.0.1",
+					Port:     port,
+				}},
+			},
+		),
+	))
+	assert.NotNil(t, server)
+	assert.True(t, server.(*Server).started)
+}

--- a/pkg/netflow/config/config.go
+++ b/pkg/netflow/config/config.go
@@ -49,18 +49,27 @@ func ReadConfig(conf ddconfig.ConfigReader) (*NetflowConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err = mainConfig.SetDefaults(conf.GetString("network_devices.namespace")); err != nil {
+		return nil, err
+	}
+	return &mainConfig, nil
+}
+
+// SetDefaults sets default values wherever possible, returning an error if
+// any values are malformed.
+func (mainConfig *NetflowConfig) SetDefaults(namespace string) error {
 	for i := range mainConfig.Listeners {
 		listenerConfig := &mainConfig.Listeners[i]
 
 		flowType, err := common.GetFlowTypeByName(listenerConfig.FlowType)
 		if err != nil {
-			return nil, fmt.Errorf("the provided flow type `%s` is not valid (valid flow types: %v)", listenerConfig.FlowType, common.GetAllFlowTypes())
+			return fmt.Errorf("the provided flow type `%s` is not valid (valid flow types: %v)", listenerConfig.FlowType, common.GetAllFlowTypes())
 		}
 
 		if listenerConfig.Port == 0 {
 			listenerConfig.Port = flowType.DefaultPort()
 			if listenerConfig.Port == 0 {
-				return nil, fmt.Errorf("no default port found for `%s`, a valid port must be set", listenerConfig.FlowType)
+				return fmt.Errorf("no default port found for `%s`, a valid port must be set", listenerConfig.FlowType)
 			}
 		}
 		if listenerConfig.BindHost == "" {
@@ -70,11 +79,11 @@ func ReadConfig(conf ddconfig.ConfigReader) (*NetflowConfig, error) {
 			listenerConfig.Workers = 1
 		}
 		if listenerConfig.Namespace == "" {
-			listenerConfig.Namespace = conf.GetString("network_devices.namespace")
+			listenerConfig.Namespace = namespace
 		}
 		normalizedNamespace, err := utils.NormalizeNamespace(listenerConfig.Namespace)
 		if err != nil {
-			return nil, fmt.Errorf("invalid namespace `%s` error: %s", listenerConfig.Namespace, err)
+			return fmt.Errorf("invalid namespace `%s` error: %s", listenerConfig.Namespace, err)
 		}
 		listenerConfig.Namespace = normalizedNamespace
 	}
@@ -104,7 +113,7 @@ func ReadConfig(conf ddconfig.ConfigReader) (*NetflowConfig, error) {
 		mainConfig.PrometheusListenerAddress = common.DefaultPrometheusListenerAddress
 	}
 
-	return &mainConfig, nil
+	return nil
 }
 
 // Addr returns the host:port address to listen on.

--- a/pkg/netflow/flowaggregator/aggregator.go
+++ b/pkg/netflow/flowaggregator/aggregator.go
@@ -34,7 +34,7 @@ const metricPrefix = "datadog.netflow."
 // FlowAggregator is used for space and time aggregation of NetFlow flows
 type FlowAggregator struct {
 	flowIn                       chan *common.Flow
-	flushFlowsToSendInterval     time.Duration // interval for checking flows to flush and send them to EP Forwarder
+	FlushFlowsToSendInterval     time.Duration // interval for checking flows to flush and send them to EP Forwarder
 	rollupTrackerRefreshInterval time.Duration
 	flowAcc                      *flowAccumulator
 	sender                       sender.Sender
@@ -82,7 +82,7 @@ func NewFlowAggregator(sender sender.Sender, epForwarder epforwarder.EventPlatfo
 	return &FlowAggregator{
 		flowIn:                       make(chan *common.Flow, config.AggregatorBufferSize),
 		flowAcc:                      newFlowAccumulator(flushInterval, flowContextTTL, config.AggregatorPortRollupThreshold, config.AggregatorPortRollupDisabled, logger),
-		flushFlowsToSendInterval:     flushFlowsToSendInterval,
+		FlushFlowsToSendInterval:     flushFlowsToSendInterval,
 		rollupTrackerRefreshInterval: rollupTrackerRefreshInterval,
 		sender:                       sender,
 		epForwarder:                  epForwarder,
@@ -207,15 +207,14 @@ func (agg *FlowAggregator) sendExporterMetadata(flows []*common.Flow, flushTime 
 func (agg *FlowAggregator) flushLoop() {
 	var flushFlowsToSendTicker <-chan time.Time
 
-	if agg.flushFlowsToSendInterval > 0 {
-		flushFlowsToSendTicker = time.NewTicker(agg.flushFlowsToSendInterval).C
+	if agg.FlushFlowsToSendInterval > 0 {
+		flushFlowsToSendTicker = time.NewTicker(agg.FlushFlowsToSendInterval).C
 	} else {
 		agg.logger.Debug("flushFlowsToSendInterval set to 0: will never flush automatically")
 	}
 
 	rollupTrackersRefresh := time.NewTicker(agg.rollupTrackerRefreshInterval).C
 	// TODO: move rollup tracker refresh to a separate loop (separate PR) to avoid rollup tracker and flush flows impacting each other
-
 	var lastFlushTime time.Time
 	for {
 		select {

--- a/pkg/netflow/flowaggregator/aggregator_test.go
+++ b/pkg/netflow/flowaggregator/aggregator_test.go
@@ -162,7 +162,7 @@ func TestAggregator(t *testing.T) {
 	logger := fxutil.Test[log.Component](t, log.MockModule)
 
 	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger)
-	aggregator.flushFlowsToSendInterval = 1 * time.Second
+	aggregator.FlushFlowsToSendInterval = 1 * time.Second
 	aggregator.TimeNowFunction = func() time.Time {
 		return flushTime
 	}
@@ -262,7 +262,7 @@ func TestAggregator_withMockPayload(t *testing.T) {
 
 	logger := fxutil.Test[log.Component](t, log.MockModule)
 	aggregator := NewFlowAggregator(sender, epForwarder, &conf, "my-hostname", logger)
-	aggregator.flushFlowsToSendInterval = 1 * time.Second
+	aggregator.FlushFlowsToSendInterval = 1 * time.Second
 	aggregator.TimeNowFunction = func() time.Time {
 		return flushTime
 	}


### PR DESCRIPTION
### What does this PR do?

This creates a netflow component that behaves just like the server in pkg/netflow, but is built using proper component patterns and fx injectables.

It also includes a port of the netflow server integration test, which starts the server on a random open port, sends some netflow packets to it, and observes that they are properly processed.

This PR does NOT register the component or remove the existing netflow server; that will be done in a follow-up PR.

### Motivation
NDM-2470.

### Describe how to test/QA your changes
Unit tests and a simple integration test are included; there is no additional QA because this PR doesn't change the agent behavior.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
