### PR TITLE
pkg/trace/api: fix flaky TestTracesDecodeMakingHugeAllocation

### DIFF
--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -144,7 +144,7 @@ func TestListenTCP(t *testing.T) {
 }
 
 func TestTracesDecodeMakingHugeAllocation(t *testing.T) {
-	r := newTestReceiverFromConfig(config.New())
+	r := newTestReceiverFromConfig(newTestReceiverConfig())
 	r.Start()
 	defer r.Stop()
 	data := []byte{0x96, 0x97, 0xa4, 0x30, 0x30, 0x30, 0x30, 0xa6, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0xa6, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0xa6, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0xa6, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0xa6, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0xa6, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x96, 0x94, 0x9c, 0x00, 0x00, 0x00, 0x30, 0x30, 0xd1, 0x30, 0x30, 0x30, 0x30, 0x30, 0xdf, 0x30, 0x30, 0x30, 0x30}
@@ -158,7 +158,7 @@ func TestTracesDecodeMakingHugeAllocation(t *testing.T) {
 
 func TestStateHeaders(t *testing.T) {
 	assert := assert.New(t)
-	cfg := config.New()
+	cfg := newTestReceiverConfig()
 	cfg.AgentVersion = "testVersion"
 	r := newTestReceiverFromConfig(cfg)
 	r.Start()
@@ -986,7 +986,7 @@ func BenchmarkDecoderMsgpack(b *testing.B) {
 
 func BenchmarkWatchdog(b *testing.B) {
 	now := time.Now()
-	conf := config.New()
+	conf := newTestReceiverConfig()
 	conf.Endpoints[0].APIKey = "apikey_2"
 	r := NewHTTPReceiver(conf, nil, nil, nil, telemetry.NewNoopCollector())
 
@@ -998,7 +998,7 @@ func BenchmarkWatchdog(b *testing.B) {
 }
 
 func TestReplyOKV5(t *testing.T) {
-	r := newTestReceiverFromConfig(config.New())
+	r := newTestReceiverFromConfig(newTestReceiverConfig())
 	r.Start()
 	defer r.Stop()
 
@@ -1020,7 +1020,7 @@ func TestExpvar(t *testing.T) {
 		return
 	}
 
-	c := config.New()
+	c := newTestReceiverConfig()
 	c.DebugServerPort = 5012
 	info.InitInfo(c)
 	s := NewDebugServer(c)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

- Fix flaky `TestTracesDecodeMakingHugeAllocation`: The default decoder timeout sometimes is not long enough to process the input payload in this test, which result in unexpected response code.
- Unify the usage of `newTestReceiverConfig` in the tests so all tests benefit from the test decoder timeout value (10s)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Flaky tests are bad

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Similar to https://github.com/DataDog/datadog-agent/pull/18868 and related to https://github.com/DataDog/datadog-agent/pull/17917

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Reproduced the flaky test with `go test -count 10000 -timeout 60s -run ^TestTracesDecodeMakingHugeAllocation$ github.com/DataDog/datadog-agent/pkg/trace/api`. Then couldn't reproduce it with the fix.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
