### PR TITLE
[PROC-2996] Periodically send a 'ping' in the gRPC workloadmeta server to keep the stream connection alive

### DIFF
--- a/pkg/process/metadata/workloadmeta/grpc.go
+++ b/pkg/process/metadata/workloadmeta/grpc.go
@@ -12,8 +12,10 @@ import (
 	"net"
 	"strconv"
 	"sync"
+	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
@@ -46,9 +48,11 @@ var (
 // NewGRPCServer creates a new instance of a GRPCServer
 func NewGRPCServer(config config.ConfigReader, extractor *WorkloadMetaExtractor) *GRPCServer {
 	l := &GRPCServer{
-		config:      config,
-		extractor:   extractor,
-		server:      grpc.NewServer(),
+		config:    config,
+		extractor: extractor,
+		server: grpc.NewServer(grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time: 10 * time.Second,
+		})),
 		streamMutex: &sync.Mutex{},
 	}
 

--- a/pkg/process/metadata/workloadmeta/grpc.go
+++ b/pkg/process/metadata/workloadmeta/grpc.go
@@ -172,6 +172,10 @@ func (l *GRPCServer) StreamEntities(_ *pbgo.ProcessStreamEntitiesRequest, out pb
 			}
 
 		case <-out.Context().Done():
+			err := out.Context().Err()
+			if err != nil {
+				log.Warn("The workloadmeta grpc stream was closed: %v", err)
+			}
 			return nil
 		case <-streamCtx.Done():
 			return DuplicateConnectionErr

--- a/pkg/process/metadata/workloadmeta/grpc.go
+++ b/pkg/process/metadata/workloadmeta/grpc.go
@@ -174,7 +174,7 @@ func (l *GRPCServer) StreamEntities(_ *pbgo.ProcessStreamEntitiesRequest, out pb
 		case <-out.Context().Done():
 			err := out.Context().Err()
 			if err != nil {
-				log.Warn("The workloadmeta grpc stream was closed: %v", err)
+				log.Warn("The workloadmeta grpc stream was closed:", err)
 			}
 			return nil
 		case <-streamCtx.Done():


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR sends a keepalive message to the gRPC client every 10 seconds. By default, if the client does not respond in 20 seconds, the connection will be closed. 

The 10 second timeout was chosen because in the worst case, the process agent will need to send a diff every 10 seconds , and so if a recv request is not sent, the process agent is at risk of dropping diffs. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Keeping the grpc stream alive in the event that the server stops responding. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
- GRPC Keepalive Docs: https://grpc.io/docs/guides/keepalive/#:~:text=Keepalive%20is%20primarily%20triggered%20when,in%2Dprogress%20RPCs%20will%20fail.
- GRPC Serverside Keepalive RFC: https://github.com/grpc/proposal/blob/master/A9-server-side-conn-mgt.md

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

```
language_detection: { enabled: true }
```

Run the agent using the above config and ensure that the connection between the process agent and the core agent is stable.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
