### PR TITLE
[CSPM] Revive lint of pkg/compliance

### DIFF
--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package compliance implements a specific part of the datadog-agent
+// responsible for scanning host and containers and report various
+// misconfigurations and compliance issues.
 package compliance
 
 import (
@@ -30,6 +33,7 @@ const containersCountMetricName = "datadog.security_agent.compliance.containers_
 
 var status = expvar.NewMap("compliance")
 
+// AgentOptions holds the different options to configure the compliance agent.
 type AgentOptions struct {
 	// ResolverOptions is the options passed to the constructed resolvers
 	// internally. See resolver.go.
@@ -62,6 +66,8 @@ type AgentOptions struct {
 	EvalThrottling time.Duration
 }
 
+// Agent is the compliance agent that is responsible for running compliance
+// continuously benchmarks and configuration checking.
 type Agent struct {
 	senderManager sender.SenderManager
 	opts          AgentOptions
@@ -78,6 +84,9 @@ func xccdfEnabled() bool {
 	return config.Datadog.GetBool("compliance_config.xccdf.enabled") || config.Datadog.GetBool("compliance_config.host_benchmarks.enabled")
 }
 
+// DefaultRuleFilter implements the default filtering of benchmarks' rules. It
+// will exclude rules based on the evaluation context / environment running
+// the benchmark.
 func DefaultRuleFilter(r *Rule) bool {
 	if config.IsKubernetes() {
 		if r.SkipOnK8s {
@@ -108,6 +117,7 @@ func DefaultRuleFilter(r *Rule) bool {
 	return true
 }
 
+// NewAgent returns a new compliance agent.
 func NewAgent(senderManager sender.SenderManager, opts AgentOptions) *Agent {
 	if opts.ConfigDir == "" {
 		panic("compliance: missing agent configuration directory")
@@ -141,6 +151,7 @@ func NewAgent(senderManager sender.SenderManager, opts AgentOptions) *Agent {
 	}
 }
 
+// Start starts the compliance agent.
 func (a *Agent) Start() error {
 	telemetry, err := telemetry.NewContainersTelemetry(a.senderManager)
 	if err != nil {
@@ -202,6 +213,7 @@ func (a *Agent) Start() error {
 	return nil
 }
 
+// Stop stops the compliance agent.
 func (a *Agent) Stop() {
 	log.Tracef("shutting down compliance agent")
 	a.cancel()
@@ -384,6 +396,7 @@ func (a *Agent) runTelemetry(ctx context.Context) {
 	}
 }
 
+// GetStatus returns a map of the different last results of our checks.
 func (a *Agent) GetStatus() map[string]interface{} {
 	return map[string]interface{}{
 		"endpoints": a.opts.Reporter.Endpoints().GetStatus(),

--- a/pkg/compliance/aptconfig/aptconfig.go
+++ b/pkg/compliance/aptconfig/aptconfig.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package aptconfig is a compliance submodule that is able to parse the APT tool
+// configuration and export it as a log.
 package aptconfig
 
 import (

--- a/pkg/compliance/data.go
+++ b/pkg/compliance/data.go
@@ -23,10 +23,13 @@ import (
 type Evaluator string
 
 const (
-	RegoEvaluator  Evaluator = "rego"
+	// RegoEvaluator uses the rego engine to evaluate a check.
+	RegoEvaluator Evaluator = "rego"
+	// XCCDFEvaluator uses OpenSCAP to evaluate a check.
 	XCCDFEvaluator Evaluator = "xccdf"
 )
 
+// CheckResult lists the different states of a check result.
 type CheckResult string
 
 const (
@@ -43,6 +46,8 @@ const (
 	CheckSkipped CheckResult = "skipped"
 )
 
+// CheckStatus is used to store the last current status of each rule inside
+// our compliance agent.
 type CheckStatus struct {
 	RuleID      string
 	Name        string
@@ -81,6 +86,7 @@ type CheckEvent struct {
 	errReason error `json:"-"`
 }
 
+// ResourceLog is the data structure holding a resource configuration data.
 type ResourceLog struct {
 	AgentVersion string      `json:"agent_version,omitempty"`
 	ExpireAt     time.Time   `json:"expire_at,omitempty"`
@@ -103,6 +109,8 @@ func (e *CheckEvent) String() string {
 	return s
 }
 
+// NewCheckError returns a CheckEvent with error status and associated error
+// reason.
 func NewCheckError(
 	evaluator Evaluator,
 	errReason error,
@@ -127,6 +135,7 @@ func NewCheckError(
 	}
 }
 
+// NewCheckEvent returns a CheckEvent with given status.
 func NewCheckEvent(
 	evaluator Evaluator,
 	result CheckResult,
@@ -150,6 +159,7 @@ func NewCheckEvent(
 	}
 }
 
+// NewCheckSkipped returns a CheckEvent with skipped status.
 func NewCheckSkipped(
 	evaluator Evaluator,
 	skipReason error,
@@ -170,6 +180,7 @@ func NewCheckSkipped(
 	}
 }
 
+// NewResourceLog returns a ResourceLog.
 func NewResourceLog(resourceID, resourceType string, resource interface{}) *ResourceLog {
 	expireAt := time.Now().Add(1 * time.Hour).UTC().Truncate(1 * time.Second)
 	return &ResourceLog{
@@ -181,15 +192,21 @@ func NewResourceLog(resourceID, resourceType string, resource interface{}) *Reso
 	}
 }
 
+// RuleScope defines the different context in which the rule is allowed to run.
 type RuleScope string
 
 const (
-	Unscoped               RuleScope = "none"
-	DockerScope            RuleScope = "docker"
-	KubernetesNodeScope    RuleScope = "kubernetesNode"
+	// Unscoped scope used when no particular scope is required
+	Unscoped RuleScope = "none"
+	// DockerScope used for rules requiring a Docker daemon running.
+	DockerScope RuleScope = "docker"
+	// KubernetesNodeScope used for rules requireing a kubelet process running.
+	KubernetesNodeScope RuleScope = "kubernetesNode"
+	// KubernetesClusterScope used for rules requireing a kube-apiserver process running.
 	KubernetesClusterScope RuleScope = "kubernetesCluster"
 )
 
+// RuleFilter defines a function type that can be used to filter rules.
 type RuleFilter func(*Rule) bool
 
 // Rule defines a list of inputs against which we can evaluate properties. It
@@ -223,29 +240,36 @@ type (
 		Type    string `yaml:"type,omitempty" json:"type,omitempty"`
 	}
 
+	// InputSpecFile describes the spec to resolve file informations.
 	InputSpecFile struct {
 		Path   string `yaml:"path" json:"path"`
 		Glob   string `yaml:"glob" json:"glob"`
 		Parser string `yaml:"parser,omitempty" json:"parser,omitempty"`
 	}
 
+	// InputSpecProcess describes the spec to resolve process informations.
 	InputSpecProcess struct {
 		Name string   `yaml:"name" json:"name"`
 		Envs []string `yaml:"envs,omitempty" json:"envs,omitempty"`
 	}
 
+	// InputSpecGroup describes the spec to resolve a unix group informations.
 	InputSpecGroup struct {
 		Name string `yaml:"name" json:"name"`
 	}
 
+	// InputSpecAudit describes the spec to resolve a Linux Audit informations.
 	InputSpecAudit struct {
 		Path string `yaml:"path" json:"path"`
 	}
 
+	// InputSpecDocker describes the spec to resolve a Docker resource informations.
 	InputSpecDocker struct {
 		Kind string `yaml:"kind" json:"kind"`
 	}
 
+	// InputSpecKubeapiserver describes the spec to resolve a Kubernetes
+	// resource information from from kube-apiserver.
 	InputSpecKubeapiserver struct {
 		Kind          string `yaml:"kind" json:"kind"`
 		Version       string `yaml:"version,omitempty" json:"version,omitempty"`
@@ -259,6 +283,7 @@ type (
 		} `yaml:"apiRequest" json:"apiRequest"`
 	}
 
+	// InputSpecXCCDF describes the spec to resolve a XCCDF evaluation result.
 	InputSpecXCCDF struct {
 		Name    string   `yaml:"name" json:"name"`
 		Profile string   `yaml:"profile" json:"profile"`
@@ -266,13 +291,14 @@ type (
 		Rules   []string `yaml:"rules,omitempty" json:"rules,omitempty"`
 	}
 
+	// InputSpecConstants can be used to pass constants data to the evaluator.
 	InputSpecConstants map[string]interface{}
 )
 
 // ResolvedInputs is the generic data structure that is returned by a Resolver.
 type ResolvedInputs map[string]interface{}
 
-// Benchmarks represents a set of rules that have a common identity, typically
+// Benchmark represents a set of rules that have a common identity, typically
 // part of the same framework. It holds metadata that are shared between these
 // rules. Rules of a same Benchmark are typically run together.
 type Benchmark struct {
@@ -289,14 +315,17 @@ type Benchmark struct {
 	} `yaml:"schema,omitempty" json:"schema,omitempty"`
 }
 
+// IsRego returns true if the rule is a rego rule.
 func (r *Rule) IsRego() bool {
 	return !r.IsXCCDF()
 }
 
+// IsXCCDF returns true if the rule is a XCCDF / OpenSCAP rule.
 func (r *Rule) IsXCCDF() bool {
 	return len(r.InputSpecs) == 1 && r.InputSpecs[0].XCCDF != nil
 }
 
+// HasScope tests if the rule has the given scope.
 func (r *Rule) HasScope(scope RuleScope) bool {
 	for _, s := range r.Scopes {
 		if s == scope {
@@ -306,6 +335,7 @@ func (r *Rule) HasScope(scope RuleScope) bool {
 	return false
 }
 
+// Valid is a validation check required for InputSpec to be executed.
 func (i *InputSpec) Valid() error {
 	// NOTE(jinroh): the current semantics allow to specify the result type as
 	// an "array". Here we enforce that the specified result type is
@@ -325,6 +355,9 @@ func (i *InputSpec) Valid() error {
 	return nil
 }
 
+// Valid is a validation check required for a Benchmark to be considered valid
+// and be executed. It checks that all rules and input specs are actually
+// valid.
 func (b *Benchmark) Valid() error {
 	if len(b.Rules) == 0 {
 		return fmt.Errorf("bad benchmark: empty rule set")

--- a/pkg/compliance/evaluator_xccdf.go
+++ b/pkg/compliance/evaluator_xccdf.go
@@ -34,6 +34,7 @@ const (
 )
 
 const (
+	//revive:disable
 	XCCDF_RESULT_PASS = iota + 1
 	XCCDF_RESULT_FAIL
 	XCCDF_RESULT_ERROR
@@ -41,6 +42,7 @@ const (
 	XCCDF_RESULT_NOT_APPLICABLE
 	XCCDF_RESULT_NOT_CHECKED
 	XCCDF_RESULT_NOT_SELECTED
+	//revive:enable
 )
 
 type oscapIORule struct {
@@ -252,6 +254,7 @@ func (p *oscapIO) Kill() error {
 	return nil
 }
 
+// EvaluateXCCDFRule evaluates the given rule using OpenSCAP tool.
 func EvaluateXCCDFRule(ctx context.Context, hostname string, statsdClient *statsd.Client, benchmark *Benchmark, rule *Rule) []*CheckEvent {
 	if !rule.IsXCCDF() {
 		log.Errorf("given rule is not an XCCDF rule %s", rule.ID)

--- a/pkg/compliance/k8sconfig/loader.go
+++ b/pkg/compliance/k8sconfig/loader.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package k8sconfig is a compliance submodule that is able to parse the
+// Kubernetes components configurations and export it as a log.
 package k8sconfig
 
 import (

--- a/pkg/compliance/k8sconfig/types.go
+++ b/pkg/compliance/k8sconfig/types.go
@@ -10,6 +10,8 @@ import (
 	"time"
 )
 
+//revive:disable
+
 type K8sNodeConfig struct {
 	Version            string               `json:"version"`
 	ManagedEnvironment *K8sManagedEnvConfig `json:"managedEnvironment,omitempty"`

--- a/pkg/compliance/k8sconfig/types_generated.go
+++ b/pkg/compliance/k8sconfig/types_generated.go
@@ -6,6 +6,8 @@
 // !!!
 // This is a generated file: regenerate with go run ./pkg/compliance/tools/k8s_types_generator.go
 // !!!
+//
+//revive:disable
 package k8sconfig
 
 import (

--- a/pkg/compliance/metrics/metrics.go
+++ b/pkg/compliance/metrics/metrics.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package metrics implements everything related to metrics of the pkg/compliance module.
 package metrics
 
 const (

--- a/pkg/compliance/metrics/rego.go
+++ b/pkg/compliance/metrics/rego.go
@@ -21,7 +21,9 @@ var (
 	registeredCounters   map[string]telemetry.Counter
 )
 
-func NewRegoTelemetry() *regoTelemetry {
+// NewRegoTelemetry returns a opa/metrics.Metrics interface to monitor rego's
+// performance.
+func NewRegoTelemetry() opametrics.Metrics {
 	return &regoTelemetry{
 		inner:      opametrics.New(),
 		counters:   make(map[string]*regoCounter),

--- a/pkg/compliance/reporter.go
+++ b/pkg/compliance/reporter.go
@@ -28,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 )
 
+// LogReporter is responsible for sending compliance logs to DataDog backends.
 type LogReporter struct {
 	logSource *sources.LogSource
 	logChan   chan *message.Message
@@ -85,10 +86,12 @@ func NewLogReporter(stopper startstop.Stopper, sourceName, sourceType, runPath s
 	}, nil
 }
 
+// Endpoints returns the endpoints associated with the log reporter.
 func (r *LogReporter) Endpoints() *config.Endpoints {
 	return r.endpoints
 }
 
+// ReportEvent should be used to send an event to the backend.
 func (r *LogReporter) ReportEvent(event interface{}) {
 	buf, err := json.Marshal(event)
 	if err != nil {

--- a/pkg/compliance/scap/document.go
+++ b/pkg/compliance/scap/document.go
@@ -33,6 +33,7 @@ const (
 	ocilOcilElement                  = "ocil"
 )
 
+// Document contains all the returned informations of an openscap evaluation.
 type Document struct {
 	Type constants.DocumentType `json:"-"`
 	*cdf.Benchmark
@@ -44,6 +45,7 @@ type Document struct {
 	*inter.Ocil
 }
 
+// ReadDocument takes an io.Reader and return a Document or error if failed.
 func ReadDocument(r io.Reader) (*Document, error) {
 	d := xml.NewDecoder(r)
 	for {

--- a/pkg/compliance/scap/syschar.go
+++ b/pkg/compliance/scap/syschar.go
@@ -3,15 +3,21 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package scap implements some internal parsing of the OpenSCAP analysis
+// results.
 package scap
 
 import "fmt"
 
+// SystemCharacteristics contains the internal charasteristics of an OVAL
+// evaluation.
 type SystemCharacteristics struct {
 	SystemInfo SystemInfo `json:"system_info"`
 	Objects    []Object   `json:"objects,omitempty"`
 }
 
+// SystemInfo is an internal field of SystemCharacteristics contains the
+// global system informations.
 type SystemInfo struct {
 	OsName          string `json:"os_name"`
 	OsVersion       string `json:"os_version"`
@@ -19,16 +25,19 @@ type SystemInfo struct {
 	PrimaryHostName string `json:"primary_host_name"`
 }
 
+// Object contains the informations of a specific OVAL Object.
 type Object struct {
 	ID    string `json:"id"`
 	Items []Item `json:"items,omitempty"`
 }
 
+// Item contains the messages of an OVAL Object's fields.
 type Item struct {
 	ID       string            `json:"id"`
 	Messages map[string]string `json:"messages"`
 }
 
+// SysChar returns the refined system characteristics from a Document.
 func SysChar(doc *Document) (*SystemCharacteristics, error) {
 	if doc.OvalSystemCharacteristics == nil {
 		return nil, fmt.Errorf("OvalSystemCharacteristics is nil")

--- a/pkg/compliance/tests/audit_test.go
+++ b/pkg/compliance/tests/audit_test.go
@@ -5,6 +5,7 @@
 
 //go:build linux
 
+// Package tests implements the test suite of our compliance package.
 package tests
 
 import (
@@ -20,7 +21,7 @@ func TestAuditInput(t *testing.T) {
 		t.Skipf("could not create audit client: %v", err)
 	}
 
-	b := NewTestBench(t).
+	b := newTestBench(t).
 		WithAuditClient(cl)
 	defer b.Run()
 

--- a/pkg/compliance/tests/badenv_test.go
+++ b/pkg/compliance/tests/badenv_test.go
@@ -10,7 +10,7 @@ package tests
 import "testing"
 
 func TestNoDocker(t *testing.T) {
-	b := NewTestBench(t)
+	b := newTestBench(t)
 	defer b.Run()
 
 	b.AddRule("NoDockerNoneScope").
@@ -82,7 +82,7 @@ findings[f] {
 }
 
 func TestNoKubernetes(t *testing.T) {
-	b := NewTestBench(t)
+	b := newTestBench(t)
 	defer b.Run()
 
 	b.AddRule("NoKubernetesNode").

--- a/pkg/compliance/tests/base_test.go
+++ b/pkg/compliance/tests/base_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestBase(t *testing.T) {
-	b := NewTestBench(t)
+	b := newTestBench(t)
 	defer b.Run()
 
 	b.AddRule("BadYamlSuiteInput").

--- a/pkg/compliance/tests/docker_test.go
+++ b/pkg/compliance/tests/docker_test.go
@@ -25,7 +25,7 @@ func TestDockerInfoInput(t *testing.T) {
 		t.Skipf("could not connect to docker to start testing: %v", err)
 	}
 
-	b := NewTestBench(t).
+	b := newTestBench(t).
 		WithHostname(dockerHostname).
 		WithDockerClient(dockerCl)
 	defer b.Run()

--- a/pkg/compliance/tests/file_test.go
+++ b/pkg/compliance/tests/file_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestFile(t *testing.T) {
-	b := NewTestBench(t)
+	b := newTestBench(t)
 	defer b.Run()
 
 	b.AddRule("FileNotExists").
@@ -155,7 +155,7 @@ findings[f] {
 }
 
 func TestFileParser(t *testing.T) {
-	b := NewTestBench(t)
+	b := newTestBench(t)
 	defer b.Run()
 
 	tmpFileJSON := b.WriteTempFile(t, `{"foo":"bar","baz": {"quz": 1}}`)
@@ -231,7 +231,7 @@ findings[f] {
 }
 
 func TestFileGlob(t *testing.T) {
-	b := NewTestBench(t)
+	b := newTestBench(t)
 	defer b.Run()
 
 	b.

--- a/pkg/compliance/tests/helpers.go
+++ b/pkg/compliance/tests/helpers.go
@@ -52,7 +52,7 @@ type assertedRule struct {
 	expectErr bool
 }
 
-func NewTestBench(t *testing.T) *suite {
+func newTestBench(t *testing.T) *suite {
 	rootDir := t.TempDir()
 	return &suite{
 		t:       t,

--- a/pkg/compliance/tests/kubernetes_test.go
+++ b/pkg/compliance/tests/kubernetes_test.go
@@ -49,7 +49,7 @@ func TestKubernetesCluster(t *testing.T) {
 		newMyObj("testns3", "dummy3", "105"),
 	)
 
-	b := NewTestBench(t).WithKubeClient(kubeClient)
+	b := newTestBench(t).WithKubeClient(kubeClient)
 	defer b.Run()
 
 	b.

--- a/pkg/compliance/tests/process_test.go
+++ b/pkg/compliance/tests/process_test.go
@@ -29,7 +29,7 @@ func TestProcessInput(t *testing.T) {
 	}
 	self = filepath.Base(self)
 
-	b := NewTestBench(t)
+	b := newTestBench(t)
 	defer b.Run()
 
 	b.AddRule("Self").
@@ -228,7 +228,7 @@ findings[f] {
 }
 
 func TestEtcGroup(t *testing.T) {
-	b := NewTestBench(t)
+	b := newTestBench(t)
 	defer b.Run()
 
 	b.AddRule("EtcRootGroup").

--- a/pkg/compliance/tools/k8s_types_generator/main.go
+++ b/pkg/compliance/tools/k8s_types_generator/main.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package main is the entrypoint of the compliance k8s_types_generator tool
+// that is responsible for generating various configuration types of
+// Kubernetes components.
 package main
 
 import (
@@ -141,6 +144,7 @@ const preamble = `// Unless explicitly stated otherwise all files in this reposi
 // !!!
 // This is a generated file: regenerate with go run ./pkg/compliance/tools/k8s_types_generator.go
 // !!!
+//revive:disable
 package k8sconfig
 
 import (
@@ -391,9 +395,8 @@ func printKomponentCode(komp *komponent) string {
 		case "*K8sConfigFileMeta":
 			if komp.name == "kubelet" && c.flagName == "config" {
 				return fmt.Sprintf("res.%s = l.loadKubeletConfigFileMeta(%s)", toGoField(c.flagName), v)
-			} else {
-				return fmt.Sprintf("res.%s = l.loadConfigFileMeta(%s)", toGoField(c.flagName), v)
 			}
+			return fmt.Sprintf("res.%s = l.loadConfigFileMeta(%s)", toGoField(c.flagName), v)
 		case "*K8sKubeletConfigFileMeta":
 			return fmt.Sprintf("res.%s = l.loadKubeletConfigFileMeta(%s)", toGoField(c.flagName), v)
 		case "*K8sAdmissionConfigFileMeta":
@@ -445,11 +448,11 @@ func downloadEtcdAndExtractFlags(componentVersion string) *komponent {
 	const componentName = "etcd"
 	componentBin := path.Join(bindir, fmt.Sprintf("%s-%s", componentName, componentVersion))
 	componentTar := path.Join(bindir, fmt.Sprintf("%s-%s.tar.gz", componentName, componentVersion))
-	componentUrl := fmt.Sprintf("https://github.com/etcd-io/etcd/releases/download/%s/etcd-%s-linux-%s.tar.gz",
+	componentURL := fmt.Sprintf("https://github.com/etcd-io/etcd/releases/download/%s/etcd-%s-linux-%s.tar.gz",
 		componentVersion, componentVersion, arch)
 	if _, err := os.Stat(componentBin); os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "downloading %s into %s...", componentUrl, componentBin)
-		if err := download(componentUrl, componentTar); err != nil {
+		fmt.Fprintf(os.Stderr, "downloading %s into %s...", componentURL, componentBin)
+		if err := download(componentURL, componentTar); err != nil {
 			log.Fatal(err)
 		}
 		t, err := os.Open(componentTar)
@@ -514,11 +517,11 @@ func downloadEtcdAndExtractFlags(componentVersion string) *komponent {
 
 func downloadKubeComponentAndExtractFlags(componentName, componentVersion string) *komponent {
 	componentBin := path.Join(bindir, fmt.Sprintf("%s-%s", componentName, componentVersion))
-	componentUrl := fmt.Sprintf("https://dl.k8s.io/%s/bin/linux/%s/%s",
+	componentURL := fmt.Sprintf("https://dl.k8s.io/%s/bin/linux/%s/%s",
 		componentVersion, arch, componentName)
 	if _, err := os.Stat(componentBin); os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "downloading %s into %s...", componentUrl, componentBin)
-		if err := download(componentUrl, componentBin); err != nil {
+		fmt.Fprintf(os.Stderr, "downloading %s into %s...", componentURL, componentBin)
+		if err := download(componentURL, componentBin); err != nil {
 			log.Fatal(err)
 		}
 		fmt.Fprintf(os.Stderr, "ok\n")

--- a/pkg/compliance/utils/inputs_files.go
+++ b/pkg/compliance/utils/inputs_files.go
@@ -5,6 +5,7 @@
 
 //go:build !windows
 
+// Package utils is a compliance internal submodule implementing various utilies.
 package utils
 
 import (
@@ -14,6 +15,7 @@ import (
 	"syscall"
 )
 
+// GetFileUser returns the file user.
 func GetFileUser(fi os.FileInfo) string {
 	if statt, ok := fi.Sys().(*syscall.Stat_t); ok {
 		u := strconv.Itoa(int(statt.Uid))
@@ -24,6 +26,7 @@ func GetFileUser(fi os.FileInfo) string {
 	return ""
 }
 
+// GetFileGroup returns the file group.
 func GetFileGroup(fi os.FileInfo) string {
 	if statt, ok := fi.Sys().(*syscall.Stat_t); ok {
 		g := strconv.Itoa(int(statt.Gid))

--- a/pkg/compliance/utils/inputs_files_nounix.go
+++ b/pkg/compliance/utils/inputs_files_nounix.go
@@ -9,10 +9,12 @@ package utils
 
 import "os"
 
+// GetFileUser returns the file user.
 func GetFileUser(fi os.FileInfo) string {
 	return ""
 }
 
+// GetFileGroup returns the file group.
 func GetFileGroup(fi os.FileInfo) string {
 	return ""
 }


### PR DESCRIPTION
### What does this PR do?

Linting pass on `pkg/compliance` (revive)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
