### PR TITLE
Fix Oracle PGA memory leak - Take 2

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/activity.go
+++ b/pkg/collector/corechecks/oracle-dbm/activity.go
@@ -162,7 +162,7 @@ END wait_class,
 s.wait_time_micro,
 c.name as pdb_name,
 dbms_lob.substr(sq.sql_fulltext, 4000, 1) sql_fulltext,
-dbms_lob.substr(sq.prev_sql_fulltext, 4000, 1) prev_sql_fulltext,
+dbms_lob.substr(sq_prev.sql_fulltext, 4000, 1) prev_sql_fulltext,
 comm.command_name
 FROM
 v$session s,

--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -25,7 +25,8 @@ type InitConfig struct {
 }
 
 type QuerySamplesConfig struct {
-	Enabled bool `yaml:"enabled"`
+	Enabled            bool `yaml:"enabled"`
+	IncludeAllSessions bool `yaml:"include_all_sessions"`
 }
 
 type QueryMetricsConfig struct {

--- a/pkg/collector/corechecks/oracle-dbm/connection_handling.go
+++ b/pkg/collector/corechecks/oracle-dbm/connection_handling.go
@@ -10,7 +10,6 @@ package oracle
 import (
 	"fmt"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	_ "github.com/godror/godror"
 	"github.com/jmoiron/sqlx"
 	go_ora "github.com/sijms/go-ora/v2"
 )

--- a/pkg/collector/corechecks/oracle-dbm/connection_handling.go
+++ b/pkg/collector/corechecks/oracle-dbm/connection_handling.go
@@ -1,0 +1,189 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle
+
+package oracle
+
+import (
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	_ "github.com/godror/godror"
+	"github.com/jmoiron/sqlx"
+	go_ora "github.com/sijms/go-ora/v2"
+)
+
+func buildGoOraURL(c *Check) string {
+	connectionOptions := map[string]string{"TIMEOUT": DB_TIMEOUT}
+	if c.config.Protocol == "TCPS" {
+		connectionOptions["SSL"] = "TRUE"
+		if c.config.Wallet != "" {
+			connectionOptions["WALLET"] = c.config.Wallet
+		}
+	}
+	return go_ora.BuildUrl(c.config.Server, c.config.Port, c.config.ServiceName, c.config.Username, c.config.Password, connectionOptions)
+}
+
+// Connect establishes a connection to an Oracle instance and returns an open connection to the database.
+func (c *Check) Connect() (*sqlx.DB, error) {
+
+	var connStr string
+	var oracleDriver string
+	if c.config.TnsAlias != "" {
+		connStr = fmt.Sprintf(`user="%s" password="%s" connectString="%s"`, c.config.Username, c.config.Password, c.config.TnsAlias)
+		oracleDriver = "godror"
+	} else {
+		//godror ezconnect string
+		if c.config.InstanceConfig.InstantClient {
+			oracleDriver = "godror"
+			protocolString := ""
+			walletString := ""
+			if c.config.Protocol == "TCPS" {
+				protocolString = "tcps://"
+				if c.config.Wallet != "" {
+					walletString = fmt.Sprintf("?wallet_location=%s", c.config.Wallet)
+				}
+			}
+			connStr = fmt.Sprintf(`user="%s" password="%s" connectString="%s%s:%d/%s%s"`, c.config.Username, c.config.Password, protocolString, c.config.Server, c.config.Port, c.config.ServiceName, walletString)
+		} else {
+			oracleDriver = "oracle"
+			connStr = buildGoOraURL(c)
+
+			// Workaround for named binds, see https://github.com/jmoiron/sqlx/issues/854#issuecomment-1504070464
+			sqlx.BindDriver("oracle", sqlx.NAMED)
+		}
+	}
+	c.driver = oracleDriver
+
+	log.Infof("driver: %s", oracleDriver)
+
+	db, err := sqlx.Open(oracleDriver, connStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to oracle instance: %w", err)
+	}
+	err = db.Ping()
+	if err != nil {
+		return nil, fmt.Errorf("failed to ping oracle instance: %w", err)
+	}
+
+	db.SetMaxOpenConns(MAX_OPEN_CONNECTIONS)
+
+	if c.cdbName == "" {
+		row := db.QueryRow("SELECT /* DD */ lower(name) FROM v$database")
+		err = row.Scan(&c.cdbName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to query db name: %w", err)
+		}
+		c.tags = append(c.tags, fmt.Sprintf("cdb:%s", c.cdbName))
+	}
+
+	if c.dbHostname == "" || c.dbVersion == "" {
+		// host_name is null on Oracle Autonomous Database
+		row := db.QueryRow("SELECT /* DD */ nvl(host_name, instance_name), version_full FROM v$instance")
+		var dbHostname string
+		err = row.Scan(&dbHostname, &c.dbVersion)
+		if err != nil {
+			return nil, fmt.Errorf("failed to query hostname and version: %w", err)
+		}
+		if c.config.ReportedHostname != "" {
+			c.dbHostname = c.config.ReportedHostname
+		} else {
+			c.dbHostname = dbHostname
+		}
+		c.tags = append(c.tags, fmt.Sprintf("host:%s", c.dbHostname), fmt.Sprintf("oracle_version:%s", c.dbVersion))
+	}
+
+	if c.filePath == "" {
+		r := db.QueryRow("SELECT SUBSTR(name, 1, 10) path FROM v$datafile WHERE rownum = 1")
+		var path string
+		err = r.Scan(&path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to query path: %w", err)
+		}
+		if path == "/rdsdbdata" {
+			c.isRDS = true
+		}
+	}
+
+	r := db.QueryRow("select decode(sys_context('USERENV','CON_ID'),1,'CDB','PDB') TYPE from DUAL")
+	var connectionType string
+	err = r.Scan(&connectionType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query connection type: %w", err)
+	}
+	var cloudRows int
+	if connectionType == "PDB" {
+		c.connectedToPdb = true
+		r := db.QueryRow("select 1 from v$pdbs where cloud_identity like '%oraclecloud%' and rownum = 1")
+		err := r.Scan(&cloudRows)
+		if err != nil {
+			log.Errorf("failed to query v$pdbs: %s", err)
+		}
+		if cloudRows == 1 {
+			r := db.QueryRow("select 1 from cdb_services where name like '%oraclecloud%' and rownum = 1")
+			err := r.Scan(&cloudRows)
+			if err != nil {
+				log.Errorf("failed to query cdb_services: %s", err)
+			}
+		}
+	}
+	if cloudRows == 1 {
+		c.isOracleCloud = true
+	}
+
+	if c.config.AgentSQLTrace.Enabled {
+		db.SetMaxOpenConns(1)
+		_, err := db.Exec("ALTER SESSION SET tracefile_identifier='DDAGENT'")
+		if err != nil {
+			log.Warnf("failed to set tracefile_identifier: %v", err)
+		}
+
+		/* We are concatenating values instead of passing parameters, because there seems to be a problem
+		 * in go-ora with passing bool parameters to PL/SQL. As a mitigation, we are asserting that the
+		 * parameters are bool
+		 */
+		binds := assertBool(c.config.AgentSQLTrace.Binds)
+		waits := assertBool(c.config.AgentSQLTrace.Waits)
+		setEventsStatement := fmt.Sprintf("BEGIN dbms_monitor.session_trace_enable (binds => %t, waits => %t); END;", binds, waits)
+		log.Trace("trace statement: %s", setEventsStatement)
+		_, err = db.Exec(setEventsStatement)
+		if err != nil {
+			log.Errorf("failed to set SQL trace: %v", err)
+		}
+		if c.config.AgentSQLTrace.TracedRuns == 0 {
+			c.config.AgentSQLTrace.TracedRuns = DEFAULT_SQL_TRACED_RUNS
+		}
+	}
+
+	return db, nil
+}
+
+func closeDatabase(c *Check, db *sqlx.DB) {
+	if db != nil {
+		if err := db.Close(); err != nil {
+			log.Warnf("failed to close oracle connection | server=[%s]: %s", c.config.Server, err.Error())
+		}
+	}
+}
+
+// Building a dedicated go-ora connection for dealing with LOBs, see https://github.com/sijms/go-ora/issues/439
+func connectGoOra(c *Check) (*go_ora.Connection, error) {
+	conn, err := go_ora.NewConnection(buildGoOraURL(c))
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect with the oracle driver %w", err)
+	}
+	err = conn.Open()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open connection with the oracle driver %w", err)
+	}
+	return conn, nil
+}
+
+func closeGoOraConnection(c *Check) {
+	err := c.connection.Close()
+	if err != nil {
+		log.Warnf("failed to close go-ora connection | server=[%s]: %s", c.config.Server, err.Error())
+	}
+}

--- a/pkg/collector/corechecks/oracle-dbm/custom_queries.go
+++ b/pkg/collector/corechecks/oracle-dbm/custom_queries.go
@@ -45,9 +45,7 @@ func (c *Check) CustomQueries() error {
 	if c.dbCustomQueries == nil {
 		db, err := c.Connect()
 		if err != nil {
-			if errClosing := CloseDatabaseConnection(db); err != nil {
-				log.Errorf("Error closing connection %s", errClosing)
-			}
+			closeDatabase(c, db)
 			return err
 		}
 		if db == nil {

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -55,6 +55,7 @@ type Check struct {
 	config                                  *config.CheckConfig
 	db                                      *sqlx.DB
 	dbCustomQueries                         *sqlx.DB
+	connection                              *go_ora.Connection
 	dbmEnabled                              bool
 	agentVersion                            string
 	checkInterval                           float64
@@ -125,6 +126,14 @@ func (c *Check) Run() error {
 		c.db = db
 	}
 
+	if c.driver == "oracle" && c.connection == nil {
+		conn, err := connectGoOra(c)
+		if err != nil {
+			return fmt.Errorf("failed to connect with go-ora %w", err)
+		}
+		c.connection = conn
+	}
+
 	metricIntervalExpired := checkIntervalExpired(&c.metricLastRun, c.config.MetricCollectionInterval)
 
 	if metricIntervalExpired {
@@ -138,9 +147,7 @@ func (c *Check) Run() error {
 			} else {
 				handleServiceCheck(c, nil)
 			}
-			if errClosing := CloseDatabaseConnection(db); err != nil {
-				log.Errorf("Error closing connection %s", errClosing)
-			}
+			closeDatabase(c, db)
 			return fmt.Errorf("failed to collect os stats %w", err)
 		} else {
 			handleServiceCheck(c, nil)
@@ -211,168 +218,18 @@ func (c *Check) Run() error {
 	return nil
 }
 
-// Connect establishes a connection to an Oracle instance and returns an open connection to the database.
-func (c *Check) Connect() (*sqlx.DB, error) {
-
-	var connStr string
-	var oracleDriver string
-	if c.config.TnsAlias != "" {
-		connStr = fmt.Sprintf(`user="%s" password="%s" connectString="%s"`, c.config.Username, c.config.Password, c.config.TnsAlias)
-		oracleDriver = "godror"
-	} else {
-		//godror ezconnect string
-		if c.config.InstanceConfig.InstantClient {
-			oracleDriver = "godror"
-			protocolString := ""
-			walletString := ""
-			if c.config.Protocol == "TCPS" {
-				protocolString = "tcps://"
-				if c.config.Wallet != "" {
-					walletString = fmt.Sprintf("?wallet_location=%s", c.config.Wallet)
-				}
-			}
-			connStr = fmt.Sprintf(`user="%s" password="%s" connectString="%s%s:%d/%s%s"`, c.config.Username, c.config.Password, protocolString, c.config.Server, c.config.Port, c.config.ServiceName, walletString)
-		} else {
-			oracleDriver = "oracle"
-			connectionOptions := map[string]string{"TIMEOUT": DB_TIMEOUT}
-			if c.config.Protocol == "TCPS" {
-				connectionOptions["SSL"] = "TRUE"
-				if c.config.Wallet != "" {
-					connectionOptions["WALLET"] = c.config.Wallet
-				}
-			}
-			connStr = go_ora.BuildUrl(c.config.Server, c.config.Port, c.config.ServiceName, c.config.Username, c.config.Password, connectionOptions)
-			// https://github.com/jmoiron/sqlx/issues/854#issuecomment-1504070464
-			sqlx.BindDriver("oracle", sqlx.NAMED)
-		}
-	}
-	c.driver = oracleDriver
-
-	log.Infof("driver: %s", oracleDriver)
-
-	db, err := sqlx.Open(oracleDriver, connStr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to oracle instance: %w", err)
-	}
-	err = db.Ping()
-	if err != nil {
-		return nil, fmt.Errorf("failed to ping oracle instance: %w", err)
-	}
-
-	db.SetMaxOpenConns(MAX_OPEN_CONNECTIONS)
-
-	if c.cdbName == "" {
-		row := db.QueryRow("SELECT /* DD */ lower(name) FROM v$database")
-		err = row.Scan(&c.cdbName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to query db name: %w", err)
-		}
-		c.tags = append(c.tags, fmt.Sprintf("cdb:%s", c.cdbName))
-	}
-
-	if c.dbHostname == "" || c.dbVersion == "" {
-		// host_name is null on Oracle Autonomous Database
-		row := db.QueryRow("SELECT /* DD */ nvl(host_name, instance_name), version_full FROM v$instance")
-		var dbHostname string
-		err = row.Scan(&dbHostname, &c.dbVersion)
-		if err != nil {
-			return nil, fmt.Errorf("failed to query hostname and version: %w", err)
-		}
-		if c.config.ReportedHostname != "" {
-			c.dbHostname = c.config.ReportedHostname
-		} else {
-			c.dbHostname = dbHostname
-		}
-		c.tags = append(c.tags, fmt.Sprintf("host:%s", c.dbHostname), fmt.Sprintf("oracle_version:%s", c.dbVersion))
-	}
-
-	if c.filePath == "" {
-		r := db.QueryRow("SELECT SUBSTR(name, 1, 10) path FROM v$datafile WHERE rownum = 1")
-		var path string
-		err = r.Scan(&path)
-		if err != nil {
-			return nil, fmt.Errorf("failed to query path: %w", err)
-		}
-		if path == "/rdsdbdata" {
-			c.isRDS = true
-		}
-	}
-
-	r := db.QueryRow("select decode(sys_context('USERENV','CON_ID'),1,'CDB','PDB') TYPE from DUAL")
-	var connectionType string
-	err = r.Scan(&connectionType)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query connection type: %w", err)
-	}
-	var cloudRows int
-	if connectionType == "PDB" {
-		c.connectedToPdb = true
-		r := db.QueryRow("select 1 from v$pdbs where cloud_identity like '%oraclecloud%' and rownum = 1")
-		err := r.Scan(&cloudRows)
-		if err != nil {
-			log.Errorf("failed to query v$pdbs: %s", err)
-		}
-		if cloudRows == 1 {
-			r := db.QueryRow("select 1 from cdb_services where name like '%oraclecloud%' and rownum = 1")
-			err := r.Scan(&cloudRows)
-			if err != nil {
-				log.Errorf("failed to query cdb_services: %s", err)
-			}
-		}
-	}
-	if cloudRows == 1 {
-		c.isOracleCloud = true
-	}
-
-	if c.config.AgentSQLTrace.Enabled {
-		db.SetMaxOpenConns(1)
-		_, err := db.Exec("ALTER SESSION SET tracefile_identifier='DDAGENT'")
-		if err != nil {
-			log.Warnf("failed to set tracefile_identifier: %v", err)
-		}
-
-		/* We are concatenating values instead of passing parameters, because there seems to be a problem
-		 * in go-ora with passing bool parameters to PL/SQL. As a mitigation, we are asserting that the
-		 * parameters are bool
-		 */
-		binds := assertBool(c.config.AgentSQLTrace.Binds)
-		waits := assertBool(c.config.AgentSQLTrace.Waits)
-		setEventsStatement := fmt.Sprintf("BEGIN dbms_monitor.session_trace_enable (binds => %t, waits => %t); END;", binds, waits)
-		log.Trace("trace statement: %s", setEventsStatement)
-		_, err = db.Exec(setEventsStatement)
-		if err != nil {
-			log.Errorf("failed to set SQL trace: %v", err)
-		}
-		if c.config.AgentSQLTrace.TracedRuns == 0 {
-			c.config.AgentSQLTrace.TracedRuns = DEFAULT_SQL_TRACED_RUNS
-		}
-	}
-
-	return db, nil
-}
-
 func assertBool(val bool) bool {
 	return val
 }
 
 // Teardown cleans up resources used throughout the check.
 func (c *Check) Teardown() {
-	if c.db != nil {
-		if err := c.db.Close(); err != nil {
-			log.Warnf("failed to close oracle connection | server=[%s]: %s", c.config.Server, err.Error())
-		}
-	}
+	closeDatabase(c, c.db)
+	closeDatabase(c, c.dbCustomQueries)
+	closeGoOraConnection(c)
+
 	c.fqtEmitted = nil
 	c.planEmitted = nil
-}
-
-func CloseDatabaseConnection(db *sqlx.DB) error {
-	if db != nil {
-		if err := db.Close(); err != nil {
-			return fmt.Errorf("failed to close oracle connection: %s", err)
-		}
-	}
-	return nil
 }
 
 // Configure configures the Oracle check.
@@ -464,41 +321,4 @@ func appendPDBTag(tags []string, pdb sql.NullString) []string {
 		return tags
 	}
 	return append(tags, "pdb:"+strings.ToLower(pdb.String))
-}
-
-func selectWrapper[T any](c *Check, s T, sql string, binds ...interface{}) error {
-	err := c.db.Select(s, sql, binds...)
-	reconnectOnConnectionError(c, &c.db, err)
-	return err
-}
-
-func reconnectOnConnectionError(c *Check, db **sqlx.DB, err error) {
-	if err == nil {
-		return
-	}
-	errors := []string{"ORA-00028", "ORA-01012", "ORA-06413", "database is closed"}
-	var isError bool
-	for _, e := range errors {
-		if strings.Contains(err.Error(), e) {
-			isError = true
-			break
-		}
-	}
-	if !isError {
-		return
-	}
-	log.Tracef("Reconnecting")
-	*db, err = c.Connect()
-	if err != nil {
-		log.Errorf("failed to reconnect %s", err)
-		closeDatabase(c, *db)
-	}
-}
-
-func closeDatabase(c *Check, db *sqlx.DB) {
-	if db != nil {
-		if err := db.Close(); err != nil {
-			log.Warnf("failed to close oracle connection | server=[%s]: %s", c.config.Server, err.Error())
-		}
-	}
 }

--- a/pkg/collector/corechecks/oracle-dbm/oracle_dictionary.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_dictionary.go
@@ -20,7 +20,6 @@ func getFullSQLText(c *Check, SQLStatement *string, key string, value string) er
 		sql = fmt.Sprintf("SELECT /* DD */ sql_fulltext FROM v$sql WHERE %s = :v AND rownum = 1", key)
 		err = c.db.Get(SQLStatement, sql, value)
 		reconnectOnConnectionError(c, &c.db, err)
-		return err
 	} else {
 		var sqlFullText go_ora.Clob
 		sql = fmt.Sprintf("BEGIN SELECT /* DD */ sql_fulltext INTO :sql_fulltext FROM v$sql WHERE %s = :v AND rownum = 1; END;", key)
@@ -42,10 +41,10 @@ func getFullSQLText(c *Check, SQLStatement *string, key string, value string) er
 			} else {
 				c.connection = conn
 			}
-			return err
+			return fmt.Errorf("failed to query sql full text for %s = %s %s", key, value, err)
 		} else if sqlFullText.String == "" {
 			return fmt.Errorf("no rows for %s = %s", key, value)
 		}
-		return err
 	}
+	return err
 }

--- a/pkg/collector/corechecks/oracle-dbm/oracle_dictionary.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_dictionary.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle
+
+package oracle
+
+import (
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	go_ora "github.com/sijms/go-ora/v2"
+)
+
+func getFullSQLText(c *Check, SQLStatement *string, key string, value string) error {
+	var err error
+	var sql string
+	if c.driver == "godror" {
+		sql = fmt.Sprintf("SELECT /* DD */ sql_fulltext FROM v$sql WHERE %s = :v AND rownum = 1", key)
+		err = c.db.Get(SQLStatement, sql, value)
+		reconnectOnConnectionError(c, &c.db, err)
+		return err
+	} else {
+		var sqlFullText go_ora.Clob
+		sql = fmt.Sprintf("BEGIN SELECT /* DD */ sql_fulltext INTO :sql_fulltext FROM v$sql WHERE %s = :v AND rownum = 1; END;", key)
+		_, err = c.connection.Exec(sql, go_ora.Out{Dest: &sqlFullText, Size: 8000}, value)
+		if err == nil && sqlFullText.Valid && sqlFullText.String != "" {
+			*SQLStatement = sqlFullText.String
+		} else if err != nil {
+			if !isConnectionError(err) {
+				return err
+			}
+			log.Debugf("Reconnecting")
+			if c.connection != nil {
+				closeGoOraConnection(c)
+			}
+			conn, errConnect := connectGoOra(c)
+			if errConnect != nil {
+				log.Errorf("failed to reconnect %s", err)
+				closeGoOraConnection(c)
+			} else {
+				c.connection = conn
+			}
+			return err
+		} else if sqlFullText.String == "" {
+			return fmt.Errorf("no rows for %s = %s", key, value)
+		}
+		return err
+	}
+}

--- a/pkg/collector/corechecks/oracle-dbm/oracle_dictionary_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_dictionary_test.go
@@ -8,54 +8,12 @@
 package oracle
 
 import (
-	"fmt"
-
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/common"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 
 	_ "github.com/godror/godror"
 )
-
-var chk Check
-
-var HOST = "localhost"
-var PORT = 1521
-var USER = "c##datadog"
-var PASSWORD = "datadog"
-var SERVICE_NAME = "XE"
-var TNS_ALIAS = "XE"
-var TNS_ADMIN = "/Users/nenad.noveljic/go/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/testutil/etc/netadmin"
-
-func TestBasic(t *testing.T) {
-	chk = Check{}
-
-	// language=yaml
-	rawInstanceConfig := []byte(fmt.Sprintf(`
-server: %s
-port: %d
-username: %s
-password: %s
-service_name: %s
-tns_alias: %s
-tns_admin: %s
-dbm: true
-`, HOST, PORT, USER, PASSWORD, SERVICE_NAME, TNS_ALIAS, TNS_ADMIN))
-
-	err := chk.Configure(aggregator.GetSenderManager(), integration.FakeConfigHash, rawInstanceConfig, []byte(``), "oracle_test")
-	require.NoError(t, err)
-
-	assert.Equal(t, chk.config.InstanceConfig.Server, HOST)
-	assert.Equal(t, chk.config.InstanceConfig.Port, PORT)
-	assert.Equal(t, chk.config.InstanceConfig.Username, USER)
-	assert.Equal(t, chk.config.InstanceConfig.Password, PASSWORD)
-	assert.Equal(t, chk.config.InstanceConfig.ServiceName, SERVICE_NAME)
-	assert.Equal(t, chk.config.InstanceConfig.TnsAlias, TNS_ALIAS)
-	assert.Equal(t, chk.config.InstanceConfig.TnsAdmin, TNS_ADMIN)
-}
 
 func TestGetFullSqlText(t *testing.T) {
 	initAndStartAgentDemultiplexer(t)

--- a/pkg/collector/corechecks/oracle-dbm/oracle_dictionary_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_dictionary_test.go
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle_test
+
+package oracle
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	_ "github.com/godror/godror"
+)
+
+var chk Check
+
+var HOST = "localhost"
+var PORT = 1521
+var USER = "c##datadog"
+var PASSWORD = "datadog"
+var SERVICE_NAME = "XE"
+var TNS_ALIAS = "XE"
+var TNS_ADMIN = "/Users/nenad.noveljic/go/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/testutil/etc/netadmin"
+
+func TestBasic(t *testing.T) {
+	chk = Check{}
+
+	// language=yaml
+	rawInstanceConfig := []byte(fmt.Sprintf(`
+server: %s
+port: %d
+username: %s
+password: %s
+service_name: %s
+tns_alias: %s
+tns_admin: %s
+dbm: true
+`, HOST, PORT, USER, PASSWORD, SERVICE_NAME, TNS_ALIAS, TNS_ADMIN))
+
+	err := chk.Configure(aggregator.GetSenderManager(), integration.FakeConfigHash, rawInstanceConfig, []byte(``), "oracle_test")
+	require.NoError(t, err)
+
+	assert.Equal(t, chk.config.InstanceConfig.Server, HOST)
+	assert.Equal(t, chk.config.InstanceConfig.Port, PORT)
+	assert.Equal(t, chk.config.InstanceConfig.Username, USER)
+	assert.Equal(t, chk.config.InstanceConfig.Password, PASSWORD)
+	assert.Equal(t, chk.config.InstanceConfig.ServiceName, SERVICE_NAME)
+	assert.Equal(t, chk.config.InstanceConfig.TnsAlias, TNS_ALIAS)
+	assert.Equal(t, chk.config.InstanceConfig.TnsAdmin, TNS_ADMIN)
+}
+
+func TestGetFullSqlText(t *testing.T) {
+	initAndStartAgentDemultiplexer(t)
+	for _, tnsAlias := range []string{"", TNS_ALIAS} {
+		chk.db = nil
+
+		chk.config.InstanceConfig.TnsAlias = tnsAlias
+		chk.dbmEnabled = false
+
+		var driver string
+		if tnsAlias == "" {
+			driver = common.GoOra
+			chk.config.InstanceConfig.InstantClient = false
+		} else {
+			driver = common.Godror
+		}
+		chk.Run()
+
+		var SQLStatement string
+		err := getFullSQLText(&chk, &SQLStatement, "sql_id", "A")
+		assert.ErrorContainsf(t, err, "no rows", "getFullSQLText didn't return `no rows` error with %s driver", driver)
+	}
+}

--- a/pkg/collector/corechecks/oracle-dbm/oracle_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/jmoiron/sqlx"
 	go_ora "github.com/sijms/go-ora/v2"
 	"github.com/stretchr/testify/assert"
-	"math"
 	"testing"
 	"time"
 
@@ -45,7 +44,7 @@ func TestConnection(t *testing.T) {
 	assert.NoError(t, err)
 
 	databaseUrl = fmt.Sprintf(`user="%s" password="%s" connectString="%s:%d/%s"`, USER, PASSWORD, HOST, PORT, SERVICE_NAME)
-	_, err = sqlx.Open("godror", databaseUrl)
+	_, err = sqlx.Open("oracle", databaseUrl)
 	assert.NoError(t, err)
 	err = db.Ping()
 	assert.NoError(t, err)
@@ -108,10 +107,28 @@ func getSession(db *sqlx.DB) (string, error) {
 	return r, err
 }
 
+func getLOBReads(db *sqlx.DB) (float64, error) {
+	var r float64
+	err := chk.db.Get(&r, `SELECT name,value 
+	FROM v$sesstat  m, v$statname n, v$session s 
+	WHERE n.statistic# = m.statistic# AND s.sid = m.sid AND s.username = 'C##DATADOG' AND n.name = 'lob reads'`)
+	return r, err
+}
+
+func getTemporaryLobs(db *sqlx.DB) (int, error) {
+	var r int
+	err := chk.db.Get(&r, `SELECT SUM(cache_lobs) + SUM(nocache_lobs) + SUM(abstract_lobs) 
+	FROM v$temporary_lobs l, v$session s WHERE s.SID = l.SID AND s.username = 'C##DATADOG'`)
+	return r, err
+}
+
 func TestChkRun(t *testing.T) {
 	initAndStartAgentDemultiplexer(t)
 	chk.dbmEnabled = true
 	chk.config.InstanceConfig.InstantClient = false
+
+	// This is to ensure that query samples return rows
+	chk.config.QuerySamples.IncludeAllSessions = true
 
 	type RowsStruct struct {
 		N int `db:"N"`
@@ -133,29 +150,47 @@ func TestChkRun(t *testing.T) {
 		err := chk.Run()
 		assert.NoError(t, err, "check run with %s driver", driver)
 
+		sessionBefore, _ := getSession(chk.db)
+
 		pgaBefore, err := getUsedPGA(chk.db)
 		assert.NoError(t, err, "get used pga with %s driver", driver)
+		chk.statementsLastRun = time.Now().Add(-48 * time.Hour)
 
-		sessionBefore, _ := getSession(chk.db)
+		tempLobsBefore, _ := getTemporaryLobs(chk.db)
+
 		_, err = chk.db.Exec(`begin
 				for i in 1..1000
 				loop
-				  execute immediate 'insert into t values (' || i || ')';
+					execute immediate 'insert into t values (' || i || ')';
 				end loop;
-			  end ;`)
+				end ;`)
 		assert.NoError(t, err, "error generating statements with %s driver", driver)
+
+		chk.Run()
+
+		pgaAfter1StRun, _ := getUsedPGA(chk.db)
+		diff1 := (pgaAfter1StRun - pgaBefore) / 1024
+		assert.Less(t, diff1, float64(1024), "extreme PGA usage (%f KB) with the %s driver", diff1, driver)
 
 		chk.statementsLastRun = time.Now().Add(-48 * time.Hour)
 		chk.Run()
-		pgaAfter, err := getUsedPGA(chk.db)
-		assert.NoError(t, err, "get used pga with %s driver", driver)
-		growth := math.Round((pgaAfter - pgaBefore) / 1024 / 1024)
-		assert.Less(t, growth, float64(50), "PGA used changed between two consecutive runs")
+
+		pgaAfter2ndRun, _ := getUsedPGA(chk.db)
+		diff2 := (pgaAfter2ndRun - pgaAfter1StRun) / 1024
+		percGrowth := (diff2 - diff1) * 100 / diff1
+		assert.Less(t, percGrowth, float64(10), "PGA memory leak (%f %% increase between two consecutive runs) with the %s driver", percGrowth, driver)
+
+		tempLobsAfter, _ := getTemporaryLobs(chk.db)
+		diffTempLobs := tempLobsAfter - tempLobsBefore
+		assert.Equal(t, 0, diffTempLobs, "temporary LOB leak (%d) with %s driver", diffTempLobs, driver)
 
 		sessionAfter, _ := getSession(chk.db)
 		assert.Equal(t, sessionBefore, sessionAfter, "The agent reconnected")
-
 	}
+}
+
+func TestGoOraMemorLeaky(t *testing.T) {
+
 }
 
 func TestLicense(t *testing.T) {

--- a/pkg/collector/corechecks/oracle-dbm/oracle_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_test.go
@@ -189,10 +189,6 @@ func TestChkRun(t *testing.T) {
 	}
 }
 
-func TestGoOraMemorLeaky(t *testing.T) {
-
-}
-
 func TestLicense(t *testing.T) {
 	oracleDriver := "oracle"
 	connStr := go_ora.BuildUrl(HOST, PORT, SERVICE_NAME, USER, PASSWORD, map[string]string{})

--- a/pkg/collector/corechecks/oracle-dbm/sql_wrappers.go
+++ b/pkg/collector/corechecks/oracle-dbm/sql_wrappers.go
@@ -9,7 +9,6 @@ package oracle
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	_ "github.com/godror/godror"
 	"github.com/jmoiron/sqlx"
 	"strings"
 )

--- a/pkg/collector/corechecks/oracle-dbm/sql_wrappers.go
+++ b/pkg/collector/corechecks/oracle-dbm/sql_wrappers.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle
+
+package oracle
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	_ "github.com/godror/godror"
+	"github.com/jmoiron/sqlx"
+	"strings"
+)
+
+func selectWrapper[T any](c *Check, s T, sql string, binds ...interface{}) error {
+	err := c.db.Select(s, sql, binds...)
+	reconnectOnConnectionError(c, &c.db, err)
+	return err
+}
+
+func isConnectionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	connectionErrors := []string{"ORA-00028", "ORA-01012", "ORA-06413", "database is closed"}
+	for _, e := range connectionErrors {
+		if strings.Contains(err.Error(), e) {
+			return true
+		}
+	}
+	return false
+}
+
+func reconnectOnConnectionError(c *Check, db **sqlx.DB, err error) {
+	if !isConnectionError(err) {
+		return
+	}
+	log.Debugf("Reconnecting")
+	if *db != nil {
+		closeDatabase(c, *db)
+	}
+	*db, err = c.Connect()
+	if err != nil {
+		log.Errorf("failed to reconnect %s", err)
+		closeDatabase(c, *db)
+	}
+}

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -967,24 +967,3 @@ func (c *Check) StatementMetrics() (int, error) {
 	}
 	return SQLCount, nil
 }
-
-func getFullSQLText(c *Check, SQLStatement *string, key string, value string) error {
-	sql := fmt.Sprintf("SELECT /* DD */ sql_fulltext FROM v$sql WHERE %s = :v AND rownum = 1", key)
-	err := c.db.Get(SQLStatement, sql, value)
-	if err != nil {
-		log.Warnf("failed to select full SQL text based on %s: %s \n%s", key, err, sql)
-		recoverFromDeadConnection(c, err)
-	}
-	return err
-}
-
-func recoverFromDeadConnection(c *Check, err error) {
-	if err != nil && (strings.Contains(err.Error(), "ORA-01012") || strings.Contains(err.Error(), "database is closed")) {
-		db, err := c.Connect()
-		if err != nil {
-			c.Teardown()
-			log.Errorf("failed to tear down check: %s", err)
-		}
-		c.db = db
-	}
-}


### PR DESCRIPTION
### What does this PR do?

This PR fixes the memory leak, which is caused by the agent queries.

### Motivation

Two customers complained about the problem: Haven and REI. The problem also appeared in our demo environment. In the end, we managed to reproduce the issue in the development environment.

### Additional Notes

The memory leak appears when the LOB data type is selected using `jmoiron/sqlx` libraries with `go-ora` driver. The LOB locators are not freed properly which leads to the leakage of the allocated LOB locators. The root cause is addressed [here](https://github.com/sijms/go-ora/issues/439).

As a workaround, we rewrote the database calls to use the native `go-ora` functions. 

The total PGA allocation doesn't exceed 20M under the full load and remains constant:

```
SQL> /

SUM(P.PGA_USED_MEM)/1024/1024
-----------------------------
		   18.5631838

SQL> /

SUM(P.PGA_USED_MEM)/1024/1024
-----------------------------
		   18.5631838

SQL> /

SUM(P.PGA_USED_MEM)/1024/1024
-----------------------------
		   18.5631838

SQL> /

SUM(P.PGA_USED_MEM)/1024/1024
-----------------------------
		   11.9129457
```

Before the change, the allocated memory was measured in GBytes, and was permanently growing.

Last but not least, we introduced lots of test cases to measure PGA increase, lob reads and temporary LOB allocations between two consecutive checks, so we would notice a problem before merging future changes.

### Possible Drawbacks / Trade-offs

We have to maintain a dedicated connection for selecting LOBs.

### Describe how to test/QA your changes

Generate load and measure the PGA consumption with the queries in [this JIRA](https://datadoghq.atlassian.net/browse/DBMON-1565)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
