### PR TITLE
[install-tools] Do not force deleting go.work file, just warn

### DIFF
--- a/tasks/test.py
+++ b/tasks/test.py
@@ -120,14 +120,19 @@ def download_tools(ctx):
 def install_tools(ctx):
     """Install all Go tools for testing."""
     if os.path.isfile("go.work") or os.path.isfile("go.work.sum"):
+        # Someone reported issues with this command when using a go.work but other people
+        # use a go.work and don't have any issue, so the root cause is unclear.
+        # Printing a warning because it might help someone but not enforcing anything.
+
+        # The issue which was reported was that `go install` would fail with the following error:
+        ### no required module provides package <package>; to add it:
+        ### go get <package>
         print(
             color_message(
-                "Detected go workspace files. Go workspaces are not currently supported, "
-                + "please remove go.work and go.work.sum",
+                "In case of issue, you might want to try disabling go workspaces by setting the environment variable GOWORK=off, or even deleting go.work and go.work.sum",
                 "red",
             )
         )
-        return
 
     with environ({'GO111MODULE': 'on'}):
         for path, tools in TOOLS.items():

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -129,8 +129,8 @@ def install_tools(ctx):
         ### go get <package>
         print(
             color_message(
-                "In case of issue, you might want to try disabling go workspaces by setting the environment variable GOWORK=off, or even deleting go.work and go.work.sum",
-                "red",
+                "WARNING: In case of issue, you might want to try disabling go workspaces by setting the environment variable GOWORK=off, or even deleting go.work and go.work.sum",
+                "orange",
             )
         )
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
https://github.com/DataDog/datadog-agent/pull/18777 enforced deleting `go.work` file to run `inv install-tools`, because it was suspected to be the cause of an issue.
Following discussion with @robertjli, this PR changes that to only warn about `go.work` potentially causing issue (without preventing running the task).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
I use a `go.work` file and don't have issues with the invoke task, the change prevent me from running it without deleting my `go.work`.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Also updated the message to tell users to try `GOWORK=off` rather than deleting the file.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
