### PR TITLE
Add connection loss handling in custom queries

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/custom_queries.go
+++ b/pkg/collector/corechecks/oracle-dbm/custom_queries.go
@@ -50,7 +50,6 @@ func (c *Check) CustomQueries() error {
 			return fmt.Errorf("empty connection")
 		}
 		c.dbCustomQueries = db
-		c.dbCustomQueries.SetMaxOpenConns(1)
 	}
 
 	var metricRows []metricRow
@@ -84,7 +83,7 @@ func (c *Check) CustomQueries() error {
 			_, err := c.dbCustomQueries.Exec(fmt.Sprintf("alter session set container = %s", pdb))
 			if err != nil {
 				log.Errorf("failed to set container %s %s", pdb, err)
-				reconnectOnConnectionError(c, c.dbCustomQueries, err)
+				reconnectOnConnectionError(c, &c.dbCustomQueries, err)
 				continue
 			}
 		}

--- a/pkg/collector/corechecks/oracle-dbm/custom_queries.go
+++ b/pkg/collector/corechecks/oracle-dbm/custom_queries.go
@@ -83,7 +83,8 @@ func (c *Check) CustomQueries() error {
 			}
 			_, err := c.dbCustomQueries.Exec(fmt.Sprintf("alter session set container = %s", pdb))
 			if err != nil {
-				log.Errorf("Can't set container to %s", pdb)
+				log.Errorf("failed to set container %s %s", pdb, err)
+				reconnectOnConnectionError(c, c.dbCustomQueries, err)
 				continue
 			}
 		}

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -466,19 +466,11 @@ func appendPDBTag(tags []string, pdb sql.NullString) []string {
 
 func selectWrapper[T any](c *Check, s T, sql string, binds ...interface{}) error {
 	err := c.db.Select(s, sql, binds...)
-	if err != nil && (strings.Contains(err.Error(), "ORA-01012") || strings.Contains(err.Error(), "ORA-06413") || strings.Contains(err.Error(), "database is closed")) {
-		db, err := c.Connect()
-		if err != nil {
-			c.Teardown()
-			return err
-		}
-		c.db = db
-	}
-
+	reconnectOnConnectionError(c, &c.db, err)
 	return err
 }
 
-func reconnectOnConnectionError(c *Check, db *sqlx.DB, err error) {
+func reconnectOnConnectionError(c *Check, db **sqlx.DB, err error) {
 	if err == nil {
 		return
 	}
@@ -493,16 +485,17 @@ func reconnectOnConnectionError(c *Check, db *sqlx.DB, err error) {
 	if !isError {
 		return
 	}
-	db, err = c.Connect()
+	log.Tracef("Reconnecting")
+	*db, err = c.Connect()
 	if err != nil {
 		log.Errorf("failed to reconnect %s", err)
-		closeDatabase(c, c.dbCustomQueries)
+		closeDatabase(c, *db)
 	}
 }
 
 func closeDatabase(c *Check, db *sqlx.DB) {
-	if c.db != nil {
-		if err := c.db.Close(); err != nil {
+	if db != nil {
+		if err := db.Close(); err != nil {
 			log.Warnf("failed to close oracle connection | server=[%s]: %s", c.config.Server, err.Error())
 		}
 	}

--- a/releasenotes/notes/oracle-set-container-connection-loss-85532c9ef33aabfc.yaml
+++ b/releasenotes/notes/oracle-set-container-connection-loss-85532c9ef33aabfc.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Improve recovering from lost connection in custom query.
+    Improve recovering from lost connections in custom queries.

--- a/releasenotes/notes/oracle-set-container-connection-loss-85532c9ef33aabfc.yaml
+++ b/releasenotes/notes/oracle-set-container-connection-loss-85532c9ef33aabfc.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Improve recovering from lost connection in custom query.


### PR DESCRIPTION
### What does this PR do?

Implementing workaround for recovering form connection loss in custom query. Refactor handling connection loss in metrics and events collection.

### Motivation

The Oracle Go libraries don't handle that.

https://datadoghq.atlassian.net/browse/DBM-2791

### Describe how to test/QA your changes

Kill sessions and verify that the agent reconnects.

`select 'alter system kill session ''' || sid || ',' || serial# || ''';' from v$session where username = 'C##DATADOG' ;`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
