### PR TITLE
Trace service start/stop logs in case of error

### DIFF
--- a/test/kitchen/test/integration/common/rspec_datadog/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec_datadog/spec_helper.rb
@@ -153,6 +153,9 @@ def stop(flavor)
     end
   end
   wait_until_service_stopped(service)
+  if result == nil || result == false
+      log_trace "datadog-agent" "stop"
+  end
   result
 end
 
@@ -171,6 +174,9 @@ def start(flavor)
     end
   end
   wait_until_service_started(service)
+  if result == nil || result == false
+      log_trace "datadog-agent" "start"
+  end
   result
 end
 
@@ -203,6 +209,9 @@ def restart(flavor)
       wait_until_service_stopped(service, 5)
       wait_until_service_started(service, 5)
     end
+  end
+  if result == nil || result == false
+      log_trace "datadog-agent" "restart"
   end
   result
 end
@@ -652,9 +661,6 @@ shared_examples_for "a running Agent with APM manually disabled" do
     File.write(conf_path, confYaml.to_yaml)
 
     output = restart "datadog-agent"
-    if output == nil || output == false
-      log_trace "datadog-agent" "restart"
-    end
     if os != :windows
       expect(output).to be_truthy
       system 'command -v systemctl 2>&1 > /dev/null || sleep 5 || true'
@@ -673,9 +679,6 @@ end
 shared_examples_for 'an Agent that stops' do
   it 'stops' do
     output = stop "datadog-agent"
-    if output == nil || output == false
-      log_trace "datadog-agent" "stop"
-    end
     if os != :windows
       expect(output).to be_truthy
     end
@@ -698,9 +701,6 @@ shared_examples_for 'an Agent that stops' do
 
   it 'starts after being stopped' do
     output = start "datadog-agent"
-    if output == nil || output == false
-      log_trace "datadog-agent" "start"
-    end
     if os != :windows
       expect(output).to be_truthy
     end
@@ -714,9 +714,6 @@ shared_examples_for 'an Agent that restarts' do
       start "datadog-agent"
     end
     output = restart "datadog-agent"
-    if output == nil || output == false
-      log_trace "datadog-agent" "restart"
-    end
     if os != :windows
       expect(output).to be_truthy
     end
@@ -728,9 +725,6 @@ shared_examples_for 'an Agent that restarts' do
       stop "datadog-agent"
     end
     output = restart "datadog-agent"
-    if output == nil || output == false
-      log_trace "datadog-agent" "restart"
-    end
     if os != :windows
       expect(output).to be_truthy
     end
@@ -749,9 +743,6 @@ shared_examples_for 'an Agent with Python' do
     File.write(conf_path, confYaml.to_yaml)
 
     output = restart "datadog-agent"
-    if output == nil || output == false
-      log_trace "datadog-agent" "restart"
-    end
     expect(output).to be_truthy
   end
 
@@ -773,9 +764,6 @@ shared_examples_for 'an Agent with Python' do
     File.write(conf_path, confYaml.to_yaml)
 
     output = restart "datadog-agent"
-    if output == nil || output == false
-      log_trace "datadog-agent" "restart"
-    end
     expect(output).to be_truthy
   end
 
@@ -974,9 +962,6 @@ shared_examples_for 'a running Agent with CWS enabled' do
     enable_cws(get_conf_file("security-agent.yaml"), true)
 
     output = restart "datadog-agent"
-    if output == nil || output == false
-      log_trace "datadog-agent" "restart"
-    end
     expect(output).to be_truthy
   end
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Displays logs for service start/stop in case of failure
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Today we only report if service start/stop was ok or ko. When it fails, we have no idea why this failed, so adding more traces could helps us debug erroneous job executions.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
I'm not 100% sure of the method to raise service logs in windows, in worst case the log command will failed while the test is already in error
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
