### PR TITLE
[dcaflare] Add profiling

### DIFF
--- a/comp/core/flare/profiling.go
+++ b/comp/core/flare/profiling.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package flare
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config/settings"
+)
+
+// ProfilingOpts defines the options used for profiling
+type ProfilingOpts struct {
+	ProfileMutex         bool
+	ProfileMutexFraction int
+	ProfileBlocking      bool
+	ProfileBlockingRate  int
+}
+
+// SetRuntimeProfilingSettings sets the runtime settings used for profiling
+func SetRuntimeProfilingSettings(opts ProfilingOpts, settingsClient settings.Client) (func(), error) {
+	if err := util.SetAuthToken(); err != nil {
+		return nil, fmt.Errorf("unable to set up authentication token: %v", err)
+	}
+
+	prev := make(map[string]interface{})
+	if opts.ProfileMutex && opts.ProfileMutexFraction > 0 {
+		old, err := setRuntimeSetting(settingsClient, "runtime_mutex_profile_fraction", opts.ProfileMutexFraction)
+		if err != nil {
+			return nil, err
+		}
+		prev["runtime_mutex_profile_fraction"] = old
+	}
+	if opts.ProfileBlocking && opts.ProfileBlockingRate > 0 {
+		old, err := setRuntimeSetting(settingsClient, "runtime_block_profile_rate", opts.ProfileBlockingRate)
+		if err != nil {
+			return nil, err
+		}
+		prev["runtime_block_profile_rate"] = old
+	}
+
+	return func() { resetRuntimeProfilingSettings(prev, settingsClient) }, nil
+}
+
+func setRuntimeSetting(c settings.Client, name string, value int) (interface{}, error) {
+	fmt.Fprintln(color.Output, color.BlueString("Setting %s to %v", name, value))
+
+	oldVal, err := c.Get(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current value of %s: %v", name, err)
+	}
+
+	if _, err := c.Set(name, fmt.Sprint(value)); err != nil {
+		return nil, fmt.Errorf("failed to set %s to %v: %v", name, value, err)
+	}
+
+	return oldVal, nil
+}
+
+func resetRuntimeProfilingSettings(prev map[string]interface{}, settingsClient settings.Client) {
+	if len(prev) == 0 {
+		return
+	}
+
+	for name, value := range prev {
+		fmt.Fprintln(color.Output, color.BlueString("Restoring %s to %v", name, value))
+		if _, err := settingsClient.Set(name, fmt.Sprint(value)); err != nil {
+			fmt.Fprintln(color.Output, color.RedString("Failed to restore previous value of %s: %v", name, err))
+		}
+	}
+}

--- a/pkg/cli/subcommands/dcaflare/command.go
+++ b/pkg/cli/subcommands/dcaflare/command.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
+
 package dcaflare
 
 import (
@@ -11,10 +12,14 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common/path"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	flareComponent "github.com/DataDog/datadog-agent/comp/core/flare"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
+	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/settings"
+	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/input"
@@ -24,9 +29,14 @@ import (
 )
 
 type cliParams struct {
-	caseID string
-	email  string
-	send   bool
+	caseID               string
+	email                string
+	send                 bool
+	profiling            int
+	profileMutex         bool
+	profileMutexFraction int
+	profileBlocking      bool
+	profileBlockingRate  int
 }
 
 type GlobalParams struct {
@@ -74,14 +84,66 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 
 	cmd.Flags().StringVarP(&cliParams.email, "email", "e", "", "Your email")
 	cmd.Flags().BoolVarP(&cliParams.send, "send", "s", false, "Automatically send flare (don't prompt for confirmation)")
+	cmd.Flags().IntVarP(&cliParams.profiling, "profile", "p", -1, "Add performance profiling data to the flare. It will collect a heap profile and a CPU profile for the amount of seconds passed to the flag, with a minimum of 30s")
+	cmd.Flags().BoolVarP(&cliParams.profileMutex, "profile-mutex", "M", false, "Add mutex profile to the performance data in the flare")
+	cmd.Flags().IntVarP(&cliParams.profileMutexFraction, "profile-mutex-fraction", "", 100, "Set the fraction of mutex contention events that are reported in the mutex profile")
+	cmd.Flags().BoolVarP(&cliParams.profileBlocking, "profile-blocking", "B", false, "Add goroutine blocking profile to the performance data in the flare")
+	cmd.Flags().IntVarP(&cliParams.profileBlockingRate, "profile-blocking-rate", "", 10000, "Set the fraction of goroutine blocking events that are reported in the blocking profile")
 	cmd.SetArgs([]string{"caseID"})
 
 	return cmd
 }
 
+func readProfileData(seconds int) (flare.ProfileData, error) {
+	pdata := flare.ProfileData{}
+	c := apiutil.GetClient(false)
+
+	fmt.Fprintln(color.Output, color.BlueString("Getting a %ds profile snapshot from datadog-cluster-agent.", seconds))
+	pprofURL := fmt.Sprintf("http://127.0.0.1:%d/debug/pprof", pkgconfig.Datadog.GetInt("expvar_port"))
+
+	for _, prof := range []struct{ name, URL string }{
+		{
+			// 1st heap profile
+			name: "datadog-cluster-agent-1st-heap.pprof",
+			URL:  pprofURL + "/heap",
+		},
+		{
+			// CPU profile
+			name: "datadog-cluster-agent-cpu.pprof",
+			URL:  fmt.Sprintf("%s/profile?seconds=%d", pprofURL, seconds),
+		},
+		{
+			// 2nd heap profile
+			name: "datadog-cluster-agent-2nd-heap.pprof",
+			URL:  pprofURL + "/heap",
+		},
+		{
+			// mutex profile
+			name: "datadog-cluster-agent-mutex.pprof",
+			URL:  pprofURL + "/mutex",
+		},
+		{
+			// goroutine blocking profile
+			name: "datadog-cluster-agent-block.pprof",
+			URL:  pprofURL + "/block",
+		},
+	} {
+		b, err := apiutil.DoGet(c, prof.URL, apiutil.LeaveConnectionOpen)
+		if err != nil {
+			return pdata, err
+		}
+		pdata[prof.name] = b
+	}
+
+	return pdata, nil
+}
+
 func run(log log.Component, config config.Component, cliParams *cliParams) error {
 	fmt.Fprintln(color.Output, color.BlueString("Asking the Cluster Agent to build the flare archive."))
-	var e error
+	var (
+		profile flare.ProfileData
+		e       error
+	)
 	c := util.GetClient(false) // FIX: get certificates right then make this true
 	urlstr := fmt.Sprintf("https://localhost:%v/flare", pkgconfig.Datadog.GetInt("cluster_agent.cmd_port"))
 
@@ -90,9 +152,35 @@ func run(log log.Component, config config.Component, cliParams *cliParams) error
 		logFile = path.DefaultDCALogFile
 	}
 
-	// Set session token
-	e = util.SetAuthToken()
-	if e != nil {
+	if cliParams.profiling >= 30 {
+		settingsClient, err := newSettingsClient()
+		if err != nil {
+			return fmt.Errorf("failed to initialize settings client: %v", err)
+		}
+
+		profilingOpts := flareComponent.ProfilingOpts{
+			ProfileMutex:         cliParams.profileMutex,
+			ProfileMutexFraction: cliParams.profileMutexFraction,
+			ProfileBlocking:      cliParams.profileBlocking,
+			ProfileBlockingRate:  cliParams.profileBlockingRate,
+		}
+
+		resetPreviousSettings, e := flareComponent.SetRuntimeProfilingSettings(profilingOpts, settingsClient)
+		if e != nil {
+			return e
+		}
+
+		if profile, e = readProfileData(cliParams.profiling); e != nil {
+			fmt.Fprintln(color.Output, color.YellowString(fmt.Sprintf("Could not collect performance profile data: %s", e)))
+		}
+
+		resetPreviousSettings()
+	} else if cliParams.profiling != -1 {
+		fmt.Fprintln(color.Output, color.RedString(fmt.Sprintf("Invalid value for profiling: %d. Please enter an integer of at least 30.", cliParams.profiling)))
+		return nil
+	}
+
+	if e = util.SetAuthToken(); e != nil {
 		return e
 	}
 
@@ -105,7 +193,7 @@ func run(log log.Component, config config.Component, cliParams *cliParams) error
 			fmt.Fprintln(color.Output, color.RedString("The agent was unable to make a full flare: %s.", e.Error()))
 		}
 		fmt.Fprintln(color.Output, color.YellowString("Initiating flare locally, some logs will be missing."))
-		filePath, e = flare.CreateDCAArchive(true, path.GetDistPath(), logFile, aggregator.GetSenderManager())
+		filePath, e = flare.CreateDCAArchive(true, path.GetDistPath(), logFile, aggregator.GetSenderManager(), profile)
 		if e != nil {
 			fmt.Printf("The flare zipfile failed to be created: %s\n", e)
 			return e
@@ -129,4 +217,15 @@ func run(log log.Component, config config.Component, cliParams *cliParams) error
 		return e
 	}
 	return nil
+}
+
+func newSettingsClient() (settings.Client, error) {
+	c := util.GetClient(false)
+
+	apiConfigURL := fmt.Sprintf(
+		"https://localhost:%v/config",
+		pkgconfig.Datadog.GetInt("cluster_agent.cmd_port"),
+	)
+
+	return settingshttp.NewClient(c, apiConfigURL, "datadog-cluster-agent"), nil
 }

--- a/releasenotes-dca/notes/dca-flare-pprof-53745b8352626a2c.yaml
+++ b/releasenotes-dca/notes/dca-flare-pprof-53745b8352626a2c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Added option to attach profiling data to a flare.


### PR DESCRIPTION

### What does this PR do?

Adds new options in the `datadog-cluster-agent flare` command to attach performance profiles: `--profile`, `--profile-blocking`, `--profile-blocking-rate`, `--profile-mutex`, `--profile-mutex-fraction`.

These are the same options that already exist in the command to generate agent flares.

```
datadog-cluster-agent flare --help
Collect a flare and send it to Datadog

Usage:
  datadog-cluster-agent flare [caseID] [flags]

Flags:
  -e, --email string                 Your email
  -h, --help                         help for flare
  -p, --profile int                  Add performance profiling data to the flare. It will collect a heap profile and a CPU profile for the amount of seconds passed to the flag, with a minimum of 30s (default -1)
  -B, --profile-blocking             Add goroutine blocking profile to the performance data in the flare
      --profile-blocking-rate int    Set the fraction of goroutine blocking events that are reported in the blocking profile (default 10000)
  -M, --profile-mutex                Add mutex profile to the performance data in the flare
      --profile-mutex-fraction int   Set the fraction of mutex contention events that are reported in the mutex profile (default 100)
  -s, --send                         Automatically send flare (don't prompt for confirmation)
```

I used #17231  by @mathieucolin as a starting point. I refactored the code a bit to adapt it to the new changes. I also extracted some functions that were duplicated, and fixed a bug (the code was using a settings client for the agent instead of the DCA).


### Describe how to test/QA your changes

- Deploy the agent on Kubernetes.
- Run `datadog-cluster-agent flare --profile 30` from the DCA pod.
- Check the profiles generated. For example, for the CPU one: `go tool pprof -http localhost:8080 datadog-cluster-agent-cpu.pprof`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
