### PR TITLE
Improve Oracle example configuration file

### DIFF
--- a/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
@@ -214,8 +214,8 @@ instances:
     #     - test:tag_value_1
     #     pdb: <MYPDB>
 
-  ## Start SQL trace for agent queries. The feature is only meant for the agent troubleshooting, and 
-  ## should be normally switched off.
+  ## Start an SQL trace for Agent queries. This feature is only meant for Agent troubleshooting, and 
+  ## should normally be switched off.
   ## Requires execute the execute privilege on `dbms_monitor` to datadog user
   #
   # agent_sql_trace:

--- a/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
@@ -122,10 +122,10 @@ instances:
   #
   # execution_plans:
 
-      ## @param enabled - boolean - optional - default: false
+      ## @param enabled - boolean - optional - default: true
       ## Enable collection of execution plans. Requires query metrics.
       #
-      # enabled: false
+      # enabled: true
 
   ## Configure how the SQL obfuscator behaves.
   ## Note: This option only applies when `dbm` is enabled.
@@ -198,7 +198,11 @@ instances:
     ## 3. tags (optional) - A list of tags to apply to each metric.
     ## 4. pdb (optional) - A PDB against which the query will be run. Default is CDB$ROOT.
                            The parameter can be defined on a self-managed instance, which
-                           connects to CDB.
+                           connects to CDB. The agent needs to have `set container` privilege
+                           on the PDB where the custom query is running.
+
+    ## WARNING: Running custom queries may result in additional costs or fees assessed by Oracle.
+    
     # custom_queries:
     #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
     #     columns:
@@ -207,10 +211,11 @@ instances:
     #     - name: event.total
     #       type: gauge
     #     tags:
-    #     - test:<INTEGRATION>
+    #     - test:tag_value_1
     #     pdb: <MYPDB>
 
-  ## Start SQL trace for agent queries
+  ## Start SQL trace for agent queries. The feature is only meant for the agent troubleshooting, and 
+  ## should be normally switched off.
   ## Requires execute the execute privilege on `dbms_monitor` to datadog user
   #
   # agent_sql_trace:

--- a/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
@@ -198,7 +198,7 @@ instances:
     ## 3. tags (optional) - A list of tags to apply to each metric.
     ## 4. pdb (optional) - A PDB against which the query will be run. Default is CDB$ROOT.
                            The parameter can be defined on a self-managed instance, which
-                           connects to CDB. The agent needs to have `set container` privilege
+                           connects to CDB. The Agent needs to have `set container` privilege
                            on the PDB where the custom query is running.
 
     ## WARNING: Running custom queries may result in additional costs or fees assessed by Oracle.

--- a/releasenotes/notes/oracle-example-config-225e6eec5e00df78.yaml
+++ b/releasenotes/notes/oracle-example-config-225e6eec5e00df78.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Improve the Oracle check example configuration file.


### PR DESCRIPTION
### What does this PR do?

Adding some more details into the example configuration file.

### Additional Notes

- Agent trace configuration: mention that is only for troubleshooting the agent.
- Custom queries:
  - add the Oracle license disclaimer
  - mention the `set container` access rights are needed.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

No tests are needed.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
