### PR TITLE
usm: Reverted changes introduced in #17586

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -53,7 +53,9 @@ typedef enum
     k400 = 12,
     k404 = 13,
     k500 = 14,
-} static_table_value_t;
+
+    __MAX_STATIC_TABLE_INDEX = 255,
+} __attribute__((packed)) static_table_value_t;
 
 typedef struct {
     char buffer[HTTP2_MAX_PATH_LEN] __attribute__((aligned(8)));
@@ -76,7 +78,7 @@ typedef struct {
     __u64 request_started;
 
     __u16 response_status_code;
-    __u32 request_method;
+    __u8 request_method;
     __u8 path_size;
     bool request_end_of_stream;
 

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -109,7 +109,7 @@ func (tx *EbpfTx) RequestStarted() uint64 {
 }
 
 func (tx *EbpfTx) SetRequestMethod(m http.Method) {
-	tx.Request_method = uint32(m)
+	tx.Request_method = uint8(m)
 }
 
 func (tx *EbpfTx) StaticTags() uint64 {

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -23,14 +23,14 @@ type EbpfTx struct {
 	Response_last_seen    uint64
 	Request_started       uint64
 	Response_status_code  uint16
-	Request_method        uint32
+	Request_method        uint8
 	Path_size             uint8
 	Request_end_of_stream bool
-	Pad_cgo_0             [6]byte
+	Pad_cgo_0             [3]byte
 	Request_path          [160]uint8
 }
 
-type StaticTableEnumValue = uint32
+type StaticTableEnumValue = uint8
 
 const (
 	GetValue       StaticTableEnumValue = 0x2


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Reverts a change introduced in #17586
Changes the type of http2 request method to a byte instead of 4 bytes.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
1. Setup a machine with kernel 5.4
2. Run system-probe with http2 monitoring enabled
3. Ensure http2 module is being loaded without verification error

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
