### PR TITLE
[omnibus] Reset OVAL results from session in OpenSCAP

### DIFF
--- a/omnibus/config/patches/openscap/dpkginfo-init.patch
+++ b/omnibus/config/patches/openscap/dpkginfo-init.patch
@@ -1,13 +1,183 @@
 --- a/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx
 +++ b/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx
-@@ -122,6 +122,10 @@ void dpkginfo_free_reply(struct dpkginfo_reply_t *reply)
+@@ -21,12 +21,7 @@
  
- int dpkginfo_init()
+ using namespace std;
+ 
+-static int _init_done = 0;
+-static pkgCacheFile *cgCache = NULL;
+-
+-static MMap *dpkg_mmap = NULL;
+-
+-static int opencache (void) {
++static int opencache (struct dpkginfo_cache *cache) {
+         if (pkgInitConfig (*_config) == false) return 0;
+ 
+         const char* root = getenv("OSCAP_PROBE_ROOT");
+@@ -48,7 +43,7 @@ static int opencache (void) {
+ 
+         if (pkgInitSystem (*_config, _system) == false) return 0;
+ 
+-        if (!cgCache->ReadOnlyOpen(NULL)) return 0;
++        if (!((pkgCacheFile*)(cache->cgCache))->ReadOnlyOpen(NULL)) return 0;
+ 
+         if (_error->PendingError () == true) {
+                 _error->DumpErrors ();
+@@ -58,9 +53,9 @@ static int opencache (void) {
+         return 1;
+ }
+ 
+-struct dpkginfo_reply_t * dpkginfo_get_by_name(const char *name, int *err)
++struct dpkginfo_reply_t * dpkginfo_get_by_name(struct dpkginfo_cache *c, const char *name, int *err)
  {
-+	if (cgCache != NULL) {
-+		return 0;
-+	}
+-        pkgCache &cache = *cgCache->GetPkgCache();
++        pkgCache &cache = *((pkgCacheFile*)(c->cgCache))->GetPkgCache();
+         pkgRecords Recs (cache);
+         struct dpkginfo_reply_t *reply = NULL;
+ 
+@@ -136,29 +131,29 @@ void dpkginfo_free_reply(struct dpkginfo_reply_t *reply)
+         }
+ }
+ 
+-int dpkginfo_init()
++int dpkginfo_init(struct dpkginfo_cache *cache)
+ {
+-        cgCache = new pkgCacheFile;
+-        if (_init_done == 0)
+-                if (opencache() != 1) {
++        if (cache->init_done == 0) {
++                cache->cgCache = new pkgCacheFile;
++                if (opencache(cache) != 1) {
++                        delete (pkgCacheFile*)(cache->cgCache);
++                        cache->cgCache = NULL;
+                         return -1;
+                 }
++                cache->init_done = 1;
++        }
+ 
+         return 0;
+ }
+ 
+-int dpkginfo_fini()
++int dpkginfo_fini(struct dpkginfo_cache *cache)
+ {
+-        if (cgCache != NULL) {
+-                cgCache->Close();
++        if (cache->cgCache != NULL) {
++                ((pkgCacheFile*)(cache->cgCache))->Close();
+         }
+ 
+-        delete cgCache;
+-        cgCache = NULL;
+-
+-        delete dpkg_mmap;
+-        dpkg_mmap = NULL;
++        delete (pkgCacheFile*)(cache->cgCache);
++        cache->cgCache = NULL;
+ 
+         return 0;
+ }
+-
+--- a/src/OVAL/probes/unix/linux/dpkginfo-helper.h
++++ b/src/OVAL/probes/unix/linux/dpkginfo-helper.h
+@@ -26,6 +26,11 @@
+ extern "C" {
+ #endif
+ 
++struct dpkginfo_cache {
++        int init_done;
++        void *cgCache; // pkgCacheFile
++};
 +
-         cgCache = new pkgCacheFile;
-         if (_init_done == 0)
-                 if (opencache() != 1) {
+ struct dpkginfo_reply_t {
+         char *name;
+         char *arch;
+@@ -35,10 +40,10 @@ struct dpkginfo_reply_t {
+         char *evr;
+ };
+ 
+-int dpkginfo_init();
+-int dpkginfo_fini();
++int dpkginfo_init(struct dpkginfo_cache *cache);
++int dpkginfo_fini(struct dpkginfo_cache *cache);
+ 
+-struct dpkginfo_reply_t * dpkginfo_get_by_name(const char *name, int *err);
++struct dpkginfo_reply_t * dpkginfo_get_by_name(struct dpkginfo_cache *cache, const char *name, int *err);
+ 
+ void dpkginfo_free_reply(struct dpkginfo_reply_t *reply);
+ 
+--- a/src/OVAL/probes/unix/linux/dpkginfo_probe.c
++++ b/src/OVAL/probes/unix/linux/dpkginfo_probe.c
+@@ -65,35 +65,39 @@
+ 
+ struct dpkginfo_global {
+         int init_done;
++        struct dpkginfo_cache cache;
+         pthread_mutex_t mutex;
+ };
+ 
+-static struct dpkginfo_global g_dpkg = {
+-        .init_done = -1,
+-};
+-
+ int dpkginfo_probe_offline_mode_supported(void) {
+         return PROBE_OFFLINE_OWN;
+ }
+ 
+ void *dpkginfo_probe_init(void)
+ {
+-        pthread_mutex_init (&(g_dpkg.mutex), NULL);
++        struct dpkginfo_global *d;
++        d = malloc(sizeof(*d));
++        if (d == NULL)
++                return NULL;
++        memset(d, 0, sizeof(*d));
+ 
+-        g_dpkg.init_done = dpkginfo_init();
+-        if (g_dpkg.init_done < 0) {
++        pthread_mutex_init (&(d->mutex), NULL);
++
++        d->init_done = dpkginfo_init(&d->cache);
++        if (d->init_done < 0) {
+                 dE("dpkginfo_init has failed.");
+         }
+ 
+-        return ((void *)&g_dpkg);
++        return ((void *)d);
+ }
+ 
+ void dpkginfo_probe_fini (void *ptr)
+ {
+         struct dpkginfo_global *d = (struct dpkginfo_global *)ptr;
+ 
+-        dpkginfo_fini();
++        dpkginfo_fini(&d->cache);
+         pthread_mutex_destroy (&(d->mutex));
++        free(d);
+ 
+         return;
+ }
+@@ -109,7 +113,9 @@ int dpkginfo_probe_main (probe_ctx *ctx, void *arg)
+ 		return PROBE_EINIT;
+ 	}
+ 
+-        if (g_dpkg.init_done < 0) {
++        struct dpkginfo_global *d = (struct dpkginfo_global *)arg;
++
++        if (d->init_done < 0) {
+                 probe_cobj_set_flag(probe_ctx_getresult(ctx), SYSCHAR_FLAG_UNKNOWN);
+                 return 0;
+         }
+@@ -148,9 +154,9 @@ int dpkginfo_probe_main (probe_ctx *ctx, void *arg)
+         }
+ 
+         /* get info from debian apt cache */
+-        pthread_mutex_lock (&(g_dpkg.mutex));
+-        dpkginfo_reply = dpkginfo_get_by_name(request_st, &errflag);
+-        pthread_mutex_unlock (&(g_dpkg.mutex));
++        pthread_mutex_lock (&(d->mutex));
++        dpkginfo_reply = dpkginfo_get_by_name(&d->cache, request_st, &errflag);
++        pthread_mutex_unlock (&(d->mutex));
+ 
+         if (dpkginfo_reply == NULL) {
+                 switch (errflag) {

--- a/omnibus/config/patches/openscap/session_reset_results.patch
+++ b/omnibus/config/patches/openscap/session_reset_results.patch
@@ -1,0 +1,58 @@
+--- a/src/OVAL/oval_agent.c
++++ b/src/OVAL/oval_agent.c
+@@ -259,6 +259,15 @@ void oval_agent_reset_syschar(oval_agent_session_t * ag_sess) {
+ 	oval_syschar_model_reset(ag_sess->sys_model);
+ }
+ 
++void oval_agent_reset_results(oval_agent_session_t * ag_sess) {
++#if defined(OVAL_PROBES_ENABLED)
++	oval_results_model_free(ag_sess->res_model);
++	ag_sess->res_model = oval_results_model_new_with_probe_session(
++			ag_sess->def_model, ag_sess->sys_models, ag_sess->psess);
++	oval_probe_session_reinit(ag_sess->psess, ag_sess->sys_model);
++#endif
++}
++
+ int oval_agent_abort_session(oval_agent_session_t *ag_sess)
+ {
+ 	if (ag_sess == NULL) {
+--- a/src/OVAL/public/oval_agent_api.h
++++ b/src/OVAL/public/oval_agent_api.h
+@@ -101,6 +101,11 @@ OSCAP_API int oval_agent_reset_session(oval_agent_session_t * ag_sess);
+  */
+ OSCAP_API void oval_agent_reset_syschar(oval_agent_session_t * ag_sess);
+ 
++/**
++ * Clean results that were generated in this agent session
++ */
++OSCAP_API void oval_agent_reset_results(oval_agent_session_t * ag_sess);
++
+ /**
+  * Abort a running probe session
+  */
+--- a/src/XCCDF/xccdf_session.c
++++ b/src/XCCDF/xccdf_session.c
+@@ -371,6 +371,15 @@ static void _xccdf_session_reset_oval_agents_syschar(struct xccdf_session *sessi
+ 	}
+ }
+ 
++static void _xccdf_session_reset_oval_agents_results(struct xccdf_session *session)
++{
++	if (session->oval.agents != NULL) {
++		for (int i=0; session->oval.agents[i]; i++) {
++			oval_agent_reset_results(session->oval.agents[i]);
++		}
++	}
++}
++
+ void xccdf_session_result_reset(struct xccdf_session *session)
+ {
+ 	if (session->xccdf.policy_model != NULL) {
+@@ -384,6 +393,7 @@ void xccdf_session_result_reset(struct xccdf_session *session)
+ 	session->skip_rules = oscap_list_new();
+ 
+ 	_xccdf_session_reset_oval_agents_syschar(session);
++	_xccdf_session_reset_oval_agents_results(session);
+ }
+ 
+ const char *xccdf_session_get_filename(const struct xccdf_session *session)

--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -46,6 +46,7 @@ build do
   patch source: "get_results_from_session.patch", env: env # add a function to retrieve results from session
   patch source: "session_result_reset.patch", env: env # add a function to reset results from session
   patch source: "session_reset_syschar.patch", env: env # also reset system characteristics
+  patch source: "session_reset_results.patch", env: env # also reset OVAL results
   patch source: "010_perlpm_install_fix.patch", env: env # fix build of perl bindings
   patch source: "dpkginfo-cacheconfig.patch", env: env # work around incomplete pkgcache path
   patch source: "dpkginfo-init.patch", env: env # fix memory leak of pkgcache in dpkginfo probe


### PR DESCRIPTION
### What does this PR do?

This change adds a patch to OpenSCAP to reset OVAL results from session when calling the `xccdf_session_result_reset` function.

This change also modifies the `dpkginfo-init` patch to allocate an instance of the dpkg cache per `dpkginfo` thread instead of a global dpkg cache shared by multiple threads.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
