### PR TITLE
[CWS] remove `withSkipIfFentry`

### DIFF
--- a/pkg/security/ebpf/probes/builder.go
+++ b/pkg/security/ebpf/probes/builder.go
@@ -15,24 +15,18 @@ import (
 )
 
 type probeSelectorBuilder struct {
-	uid          string
-	skipIfFentry bool
+	uid string
 }
 
 type psbOption func(*probeSelectorBuilder)
 
 func kprobeOrFentry(funcName string, fentry bool, options ...psbOption) *manager.ProbeSelector {
 	psb := &probeSelectorBuilder{
-		uid:          SecurityAgentUID,
-		skipIfFentry: false,
+		uid: SecurityAgentUID,
 	}
 
 	for _, opt := range options {
 		opt(psb)
-	}
-
-	if fentry && psb.skipIfFentry {
-		return nil
 	}
 
 	return &manager.ProbeSelector{
@@ -45,16 +39,11 @@ func kprobeOrFentry(funcName string, fentry bool, options ...psbOption) *manager
 
 func kretprobeOrFexit(funcName string, fentry bool, options ...psbOption) *manager.ProbeSelector {
 	psb := &probeSelectorBuilder{
-		uid:          SecurityAgentUID,
-		skipIfFentry: false,
+		uid: SecurityAgentUID,
 	}
 
 	for _, opt := range options {
 		opt(psb)
-	}
-
-	if fentry && psb.skipIfFentry {
-		return nil
 	}
 
 	return &manager.ProbeSelector{
@@ -62,12 +51,6 @@ func kretprobeOrFexit(funcName string, fentry bool, options ...psbOption) *manag
 			UID:          psb.uid,
 			EBPFFuncName: fmt.Sprintf("rethook_%s", funcName),
 		},
-	}
-}
-
-func withSkipIfFentry(skip bool) psbOption {
-	return func(psb *probeSelectorBuilder) {
-		psb.skipIfFentry = skip
 	}
 }
 

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -93,9 +93,9 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "sched_process_fork"}},
 				kprobeOrFentry("do_exit", fentry),
 				&manager.BestEffort{Selectors: []manager.ProbesSelector{
-					kprobeOrFentry("prepare_binprm", fentry, withSkipIfFentry(true)),
+					kprobeOrFentry("prepare_binprm", fentry),
 					kprobeOrFentry("bprm_execve", fentry),
-					kprobeOrFentry("security_bprm_check", fentry, withSkipIfFentry(true)),
+					kprobeOrFentry("security_bprm_check", fentry),
 				}},
 				kprobeOrFentry("setup_new_exec_interp", fentry),
 				kprobeOrFentry("setup_new_exec_args_envs", fentry, withUid(SecurityAgentUID+"_a")),
@@ -113,15 +113,15 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				kprobeOrFentry("cgroup1_procs_write", fentry),
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
-				kprobeOrFentry("_do_fork", fentry, withSkipIfFentry(true)),
-				kprobeOrFentry("do_fork", fentry, withSkipIfFentry(true)),
+				kprobeOrFentry("_do_fork", fentry),
+				kprobeOrFentry("do_fork", fentry),
 				kprobeOrFentry("kernel_clone", fentry),
 				kprobeOrFentry("kernel_thread", fentry),
 				kprobeOrFentry("user_mode_thread", fentry),
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
-				kprobeOrFentry("cgroup_tasks_write", fentry, withSkipIfFentry(true)),
-				kprobeOrFentry("cgroup1_tasks_write", fentry, withSkipIfFentry(true)),
+				kprobeOrFentry("cgroup_tasks_write", fentry),
+				kprobeOrFentry("cgroup1_tasks_write", fentry),
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "execve", fentry, Entry|SupportFentry)},
 			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "execveat", fentry, Entry|SupportFentry)},
@@ -170,7 +170,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "io_uring_create"}},
 				&manager.OneOf{Selectors: []manager.ProbesSelector{
 					kprobeOrFentry("io_allocate_scq_urings", fentry),
-					kprobeOrFentry("io_sq_offload_start", fentry, withSkipIfFentry(true)),
+					kprobeOrFentry("io_sq_offload_start", fentry),
 					kretprobeOrFexit("io_ring_ctx_alloc", fentry),
 				}},
 			}},
@@ -255,7 +255,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			// selinux
 			// This needs to be best effort, as sel_write_disable is in the process of being removed
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
-				kprobeOrFentry("sel_write_disable", fentry, withSkipIfFentry(true)),
+				kprobeOrFentry("sel_write_disable", fentry),
 				kprobeOrFentry("sel_write_enforce", fentry),
 				kprobeOrFentry("sel_write_bool", fentry),
 				kprobeOrFentry("sel_commit_bools_write", fentry),
@@ -278,7 +278,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
 				kprobeOrFentry("mnt_want_write_file", fentry),
-				kprobeOrFentry("mnt_want_write_file_path", fentry, withSkipIfFentry(true)),
+				kprobeOrFentry("mnt_want_write_file_path", fentry),
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chown", fentry, EntryAndExit|SupportFentry|SupportFexit)},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chown16", fentry, EntryAndExit|SupportFentry|SupportFexit)},
@@ -314,7 +314,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
 				kprobeOrFentry("mnt_want_write_file", fentry),
-				kprobeOrFentry("mnt_want_write_file_path", fentry, withSkipIfFentry(true)),
+				kprobeOrFentry("mnt_want_write_file_path", fentry),
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "removexattr", fentry, EntryAndExit|SupportFentry|SupportFexit)},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fremovexattr", fentry, EntryAndExit|SupportFentry|SupportFexit)},
@@ -329,7 +329,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
 				kprobeOrFentry("mnt_want_write_file", fentry),
-				kprobeOrFentry("mnt_want_write_file_path", fentry, withSkipIfFentry(true)),
+				kprobeOrFentry("mnt_want_write_file_path", fentry),
 			}},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setxattr", fentry, EntryAndExit|SupportFentry|SupportFexit)},
 			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fsetxattr", fentry, EntryAndExit|SupportFentry|SupportFexit)},
@@ -390,7 +390,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				&manager.OneOf{Selectors: []manager.ProbesSelector{
 					kprobeOrFentry("security_kernel_read_file", fentry),
-					kprobeOrFentry("security_kernel_module_from_file", fentry, withSkipIfFentry(true)),
+					kprobeOrFentry("security_kernel_module_from_file", fentry),
 				}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFFuncName: "kprobe_parse_args"}},
 			}},


### PR DESCRIPTION
### What does this PR do?

Now that the probe hooking is able to dynamically remove non-hookable probes, we don't need this check anymore. This PR removes it.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
