### PR TITLE
Fix the issue that enable 'logs_config.file_wildcard_selection_mode: by_name'config in default datadog.yaml causing agent startup error

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1191,7 +1191,7 @@ api_key:
   ## WARNING: `by_modification_time` is less performant than `by_name` and will trigger
   ## more disk I/O at the configured wildcard log paths.
   #
-  # file_wildcard_selection_mode: `by_name`
+  # file_wildcard_selection_mode: by_name
 
 {{ end -}}
 {{- if .TraceAgent }}


### PR DESCRIPTION
After compiled datadog-agent，I found logs_config.file_wildcard_selection_mode config in datadog.yaml as followiing：
**# file_wildcard_selection_mode: by_name`**
when I open the comment，causing agent startup error as following：
Error: unable to load Datadog config file: While parsing config: yaml: line 1145
So when I adjusted it to **file_wildcard_selection_mode: by_name**，startup success。