### PR TITLE
Fix data race in workloadmeta

### DIFF
--- a/pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector_test.go
+++ b/pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector_test.go
@@ -292,10 +292,10 @@ func TestCollection(t *testing.T) {
 					j++
 				}
 				close(doneCh)
+				mockStore.Unsubscribe(ch)
 			}()
 
 			<-doneCh
-			mockStore.Unsubscribe(ch)
 
 			// wait that the store gets populated
 			time.Sleep(time.Second)

--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -204,7 +204,7 @@ func (s *store) Subscribe(name string, priority SubscriberPriority, filter *Filt
 
 	// notifyChannel should not wait when doing the first subscription, as
 	// the subscriber is not ready to receive events yet
-	notifyChannel(sub.name, sub.ch, events, false)
+	s.notifyChannel(sub.name, sub.ch, events, false)
 
 	s.subscribersMut.Lock()
 	defer s.subscribersMut.Unlock()
@@ -694,7 +694,7 @@ func (s *store) handleEvents(evs []CollectorEvent) {
 			continue
 		}
 
-		notifyChannel(sub.name, sub.ch, evs, true)
+		s.notifyChannel(sub.name, sub.ch, evs, true)
 	}
 }
 
@@ -745,13 +745,14 @@ func (s *store) unsubscribeAll() {
 	telemetry.Subscribers.Set(0)
 }
 
-func notifyChannel(name string, ch chan EventBundle, events []Event, wait bool) {
+func (s *store) notifyChannel(name string, ch chan EventBundle, events []Event, wait bool) {
 	bundle := EventBundle{
 		Ch:     make(chan struct{}),
 		Events: events,
 	}
-
+	s.subscribersMut.Lock()
 	ch <- bundle
+	s.subscribersMut.Unlock()
 
 	if wait {
 		timer := time.NewTimer(eventBundleChTimeout)

--- a/releasenotes/notes/fix-data-race-workloadmeta-da19d7b3c1920045.yaml
+++ b/releasenotes/notes/fix-data-race-workloadmeta-da19d7b3c1920045.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fixes a critical data race in ``workloadmeta`` that was causing issues when a subscriber attempted to unsubscribe while events were being handled in another goroutine.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR fixes a datarace in workloadmeta.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
```
=== RUN   TestCollection/initially_empty
==================
Write at 0x00c0001335d0 by goroutine 27:
  runtime.closechan()
      /Users/runner/.gimme/versions/go1.20.7.darwin.amd64/src/runtime/chan.go:357 +0x0
  github.com/DataDog/datadog-agent/pkg/workloadmeta.(*store).Unsubscribe()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/store.go:231 +0x35b
  github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote/process_collector.TestCollection.func2()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector_test.go:298 +0x9ce
  testing.tRunner()
      /Users/runner/.gimme/versions/go1.20.7.darwin.amd64/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /Users/runner/.gimme/versions/go1.20.7.darwin.amd64/src/testing/testing.go:1629 +0x47

Previous read at 0x00c0001335d0 by goroutine 32:
  runtime.chansend()
      /Users/runner/.gimme/versions/go1.20.7.darwin.amd64/src/runtime/chan.go:160 +0x0
  github.com/DataDog/datadog-agent/pkg/workloadmeta.notifyChannel()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/store.go:754 +0xca
  github.com/DataDog/datadog-agent/pkg/workloadmeta.(*store).handleEvents()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/store.go:697 +0xdab
  github.com/DataDog/datadog-agent/pkg/workloadmeta.(*MockStore).Notify()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/mock_store.go:26 +0x59
  github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote.(*GenericCollector).Run()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote/generic.go:218 +0x5e4
  github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote.(*GenericCollector).Start.func5()
      /Users/runner/go/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote/generic.go:118 +0x39
```
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
It might affect workloadmeta performances because acquiring a mutex is costly.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Deploy the Agent, make sure basic features are still working (tagger, autodiscovery...)

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
