### PR TITLE
Add tracer logging for lambda extension

### DIFF
--- a/cmd/serverless/log.go
+++ b/cmd/serverless/log.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package main
+
+import "github.com/DataDog/datadog-agent/pkg/util/log"
+
+// Stack depth of 3 since the `corelogger` struct adds a layer above the logger
+const stackDepth = 3
+
+type corelogger struct{}
+
+// Trace implements Logger.
+func (corelogger) Trace(v ...interface{}) { log.TraceStackDepth(stackDepth, v...) }
+
+// Tracef implements Logger.
+func (corelogger) Tracef(format string, params ...interface{}) {
+	log.TracefStackDepth(stackDepth, format, params...)
+}
+
+// Debug implements Logger.
+func (corelogger) Debug(v ...interface{}) { log.DebugStackDepth(stackDepth, v...) }
+
+// Debugf implements Logger.
+func (corelogger) Debugf(format string, params ...interface{}) {
+	log.DebugfStackDepth(stackDepth, format, params...)
+}
+
+// Info implements Logger.
+func (corelogger) Info(v ...interface{}) { log.InfoStackDepth(stackDepth, v...) }
+
+// Infof implements Logger.
+func (corelogger) Infof(format string, params ...interface{}) {
+	log.InfofStackDepth(stackDepth, format, params...)
+}
+
+// Warn implements Logger.
+func (corelogger) Warn(v ...interface{}) error { return log.WarnStackDepth(stackDepth, v...) }
+
+// Warnf implements Logger.
+func (corelogger) Warnf(format string, params ...interface{}) error {
+	return log.WarnfStackDepth(stackDepth, format, params...)
+}
+
+// Error implements Logger.
+func (corelogger) Error(v ...interface{}) error { return log.ErrorStackDepth(stackDepth, v...) }
+
+// Errorf implements Logger.
+func (corelogger) Errorf(format string, params ...interface{}) error {
+	return log.ErrorfStackDepth(stackDepth, format, params...)
+}
+
+// Critical implements Logger.
+func (corelogger) Critical(v ...interface{}) error { return log.CriticalStackDepth(stackDepth, v...) }
+
+// Criticalf implements Logger.
+func (corelogger) Criticalf(format string, params ...interface{}) error {
+	return log.CriticalfStackDepth(stackDepth, format, params...)
+}
+
+// Flush implements Logger.
+func (corelogger) Flush() { log.Flush() }

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serverless/registration"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace/inferredspan"
+	tracelog "github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -82,6 +83,8 @@ func main() {
 		log.Error(err)
 		os.Exit(-1)
 	}
+
+	tracelog.SetLogger(&corelogger{})
 
 	// handle SIGTERM signal
 	go handleSignals(serverlessDaemon, stopCh)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Same as https://github.com/DataDog/datadog-agent/pull/19032 but for our lambda extension.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
