### PR TITLE
Seek to reuse allocations in dogstatsd's intern mechanism

### DIFF
--- a/comp/dogstatsd/server/intern.go
+++ b/comp/dogstatsd/server/intern.go
@@ -44,7 +44,7 @@ type stringInterner struct {
 
 func newStringInterner(maxSize int) *stringInterner {
 	i := &stringInterner{
-		strings:    make(map[string]string),
+		strings:    make(map[string]string, maxSize),
 		maxSize:    maxSize,
 		tlmEnabled: utils.IsTelemetryEnabled(),
 	}
@@ -78,7 +78,11 @@ func (i *stringInterner) LoadOrStore(key []byte) string {
 			i.curBytes = 0
 		}
 
-		i.strings = make(map[string]string)
+		// Clear strings of keys, leave the underlying allocation
+		// intact.
+		for k := range i.strings {
+			delete(i.strings, k)
+		}
 		log.Debug("clearing the string interner cache")
 
 	}

--- a/comp/dogstatsd/server/intern.go
+++ b/comp/dogstatsd/server/intern.go
@@ -80,9 +80,7 @@ func (i *stringInterner) LoadOrStore(key []byte) string {
 
 		// Clear strings of keys, leave the underlying allocation
 		// intact.
-		for k := range i.strings {
-			delete(i.strings, k)
-		}
+		clear(i.strings)
 		log.Debug("clearing the string interner cache")
 
 	}

--- a/comp/dogstatsd/server/intern.go
+++ b/comp/dogstatsd/server/intern.go
@@ -80,7 +80,9 @@ func (i *stringInterner) LoadOrStore(key []byte) string {
 
 		// Clear strings of keys, leave the underlying allocation
 		// intact.
-		clear(i.strings)
+		for k := range i.strings {
+			delete(i.strings, k)
+		}
 		log.Debug("clearing the string interner cache")
 
 	}


### PR DESCRIPTION
### What does this PR do?

This commit makes two changes to the dogstatsd string intern mechanism. When creating a new instance of stringInterner we now size the strings map up to its maximum size. In addition when we must purge the strings map we now loop through the map and delete each value, preferring to retain and reuse the allocation.

### Additional Notes

Profiles suggest purges are relatively rare -- or, at least, they don't show up in the profiles -- and it is growing the map that is the time cost.

### Possible Drawbacks / Trade-offs

Depending on the value of maxSize we may preallocate a truly large map where, in practice, the majority of this state space might not be used. Considering the amount of time we spend growing the map and the extant call-sites I do not believe this to be a concern at present. 

REF #19125
REF #19142
REF SMP-677

