### PR TITLE
Use table formatting for go dep diff PR comments

### DIFF
--- a/tasks/diff.py
+++ b/tasks/diff.py
@@ -135,6 +135,7 @@ def go_deps(ctx, baseline_ref=None, report_file=None):
             pr_comment = [
                 f"Baseline: {baseline_ref}",
                 f"Comparison: {commit_sha}\n",
+                "<table><thead><tr><th>binary</th><th>os</th><th>arch</th><th>change</th></tr></thead><tbody>",
             ]
             for binary, details in binaries.items():
                 for combo in details.get("platforms"):
@@ -151,12 +152,15 @@ def go_deps(ctx, baseline_ref=None, report_file=None):
                         print(f"== {prettytarget} {color_add}, {color_remove} ==")
                         print(f"{color_patch(targetdiffs)}\n")
 
-                        summary = f"<summary>{prettytarget} +{add}, -{remove}</summary>"
-                        diff_block = f"\n```diff\n{targetdiffs}\n```\n"
-                        pr_comment.append(f"<details>{summary}\n{diff_block}</details>\n")
+                        summary = f"<summary>+{add}, -{remove}</summary>"
+                        diff_block = f"<pre lang='diff'>\n{targetdiffs}\n</pre>"
+                        pr_comment.append(
+                            f"<tr><td>{binary}</td><td>{goos}</td><td>{goarch}</td><td><details>{summary}\n{diff_block}</details></td></tr>"
+                        )
                     else:
                         print(f"== {prettytarget} ==\nno changes\n")
 
+            pr_comment.append("</tbody></table>")
             if report_file:
                 with open(report_file, 'w') as f:
                     f.write("\n".join(pr_comment))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Uses the following table formatting for the Go import difference PR comments:

<table>
  <thead>
    <tr>
      <th>binary</th>
      <th>os</th>
      <th>arch</th>
      <th>change</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>agent</td>
      <td>linux</td>
      <td>amd64</td>
      <td>
        <details>
          <summary>+1,-0</summary>
          <pre lang='diff'>
+golang.org/x/net/http2/h2c
          </pre>
        </details>
      </td>
    </tr>
  </tbody>
</table>

### Motivation

Make it easier to scan the results

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
