### PR TITLE
[usm] remove dependency on enable https monitoring

### DIFF
--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -996,7 +996,6 @@ func testHTTPGoTLSCaptureNewProcess(t *testing.T, cfg *config.Config) {
 
 	cfg.EnableGoTLSSupport = true
 	cfg.EnableHTTPMonitoring = true
-	cfg.EnableHTTPSMonitoring = true
 
 	tr := setupTracer(t, cfg)
 
@@ -1030,7 +1029,6 @@ func testHTTPGoTLSCaptureAlreadyRunning(t *testing.T, cfg *config.Config) {
 
 	cfg.EnableGoTLSSupport = true
 	cfg.EnableHTTPMonitoring = true
-	cfg.EnableHTTPSMonitoring = true
 
 	tr := setupTracer(t, cfg)
 
@@ -1065,7 +1063,6 @@ func testHTTPsGoTLSCaptureNewProcessContainer(t *testing.T, cfg *config.Config) 
 	// Setup
 	cfg.EnableGoTLSSupport = true
 	cfg.EnableHTTPMonitoring = true
-	cfg.EnableHTTPSMonitoring = true
 	cfg.EnableHTTPStatsByStatusCode = true
 
 	tr := setupTracer(t, cfg)
@@ -1101,7 +1098,6 @@ func testHTTPsGoTLSCaptureAlreadyRunningContainer(t *testing.T, cfg *config.Conf
 	// Setup
 	cfg.EnableGoTLSSupport = true
 	cfg.EnableHTTPMonitoring = true
-	cfg.EnableHTTPSMonitoring = true
 	cfg.EnableHTTPStatsByStatusCode = true
 
 	tr := setupTracer(t, cfg)

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -702,7 +702,6 @@ func (s *USMSuite) TestJavaInjection() {
 
 	cfg := testConfig()
 	cfg.EnableHTTPMonitoring = true
-	cfg.EnableHTTPSMonitoring = true
 	cfg.EnableJavaTLSSupport = true
 	defaultCfg := cfg
 

--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -161,7 +161,7 @@ type GoTLSProgram struct {
 var _ subprogram = &GoTLSProgram{}
 
 func newGoTLSProgram(c *config.Config) *GoTLSProgram {
-	if !c.EnableHTTPSMonitoring || !c.EnableGoTLSSupport {
+	if !c.EnableGoTLSSupport {
 		return nil
 	}
 

--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/ebpfcheck"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
 	"github.com/DataDog/datadog-agent/pkg/network/go/binversion"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
@@ -155,12 +156,15 @@ type GoTLSProgram struct {
 
 	// blockCache is a sized limited cache for processes that cannot be hooked (binversion.ErrNotGoExe).
 	blockCache *simplelru.LRU[binaryID, struct{}]
+
+	// sockFDMap is the user mode handler of `sock_by_pid_fd` map, which is shared among NPM and USM.
+	sockFDMap *ebpf.Map
 }
 
 // Static evaluation to make sure we are not breaking the interface.
 var _ subprogram = &GoTLSProgram{}
 
-func newGoTLSProgram(c *config.Config) *GoTLSProgram {
+func newGoTLSProgram(c *config.Config, sockFD *ebpf.Map) *GoTLSProgram {
 	if !c.EnableGoTLSSupport {
 		return nil
 	}
@@ -188,6 +192,7 @@ func newGoTLSProgram(c *config.Config) *GoTLSProgram {
 		binaries:   make(map[binaryID]*runningBinary),
 		processes:  make(map[pid]binaryID),
 		blockCache: blockCache,
+		sockFDMap:  sockFD,
 	}
 
 	p.binAnalysisMetric = libtelemetry.NewCounter("gotls.analysis_time", libtelemetry.OptStatsd)
@@ -223,6 +228,12 @@ func (p *GoTLSProgram) ConfigureOptions(options *manager.Options) {
 		MaxEntries: p.cfg.MaxTrackedConnections,
 		EditorFlag: manager.EditMaxEntries,
 	}
+
+	if options.MapEditors == nil {
+		options.MapEditors = make(map[string]*ebpf.Map)
+	}
+
+	options.MapEditors[probes.SockByPidFDMap] = p.sockFDMap
 }
 
 // GetAllUndefinedProbes returns a list of the program's probes.

--- a/pkg/network/usm/ebpf_javatls.go
+++ b/pkg/network/usm/ebpf_javatls.go
@@ -127,7 +127,7 @@ var javaTLSSpec = &protocols.ProtocolSpec{
 }
 
 func newJavaTLSProgram(c *config.Config) (protocols.Protocol, error) {
-	if !c.EnableJavaTLSSupport || !c.EnableHTTPSMonitoring || !http.HTTPSSupported(c) {
+	if !c.EnableJavaTLSSupport || !http.HTTPSSupported(c) {
 		return nil, nil
 	}
 

--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -105,7 +105,7 @@ type subprogram interface {
 	Stop()
 }
 
-func newEBPFProgram(c *config.Config, connectionProtocolMap *ebpf.Map, bpfTelemetry *errtelemetry.EBPFTelemetry) (*ebpfProgram, error) {
+func newEBPFProgram(c *config.Config, sockFD, connectionProtocolMap *ebpf.Map, bpfTelemetry *errtelemetry.EBPFTelemetry) (*ebpfProgram, error) {
 	mgr := &manager.Manager{
 		Maps: []*manager.Map{
 			{Name: sslSockByCtxMap},
@@ -143,7 +143,7 @@ func newEBPFProgram(c *config.Config, connectionProtocolMap *ebpf.Map, bpfTeleme
 	subprograms := make([]subprogram, 0, 1)
 	var tailCalls []manager.TailCallRoute
 
-	goTLSProg := newGoTLSProgram(c)
+	goTLSProg := newGoTLSProgram(c, sockFD)
 	subprogramProbesResolvers = append(subprogramProbesResolvers, goTLSProg)
 	if goTLSProg != nil {
 		subprograms = append(subprograms, goTLSProg)

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -214,7 +214,7 @@ func (m *Monitor) Start() error {
 	}
 
 	// Need to explicitly save the error in `err` so the defer function could save the startup error.
-	if m.cfg.EnableHTTPSMonitoring || m.cfg.EnableGoTLSSupport || m.cfg.EnableIstioMonitoring {
+	if m.cfg.EnableHTTPSMonitoring || m.cfg.EnableGoTLSSupport || m.cfg.EnableJavaTLSSupport || m.cfg.EnableIstioMonitoring {
 		err = m.processMonitor.Initialize()
 	}
 

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -214,7 +214,7 @@ func (m *Monitor) Start() error {
 	}
 
 	// Need to explicitly save the error in `err` so the defer function could save the startup error.
-	if m.cfg.EnableHTTPSMonitoring || m.cfg.EnableIstioMonitoring {
+	if m.cfg.EnableHTTPSMonitoring || m.cfg.EnableGoTLSSupport || m.cfg.EnableIstioMonitoring {
 		err = m.processMonitor.Initialize()
 	}
 

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -87,7 +87,7 @@ func NewMonitor(c *config.Config, connectionProtocolMap, sockFD *ebpf.Map, bpfTe
 		}
 	}()
 
-	mgr, err := newEBPFProgram(c, connectionProtocolMap, bpfTelemetry)
+	mgr, err := newEBPFProgram(c, sockFD, connectionProtocolMap, bpfTelemetry)
 	if err != nil {
 		return nil, fmt.Errorf("error setting up ebpf program: %w", err)
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Removes the dependency of gotls and javatls on the general EnableHTTPSMonitoring.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
EnableHTTPSMonitoring is referring to native tls support (openssl), and there is no reason to have 2 different keys to control a single operation
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
