### PR TITLE
Add non-allocating path for `toValidUtf8`

### DIFF
--- a/pkg/logs/internal/processor/encoder.go
+++ b/pkg/logs/internal/processor/encoder.go
@@ -8,6 +8,7 @@ package processor
 import (
 	"unicode"
 	"unicode/utf8"
+	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
@@ -17,10 +18,11 @@ type Encoder interface {
 	Encode(msg *message.Message, redactedMsg []byte) ([]byte, error)
 }
 
-// toValidUtf8 ensures all characters are UTF-8.
+// toValidUtf8 ensures all characters are UTF-8. `msg` must not be modified
+// after calling this function.
 func toValidUtf8(msg []byte) string {
 	if utf8.Valid(msg) {
-		return string(msg)
+		return unsafe.String(unsafe.SliceData(msg), len(msg))
 	}
 	str := make([]rune, 0, len(msg))
 	for i := range msg {


### PR DESCRIPTION
### What does this PR do?

Adds a non-allocating fast-path to `toValidUtf8` for byte slices that are valid UTF8.

### Motivation

This eliminates a source of allocations in the log handling code.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

The underlying list must not change once this function has been called.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
