### PR TITLE
[serverless] fix missing report log spindown metrics

### DIFF
--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -27,7 +27,7 @@ import (
 // ShutdownDelay is the amount of time we wait before shutting down the HTTP server
 // after we receive a Shutdown event. This allows time for the final log messages
 // to arrive from the Logs API.
-var ShutdownDelay time.Duration = 1 * time.Second
+var ShutdownDelay time.Duration = 100 * time.Millisecond
 
 // FlushTimeout is the amount of time to wait for a flush to complete.
 const FlushTimeout time.Duration = 5 * time.Second

--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -27,7 +27,7 @@ import (
 // ShutdownDelay is the amount of time we wait before shutting down the HTTP server
 // after we receive a Shutdown event. This allows time for the final log messages
 // to arrive from the Logs API.
-var ShutdownDelay time.Duration = 200 * time.Millisecond
+var ShutdownDelay = 200 * time.Millisecond
 
 // FlushTimeout is the amount of time to wait for a flush to complete.
 const FlushTimeout time.Duration = 5 * time.Second

--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -27,7 +27,7 @@ import (
 // ShutdownDelay is the amount of time we wait before shutting down the HTTP server
 // after we receive a Shutdown event. This allows time for the final log messages
 // to arrive from the Logs API.
-var ShutdownDelay time.Duration = 100 * time.Millisecond
+var ShutdownDelay time.Duration = 200 * time.Millisecond
 
 // FlushTimeout is the amount of time to wait for a flush to complete.
 const FlushTimeout time.Duration = 5 * time.Second


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Fixes a bug where we won't receive report log generated enhanced metrics when a lambda is idle and receives a spindown event. This happens with specific runtimes, I've noticed it mainly with low memory nodejs custom runtime container lambdas as well as ruby non-container lambdas, predominantly with 128 or 256mb.

AWS advertises we will have ~1.7 seconds after receiving a spindown event to do work, though in these specific runtimes it will sometimes be <1.3 seconds (AWS gives us the deadline timestamp alongside the spindown event). This causes the lambda to be shutdown before we are able to send the outgoing http request (as serialization and goroutine context switching takes hundreds of ms)

The fix for this is lowering the shutdown delay. We can do this as I've benchmarked how long it actually takes to receive and process the `REPORT` log from the lambda API, and it's fully processed on average just single milliseconds after getting the spindown event, sometimes even before that. Occasionally it will creep closer to 100ms.

Through RCs and self-monitoring apps, 200ms shutdown delay seems to be the sweetspot for very consistent reporting of report log metrics.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

![image](https://github.com/DataDog/datadog-agent/assets/51187184/f5e075ae-30a0-4bf3-bf1b-644cd87e5a06)
- Self-monitoring app of node custom runtime container, node alpine custom runtime container, and python custom runtime container lambdas
![image](https://github.com/DataDog/datadog-agent/assets/51187184/789f3ff2-38c0-41d4-80f3-62d0d880518e)
- No regressions in our old deprecated self-monitoring app
![image](https://github.com/DataDog/datadog-agent/assets/51187184/2c361c9c-e626-46ed-be01-8d4bcb4109f3)
- No regressions in our new RC self-monitoring app
![image](https://github.com/DataDog/datadog-agent/assets/51187184/1d2161fb-3e64-4957-ac67-b7acc017c194)
- new RC self-monitoring app cold start lambdas are stable before & after the changes

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
