### PR TITLE
[PROC-3080][process-agent] Block startup if the language detection grpc server fails to start

### DIFF
--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -145,7 +145,7 @@ func (p *ProcessCheck) Init(syscfg *SysProbeConfig, info *HostInfo) error {
 	if workloadmeta.Enabled(p.config) {
 		err = p.workloadMetaServer.Start()
 		if err != nil {
-			_ = log.Error("Failed to start the workloadmeta process entity gRPC server:", err)
+			return log.Error("Failed to start the workloadmeta process entity gRPC server:", err)
 		} else {
 			p.extractors = append(p.extractors, p.workloadMetaExtractor)
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR blocks the agent from starting up if there is an error starting the gRPC server that is used for language detection. This startup block only occurs if language detection is enabled.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Setting up language detection errors as a critical failure that need to be addressed.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
Failure to start the language detection grpc server will cause the process agent to exit.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
```yaml
process_config:
  process_collection: { enabled: true }
language_detection: { enabled: true }
```

Using the above config, start the process agent and wait for this message:
```
2023-08-30 19:07:14 UTC | PROCESS | INFO | (pkg/process/metadata/workloadmeta/grpc.go:81 in Start) | Process Entity WorkloadMeta gRPC server has started listening on 127.0.0.1:8080
```
Next, start a second instance of the process agent with the same config. The process agent should immediately exit due to a port conflict with the cmd port.

There is no need to test with `process_collection.enabled = false` because the process agent already fails to start on this error.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
