### PR TITLE
[CWS] fix superblock flag on CentOS

### DIFF
--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -217,7 +217,7 @@ static __attribute__((always_inline)) int get_sb_flags(struct super_block *sb) {
 
 static __attribute__((always_inline)) int is_non_mountable_dentry(struct dentry *dentry) {
     struct super_block *sb = get_dentry_sb(dentry);
-    return get_sb_flags(sb) & SB_NOUSER;
+    return get_sb_flags(sb) & MS_NOUSER;
 }
 
 static __attribute__((always_inline)) int is_tmpfs(struct dentry *dentry) {

--- a/pkg/security/ebpf/c/prebuilt/probe.c
+++ b/pkg/security/ebpf/c/prebuilt/probe.c
@@ -26,8 +26,13 @@
 #include <uapi/linux/udp.h>
 #include <uapi/linux/tcp.h>
 #include <uapi/linux/utime.h>
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
 #include <uapi/linux/mount.h>
+#elif defined(RHEL_RELEASE_CODE) && defined(RHEL_RELEASE_VERSION)
+#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8,0)
+#include <uapi/linux/mount.h>
+#endif
 #else
 #include <uapi/linux/fs.h>
 #endif

--- a/pkg/security/ebpf/c/prebuilt/probe.c
+++ b/pkg/security/ebpf/c/prebuilt/probe.c
@@ -26,6 +26,11 @@
 #include <uapi/linux/udp.h>
 #include <uapi/linux/tcp.h>
 #include <uapi/linux/utime.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
+#include <uapi/linux/mount.h>
+#else
+#include <uapi/linux/fs.h>
+#endif
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -210,13 +210,7 @@ func getSizeOfStructInode(kv *kernel.Version) uint64 {
 }
 
 func getSuperBlockFlagsOffset(kv *kernel.Version) uint64 {
-	offset := uint64(80)
-
-	if kv.IsRH7Kernel() {
-		offset = 72
-	}
-
-	return offset
+	return uint64(80)
 }
 
 func getSuperBlockMagicOffset(kv *kernel.Version) uint64 {


### PR DESCRIPTION
Switch the NOUSER superblock flag from `SB_NOUSER` to `MS_NOUSER` as the former doesn't exist on kernel versions prior to 4.14.

The flag was introduced in #19163 

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
