### PR TITLE
Protect status from concurrent modification

### DIFF
--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -8,6 +8,7 @@ package status
 import (
 	"expvar"
 	"strings"
+	"sync"
 
 	"go.uber.org/atomic"
 
@@ -28,6 +29,12 @@ const (
 )
 
 var (
+	// globalsLock prevents the builder, warnings and errors variables
+	// (not objects behind them, they have their own locks) from data
+	// races between reads in Add* and Get, and writes in Init and
+	// Clear.
+	globalsLock sync.RWMutex
+
 	builder  *Builder
 	warnings *config.Messages
 	errors   *config.Messages
@@ -73,6 +80,9 @@ type Status struct {
 
 // Init instantiates the builder that builds the status on the fly.
 func Init(isRunning *atomic.Bool, endpoints *config.Endpoints, sources *sources.LogSources, tracker *tailers.TailerTracker, logExpVars *expvar.Map) {
+	globalsLock.Lock()
+	defer globalsLock.Unlock()
+
 	warnings = config.NewMessages()
 	errors = config.NewMessages()
 	builder = NewBuilder(isRunning, endpoints, sources, tracker, warnings, errors, logExpVars)
@@ -80,6 +90,9 @@ func Init(isRunning *atomic.Bool, endpoints *config.Endpoints, sources *sources.
 
 // Clear clears the status which means it needs to be initialized again to be used.
 func Clear() {
+	globalsLock.Lock()
+	defer globalsLock.Unlock()
+
 	builder = nil
 	warnings = nil
 	errors = nil
@@ -87,6 +100,9 @@ func Clear() {
 
 // Get returns the status of the logs-agent computed on the fly.
 func Get(verbose bool) Status {
+	globalsLock.RLock()
+	defer globalsLock.RUnlock()
+
 	if builder == nil {
 		return Status{
 			IsRunning: false,
@@ -97,6 +113,9 @@ func Get(verbose bool) Status {
 
 // AddGlobalWarning keeps track of a warning message to display on the status.
 func AddGlobalWarning(key string, warning string) {
+	globalsLock.RLock()
+	defer globalsLock.RUnlock()
+
 	if warnings != nil {
 		warnings.AddMessage(key, warning)
 	}
@@ -105,6 +124,9 @@ func AddGlobalWarning(key string, warning string) {
 // RemoveGlobalWarning loses track of a warning message
 // that does not need to be displayed on the status anymore.
 func RemoveGlobalWarning(key string) {
+	globalsLock.RLock()
+	defer globalsLock.RUnlock()
+
 	if warnings != nil {
 		warnings.RemoveMessage(key)
 	}
@@ -112,6 +134,9 @@ func RemoveGlobalWarning(key string) {
 
 // AddGlobalError an error message for the status display (errors will stop the agent)
 func AddGlobalError(key string, errorMessage string) {
+	globalsLock.RLock()
+	defer globalsLock.RUnlock()
+
 	if errors != nil {
 		errors.AddMessage(key, errorMessage)
 	}


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
If a destination fails to connect during agent shutdown, it may try to set status at the same time it is being cleared. Protect global status variables with a RWMutex to avoid this data race.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Prevent a data race and fix a flaky test.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
