### PR TITLE
[process-agent] Add timeout to workloadmeta grpc server

### DIFF
--- a/pkg/process/metadata/workloadmeta/grpc.go
+++ b/pkg/process/metadata/workloadmeta/grpc.go
@@ -40,6 +40,8 @@ type GRPCServer struct {
 	closeExistingStream context.CancelFunc
 }
 
+const connectionTimeout = 10 * time.Minute
+
 var (
 	invalidVersionError = telemetry.NewSimpleCounter(subsystem, "invalid_version_errors", "The number of times the grpc server receives an entity diff that has an invalid version.")
 	streamServerError   = telemetry.NewSimpleCounter(subsystem, "stream_send_errors", "The number of times the grpc server has failed to send an entity diff to the core agent.")
@@ -50,9 +52,12 @@ func NewGRPCServer(config config.ConfigReader, extractor *WorkloadMetaExtractor)
 	l := &GRPCServer{
 		config:    config,
 		extractor: extractor,
-		server: grpc.NewServer(grpc.KeepaliveParams(keepalive.ServerParameters{
-			Time: 10 * time.Second,
-		})),
+		server: grpc.NewServer(
+			grpc.KeepaliveParams(keepalive.ServerParameters{
+				Time: 10 * time.Second,
+			}),
+			grpc.ConnectionTimeout(connectionTimeout),
+		),
 		streamMutex: &sync.Mutex{},
 	}
 

--- a/pkg/process/metadata/workloadmeta/grpc.go
+++ b/pkg/process/metadata/workloadmeta/grpc.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"
 	"net"
 	"strconv"
 	"sync"
@@ -21,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 

--- a/pkg/process/metadata/workloadmeta/grpc.go
+++ b/pkg/process/metadata/workloadmeta/grpc.go
@@ -41,6 +41,7 @@ type GRPCServer struct {
 }
 
 const connectionTimeout = 10 * time.Minute
+const keepaliveInterval = 10 * time.Second
 
 var (
 	invalidVersionError = telemetry.NewSimpleCounter(subsystem, "invalid_version_errors", "The number of times the grpc server receives an entity diff that has an invalid version.")
@@ -54,7 +55,7 @@ func NewGRPCServer(config config.ConfigReader, extractor *WorkloadMetaExtractor)
 		extractor: extractor,
 		server: grpc.NewServer(
 			grpc.KeepaliveParams(keepalive.ServerParameters{
-				Time: 10 * time.Second,
+				Time: keepaliveInterval,
 			}),
 			grpc.ConnectionTimeout(connectionTimeout),
 		),


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add a timeout to the workloadmeta GRPC server. The timeout is set to 1 minutes, which is based on the collection interval used by the process collector in the process agent. 1 minute was chosen instead of 10 (like what is used in the client), because an error in sending messages could cause the extractor to drop messages.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Improving reliability of the workloadmeta extractor's grpc server.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Default process collector collection interval: https://github.com/DataDog/datadog-agent/blob/141e4af8779c01691503631ab4af78b421e0e0fc/pkg/config/config.go#L100

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

The connection can die after 1 minutes.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
```yaml
language_detection: { enabled: true }
```

Run the agent using the above config and ensure that the connection between the process agent and the core agent is stable.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
