### PR TITLE
Fix linter revive errors

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -67,8 +67,8 @@ GROUP BY s.con_id, c.name, force_matching_signature, plan_hash_value
 HAVING MAX (last_active_time) > sysdate - :seconds/24/60/60
 FETCH FIRST :limit ROWS ONLY`
 
-// Querying force_matching_signature = 0
-const QUERY_FMS_LAST_ACTIVE = `SELECT /* DD_QM_FMS */ s.con_id con_id, c.name pdb_name, s.force_matching_signature, plan_hash_value, 
+// queryForceMatchingSignatureLastActive Querying force_matching_signature = 0
+const queryForceMatchingSignatureLastActive = `SELECT /* DD_QM_FMS */ s.con_id con_id, c.name pdb_name, s.force_matching_signature, plan_hash_value, 
 	max(dbms_lob.substr(sql_fulltext, 1000, 1)) sql_text, max(length(sql_text)) sql_text_length, sq.sql_id,
 	sum(parse_calls) as parse_calls,
 	sum(disk_reads) as disk_reads,
@@ -117,8 +117,8 @@ WHERE s.con_id = c.con_id (+) AND sq.force_matching_signature = s.force_matching
 GROUP BY s.con_id, c.name, s.force_matching_signature, plan_hash_value, sq.sql_id 
 FETCH FIRST :limit ROWS ONLY`
 
-// Querying force_matching_signature = 0
-const QUERY_SQLID = `SELECT /* DD_QM_SQLID */ s.con_id con_id, c.name pdb_name, sql_id, plan_hash_value, 
+// querySQLID force_matching_signature = 0
+const querySQLID = `SELECT /* DD_QM_SQLID */ s.con_id con_id, c.name pdb_name, sql_id, plan_hash_value, 
 	dbms_lob.substr(sql_fulltext, 1000, 1) sql_text, length(sql_text) sql_text_length, 
 	parse_calls,
 	disk_reads,
@@ -512,7 +512,7 @@ func (c *Check) StatementMetrics() (int, error) {
 		if c.config.QueryMetrics.DisableLastActive {
 			sql = QUERY_FMS_RANDOM
 		} else {
-			sql = QUERY_FMS_LAST_ACTIVE
+			sql = queryForceMatchingSignatureLastActive
 		}
 		err := selectWrapper(
 			c,
@@ -529,7 +529,7 @@ func (c *Check) StatementMetrics() (int, error) {
 		statementMetricsAll := make([]StatementMetricsDB, len(statementMetrics))
 		copy(statementMetricsAll, statementMetrics)
 
-		sql = QUERY_SQLID
+		sql = querySQLID
 		err = selectWrapper(
 			c,
 			&statementMetrics,


### PR DESCRIPTION
### What does this PR do?

Fix linter revive errors.

### Additional Notes

The problem was introduced with https://github.com/DataDog/datadog-agent/pull/18903 . Unfortunately, it remained unnoticed because linter revive check has been recently introduced, and the branch wasn't rebased before merging.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
