### PR TITLE
Revert "Stop manually building the oracledb python dependency in omnibus (#18860)"

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -119,6 +119,12 @@ if arm? || !_64_bit? || (windows? && windows_arch_i386?)
   blacklist_packages.push(/^orjson==/)
 end
 
+if linux?
+  # We need to use cython<3.0.0 to build oracledb
+  dependency 'oracledb-py3'
+  blacklist_packages.push(/^oracledb==/)
+end
+
 final_constraints_file = 'final_constraints-py3.txt'
 agent_requirements_file = 'agent_requirements-py3.txt'
 filtered_agent_requirements_in = 'agent_requirements-py3.in'

--- a/omnibus/config/software/oracledb-py3.rb
+++ b/omnibus/config/software/oracledb-py3.rb
@@ -1,0 +1,21 @@
+name "oracledb-py3"
+default_version "1.3.2"
+
+dependency "pip3"
+
+# The github repository contains a submodule which is not shipped with their released file.
+# Grabbing the tar from PyPi instead
+source :url => "https://files.pythonhosted.org/packages/05/18/516f38a55c99d8ac417a817afff88f484300ce7e4d94058055af1f1461e5/oracledb-#{version}.tar.gz",
+       :sha256 => "bb3c391c167b5778ddb15a7538a2b36db5c9b88a50c86c61781ca9ff302bb643",
+       :extract => :seven_zip
+
+relative_path "oracledb-#{version}"
+
+build do
+  license "Apache-2.0"
+  license_file "./LICENSE.txt"
+
+  command "sed -i 's/cython/cython<3.0.0/g' pyproject.toml"
+
+  command "#{install_dir}/embedded/bin/pip3 install ."
+end


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This reverts commit 8a99f117972284bb7e1b1d69737ce7d326837d42.


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We are facing an unexpected issue with oracledb 1.4.0:
- oracledb 1.4.0 is shipped with odpi 5.0.0
- the go oracle integration shipped with the agent includes [godror](https://github.com/DataDog/datadog-agent/blob/14e50af94e9ba009337a700b3895c256249a3e37/go.mod#L568) that is shipped with [odpi 4.6.1](https://github.com/godror/godror/tree/main/odpi)
- Somehow (to be investigated) our oracledb dependency loads the version of odpi that is shipped with godror instead of the one shipped with the wheel, so it uses odpi 4.6.1 instead of 5.0.0 when using the oracle instant client. This breaks our integration.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

I will investigate why this happens and revert this revert ASAP.

To be merged at then same time as https://github.com/DataDog/integrations-core/pull/15741

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
