### PR TITLE
[serverless] fix untagged custom metrics race

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -337,6 +337,8 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 		)
 	}
 
+	serverlessDaemon.ComputeGlobalTags(configUtils.GetConfiguredTags(config.Datadog, true))
+
 	// run the invocation loop in a routine
 	// we don't want to start this mainloop before because once we're waiting on
 	// the invocation route, we can't report init errors anymore.

--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -172,6 +172,9 @@ func callInvocationHandler(daemon *daemon.Daemon, arn string, deadlineMs int64, 
 func handleInvocation(doneChannel chan bool, daemon *daemon.Daemon, arn string, requestID string) {
 	log.Debug("Received invocation event...")
 	daemon.ExecutionContext.SetFromInvocation(arn, requestID)
+	if daemon.ExecutionContext.GetColdStartTagsForRequestID(requestID).IsColdStart {
+		daemon.ExtraTags.Tags = nil
+	}
 	daemon.ComputeGlobalTags(configUtils.GetConfiguredTags(config.Datadog, true))
 	daemon.StartLogCollection()
 	coldStartTags := daemon.ExecutionContext.GetColdStartTagsForRequestID(requestID)

--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -14,8 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
-	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/serverless/daemon"
 	"github.com/DataDog/datadog-agent/pkg/serverless/flush"
 	"github.com/DataDog/datadog-agent/pkg/serverless/metrics"
@@ -172,14 +170,6 @@ func callInvocationHandler(daemon *daemon.Daemon, arn string, deadlineMs int64, 
 func handleInvocation(doneChannel chan bool, daemon *daemon.Daemon, arn string, requestID string) {
 	log.Debug("Received invocation event...")
 	daemon.ExecutionContext.SetFromInvocation(arn, requestID)
-	if daemon.ExecutionContext.GetColdStartTagsForRequestID(requestID).IsColdStart {
-		// Recompute extra tags on first invocation.
-		// Context: they're first processed after extension registration. Re-computing them
-		// fixes any wrong tags, namely that sometimes the process containing the lambda runtime
-		// variable isn't up yet on first tag computation leading to a wrong runtime tag.
-		daemon.ExtraTags.Tags = nil
-	}
-	daemon.ComputeGlobalTags(configUtils.GetConfiguredTags(config.Datadog, true))
 	daemon.StartLogCollection()
 	coldStartTags := daemon.ExecutionContext.GetColdStartTagsForRequestID(requestID)
 

--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -14,8 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
-	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/serverless/daemon"
 	"github.com/DataDog/datadog-agent/pkg/serverless/flush"
 	"github.com/DataDog/datadog-agent/pkg/serverless/metrics"
@@ -172,10 +170,6 @@ func callInvocationHandler(daemon *daemon.Daemon, arn string, deadlineMs int64, 
 func handleInvocation(doneChannel chan bool, daemon *daemon.Daemon, arn string, requestID string) {
 	log.Debug("Received invocation event...")
 	daemon.ExecutionContext.SetFromInvocation(arn, requestID)
-	if daemon.ExecutionContext.GetColdStartTagsForRequestID(requestID).IsColdStart {
-		daemon.ExtraTags.Tags = nil
-		daemon.ComputeGlobalTags(configUtils.GetConfiguredTags(config.Datadog, true))
-	}
 	daemon.StartLogCollection()
 	coldStartTags := daemon.ExecutionContext.GetColdStartTagsForRequestID(requestID)
 

--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -173,6 +173,10 @@ func handleInvocation(doneChannel chan bool, daemon *daemon.Daemon, arn string, 
 	log.Debug("Received invocation event...")
 	daemon.ExecutionContext.SetFromInvocation(arn, requestID)
 	if daemon.ExecutionContext.GetColdStartTagsForRequestID(requestID).IsColdStart {
+		// Recompute extra tags on first invocation.
+		// Context: they're first processed after extension registration. Re-computing them
+		// fixes any wrong tags, namely that sometimes the process containing the lambda runtime
+		// variable isn't up yet on first tag computation leading to a wrong runtime tag.
 		daemon.ExtraTags.Tags = nil
 	}
 	daemon.ComputeGlobalTags(configUtils.GetConfiguredTags(config.Datadog, true))

--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
+	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/serverless/daemon"
 	"github.com/DataDog/datadog-agent/pkg/serverless/flush"
 	"github.com/DataDog/datadog-agent/pkg/serverless/metrics"
@@ -170,6 +172,10 @@ func callInvocationHandler(daemon *daemon.Daemon, arn string, deadlineMs int64, 
 func handleInvocation(doneChannel chan bool, daemon *daemon.Daemon, arn string, requestID string) {
 	log.Debug("Received invocation event...")
 	daemon.ExecutionContext.SetFromInvocation(arn, requestID)
+	if daemon.ExecutionContext.GetColdStartTagsForRequestID(requestID).IsColdStart {
+		daemon.ExtraTags.Tags = nil
+		daemon.ComputeGlobalTags(configUtils.GetConfiguredTags(config.Datadog, true))
+	}
 	daemon.StartLogCollection()
 	coldStartTags := daemon.ExecutionContext.GetColdStartTagsForRequestID(requestID)
 

--- a/pkg/serverless/serverless_test.go
+++ b/pkg/serverless/serverless_test.go
@@ -9,15 +9,12 @@ import (
 	"fmt"
 	"os"
 	"runtime/debug"
-	"sort"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/serverless/daemon"
-	"github.com/DataDog/datadog-agent/pkg/serverless/flush"
-	"github.com/DataDog/datadog-agent/pkg/serverless/tags"
 )
 
 func TestMain(m *testing.M) {
@@ -25,47 +22,6 @@ func TestMain(m *testing.M) {
 	daemon.ShutdownDelay = 0
 	defer func() { daemon.ShutdownDelay = origShutdownDelay }()
 	os.Exit(m.Run())
-}
-
-func TestHandleInvocationShouldSetExtraTags(t *testing.T) {
-	d := daemon.StartDaemon("http://localhost:8124")
-	defer d.Stop()
-
-	// force daemon not to wait for flush at end of handleInvocation
-	d.SetFlushStrategy(flush.NewPeriodically(time.Second))
-	d.UseAdaptiveFlush(false)
-
-	// deadline = current time + 5s
-	deadlineMs := (time.Now().UnixNano())/1000000 + 5000
-
-	// setting DD_TAGS and DD_EXTRA_TAGS
-	t.Setenv("DD_TAGS", "a1:valueA1,a2:valueA2,A_MAJ:valueAMaj")
-	t.Setenv("DD_EXTRA_TAGS", "a3:valueA3 a4:valueA4")
-
-	callInvocationHandler(d, "arn:aws:lambda:us-east-1:123456789012:function:my-function", deadlineMs, 0, "myRequestID", handleInvocation)
-	architecture := fmt.Sprintf("architecture:%s", tags.ResolveRuntimeArch())
-
-	assert.Equal(t, 14, len(d.ExtraTags.Tags))
-
-	sort.Strings(d.ExtraTags.Tags)
-	assert.Equal(t, "a1:valuea1", d.ExtraTags.Tags[0])
-	assert.Equal(t, "a2:valuea2", d.ExtraTags.Tags[1])
-	assert.Equal(t, "a3:valuea3", d.ExtraTags.Tags[2])
-	assert.Equal(t, "a4:valuea4", d.ExtraTags.Tags[3])
-	assert.Equal(t, "a_maj:valueamaj", d.ExtraTags.Tags[4])
-	assert.Equal(t, "account_id:123456789012", d.ExtraTags.Tags[5])
-	assert.Equal(t, architecture, d.ExtraTags.Tags[6])
-	assert.Equal(t, "aws_account:123456789012", d.ExtraTags.Tags[7])
-	assert.Equal(t, "dd_extension_version:xxx", d.ExtraTags.Tags[8])
-	assert.Equal(t, "function_arn:arn:aws:lambda:us-east-1:123456789012:function:my-function", d.ExtraTags.Tags[9])
-	assert.Equal(t, "functionname:my-function", d.ExtraTags.Tags[10])
-	assert.Equal(t, "region:us-east-1", d.ExtraTags.Tags[11])
-	assert.Equal(t, "resource:my-function", d.ExtraTags.Tags[12])
-	assert.True(t, d.ExtraTags.Tags[13] == "runtime:unknown" || d.ExtraTags.Tags[13] == "runtime:provided.al2")
-
-	ecs := d.ExecutionContext.GetCurrentState()
-	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", ecs.ARN)
-	assert.Equal(t, "myRequestID", ecs.LastRequestID)
 }
 
 func TestHandleInvocationShouldNotSIGSEGVWhenTimedOut(t *testing.T) {

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -243,7 +243,6 @@ func getRuntime(procPath string, osReleasePath string, varName string) string {
 		runtime = strings.Replace(runtime, "AWS_Lambda_", "", 1)
 		counter++
 	}
-	runtime = strings.Replace(runtime, "AWS_Lambda_", "", 1)
 	log.Debugf("finding the lambda runtime took %v. found runtime: %s", time.Since(start), runtime)
 	if len(runtime) == 0 {
 		runtime = getRuntimeFromOsReleaseFile(osReleasePath)

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -234,7 +234,7 @@ func getRuntime(procPath string, osReleasePath string, varName string) string {
 	runtime := ""
 	counter := 0
 	start := time.Now()
-	for len(runtime) == 0 && counter < 5 {
+	for len(runtime) == 0 && counter < 10 {
 		if counter > 0 {
 			time.Sleep(5 * time.Millisecond)
 		}

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -84,7 +84,7 @@ func BuildTagMap(arn string, configTags []string) map[string]string {
 	architecture := ResolveRuntimeArch()
 	tags = setIfNotEmpty(tags, ArchitectureKey, architecture)
 
-	tags = setIfNotEmpty(tags, RuntimeKey, getRuntime("/proc", "/etc", runtimeVar))
+	tags = setIfNotEmpty(tags, RuntimeKey, getRuntime("/proc", "/etc", runtimeVar, 5))
 
 	tags = setIfNotEmpty(tags, MemorySizeKey, os.Getenv(memorySizeVar))
 
@@ -230,11 +230,11 @@ func getRuntimeFromOsReleaseFile(osReleasePath string) string {
 	return runtime
 }
 
-func getRuntime(procPath string, osReleasePath string, varName string) string {
+func getRuntime(procPath string, osReleasePath string, varName string, retries int) string {
 	runtime := ""
 	counter := 0
 	start := time.Now()
-	for len(runtime) == 0 && counter < 6 {
+	for len(runtime) == 0 && counter <= retries {
 		if counter > 0 {
 			time.Sleep(5 * time.Millisecond)
 		}

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -234,7 +234,7 @@ func getRuntime(procPath string, osReleasePath string, varName string) string {
 	runtime := ""
 	counter := 0
 	start := time.Now()
-	for len(runtime) == 0 && counter < 10 {
+	for len(runtime) == 0 && counter < 6 {
 		if counter > 0 {
 			time.Sleep(5 * time.Millisecond)
 		}

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -240,10 +240,9 @@ func getRuntime(procPath string, osReleasePath string, varName string, retries i
 		}
 		foundRuntimes := proc.SearchProcsForEnvVariable(procPath, varName)
 		runtime = cleanRuntimes(foundRuntimes)
-		runtime = strings.Replace(runtime, "AWS_Lambda_", "", 1)
 		counter++
 	}
-	log.Debugf("finding the lambda runtime took %v. found runtime: %s", time.Since(start), runtime)
+	runtime = strings.Replace(runtime, "AWS_Lambda_", "", 1)
 	if len(runtime) == 0 {
 		runtime = getRuntimeFromOsReleaseFile(osReleasePath)
 	}
@@ -251,6 +250,7 @@ func getRuntime(procPath string, osReleasePath string, varName string, retries i
 		log.Debug("could not find a valid runtime, defaulting to unknown")
 		runtime = "unknown"
 	}
+	log.Debugf("finding the lambda runtime took %v. found runtime: %s", time.Since(start), runtime)
 	return runtime
 }
 

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -234,6 +234,9 @@ func getRuntime(procPath string, osReleasePath string, varName string, retries i
 	runtime := ""
 	counter := 0
 	start := time.Now()
+	// Retry as the process holding the runtime env var is sometimes not up during extension init.
+	// This predominantly happens with csharp lambdas.
+	// The max possible wait is 25ms + time taken for proc/env var search, usually ~28ms total.
 	for len(runtime) == 0 && counter <= retries {
 		if counter > 0 {
 			time.Sleep(5 * time.Millisecond)

--- a/pkg/serverless/tags/tags_test.go
+++ b/pkg/serverless/tags/tags_test.go
@@ -6,8 +6,10 @@
 package tags
 
 import (
+	"os"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -335,7 +337,31 @@ func TestBuildTagMapWithRuntimeAndMemoryTag(t *testing.T) {
 }
 
 func TestGetRuntimeFound(t *testing.T) {
-	result := getRuntime("../proc/testData", "./testValidData", "AWS_EXECUTION_ENV")
+	result := getRuntime("../proc/testData", "./testValidData", "AWS_EXECUTION_ENV", 0)
+	assert.Equal(t, "nodejs14.x", result)
+}
+
+func TestGetRuntimeRetries(t *testing.T) {
+	// create empty environ file
+	os.MkdirAll("./testGetRuntimeRetries/13", os.ModePerm)
+	f, _ := os.OpenFile("./testGetRuntimeRetries/13/environ", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+	f.Close()
+
+	output := make(chan string)
+	go func() {
+		// 5 seconds of retries
+		res := getRuntime("./testGetRuntimeRetries", "./testValidData", "AWS_EXECUTION_ENV", 1000)
+		output <- res
+	}()
+	go func() {
+		// after 1 second, append the runtime env var to environ file
+		envVarToAppend := "AWS_EXECUTION_ENV=nodejs14.x"
+		time.Sleep(1 * time.Second)
+		f, _ := os.OpenFile("./testGetRuntimeRetries/13/environ", os.O_APPEND|os.O_WRONLY, 0666)
+		defer f.Close()
+		f.Write([]byte(envVarToAppend))
+	}()
+	result := <-output
 	assert.Equal(t, "nodejs14.x", result)
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

We've got a race condition where if a custom metric is submitted + processed quick enough on first invocation, it'll beat global tags computation and will miss many of the lambda metadata tags (such as `functionname` or `runtime`). We're now able to access the functionArn from extension registration so we can compute global tags (and fix this race) before serving the first function invocation.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Tested with an RC to ensure custom metrics remained unaffected (the race only came up during integration tests).

Ran updated integration tests (branched off of this PR) to ensure the race condition was fixed.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
