### PR TITLE
Add python check context

### DIFF
--- a/pkg/collector/corechecks/embed/jmx/loader.go
+++ b/pkg/collector/corechecks/embed/jmx/loader.go
@@ -73,7 +73,7 @@ func (jl *JMXCheckLoader) String() string {
 }
 
 func init() {
-	factory := func() (check.Loader, error) {
+	factory := func(sender.SenderManager) (check.Loader, error) {
 		return NewJMXCheckLoader()
 	}
 

--- a/pkg/collector/corechecks/loader.go
+++ b/pkg/collector/corechecks/loader.go
@@ -74,7 +74,7 @@ func (gl *GoCheckLoader) String() string {
 }
 
 func init() {
-	factory := func() (check.Loader, error) {
+	factory := func(sender.SenderManager) (check.Loader, error) {
 		return NewGoCheckLoader()
 	}
 

--- a/pkg/collector/loaders/loaders.go
+++ b/pkg/collector/loaders/loaders.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -16,7 +17,7 @@ import (
 // LoaderFactory helps to defer actual instantiation of Check Loaders,
 // mostly helpful with code involving calls to cgo (for example, the Python
 // interpreter might not be initialized when `init`ing a package)
-type LoaderFactory func() (check.Loader, error)
+type LoaderFactory func(sender.SenderManager) (check.Loader, error)
 
 var factoryCatalog = make(map[int][]LoaderFactory)
 var loaderCatalog = []check.Loader{}
@@ -28,7 +29,7 @@ func RegisterLoader(order int, factory LoaderFactory) {
 }
 
 // LoaderCatalog returns the loaders sorted by desired sequence order
-func LoaderCatalog() []check.Loader {
+func LoaderCatalog(senderManager sender.SenderManager) []check.Loader {
 	// the catalog is supposed to be built only once, don't see a clear
 	// use case to add Loaders at runtime
 	once.Do(func() {
@@ -43,7 +44,7 @@ func LoaderCatalog() []check.Loader {
 		// the final slice of loaders
 		for _, k := range keys {
 			for _, factory := range factoryCatalog[k] {
-				loader, err := factory()
+				loader, err := factory(senderManager)
 				if err != nil {
 					log.Infof("Failed to instantiate %s: %v", loader, err)
 					continue

--- a/pkg/collector/loaders/loaders_test.go
+++ b/pkg/collector/loaders/loaders_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -52,17 +53,17 @@ func (lt *LoaderThree) Load(senderManager sender.SenderManager, config integrati
 
 func TestLoaderCatalog(t *testing.T) {
 	l1 := LoaderOne{}
-	factory1 := func() (check.Loader, error) { return l1, nil }
+	factory1 := func(sender.SenderManager) (check.Loader, error) { return l1, nil }
 	l2 := LoaderTwo{}
-	factory2 := func() (check.Loader, error) { return l2, nil }
+	factory2 := func(sender.SenderManager) (check.Loader, error) { return l2, nil }
 	var l3 *LoaderThree
-	factory3 := func() (check.Loader, error) { return l3, errors.New("error") }
+	factory3 := func(sender.SenderManager) (check.Loader, error) { return l3, errors.New("error") }
 
 	RegisterLoader(20, factory1)
 	RegisterLoader(10, factory2)
 	RegisterLoader(30, factory3)
-
-	require.Len(t, LoaderCatalog(), 2)
-	assert.Equal(t, l1, LoaderCatalog()[1])
-	assert.Equal(t, l2, LoaderCatalog()[0])
+	senderManager := aggregator.GetSenderManager()
+	require.Len(t, LoaderCatalog(senderManager), 2)
+	assert.Equal(t, l1, LoaderCatalog(senderManager)[1])
+	assert.Equal(t, l2, LoaderCatalog(senderManager)[0])
 }

--- a/pkg/collector/python/aggregator.go
+++ b/pkg/collector/python/aggregator.go
@@ -10,7 +10,6 @@ package python
 import (
 	"unsafe"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	metricsevent "github.com/DataDog/datadog-agent/pkg/metrics/event"
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
@@ -31,7 +30,13 @@ import "C"
 func SubmitMetric(checkID *C.char, metricType C.metric_type_t, metricName *C.char, value C.double, tags **C.char, hostname *C.char, flushFirstValue C.bool) {
 	goCheckID := C.GoString(checkID)
 
-	sender, err := aggregator.GetSender(checkid.ID(goCheckID))
+	checkContext, err := getCheckContext()
+	if err != nil {
+		log.Errorf("Python check context: %v", err)
+		return
+	}
+
+	sender, err := checkContext.senderManager.GetSender(checkid.ID(goCheckID))
 	if err != nil || sender == nil {
 		log.Errorf("Error submitting metric to the Sender: %v", err)
 		return
@@ -67,7 +72,13 @@ func SubmitMetric(checkID *C.char, metricType C.metric_type_t, metricName *C.cha
 func SubmitServiceCheck(checkID *C.char, scName *C.char, status C.int, tags **C.char, hostname *C.char, message *C.char) {
 	goCheckID := C.GoString(checkID)
 
-	sender, err := aggregator.GetSender(checkid.ID(goCheckID))
+	checkContext, err := getCheckContext()
+	if err != nil {
+		log.Errorf("Python check context: %v", err)
+		return
+	}
+
+	sender, err := checkContext.senderManager.GetSender(checkid.ID(goCheckID))
 	if err != nil || sender == nil {
 		log.Errorf("Error submitting metric to the Sender: %v", err)
 		return
@@ -96,7 +107,13 @@ func eventParseString(value *C.char, fieldName string) string {
 func SubmitEvent(checkID *C.char, event *C.event_t) {
 	goCheckID := C.GoString(checkID)
 
-	sender, err := aggregator.GetSender(checkid.ID(goCheckID))
+	checkContext, err := getCheckContext()
+	if err != nil {
+		log.Errorf("Python check context: %v", err)
+		return
+	}
+
+	sender, err := checkContext.senderManager.GetSender(checkid.ID(goCheckID))
 	if err != nil || sender == nil {
 		log.Errorf("Error submitting metric to the Sender: %v", err)
 		return
@@ -122,7 +139,13 @@ func SubmitEvent(checkID *C.char, event *C.event_t) {
 //export SubmitHistogramBucket
 func SubmitHistogramBucket(checkID *C.char, metricName *C.char, value C.longlong, lowerBound C.float, upperBound C.float, monotonic C.int, hostname *C.char, tags **C.char, flushFirstValue C.bool) {
 	goCheckID := C.GoString(checkID)
-	sender, err := aggregator.GetSender(checkid.ID(goCheckID))
+	checkContext, err := getCheckContext()
+	if err != nil {
+		log.Errorf("Python check context: %v", err)
+		return
+	}
+
+	sender, err := checkContext.senderManager.GetSender(checkid.ID(goCheckID))
 	if err != nil || sender == nil {
 		log.Errorf("Error submitting histogram bucket to the Sender: %v", err)
 		return
@@ -145,7 +168,13 @@ func SubmitHistogramBucket(checkID *C.char, metricName *C.char, value C.longlong
 //export SubmitEventPlatformEvent
 func SubmitEventPlatformEvent(checkID *C.char, rawEventPtr *C.char, rawEventSize C.int, eventType *C.char) {
 	_checkID := C.GoString(checkID)
-	sender, err := aggregator.GetSender(checkid.ID(_checkID))
+	checkContext, err := getCheckContext()
+	if err != nil {
+		log.Errorf("Python check context: %v", err)
+		return
+	}
+
+	sender, err := checkContext.senderManager.GetSender(checkid.ID(_checkID))
 	if err != nil || sender == nil {
 		log.Errorf("Error submitting event platform event to the Sender: %v", err)
 		return

--- a/pkg/collector/python/check_context.go
+++ b/pkg/collector/python/check_context.go
@@ -42,3 +42,9 @@ func initializeCheckContext(senderManager sender.SenderManager) {
 	}
 	checkContextMutex.Unlock()
 }
+
+func releaseCheckContext() {
+	checkContextMutex.Lock()
+	checkCtx = nil
+	checkContextMutex.Unlock()
+}

--- a/pkg/collector/python/check_context.go
+++ b/pkg/collector/python/check_context.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build python
+
+package python
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+)
+
+var checkCtx *checkContext = nil
+var checkContextMutex = sync.Mutex{}
+
+// As it is difficult to pass Go context to Go methods like SubmitMetric,
+// checkContext stores the global context required by these functions.
+// Doing so allow to have a single global state instead of having one
+// per dependency used inside SubmitMetric like methods.
+type checkContext struct {
+	senderManager sender.SenderManager
+}
+
+func getCheckContext() (*checkContext, error) {
+	checkContextMutex.Lock()
+	defer checkContextMutex.Unlock()
+
+	if checkCtx == nil {
+		return nil, errors.New("Python check context was not set")
+	}
+	return checkCtx, nil
+}
+
+func initializeCheckContext(senderManager sender.SenderManager) {
+	checkContextMutex.Lock()
+	if checkCtx == nil {
+		checkCtx = &checkContext{senderManager: senderManager}
+	}
+	checkContextMutex.Unlock()
+}

--- a/pkg/collector/python/check_context.go
+++ b/pkg/collector/python/check_context.go
@@ -14,7 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 )
 
-var checkCtx *checkContext = nil
+var checkCtx *checkContext
 var checkContextMutex = sync.Mutex{}
 
 // As it is difficult to pass Go context to Go methods like SubmitMetric,

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -57,8 +57,8 @@ const (
 )
 
 func init() {
-	factory := func() (check.Loader, error) {
-		return NewPythonCheckLoader()
+	factory := func(senderManager sender.SenderManager) (check.Loader, error) {
+		return NewPythonCheckLoader(senderManager)
 	}
 	loaders.RegisterLoader(20, factory)
 
@@ -83,7 +83,8 @@ func init() {
 type PythonCheckLoader struct{}
 
 // NewPythonCheckLoader creates an instance of the Python checks loader
-func NewPythonCheckLoader() (*PythonCheckLoader, error) {
+func NewPythonCheckLoader(senderManager sender.SenderManager) (*PythonCheckLoader, error) {
+	initializeCheckContext(senderManager)
 	return &PythonCheckLoader{}, nil
 }
 
@@ -106,7 +107,6 @@ func (cl *PythonCheckLoader) Load(senderManager sender.SenderManager, config int
 	if rtloader == nil {
 		return nil, fmt.Errorf("python is not initialized")
 	}
-	initializeCheckContext(senderManager)
 	moduleName := config.Name
 	// FastDigest is used as check id calculation does not account for tags order
 	configDigest := config.FastDigest()

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -106,7 +106,7 @@ func (cl *PythonCheckLoader) Load(senderManager sender.SenderManager, config int
 	if rtloader == nil {
 		return nil, fmt.Errorf("python is not initialized")
 	}
-
+	initializeCheckContext(senderManager)
 	moduleName := config.Name
 	// FastDigest is used as check id calculation does not account for tags order
 	configDigest := config.FastDigest()

--- a/pkg/collector/python/test_aggregator.go
+++ b/pkg/collector/python/test_aggregator.go
@@ -10,7 +10,9 @@ package python
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
@@ -20,6 +22,9 @@ import (
 import "C"
 
 func testSubmitMetric(t *testing.T) {
+	release := scopeInitCheckContext(aggregator.GetSenderManager())
+	defer release()
+
 	sender := mocksender.NewMockSender(checkid.ID("testID"))
 	sender.SetupAcceptAll()
 
@@ -92,6 +97,9 @@ func testSubmitMetric(t *testing.T) {
 }
 
 func testSubmitMetricEmptyTags(t *testing.T) {
+	release := scopeInitCheckContext(aggregator.GetSenderManager())
+	defer release()
+
 	sender := mocksender.NewMockSender(checkid.ID("testID"))
 	sender.SetupAcceptAll()
 
@@ -108,6 +116,9 @@ func testSubmitMetricEmptyTags(t *testing.T) {
 }
 
 func testSubmitMetricEmptyHostname(t *testing.T) {
+	release := scopeInitCheckContext(aggregator.GetSenderManager())
+	defer release()
+
 	sender := mocksender.NewMockSender(checkid.ID("testID"))
 	sender.SetupAcceptAll()
 
@@ -124,6 +135,9 @@ func testSubmitMetricEmptyHostname(t *testing.T) {
 }
 
 func testSubmitServiceCheck(t *testing.T) {
+	release := scopeInitCheckContext(aggregator.GetSenderManager())
+	defer release()
+
 	sender := mocksender.NewMockSender(checkid.ID("testID"))
 	sender.SetupAcceptAll()
 
@@ -139,6 +153,9 @@ func testSubmitServiceCheck(t *testing.T) {
 }
 
 func testSubmitServiceCheckEmptyTag(t *testing.T) {
+	release := scopeInitCheckContext(aggregator.GetSenderManager())
+	defer release()
+
 	sender := mocksender.NewMockSender(checkid.ID("testID"))
 	sender.SetupAcceptAll()
 
@@ -154,6 +171,9 @@ func testSubmitServiceCheckEmptyTag(t *testing.T) {
 }
 
 func testSubmitServiceCheckEmptyHostame(t *testing.T) {
+	release := scopeInitCheckContext(aggregator.GetSenderManager())
+	defer release()
+
 	sender := mocksender.NewMockSender(checkid.ID("testID"))
 	sender.SetupAcceptAll()
 
@@ -169,6 +189,9 @@ func testSubmitServiceCheckEmptyHostame(t *testing.T) {
 }
 
 func testSubmitEvent(t *testing.T) {
+	release := scopeInitCheckContext(aggregator.GetSenderManager())
+	defer release()
+
 	sender := mocksender.NewMockSender(checkid.ID("testID"))
 	sender.SetupAcceptAll()
 
@@ -202,6 +225,9 @@ func testSubmitEvent(t *testing.T) {
 }
 
 func testSubmitHistogramBucket(t *testing.T) {
+	release := scopeInitCheckContext(aggregator.GetSenderManager())
+	defer release()
+
 	sender := mocksender.NewMockSender(checkid.ID("testID"))
 	sender.SetupAcceptAll()
 
@@ -222,6 +248,9 @@ func testSubmitHistogramBucket(t *testing.T) {
 }
 
 func testSubmitEventPlatformEvent(t *testing.T) {
+	release := scopeInitCheckContext(aggregator.GetSenderManager())
+	defer release()
+
 	sender := mocksender.NewMockSender("testID")
 	sender.SetupAcceptAll()
 	SubmitEventPlatformEvent(
@@ -232,4 +261,9 @@ func testSubmitEventPlatformEvent(t *testing.T) {
 	)
 
 	sender.AssertEventPlatformEvent(t, []byte("raw-event"), "dbm-sample")
+}
+
+func scopeInitCheckContext(senderManager sender.SenderManager) func() {
+	initializeCheckContext(senderManager)
+	return releaseCheckContext
 }

--- a/pkg/collector/python/test_loader.go
+++ b/pkg/collector/python/test_loader.go
@@ -139,7 +139,7 @@ func testLoadCustomCheck(t *testing.T) {
 	rtloader = newMockRtLoaderPtr()
 	defer func() { rtloader = nil }()
 
-	loader, err := NewPythonCheckLoader()
+	loader, err := NewPythonCheckLoader(aggregator.GetSenderManager())
 	assert.Nil(t, err)
 
 	// testing loading custom checks
@@ -175,7 +175,7 @@ func testLoadWheelCheck(t *testing.T) {
 	rtloader = newMockRtLoaderPtr()
 	defer func() { rtloader = nil }()
 
-	loader, err := NewPythonCheckLoader()
+	loader, err := NewPythonCheckLoader(aggregator.GetSenderManager())
 	assert.Nil(t, err)
 
 	// testing loading dd wheels

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -61,10 +61,10 @@ func InitCheckScheduler(collector *Collector, senderManager sender.SenderManager
 		collector:      collector,
 		senderManager:  senderManager,
 		configToChecks: make(map[string][]checkid.ID),
-		loaders:        make([]check.Loader, 0, len(loaders.LoaderCatalog())),
+		loaders:        make([]check.Loader, 0, len(loaders.LoaderCatalog(senderManager))),
 	}
 	// add the check loaders
-	for _, loader := range loaders.LoaderCatalog() {
+	for _, loader := range loaders.LoaderCatalog(senderManager) {
 		checkScheduler.AddLoader(loader)
 		log.Debugf("Added %s to Check Scheduler", loader)
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR adds a global python check context as it is difficult to pass Go context to Go methods like [SubmitMetric](https://github.com/DataDog/datadog-agent/blob/7.46.0/pkg/collector/python/aggregator.go#L30).
It allows to have a single global state instead of having one per dependency used inside SubmitMetric like methods.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The goal is to remove the call to the function [aggregator.GetSender](https://github.com/DataDog/datadog-agent/blob/7.46.0/pkg/collector/python/aggregator.go#L33) that uses [demultiplexerInstance](https://github.com/DataDog/datadog-agent/blob/7.46.0/pkg/aggregator/demultiplexer.go#L26).

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Run a python integration and checks metrics are correctly sent to the backend.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
