### PR TITLE
Bump invoke version used for notification steps

### DIFF
--- a/tasks/libs/requirements-notifications.txt
+++ b/tasks/libs/requirements-notifications.txt
@@ -1,5 +1,5 @@
 # codeowners pinned to a version that works with Python 3.6, which is the
 # Python version in the slack-notifier image
-invoke==1.7.1
+invoke==2.2.0
 codeowners==0.1.4; python_version < '3.7'
 codeowners==0.6.0; python_version >= '3.7'

--- a/tasks/libs/requirements-stats.txt
+++ b/tasks/libs/requirements-stats.txt
@@ -1,2 +1,2 @@
-invoke==1.7.1
+invoke==2.2.0
 datadog-api-client==2.3.0


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Use a more recent version of invoke that allows using annotation in task prototype
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Notify and stat_pipeline jobs where failing with this backtrace
```
File "/go/src/github.com/DataDog/datadog-agent/tasks/test.py", line 792, in <module>
    golangci_lint_kwargs="",
  File "/usr/local/lib/python3.6/dist-packages/invoke/tasks.py", line 372, in inner
    **kwargs
  File "/usr/local/lib/python3.6/dist-packages/invoke/tasks.py", line [76](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/323688176#L76), in __init__
    self.positional = self.fill_implicit_positionals(positional)
  File "/usr/local/lib/python3.6/dist-packages/invoke/tasks.py", line 167, in fill_implicit_positionals
    args, spec_dict = self.argspec(self.body)
  File "/usr/local/lib/python3.6/dist-packages/invoke/tasks.py", line 153, in argspec
    spec = inspect.getargspec(func)
  File "/usr/lib/python3.6/inspect.py", line 10[82](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/323688176#L82), in getargspec
    raise ValueError("Function has keyword-only parameters or annotations"
ValueError: Function has keyword-only parameters or annotations, use getfullargspec() API which can support them
```
This issue required to change this [line](https://github.com/pyinvoke/invoke/blob/1.7.1/invoke/tasks.py#L153), which is done in invoke [latest version](https://github.com/pyinvoke/invoke/blob/2.2.0/invoke/tasks.py#L168)
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
