### PR TITLE
[CWS] do not fork from the wrong parent

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -630,6 +630,8 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
     fill_file(syscall->exec.dentry, &pc.entry.executable);
     bpf_get_current_comm(&pc.entry.comm, sizeof(pc.entry.comm));
 
+    u64 parent_inode = 0;
+
     // select the previous cookie entry in cache of the current process
     // (this entry was created by the fork of the current process)
     struct pid_cache_t *fork_entry = (struct pid_cache_t *) bpf_map_lookup_elem(&pid_cache, &tgid);
@@ -638,6 +640,8 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
         u64 parent_cookie = fork_entry->cookie;
         struct proc_cache_t *parent_pc = get_proc_from_cookie(parent_cookie);
         if (parent_pc) {
+            parent_inode = parent_pc->entry.executable.path_key.ino;
+
             // inherit the parent container context
             fill_container_context(parent_pc, &pc.container);
             dec_mount_ref(ctx, parent_pc->entry.executable.path_key.mount_id);
@@ -679,6 +683,9 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
     // add pid / tid context
     struct process_context_t *on_stack_process = &event->process;
     fill_process_context(on_stack_process);
+
+    // override the pid context inode with the parent inode so that we can compare
+    on_stack_process->inode = parent_inode;
 
     copy_span_context(&syscall->exec.span_context, &event->span);
     fill_args_envs(event, syscall);

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -155,6 +155,9 @@ var (
 	// MetricProcessEventBrokenLineage is the name of the metric used to report a broken lineage
 	// Tags: -
 	MetricProcessEventBrokenLineage = newRuntimeMetric(".process_resolver.event_broken_lineage")
+	// MetricProcessEventBrokenLineage is the name of the metric used to report a broken lineage
+	// Tags: -
+	MetricProcessInodeError = newRuntimeMetric(".process_resolver.inode_error")
 
 	// Mount resolver metrics
 

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -155,7 +155,7 @@ var (
 	// MetricProcessEventBrokenLineage is the name of the metric used to report a broken lineage
 	// Tags: -
 	MetricProcessEventBrokenLineage = newRuntimeMetric(".process_resolver.event_broken_lineage")
-	// MetricProcessEventBrokenLineage is the name of the metric used to report a broken lineage
+	// MetricProcessInodeError is the name of the metric used to report a broken lineage with a inode mismatch
 	// Tags: -
 	MetricProcessInodeError = newRuntimeMetric(".process_resolver.inode_error")
 

--- a/pkg/security/resolvers/process/resolver_linux.go
+++ b/pkg/security/resolvers/process/resolver_linux.go
@@ -530,9 +530,16 @@ func (p *Resolver) insertForkEntry(entry *model.ProcessCacheEntry, source uint64
 		parent = p.resolve(entry.PPid, entry.PPid, entry.ExecInode, true)
 	}
 
-	if parent != nil {
-		parent.Fork(entry)
+	if parent == nil {
+		return
 	}
+
+	// check the inode to make sure that if we miss an exec, we don't copy the data from the wrong parent.
+	if parent.FileEvent.Inode != entry.ExecInode {
+		return
+	}
+
+	parent.Fork(entry)
 
 	p.insertEntry(entry, prev, source)
 }

--- a/pkg/security/resolvers/process/resolver_test.go
+++ b/pkg/security/resolvers/process/resolver_test.go
@@ -47,14 +47,14 @@ func TestFork1st(t *testing.T) {
 	child.ForkTime = time.Now()
 
 	// parent
-	resolver.AddForkEntry(parent)
+	resolver.AddForkEntry(parent, 0)
 	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.EqualValues(t, 1, resolver.cacheSize.Load())
 
 	// parent
 	//     \ child
-	resolver.AddForkEntry(child)
+	resolver.AddForkEntry(child, 0)
 	assert.Equal(t, child, resolver.entryCache[child.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent, child.Ancestor)
@@ -86,14 +86,14 @@ func TestFork2nd(t *testing.T) {
 	child.ForkTime = time.Now()
 
 	// parent
-	resolver.AddForkEntry(parent)
+	resolver.AddForkEntry(parent, 0)
 	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.EqualValues(t, 1, resolver.cacheSize.Load())
 
 	// parent
 	//     \ child
-	resolver.AddForkEntry(child)
+	resolver.AddForkEntry(child, 0)
 	assert.Equal(t, child, resolver.entryCache[child.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent, child.Ancestor)
@@ -132,14 +132,14 @@ func TestForkExec(t *testing.T) {
 	exec.ExecTime = time.Now()
 
 	// parent
-	resolver.AddForkEntry(parent)
+	resolver.AddForkEntry(parent, 0)
 	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.EqualValues(t, 1, resolver.cacheSize.Load())
 
 	// parent
 	//     \ child
-	resolver.AddForkEntry(child)
+	resolver.AddForkEntry(child, 0)
 	assert.Equal(t, child, resolver.entryCache[child.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent, child.Ancestor)
@@ -147,7 +147,7 @@ func TestForkExec(t *testing.T) {
 
 	// parent
 	//     \ [child] -> exec
-	resolver.AddExecEntry(exec)
+	resolver.AddExecEntry(exec, 0)
 	assert.Equal(t, exec, resolver.entryCache[exec.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, child, exec.Ancestor)
@@ -189,14 +189,14 @@ func TestOrphanExec(t *testing.T) {
 	exec.ExecTime = time.Now()
 
 	// parent
-	resolver.AddForkEntry(parent)
+	resolver.AddForkEntry(parent, 0)
 	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.EqualValues(t, 1, resolver.cacheSize.Load())
 
 	// parent
 	//     \ child
-	resolver.AddForkEntry(child)
+	resolver.AddForkEntry(child, 0)
 	assert.Equal(t, child, resolver.entryCache[child.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent, child.Ancestor)
@@ -211,7 +211,7 @@ func TestOrphanExec(t *testing.T) {
 
 	// [parent]
 	//     \ [child] -> exec
-	resolver.AddExecEntry(exec)
+	resolver.AddExecEntry(exec, 0)
 	assert.Equal(t, exec, resolver.entryCache[exec.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.Equal(t, child, exec.Ancestor)
@@ -250,14 +250,14 @@ func TestForkExecExec(t *testing.T) {
 	exec2.ExecTime = time.Now()
 
 	// parent
-	resolver.AddForkEntry(parent)
+	resolver.AddForkEntry(parent, 0)
 	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.EqualValues(t, 1, resolver.cacheSize.Load())
 
 	// parent
 	//     \ child
-	resolver.AddForkEntry(child)
+	resolver.AddForkEntry(child, 0)
 	assert.Equal(t, child, resolver.entryCache[child.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent, child.Ancestor)
@@ -272,7 +272,7 @@ func TestForkExecExec(t *testing.T) {
 
 	// [parent]
 	//     \ [child] -> exec1
-	resolver.AddExecEntry(exec1)
+	resolver.AddExecEntry(exec1, 0)
 	assert.Equal(t, exec1, resolver.entryCache[exec1.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.Equal(t, child, exec1.Ancestor)
@@ -281,7 +281,7 @@ func TestForkExecExec(t *testing.T) {
 
 	// [parent]
 	//     \ [child] -> [exec1] -> exec2
-	resolver.AddExecEntry(exec2)
+	resolver.AddExecEntry(exec2, 0)
 	assert.Equal(t, exec2, resolver.entryCache[exec2.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.Equal(t, exec1, exec2.Ancestor)
@@ -322,14 +322,14 @@ func TestForkReuse(t *testing.T) {
 	child2.ForkTime = time.Now()
 
 	// parent1
-	resolver.AddForkEntry(parent1)
+	resolver.AddForkEntry(parent1, 0)
 	assert.Equal(t, parent1, resolver.entryCache[parent1.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.EqualValues(t, 1, resolver.cacheSize.Load())
 
 	// parent1
 	//     \ child1
-	resolver.AddForkEntry(child1)
+	resolver.AddForkEntry(child1, 0)
 	assert.Equal(t, child1, resolver.entryCache[child1.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent1, child1.Ancestor)
@@ -344,7 +344,7 @@ func TestForkReuse(t *testing.T) {
 
 	// [parent1]
 	//     \ [child1] -> exec1
-	resolver.AddExecEntry(exec1)
+	resolver.AddExecEntry(exec1, 0)
 	assert.Equal(t, exec1, resolver.entryCache[exec1.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.Equal(t, child1, exec1.Ancestor)
@@ -355,7 +355,7 @@ func TestForkReuse(t *testing.T) {
 	//     \ [child1] -> exec1
 	//
 	// parent2:pid1
-	resolver.AddForkEntry(parent2)
+	resolver.AddForkEntry(parent2, 0)
 	assert.Equal(t, parent2, resolver.entryCache[parent2.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.EqualValues(t, 4, resolver.cacheSize.Load())
@@ -365,7 +365,7 @@ func TestForkReuse(t *testing.T) {
 	//
 	// parent2:pid1
 	//     \ child2
-	resolver.AddForkEntry(child2)
+	resolver.AddForkEntry(child2, 0)
 	assert.Equal(t, child2, resolver.entryCache[child2.Pid])
 	assert.Equal(t, 3, len(resolver.entryCache))
 	assert.Equal(t, parent2, child2.Ancestor)
@@ -415,13 +415,13 @@ func TestForkForkExec(t *testing.T) {
 	childExec.ExecTime = time.Now()
 
 	// parent
-	resolver.AddForkEntry(parent)
+	resolver.AddForkEntry(parent, 0)
 	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 
 	// parent
 	//     \ child
-	resolver.AddForkEntry(child)
+	resolver.AddForkEntry(child, 0)
 	assert.Equal(t, child, resolver.entryCache[child.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent, child.Ancestor)
@@ -429,7 +429,7 @@ func TestForkForkExec(t *testing.T) {
 	// parent
 	//     \ child
 	//          \ grandChild
-	resolver.AddForkEntry(grandChild)
+	resolver.AddForkEntry(grandChild, 0)
 	assert.Equal(t, grandChild, resolver.entryCache[grandChild.Pid])
 	assert.Equal(t, 3, len(resolver.entryCache))
 	assert.Equal(t, child, grandChild.Ancestor)
@@ -438,7 +438,7 @@ func TestForkForkExec(t *testing.T) {
 	// parent
 	//     \ [child] -> childExec
 	//          \ grandChild
-	resolver.AddExecEntry(childExec)
+	resolver.AddExecEntry(childExec, 0)
 	assert.Equal(t, childExec, resolver.entryCache[childExec.Pid])
 	assert.Equal(t, 3, len(resolver.entryCache))
 	assert.Equal(t, child, childExec.Ancestor)
@@ -492,14 +492,14 @@ func TestExecBomb(t *testing.T) {
 	exec2.ExecTime = time.Now()
 
 	// parent
-	resolver.AddForkEntry(parent)
+	resolver.AddForkEntry(parent, 0)
 	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.EqualValues(t, 1, resolver.cacheSize.Load())
 
 	// parent
 	//     \ child
-	resolver.AddForkEntry(child)
+	resolver.AddForkEntry(child, 0)
 	assert.Equal(t, child, resolver.entryCache[child.Pid])
 	assert.Equal(t, 2, len(resolver.entryCache))
 	assert.Equal(t, parent, child.Ancestor)
@@ -514,7 +514,7 @@ func TestExecBomb(t *testing.T) {
 
 	// [parent]
 	//     \ [child] -> exec1
-	resolver.AddExecEntry(exec1)
+	resolver.AddExecEntry(exec1, 0)
 	assert.Equal(t, exec1, resolver.entryCache[exec1.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.Equal(t, child, exec1.Ancestor)
@@ -523,7 +523,7 @@ func TestExecBomb(t *testing.T) {
 
 	// [parent]
 	//     \ [child] -> [exec1] -> exec2
-	resolver.AddExecEntry(exec2)
+	resolver.AddExecEntry(exec2, 0)
 	assert.Equal(t, exec1, resolver.entryCache[exec2.Pid])
 	assert.Equal(t, 1, len(resolver.entryCache))
 	assert.Equal(t, exec1.ExecTime, exec2.ExecTime)
@@ -536,43 +536,88 @@ func TestExecBomb(t *testing.T) {
 	testCacheSize(t, resolver)
 }
 
-func TestExecLoss(t *testing.T) {
+func TestExecLostFork(t *testing.T) {
 	resolver, err := NewResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	parent := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 1, Tid: 1})
+	parent := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 11, Tid: 11})
 	parent.FileEvent.BasenameStr = "agent"
 	parent.ForkTime = time.Now()
 	parent.FileEvent.Inode = 1
 	parent.ExecInode = 1
 
 	// parent
-	resolver.AddForkEntry(parent)
+	resolver.AddForkEntry(parent, 0)
 
-	child := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 2, Tid: 2})
+	child := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 22, Tid: 22})
 	child.PPid = parent.Pid
 	child.FileEvent.Inode = 1
-	parent.ExecInode = 1
 
 	// parent
 	//     \ child
-	resolver.AddForkEntry(child)
+	resolver.AddForkEntry(child, parent.ExecInode)
 
-	// exec loss
+	assert.Equal(t, "agent", child.FileEvent.BasenameStr)
+	assert.False(t, child.IsParentMissing)
 
-	child1 := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 3, Tid: 3})
+	// exec loss with inode 2
+
+	child1 := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 33, Tid: 33})
 	child1.FileEvent.BasenameStr = "sh"
 	child1.PPid = child.Pid
 	child1.ExecInode = 2
 
 	// parent
 	//     \ child
-	resolver.AddForkEntry(child1)
+	//		\ child1
+	resolver.AddForkEntry(child1, child1.ExecInode)
 
-	assert.Equal(t, "sh", child1.FileEvent.BasenameStr)
-	assert.Nil(t, child1.Parent)
+	assert.Equal(t, "agent", child1.FileEvent.BasenameStr)
+	assert.True(t, child1.IsParentMissing)
+}
+
+func TestExecLostExec(t *testing.T) {
+	resolver, err := NewResolver(nil, nil, &statsd.NoOpClient{}, nil, nil, nil, nil, nil, nil, nil, NewResolverOpts())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parent := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 11, Tid: 11})
+	parent.FileEvent.BasenameStr = "agent"
+	parent.ForkTime = time.Now()
+	parent.FileEvent.Inode = 1
+	parent.ExecInode = 1
+
+	// parent
+	resolver.AddForkEntry(parent, 0)
+
+	child := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 11, Tid: 11})
+	child.PPid = parent.Pid
+	child.FileEvent.Inode = 2
+
+	// parent
+	//     \ child
+	resolver.AddExecEntry(child, parent.ExecInode)
+
+	assert.Equal(t, "agent", child.FileEvent.BasenameStr)
+	assert.False(t, child.IsParentMissing)
+
+	// exec loss with inode 2
+
+	child1 := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 33, Tid: 33})
+	child1.FileEvent.BasenameStr = "sh"
+	child1.PPid = child.Pid
+	child1.ExecInode = 2
+
+	// parent
+	//     \ child
+	//		\ child1
+	resolver.AddForkEntry(child1, child1.ExecInode)
+
+	assert.Equal(t, "agent", child1.FileEvent.BasenameStr)
+	assert.True(t, child1.IsParentMissing)
 }
 
 func TestIsExecChildRuntime(t *testing.T) {
@@ -586,7 +631,7 @@ func TestIsExecChildRuntime(t *testing.T) {
 	parent.FileEvent.Inode = 1
 
 	// parent
-	resolver.AddForkEntry(parent)
+	resolver.AddForkEntry(parent, 0)
 
 	child := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 2, Tid: 2})
 	child.PPid = parent.Pid
@@ -594,7 +639,7 @@ func TestIsExecChildRuntime(t *testing.T) {
 
 	// parent
 	//     \ child
-	resolver.AddForkEntry(child)
+	resolver.AddForkEntry(child, 0)
 
 	// parent
 	//     \ child
@@ -603,7 +648,7 @@ func TestIsExecChildRuntime(t *testing.T) {
 	child2 := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 2, Tid: 2})
 	child2.FileEvent.Inode = 2
 	child2.PPid = child.Pid
-	resolver.AddExecEntry(child2)
+	resolver.AddExecEntry(child2, 0)
 
 	// parent
 	//     \ child
@@ -613,7 +658,7 @@ func TestIsExecChildRuntime(t *testing.T) {
 	child3 := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 2, Tid: 2})
 	child3.FileEvent.Inode = 3
 	child3.PPid = child2.Pid
-	resolver.AddExecEntry(child3)
+	resolver.AddExecEntry(child3, 0)
 
 	assert.False(t, parent.IsExecChild)
 	assert.False(t, parent.IsThread) // root node, no fork
@@ -630,7 +675,7 @@ func TestIsExecChildRuntime(t *testing.T) {
 	child4 := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 2, Tid: 2})
 	child4.FileEvent.Inode = 3
 	child4.PPid = child3.Pid
-	resolver.AddExecEntry(child4)
+	resolver.AddExecEntry(child4, 0)
 
 	assert.True(t, child3.IsExecChild)
 	assert.False(t, child3.IsThread)
@@ -674,7 +719,7 @@ func TestIsExecChildSnapshot(t *testing.T) {
 	child2 := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 2, Tid: 2})
 	child2.FileEvent.Inode = 3
 	child2.PPid = child.Pid
-	resolver.AddExecEntry(child2)
+	resolver.AddExecEntry(child2, 0)
 
 	assert.False(t, child2.IsExecChild)
 	assert.False(t, child2.IsThread)
@@ -682,7 +727,7 @@ func TestIsExecChildSnapshot(t *testing.T) {
 	child3 := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 2, Tid: 2})
 	child3.FileEvent.Inode = 4
 	child3.PPid = child2.Pid
-	resolver.AddExecEntry(child3)
+	resolver.AddExecEntry(child3, 0)
 
 	assert.True(t, child3.IsExecChild)
 	assert.False(t, child3.IsThread)

--- a/pkg/security/resolvers/process/resolver_test.go
+++ b/pkg/security/resolvers/process/resolver_test.go
@@ -593,31 +593,32 @@ func TestExecLostExec(t *testing.T) {
 	// parent
 	resolver.AddForkEntry(parent, 0)
 
-	child := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 11, Tid: 11})
-	child.PPid = parent.Pid
-	child.FileEvent.Inode = 2
+	child1 := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 22, Tid: 22})
+	child1.PPid = parent.Pid
+	child1.FileEvent.Inode = 1
+	child1.ExecInode = 1
 
 	// parent
-	//     \ child
-	resolver.AddExecEntry(child, parent.ExecInode)
-
-	assert.Equal(t, "agent", child.FileEvent.BasenameStr)
-	assert.False(t, child.IsParentMissing)
-
-	// exec loss with inode 2
-
-	child1 := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 33, Tid: 33})
-	child1.FileEvent.BasenameStr = "sh"
-	child1.PPid = child.Pid
-	child1.ExecInode = 2
-
-	// parent
-	//     \ child
-	//		\ child1
-	resolver.AddForkEntry(child1, child1.ExecInode)
+	//     \ child1
+	resolver.AddForkEntry(child1, parent.ExecInode)
 
 	assert.Equal(t, "agent", child1.FileEvent.BasenameStr)
-	assert.True(t, child1.IsParentMissing)
+	assert.False(t, child1.IsParentMissing)
+
+	// exec loss with inode 2 and pid 22
+
+	child2 := resolver.NewProcessCacheEntry(model.PIDContext{Pid: 33, Tid: 33})
+	child2.FileEvent.BasenameStr = "sh"
+	child2.PPid = child1.Pid
+	child2.ExecInode = 2
+
+	// parent
+	//     \ child1
+	//		\ child2
+	resolver.AddForkEntry(child2, child2.ExecInode)
+
+	assert.Equal(t, "agent", child2.FileEvent.BasenameStr)
+	assert.True(t, child2.IsParentMissing)
 }
 
 func TestIsExecChildRuntime(t *testing.T) {

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -337,8 +337,9 @@ type Process struct {
 	ScrubbedArgsTruncated bool           `field:"-" json:"-"`
 	Variables             eval.Variables `field:"-" json:"-"`
 
-	IsThread    bool `field:"is_thread"` // SECLDoc[is_thread] Definition:`Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)`
-	IsExecChild bool `field:"-"`         // Indicates whether the process is an exec child of its parent
+	IsThread        bool `field:"is_thread"` // SECLDoc[is_thread] Definition:`Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)`
+	IsExecChild     bool `field:"-"`         // Indicates whether the process is an exec child of its parent
+	IsParentMissing bool `field:"-"`         // Indicates the direct parent is missing
 
 	Source uint64 `field:"-" json:"-"`
 }

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -550,7 +550,7 @@ const (
 	ProcessCacheEntryFromUnknown   = iota // ProcessCacheEntryFromUnknown defines a process cache entry from unknown
 	ProcessCacheEntryFromEvent            // ProcessCacheEntryFromEvent defines a process cache entry from event
 	ProcessCacheEntryFromKernelMap        // ProcessCacheEntryFromKernelMap defines a process cache entry from kernel map
-	ProcessCacheEntryFromProcFS           // ProcessCacheEntryFromProcFS defines a process cache entry from procfs
+	ProcessCacheEntryFromProcFS           // ProcessCacheEntryFromProcFS defines a process cache entry from procfs. Note that some exec parent may be missing.
 	ProcessCacheEntryFromSnapshot         // ProcessCacheEntryFromSnapshot defines a process cache entry from snapshot
 )
 

--- a/pkg/security/secl/model/process_cache_entry_unix.go
+++ b/pkg/security/secl/model/process_cache_entry_unix.go
@@ -39,6 +39,21 @@ func (pc *ProcessCacheEntry) HasCompleteLineage() bool {
 	return false
 }
 
+// HasValidLineage returns false if, from the entry, we cannot ascend the ancestors list to PID 1 or if a new is having a missing parent
+func (pc *ProcessCacheEntry) HasValidLineage() bool {
+	for pc != nil {
+		if pc.IsParentMissing {
+			return false
+		}
+
+		if pc.Pid == 1 {
+			return true
+		}
+		pc = pc.Ancestor
+	}
+	return false
+}
+
 // Exit a process
 func (pc *ProcessCacheEntry) Exit(exitTime time.Time) {
 	pc.ExitTime = exitTime


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This fixes:

```
agent -> [fork] -> agent -> [exec loss] -> dash -> [fork] -> dash
```
generating
```
agent -> [fork] -> agent -> [fork] -> agent
```

The node is inserted but without a parent. This will generate a broken lineage error.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
