### PR TITLE
[CWS] fix `parse_args` issue with fentry

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/module.h
+++ b/pkg/security/ebpf/c/include/hooks/module.h
@@ -55,15 +55,15 @@ int __attribute__((always_inline)) trace_kernel_file(ctx_t *ctx, struct file *f,
     return 0;
 }
 
-SEC("kprobe/parse_args")
-int kprobe_parse_args(struct pt_regs *ctx) {
+HOOK_ENTRY("parse_args")
+int hook_parse_args(ctx_t *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_INIT_MODULE);
     if (!syscall) {
         return 0;
     }
 
-    char *name = (char *)PT_REGS_PARM1(ctx);
-    char *args = (char *)PT_REGS_PARM2(ctx);
+    char *name = (char *)CTX_PARM1(ctx);
+    char *args = (char *)CTX_PARM2(ctx);
 
     bpf_probe_read_str(&syscall->init_module.name, sizeof(syscall->init_module.name), name);
 

--- a/pkg/security/ebpf/c/include/hooks/module.h
+++ b/pkg/security/ebpf/c/include/hooks/module.h
@@ -77,13 +77,13 @@ int __attribute__((always_inline)) fetch_mod_name_common(struct module *m) {
 HOOK_ENTRY("mod_sysfs_setup")
 int hook_mod_sysfs_setup(ctx_t *ctx) {
     struct module *m = (struct module*)CTX_PARM1(ctx);
-	return fetch_mod_name_common(m);
+    return fetch_mod_name_common(m);
 }
 
 HOOK_ENTRY("module_param_sysfs_setup")
 int hook_module_param_sysfs_setup(ctx_t *ctx) {
     struct module *m = (struct module*)CTX_PARM1(ctx);
-	return fetch_mod_name_common(m);
+    return fetch_mod_name_common(m);
 }
 
 HOOK_ENTRY("security_kernel_module_from_file")

--- a/pkg/security/ebpf/c/include/hooks/module.h
+++ b/pkg/security/ebpf/c/include/hooks/module.h
@@ -55,7 +55,6 @@ int __attribute__((always_inline)) trace_kernel_file(ctx_t *ctx, struct file *f,
     return 0;
 }
 
-// fentry blocked by: parse args special bug
 SEC("kprobe/parse_args")
 int kprobe_parse_args(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_INIT_MODULE);

--- a/pkg/security/ebpf/c/include/hooks/module.h
+++ b/pkg/security/ebpf/c/include/hooks/module.h
@@ -67,7 +67,7 @@ int hook_mod_sysfs_setup(ctx_t *ctx) {
         return 0;
     }
 
-	struct module *m = (struct module*)CTX_PARM1(ctx);
+    struct module *m = (struct module*)CTX_PARM1(ctx);
     bpf_probe_read_str(&syscall->init_module.name, sizeof(syscall->init_module.name), &m->name);
     return 0;
 }

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -392,6 +392,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 					kprobeOrFentry("security_kernel_read_file", fentry),
 					kprobeOrFentry("security_kernel_module_from_file", fentry),
 				}},
+				kprobeOrFentry("load_module", fentry),
 				kprobeOrFentry("mod_sysfs_setup", fentry),
 			}},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "init_module", fentry, EntryAndExit|SupportFentry|SupportFexit)},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -392,7 +392,10 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 					kprobeOrFentry("security_kernel_read_file", fentry),
 					kprobeOrFentry("security_kernel_module_from_file", fentry),
 				}},
-				kprobeOrFentry("mod_sysfs_setup", fentry),
+				&manager.OneOf{Selectors: []manager.ProbesSelector{
+					kprobeOrFentry("mod_sysfs_setup", fentry),
+					kprobeOrFentry("module_param_sysfs_setup", fentry),
+				}},
 			}},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "init_module", fentry, EntryAndExit|SupportFentry|SupportFexit)},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "finit_module", fentry, EntryAndExit|SupportFentry|SupportFexit)},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -392,7 +392,6 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 					kprobeOrFentry("security_kernel_read_file", fentry),
 					kprobeOrFentry("security_kernel_module_from_file", fentry),
 				}},
-				kprobeOrFentry("load_module", fentry),
 				kprobeOrFentry("mod_sysfs_setup", fentry),
 			}},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "init_module", fentry, EntryAndExit|SupportFentry|SupportFexit)},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -392,7 +392,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 					kprobeOrFentry("security_kernel_read_file", fentry),
 					kprobeOrFentry("security_kernel_module_from_file", fentry),
 				}},
-				kprobeOrFentry("parse_args", fentry),
+				kprobeOrFentry("mod_sysfs_setup", fentry),
 			}},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "init_module", fentry, EntryAndExit|SupportFentry|SupportFexit)},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "finit_module", fentry, EntryAndExit|SupportFentry|SupportFexit)},

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -392,7 +392,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 					kprobeOrFentry("security_kernel_read_file", fentry),
 					kprobeOrFentry("security_kernel_module_from_file", fentry),
 				}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_parse_args"}},
+				kprobeOrFentry("parse_args", fentry),
 			}},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "init_module", fentry, EntryAndExit|SupportFentry|SupportFexit)},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "finit_module", fentry, EntryAndExit|SupportFentry|SupportFexit)},

--- a/pkg/security/ebpf/probes/module.go
+++ b/pkg/security/ebpf/probes/module.go
@@ -28,7 +28,7 @@ func getModuleProbes(fentry bool) []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "hook_parse_args",
+				EBPFFuncName: "hook_mod_sysfs_setup",
 			},
 		},
 		{

--- a/pkg/security/ebpf/probes/module.go
+++ b/pkg/security/ebpf/probes/module.go
@@ -28,6 +28,12 @@ func getModuleProbes(fentry bool) []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_load_module",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook_mod_sysfs_setup",
 			},
 		},

--- a/pkg/security/ebpf/probes/module.go
+++ b/pkg/security/ebpf/probes/module.go
@@ -28,12 +28,6 @@ func getModuleProbes(fentry bool) []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "hook_load_module",
-			},
-		},
-		{
-			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook_mod_sysfs_setup",
 			},
 		},

--- a/pkg/security/ebpf/probes/module.go
+++ b/pkg/security/ebpf/probes/module.go
@@ -34,6 +34,12 @@ func getModuleProbes(fentry bool) []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_module_param_sysfs_setup",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook_security_kernel_module_from_file",
 			},
 		},

--- a/pkg/security/ebpf/probes/module.go
+++ b/pkg/security/ebpf/probes/module.go
@@ -28,7 +28,7 @@ func getModuleProbes(fentry bool) []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "kprobe_parse_args",
+				EBPFFuncName: "hook_parse_args",
 			},
 		},
 		{


### PR DESCRIPTION
### What does this PR do?

`parse_args` was the last remaining function not onboarded to fentry support. It was failing to open the raw tracepoint for unknown reasons.

After investigation we discovered that you actually cannot hook a fentry on a function with more than 6 arguments on x64 (https://elixir.bootlin.com/linux/latest/source/arch/x86/net/bpf_jit_comp.c#L2155). To fix this issue this PR moves around the `args` and `name` collection to other hookpoints, on functions with less than 6 args.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
