### PR TITLE
Use a bytes buffer internally in the logs prefixer

### DIFF
--- a/pkg/logs/client/tcp/prefixer.go
+++ b/pkg/logs/client/tcp/prefixer.go
@@ -5,19 +5,25 @@
 
 package tcp
 
+import "bytes"
+
 // prefixer prepends a prefix to a message.
 type prefixer struct {
-	prefix []byte
+	prefix string
+	buffer bytes.Buffer
 }
 
 // newPrefixer returns a prefixer that prepends the given prefix to a message.
 func newPrefixer(prefix string) *prefixer {
 	return &prefixer{
-		prefix: []byte(prefix),
+		prefix: prefix,
 	}
 }
 
 // apply prepends the prefix to the message.
 func (p *prefixer) apply(content []byte) []byte {
-	return append(p.prefix, content...)
+	p.buffer.Reset()
+	p.buffer.WriteString(p.prefix)
+	p.buffer.Write(content)
+	return p.buffer.Bytes()
 }


### PR DESCRIPTION
### What does this PR do?

The logs prefixer prepends a prefix to passed bytes per-destination. Our [profiles](https://app.datadoghq.com/profiling/search?query=account%3Asingle-machine-performance%20client_team%3Aagent%20runtime%3Ago%20&my_code=disabled&profile_type=alloc-samples&viz=flame_graph&start=1693503706271&end=1693507306271&paused=false) flag the `apply` function as allocation center. Considering that each destination maintains an instantiated `prefixer` we can elide some of that allocation pressure through the use of a buffer.

Note also we avoid converting the passed `prefix` from a string to bytes, storing it as a string internally.

### Motivation

Reduce allocation load in the Agent. 

### Possible Drawbacks / Trade-offs

If a particularly large `content` is passed to `apply` we will size the `bytes.Buffer` up to accommodate it. This space is not reclaimed. Previously we would incur the same allocation pattern but temporarily as the heap allocation would subsequently be freed. 

### Describe how to test/QA your changes

I expect most of the result to come in the regression detector results and in profiles. I'll link those below when ready.

### Related 

REF #19125
REF SMP-664

