### PR TITLE
Remove `force_use_tcp` in tcp-syslog-to-blackhole experiment

### DIFF
--- a/test/regression/cases/tcp_syslog_to_blackhole/datadog-agent/datadog.yaml
+++ b/test/regression/cases/tcp_syslog_to_blackhole/datadog-agent/datadog.yaml
@@ -11,4 +11,3 @@ logs_enabled: true
 logs_config:
   logs_dd_url: 127.0.0.1:9091
   logs_no_ssl: true
-  force_use_tcp: true


### PR DESCRIPTION
### What does this PR do?

This regression experiment previously forced the use of TCP egress on the Agent as we misunderstood the purpose of this configuration option. This is not representative of how the Agent is used in practice and, as the TCP egress lacks buffered IO, skews profiling results.

REF SMP-664

