### PR TITLE
[e2e] run subcommands on branch version

### DIFF
--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -188,6 +188,7 @@ new-e2e-agent-subcommands-dev:
   variables:
     TARGETS: ./agent-subcommands
     TEAM: "agent-shared-components"
+    CONFIGPARAMS: "-c ddagent:pipeline_id=${CI_PIPELINE_ID}"
 
 new-e2e-agent-subcommands-main:
   extends: .new_e2e_template
@@ -195,6 +196,7 @@ new-e2e-agent-subcommands-main:
   variables:
     TARGETS: ./agent-subcommands
     TEAM: "agent-shared-components"
+    CONFIGPARAMS: "-c ddagent:pipeline_id=${CI_PIPELINE_ID}"
   # Temporary, until we manage to stabilize those tests.
   allow_failure: true
 #   ^    If you create a new job here that extends `.new_e2e_template`,

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -158,6 +158,7 @@ new-e2e-containers-dev:
   needs: []
   variables:
     TARGETS: ./containers
+    TEAM: "container-integrations"
     CONFIGPARAMS: "-c ddagent:fullImagePath=datadog/agent-dev:${CI_COMMIT_REF_SLUG}-py3 -c ddagent:clusterAgentFullImagePath=datadog/cluster-agent-dev:${CI_COMMIT_REF_SLUG}"
   parallel:
     matrix:
@@ -175,6 +176,7 @@ new-e2e-containers-main:
     - qa_dogstatsd
   variables:
     TARGETS: ./containers
+    TEAM: "container-integrations"
     CONFIGPARAMS: "-c ddagent:fullImagePath=669783387624.dkr.ecr.us-east-1.amazonaws.com/agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA} -c ddagent:clusterAgentFullImagePath=669783387624.dkr.ecr.us-east-1.amazonaws.com/cluster-agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
   # Temporary, until we manage to stabilize those tests.
   allow_failure: true
@@ -185,15 +187,16 @@ new-e2e-agent-subcommands-dev:
   needs: []
   variables:
     TARGETS: ./agent-subcommands
+    TEAM: "agent-shared-components"
 
 new-e2e-agent-subcommands-main:
   extends: .new_e2e_template
   rules: !reference [.on_main]
   variables:
     TARGETS: ./agent-subcommands
+    TEAM: "agent-shared-components"
   # Temporary, until we manage to stabilize those tests.
   allow_failure: true
-
 #   ^    If you create a new job here that extends `.new_e2e_template`,
 #  /!\   do not forget to add it in the `dependencies` statement of the
 # /___\  `e2e_test_junit_upload` job in the `.gitlab/e2e_test_junit_upload.yml` file


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add config parameters to run e2e tests against agent builds from the running pipeline

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Run e2e tests on the CI using the current pipeline version of the agent


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
