### PR TITLE
Use buffered IO in the log socket tailer

### DIFF
--- a/pkg/logs/launchers/listener/tcp.go
+++ b/pkg/logs/launchers/listener/tcp.go
@@ -132,7 +132,7 @@ func (l *TCPListener) read(tailer *tailer.Tailer) ([]byte, error) {
 		tailer.Conn.SetReadDeadline(time.Now().Add(l.idleTimeout)) //nolint:errcheck
 	}
 	frame := make([]byte, l.frameSize)
-	n, err := tailer.Conn.Read(frame)
+	n, err := tailer.Reader.Read(frame)
 	if err != nil {
 		l.source.Status.Error(err)
 		go l.stopTailer(tailer)

--- a/pkg/logs/launchers/listener/udp.go
+++ b/pkg/logs/launchers/listener/udp.go
@@ -88,7 +88,7 @@ func (l *UDPListener) newUDPConnection() (net.Conn, error) {
 // read reads data from the tailer connection, returns an error if it failed and reset the tailer.
 func (l *UDPListener) read(tailer *tailer.Tailer) ([]byte, error) {
 	frame := make([]byte, l.frameSize+1)
-	n, err := tailer.Conn.Read(frame)
+	n, err := tailer.Reader.Read(frame)
 	switch {
 	case err != nil && isClosedConnError(err):
 		return nil, err

--- a/pkg/logs/tailers/socket/tailer_test.go
+++ b/pkg/logs/tailers/socket/tailer_test.go
@@ -60,7 +60,7 @@ func TestReadShouldFailWithError(t *testing.T) {
 
 func read(tailer *Tailer) ([]byte, error) {
 	inBuf := make([]byte, 4096)
-	n, err := tailer.Conn.Read(inBuf)
+	n, err := tailer.Reader.Read(inBuf)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What does this PR do?

Per [our profiles](https://app.datadoghq.com/profiling/search?query=account%3Asingle-machine-performance%20client_team%3Aagent%20runtime%3Ago%20experiment%3Atcp_dd_logs_filter_exclude&compareValuesMode=absolute&my_code=disabled&viz=flame_graph&start=1693947275563&end=1693950875563&paused=false) we spend a good deal of runtime doing read syscalls. This commit is an experiment to use buffered reads instead of direct IO.

### Motivation

Improve Agent's throughput when ingesting logs through a socket.

### Possible Drawbacks / Trade-offs

We now maintain a buffer where we previously did not, incurring a 1Mb memory penalty. We also assume that the caller will set deadlines appropriately. 

