### PR TITLE
[deps] Exclude some versions of knadh/koanf to fix building with go.work

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -664,3 +664,10 @@ replace github.com/moby/buildkit v0.11.0 => github.com/moby/buildkit v0.11.4
 
 // Fixes a panic in trivy, see gitlab.com/cznic/libc/-/issues/25
 replace modernc.org/sqlite v1.17.3 => modernc.org/sqlite v1.19.3
+
+// Exclude specific versions of knadh/koanf to fix building with a `go.work`, following
+// https://github.com/open-telemetry/opentelemetry-collector/issues/8127
+exclude (
+	github.com/knadh/koanf/maps v0.1.1
+	github.com/knadh/koanf/providers/confmap v0.1.0
+)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Exclude specific versions of `knadh/koanf` to fix compiling with a `go.work` file.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Some modules in `knadh/koanf` seem to be exported with different paths depending on the version, when using a `go.work` file Go seem to struggle to choose which it should use, giving the following errors:
```
../../go/pkg/mod/go.opentelemetry.io/collector/confmap@v0.84.0/confmap.go:11:2: ambiguous import: found package github.com/knadh/koanf/maps in multiple modules:
	github.com/knadh/koanf v1.4.1 (/Users/pierre.gimalac/go/pkg/mod/github.com/knadh/koanf@v1.4.1/maps)
	github.com/knadh/koanf/maps v0.1.1 (/Users/pierre.gimalac/go/pkg/mod/github.com/knadh/koanf/maps@v0.1.1)
../../go/pkg/mod/go.opentelemetry.io/collector/confmap@v0.84.0/confmap.go:12:2: ambiguous import: found package github.com/knadh/koanf/providers/confmap in multiple modules:
	github.com/knadh/koanf v1.4.1 (/Users/pierre.gimalac/go/pkg/mod/github.com/knadh/koanf@v1.4.1/providers/confmap)
	github.com/knadh/koanf/providers/confmap v0.1.0 (/Users/pierre.gimalac/go/pkg/mod/github.com/knadh/koanf/providers/confmap@v0.1.0)
 ```

Excluding the problematic version solved it, the solution was found on this issue https://github.com/open-telemetry/opentelemetry-collector/issues/8127.

I use a `go.work` file to work in the datadog-agent repository so having it fixed would be very convenient.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Asking for review from `opentelemetry` as it was introduced by https://github.com/DataDog/datadog-agent/pull/19166 (and the fix was found on an issue opened on `opentelemetry-collector` !).

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
