### PR TITLE
[Doc] Bump python in the doc for dev env `3.8` -> `3.9`

### DIFF
--- a/docs/dev/agent_dev_env.md
+++ b/docs/dev/agent_dev_env.md
@@ -9,26 +9,26 @@ development files to be available in the dev env. The Agent can embed Python2
 and/or Python3, you will need development files for all versions you want to
 support.
 
-If you're on OSX/macOS, installing Python 2.7 and/or 3.8 with [Homebrew](https://brew.sh)
+If you're on OSX/macOS, installing Python 2.7 and/or 3.9 with [Homebrew](https://brew.sh)
 brings along all the development files needed:
 
 **Please note that not using Python versions explicitly supported, you may have
 problems running the built Agent's Python checks, especially if using a virtualenv.
-At this time, only Python 3.8 is confirmed to work as expected in the development
+At this time, only Python 3.9 is confirmed to work as expected in the development
 environment.**
 ```
 brew install python@2
-brew install python@3.8
+brew install python@3.9
 ```
 
 On Linux, depending on the distribution, you might need to explicitly install
 the development files, for example on Ubuntu:
 ```
 sudo apt-get install python2.7-dev
-sudo apt-get install python3.8-dev
+sudo apt-get install python3.9-dev
 ```
 
-On Windows, install Python 2.7 and/or 3.8 via the [official installer](https://www.python.org/downloads/).
+On Windows, install Python 2.7 and/or 3.9 via the [official installer](https://www.python.org/downloads/).
 
 #### Additional Windows Tools
 You will also need the Visual Studio for [Visual Studio for Python installer](http://aka.ms/vcpython27)
@@ -65,7 +65,7 @@ Agent's search path for Python check packages using the `PYTHONPATH` variable (y
 must have the [pre-requisite core integration packages installed](https://datadoghq.dev/integrations-core/setup/)
 though).
 ```sh
-PYTHONPATH="./venv/lib/python3.8/site-packages:$PYTHONPATH" ./agent run ...
+PYTHONPATH="./venv/lib/python3.9/site-packages:$PYTHONPATH" ./agent run ...
 ```
 
 See also some notes in [./checks](./checks) about running custom python checks.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR updates the documentation for the developer environment.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The dev now needs Python `3.9` instead of `3.8`.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
