### PR TITLE
USM: grpc: increment data offset properly when skipping a header

### DIFF
--- a/pkg/network/ebpf/c/protocols/grpc/defs.h
+++ b/pkg/network/ebpf/c/protocols/grpc/defs.h
@@ -10,6 +10,6 @@ typedef enum {
 typedef struct {
     __u32 offset;
     __u32 length;
-} header_info_t;
+} frame_info_t;
 
 #endif

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -1543,6 +1543,25 @@ func testHTTP2ProtocolClassification(t *testing.T, tr *Tracer, clientHost, targe
 			validation: validateProtocolConnection(&protocols.Stack{Application: protocols.HTTP2, Api: protocols.GRPC}),
 		},
 		{
+			name:    "http2 traffic using gRPC - stream call",
+			context: grpcContext,
+			postTracerSetup: func(t *testing.T, ctx testContext) {
+				skipIfNotLinux(t, ctx)
+
+				c, err := grpc.NewClient(ctx.targetAddress, grpc.Options{
+					CustomDialer: defaultDialer,
+				})
+				require.NoError(t, err)
+				defer c.Close()
+				timedContext, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+				defer cancel()
+				require.NoError(t, c.HandleStream(timedContext, 5))
+			},
+			validation: validateProtocolConnection(&protocols.Stack{Application: protocols.HTTP2, Api: protocols.GRPC}),
+		},
+		{
+			// This test checks if the classifier can properly skip literal
+			// headers that are not useful to determine if gRPC is used.
 			name: "http2 traffic using gRPC - irrelevant literal headers",
 			context: testContext{
 				serverPort:    http2Port,
@@ -1562,6 +1581,9 @@ func testHTTP2ProtocolClassification(t *testing.T, tr *Tracer, clientHost, targe
 				req, err := nethttp.NewRequest("POST", "http://"+ctx.targetAddress, bytes.NewReader([]byte("test")))
 				require.NoError(t, err)
 
+				// Add some literal headers that needs to be skipped by the
+				// classifier. Also adding a grpc content-type to emulate grpc
+				// traffic
 				req.Header.Add("someheader", "somevalue")
 				req.Header.Add("Content-type", "application/grpc")
 				req.Header.Add("someotherheader", "someothervalue")
@@ -1570,23 +1592,6 @@ func testHTTP2ProtocolClassification(t *testing.T, tr *Tracer, clientHost, targe
 				require.NoError(t, err)
 
 				resp.Body.Close()
-			},
-			validation: validateProtocolConnection(&protocols.Stack{Application: protocols.HTTP2, Api: protocols.GRPC}),
-		},
-		{
-			name:    "http2 traffic using gRPC - stream call",
-			context: grpcContext,
-			postTracerSetup: func(t *testing.T, ctx testContext) {
-				skipIfNotLinux(t, ctx)
-
-				c, err := grpc.NewClient(ctx.targetAddress, grpc.Options{
-					CustomDialer: defaultDialer,
-				})
-				require.NoError(t, err)
-				defer c.Close()
-				timedContext, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-				defer cancel()
-				require.NoError(t, c.HandleStream(timedContext, 5))
 			},
 			validation: validateProtocolConnection(&protocols.Stack{Application: protocols.HTTP2, Api: protocols.GRPC}),
 		},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR aims to fix a bug in the gRPC classification where the data offset of the skb_info was not properly incremented if trying to parse an irrelevant (to us) literal header.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
