### PR TITLE
[CSPM] Compliance checks: cross-container inputs resolving

### DIFF
--- a/pkg/compliance/cgroups_linux.go
+++ b/pkg/compliance/cgroups_linux.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package compliance
+
+import (
+	// We wrap pkg/security/utils here only for compat reason to be able to
+	// still compile pkg/compliance on !linux.
+	secutils "github.com/DataDog/datadog-agent/pkg/security/utils"
+)
+
+func getProcessContainerID(pid int32) (string, bool) {
+	containerID, err := secutils.GetProcContainerID(uint32(pid), uint32(pid))
+	if containerID == "" || err != nil {
+		return "", false
+	}
+	return string(containerID), true
+}
+
+func getProcessRootPath(pid int32) (string, bool) {
+	return secutils.ProcRootPath(uint32(pid)), true
+}

--- a/pkg/compliance/cgroups_nolinux.go
+++ b/pkg/compliance/cgroups_nolinux.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux
+
+package compliance
+
+func getProcessContainerID(pid int32) (string, bool) {
+	return "", false
+}
+
+func getProcessRootPath(pid int32) (string, bool) {
+	return "", false
+}

--- a/pkg/compliance/data.go
+++ b/pkg/compliance/data.go
@@ -54,6 +54,14 @@ type CheckStatus struct {
 	LastEvent   *CheckEvent
 }
 
+// CheckContainerMeta holds metadata related to the container that has been checked.
+type CheckContainerMeta struct {
+	ContainerID string `json:"container_id"`
+	ImageID     string `json:"image_id"`
+	ImageName   string `json:"image_name"`
+	ImageTag    string `json:"image_tag"`
+}
+
 // CheckEvent is the data structure sent to the backend as a result of a rule
 // evaluation.
 type CheckEvent struct {
@@ -66,6 +74,7 @@ type CheckEvent struct {
 	Result       CheckResult            `json:"result,omitempty"`
 	ResourceType string                 `json:"resource_type,omitempty"`
 	ResourceID   string                 `json:"resource_id,omitempty"`
+	Container    *CheckContainerMeta    `json:"container,omitempty"`
 	Tags         []string               `json:"tags"`
 	Data         map[string]interface{} `json:"data"`
 

--- a/pkg/compliance/evaluator_rego.go
+++ b/pkg/compliance/evaluator_rego.go
@@ -139,10 +139,27 @@ func newCheckEventFromRegoResult(data interface{}, rule *Rule, resolvedInputs Re
 	eventData, _ := m["data"].(map[string]interface{})
 	resourceID, _ := m["resource_id"].(string)
 	resourceType, _ := m["resource_type"].(string)
+
+	var event *CheckEvent
 	if errReason != nil {
-		return NewCheckError(RegoEvaluator, errReason, resourceID, resourceType, rule, benchmark)
+		event = NewCheckError(RegoEvaluator, errReason, resourceID, resourceType, rule, benchmark)
+	} else {
+		event = NewCheckEvent(RegoEvaluator, result, eventData, resourceID, resourceType, rule, benchmark)
 	}
-	return NewCheckEvent(RegoEvaluator, result, eventData, resourceID, resourceType, rule, benchmark)
+
+	if containerID, _ := m["container_id"].(string); containerID != "" {
+		imageID, _ := m["image_id"].(string)
+		imageName, _ := m["image_name"].(string)
+		imageTag, _ := m["image_tag"].(string)
+		event.Container = &CheckContainerMeta{
+			ContainerID: containerID,
+			ImageID: imageID,
+			ImageName: imageName,
+			ImageTag: imageTag,
+		}
+	}
+
+	return event
 }
 
 func buildRegoModules(rootDir string, rule *Rule) (map[string]string, error) {
@@ -177,6 +194,10 @@ raw_finding(status, resource_type, resource_id, event_data) = f {
 		"status": status,
 		"resource_type": resource_type,
 		"resource_id": resource_id,
+		"image_id": input.context.image_id,
+		"image_name": input.context.image_name,
+		"image_tag": input.context.image_tag,
+		"container_id": input.context.container_id,
 		"data": event_data,
 	}
 }

--- a/pkg/compliance/evaluator_rego.go
+++ b/pkg/compliance/evaluator_rego.go
@@ -153,9 +153,9 @@ func newCheckEventFromRegoResult(data interface{}, rule *Rule, resolvedInputs Re
 		imageTag, _ := m["image_tag"].(string)
 		event.Container = &CheckContainerMeta{
 			ContainerID: containerID,
-			ImageID: imageID,
-			ImageName: imageName,
-			ImageTag: imageTag,
+			ImageID:     imageID,
+			ImageName:   imageName,
+			ImageTag:    imageTag,
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

Adds the capability to resolve inputs related to a given container ID.

When a Resolver in created with ContainerID as option, we try and detect the associated processes that run on this container. We then resolve file contents related to the mounted root path of this process.

We also link to the resulting check events some metadata about which container and image was associated with the check.

### Motivation

Running cross-container compliance checks.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
