### PR TITLE
[gitlab] skip e2e tests when RUN_KITCHEN_TESTS is false

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -269,6 +269,9 @@ variables:
 .if_testing_cleanup: &if_testing_cleanup
   if: $TESTING_CLEANUP == "true"
 
+.if_not_e2e: &if_not_e2e
+  if: $RUN_KITCHEN_TESTS == "false"
+
 .if_deploy_on_beta_repo_branch: &if_deploy_on_beta_repo_branch
   if: $DEPLOY_AGENT == "true" && $BUCKET_BRANCH == "beta"
 
@@ -909,3 +912,9 @@ workflow:
     when: always
   - when: manual
     allow_failure: true
+
+.on_main_and_no_skip_e2e:
+  - <<: *if_not_e2e
+    when: never
+  - <<: *if_main_branch
+    when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -917,4 +917,4 @@ workflow:
   - <<: *if_not_e2e
     when: never
   - <<: *if_main_branch
-    when: always
+    when: on_success

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -155,6 +155,9 @@ k8s-e2e-otlp-main:
 
 new-e2e-containers-dev:
   extends: .new_e2e_template
+  # TODO once images are deployed to ECR for dev branches, update
+  # on_main_and_no_skip_e2e adding on_dev_branch_manual rules
+  # and move rules to template
   rules: !reference [.on_dev_branch_manual]
   needs: []
   variables:
@@ -169,7 +172,7 @@ new-e2e-containers-dev:
 
 new-e2e-containers-main:
   extends: .new_e2e_template
-  rules: !reference [.on_main]
+  rules: !reference [.on_main_and_no_skip_e2e]
   needs:
     - qa_agent
     - qa_dca
@@ -189,7 +192,7 @@ new-e2e-agent-subcommands-dev:
 
 new-e2e-agent-subcommands-main:
   extends: .new_e2e_template
-  rules: !reference [.on_main]
+  rules: !reference [.on_main_and_no_skip_e2e]
   variables:
     TARGETS: ./agent-subcommands
   # Temporary, until we manage to stabilize those tests.
@@ -197,19 +200,18 @@ new-e2e-agent-subcommands-main:
 
 new-e2e-language-detection-dev:
   extends: .new_e2e_template
-  rules: !reference [ .on_dev_branch_manual ]
-  needs: [ ]
+  rules: !reference [.on_dev_branch_manual]
+  needs: []
   variables:
     TARGETS: ./language-detection
     TEAM: processes
 
 new-e2e-language-detection-main:
   extends: .new_e2e_template
-  rules: !reference [ .on_main ]
+  rules: !reference [.on_main_and_no_skip_e2e]
   variables:
     TARGETS: ./language-detection
     TEAM: processes
-
 #   ^    If you create a new job here that extends `.new_e2e_template`,
 #  /!\   do not forget to add it in the `dependencies` statement of the
 # /___\  `e2e_test_junit_upload` job in the `.gitlab/e2e_test_junit_upload.yml` file


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Skip new e2e tests when `RUN_KITCHEN_TESTS` is false

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

`datadog-agent` pipeline is triggered by `integrations-core` pipeline, but it should skip new e2e tests. `RUN_KITCHEN_TESTS == false` disables all kitchen stages, including the docker image deployment. Docker images are required by e2e tests, so all pipelines on `main` triggered with `RUN_KITCHEN_TESTS` fail.

It is also expected to skip e2e tests on `main` when triggered out of `datadog-agent`

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
