### PR TITLE
[windows] update to new NPM driver (#18823)

### DIFF
--- a/release.json
+++ b/release.json
@@ -12,8 +12,8 @@
         "JMXFETCH_HASH": "fb5c3fc2fb42db1ee5c3a7c6187b316d79d69c50b967db0b7ffde590622d0395",
         "MACOS_BUILD_VERSION": "7.47.x",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.4.1",
-        "WINDOWS_DDNPM_SHASUM": "f12af44306eac3ea15828fd12c24d44ae519692a94a0f1f5d4fa868c3e596b07",
+        "WINDOWS_DDNPM_VERSION": "2.5.2",
+        "WINDOWS_DDNPM_SHASUM": "57a53c23e0b40da1e75094058498f9982dc80f6aa7feb5a1c8aece6e08292840",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -24,8 +24,8 @@
         "JMXFETCH_HASH": "fb5c3fc2fb42db1ee5c3a7c6187b316d79d69c50b967db0b7ffde590622d0395",
         "MACOS_BUILD_VERSION": "7.47.x",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.4.1",
-        "WINDOWS_DDNPM_SHASUM": "f12af44306eac3ea15828fd12c24d44ae519692a94a0f1f5d4fa868c3e596b07",
+        "WINDOWS_DDNPM_VERSION": "2.5.2",
+        "WINDOWS_DDNPM_SHASUM": "57a53c23e0b40da1e75094058498f9982dc80f6aa7feb5a1c8aece6e08292840",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {
@@ -37,8 +37,8 @@
         "SECURITY_AGENT_POLICIES_VERSION": "v0.47.1",
         "MACOS_BUILD_VERSION": "6.47.0",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.4.1",
-        "WINDOWS_DDNPM_SHASUM": "f12af44306eac3ea15828fd12c24d44ae519692a94a0f1f5d4fa868c3e596b07"
+        "WINDOWS_DDNPM_VERSION": "2.5.2",
+        "WINDOWS_DDNPM_SHASUM": "57a53c23e0b40da1e75094058498f9982dc80f6aa7feb5a1c8aece6e08292840"
     },
     "release-a7": {
         "INTEGRATIONS_CORE_VERSION": "7.47.0",
@@ -49,8 +49,8 @@
         "SECURITY_AGENT_POLICIES_VERSION": "v0.47.1",
         "MACOS_BUILD_VERSION": "7.47.0",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "2.4.1",
-        "WINDOWS_DDNPM_SHASUM": "f12af44306eac3ea15828fd12c24d44ae519692a94a0f1f5d4fa868c3e596b07"
+        "WINDOWS_DDNPM_VERSION": "2.5.2",
+        "WINDOWS_DDNPM_SHASUM": "57a53c23e0b40da1e75094058498f9982dc80f6aa7feb5a1c8aece6e08292840"
     },
     "dca-1.17.0": {
         "SECURITY_AGENT_POLICIES_VERSION": "v0.18.6"

--- a/releasenotes/notes/fix-restarting-npm-driver-2a32ab51d0bea48a.yaml
+++ b/releasenotes/notes/fix-restarting-npm-driver-2a32ab51d0bea48a.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes issue with NPM driver restart failing with "File Not Found" error on Windows.


### PR DESCRIPTION
### What does this PR do?

Backports driver fix to 7.47.x for potential point release.

### Motivation

Customers getting "file not found" error trying to load npm

### Describe how to test/QA your changes

Original bug was fairly rare.
Was able to reproduce in some cases by opening two powershell windows.
In one run this loop:
while ($true) { stop-service datadog-system-probe; get-service ddnpm; start-service datadog-system-probe; get-service ddnpm }
In another
while ($true) { ipconfig /release; ipconfig /renew }
### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
