### PR TITLE
Fix flakiness in dsd server tests

### DIFF
--- a/comp/dogstatsd/listeners/udp.go
+++ b/comp/dogstatsd/listeners/udp.go
@@ -97,6 +97,11 @@ func NewUDPListener(packetOut chan packets.Packets, sharedPacketPoolManager *pac
 	return listener, nil
 }
 
+// LocalAddr returns the local network address of the listener.
+func (l *UDPListener) LocalAddr() string {
+	return l.conn.LocalAddr().String()
+}
+
 // Listen runs the intake loop. Should be called in its own goroutine
 func (l *UDPListener) Listen() {
 	var t1, t2 time.Time

--- a/comp/dogstatsd/listeners/udp.go
+++ b/comp/dogstatsd/listeners/udp.go
@@ -25,6 +25,9 @@ var (
 	udpBytes               = expvar.Int{}
 )
 
+// RandomPortName is the value for dogstatsd_port setting that indicates that the server should allocate a random unique port.
+const RandomPortName = "__random__" // this would be zero if zero wasn't used already to disable udp support.
+
 func init() {
 	udpExpvars.Set("PacketReadingErrors", &udpPacketReadingErrors)
 	udpExpvars.Set("Packets", &udpPackets)
@@ -48,11 +51,16 @@ func NewUDPListener(packetOut chan packets.Packets, sharedPacketPoolManager *pac
 	var err error
 	var url string
 
+	port := cfg.GetString("dogstatsd_port")
+	if port == RandomPortName {
+		port = "0"
+	}
+
 	if cfg.GetBool("dogstatsd_non_local_traffic") {
 		// Listen to all network interfaces
-		url = fmt.Sprintf(":%d", cfg.GetInt("dogstatsd_port"))
+		url = fmt.Sprintf(":%s", port)
 	} else {
-		url = net.JoinHostPort(config.GetBindHostFromConfig(cfg), cfg.GetString("dogstatsd_port"))
+		url = net.JoinHostPort(config.GetBindHostFromConfig(cfg), port)
 	}
 
 	addr, err := net.ResolveUDPAddr("udp", url)

--- a/comp/dogstatsd/server/component.go
+++ b/comp/dogstatsd/server/component.go
@@ -35,8 +35,8 @@ type Component interface {
 	// SetExtraTags sets extra tags. All metrics sent to the DogstatsD will be tagged with them.
 	SetExtraTags(tags []string)
 
-	// UdpLocalAddr returns the local address of the UDP statsd listener, if enabled.
-	UdpLocalAddr() string
+	// UDPLocalAddr returns the local address of the UDP statsd listener, if enabled.
+	UDPLocalAddr() string
 }
 
 // Mock implements mock-specific methods.

--- a/comp/dogstatsd/server/component.go
+++ b/comp/dogstatsd/server/component.go
@@ -34,6 +34,9 @@ type Component interface {
 
 	// SetExtraTags sets extra tags. All metrics sent to the DogstatsD will be tagged with them.
 	SetExtraTags(tags []string)
+
+	// UdpLocalAddr returns the local address of the UDP statsd listener, if enabled.
+	UdpLocalAddr() string
 }
 
 // Mock implements mock-specific methods.

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -327,7 +327,8 @@ func (s *server) Start(demultiplexer aggregator.Demultiplexer) error {
 			udsListenerRunning = true
 		}
 	}
-	if s.config.GetInt("dogstatsd_port") > 0 {
+
+	if s.config.GetString("dogstatsd_port") == listeners.RandomPortName || s.config.GetInt("dogstatsd_port") > 0 {
 		udpListener, err := listeners.NewUDPListener(packetsChannel, sharedPacketPoolManager, s.config, s.tCapture)
 		if err != nil {
 			s.log.Errorf(err.Error())

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -465,7 +465,7 @@ func (s *server) handleMessages() {
 	}
 }
 
-func (s *server) UdpLocalAddr() string {
+func (s *server) UDPLocalAddr() string {
 	return s.udpLocalAddr
 }
 

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -133,6 +133,7 @@ type server struct {
 	// ServerlessMode is set to true if we're running in a serverless environment.
 	ServerlessMode     bool
 	udsListenerRunning bool
+	udpLocalAddr       string
 
 	// originTelemetry is true if we want to report telemetry per origin.
 	originTelemetry bool
@@ -334,6 +335,7 @@ func (s *server) Start(demultiplexer aggregator.Demultiplexer) error {
 			s.log.Errorf(err.Error())
 		} else {
 			tmpListeners = append(tmpListeners, udpListener)
+			s.udpLocalAddr = udpListener.LocalAddr()
 		}
 	}
 
@@ -461,6 +463,10 @@ func (s *server) handleMessages() {
 		go worker.run()
 		s.workers = append(s.workers, worker)
 	}
+}
+
+func (s *server) UdpLocalAddr() string {
+	return s.udpLocalAddr
 }
 
 func (s *server) forwarder(fcon net.Conn) {

--- a/comp/dogstatsd/server/server_mock.go
+++ b/comp/dogstatsd/server/server_mock.go
@@ -40,7 +40,7 @@ func (s *serverMock) UdsListenerRunning() bool {
 	return false
 }
 
-func (s *serverMock) UdpLocalAddr() string {
+func (s *serverMock) UDPLocalAddr() string {
 	return ""
 }
 

--- a/comp/dogstatsd/server/server_mock.go
+++ b/comp/dogstatsd/server/server_mock.go
@@ -40,6 +40,10 @@ func (s *serverMock) UdsListenerRunning() bool {
 	return false
 }
 
+func (s *serverMock) UdpLocalAddr() string {
+	return ""
+}
+
 func (s *serverMock) ServerlessFlush() {}
 
 func (s *serverMock) SetExtraTags(tags []string) {}

--- a/comp/dogstatsd/server/server_test.go
+++ b/comp/dogstatsd/server/server_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/listeners"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/replay"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
@@ -824,15 +825,12 @@ dogstatsd_mapper_profiles:
 	samples := []metrics.MetricSample{}
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
-			port, err := getAvailableUDPPort()
-			require.NoError(t, err, "Case `%s` failed. getAvailableUDPPort should not return error %v", scenario.name, err)
-
 			deps := fulfillDepsWithConfigYaml(t, scenario.config)
 
 			s := deps.Server.(*server)
 			cw := deps.Config.(config.ConfigReaderWriter)
 
-			cw.Set("dogstatsd_port", port)
+			cw.Set("dogstatsd_port", listeners.RandomPortName)
 
 			demux := mockDemultiplexer(deps.Config, deps.Log)
 			defer demux.Stop(false)

--- a/comp/dogstatsd/server/server_test.go
+++ b/comp/dogstatsd/server/server_test.go
@@ -104,7 +104,7 @@ func TestStopServer(t *testing.T) {
 	deps.Server.Stop()
 
 	// check that the port can be bound, try for 100 ms
-	address, err := net.ResolveUDPAddr("udp", deps.Server.UdpLocalAddr())
+	address, err := net.ResolveUDPAddr("udp", deps.Server.UDPLocalAddr())
 	require.NoError(t, err, "cannot resolve address")
 	for i := 0; i < 10; i++ {
 		var conn net.Conn
@@ -161,7 +161,7 @@ func TestUDPReceive(t *testing.T) {
 	requireStart(t, deps.Server, demux)
 	defer deps.Server.Stop()
 
-	conn, err := net.Dial("udp", deps.Server.UdpLocalAddr())
+	conn, err := net.Dial("udp", deps.Server.UDPLocalAddr())
 	require.NoError(t, err, "cannot connect to DSD socket")
 	defer conn.Close()
 
@@ -444,7 +444,7 @@ func TestUDPForward(t *testing.T) {
 	requireStart(t, deps.Server, demux)
 	defer deps.Server.Stop()
 
-	conn, err := net.Dial("udp", deps.Server.UdpLocalAddr())
+	conn, err := net.Dial("udp", deps.Server.UDPLocalAddr())
 	require.NoError(t, err, "cannot connect to DSD socket")
 	defer conn.Close()
 
@@ -477,7 +477,7 @@ func TestHistToDist(t *testing.T) {
 	requireStart(t, deps.Server, demux)
 	defer deps.Server.Stop()
 
-	conn, err := net.Dial("udp", deps.Server.UdpLocalAddr())
+	conn, err := net.Dial("udp", deps.Server.UDPLocalAddr())
 	require.NoError(t, err, "cannot connect to DSD socket")
 	defer conn.Close()
 
@@ -563,7 +563,7 @@ func TestE2EParsing(t *testing.T) {
 	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(log, 10*time.Millisecond)
 	requireStart(t, deps.Server, demux)
 
-	conn, err := net.Dial("udp", deps.Server.UdpLocalAddr())
+	conn, err := net.Dial("udp", deps.Server.UDPLocalAddr())
 	require.NoError(t, err, "cannot connect to DSD socket")
 	defer conn.Close()
 
@@ -583,7 +583,7 @@ func TestE2EParsing(t *testing.T) {
 	demux = aggregator.InitTestAgentDemultiplexerWithFlushInterval(deps.Log, 10*time.Millisecond)
 	requireStart(t, deps.Server, demux)
 
-	conn, err = net.Dial("udp", deps.Server.UdpLocalAddr())
+	conn, err = net.Dial("udp", deps.Server.UDPLocalAddr())
 	require.NoError(t, err, "cannot connect to DSD socket")
 	defer conn.Close()
 
@@ -609,7 +609,7 @@ func TestExtraTags(t *testing.T) {
 	requireStart(t, deps.Server, demux)
 	defer deps.Server.Stop()
 
-	conn, err := net.Dial("udp", deps.Server.UdpLocalAddr())
+	conn, err := net.Dial("udp", deps.Server.UDPLocalAddr())
 	require.NoError(t, err, "cannot connect to DSD socket")
 	defer conn.Close()
 
@@ -639,7 +639,7 @@ func TestStaticTags(t *testing.T) {
 	requireStart(t, deps.Server, demux)
 	defer deps.Server.Stop()
 
-	conn, err := net.Dial("udp", deps.Server.UdpLocalAddr())
+	conn, err := net.Dial("udp", deps.Server.UDPLocalAddr())
 	require.NoError(t, err, "cannot connect to DSD socket")
 	defer conn.Close()
 

--- a/comp/dogstatsd/server/server_test.go
+++ b/comp/dogstatsd/server/server_test.go
@@ -99,9 +99,7 @@ func fulfillDepsWithConfigYaml(t testing.TB, yaml string) serverDeps {
 func TestNewServer(t *testing.T) {
 	cfg := make(map[string]interface{})
 
-	port, err := getAvailableUDPPort()
-	require.NoError(t, err)
-	cfg["dogstatsd_port"] = port
+	cfg["dogstatsd_port"] = listeners.RandomPortName
 
 	deps := fulfillDepsWithConfigOverride(t, cfg)
 
@@ -710,13 +708,10 @@ func TestStaticTags(t *testing.T) {
 func TestNoMappingsConfig(t *testing.T) {
 	datadogYaml := ``
 
-	port, err := getAvailableUDPPort()
-	require.NoError(t, err)
-
 	deps := fulfillDepsWithConfigYaml(t, datadogYaml)
 	s := deps.Server.(*server)
 	cw := deps.Config.(config.ConfigWriter)
-	cw.Set("dogstatsd_port", port)
+	cw.Set("dogstatsd_port", listeners.RandomPortName)
 
 	samples := []metrics.MetricSample{}
 
@@ -727,7 +722,7 @@ func TestNoMappingsConfig(t *testing.T) {
 	assert.Nil(t, s.mapper)
 
 	parser := newParser(deps.Config, newFloat64ListPool())
-	samples, err = s.parseMetricMessage(samples, parser, []byte("test.metric:666|g"), "", false)
+	samples, err := s.parseMetricMessage(samples, parser, []byte("test.metric:666|g"), "", false)
 	assert.NoError(t, err)
 	assert.Len(t, samples, 1)
 }
@@ -863,9 +858,7 @@ func TestNewServerExtraTags(t *testing.T) {
 	cfg := make(map[string]interface{})
 
 	require := require.New(t)
-	port, err := getAvailableUDPPort()
-	require.NoError(err)
-	cfg["dogstatsd_port"] = port
+	cfg["dogstatsd_port"] = listeners.RandomPortName
 
 	deps := fulfillDepsWithConfigOverride(t, cfg)
 	s := deps.Server.(*server)


### PR DESCRIPTION

### What does this PR do?

Avoid time-of-check to time-of-use (TOCTOU) conditions when starting udp servers in dogstatsd tests. Make it possible to bind the dogstatsd udp listener to a random free port, and make the OS-assigned port available for tests.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fix an assortment of flaky tests.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
