### PR TITLE
[PROCS-2802][process-agent] Fix flaky `TestStatsWithPermByPID`

### DIFF
--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -72,8 +72,8 @@ func WithReturnZeroPermStats(enabled bool) Option {
 	}
 }
 
-// WithCustomProcFSRoot confiugres the procfs directory that the probe reads from
-func WithCustomProcFSRoot(path string) Option {
+// WithProcFSRoot confiugres the procfs directory that the probe reads from
+func WithProcFSRoot(path string) Option {
 	return func(p Probe) {
 		if linuxProbe, ok := p.(*probe); ok {
 			linuxProbe.procRootLoc = path

--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -72,6 +72,7 @@ func WithReturnZeroPermStats(enabled bool) Option {
 	}
 }
 
+// WithCustomProcFSRoot confiugres the procfs directory that the probe reads from
 func WithCustomProcFSRoot(path string) Option {
 	return func(p Probe) {
 		if linuxProbe, ok := p.(*probe); ok {

--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -72,6 +72,14 @@ func WithReturnZeroPermStats(enabled bool) Option {
 	}
 }
 
+func WithCustomProcFSRoot(path string) Option {
+	return func(p Probe) {
+		if linuxProbe, ok := p.(*probe); ok {
+			linuxProbe.procRootLoc = path
+		}
+	}
+}
+
 // WithPermission configures if process collection should fetch fields
 // that require elevated permission or not
 func WithPermission(elevatedPermissions bool) Option {

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -40,7 +40,7 @@ func getProbeWithPermission(options ...Option) *probe {
 
 func TestGetActivePIDs(t *testing.T) {
 	t.Setenv("HOST_PROC", "resources/test_procfs/proc")
-	probe := getProbeWithPermission(WithCustomProcFSRoot("resources/test_procfs/proc"))
+	probe := getProbeWithPermission(WithProcFSRoot("resources/test_procfs/proc"))
 	defer probe.Close()
 
 	actual, err := probe.getActivePIDs()
@@ -106,7 +106,7 @@ func TestTrimAndSplitBytes(t *testing.T) {
 
 func TestGetCmdlineTestFS(t *testing.T) {
 	t.Setenv("HOST_PROC", "resources/test_procfs/proc") // For gopsutil
-	testGetCmdline(t, WithCustomProcFSRoot("resources/test_procfs/proc"))
+	testGetCmdline(t, WithProcFSRoot("resources/test_procfs/proc"))
 }
 
 func TestGetCmdlineLocalFS(t *testing.T) {
@@ -134,7 +134,7 @@ func testGetCmdline(t *testing.T, probeOptions ...Option) {
 }
 
 func TestGetCommandName(t *testing.T) {
-	probe := getProbeWithPermission(WithCustomProcFSRoot("resources/test_procfs/proc/"))
+	probe := getProbeWithPermission(WithProcFSRoot("resources/test_procfs/proc/"))
 	defer probe.Close()
 
 	// Hardcode pid that has `comm` file set
@@ -145,7 +145,7 @@ func TestGetCommandName(t *testing.T) {
 
 func TestProcessesByPIDTestFS(t *testing.T) {
 	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
-	testProcessesByPID(t, WithCustomProcFSRoot("resources/test_procfs/proc/"))
+	testProcessesByPID(t, WithProcFSRoot("resources/test_procfs/proc/"))
 }
 
 func TestProcessesByPIDLocalFS(t *testing.T) {
@@ -235,7 +235,7 @@ func compareStats(t *testing.T, st1, st2 *Stats) {
 
 func TestStatsForPIDsTestFS(t *testing.T) {
 	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
-	testStatsForPIDs(t, WithCustomProcFSRoot("resources/test_procfs/proc/"))
+	testStatsForPIDs(t, WithProcFSRoot("resources/test_procfs/proc/"))
 }
 
 func TestStatsForPIDsLocalFS(t *testing.T) {
@@ -276,10 +276,10 @@ func testStatsForPIDs(t *testing.T, probeOptions ...Option) {
 }
 
 func TestMultipleProbes(t *testing.T) {
-	probe1 := getProbeWithPermission(WithCustomProcFSRoot("resources/test_procfs/proc/"))
+	probe1 := getProbeWithPermission(WithProcFSRoot("resources/test_procfs/proc/"))
 	defer probe1.Close()
 
-	probe2 := getProbeWithPermission(WithCustomProcFSRoot("resources/test_procfs/proc/"))
+	probe2 := getProbeWithPermission(WithProcFSRoot("resources/test_procfs/proc/"))
 	defer probe2.Close()
 
 	now := time.Now()
@@ -306,7 +306,7 @@ func TestMultipleProbes(t *testing.T) {
 }
 
 func TestProcfsChange(t *testing.T) {
-	probe := getProbeWithPermission(WithCustomProcFSRoot("resources/test_procfs/proc"))
+	probe := getProbeWithPermission(WithProcFSRoot("resources/test_procfs/proc"))
 	defer probe.Close()
 
 	now := time.Now()
@@ -481,7 +481,7 @@ func TestParseStatusLine(t *testing.T) {
 
 func TestParseStatusTestFS(t *testing.T) {
 	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
-	testParseStatus(t, WithCustomProcFSRoot("resources/test_procfs/proc/"))
+	testParseStatus(t, WithProcFSRoot("resources/test_procfs/proc/"))
 }
 
 func TestParseStatusLocalFS(t *testing.T) {
@@ -532,7 +532,7 @@ func testParseStatus(t *testing.T, probeOptions ...Option) {
 }
 
 func TestFillNsPidFromStatus(t *testing.T) {
-	probe := getProbeWithPermission(WithCustomProcFSRoot("resources/test_procfs/proc/"))
+	probe := getProbeWithPermission(WithProcFSRoot("resources/test_procfs/proc/"))
 	defer probe.Close()
 
 	t.Run("Linux versions 4.1+", func(t *testing.T) {
@@ -611,7 +611,7 @@ func TestParseIOLine(t *testing.T) {
 
 func TestParseIOTestFS(t *testing.T) {
 	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
-	testParseIO(t, WithCustomProcFSRoot("resources/test_procfs/proc/"))
+	testParseIO(t, WithProcFSRoot("resources/test_procfs/proc/"))
 }
 
 func TestParseIOLocalFS(t *testing.T) {
@@ -738,7 +738,7 @@ func TestParseStatContent(t *testing.T) {
 
 func TestParseStatTestFS(t *testing.T) {
 	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
-	testParseStat(t, WithCustomProcFSRoot("resources/test_procfs/proc/"))
+	testParseStat(t, WithProcFSRoot("resources/test_procfs/proc/"))
 }
 
 // TestParseStatLocalFS has to run on its own because gopsutil caches boot time,
@@ -793,7 +793,7 @@ func TestBootTimeLocalFS(t *testing.T) {
 }
 
 func TestBootTimeRefresh(t *testing.T) {
-	probe := getProbeWithPermission(WithBootTimeRefreshInterval(500*time.Millisecond), WithCustomProcFSRoot("resources/test_procfs/proc/"))
+	probe := getProbeWithPermission(WithBootTimeRefreshInterval(500*time.Millisecond), WithProcFSRoot("resources/test_procfs/proc/"))
 	defer probe.Close()
 
 	assert.Equal(t, uint64(1606127264), probe.bootTime.Load())
@@ -812,7 +812,7 @@ func TestBootTimeRefresh(t *testing.T) {
 
 func TestParseStatmTestFS(t *testing.T) {
 	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
-	testParseStatm(t, WithCustomProcFSRoot("resources/test_procfs/proc/"))
+	testParseStatm(t, WithProcFSRoot("resources/test_procfs/proc/"))
 }
 
 func TestParseStatmLocalFS(t *testing.T) {
@@ -847,7 +847,7 @@ func testParseStatm(t *testing.T, probeOptions ...Option) {
 }
 
 func TestParseStatmStatusMatchTestFS(t *testing.T) {
-	testParseStatmStatusMatch(t, WithCustomProcFSRoot("resources/test_procfs/proc/"))
+	testParseStatmStatusMatch(t, WithProcFSRoot("resources/test_procfs/proc/"))
 }
 
 func TestParseStatmStatusMatchLocalFS(t *testing.T) {
@@ -932,7 +932,7 @@ func TestStatsWithPermByPID(t *testing.T) {
 	t.Cleanup(func() { _ = os.Remove("resources/zero_io/3/fd") })
 	require.NoError(t, err)
 
-	probe := getProbeWithPermission(WithCustomProcFSRoot("resources/zero_io"))
+	probe := getProbeWithPermission(WithProcFSRoot("resources/zero_io"))
 	defer probe.Close()
 
 	WithReturnZeroPermStats(true)(probe)
@@ -949,7 +949,7 @@ func TestStatsWithPermByPID(t *testing.T) {
 }
 
 func TestStatsForPIDsAndPerm(t *testing.T) {
-	probe := getProbeWithPermission(WithCustomProcFSRoot("resources/test_procfs/proc"))
+	probe := getProbeWithPermission(WithProcFSRoot("resources/test_procfs/proc"))
 	defer probe.Close()
 	stats, err := probe.StatsForPIDs([]int32{1}, time.Now())
 	require.NoError(t, err)
@@ -969,7 +969,7 @@ func TestStatsForPIDsAndPerm(t *testing.T) {
 }
 
 func TestProcessesByPIDsAndPerm(t *testing.T) {
-	probe := getProbeWithPermission(WithCustomProcFSRoot("resources/test_procfs/proc"))
+	probe := getProbeWithPermission(WithProcFSRoot("resources/test_procfs/proc"))
 	probe.procRootLoc = "resources/test_procfs/proc"
 	defer probe.Close()
 	procs, err := probe.ProcessesByPID(time.Now(), true)

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -610,6 +610,7 @@ func TestParseIOLine(t *testing.T) {
 }
 
 func TestParseIOTestFS(t *testing.T) {
+	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
 	testParseIO(t, WithCustomProcFSRoot("resources/test_procfs/proc/"))
 }
 
@@ -810,6 +811,7 @@ func TestBootTimeRefresh(t *testing.T) {
 }
 
 func TestParseStatmTestFS(t *testing.T) {
+	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
 	testParseStatm(t, WithCustomProcFSRoot("resources/test_procfs/proc/"))
 }
 

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -39,9 +39,7 @@ func getProbeWithPermission(options ...Option) *probe {
 }
 
 func TestGetActivePIDs(t *testing.T) {
-	t.Setenv("HOST_PROC", "resources/test_procfs/proc")
-
-	probe := getProbeWithPermission()
+	probe := getProbeWithPermission(WithCustomProcFSRoot("resources/test_procfs/proc"))
 	defer probe.Close()
 
 	actual, err := probe.getActivePIDs()
@@ -105,9 +103,7 @@ func TestTrimAndSplitBytes(t *testing.T) {
 }
 
 func TestGetCmdlineTestFS(t *testing.T) {
-	t.Setenv("HOST_PROC", "resources/test_procfs/proc")
-
-	testGetCmdline(t)
+	testGetCmdline(t, WithCustomProcFSRoot("resources/test_procfs/proc"))
 }
 
 func TestGetCmdlineLocalFS(t *testing.T) {
@@ -115,8 +111,8 @@ func TestGetCmdlineLocalFS(t *testing.T) {
 	testGetCmdline(t)
 }
 
-func testGetCmdline(t *testing.T) {
-	probe := getProbeWithPermission()
+func testGetCmdline(t *testing.T, probeOptions ...Option) {
+	probe := getProbeWithPermission(probeOptions...)
 	defer probe.Close()
 
 	pids, err := probe.getActivePIDs()
@@ -135,9 +131,7 @@ func testGetCmdline(t *testing.T) {
 }
 
 func TestGetCommandName(t *testing.T) {
-	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
-
-	probe := getProbeWithPermission()
+	probe := getProbeWithPermission(WithCustomProcFSRoot("resources/test_procfs/proc/"))
 	defer probe.Close()
 
 	// Hardcode pid that has `comm` file set
@@ -147,9 +141,7 @@ func TestGetCommandName(t *testing.T) {
 }
 
 func TestProcessesByPIDTestFS(t *testing.T) {
-	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
-
-	testProcessesByPID(t)
+	testProcessesByPID(t, WithCustomProcFSRoot("resources/test_procfs/proc/"))
 }
 
 func TestProcessesByPIDLocalFS(t *testing.T) {
@@ -157,12 +149,12 @@ func TestProcessesByPIDLocalFS(t *testing.T) {
 	testProcessesByPID(t)
 }
 
-func testProcessesByPID(t *testing.T) {
+func testProcessesByPID(t *testing.T, probeOptions ...Option) {
 	// disable log output from gopsutil, the testFS doesn't have `cwd`, `fd` and `exe` dir setup,
 	// gopsutil print verbose debug log regarding this
 	seelog.UseLogger(seelog.Disabled)
 
-	probe := getProbeWithPermission()
+	probe := getProbeWithPermission(probeOptions...)
 	defer probe.Close()
 
 	expectedProcs, err := process.AllProcesses()
@@ -238,9 +230,7 @@ func compareStats(t *testing.T, st1, st2 *Stats) {
 }
 
 func TestStatsForPIDsTestFS(t *testing.T) {
-	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
-
-	testStatsForPIDs(t)
+	testStatsForPIDs(t, WithCustomProcFSRoot("resources/test_procfs/proc/"))
 }
 
 func TestStatsForPIDsLocalFS(t *testing.T) {
@@ -248,12 +238,12 @@ func TestStatsForPIDsLocalFS(t *testing.T) {
 	testStatsForPIDs(t)
 }
 
-func testStatsForPIDs(t *testing.T) {
+func testStatsForPIDs(t *testing.T, probeOptions ...Option) {
 	// disable log output from gopsutil, the testFS doesn't have `cwd`, `fd` and `exe` dir setup,
 	// gopsutil print verbose debug log regarding this
 	seelog.UseLogger(seelog.Disabled)
 
-	probe := getProbeWithPermission()
+	probe := getProbeWithPermission(probeOptions...)
 	defer probe.Close()
 
 	expectProcs, err := process.AllProcesses()
@@ -281,12 +271,10 @@ func testStatsForPIDs(t *testing.T) {
 }
 
 func TestMultipleProbes(t *testing.T) {
-	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
-
-	probe1 := getProbeWithPermission()
+	probe1 := getProbeWithPermission(WithCustomProcFSRoot("resources/test_procfs/proc/"))
 	defer probe1.Close()
 
-	probe2 := getProbeWithPermission()
+	probe2 := getProbeWithPermission(WithCustomProcFSRoot("resources/test_procfs/proc/"))
 	defer probe2.Close()
 
 	now := time.Now()
@@ -313,9 +301,7 @@ func TestMultipleProbes(t *testing.T) {
 }
 
 func TestProcfsChange(t *testing.T) {
-	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
-
-	probe := getProbeWithPermission()
+	probe := getProbeWithPermission(WithCustomProcFSRoot("resources/test_procfs/proc"))
 	defer probe.Close()
 
 	now := time.Now()
@@ -489,9 +475,7 @@ func TestParseStatusLine(t *testing.T) {
 }
 
 func TestParseStatusTestFS(t *testing.T) {
-	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
-
-	testParseStatus(t)
+	testParseStatus(t, WithCustomProcFSRoot("resources/test_procfs/proc/"))
 }
 
 func TestParseStatusLocalFS(t *testing.T) {
@@ -499,8 +483,8 @@ func TestParseStatusLocalFS(t *testing.T) {
 	testParseStatus(t)
 }
 
-func testParseStatus(t *testing.T) {
-	probe := getProbeWithPermission()
+func testParseStatus(t *testing.T, probeOptions ...Option) {
+	probe := getProbeWithPermission(probeOptions...)
 	defer probe.Close()
 
 	pids, err := probe.getActivePIDs()
@@ -542,9 +526,7 @@ func testParseStatus(t *testing.T) {
 }
 
 func TestFillNsPidFromStatus(t *testing.T) {
-	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
-
-	probe := getProbeWithPermission()
+	probe := getProbeWithPermission(WithCustomProcFSRoot("resources/test_procfs/proc/"))
 	defer probe.Close()
 
 	t.Run("Linux versions 4.1+", func(t *testing.T) {
@@ -622,9 +604,7 @@ func TestParseIOLine(t *testing.T) {
 }
 
 func TestParseIOTestFS(t *testing.T) {
-	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
-
-	testParseIO(t)
+	testParseIO(t, WithCustomProcFSRoot("resources/test_procfs/proc/"))
 }
 
 func TestParseIOLocalFS(t *testing.T) {
@@ -632,8 +612,8 @@ func TestParseIOLocalFS(t *testing.T) {
 	testParseIO(t)
 }
 
-func testParseIO(t *testing.T) {
-	probe := getProbeWithPermission()
+func testParseIO(t *testing.T, probeOptions ...Option) {
+	probe := getProbeWithPermission(probeOptions...)
 	defer probe.Close()
 
 	pids, err := probe.getActivePIDs()
@@ -750,9 +730,7 @@ func TestParseStatContent(t *testing.T) {
 }
 
 func TestParseStatTestFS(t *testing.T) {
-	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
-
-	testParseStat(t)
+	testParseStat(t, WithCustomProcFSRoot("resources/test_procfs/proc/"))
 }
 
 // TestParseStatLocalFS has to run on its own because gopsutil caches boot time,
@@ -763,8 +741,8 @@ func TestParseStatLocalFS(t *testing.T) {
 	testParseStat(t)
 }
 
-func testParseStat(t *testing.T) {
-	probe := getProbeWithPermission()
+func testParseStat(t *testing.T, probeOptions ...Option) {
+	probe := getProbeWithPermission(probeOptions...)
 	defer probe.Close()
 
 	pids, err := probe.getActivePIDs()
@@ -807,8 +785,7 @@ func TestBootTimeLocalFS(t *testing.T) {
 }
 
 func TestBootTimeRefresh(t *testing.T) {
-	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
-	probe := getProbeWithPermission(WithBootTimeRefreshInterval(500 * time.Millisecond))
+	probe := getProbeWithPermission(WithBootTimeRefreshInterval(500*time.Millisecond), WithCustomProcFSRoot("resources/test_procfs/proc/"))
 	defer probe.Close()
 
 	assert.Equal(t, uint64(1606127264), probe.bootTime.Load())
@@ -826,9 +803,7 @@ func TestBootTimeRefresh(t *testing.T) {
 }
 
 func TestParseStatmTestFS(t *testing.T) {
-	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
-
-	testParseStatm(t)
+	testParseStatm(t, WithCustomProcFSRoot("resources/test_procfs/proc/"))
 }
 
 func TestParseStatmLocalFS(t *testing.T) {
@@ -836,8 +811,8 @@ func TestParseStatmLocalFS(t *testing.T) {
 	testParseStatm(t)
 }
 
-func testParseStatm(t *testing.T) {
-	probe := getProbeWithPermission()
+func testParseStatm(t *testing.T, probeOptions ...Option) {
+	probe := getProbeWithPermission(probeOptions...)
 	defer probe.Close()
 
 	pids, err := probe.getActivePIDs()
@@ -863,9 +838,7 @@ func testParseStatm(t *testing.T) {
 }
 
 func TestParseStatmStatusMatchTestFS(t *testing.T) {
-	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
-
-	testParseStatmStatusMatch(t)
+	testParseStatmStatusMatch(t, WithCustomProcFSRoot("resources/test_procfs/proc/"))
 }
 
 func TestParseStatmStatusMatchLocalFS(t *testing.T) {
@@ -873,8 +846,8 @@ func TestParseStatmStatusMatchLocalFS(t *testing.T) {
 	testParseStatmStatusMatch(t)
 }
 
-func testParseStatmStatusMatch(t *testing.T) {
-	probe := getProbeWithPermission()
+func testParseStatmStatusMatch(t *testing.T, probeOptions ...Option) {
+	probe := getProbeWithPermission(probeOptions...)
 	defer probe.Close()
 
 	pids, err := probe.getActivePIDs()
@@ -945,13 +918,12 @@ func TestGetFDCountLocalFS(t *testing.T) {
 }
 
 func TestStatsWithPermByPID(t *testing.T) {
-	t.Setenv("HOST_PROC", "resources/zero_io")
 	// create a fd dir so that the FD collection doesn't return -1
 	err := os.Mkdir("resources/zero_io/3/fd", 0500)
+	t.Cleanup(func() { _ = os.Remove("resources/zero_io/3/fd") })
 	require.NoError(t, err)
-	defer os.Remove("resources/zero_io/3/fd")
 
-	probe := getProbeWithPermission()
+	probe := getProbeWithPermission(WithCustomProcFSRoot("resources/zero_io"))
 	defer probe.Close()
 
 	WithReturnZeroPermStats(true)(probe)
@@ -968,9 +940,7 @@ func TestStatsWithPermByPID(t *testing.T) {
 }
 
 func TestStatsForPIDsAndPerm(t *testing.T) {
-	t.Setenv("HOST_PROC", "resources/test_procfs/proc")
-
-	probe := getProbeWithPermission()
+	probe := getProbeWithPermission(WithCustomProcFSRoot("resources/test_procfs/proc"))
 	defer probe.Close()
 	stats, err := probe.StatsForPIDs([]int32{1}, time.Now())
 	require.NoError(t, err)
@@ -990,9 +960,8 @@ func TestStatsForPIDsAndPerm(t *testing.T) {
 }
 
 func TestProcessesByPIDsAndPerm(t *testing.T) {
-	t.Setenv("HOST_PROC", "resources/test_procfs/proc")
-
-	probe := getProbeWithPermission()
+	probe := getProbeWithPermission(WithCustomProcFSRoot("resources/test_procfs/proc"))
+	probe.procRootLoc = "resources/test_procfs/proc"
 	defer probe.Close()
 	procs, err := probe.ProcessesByPID(time.Now(), true)
 	require.NoError(t, err)

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -945,11 +945,9 @@ func TestGetFDCountLocalFS(t *testing.T) {
 }
 
 func TestStatsWithPermByPID(t *testing.T) {
-	t.Skip("flaky")
-
 	t.Setenv("HOST_PROC", "resources/zero_io")
 	// create a fd dir so that the FD collection doesn't return -1
-	os.Mkdir("resources/zero_io/3/fd", 0400)
+	os.Mkdir("resources/zero_io/3/fd", 0500)
 	defer os.Remove("resources/zero_io/3/fd")
 
 	probe := getProbeWithPermission()

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -39,12 +39,14 @@ func getProbeWithPermission(options ...Option) *probe {
 }
 
 func TestGetActivePIDs(t *testing.T) {
+	t.Setenv("HOST_PROC", "resources/test_procfs/proc")
 	probe := getProbeWithPermission(WithCustomProcFSRoot("resources/test_procfs/proc"))
 	defer probe.Close()
 
 	actual, err := probe.getActivePIDs()
 	assert.NoError(t, err)
 
+	t.Setenv("HOST_PROC", "resources/test_procfs/proc") // Used by gopsutil
 	expect, err := process.Pids()
 	assert.NoError(t, err)
 
@@ -103,6 +105,7 @@ func TestTrimAndSplitBytes(t *testing.T) {
 }
 
 func TestGetCmdlineTestFS(t *testing.T) {
+	t.Setenv("HOST_PROC", "resources/test_procfs/proc") // For gopsutil
 	testGetCmdline(t, WithCustomProcFSRoot("resources/test_procfs/proc"))
 }
 
@@ -141,6 +144,7 @@ func TestGetCommandName(t *testing.T) {
 }
 
 func TestProcessesByPIDTestFS(t *testing.T) {
+	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
 	testProcessesByPID(t, WithCustomProcFSRoot("resources/test_procfs/proc/"))
 }
 
@@ -230,6 +234,7 @@ func compareStats(t *testing.T, st1, st2 *Stats) {
 }
 
 func TestStatsForPIDsTestFS(t *testing.T) {
+	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
 	testStatsForPIDs(t, WithCustomProcFSRoot("resources/test_procfs/proc/"))
 }
 
@@ -475,6 +480,7 @@ func TestParseStatusLine(t *testing.T) {
 }
 
 func TestParseStatusTestFS(t *testing.T) {
+	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
 	testParseStatus(t, WithCustomProcFSRoot("resources/test_procfs/proc/"))
 }
 
@@ -730,6 +736,7 @@ func TestParseStatContent(t *testing.T) {
 }
 
 func TestParseStatTestFS(t *testing.T) {
+	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
 	testParseStat(t, WithCustomProcFSRoot("resources/test_procfs/proc/"))
 }
 

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -947,7 +947,8 @@ func TestGetFDCountLocalFS(t *testing.T) {
 func TestStatsWithPermByPID(t *testing.T) {
 	t.Setenv("HOST_PROC", "resources/zero_io")
 	// create a fd dir so that the FD collection doesn't return -1
-	os.Mkdir("resources/zero_io/3/fd", 0500)
+	err := os.Mkdir("resources/zero_io/3/fd", 0500)
+	require.NoError(t, err)
 	defer os.Remove("resources/zero_io/3/fd")
 
 	probe := getProbeWithPermission()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
This PR fixes the `TestStatsWithPermByPID`. https://github.com/DataDog/datadog-agent/pull/18649 had originally broken this test because it changes `util.HostProc()` to `kenel.ProcFSRoot()` which is memoized and persists between tests. This causes the procutil tests to be reading the wrong procfs directory. 

This PR fixes the issue by adding a `WithCustomProcFSRoot(path string)` option to the process probe and using that in favor of `t.SetEnv("HOST_PROC", "path/to/host/proc")`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Flaky test

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Note that `t.SetEnv()` is still used in cases where the output of the process probe is compared against gopsutil, since there is no other way to customize the procfs directory it reads from.

 **NOTE FOR REVIEWERS**
Please double check the `unit_tests` job, as I have seen some instance of `TestStatsWithPermByPID` failing, but CircleCI still marking the job as passed (example: b54ca72)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
N/A - only affects unit tests.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
