### PR TITLE
[CWS] Fix cacheless resolution tag

### DIFF
--- a/docs/cloud-workload-security/secl.json
+++ b/docs/cloud-workload-security/secl.json
@@ -169,7 +169,7 @@
         },
         {
           "name": "process.ancestors.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -209,7 +209,7 @@
         },
         {
           "name": "process.ancestors.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -299,7 +299,7 @@
         },
         {
           "name": "process.ancestors.interpreter.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -339,7 +339,7 @@
         },
         {
           "name": "process.ancestors.interpreter.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -529,7 +529,7 @@
         },
         {
           "name": "process.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -569,7 +569,7 @@
         },
         {
           "name": "process.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -659,7 +659,7 @@
         },
         {
           "name": "process.interpreter.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -699,7 +699,7 @@
         },
         {
           "name": "process.interpreter.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -859,7 +859,7 @@
         },
         {
           "name": "process.parent.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -899,7 +899,7 @@
         },
         {
           "name": "process.parent.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -989,7 +989,7 @@
         },
         {
           "name": "process.parent.interpreter.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -1029,7 +1029,7 @@
         },
         {
           "name": "process.parent.interpreter.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -1270,7 +1270,7 @@
       "properties": [
         {
           "name": "chmod.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -1320,7 +1320,7 @@
         },
         {
           "name": "chmod.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -1394,7 +1394,7 @@
       "properties": [
         {
           "name": "chown.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -1454,7 +1454,7 @@
         },
         {
           "name": "chown.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -1662,7 +1662,7 @@
         },
         {
           "name": "exec.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -1702,7 +1702,7 @@
         },
         {
           "name": "exec.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -1792,7 +1792,7 @@
         },
         {
           "name": "exec.interpreter.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -1832,7 +1832,7 @@
         },
         {
           "name": "exec.interpreter.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -2041,7 +2041,7 @@
         },
         {
           "name": "exit.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -2081,7 +2081,7 @@
         },
         {
           "name": "exit.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -2171,7 +2171,7 @@
         },
         {
           "name": "exit.interpreter.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -2211,7 +2211,7 @@
         },
         {
           "name": "exit.interpreter.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -2320,12 +2320,12 @@
       "properties": [
         {
           "name": "link.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "link.file.destination.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -2365,7 +2365,7 @@
         },
         {
           "name": "link.file.destination.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -2460,7 +2460,7 @@
         },
         {
           "name": "link.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -2549,7 +2549,7 @@
         },
         {
           "name": "load_module.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -2589,7 +2589,7 @@
         },
         {
           "name": "load_module.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -2673,7 +2673,7 @@
       "properties": [
         {
           "name": "mkdir.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -2723,7 +2723,7 @@
         },
         {
           "name": "mkdir.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -2797,7 +2797,7 @@
       "properties": [
         {
           "name": "mmap.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -2837,7 +2837,7 @@
         },
         {
           "name": "mmap.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -2974,7 +2974,7 @@
       "properties": [
         {
           "name": "open.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -3019,7 +3019,7 @@
         },
         {
           "name": "open.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -3198,7 +3198,7 @@
         },
         {
           "name": "ptrace.tracee.ancestors.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -3238,7 +3238,7 @@
         },
         {
           "name": "ptrace.tracee.ancestors.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -3328,7 +3328,7 @@
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -3368,7 +3368,7 @@
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -3558,7 +3558,7 @@
         },
         {
           "name": "ptrace.tracee.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -3598,7 +3598,7 @@
         },
         {
           "name": "ptrace.tracee.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -3688,7 +3688,7 @@
         },
         {
           "name": "ptrace.tracee.interpreter.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -3728,7 +3728,7 @@
         },
         {
           "name": "ptrace.tracee.interpreter.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -3888,7 +3888,7 @@
         },
         {
           "name": "ptrace.tracee.parent.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -3928,7 +3928,7 @@
         },
         {
           "name": "ptrace.tracee.parent.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -4018,7 +4018,7 @@
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -4058,7 +4058,7 @@
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -4197,7 +4197,7 @@
       "properties": [
         {
           "name": "removexattr.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -4247,7 +4247,7 @@
         },
         {
           "name": "removexattr.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -4321,12 +4321,12 @@
       "properties": [
         {
           "name": "rename.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "rename.file.destination.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -4366,7 +4366,7 @@
         },
         {
           "name": "rename.file.destination.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -4461,7 +4461,7 @@
         },
         {
           "name": "rename.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -4535,7 +4535,7 @@
       "properties": [
         {
           "name": "rmdir.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -4575,7 +4575,7 @@
         },
         {
           "name": "rmdir.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -4756,7 +4756,7 @@
       "properties": [
         {
           "name": "setxattr.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -4806,7 +4806,7 @@
         },
         {
           "name": "setxattr.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -4980,7 +4980,7 @@
         },
         {
           "name": "signal.target.ancestors.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -5020,7 +5020,7 @@
         },
         {
           "name": "signal.target.ancestors.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -5110,7 +5110,7 @@
         },
         {
           "name": "signal.target.ancestors.interpreter.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -5150,7 +5150,7 @@
         },
         {
           "name": "signal.target.ancestors.interpreter.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -5340,7 +5340,7 @@
         },
         {
           "name": "signal.target.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -5380,7 +5380,7 @@
         },
         {
           "name": "signal.target.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -5470,7 +5470,7 @@
         },
         {
           "name": "signal.target.interpreter.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -5510,7 +5510,7 @@
         },
         {
           "name": "signal.target.interpreter.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -5670,7 +5670,7 @@
         },
         {
           "name": "signal.target.parent.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -5710,7 +5710,7 @@
         },
         {
           "name": "signal.target.parent.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -5800,7 +5800,7 @@
         },
         {
           "name": "signal.target.parent.interpreter.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -5840,7 +5840,7 @@
         },
         {
           "name": "signal.target.parent.interpreter.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -5984,7 +5984,7 @@
       "properties": [
         {
           "name": "splice.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -6024,7 +6024,7 @@
         },
         {
           "name": "splice.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -6108,7 +6108,7 @@
       "properties": [
         {
           "name": "unlink.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -6148,7 +6148,7 @@
         },
         {
           "name": "unlink.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -6246,7 +6246,7 @@
       "properties": [
         {
           "name": "utimes.file.change_time",
-          "definition": "Change time of the file",
+          "definition": "Change time (ctime) of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -6286,7 +6286,7 @@
         },
         {
           "name": "utimes.file.modification_time",
-          "definition": "Modification time of the file",
+          "definition": "Modification time (mtime) of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -6557,7 +6557,7 @@
       "name": "*.change_time",
       "link": "common-filefields-change_time-doc",
       "type": "int",
-      "definition": "Change time of the file",
+      "definition": "Change time (ctime) of the file",
       "prefixes": [
         "chmod.file",
         "chown.file",
@@ -7473,7 +7473,7 @@
       "name": "*.modification_time",
       "link": "common-filefields-modification_time-doc",
       "type": "int",
-      "definition": "Modification time of the file",
+      "definition": "Modification time (mtime) of the file",
       "prefixes": [
         "chmod.file",
         "chown.file",

--- a/docs/cloud-workload-security/secl.json
+++ b/docs/cloud-workload-security/secl.json
@@ -169,7 +169,7 @@
         },
         {
           "name": "process.ancestors.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -209,7 +209,7 @@
         },
         {
           "name": "process.ancestors.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -299,7 +299,7 @@
         },
         {
           "name": "process.ancestors.interpreter.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -339,7 +339,7 @@
         },
         {
           "name": "process.ancestors.interpreter.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -529,7 +529,7 @@
         },
         {
           "name": "process.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -569,7 +569,7 @@
         },
         {
           "name": "process.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -659,7 +659,7 @@
         },
         {
           "name": "process.interpreter.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -699,7 +699,7 @@
         },
         {
           "name": "process.interpreter.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -859,7 +859,7 @@
         },
         {
           "name": "process.parent.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -899,7 +899,7 @@
         },
         {
           "name": "process.parent.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -989,7 +989,7 @@
         },
         {
           "name": "process.parent.interpreter.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -1029,7 +1029,7 @@
         },
         {
           "name": "process.parent.interpreter.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -1270,7 +1270,7 @@
       "properties": [
         {
           "name": "chmod.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -1320,7 +1320,7 @@
         },
         {
           "name": "chmod.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -1394,7 +1394,7 @@
       "properties": [
         {
           "name": "chown.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -1454,7 +1454,7 @@
         },
         {
           "name": "chown.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -1662,7 +1662,7 @@
         },
         {
           "name": "exec.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -1702,7 +1702,7 @@
         },
         {
           "name": "exec.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -1792,7 +1792,7 @@
         },
         {
           "name": "exec.interpreter.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -1832,7 +1832,7 @@
         },
         {
           "name": "exec.interpreter.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -2041,7 +2041,7 @@
         },
         {
           "name": "exit.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -2081,7 +2081,7 @@
         },
         {
           "name": "exit.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -2171,7 +2171,7 @@
         },
         {
           "name": "exit.interpreter.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -2211,7 +2211,7 @@
         },
         {
           "name": "exit.interpreter.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -2320,12 +2320,12 @@
       "properties": [
         {
           "name": "link.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "link.file.destination.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -2365,7 +2365,7 @@
         },
         {
           "name": "link.file.destination.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -2460,7 +2460,7 @@
         },
         {
           "name": "link.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -2549,7 +2549,7 @@
         },
         {
           "name": "load_module.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -2589,7 +2589,7 @@
         },
         {
           "name": "load_module.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -2673,7 +2673,7 @@
       "properties": [
         {
           "name": "mkdir.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -2723,7 +2723,7 @@
         },
         {
           "name": "mkdir.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -2797,7 +2797,7 @@
       "properties": [
         {
           "name": "mmap.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -2837,7 +2837,7 @@
         },
         {
           "name": "mmap.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -2974,7 +2974,7 @@
       "properties": [
         {
           "name": "open.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -3019,7 +3019,7 @@
         },
         {
           "name": "open.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -3198,7 +3198,7 @@
         },
         {
           "name": "ptrace.tracee.ancestors.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -3238,7 +3238,7 @@
         },
         {
           "name": "ptrace.tracee.ancestors.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -3328,7 +3328,7 @@
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -3368,7 +3368,7 @@
         },
         {
           "name": "ptrace.tracee.ancestors.interpreter.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -3558,7 +3558,7 @@
         },
         {
           "name": "ptrace.tracee.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -3598,7 +3598,7 @@
         },
         {
           "name": "ptrace.tracee.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -3688,7 +3688,7 @@
         },
         {
           "name": "ptrace.tracee.interpreter.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -3728,7 +3728,7 @@
         },
         {
           "name": "ptrace.tracee.interpreter.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -3888,7 +3888,7 @@
         },
         {
           "name": "ptrace.tracee.parent.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -3928,7 +3928,7 @@
         },
         {
           "name": "ptrace.tracee.parent.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -4018,7 +4018,7 @@
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -4058,7 +4058,7 @@
         },
         {
           "name": "ptrace.tracee.parent.interpreter.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -4197,7 +4197,7 @@
       "properties": [
         {
           "name": "removexattr.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -4247,7 +4247,7 @@
         },
         {
           "name": "removexattr.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -4321,12 +4321,12 @@
       "properties": [
         {
           "name": "rename.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
           "name": "rename.file.destination.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -4366,7 +4366,7 @@
         },
         {
           "name": "rename.file.destination.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -4461,7 +4461,7 @@
         },
         {
           "name": "rename.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -4535,7 +4535,7 @@
       "properties": [
         {
           "name": "rmdir.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -4575,7 +4575,7 @@
         },
         {
           "name": "rmdir.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -4756,7 +4756,7 @@
       "properties": [
         {
           "name": "setxattr.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -4806,7 +4806,7 @@
         },
         {
           "name": "setxattr.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -4980,7 +4980,7 @@
         },
         {
           "name": "signal.target.ancestors.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -5020,7 +5020,7 @@
         },
         {
           "name": "signal.target.ancestors.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -5110,7 +5110,7 @@
         },
         {
           "name": "signal.target.ancestors.interpreter.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -5150,7 +5150,7 @@
         },
         {
           "name": "signal.target.ancestors.interpreter.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -5340,7 +5340,7 @@
         },
         {
           "name": "signal.target.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -5380,7 +5380,7 @@
         },
         {
           "name": "signal.target.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -5470,7 +5470,7 @@
         },
         {
           "name": "signal.target.interpreter.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -5510,7 +5510,7 @@
         },
         {
           "name": "signal.target.interpreter.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -5670,7 +5670,7 @@
         },
         {
           "name": "signal.target.parent.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -5710,7 +5710,7 @@
         },
         {
           "name": "signal.target.parent.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -5800,7 +5800,7 @@
         },
         {
           "name": "signal.target.parent.interpreter.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -5840,7 +5840,7 @@
         },
         {
           "name": "signal.target.parent.interpreter.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -5984,7 +5984,7 @@
       "properties": [
         {
           "name": "splice.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -6024,7 +6024,7 @@
         },
         {
           "name": "splice.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -6108,7 +6108,7 @@
       "properties": [
         {
           "name": "unlink.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -6148,7 +6148,7 @@
         },
         {
           "name": "unlink.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -6246,7 +6246,7 @@
       "properties": [
         {
           "name": "utimes.file.change_time",
-          "definition": "Change time (ctime) of the file",
+          "definition": "Change time of the file",
           "property_doc_link": "common-filefields-change_time-doc"
         },
         {
@@ -6286,7 +6286,7 @@
         },
         {
           "name": "utimes.file.modification_time",
-          "definition": "Modification time (mtime) of the file",
+          "definition": "Modification time of the file",
           "property_doc_link": "common-filefields-modification_time-doc"
         },
         {
@@ -6557,7 +6557,7 @@
       "name": "*.change_time",
       "link": "common-filefields-change_time-doc",
       "type": "int",
-      "definition": "Change time (ctime) of the file",
+      "definition": "Change time of the file",
       "prefixes": [
         "chmod.file",
         "chown.file",
@@ -7473,7 +7473,7 @@
       "name": "*.modification_time",
       "link": "common-filefields-modification_time-doc",
       "type": "int",
-      "definition": "Modification time (mtime) of the file",
+      "definition": "Modification time of the file",
       "prefixes": [
         "chmod.file",
         "chown.file",

--- a/pkg/security/secl/model/field_handlers_unix.go
+++ b/pkg/security/secl/model/field_handlers_unix.go
@@ -66,9 +66,6 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
 	}
 	if ev.BaseEvent.ProcessContext.Process.IsNotKworker() {
-		_ = ev.FieldHandlers.ResolveRights(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent.FileFields)
-	}
-	if ev.BaseEvent.ProcessContext.Process.IsNotKworker() {
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent.FileFields)
 	}
 	if ev.BaseEvent.ProcessContext.Process.HasInterpreter() {
@@ -99,9 +96,6 @@ func (ev *Event) resolveFields(forADs bool) {
 	}
 	if ev.BaseEvent.ProcessContext.Process.HasInterpreter() {
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent)
-	}
-	if ev.BaseEvent.ProcessContext.Process.HasInterpreter() {
-		_ = ev.FieldHandlers.ResolveRights(ev, &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent.FileFields)
 	}
 	if ev.BaseEvent.ProcessContext.Process.HasInterpreter() {
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.BaseEvent.ProcessContext.Process.LinuxBinprm.FileEvent.FileFields)
@@ -160,9 +154,6 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
 	}
 	if ev.BaseEvent.ProcessContext.HasParent() && ev.BaseEvent.ProcessContext.Parent.IsNotKworker() {
-		_ = ev.FieldHandlers.ResolveRights(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent.FileFields)
-	}
-	if ev.BaseEvent.ProcessContext.HasParent() && ev.BaseEvent.ProcessContext.Parent.IsNotKworker() {
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent.FileFields)
 	}
 	if ev.BaseEvent.ProcessContext.HasParent() && ev.BaseEvent.ProcessContext.Parent.HasInterpreter() {
@@ -195,9 +186,6 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent)
 	}
 	if ev.BaseEvent.ProcessContext.HasParent() && ev.BaseEvent.ProcessContext.Parent.HasInterpreter() {
-		_ = ev.FieldHandlers.ResolveRights(ev, &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent.FileFields)
-	}
-	if ev.BaseEvent.ProcessContext.HasParent() && ev.BaseEvent.ProcessContext.Parent.HasInterpreter() {
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.BaseEvent.ProcessContext.Parent.LinuxBinprm.FileEvent.FileFields)
 	}
 	// resolve event specific fields
@@ -208,7 +196,6 @@ func (ev *Event) resolveFields(forADs bool) {
 	case "chmod":
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Chmod.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Chmod.File.FileFields)
-		_ = ev.FieldHandlers.ResolveRights(ev, &ev.Chmod.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.Chmod.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.Chmod.File)
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.Chmod.File)
@@ -222,7 +209,6 @@ func (ev *Event) resolveFields(forADs bool) {
 	case "chown":
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Chown.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Chown.File.FileFields)
-		_ = ev.FieldHandlers.ResolveRights(ev, &ev.Chown.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.Chown.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.Chown.File)
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.Chown.File)
@@ -242,9 +228,6 @@ func (ev *Event) resolveFields(forADs bool) {
 		}
 		if ev.Exec.Process.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Exec.Process.FileEvent.FileFields)
-		}
-		if ev.Exec.Process.IsNotKworker() {
-			_ = ev.FieldHandlers.ResolveRights(ev, &ev.Exec.Process.FileEvent.FileFields)
 		}
 		if ev.Exec.Process.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.Exec.Process.FileEvent.FileFields)
@@ -277,9 +260,6 @@ func (ev *Event) resolveFields(forADs bool) {
 		}
 		if ev.Exec.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Exec.Process.LinuxBinprm.FileEvent.FileFields)
-		}
-		if ev.Exec.Process.HasInterpreter() {
-			_ = ev.FieldHandlers.ResolveRights(ev, &ev.Exec.Process.LinuxBinprm.FileEvent.FileFields)
 		}
 		if ev.Exec.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.Exec.Process.LinuxBinprm.FileEvent.FileFields)
@@ -323,9 +303,6 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Exit.Process.FileEvent.FileFields)
 		}
 		if ev.Exit.Process.IsNotKworker() {
-			_ = ev.FieldHandlers.ResolveRights(ev, &ev.Exit.Process.FileEvent.FileFields)
-		}
-		if ev.Exit.Process.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.Exit.Process.FileEvent.FileFields)
 		}
 		if ev.Exit.Process.IsNotKworker() {
@@ -356,9 +333,6 @@ func (ev *Event) resolveFields(forADs bool) {
 		}
 		if ev.Exit.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Exit.Process.LinuxBinprm.FileEvent.FileFields)
-		}
-		if ev.Exit.Process.HasInterpreter() {
-			_ = ev.FieldHandlers.ResolveRights(ev, &ev.Exit.Process.LinuxBinprm.FileEvent.FileFields)
 		}
 		if ev.Exit.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.Exit.Process.LinuxBinprm.FileEvent.FileFields)
@@ -397,7 +371,6 @@ func (ev *Event) resolveFields(forADs bool) {
 	case "link":
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Link.Source.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Link.Source.FileFields)
-		_ = ev.FieldHandlers.ResolveRights(ev, &ev.Link.Source.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.Link.Source.FileFields)
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.Link.Source)
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.Link.Source)
@@ -410,7 +383,6 @@ func (ev *Event) resolveFields(forADs bool) {
 		}
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Link.Target.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Link.Target.FileFields)
-		_ = ev.FieldHandlers.ResolveRights(ev, &ev.Link.Target.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.Link.Target.FileFields)
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.Link.Target)
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.Link.Target)
@@ -424,7 +396,6 @@ func (ev *Event) resolveFields(forADs bool) {
 	case "load_module":
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.LoadModule.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.LoadModule.File.FileFields)
-		_ = ev.FieldHandlers.ResolveRights(ev, &ev.LoadModule.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.LoadModule.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.LoadModule.File)
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.LoadModule.File)
@@ -440,7 +411,6 @@ func (ev *Event) resolveFields(forADs bool) {
 	case "mkdir":
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Mkdir.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Mkdir.File.FileFields)
-		_ = ev.FieldHandlers.ResolveRights(ev, &ev.Mkdir.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.Mkdir.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.Mkdir.File)
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.Mkdir.File)
@@ -454,7 +424,6 @@ func (ev *Event) resolveFields(forADs bool) {
 	case "mmap":
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.MMap.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.MMap.File.FileFields)
-		_ = ev.FieldHandlers.ResolveRights(ev, &ev.MMap.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.MMap.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.MMap.File)
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.MMap.File)
@@ -472,7 +441,6 @@ func (ev *Event) resolveFields(forADs bool) {
 	case "open":
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Open.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Open.File.FileFields)
-		_ = ev.FieldHandlers.ResolveRights(ev, &ev.Open.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.Open.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.Open.File)
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.Open.File)
@@ -489,9 +457,6 @@ func (ev *Event) resolveFields(forADs bool) {
 		}
 		if ev.PTrace.Tracee.Process.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.PTrace.Tracee.Process.FileEvent.FileFields)
-		}
-		if ev.PTrace.Tracee.Process.IsNotKworker() {
-			_ = ev.FieldHandlers.ResolveRights(ev, &ev.PTrace.Tracee.Process.FileEvent.FileFields)
 		}
 		if ev.PTrace.Tracee.Process.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.PTrace.Tracee.Process.FileEvent.FileFields)
@@ -524,9 +489,6 @@ func (ev *Event) resolveFields(forADs bool) {
 		}
 		if ev.PTrace.Tracee.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent.FileFields)
-		}
-		if ev.PTrace.Tracee.Process.HasInterpreter() {
-			_ = ev.FieldHandlers.ResolveRights(ev, &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent.FileFields)
 		}
 		if ev.PTrace.Tracee.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.PTrace.Tracee.Process.LinuxBinprm.FileEvent.FileFields)
@@ -569,9 +531,6 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.PTrace.Tracee.Parent.FileEvent.FileFields)
 		}
 		if ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.IsNotKworker() {
-			_ = ev.FieldHandlers.ResolveRights(ev, &ev.PTrace.Tracee.Parent.FileEvent.FileFields)
-		}
-		if ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.PTrace.Tracee.Parent.FileEvent.FileFields)
 		}
 		if ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.IsNotKworker() {
@@ -602,9 +561,6 @@ func (ev *Event) resolveFields(forADs bool) {
 		}
 		if ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent.FileFields)
-		}
-		if ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.HasInterpreter() {
-			_ = ev.FieldHandlers.ResolveRights(ev, &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent.FileFields)
 		}
 		if ev.PTrace.Tracee.HasParent() && ev.PTrace.Tracee.Parent.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.PTrace.Tracee.Parent.LinuxBinprm.FileEvent.FileFields)
@@ -659,7 +615,6 @@ func (ev *Event) resolveFields(forADs bool) {
 	case "removexattr":
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.RemoveXAttr.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.RemoveXAttr.File.FileFields)
-		_ = ev.FieldHandlers.ResolveRights(ev, &ev.RemoveXAttr.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.RemoveXAttr.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.RemoveXAttr.File)
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.RemoveXAttr.File)
@@ -675,7 +630,6 @@ func (ev *Event) resolveFields(forADs bool) {
 	case "rename":
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Rename.Old.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Rename.Old.FileFields)
-		_ = ev.FieldHandlers.ResolveRights(ev, &ev.Rename.Old.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.Rename.Old.FileFields)
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.Rename.Old)
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.Rename.Old)
@@ -688,7 +642,6 @@ func (ev *Event) resolveFields(forADs bool) {
 		}
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Rename.New.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Rename.New.FileFields)
-		_ = ev.FieldHandlers.ResolveRights(ev, &ev.Rename.New.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.Rename.New.FileFields)
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.Rename.New)
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.Rename.New)
@@ -702,7 +655,6 @@ func (ev *Event) resolveFields(forADs bool) {
 	case "rmdir":
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Rmdir.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Rmdir.File.FileFields)
-		_ = ev.FieldHandlers.ResolveRights(ev, &ev.Rmdir.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.Rmdir.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.Rmdir.File)
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.Rmdir.File)
@@ -726,7 +678,6 @@ func (ev *Event) resolveFields(forADs bool) {
 	case "setxattr":
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.SetXAttr.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.SetXAttr.File.FileFields)
-		_ = ev.FieldHandlers.ResolveRights(ev, &ev.SetXAttr.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.SetXAttr.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.SetXAttr.File)
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.SetXAttr.File)
@@ -745,9 +696,6 @@ func (ev *Event) resolveFields(forADs bool) {
 		}
 		if ev.Signal.Target.Process.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Signal.Target.Process.FileEvent.FileFields)
-		}
-		if ev.Signal.Target.Process.IsNotKworker() {
-			_ = ev.FieldHandlers.ResolveRights(ev, &ev.Signal.Target.Process.FileEvent.FileFields)
 		}
 		if ev.Signal.Target.Process.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.Signal.Target.Process.FileEvent.FileFields)
@@ -780,9 +728,6 @@ func (ev *Event) resolveFields(forADs bool) {
 		}
 		if ev.Signal.Target.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Signal.Target.Process.LinuxBinprm.FileEvent.FileFields)
-		}
-		if ev.Signal.Target.Process.HasInterpreter() {
-			_ = ev.FieldHandlers.ResolveRights(ev, &ev.Signal.Target.Process.LinuxBinprm.FileEvent.FileFields)
 		}
 		if ev.Signal.Target.Process.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.Signal.Target.Process.LinuxBinprm.FileEvent.FileFields)
@@ -825,9 +770,6 @@ func (ev *Event) resolveFields(forADs bool) {
 			_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Signal.Target.Parent.FileEvent.FileFields)
 		}
 		if ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.IsNotKworker() {
-			_ = ev.FieldHandlers.ResolveRights(ev, &ev.Signal.Target.Parent.FileEvent.FileFields)
-		}
-		if ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.Signal.Target.Parent.FileEvent.FileFields)
 		}
 		if ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.IsNotKworker() {
@@ -858,9 +800,6 @@ func (ev *Event) resolveFields(forADs bool) {
 		}
 		if ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Signal.Target.Parent.LinuxBinprm.FileEvent.FileFields)
-		}
-		if ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.HasInterpreter() {
-			_ = ev.FieldHandlers.ResolveRights(ev, &ev.Signal.Target.Parent.LinuxBinprm.FileEvent.FileFields)
 		}
 		if ev.Signal.Target.HasParent() && ev.Signal.Target.Parent.HasInterpreter() {
 			_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.Signal.Target.Parent.LinuxBinprm.FileEvent.FileFields)
@@ -915,7 +854,6 @@ func (ev *Event) resolveFields(forADs bool) {
 	case "splice":
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Splice.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Splice.File.FileFields)
-		_ = ev.FieldHandlers.ResolveRights(ev, &ev.Splice.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.Splice.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.Splice.File)
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.Splice.File)
@@ -929,7 +867,6 @@ func (ev *Event) resolveFields(forADs bool) {
 	case "unlink":
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Unlink.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Unlink.File.FileFields)
-		_ = ev.FieldHandlers.ResolveRights(ev, &ev.Unlink.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.Unlink.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.Unlink.File)
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.Unlink.File)
@@ -944,7 +881,6 @@ func (ev *Event) resolveFields(forADs bool) {
 	case "utimes":
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Utimes.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.Utimes.File.FileFields)
-		_ = ev.FieldHandlers.ResolveRights(ev, &ev.Utimes.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsInUpperLayer(ev, &ev.Utimes.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFilePath(ev, &ev.Utimes.File)
 		_ = ev.FieldHandlers.ResolveFileBasename(ev, &ev.Utimes.File)

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -355,11 +355,11 @@ type ExitEvent struct {
 
 // FileFields holds the information required to identify a file
 type FileFields struct {
-	UID   uint32 `field:"uid"`                                                         // SECLDoc[uid] Definition:`UID of the file's owner`
-	User  string `field:"user,handler:ResolveFileFieldsUser"`                          // SECLDoc[user] Definition:`User of the file's owner`
-	GID   uint32 `field:"gid"`                                                         // SECLDoc[gid] Definition:`GID of the file's owner`
-	Group string `field:"group,handler:ResolveFileFieldsGroup"`                        // SECLDoc[group] Definition:`Group of the file's owner`
-	Mode  uint16 `field:"mode;rights,handler:ResolveRights,opts:cacheless_resolution"` // SECLDoc[mode] Definition:`Mode of the file` Constants:`Inode mode constants` SECLDoc[rights] Definition:`Rights of the file` Constants:`File mode constants`
+	UID   uint32 `field:"uid"`                                           // SECLDoc[uid] Definition:`UID of the file's owner`
+	User  string `field:"user,handler:ResolveFileFieldsUser"`            // SECLDoc[user] Definition:`User of the file's owner`
+	GID   uint32 `field:"gid"`                                           // SECLDoc[gid] Definition:`GID of the file's owner`
+	Group string `field:"group,handler:ResolveFileFieldsGroup"`          // SECLDoc[group] Definition:`Group of the file's owner`
+	Mode  uint16 `field:"mode;rights,handler:ResolveRights,opts:helper"` // SECLDoc[mode] Definition:`Mode of the file` Constants:`Inode mode constants` SECLDoc[rights] Definition:`Rights of the file` Constants:`File mode constants`
 	CTime uint64 `field:"change_time"`                                   // SECLDoc[change_time] Definition:`Change time (ctime) of the file`
 	MTime uint64 `field:"modification_time"`                             // SECLDoc[modification_time] Definition:`Modification time (mtime) of the file`
 

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -360,8 +360,8 @@ type FileFields struct {
 	GID   uint32 `field:"gid"`                                           // SECLDoc[gid] Definition:`GID of the file's owner`
 	Group string `field:"group,handler:ResolveFileFieldsGroup"`          // SECLDoc[group] Definition:`Group of the file's owner`
 	Mode  uint16 `field:"mode;rights,handler:ResolveRights,opts:helper"` // SECLDoc[mode] Definition:`Mode of the file` Constants:`Inode mode constants` SECLDoc[rights] Definition:`Rights of the file` Constants:`File mode constants`
-	CTime uint64 `field:"change_time"`                                   // SECLDoc[change_time] Definition:`Change time (ctime) of the file`
-	MTime uint64 `field:"modification_time"`                             // SECLDoc[modification_time] Definition:`Modification time (mtime) of the file`
+	CTime uint64 `field:"change_time"`                                   // SECLDoc[change_time] Definition:`Change time of the file`
+	MTime uint64 `field:"modification_time"`                             // SECLDoc[modification_time] Definition:`Modification time of the file`
 
 	PathKey
 	InUpperLayer bool `field:"in_upper_layer,handler:ResolveFileFieldsInUpperLayer"` // SECLDoc[in_upper_layer] Definition:`Indicator of the file layer, for example, in an OverlayFS`

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -360,8 +360,8 @@ type FileFields struct {
 	GID   uint32 `field:"gid"`                                                         // SECLDoc[gid] Definition:`GID of the file's owner`
 	Group string `field:"group,handler:ResolveFileFieldsGroup"`                        // SECLDoc[group] Definition:`Group of the file's owner`
 	Mode  uint16 `field:"mode;rights,handler:ResolveRights,opts:cacheless_resolution"` // SECLDoc[mode] Definition:`Mode of the file` Constants:`Inode mode constants` SECLDoc[rights] Definition:`Rights of the file` Constants:`File mode constants`
-	CTime uint64 `field:"change_time"`                                                 // SECLDoc[change_time] Definition:`Change time of the file`
-	MTime uint64 `field:"modification_time"`                                           // SECLDoc[modification_time] Definition:`Modification time of the file`
+	CTime uint64 `field:"change_time"`                                   // SECLDoc[change_time] Definition:`Change time (ctime) of the file`
+	MTime uint64 `field:"modification_time"`                             // SECLDoc[modification_time] Definition:`Modification time (mtime) of the file`
 
 	PathKey
 	InUpperLayer bool `field:"in_upper_layer,handler:ResolveFileFieldsInUpperLayer"` // SECLDoc[in_upper_layer] Definition:`Indicator of the file layer, for example, in an OverlayFS`


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Cleanup converting the `cacheless_resolution` opt to the `helper` opt

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
