### PR TITLE
Extract helper function from the config pkg

### DIFF
--- a/comp/core/flare/helpers/send_flare.go
+++ b/comp/core/flare/helpers/send_flare.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	hostnameUtil "github.com/DataDog/datadog-agent/pkg/util/hostname"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -202,8 +202,8 @@ func SendTo(archivePath, caseID, email, source, apiKey, url string) (string, err
 		hostname = "unknown"
 	}
 
-	apiKey = config.SanitizeAPIKey(apiKey)
-	baseURL, _ := config.AddAgentVersionToDomain(url, "flare")
+	apiKey = configUtils.SanitizeAPIKey(apiKey)
+	baseURL, _ := configUtils.AddAgentVersionToDomain(url, "flare")
 
 	transport := httputils.CreateHTTPTransport()
 	client := &http.Client{

--- a/comp/forwarder/defaultforwarder/default_forwarder.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder.go
@@ -24,6 +24,7 @@ import (
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/resolver"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -271,7 +272,7 @@ func NewDefaultForwarder(config config.Component, log log.Component, options *Op
 	transactionContainerSort := transaction.SortByCreatedTimeAndPriority{HighPriorityFirst: false}
 
 	for domain, resolver := range options.DomainResolvers {
-		domain, _ := pkgconfig.AddAgentVersionToDomain(domain, "app")
+		domain, _ := configUtils.AddAgentVersionToDomain(domain, "app")
 		resolver.SetBaseDomain(domain)
 		if resolver.GetAPIKeys() == nil || len(resolver.GetAPIKeys()) == 0 {
 			log.Errorf("No API keys for domain '%s', dropping domain ", domain)

--- a/comp/forwarder/defaultforwarder/forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/forwarder_test.go
@@ -22,15 +22,15 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/endpoints"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/resolver"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 var (
 	testDomain           = "http://app.datadoghq.com"
-	testVersionDomain, _ = config.AddAgentVersionToDomain(testDomain, "app")
+	testVersionDomain, _ = configUtils.AddAgentVersionToDomain(testDomain, "app")
 	monoKeysDomains      = map[string][]string{
 		testVersionDomain: {"monokey"},
 	}
@@ -48,7 +48,7 @@ var (
 )
 
 func TestNewDefaultForwarder(t *testing.T) {
-	mockConfig := pkgconfig.Mock(t)
+	mockConfig := config.Mock(t)
 	log := fxutil.Test[log.Component](t, log.MockModule)
 	forwarder := NewDefaultForwarder(mockConfig, log, NewOptionsWithResolvers(mockConfig, log, resolver.NewSingleDomainResolvers(keysPerDomains)))
 
@@ -80,7 +80,7 @@ func TestFeature(t *testing.T) {
 }
 
 func TestStart(t *testing.T) {
-	mockConfig := pkgconfig.Mock(t)
+	mockConfig := config.Mock(t)
 	log := fxutil.Test[log.Component](t, log.MockModule)
 	forwarder := NewDefaultForwarder(mockConfig, log, NewOptionsWithResolvers(mockConfig, log, resolver.NewSingleDomainResolvers(monoKeysDomains)))
 	err := forwarder.Start()
@@ -110,7 +110,7 @@ func TestStopWithPurgingTransaction(t *testing.T) {
 }
 
 func testStop(t *testing.T) {
-	mockConfig := pkgconfig.Mock(t)
+	mockConfig := config.Mock(t)
 	log := fxutil.Test[log.Component](t, log.MockModule)
 	forwarder := NewDefaultForwarder(mockConfig, log, NewOptionsWithResolvers(mockConfig, log, resolver.NewSingleDomainResolvers(keysPerDomains)))
 	assert.Equal(t, Stopped, forwarder.State())
@@ -127,7 +127,7 @@ func testStop(t *testing.T) {
 }
 
 func TestSubmitIfStopped(t *testing.T) {
-	mockConfig := pkgconfig.Mock(t)
+	mockConfig := config.Mock(t)
 	log := fxutil.Test[log.Component](t, log.MockModule)
 	forwarder := NewDefaultForwarder(mockConfig, log, NewOptionsWithResolvers(mockConfig, log, resolver.NewSingleDomainResolvers(monoKeysDomains)))
 
@@ -143,7 +143,7 @@ func TestSubmitIfStopped(t *testing.T) {
 }
 
 func TestCreateHTTPTransactions(t *testing.T) {
-	mockConfig := pkgconfig.Mock(t)
+	mockConfig := config.Mock(t)
 	log := fxutil.Test[log.Component](t, log.MockModule)
 	forwarder := NewDefaultForwarder(mockConfig, log, NewOptionsWithResolvers(mockConfig, log, resolver.NewSingleDomainResolvers(keysPerDomains)))
 	endpoint := transaction.Endpoint{Route: "/api/foo", Name: "foo"}
@@ -176,7 +176,7 @@ func TestCreateHTTPTransactions(t *testing.T) {
 }
 
 func TestCreateHTTPTransactionsWithMultipleDomains(t *testing.T) {
-	mockConfig := pkgconfig.Mock(t)
+	mockConfig := config.Mock(t)
 	log := fxutil.Test[log.Component](t, log.MockModule)
 	forwarder := NewDefaultForwarder(mockConfig, log, NewOptionsWithResolvers(mockConfig, log, resolver.NewSingleDomainResolvers(keysWithMultipleDomains)))
 	endpoint := transaction.Endpoint{Route: "/api/foo", Name: "foo"}
@@ -217,7 +217,7 @@ func TestCreateHTTPTransactionsWithDifferentResolvers(t *testing.T) {
 	additionalResolver := resolver.NewMultiDomainResolver("datadog.vector", []string{"api-key-4"})
 	additionalResolver.RegisterAlternateDestination("diversion.domain", "diverted_name", resolver.Vector)
 	resolvers["datadog.vector"] = additionalResolver
-	mockConfig := pkgconfig.Mock(t)
+	mockConfig := config.Mock(t)
 	log := fxutil.Test[log.Component](t, log.MockModule)
 	forwarder := NewDefaultForwarder(mockConfig, log, NewOptionsWithResolvers(mockConfig, log, resolvers))
 	endpoint := transaction.Endpoint{Route: "/api/foo", Name: "diverted_name"}
@@ -261,7 +261,7 @@ func TestCreateHTTPTransactionsWithOverrides(t *testing.T) {
 	r := resolver.NewMultiDomainResolver(testDomain, []string{"api-key-1"})
 	r.RegisterAlternateDestination("observability_pipelines_worker.tld", "diverted", resolver.Vector)
 	resolvers[testDomain] = r
-	mockConfig := pkgconfig.Mock(t)
+	mockConfig := config.Mock(t)
 	log := fxutil.Test[log.Component](t, log.MockModule)
 	forwarder := NewDefaultForwarder(mockConfig, log, NewOptionsWithResolvers(mockConfig, log, resolvers))
 
@@ -301,7 +301,7 @@ func TestArbitraryTagsHTTPHeader(t *testing.T) {
 }
 
 func TestSendHTTPTransactions(t *testing.T) {
-	mockConfig := pkgconfig.Mock(t)
+	mockConfig := config.Mock(t)
 	log := fxutil.Test[log.Component](t, log.MockModule)
 	forwarder := NewDefaultForwarder(mockConfig, log, NewOptionsWithResolvers(mockConfig, log, resolver.NewSingleDomainResolvers(keysPerDomains)))
 	endpoint := transaction.Endpoint{Route: "/api/foo", Name: "foo"}
@@ -321,7 +321,7 @@ func TestSendHTTPTransactions(t *testing.T) {
 }
 
 func TestSubmitV1Intake(t *testing.T) {
-	mockConfig := pkgconfig.Mock(t)
+	mockConfig := config.Mock(t)
 	log := fxutil.Test[log.Component](t, log.MockModule)
 	forwarder := NewDefaultForwarder(mockConfig, log, NewOptionsWithResolvers(mockConfig, log, resolver.NewSingleDomainResolvers(monoKeysDomains)))
 	forwarder.Start()
@@ -632,7 +632,7 @@ func TestHighPriorityTransaction(t *testing.T) {
 	flushInterval = 500 * time.Millisecond
 	defer func() { flushInterval = oldFlushInterval }()
 
-	mockConfig := pkgconfig.Mock(t)
+	mockConfig := config.Mock(t)
 	log := fxutil.Test[log.Component](t, log.MockModule)
 	f := NewDefaultForwarder(mockConfig, log, NewOptionsWithResolvers(mockConfig, log, resolver.NewSingleDomainResolvers(map[string][]string{ts.URL: {"api_key1"}})))
 
@@ -678,7 +678,7 @@ func TestCustomCompletionHandler(t *testing.T) {
 	var handler transaction.HTTPCompletionHandler = func(transaction *transaction.HTTPTransaction, statusCode int, body []byte, err error) {
 		done <- struct{}{}
 	}
-	mockConfig := pkgconfig.Mock(t)
+	mockConfig := config.Mock(t)
 	log := fxutil.Test[log.Component](t, log.MockModule)
 	options := NewOptionsWithResolvers(mockConfig, log, resolver.NewSingleDomainResolvers(map[string][]string{
 		srv.URL: {"api_key1"},

--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -16,6 +16,7 @@ import (
 
 	pkgConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -177,7 +178,7 @@ func buildTCPEndpoints(coreConfig pkgConfig.ConfigReader, logsConfig *LogsConfig
 	for i := 0; i < len(additionals); i++ {
 		additionals[i].UseSSL = main.UseSSL
 		additionals[i].ProxyAddress = proxyAddress
-		additionals[i].APIKey = pkgConfig.SanitizeAPIKey(additionals[i].APIKey)
+		additionals[i].APIKey = configUtils.SanitizeAPIKey(additionals[i].APIKey)
 	}
 	return NewEndpoints(main, additionals, useProto, false), nil
 }
@@ -249,7 +250,7 @@ func BuildHTTPEndpointsWithConfig(coreConfig pkgConfig.ConfigReader, logsConfig 
 	additionals := logsConfig.getAdditionalEndpoints()
 	for i := 0; i < len(additionals); i++ {
 		additionals[i].UseSSL = main.UseSSL
-		additionals[i].APIKey = pkgConfig.SanitizeAPIKey(additionals[i].APIKey)
+		additionals[i].APIKey = configUtils.SanitizeAPIKey(additionals[i].APIKey)
 		additionals[i].UseCompression = main.UseCompression
 		additionals[i].CompressionLevel = main.CompressionLevel
 		additionals[i].BackoffBase = main.BackoffBase

--- a/comp/logs/agent/config/config_keys.go
+++ b/comp/logs/agent/config/config_keys.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -122,9 +123,9 @@ func (l *LogsConfigKeys) hasAdditionalEndpoints() bool {
 // getLogsAPIKey provides the dd api key used by the main logs agent sender.
 func (l *LogsConfigKeys) getLogsAPIKey() string {
 	if configKey := l.getConfigKey("api_key"); l.isSetAndNotEmpty(configKey) {
-		return coreConfig.SanitizeAPIKey(l.getConfig().GetString(configKey))
+		return configUtils.SanitizeAPIKey(l.getConfig().GetString(configKey))
 	}
-	return coreConfig.SanitizeAPIKey(l.getConfig().GetString("api_key"))
+	return configUtils.SanitizeAPIKey(l.getConfig().GetString("api_key"))
 }
 
 func (l *LogsConfigKeys) connectionResetInterval() time.Duration {

--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -139,7 +139,7 @@ func appendEndpoints(endpoints []*config.Endpoint, cfgKey string) []*config.Endp
 			continue
 		}
 		for _, key := range keys {
-			endpoints = append(endpoints, &config.Endpoint{Host: url, APIKey: coreconfig.SanitizeAPIKey(key)})
+			endpoints = append(endpoints, &config.Endpoint{Host: url, APIKey: configUtils.SanitizeAPIKey(key)})
 		}
 	}
 	return endpoints
@@ -150,7 +150,7 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 		c.Endpoints = []*config.Endpoint{{}}
 	}
 	if core.IsSet("api_key") {
-		c.Endpoints[0].APIKey = coreconfig.SanitizeAPIKey(coreconfig.Datadog.GetString("api_key"))
+		c.Endpoints[0].APIKey = configUtils.SanitizeAPIKey(coreconfig.Datadog.GetString("api_key"))
 	}
 	if core.IsSet("hostname") {
 		c.Hostname = core.GetString("hostname")
@@ -564,7 +564,7 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 func loadDeprecatedValues(c *config.AgentConfig) error {
 	cfg := coreconfig.Datadog
 	if cfg.IsSet("apm_config.api_key") {
-		c.Endpoints[0].APIKey = coreconfig.SanitizeAPIKey(cfg.GetString("apm_config.api_key"))
+		c.Endpoints[0].APIKey = configUtils.SanitizeAPIKey(cfg.GetString("apm_config.api_key"))
 	}
 	if cfg.IsSet("apm_config.log_throttling") {
 		c.LogThrottling = cfg.GetBool("apm_config.log_throttling")

--- a/pkg/collector/corechecks/embed/apm.go
+++ b/pkg/collector/corechecks/embed/apm.go
@@ -26,6 +26,7 @@ import (
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -89,7 +90,7 @@ func (c *APMCheck) run() error {
 	hname, _ := hostname.Get(context.TODO())
 
 	env := os.Environ()
-	env = append(env, fmt.Sprintf("DD_API_KEY=%s", config.SanitizeAPIKey(config.Datadog.GetString("api_key"))))
+	env = append(env, fmt.Sprintf("DD_API_KEY=%s", configUtils.SanitizeAPIKey(config.Datadog.GetString("api_key"))))
 	env = append(env, fmt.Sprintf("DD_HOSTNAME=%s", hname))
 	env = append(env, fmt.Sprintf("DD_DOGSTATSD_PORT=%s", config.Datadog.GetString("dogstatsd_port")))
 	env = append(env, fmt.Sprintf("DD_LOG_LEVEL=%s", config.Datadog.GetString("log_level")))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,7 +15,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -26,7 +25,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/secrets"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/version"
 
 	"gopkg.in/yaml.v2"
 )
@@ -1270,10 +1268,6 @@ func InitConfig(config Config) {
 	setupProcesses(config)
 }
 
-// ddURLRegexp determines if an URL belongs to Datadog or not. If the URL belongs to Datadog it's prefixed with the Agent
-// version (see AddAgentVersionToDomain).
-var ddURLRegexp = regexp.MustCompile(`^app(\.[a-z]{2}\d)?\.(datad(oghq|0g)\.(com|eu)|ddog-gov\.com)$`)
-
 // LoadProxyFromEnv overrides the proxy settings with environment variables
 func LoadProxyFromEnv(config Config) {
 	// Viper doesn't handle mixing nested variables from files and set
@@ -1559,8 +1553,8 @@ func LoadDatadogCustom(config Config, origin string, loadSecret bool, additional
 		AddOverride("python_version", DefaultPython)
 	}
 
-	SanitizeAPIKeyConfig(config, "api_key")
-	SanitizeAPIKeyConfig(config, "logs_config.api_key")
+	sanitizeAPIKeyConfig(config, "api_key")
+	sanitizeAPIKeyConfig(config, "logs_config.api_key")
 	// setTracemallocEnabled *must* be called before setNumWorkers
 	warnings.TraceMallocEnabledWithPy2 = setTracemallocEnabled(config)
 	setNumWorkers(config)
@@ -1759,12 +1753,12 @@ func EnvVarAreSetAndNotEqual(lhsName string, rhsName string) bool {
 	return lhsIsSet && rhsIsSet && lhsValue != rhsValue
 }
 
-// SanitizeAPIKeyConfig strips newlines and other control characters from a given key.
-func SanitizeAPIKeyConfig(config Config, key string) {
+// sanitizeAPIKeyConfig strips newlines and other control characters from a given key.
+func sanitizeAPIKeyConfig(config Config, key string) {
 	if !config.IsKnown(key) {
 		return
 	}
-	config.Set(key, SanitizeAPIKey(config.GetString(key)))
+	config.Set(key, strings.TrimSpace(config.GetString(key)))
 }
 
 // sanitizeExternalMetricsProviderChunkSize ensures the value of `external_metrics_provider.chunk_size` is within an acceptable range
@@ -1782,11 +1776,6 @@ func sanitizeExternalMetricsProviderChunkSize(config Config) {
 		log.Warnf("external_metrics_provider.chunk_size has been set to %d, which is higher than the maximum allowed value %d. Using %d.", chunkSize, maxExternalMetricsProviderChunkSize, maxExternalMetricsProviderChunkSize)
 		config.Set("external_metrics_provider.chunk_size", maxExternalMetricsProviderChunkSize)
 	}
-}
-
-// SanitizeAPIKey strips newlines and other control characters from a given string.
-func SanitizeAPIKey(key string) string {
-	return strings.TrimSpace(key)
 }
 
 func bindEnvAndSetLogsConfigKeys(config Config, prefix string) {
@@ -1808,31 +1797,6 @@ func bindEnvAndSetLogsConfigKeys(config Config, prefix string) {
 	config.BindEnvAndSetDefault(prefix+"sender_recovery_interval", DefaultForwarderRecoveryInterval)
 	config.BindEnvAndSetDefault(prefix+"sender_recovery_reset", false)
 	config.BindEnvAndSetDefault(prefix+"use_v2_api", true)
-}
-
-// getDomainPrefix provides the right prefix for agent X.Y.Z
-func getDomainPrefix(app string) string {
-	v, _ := version.Agent()
-	return fmt.Sprintf("%d-%d-%d-%s.agent", v.Major, v.Minor, v.Patch, app)
-}
-
-// AddAgentVersionToDomain prefixes the domain with the agent version: X-Y-Z.domain
-func AddAgentVersionToDomain(DDURL string, app string) (string, error) {
-	u, err := url.Parse(DDURL)
-	if err != nil {
-		return "", err
-	}
-
-	// we don't update unknown URLs (ie: proxy or custom DD domain)
-	if !ddURLRegexp.MatchString(u.Host) {
-		return DDURL, nil
-	}
-
-	subdomain := strings.Split(u.Host, ".")[0]
-	newSubdomain := getDomainPrefix(app)
-
-	u.Host = strings.Replace(u.Host, subdomain, newSubdomain, 1)
-	return u.String(), nil
 }
 
 // IsCloudProviderEnabled checks the cloud provider family provided in

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -172,83 +172,6 @@ func TestDDHostnameFileEnvVar(t *testing.T) {
 	assert.Equal(t, "somefile", testConfig.Get("hostname_file"))
 }
 
-func TestAddAgentVersionToDomain(t *testing.T) {
-	appVersionPrefix := getDomainPrefix("app")
-	flareVersionPrefix := getDomainPrefix("flare")
-
-	versionURLTests := []struct {
-		url                 string
-		expectedURL         string
-		shouldAppendVersion bool
-	}{
-		{ // US
-			"https://app.datadoghq.com",
-			".datadoghq.com",
-			true,
-		},
-		{ // EU
-			"https://app.datadoghq.eu",
-			".datadoghq.eu",
-			true,
-		},
-		{ // Gov
-			"https://app.ddog-gov.com",
-			".ddog-gov.com",
-			true,
-		},
-		{ // Additional site
-			"https://app.us2.datadoghq.com",
-			".us2.datadoghq.com",
-			true,
-		},
-		{ // arbitrary site
-			"https://app.xx9.datadoghq.com",
-			".xx9.datadoghq.com",
-			true,
-		},
-		{ // Custom DD URL: leave unchanged
-			"https://custom.datadoghq.com",
-			"custom.datadoghq.com",
-			false,
-		},
-		{ // Custom DD URL with 'agent' subdomain: leave unchanged
-			"https://custom.agent.datadoghq.com",
-			"custom.agent.datadoghq.com",
-			false,
-		},
-		{ // Custom DD URL: unclear if anyone is actually using such a URL, but for now leave unchanged
-			"https://app.custom.datadoghq.com",
-			"app.custom.datadoghq.com",
-			false,
-		},
-		{ // Custom top-level domain: unclear if anyone is actually using this, but for now leave unchanged
-			"https://app.datadoghq.internal",
-			"app.datadoghq.internal",
-			false,
-		},
-		{ // DD URL set to proxy, leave unchanged
-			"https://app.myproxy.com",
-			"app.myproxy.com",
-			false,
-		},
-	}
-
-	for _, testCase := range versionURLTests {
-		appURL, err := AddAgentVersionToDomain(testCase.url, "app")
-		require.Nil(t, err)
-		flareURL, err := AddAgentVersionToDomain(testCase.url, "flare")
-		require.Nil(t, err)
-
-		if testCase.shouldAppendVersion {
-			assert.Equal(t, "https://"+appVersionPrefix+testCase.expectedURL, appURL)
-			assert.Equal(t, "https://"+flareVersionPrefix+testCase.expectedURL, flareURL)
-		} else {
-			assert.Equal(t, "https://"+testCase.expectedURL, appURL)
-			assert.Equal(t, "https://"+testCase.expectedURL, flareURL)
-		}
-	}
-}
-
 func TestIsCloudProviderEnabled(t *testing.T) {
 	holdValue := Datadog.Get("cloud_provider_metadata")
 	defer Datadog.Set("cloud_provider_metadata", holdValue)
@@ -515,19 +438,19 @@ func TestSanitizeAPIKeyConfig(t *testing.T) {
 	config := SetupConf()
 
 	config.Set("api_key", "foo")
-	SanitizeAPIKeyConfig(config, "api_key")
+	sanitizeAPIKeyConfig(config, "api_key")
 	assert.Equal(t, "foo", config.GetString("api_key"))
 
 	config.Set("api_key", "foo\n")
-	SanitizeAPIKeyConfig(config, "api_key")
+	sanitizeAPIKeyConfig(config, "api_key")
 	assert.Equal(t, "foo", config.GetString("api_key"))
 
 	config.Set("api_key", "foo\n\n")
-	SanitizeAPIKeyConfig(config, "api_key")
+	sanitizeAPIKeyConfig(config, "api_key")
 	assert.Equal(t, "foo", config.GetString("api_key"))
 
 	config.Set("api_key", " \n  foo   \n")
-	SanitizeAPIKeyConfig(config, "api_key")
+	sanitizeAPIKeyConfig(config, "api_key")
 	assert.Equal(t, "foo", config.GetString("api_key"))
 }
 

--- a/pkg/config/legacy/converter.go
+++ b/pkg/config/legacy/converter.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 )
 
 // FromAgentConfig reads the old agentConfig configuration, converts and merges
@@ -245,7 +246,7 @@ func extractURLAPIKeys(agentConfig Config, converter *config.LegacyConfigConvert
 		converter.Set("dd_url", urls[0])
 	}
 
-	converter.Set("api_key", config.SanitizeAPIKey(keys[0]))
+	converter.Set("api_key", configUtils.SanitizeAPIKey(keys[0]))
 	if len(urls) == 1 {
 		return nil
 	}
@@ -258,7 +259,7 @@ func extractURLAPIKeys(agentConfig Config, converter *config.LegacyConfigConvert
 		if url == "" || keys[idx] == "" {
 			return fmt.Errorf("Found empty additional 'dd_url' or 'api_key'. Please check that you don't have any misplaced commas")
 		}
-		keys[idx] = config.SanitizeAPIKey(keys[idx])
+		keys[idx] = configUtils.SanitizeAPIKey(keys[idx])
 		additionalEndpoints[url] = append(additionalEndpoints[url], keys[idx])
 	}
 	converter.Set("additional_endpoints", additionalEndpoints)

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -182,7 +182,7 @@ func NewService() (*Service, error) {
 	if config.Datadog.IsSet("remote_configuration.api_key") {
 		apiKey = config.Datadog.GetString("remote_configuration.api_key")
 	}
-	apiKey = config.SanitizeAPIKey(apiKey)
+	apiKey = configUtils.SanitizeAPIKey(apiKey)
 	rcKey := config.Datadog.GetString("remote_configuration.key")
 	authKeys, err := getRemoteConfigAuthKeys(apiKey, rcKey)
 	if err != nil {

--- a/pkg/config/utils/api_key.go
+++ b/pkg/config/utils/api_key.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import (
+	"strings"
+)
+
+// SanitizeAPIKey strips newlines and other control characters from a given string.
+func SanitizeAPIKey(key string) string {
+	return strings.TrimSpace(key)
+}

--- a/pkg/config/utils/miscellaneous.go
+++ b/pkg/config/utils/miscellaneous.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package utils offers a number of high level helpers to work with the configuration
 package utils
 
 import (

--- a/pkg/metadata/common/common.go
+++ b/pkg/metadata/common/common.go
@@ -7,6 +7,7 @@ package common
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -20,7 +21,7 @@ func GetPayload(hostname string) *Payload {
 		// olivier: I _think_ `APIKey` is only a legacy field, and
 		// is not actually used by the backend
 		AgentVersion:     version.AgentVersion,
-		APIKey:           config.SanitizeAPIKey(config.Datadog.GetString("api_key")),
+		APIKey:           configUtils.SanitizeAPIKey(config.Datadog.GetString("api_key")),
 		UUID:             getUUID(),
 		InternalHostname: hostname,
 	}

--- a/pkg/orchestrator/config/config.go
+++ b/pkg/orchestrator/config/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/resolver"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/orchestrator/redact"
 	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
@@ -83,7 +84,7 @@ func (oc *OrchestratorConfig) Load() error {
 	oc.OrchestratorEndpoints[0].Endpoint = URL
 
 	if key := "api_key"; config.Datadog.IsSet(key) {
-		oc.OrchestratorEndpoints[0].APIKey = config.SanitizeAPIKey(config.Datadog.GetString(key))
+		oc.OrchestratorEndpoints[0].APIKey = configUtils.SanitizeAPIKey(config.Datadog.GetString(key))
 	}
 
 	if err := extractOrchestratorAdditionalEndpoints(URL, &oc.OrchestratorEndpoints); err != nil {
@@ -140,7 +141,7 @@ func extractEndpoints(URL *url.URL, k string, endpoints *[]apicfg.Endpoint) erro
 		}
 		for _, k := range apiKeys {
 			*endpoints = append(*endpoints, apicfg.Endpoint{
-				APIKey:   config.SanitizeAPIKey(k),
+				APIKey:   configUtils.SanitizeAPIKey(k),
 				Endpoint: u,
 			})
 		}

--- a/pkg/process/runner/endpoint/endpoints.go
+++ b/pkg/process/runner/endpoint/endpoints.go
@@ -11,6 +11,7 @@ import (
 
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
 )
 
@@ -29,7 +30,7 @@ func getAPIEndpointsWithKeys(config ddconfig.ConfigReader, prefix, defaultEpKey,
 		return nil, fmt.Errorf("error parsing %s: %s", defaultEpKey, err)
 	}
 	eps = append(eps, apicfg.Endpoint{
-		APIKey:   ddconfig.SanitizeAPIKey(config.GetString("api_key")),
+		APIKey:   configUtils.SanitizeAPIKey(config.GetString("api_key")),
 		Endpoint: mainEndpointURL,
 	})
 
@@ -41,7 +42,7 @@ func getAPIEndpointsWithKeys(config ddconfig.ConfigReader, prefix, defaultEpKey,
 		}
 		for _, k := range apiKeys {
 			eps = append(eps, apicfg.Endpoint{
-				APIKey:   ddconfig.SanitizeAPIKey(k),
+				APIKey:   configUtils.SanitizeAPIKey(k),
 				Endpoint: u,
 			})
 		}

--- a/pkg/util/kubernetes/autoscalers/datadogclient.go
+++ b/pkg/util/kubernetes/autoscalers/datadogclient.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -42,14 +43,14 @@ func NewDatadogClient() (DatadogClient, error) {
 
 // NewDatadogSingleClient generates a new client to query metrics from Datadog
 func newDatadogSingleClient() (*datadog.Client, error) {
-	apiKey := config.SanitizeAPIKey(config.Datadog.GetString("external_metrics_provider.api_key"))
+	apiKey := configUtils.SanitizeAPIKey(config.Datadog.GetString("external_metrics_provider.api_key"))
 	if apiKey == "" {
-		apiKey = config.SanitizeAPIKey(config.Datadog.GetString("api_key"))
+		apiKey = configUtils.SanitizeAPIKey(config.Datadog.GetString("api_key"))
 	}
 
-	appKey := config.SanitizeAPIKey(config.Datadog.GetString("external_metrics_provider.app_key"))
+	appKey := configUtils.SanitizeAPIKey(config.Datadog.GetString("external_metrics_provider.app_key"))
 	if appKey == "" {
-		appKey = config.SanitizeAPIKey(config.Datadog.GetString("app_key"))
+		appKey = configUtils.SanitizeAPIKey(config.Datadog.GetString("app_key"))
 	}
 
 	// DATADOG_HOST used to be the only way to set the external metrics


### PR DESCRIPTION
### What does this PR do?

Moving pure helper function to pkg/config/utils so they can be used with comp/core/config comp

### Describe how to test/QA your changes

Our automatic tests should be enough to detect any regression. The deploy to our staging env during the QA process will also detect any regression.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
