### PR TITLE
Avoid unnecessary allocations in `BuildAgentKey`

### DIFF
--- a/pkg/util/cache/cache.go
+++ b/pkg/util/cache/cache.go
@@ -32,6 +32,9 @@ var Cache = cache.New(defaultExpire, defaultPurge)
 // and path elements passed as arguments. It is to be used by core agent
 // packages to reuse the prefix constant
 func BuildAgentKey(keys ...string) string {
+	// NOTE this function is called repeatedly in the normal operation of
+	// the Agent. In PR #19125 we modified its internals to allocate
+	// less. Please be aware that this function is an allocation hotspot.
 	var builder strings.Builder
 
 	// Preallocate memory for the passed keys and the slashes. This will be


### PR DESCRIPTION
### What does this PR do?

In the regression detector experiment `tcp_syslog_to_blackhole` we see that `BuildAgentKey` accounts for ~20% of Agent allocations, see [this notebook](https://app.datadoghq.com/notebook/6376068/agent-performance-investigation-gethostname?view=view-mode) for reference to the profiles. Most of _those_ allocations are in `path.Join` and as the Agent never has a '..' et al present in its keys and the prefix is guaranteed non-empty we can simplify to just the use of a `strings.Builder`.

### Motivation

Reduce allocation load in the Agent. 

### Possible Drawbacks / Trade-offs

We don't document that `BuildAgentKey` has the same semantics in joining as `path.Join` but this is a change to how this function operates in practice, not just a simple internals swap. Examining the project I don't believe any of the more elaborate nature of `path.Join` is relied on, but I suppose tests will tell. 

### Describe how to test/QA your changes

I expect most of the result to come in the regression detector results and in profiles. I'll link here when those are ready.

### Related Issues 

REF SMP-673

