### PR TITLE
[RC] Add apply state callback function in param

### DIFF
--- a/comp/remote-config/rcclient/component.go
+++ b/comp/remote-config/rcclient/component.go
@@ -23,7 +23,7 @@ type Component interface {
 	// SubscribeAgentTask subscribe the remote-config client to AGENT_TASK
 	SubscribeAgentTask()
 	// Subscribe is the generic way to start listening to a specific product update
-	Subscribe(product data.Product, fn func(update map[string]state.RawConfig))
+	Subscribe(product data.Product, fn func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)))
 }
 
 // Module defines the fx options for this component.

--- a/comp/remote-config/rcclient/rcclient_test.go
+++ b/comp/remote-config/rcclient/rcclient_test.go
@@ -57,6 +57,7 @@ func (m *mockLogLevelRuntimeSettings) GetSource() settings.Source {
 	return m.source
 }
 
+// nolint: revive
 func applyEmpty(s string, as state.ApplyStatus) {}
 
 func TestAgentConfigCallback(t *testing.T) {

--- a/comp/remote-config/rcclient/rcclient_test.go
+++ b/comp/remote-config/rcclient/rcclient_test.go
@@ -86,7 +86,7 @@ func TestAgentConfigCallback(t *testing.T) {
 	structRC.agentConfigUpdateCallback(map[string]state.RawConfig{
 		"datadog/2/AGENT_CONFIG/layer1/configname":              layerStartFlare,
 		"datadog/2/AGENT_CONFIG/configuration_order/configname": configOrder,
-	})
+	}, func(s string, as state.ApplyStatus) {})
 	assert.Equal(t, "debug", mockSettings.logLevel)
 	assert.Equal(t, settings.SourceRC, mockSettings.source)
 
@@ -95,7 +95,7 @@ func TestAgentConfigCallback(t *testing.T) {
 	structRC.agentConfigUpdateCallback(map[string]state.RawConfig{
 		"datadog/2/AGENT_CONFIG/layer1/configname":              layerEndFlare,
 		"datadog/2/AGENT_CONFIG/configuration_order/configname": configOrder,
-	})
+	}, func(s string, as state.ApplyStatus) {})
 	assert.Equal(t, "info", mockSettings.logLevel)
 	assert.Equal(t, settings.SourceConfig, mockSettings.source)
 
@@ -105,7 +105,7 @@ func TestAgentConfigCallback(t *testing.T) {
 	structRC.agentConfigUpdateCallback(map[string]state.RawConfig{
 		"datadog/2/AGENT_CONFIG/layer1/configname":              layerStartFlare,
 		"datadog/2/AGENT_CONFIG/configuration_order/configname": configOrder,
-	})
+	}, func(s string, as state.ApplyStatus) {})
 	// Log level should still be "info" because it was enforced by the user
 	assert.Equal(t, "info", mockSettings.logLevel)
 	// Source should still be CLI as it has priority over RC
@@ -117,7 +117,7 @@ func TestAgentConfigCallback(t *testing.T) {
 	structRC.agentConfigUpdateCallback(map[string]state.RawConfig{
 		"datadog/2/AGENT_CONFIG/layer1/configname":              layerStartFlare,
 		"datadog/2/AGENT_CONFIG/configuration_order/configname": configOrder,
-	})
+	}, func(s string, as state.ApplyStatus) {})
 	assert.Equal(t, "debug", mockSettings.logLevel)
 	assert.Equal(t, settings.SourceRC, mockSettings.source)
 
@@ -125,7 +125,7 @@ func TestAgentConfigCallback(t *testing.T) {
 	structRC.agentConfigUpdateCallback(map[string]state.RawConfig{
 		"datadog/2/AGENT_CONFIG/layer1/configname":              layerEndFlare,
 		"datadog/2/AGENT_CONFIG/configuration_order/configname": configOrder,
-	})
+	}, func(s string, as state.ApplyStatus) {})
 	assert.Equal(t, "debug", mockSettings.logLevel)
 	assert.Equal(t, settings.SourceCLI, mockSettings.source)
 }

--- a/comp/remote-config/rcclient/rcclient_test.go
+++ b/comp/remote-config/rcclient/rcclient_test.go
@@ -57,6 +57,8 @@ func (m *mockLogLevelRuntimeSettings) GetSource() settings.Source {
 	return m.source
 }
 
+func applyEmpty(s string, as state.ApplyStatus) {}
+
 func TestAgentConfigCallback(t *testing.T) {
 	pkglog.SetupLogger(seelog.Default, "info")
 	mockSettings := &mockLogLevelRuntimeSettings{logLevel: "info", source: settings.SourceDefault}
@@ -86,7 +88,7 @@ func TestAgentConfigCallback(t *testing.T) {
 	structRC.agentConfigUpdateCallback(map[string]state.RawConfig{
 		"datadog/2/AGENT_CONFIG/layer1/configname":              layerStartFlare,
 		"datadog/2/AGENT_CONFIG/configuration_order/configname": configOrder,
-	}, func(s string, as state.ApplyStatus) {})
+	}, applyEmpty)
 	assert.Equal(t, "debug", mockSettings.logLevel)
 	assert.Equal(t, settings.SourceRC, mockSettings.source)
 
@@ -95,7 +97,7 @@ func TestAgentConfigCallback(t *testing.T) {
 	structRC.agentConfigUpdateCallback(map[string]state.RawConfig{
 		"datadog/2/AGENT_CONFIG/layer1/configname":              layerEndFlare,
 		"datadog/2/AGENT_CONFIG/configuration_order/configname": configOrder,
-	}, func(s string, as state.ApplyStatus) {})
+	}, applyEmpty)
 	assert.Equal(t, "info", mockSettings.logLevel)
 	assert.Equal(t, settings.SourceConfig, mockSettings.source)
 
@@ -105,7 +107,7 @@ func TestAgentConfigCallback(t *testing.T) {
 	structRC.agentConfigUpdateCallback(map[string]state.RawConfig{
 		"datadog/2/AGENT_CONFIG/layer1/configname":              layerStartFlare,
 		"datadog/2/AGENT_CONFIG/configuration_order/configname": configOrder,
-	}, func(s string, as state.ApplyStatus) {})
+	}, applyEmpty)
 	// Log level should still be "info" because it was enforced by the user
 	assert.Equal(t, "info", mockSettings.logLevel)
 	// Source should still be CLI as it has priority over RC
@@ -117,7 +119,7 @@ func TestAgentConfigCallback(t *testing.T) {
 	structRC.agentConfigUpdateCallback(map[string]state.RawConfig{
 		"datadog/2/AGENT_CONFIG/layer1/configname":              layerStartFlare,
 		"datadog/2/AGENT_CONFIG/configuration_order/configname": configOrder,
-	}, func(s string, as state.ApplyStatus) {})
+	}, applyEmpty)
 	assert.Equal(t, "debug", mockSettings.logLevel)
 	assert.Equal(t, settings.SourceRC, mockSettings.source)
 
@@ -125,7 +127,7 @@ func TestAgentConfigCallback(t *testing.T) {
 	structRC.agentConfigUpdateCallback(map[string]state.RawConfig{
 		"datadog/2/AGENT_CONFIG/layer1/configname":              layerEndFlare,
 		"datadog/2/AGENT_CONFIG/configuration_order/configname": configOrder,
-	}, func(s string, as state.ApplyStatus) {})
+	}, applyEmpty)
 	assert.Equal(t, "debug", mockSettings.logLevel)
 	assert.Equal(t, settings.SourceCLI, mockSettings.source)
 }

--- a/pkg/clusteragent/admission/patch/rc_provider.go
+++ b/pkg/clusteragent/admission/patch/rc_provider.go
@@ -66,7 +66,8 @@ func (rcp *remoteConfigProvider) subscribe(kind TargetObjKind) chan PatchRequest
 }
 
 // process is the event handler called by the RC client on config updates
-func (rcp *remoteConfigProvider) process(update map[string]state.RawConfig, _ func(string, state.ApplyStatus)) {
+// nolint: revive
+func (rcp *remoteConfigProvider) process(update map[string]state.RawConfig, applyState func(string, state.ApplyStatus)) {
 	log.Infof("Got %d updates from remote-config", len(update))
 	var valid, invalid float64
 	for path, config := range update {

--- a/pkg/clusteragent/admission/patch/rc_provider.go
+++ b/pkg/clusteragent/admission/patch/rc_provider.go
@@ -50,7 +50,7 @@ func (rcp *remoteConfigProvider) start(stopCh <-chan struct{}) {
 		select {
 		case <-rcp.isLeaderNotif:
 			log.Info("Got a leader notification, polling from remote-config")
-			rcp.process(rcp.client.GetConfigs(state.ProductAPMTracing))
+			rcp.process(rcp.client.GetConfigs(state.ProductAPMTracing), nil)
 		case <-stopCh:
 			log.Info("Shutting down remote-config patch provider")
 			rcp.client.Close()
@@ -66,7 +66,7 @@ func (rcp *remoteConfigProvider) subscribe(kind TargetObjKind) chan PatchRequest
 }
 
 // process is the event handler called by the RC client on config updates
-func (rcp *remoteConfigProvider) process(update map[string]state.RawConfig) {
+func (rcp *remoteConfigProvider) process(update map[string]state.RawConfig, _ func(string, state.ApplyStatus)) {
 	log.Infof("Got %d updates from remote-config", len(update))
 	var valid, invalid float64
 	for path, config := range update {

--- a/pkg/clusteragent/admission/patch/rc_provider.go
+++ b/pkg/clusteragent/admission/patch/rc_provider.go
@@ -50,7 +50,7 @@ func (rcp *remoteConfigProvider) start(stopCh <-chan struct{}) {
 		select {
 		case <-rcp.isLeaderNotif:
 			log.Info("Got a leader notification, polling from remote-config")
-			rcp.process(rcp.client.GetConfigs(state.ProductAPMTracing), nil)
+			rcp.process(rcp.client.GetConfigs(state.ProductAPMTracing), rcp.client.UpdateApplyStatus)
 		case <-stopCh:
 			log.Info("Shutting down remote-config patch provider")
 			rcp.client.Close()

--- a/pkg/clusteragent/admission/patch/rc_provider.go
+++ b/pkg/clusteragent/admission/patch/rc_provider.go
@@ -66,8 +66,7 @@ func (rcp *remoteConfigProvider) subscribe(kind TargetObjKind) chan PatchRequest
 }
 
 // process is the event handler called by the RC client on config updates
-// nolint: revive
-func (rcp *remoteConfigProvider) process(update map[string]state.RawConfig, applyState func(string, state.ApplyStatus)) {
+func (rcp *remoteConfigProvider) process(update map[string]state.RawConfig, _ func(string, state.ApplyStatus)) {
 	log.Infof("Got %d updates from remote-config", len(update))
 	var valid, invalid float64
 	for path, config := range update {

--- a/pkg/clusteragent/admission/patch/rc_provider_test.go
+++ b/pkg/clusteragent/admission/patch/rc_provider_test.go
@@ -9,9 +9,8 @@ package patch
 
 import (
 	"fmt"
-	"testing"
-
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/telemetry"
+	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/config/remote"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"

--- a/pkg/clusteragent/admission/patch/rc_provider_test.go
+++ b/pkg/clusteragent/admission/patch/rc_provider_test.go
@@ -9,8 +9,9 @@ package patch
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/telemetry"
 	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/telemetry"
 
 	"github.com/DataDog/datadog-agent/pkg/config/remote"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
@@ -48,7 +49,7 @@ func TestProcess(t *testing.T) {
 		"path3": {Config: genConfig("dev", "wrong")},        // kind mismatch
 		"path4": {Config: genConfig("wrong", "deployment")}, // cluster mismatch
 	}
-	rcp.process(in)
+	rcp.process(in, nil)
 	require.Len(t, notifs, 1)
 	pr := <-notifs
 	require.Equal(t, "17945471932432318983", pr.ID)

--- a/pkg/config/remote/client.go
+++ b/pkg/config/remote/client.go
@@ -74,7 +74,7 @@ type Client struct {
 
 	state *state.Repository
 
-	listeners map[string][]func(update map[string]state.RawConfig)
+	listeners map[string][]func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus))
 }
 
 // agentGRPCConfigFetcher defines how to retrieve config updates over a
@@ -197,7 +197,7 @@ func newClient(agentName string, updater ConfigUpdater, doTufVerification bool, 
 		state:         repository,
 		pollInterval:  pollInterval,
 		backoffPolicy: backoffPolicy,
-		listeners:     make(map[string][]func(update map[string]state.RawConfig)),
+		listeners:     make(map[string][]func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus))),
 		updater:       updater,
 	}, nil
 }
@@ -233,7 +233,7 @@ func (c *Client) SetAgentName(agentName string) {
 }
 
 // Subscribe subscribes to config updates of a product.
-func (c *Client) Subscribe(product string, fn func(update map[string]state.RawConfig)) {
+func (c *Client) Subscribe(product string, fn func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus))) {
 	c.m.Lock()
 	defer c.m.Unlock()
 
@@ -250,7 +250,7 @@ func (c *Client) Subscribe(product string, fn func(update map[string]state.RawCo
 	}
 
 	c.listeners[product] = append(c.listeners[product], fn)
-	fn(c.state.GetConfigs(product))
+	fn(c.state.GetConfigs(product), c.state.UpdateApplyStatus)
 }
 
 // GetConfigs returns the current configs applied of a product.
@@ -342,7 +342,7 @@ func (c *Client) update() error {
 	for product, productListeners := range c.listeners {
 		if containsProduct(changedProducts, product) {
 			for _, listener := range productListeners {
-				listener(c.state.GetConfigs(product))
+				listener(c.state.GetConfigs(product), c.state.UpdateApplyStatus)
 			}
 		}
 	}

--- a/pkg/security/rconfig/policies.go
+++ b/pkg/security/rconfig/policies.go
@@ -73,8 +73,7 @@ func (r *RCPolicyProvider) Start() {
 	r.client.Start()
 }
 
-// nolint: revive
-func (r *RCPolicyProvider) rcDefaultsUpdateCallback(configs map[string]state.RawConfig, applyStatus func(string, state.ApplyStatus)) {
+func (r *RCPolicyProvider) rcDefaultsUpdateCallback(configs map[string]state.RawConfig, _ func(string, state.ApplyStatus)) {
 	r.Lock()
 	r.lastDefaults = configs
 	r.Unlock()
@@ -84,8 +83,7 @@ func (r *RCPolicyProvider) rcDefaultsUpdateCallback(configs map[string]state.Raw
 	r.debouncer.Call()
 }
 
-// nolint: revive
-func (r *RCPolicyProvider) rcCustomsUpdateCallback(configs map[string]state.RawConfig, applyStatus func(string, state.ApplyStatus)) {
+func (r *RCPolicyProvider) rcCustomsUpdateCallback(configs map[string]state.RawConfig, _ func(string, state.ApplyStatus)) {
 	r.Lock()
 	r.lastCustoms = configs
 	r.Unlock()

--- a/pkg/security/rconfig/policies.go
+++ b/pkg/security/rconfig/policies.go
@@ -73,7 +73,8 @@ func (r *RCPolicyProvider) Start() {
 	r.client.Start()
 }
 
-func (r *RCPolicyProvider) rcDefaultsUpdateCallback(configs map[string]state.RawConfig, _ func(string, state.ApplyStatus)) {
+// nolint: revive
+func (r *RCPolicyProvider) rcDefaultsUpdateCallback(configs map[string]state.RawConfig, applyStatus func(string, state.ApplyStatus)) {
 	r.Lock()
 	r.lastDefaults = configs
 	r.Unlock()
@@ -83,7 +84,8 @@ func (r *RCPolicyProvider) rcDefaultsUpdateCallback(configs map[string]state.Raw
 	r.debouncer.Call()
 }
 
-func (r *RCPolicyProvider) rcCustomsUpdateCallback(configs map[string]state.RawConfig, _ func(string, state.ApplyStatus)) {
+// nolint: revive
+func (r *RCPolicyProvider) rcCustomsUpdateCallback(configs map[string]state.RawConfig, applyStatus func(string, state.ApplyStatus)) {
 	r.Lock()
 	r.lastCustoms = configs
 	r.Unlock()

--- a/pkg/security/rconfig/policies.go
+++ b/pkg/security/rconfig/policies.go
@@ -73,7 +73,7 @@ func (r *RCPolicyProvider) Start() {
 	r.client.Start()
 }
 
-func (r *RCPolicyProvider) rcDefaultsUpdateCallback(configs map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
+func (r *RCPolicyProvider) rcDefaultsUpdateCallback(configs map[string]state.RawConfig, _ func(string, state.ApplyStatus)) {
 	r.Lock()
 	r.lastDefaults = configs
 	r.Unlock()
@@ -83,7 +83,7 @@ func (r *RCPolicyProvider) rcDefaultsUpdateCallback(configs map[string]state.Raw
 	r.debouncer.Call()
 }
 
-func (r *RCPolicyProvider) rcCustomsUpdateCallback(configs map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
+func (r *RCPolicyProvider) rcCustomsUpdateCallback(configs map[string]state.RawConfig, _ func(string, state.ApplyStatus)) {
 	r.Lock()
 	r.lastCustoms = configs
 	r.Unlock()

--- a/pkg/security/rconfig/policies.go
+++ b/pkg/security/rconfig/policies.go
@@ -73,7 +73,7 @@ func (r *RCPolicyProvider) Start() {
 	r.client.Start()
 }
 
-func (r *RCPolicyProvider) rcDefaultsUpdateCallback(configs map[string]state.RawConfig) {
+func (r *RCPolicyProvider) rcDefaultsUpdateCallback(configs map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
 	r.Lock()
 	r.lastDefaults = configs
 	r.Unlock()
@@ -83,7 +83,7 @@ func (r *RCPolicyProvider) rcDefaultsUpdateCallback(configs map[string]state.Raw
 	r.debouncer.Call()
 }
 
-func (r *RCPolicyProvider) rcCustomsUpdateCallback(configs map[string]state.RawConfig) {
+func (r *RCPolicyProvider) rcCustomsUpdateCallback(configs map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
 	r.Lock()
 	r.lastCustoms = configs
 	r.Unlock()

--- a/pkg/security/rconfig/profiles.go
+++ b/pkg/security/rconfig/profiles.go
@@ -47,7 +47,7 @@ func (r *RCProfileProvider) Stop() error {
 	return nil
 }
 
-func (r *RCProfileProvider) rcProfilesUpdateCallback(configs map[string]state.RawConfig) {
+func (r *RCProfileProvider) rcProfilesUpdateCallback(configs map[string]state.RawConfig, _ func(string, state.ApplyStatus)) {
 	for _, config := range configs {
 		var profCfg ProfileConfig
 		if err := json.Unmarshal(config.Config, &profCfg); err != nil {

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -478,7 +478,7 @@ type AgentConfig struct {
 type RemoteClient interface {
 	Close()
 	Start()
-	Subscribe(string, func(update map[string]state.RawConfig))
+	Subscribe(string, func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)))
 	UpdateApplyStatus(cfgPath string, status state.ApplyStatus)
 }
 

--- a/pkg/trace/remoteconfighandler/mock_remote_client.go
+++ b/pkg/trace/remoteconfighandler/mock_remote_client.go
@@ -46,7 +46,7 @@ func (mr *MockRemoteClientMockRecorder) Close() *gomock.Call {
 }
 
 // Subscribe mocks base method.
-func (m *MockRemoteClient) Subscribe(arg0 string, arg1 func(map[string]state.RawConfig)) {
+func (m *MockRemoteClient) Subscribe(arg0 string, arg1 func(map[string]state.RawConfig, func(string, state.ApplyStatus))) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Subscribe", arg0, arg1)
 }

--- a/pkg/trace/remoteconfighandler/remote_config_handler_test.go
+++ b/pkg/trace/remoteconfighandler/remote_config_handler_test.go
@@ -222,7 +222,7 @@ func TestLogLevel(t *testing.T) {
 	h.onAgentConfigUpdate(map[string]state.RawConfig{
 		"datadog/2/AGENT_CONFIG/layer1/configname":              layer,
 		"datadog/2/AGENT_CONFIG/configuration_order/configname": configOrder,
-	}, applyEmpty)
+	}, remoteClient.UpdateApplyStatus)
 
 	ctrl.Finish()
 }

--- a/pkg/trace/remoteconfighandler/remote_config_handler_test.go
+++ b/pkg/trace/remoteconfighandler/remote_config_handler_test.go
@@ -222,7 +222,7 @@ func TestLogLevel(t *testing.T) {
 	h.onAgentConfigUpdate(map[string]state.RawConfig{
 		"datadog/2/AGENT_CONFIG/layer1/configname":              layer,
 		"datadog/2/AGENT_CONFIG/configuration_order/configname": configOrder,
-	})
+	}, applyEmpty)
 
 	ctrl.Finish()
 }

--- a/pkg/trace/remoteconfighandler/remote_config_handler_test.go
+++ b/pkg/trace/remoteconfighandler/remote_config_handler_test.go
@@ -23,6 +23,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// nolint: revive
+func applyEmpty(s string, as state.ApplyStatus) {}
+
 func TestStart(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	remoteClient := NewMockRemoteClient(ctrl)
@@ -74,7 +77,7 @@ func TestPrioritySampler(t *testing.T) {
 	errorsSampler.EXPECT().UpdateTargetTPS(float64(41)).Times(1)
 	rareSampler.EXPECT().SetEnabled(true).Times(1)
 
-	h.onUpdate(map[string]state.RawConfig{"datadog/2/APM_SAMPLING/samplerconfig/config": config})
+	h.onUpdate(map[string]state.RawConfig{"datadog/2/APM_SAMPLING/samplerconfig/config": config}, applyEmpty)
 
 	ctrl.Finish()
 }
@@ -105,7 +108,7 @@ func TestErrorsSampler(t *testing.T) {
 	errorsSampler.EXPECT().UpdateTargetTPS(float64(42)).Times(1)
 	rareSampler.EXPECT().SetEnabled(true).Times(1)
 
-	h.onUpdate(map[string]state.RawConfig{"datadog/2/APM_SAMPLING/samplerconfig/config": config})
+	h.onUpdate(map[string]state.RawConfig{"datadog/2/APM_SAMPLING/samplerconfig/config": config}, applyEmpty)
 
 	ctrl.Finish()
 }
@@ -136,7 +139,7 @@ func TestRareSampler(t *testing.T) {
 	errorsSampler.EXPECT().UpdateTargetTPS(float64(41)).Times(1)
 	rareSampler.EXPECT().SetEnabled(false).Times(1)
 
-	h.onUpdate(map[string]state.RawConfig{"datadog/2/APM_SAMPLING/samplerconfig/config": config})
+	h.onUpdate(map[string]state.RawConfig{"datadog/2/APM_SAMPLING/samplerconfig/config": config}, applyEmpty)
 
 	ctrl.Finish()
 }
@@ -177,7 +180,7 @@ func TestEnvPrecedence(t *testing.T) {
 	errorsSampler.EXPECT().UpdateTargetTPS(float64(43)).Times(1)
 	rareSampler.EXPECT().SetEnabled(false).Times(1)
 
-	h.onUpdate(map[string]state.RawConfig{"datadog/2/APM_SAMPLING/samplerconfig/config": config})
+	h.onUpdate(map[string]state.RawConfig{"datadog/2/APM_SAMPLING/samplerconfig/config": config}, applyEmpty)
 
 	ctrl.Finish()
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add `updateApplyState` callback function, so the update function can change the config apply state itself more easily

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Make sure configurations sent by RC are still sending the apply state to the backend

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
