### PR TITLE
usm: Split gRPC large payloads test to fix flakiness

### DIFF
--- a/pkg/network/protocols/grpc/monitor_test.go
+++ b/pkg/network/protocols/grpc/monitor_test.go
@@ -10,12 +10,12 @@ package grpc
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/suite"
 	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"

--- a/pkg/network/protocols/grpc/monitor_test.go
+++ b/pkg/network/protocols/grpc/monitor_test.go
@@ -10,6 +10,7 @@ package grpc
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/suite"
 	"math/rand"
 	"testing"
 	"time"
@@ -41,6 +42,10 @@ func randStringRunes(n int) string {
 	return string(b)
 }
 
+type USMgRPCSuite struct {
+	suite.Suite
+}
+
 func TestGRPCScenarios(t *testing.T) {
 	currKernelVersion, err := kernel.HostVersion()
 	require.NoError(t, err)
@@ -50,7 +55,9 @@ func TestGRPCScenarios(t *testing.T) {
 
 	rand.Seed(time.Now().UnixNano())
 
-	ebpftest.TestBuildModes(t, []ebpftest.BuildMode{ebpftest.Prebuilt, ebpftest.RuntimeCompiled, ebpftest.CORE}, "", testGRPCScenarios)
+	ebpftest.TestBuildModes(t, []ebpftest.BuildMode{ebpftest.Prebuilt, ebpftest.RuntimeCompiled, ebpftest.CORE}, "", func(t *testing.T) {
+		suite.Run(t, new(USMgRPCSuite))
+	})
 }
 
 func getClientsArray(t *testing.T, size int, options grpc.Options) []*grpc.Client {
@@ -69,15 +76,15 @@ func getClientsIndex(index, totalCount int) int {
 	return index % totalCount
 }
 
-func testGRPCScenarios(t *testing.T) {
+func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
+	t := s.T()
 	cfg := config.New()
-	cfg.BPFDebug = true
 	cfg.EnableHTTP2Monitoring = true
 
-	s, err := grpc.NewServer(srvAddr)
+	srv, err := grpc.NewServer(srvAddr)
 	require.NoError(t, err)
-	s.Run()
-	t.Cleanup(s.Stop)
+	srv.Run()
+	t.Cleanup(srv.Stop)
 	defaultCtx := context.Background()
 
 	// c is a stream endpoint
@@ -206,46 +213,6 @@ func testGRPCScenarios(t *testing.T) {
 			},
 		},
 		{
-			name: "request with large body (50MB)",
-			runClients: func(t *testing.T, clientsCount int) {
-				clients := getClientsArray(t, clientsCount, grpc.Options{})
-
-				for i := 0; i < 5; i++ {
-					longName := randStringRunes(50 * 1024 * 1024)
-					require.NoError(t, clients[getClientsIndex(i, clientsCount)].HandleUnary(defaultCtx, longName))
-				}
-			},
-			expectedEndpoints: map[http.Key]int{
-				{
-					Path:   http.Path{Content: "/helloworld.Greeter/SayHello"},
-					Method: http.MethodPost,
-				}: 5,
-			},
-		},
-		{
-			name: "request with large body (5MB) -> b -> request with large body (5MB) -> b",
-			runClients: func(t *testing.T, clientsCount int) {
-				clients := getClientsArray(t, clientsCount, grpc.Options{})
-
-				longName := randStringRunes(5 * 1024 * 1024)
-
-				require.NoError(t, clients[getClientsIndex(0, clientsCount)].HandleUnary(defaultCtx, longName))
-				require.NoError(t, clients[getClientsIndex(1, clientsCount)].GetFeature(defaultCtx, -746143763, 407838351))
-				require.NoError(t, clients[getClientsIndex(2, clientsCount)].HandleUnary(defaultCtx, longName))
-				require.NoError(t, clients[getClientsIndex(3, clientsCount)].GetFeature(defaultCtx, -743999179, 408122808))
-			},
-			expectedEndpoints: map[http.Key]int{
-				{
-					Path:   http.Path{Content: "/routeguide.RouteGuide/GetFeature"},
-					Method: http.MethodPost,
-				}: 2,
-				{
-					Path:   http.Path{Content: "/helloworld.Greeter/SayHello"},
-					Method: http.MethodPost,
-				}: 2,
-			},
-		},
-		{
 			name: "500 headers -> b -> 500 headers -> b",
 			runClients: func(t *testing.T, clientsCount int) {
 				clients := getClientsArray(t, clientsCount, grpc.Options{})
@@ -358,6 +325,134 @@ func testGRPCScenarios(t *testing.T) {
 							return false
 						}
 						if val != count {
+							return false
+						}
+					}
+
+					return true
+				}, time.Second*5, time.Millisecond*100, "%v != %v", res, tt.expectedEndpoints)
+			})
+		}
+	}
+}
+
+type captureRange struct {
+	lower int
+	upper int
+}
+
+func (s *USMgRPCSuite) TestLargeBodiesGRPCScenarios() {
+	t := s.T()
+	cfg := config.New()
+	cfg.EnableHTTP2Monitoring = true
+
+	srv, err := grpc.NewServer(srvAddr)
+	require.NoError(t, err)
+	srv.Run()
+	t.Cleanup(srv.Stop)
+	defaultCtx := context.Background()
+
+	// c is a stream endpoint
+	// a + b are unary endpoints
+	tests := []struct {
+		name              string
+		runClients        func(t *testing.T, clientsCount int)
+		expectedEndpoints map[http.Key]captureRange
+	}{
+		{
+			name: "request with large body (50MB)",
+			runClients: func(t *testing.T, clientsCount int) {
+				clients := getClientsArray(t, clientsCount, grpc.Options{})
+
+				for i := 0; i < 5; i++ {
+					longName := randStringRunes(50 * 1024 * 1024)
+					require.NoError(t, clients[getClientsIndex(i, clientsCount)].HandleUnary(defaultCtx, longName))
+				}
+			},
+			expectedEndpoints: map[http.Key]captureRange{
+				{
+					Path:   http.Path{Content: "/helloworld.Greeter/SayHello"},
+					Method: http.MethodPost,
+				}: {
+					lower: 4,
+					upper: 5,
+				},
+			},
+		},
+		{
+			name: "request with large body (5MB) -> b -> request with large body (5MB) -> b",
+			runClients: func(t *testing.T, clientsCount int) {
+				clients := getClientsArray(t, clientsCount, grpc.Options{})
+
+				longName := randStringRunes(5 * 1024 * 1024)
+
+				require.NoError(t, clients[getClientsIndex(0, clientsCount)].HandleUnary(defaultCtx, longName))
+				require.NoError(t, clients[getClientsIndex(1, clientsCount)].GetFeature(defaultCtx, -746143763, 407838351))
+				require.NoError(t, clients[getClientsIndex(2, clientsCount)].HandleUnary(defaultCtx, longName))
+				require.NoError(t, clients[getClientsIndex(3, clientsCount)].GetFeature(defaultCtx, -743999179, 408122808))
+			},
+			expectedEndpoints: map[http.Key]captureRange{
+				{
+					Path:   http.Path{Content: "/routeguide.RouteGuide/GetFeature"},
+					Method: http.MethodPost,
+				}: {
+					lower: 2,
+					upper: 2,
+				},
+				{
+					Path:   http.Path{Content: "/helloworld.Greeter/SayHello"},
+					Method: http.MethodPost,
+				}: {
+					lower: 1,
+					upper: 2,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		for _, clientCount := range []int{1, 2, 5} {
+			testNameSuffix := fmt.Sprintf("-different clients - %v", clientCount)
+			t.Run(tt.name+testNameSuffix, func(t *testing.T) {
+				monitor, err := usm.NewMonitor(cfg, nil, nil, nil)
+				require.NoError(t, err)
+				require.NoError(t, monitor.Start())
+				defer monitor.Stop()
+
+				tt.runClients(t, clientCount)
+
+				res := make(map[http.Key]int)
+				require.Eventually(t, func() bool {
+					stats := monitor.GetProtocolStats()
+					http2Stats, ok := stats[protocols.HTTP2]
+					if !ok {
+						return false
+					}
+					http2StatsTyped := http2Stats.(map[http.Key]*http.RequestStats)
+					for key, stat := range http2StatsTyped {
+						if key.DstPort == 5050 || key.SrcPort == 5050 {
+							count := stat.Data[200].Count
+							newKey := http.Key{
+								Path:   http.Path{Content: key.Path.Content},
+								Method: key.Method,
+							}
+							if _, ok := res[newKey]; !ok {
+								res[newKey] = count
+							} else {
+								res[newKey] += count
+							}
+						}
+					}
+
+					if len(res) != len(tt.expectedEndpoints) {
+						return false
+					}
+
+					for key, count := range res {
+						valRange, ok := tt.expectedEndpoints[key]
+						if !ok {
+							return false
+						}
+						if count < valRange.lower || valRange.upper > count {
 							return false
 						}
 					}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Workaround to handle CI flakiness around the tests

For the large-body tests, we are defining a range of lower and upper bounds for capturing, to handle the edge case where we might not capture first / last requests in the CI.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Tests are flaky

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
