### PR TITLE
Truncate log lines into a shared buffer

### DIFF
--- a/pkg/logs/internal/decoder/single_line_handler.go
+++ b/pkg/logs/internal/decoder/single_line_handler.go
@@ -18,6 +18,7 @@ type SingleLineHandler struct {
 	outputFn       func(*message.Message)
 	shouldTruncate bool
 	lineLimit      int
+	buffer         []byte // buffer to avoid reallocs in `process`
 }
 
 // NewSingleLineHandler returns a new SingleLineHandler.
@@ -36,31 +37,39 @@ func (h *SingleLineHandler) flush() {
 	// do nothing
 }
 
-// process transforms a raw line into a structured line,
-// it guarantees that the content of the line won't exceed
-// the limit and that the length of the line is properly tracked
-// so that the agent restarts tailing from the right place.
+// process transforms a raw line into a structured line, it guarantees that the
+// content of the line won't exceed the limit and that the length of the line is
+// properly tracked so that the agent restarts tailing from the right place.
 func (h *SingleLineHandler) process(message *message.Message) {
 	isTruncated := h.shouldTruncate
 	h.shouldTruncate = false
 
 	message.Content = bytes.TrimSpace(message.Content)
 
+	h.buffer = h.buffer[:0] // reset, avoid polluting different process calls
+
 	if isTruncated {
 		// the previous line has been truncated because it was too long,
-		// the new line is just a remainder,
-		// adding the truncated flag at the beginning of the content
-		message.Content = append(truncatedFlag, message.Content...)
+		// the new line is just a remainder, adding the truncated flag
+		// at the beginning of the content
+		h.buffer = append(h.buffer, truncatedFlag...)
+		h.buffer = append(h.buffer, message.Content...)
+		message.Content = h.buffer
 	}
 
-	if len(message.Content) < h.lineLimit {
-		h.outputFn(message)
-	} else {
-		// the line is too long, it needs to be cut off and send,
-		// adding the truncated flag the end of the content
-		message.Content = append(message.Content, truncatedFlag...)
-		h.outputFn(message)
-		// make sure the following part of the line will be cut off as well
+	if len(message.Content) >= h.lineLimit {
+		if !isTruncated {
+			// The line is too long but we're not dealing with the
+			// truncated side.
+			h.buffer = append(h.buffer, message.Content...)
+		}
+		// the line is too long, it needs to be cut off and send, adding
+		// the truncated flag the end of the content
+		h.buffer = append(h.buffer, truncatedFlag...)
+		message.Content = h.buffer
+		// make sure the following part of the line will be cut off as
+		// well
 		h.shouldTruncate = true
 	}
+	h.outputFn(message)
 }


### PR DESCRIPTION
### What does this PR do?

This commit is an attempt to reduce the amount of slice growth that's present in our profiles of log ingest. When we trim lines we allocate storage space for the trimming which, if we truncate enough, shows up non-trivially in CPU time. This maintains a buffer to avoid that realloc and also attempts to avoid appends whenever possible.

### Motivation

The `process` function is a hotspot in Regression Detector profiles, specifically with regard to growslice allocations. 

### Possible Drawbacks / Trade-offs

This function may cause the Agent to consume more memory even while it reduces overall GC pressure, allowing it to reclaim memory more easily. 
