### PR TITLE
Only build nightly SMP images for `main` branch

### DIFF
--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -224,10 +224,9 @@ single_machine_performance-nightly-amd64-a7:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
   rules:
-    !reference [.on_deploy_nightly_repo_branch_a7]
-  only:
-    variables:
-      - $CI_COMMIT_BRANCH == "main"
+    - !reference [.on_deploy_nightly_repo_branch_a7]
+    - if $CI_COMMIT_BRANCH != main
+      when: never
   needs:
     - docker_build_agent7
   variables:

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -225,7 +225,7 @@ single_machine_performance-nightly-amd64-a7:
   stage: dev_container_deploy
   rules:
     - !reference [.on_deploy_nightly_repo_branch_a7]
-    - if: $CI_COMMIT_BRANCH == main
+    - !reference [.if_main_branch]
   needs:
     - docker_build_agent7
   variables:

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -225,12 +225,15 @@ single_machine_performance-nightly-amd64-a7:
   stage: dev_container_deploy
   rules:
     !reference [.on_deploy_nightly_repo_branch_a7]
+  only:
+    variables:
+      - $CI_COMMIT_BRANCH == "main"
   needs:
     - docker_build_agent7
   variables:
     IMG_REGISTRIES: internal-aws-smp
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64
-    IMG_DESTINATIONS: 08450328-agent:nightly-${CI_COMMIT_SHA}-7-amd64
+    IMG_DESTINATIONS: 08450328-agent:nightly-${CI_COMMIT_BRANCH}-${CI_COMMIT_SHA}-7-amd64
 
 # deploys nightlies to agent-dev
 dev_nightly-dogstatsd:

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -224,8 +224,7 @@ single_machine_performance-nightly-amd64-a7:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
   rules:
-    - !reference [.on_deploy_nightly_repo_branch_a7]
-    - !reference [.if_main_branch]
+    - !reference [.if_scheduled_main]
   needs:
     - docker_build_agent7
   variables:

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -225,7 +225,7 @@ single_machine_performance-nightly-amd64-a7:
   stage: dev_container_deploy
   rules:
     - !reference [.on_deploy_nightly_repo_branch_a7]
-    - if $CI_COMMIT_BRANCH == main
+    - if: $CI_COMMIT_BRANCH == main
   needs:
     - docker_build_agent7
   variables:

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -225,8 +225,7 @@ single_machine_performance-nightly-amd64-a7:
   stage: dev_container_deploy
   rules:
     - !reference [.on_deploy_nightly_repo_branch_a7]
-    - if $CI_COMMIT_BRANCH != main
-      when: never
+    - if $CI_COMMIT_BRANCH == main
   needs:
     - docker_build_agent7
   variables:


### PR DESCRIPTION
### What does this PR do?

The Workload Checks analysis is built with the assumption that we will be comparing successive main branches. We misunderstood how the nightly scheduled functioned and believed that we would be running from simply main. This is not true. To correct this we restrict builds of
single_machine_performance-nightly-amd64-a7 to main branch only.

### Related Issues 

REF SMP-673
