### PR TITLE
[CWS] `security_inode_attr`: ensure we never read PARM3 if not needed

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/setattr.h
+++ b/pkg/security/ebpf/c/include/hooks/setattr.h
@@ -17,13 +17,12 @@ int hook_security_inode_setattr(ctx_t *ctx) {
 
     u64 param1 = CTX_PARM1(ctx);
     u64 param2 = CTX_PARM2(ctx);
-    u64 param3 = CTX_PARM3(ctx);
 
     struct dentry *dentry;
     struct iattr *iattr;
     if (security_have_usernamespace_first_arg()) {
         dentry = (struct dentry *)param2;
-        iattr = (struct iattr *)param3;
+        iattr = (struct iattr *)CTX_PARM3(ctx);
     } else {
         dentry = (struct dentry *)param1;
         iattr = (struct iattr *)param2;


### PR DESCRIPTION
### What does this PR do?

The `security_inode_attr` has 2 modes depending on the position of arguments. This works fine with kprobe because the verifier does not check that the function has only 2 arguments in some modes but fentry verifier actually checks this and the `param3` variable can trip this on old kernels.

This PR fixes the issue by ensuring the param3 is only computed in the if branch that matches more recent kernels.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
