### PR TITLE
e2e: don't check for specific string in Remote Configuration status section

### DIFF
--- a/test/new-e2e/agent-subcommands/configcheck_test.go
+++ b/test/new-e2e/agent-subcommands/configcheck_test.go
@@ -26,7 +26,7 @@ func TestAgentConfigCheckSuite(t *testing.T) {
 type CheckConfigOutput struct {
 	CheckName  string
 	Filepath   string
-	InstanceId string
+	InstanceID string
 	Settings   string
 }
 
@@ -52,7 +52,7 @@ func MatchCheckToTemplate(checkname, input string) (*CheckConfigOutput, error) {
 	return &CheckConfigOutput{
 		CheckName:  checkname,
 		Filepath:   matches[filepathIndex],
-		InstanceId: matches[instanceIndex],
+		InstanceID: matches[instanceIndex],
 		Settings:   matches[settingsIndex],
 	}, nil
 }
@@ -88,7 +88,7 @@ Config for instance ID: cpu:e331d61ed1323219
 
 	assert.Contains(v.T(), result.CheckName, "uptime")
 	assert.Contains(v.T(), result.Filepath, "file:/etc/datadog-agent/conf.d/uptime.d/conf.yaml.default")
-	assert.Contains(v.T(), result.InstanceId, "uptime:c72f390abdefdf1a")
+	assert.Contains(v.T(), result.InstanceID, "uptime:c72f390abdefdf1a")
 	assert.Contains(v.T(), result.Settings, "key: value")
 	assert.Contains(v.T(), result.Settings, "path: http://example.com/foo")
 	assert.NotContains(v.T(), result.Settings, "{}")
@@ -98,7 +98,7 @@ Config for instance ID: cpu:e331d61ed1323219
 
 	assert.Contains(v.T(), result.CheckName, "cpu")
 	assert.Contains(v.T(), result.Filepath, "file:/etc/datadog-agent/conf.d/cpu.d/conf.yaml.default")
-	assert.Contains(v.T(), result.InstanceId, "cpu:e331d61ed1323219")
+	assert.Contains(v.T(), result.InstanceID, "cpu:e331d61ed1323219")
 	assert.Contains(v.T(), result.Settings, "{}")
 }
 
@@ -110,55 +110,55 @@ func (v *agentConfigCheckSuite) TestDefaultInstalledChecks() {
 		{
 			CheckName:  "cpu",
 			Filepath:   "file:/etc/datadog-agent/conf.d/cpu.d/conf.yaml.default",
-			InstanceId: "cpu:",
+			InstanceID: "cpu:",
 			Settings:   "{}",
 		},
 		{
 			CheckName:  "disk",
 			Filepath:   "file:/etc/datadog-agent/conf.d/disk.d/conf.yaml.default",
-			InstanceId: "disk:",
+			InstanceID: "disk:",
 			Settings:   "use_mount: false",
 		},
 		{
 			CheckName:  "file_handle",
 			Filepath:   "file:/etc/datadog-agent/conf.d/file_handle.d/conf.yaml.default",
-			InstanceId: "file_handle:",
+			InstanceID: "file_handle:",
 			Settings:   "{}",
 		},
 		{
 			CheckName:  "io",
 			Filepath:   "file:/etc/datadog-agent/conf.d/io.d/conf.yaml.default",
-			InstanceId: "io:",
+			InstanceID: "io:",
 			Settings:   "{}",
 		},
 		{
 			CheckName:  "load",
 			Filepath:   "file:/etc/datadog-agent/conf.d/load.d/conf.yaml.default",
-			InstanceId: "load:",
+			InstanceID: "load:",
 			Settings:   "{}",
 		},
 		{
 			CheckName:  "memory",
 			Filepath:   "file:/etc/datadog-agent/conf.d/memory.d/conf.yaml.default",
-			InstanceId: "memory:",
+			InstanceID: "memory:",
 			Settings:   "{}",
 		},
 		{
 			CheckName:  "network",
 			Filepath:   "file:/etc/datadog-agent/conf.d/network.d/conf.yaml.default",
-			InstanceId: "network:",
+			InstanceID: "network:",
 			Settings:   "{}",
 		},
 		{
 			CheckName:  "ntp",
 			Filepath:   "file:/etc/datadog-agent/conf.d/ntp.d/conf.yaml.default",
-			InstanceId: "ntp:",
+			InstanceID: "ntp:",
 			Settings:   "{}",
 		},
 		{
 			CheckName:  "uptime",
 			Filepath:   "file:/etc/datadog-agent/conf.d/uptime.d/conf.yaml.default",
-			InstanceId: "uptime:",
+			InstanceID: "uptime:",
 			Settings:   "{}",
 		},
 	}
@@ -172,7 +172,7 @@ func (v *agentConfigCheckSuite) TestDefaultInstalledChecks() {
 			result, err := MatchCheckToTemplate(testCheck.CheckName, output)
 			assert.NoError(t, err)
 			assert.Contains(t, result.Filepath, testCheck.Filepath)
-			assert.Contains(t, result.InstanceId, testCheck.InstanceId)
+			assert.Contains(t, result.InstanceID, testCheck.InstanceID)
 			assert.Contains(t, result.Settings, testCheck.Settings)
 		})
 	}
@@ -204,7 +204,7 @@ func (v *agentConfigCheckSuite) TestWithAddedIntegrationsCheck() {
 	result, err := MatchCheckToTemplate("http_check", output)
 	assert.NoError(v.T(), err)
 	assert.Contains(v.T(), result.Filepath, "file:/etc/datadog-agent/conf.d/http_check.d/conf.yaml")
-	assert.Contains(v.T(), result.InstanceId, "http_check:")
+	assert.Contains(v.T(), result.InstanceID, "http_check:")
 	assert.Contains(v.T(), result.Settings, "name: My First Service")
 	assert.Contains(v.T(), result.Settings, "url: http://some.url.example.com")
 }

--- a/test/new-e2e/agent-subcommands/hostname_ec2_test.go
+++ b/test/new-e2e/agent-subcommands/hostname_ec2_test.go
@@ -31,8 +31,8 @@ func (v *agentHostnameSuite) TestAgentHostnameDefaultsToResourceId() {
 	hostname := v.Env().Agent.Hostname()
 
 	// Default configuration of hostname for EC2 instances is the resource-id
-	resourceId := metadata.Get("instance-id")
-	assert.Equal(v.T(), hostname, resourceId)
+	resourceID := metadata.Get("instance-id")
+	assert.Equal(v.T(), hostname, resourceID)
 }
 
 func (v *agentHostnameSuite) TestAgentConfigHostnameVarOverride() {
@@ -77,6 +77,6 @@ func (v *agentHostnameSuite) TestAgentConfigPreferImdsv2() {
 	metadata := client.NewEC2Metadata(v.Env().VM)
 
 	hostname := v.Env().Agent.Hostname()
-	resourceId := metadata.Get("instance-id")
-	assert.Equal(v.T(), hostname, resourceId)
+	resourceID := metadata.Get("instance-id")
+	assert.Equal(v.T(), hostname, resourceID)
 }

--- a/test/new-e2e/agent-subcommands/subcommands_test.go
+++ b/test/new-e2e/agent-subcommands/subcommands_test.go
@@ -157,7 +157,6 @@ func (v *subcommandSuite) TestDefaultInstallStatus() {
 		{
 			name:            "Remote Configuration",
 			shouldBePresent: true,
-			shouldContain:   []string{"Organization enabled: False"},
 		},
 		{
 			name:            "Runtime Security",


### PR DESCRIPTION

### What does this PR do?

Remove a check for the remote configuration section status

### Motivation

The test is flaky + we don't have the knowledge about how RC should behave by default. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
