### PR TITLE
Add E2E tests for language detection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -430,6 +430,7 @@
 /test/fakeintake/                       @DataDog/agent-e2e-testing
 /test/new-e2e/                          @DataDog/agent-e2e-testing
 /test/new-e2e/agent-subcommands         @DataDog/agent-shared-components
+/test/new-e2e/language-detection        @DataDog/processes
 /test/new-e2e/ndm                       @DataDog/network-device-monitoring
 /test/new-e2e/scenarios/ndm             @DataDog/network-device-monitoring
 /test/new-e2e/system-probe              @DataDog/ebpf-platform

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -200,6 +200,7 @@ new-e2e-language-detection-dev:
   needs: [ ]
   variables:
     TARGETS: ./language-detection
+    TEAM: processes
     CONFIGPARAMS: "-c ddagent:fullImagePath=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3"
 
 new-e2e-language-detection-main:
@@ -207,6 +208,7 @@ new-e2e-language-detection-main:
   rules: !reference [ .on_main ]
   variables:
     TARGETS: ./language-detection
+    TEAM: processes
     CONFIGPARAMS: "-c ddagent:fullImagePath=669783387624.dkr.ecr.us-east-1.amazonaws.com/agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
 
 #   ^    If you create a new job here that extends `.new_e2e_template`,

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -194,6 +194,21 @@ new-e2e-agent-subcommands-main:
   # Temporary, until we manage to stabilize those tests.
   allow_failure: true
 
+new-e2e-language-detection-dev:
+  extends: .new_e2e_template
+  rules: !reference [ .on_dev_branch_manual ]
+  needs: [ ]
+  variables:
+    TARGETS: ./language-detection
+    CONFIGPARAMS: "-c ddagent:fullImagePath=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3"
+
+new-e2e-language-detection-main:
+  extends: .new_e2e_template
+  rules: !reference [ .on_main ]
+  variables:
+    TARGETS: ./language-detection
+    CONFIGPARAMS: "-c ddagent:fullImagePath=669783387624.dkr.ecr.us-east-1.amazonaws.com/agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+
 #   ^    If you create a new job here that extends `.new_e2e_template`,
 #  /!\   do not forget to add it in the `dependencies` statement of the
 # /___\  `e2e_test_junit_upload` job in the `.gitlab/e2e_test_junit_upload.yml` file

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -201,7 +201,6 @@ new-e2e-language-detection-dev:
   variables:
     TARGETS: ./language-detection
     TEAM: processes
-    CONFIGPARAMS: "-c ddagent:fullImagePath=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3"
 
 new-e2e-language-detection-main:
   extends: .new_e2e_template
@@ -209,7 +208,6 @@ new-e2e-language-detection-main:
   variables:
     TARGETS: ./language-detection
     TEAM: processes
-    CONFIGPARAMS: "-c ddagent:fullImagePath=669783387624.dkr.ecr.us-east-1.amazonaws.com/agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
 
 #   ^    If you create a new job here that extends `.new_e2e_template`,
 #  /!\   do not forget to add it in the `dependencies` statement of the

--- a/.gitlab/e2e_test_junit_upload.yml
+++ b/.gitlab/e2e_test_junit_upload.yml
@@ -13,6 +13,7 @@ e2e_test_junit_upload:
     # to avoid downloading all the artifacts of all the jobs of all the previous stages.
     - new-e2e-containers-main
     - new-e2e-agent-subcommands-main
+    - new-e2e-language-detection-main
   script:
     - set +x
     - export DATADOG_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)

--- a/test/new-e2e/language-detection/etc/node_server.js
+++ b/test/new-e2e/language-detection/etc/node_server.js
@@ -1,0 +1,14 @@
+const http = require('http');
+
+const hostname = '127.0.0.1';
+const port = 3000;
+
+const server = http.createServer((req, res) => {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'text/plain');
+  res.end('Hello World');
+});
+
+server.listen(port, hostname, () => {
+  console.log('Server running');
+});

--- a/test/new-e2e/language-detection/etc/process_config.yaml
+++ b/test/new-e2e/language-detection/etc/process_config.yaml
@@ -1,0 +1,7 @@
+process_config:
+  process_collection:
+    enabled: true
+  intervals:
+    process: 1
+language_detection:
+  enabled: true

--- a/test/new-e2e/language-detection/language_detection_test.go
+++ b/test/new-e2e/language-detection/language_detection_test.go
@@ -9,6 +9,8 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -19,10 +21,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
 )
-
-// testLocally should be set to true if running the test from a developer machine (i.e. not CI)
-// This sets the test suite to use the hardcoded agent version `versionStr`
-const testLocally = false
 
 const versionStr = "7.48.0~rc.1-1"
 
@@ -45,7 +43,8 @@ func TestLanguageDetectionSuite(t *testing.T) {
 		agentparams.WithAgentConfig(configStr),
 	}
 
-	if testLocally {
+	isCI, _ := strconv.ParseBool(os.Getenv("CI"))
+	if !isCI {
 		agentParams = append(agentParams, agentparams.WithVersion(versionStr))
 	}
 
@@ -54,7 +53,7 @@ func TestLanguageDetectionSuite(t *testing.T) {
 
 func (s *languageDetectionSuite) checkDetectedLanguage(command string, language string) {
 	var pid string
-	assert.Eventually(s.T(),
+	require.Eventually(s.T(),
 		func() bool {
 			pid = s.getPidForCommand(command)
 			return len(pid) > 0
@@ -62,10 +61,6 @@ func (s *languageDetectionSuite) checkDetectedLanguage(command string, language 
 		1*time.Second, 10*time.Millisecond,
 		fmt.Sprintf("pid not found for command %s", command),
 	)
-	require.NotEmpty(s.T(), pid)
-
-	// ensure check is able to run
-	time.Sleep(2 * time.Second)
 
 	var actualLanguage string
 	var err error

--- a/test/new-e2e/language-detection/language_detection_test.go
+++ b/test/new-e2e/language-detection/language_detection_test.go
@@ -1,0 +1,111 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package languagedetection
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
+)
+
+// testLocally should be set to true if running the test from a developer machine (i.e. not CI)
+// This sets the test suite to use the hardcoded agent version `versionStr`
+const testLocally = false
+
+const versionStr = "7.48.0~rc.1-1"
+
+const configStr = `
+process_config:
+  process_collection:
+    enabled: true
+  intervals:
+    process: 1
+language_detection:
+  enabled: true
+`
+
+type languageDetectionSuite struct {
+	e2e.Suite[e2e.AgentEnv]
+}
+
+func TestLanguageDetectionSuite(t *testing.T) {
+	agentParams := []func(*agentparams.Params) error{
+		agentparams.WithAgentConfig(configStr),
+	}
+
+	if testLocally {
+		agentParams = append(agentParams, agentparams.WithVersion(versionStr))
+	}
+
+	e2e.Run(t, &languageDetectionSuite{}, e2e.AgentStackDef(nil, agentParams...))
+}
+
+func (s *languageDetectionSuite) checkDetectedLanguage(command string, language string) {
+	var pid string
+	assert.Eventually(s.T(),
+		func() bool {
+			pid = s.getPidForCommand(command)
+			return len(pid) > 0
+		},
+		1*time.Second, 10*time.Millisecond,
+		fmt.Sprintf("pid not found for command %s", command),
+	)
+	require.NotEmpty(s.T(), pid)
+
+	// ensure check is able to run
+	time.Sleep(2 * time.Second)
+
+	var actualLanguage string
+	var err error
+	assert.Eventually(s.T(),
+		func() bool {
+			actualLanguage, err = s.getLanguageForPid(pid)
+			return err == nil && actualLanguage == language
+		},
+		10*time.Second, 100*time.Millisecond,
+		fmt.Sprintf("language match not found, pid = %s, expected = %s, actual = %s, err = %v",
+			pid, language, actualLanguage, err),
+	)
+}
+
+func (s *languageDetectionSuite) getPidForCommand(command string) string {
+	pid, err := s.Env().VM.ExecuteWithError(fmt.Sprintf("ps -C %s -o pid=", command))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(pid)
+}
+
+func (s *languageDetectionSuite) getLanguageForPid(pid string) (string, error) {
+	wl := s.Env().VM.Execute("sudo /opt/datadog-agent/bin/agent/agent workload-list")
+	if len(strings.TrimSpace(wl)) == 0 {
+		return "", errors.New("agent workload-list was empty")
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(wl))
+	pidLine := fmt.Sprintf("PID: %s", pid)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == pidLine {
+			scanner.Scan() // nspid
+			scanner.Scan() // container id
+			scanner.Scan() // creation time
+			scanner.Scan() // language
+			return scanner.Text()[len("Language: "):], nil
+		}
+	}
+
+	return "", errors.New("no language found")
+}

--- a/test/new-e2e/language-detection/language_detection_test.go
+++ b/test/new-e2e/language-detection/language_detection_test.go
@@ -67,6 +67,8 @@ func (s *languageDetectionSuite) checkDetectedLanguage(command string, language 
 		fmt.Sprintf("language match not found, pid = %s, expected = %s, actual = %s, err = %v",
 			pid, language, actualLanguage, err),
 	)
+
+	s.Env().VM.Execute(fmt.Sprintf("kill -SIGTERM %s", pid))
 }
 
 func (s *languageDetectionSuite) getPidForCommand(command string) string {

--- a/test/new-e2e/language-detection/language_detection_test.go
+++ b/test/new-e2e/language-detection/language_detection_test.go
@@ -7,6 +7,7 @@ package languagedetection
 
 import (
 	"bufio"
+	_ "embed"
 	"errors"
 	"fmt"
 	"os"
@@ -24,15 +25,8 @@ import (
 
 const versionStr = "7.48.0~rc.1-1"
 
-const configStr = `
-process_config:
-  process_collection:
-    enabled: true
-  intervals:
-    process: 1
-language_detection:
-  enabled: true
-`
+//go:embed etc/process_config.yaml
+var configStr string
 
 type languageDetectionSuite struct {
 	e2e.Suite[e2e.AgentEnv]

--- a/test/new-e2e/language-detection/node_test.go
+++ b/test/new-e2e/language-detection/node_test.go
@@ -6,28 +6,15 @@
 package languagedetection
 
 import (
+	_ "embed"
 	"fmt"
 	"strings"
 
 	"github.com/stretchr/testify/require"
 )
 
-const nodeProg = `
-const http = require('http');
-
-const hostname = '127.0.0.1';
-const port = 3000;
-
-const server = http.createServer((req, res) => {
-  res.statusCode = 200;
-  res.setHeader('Content-Type', 'text/plain');
-  res.end('Hello World');
-});
-
-server.listen(port, hostname, () => {
-  console.log('Server running');
-});
-`
+//go:embed etc/node_server.js
+var nodeProg string
 
 func (s *languageDetectionSuite) installNode() {
 	s.Env().VM.Execute(

--- a/test/new-e2e/language-detection/node_test.go
+++ b/test/new-e2e/language-detection/node_test.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package languagedetection
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/stretchr/testify/require"
+)
+
+const nodeProg = `
+const http = require('http');
+
+const hostname = '127.0.0.1';
+const port = 3000;
+
+const server = http.createServer((req, res) => {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'text/plain');
+  res.end('Hello World');
+});
+
+server.listen(port, hostname, () => {
+  console.log('Server running');
+});
+`
+
+func (s *languageDetectionSuite) installNode() {
+	s.Env().VM.Execute(
+		"curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash - && " +
+			"sudo apt-get install -y nodejs")
+	nodeVersion := s.Env().VM.Execute("node --version")
+	require.True(s.T(), strings.HasPrefix(nodeVersion, "v20."))
+}
+
+func (s *languageDetectionSuite) TestNodeDetection() {
+	s.installNode()
+
+	s.Env().VM.Execute(fmt.Sprintf(`echo "%s" > prog.js`, nodeProg))
+	s.Env().VM.Execute("nohup node prog.js >myscript.log 2>&1 </dev/null &")
+
+	s.checkDetectedLanguage("node", "node")
+}

--- a/test/new-e2e/language-detection/python_test.go
+++ b/test/new-e2e/language-detection/python_test.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package languagedetection
+
+import (
+	"strings"
+
+	"github.com/stretchr/testify/require"
+)
+
+func (s *languageDetectionSuite) installPython() {
+	s.Env().VM.Execute("sudo apt-get -y install python3")
+	pyVersion := s.Env().VM.Execute("python3 --version")
+	require.True(s.T(), strings.HasPrefix(pyVersion, "Python 3"))
+}
+
+func (s *languageDetectionSuite) TestPythonDetection() {
+	s.installPython()
+
+	s.Env().VM.Execute("echo 'import time\ntime.sleep(30)' > prog.py")
+	s.Env().VM.Execute("nohup python3 prog.py >myscript.log 2>&1 </dev/null &")
+
+	s.checkDetectedLanguage("python3", "python")
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Add end-to-end tests for detecting processes running python and node, as well as a CI job to run these tests.

For commits on `main`, CI will push a build from that pipeline to the agent QA ECR repository, which will be pulled for the E2E tests.

On dev branches, CI will pull the `agent-dev` image from the Datadog docker repository. Note that engineers need to manually build and push the agent to that repository in order for CI to pull the image. These CI jobs also must be manually run.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

https://datadoghq.atlassian.net/browse/PROC-3010

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
