### PR TITLE
Use a second dogstatsd timeSamplerWorker

### DIFF
--- a/test/regression/cases/uds_dogstatsd_to_api/experiment.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api/experiment.yaml
@@ -3,6 +3,7 @@ erratic: false
 
 environment:
   DD_TELEMETRY_ENABLED: true
+  DD_DOGSTATSD_PIPELINE_COUNT: 2
 
 profiling_environment:
   DD_INTERNAL_PROFILING_ENABLED: true


### PR DESCRIPTION
### What does this PR do?

The gorountine timeline [here](https://app.datadoghq.com/profiling/search?query=account%3Asingle-machine-performance%20service%3Adatadog-agent%20experiment%3Auds_dogstatsd_to_api%20version%3A%2A01a9f1e%2A%20&event=AgAAAYpLigLQGdtk7AAAAAAAAAAYAAAAAEFZcExpZ1d3QUFBbFdMd3hGYU44QkFBQQAAACQAAAAAMDE4YTRiOGMtN2FmZi00OTQ1LTg5YmMtOGVlMWYyNmEzNTVi&limit=1000&my_code=disabled&p_tl_collapsed=false&p_tl_expanded_lines=361020042%2C1339655711%2C-1659932613&p_tl_selected_lines=1525581833&p_tl_summary_tab=call-tree&p_tl_tf_f_1=42469441869&p_tl_tf_s_0=0&p_tl_tf_s_1=42469441869&p_tl_tf_us_0=0&p_tl_tf_us_1=42469441869&profileId=AYpLigWwAAAlWLwxFaN8BAAA&profileViz=timeline&viz=thread_timeline_list&start=1693432800000&end=1693486500000&paused=true) shows that the dogstatsd flow is bottlenecked by the `samplesChan` receiver. There are 7 vCPUs available in this SMP test. This gives us 5 DogStatsD server workers and one `timeSamplerAggregator` worker. The DogStatsD workers are mostly sitting around waiting to send samples on `samplesChan`. My expectation is that doubling the number of aggregator workers will significantly boost the performance of this experiment.

**This PR should not be merged as-is**. If this change does give a positive improvement, we should evaluate the impact and consider changing the default config. The results will also inform upcoming performance work.

### Motivation

Improve DogStatsD throughput

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
