### PR TITLE
Revert "PerCPU hashmaps for eBPF telemetry (#18398)"

### DIFF
--- a/pkg/network/telemetry/ebpf_telemetry.go
+++ b/pkg/network/telemetry/ebpf_telemetry.go
@@ -385,7 +385,8 @@ func ActivateBPFTelemetry(m *manager.Manager, undefinedProbes []manager.ProbeIde
 	return nil
 }
 
-// EBPF telemetry depends on the presence of the 'lock xadd' instruction
+// EBPFTelemetrySupported returns whether eBPF telemetry is supported.
+// eBPF telemetry depends on the verifier in 4.14+
 func EBPFTelemetrySupported() bool {
 	kversion, err := kernel.HostVersion()
 	if err != nil {

--- a/pkg/network/tracer/connection/fentry/tracer.go
+++ b/pkg/network/tracer/connection/fentry/tracer.go
@@ -19,11 +19,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
-	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	errtelemetry "github.com/DataDog/datadog-agent/pkg/network/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
-	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/features"
 )
 
 const probeUID = "net"
@@ -49,21 +46,6 @@ func LoadTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *
 		}
 
 		initManager(m, config, perfHandlerTCP)
-
-		// Replace ebpf telemetry maps with Percpu maps if kernel supports
-		if features.HaveMapType(ebpf.PerCPUHash) == nil {
-			if mgrOpts.MapSpecEditors == nil {
-				mgrOpts.MapSpecEditors = make(map[string]manager.MapSpecEditor)
-			}
-			mgrOpts.MapSpecEditors[probes.MapErrTelemetryMap] = manager.MapSpecEditor{
-				Type:       ebpf.PerCPUHash,
-				EditorFlag: manager.EditType,
-			}
-			mgrOpts.MapSpecEditors[probes.HelperErrTelemetryMap] = manager.MapSpecEditor{
-				Type:       ebpf.PerCPUHash,
-				EditorFlag: manager.EditType,
-			}
-		}
 
 		if err := errtelemetry.ActivateBPFTelemetry(m, nil); err != nil {
 			return fmt.Errorf("could not activate ebpf telemetry: %w", err)

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/features"
 
 	manager "github.com/DataDog/ebpf-manager"
 
@@ -224,21 +223,6 @@ func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer boo
 				Type:       ebpf.Array,
 				EditorFlag: manager.EditType,
 			}
-		}
-	}
-
-	// Replace ebpf telemetry maps with Percpu maps if kernel supports
-	if features.HaveMapType(ebpf.PerCPUHash) == nil {
-		if mgrOpts.MapSpecEditors == nil {
-			mgrOpts.MapSpecEditors = make(map[string]manager.MapSpecEditor)
-		}
-		mgrOpts.MapSpecEditors[probes.MapErrTelemetryMap] = manager.MapSpecEditor{
-			Type:       ebpf.PerCPUHash,
-			EditorFlag: manager.EditType,
-		}
-		mgrOpts.MapSpecEditors[probes.HelperErrTelemetryMap] = manager.MapSpecEditor{
-			Type:       ebpf.PerCPUHash,
-			EditorFlag: manager.EditType,
 		}
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Reverts #18398 

### Motivation

It is causing excessive allocations due to internal slice allocations in `cilium/ebpf` during each per-CPU lookup.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
