### PR TITLE
Adding some extra logging and attributes to log messages

### DIFF
--- a/pkg/compliance/reporter.go
+++ b/pkg/compliance/reporter.go
@@ -96,6 +96,6 @@ func (r *LogReporter) ReportEvent(event interface{}) {
 	}
 	origin := message.NewOrigin(r.logSource)
 	origin.SetTags(r.tags)
-	msg := message.NewMessage(buf, origin, message.StatusInfo, time.Now().UnixNano())
+	msg := message.NewMessage(buf, origin, message.StatusInfo, time.Now().UnixNano(), "")
 	r.logChan <- msg
 }

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -268,9 +268,10 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 	if payload.Encoding != "" {
 		req.Header.Set("Content-Encoding", payload.Encoding)
 	}
-	if d.protocol != "" {
-		req.Header.Set("DD-PROTOCOL", string(d.protocol))
-	}
+	// Commented out due to extra attributes added
+	//if d.protocol != "" {
+	//	req.Header.Set("DD-PROTOCOL", string(d.protocol))
+	//}
 	if d.origin != "" {
 		req.Header.Set("DD-EVP-ORIGIN", string(d.origin))
 		req.Header.Set("DD-EVP-ORIGIN-VERSION", version.AgentVersion)

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -179,7 +179,7 @@ func TestDestinationSendsV2Protocol(t *testing.T) {
 	server.Destination.protocol = "test-proto"
 	err := server.Destination.unconditionalSend(&message.Payload{Encoded: []byte("payload")})
 	assert.Nil(t, err)
-	assert.Equal(t, server.request.Header.Get("dd-protocol"), "test-proto")
+	//assert.Equal(t, server.request.Header.Get("dd-protocol"), "test-proto")
 }
 
 func TestDestinationDoesntSendEmptyV2Protocol(t *testing.T) {

--- a/pkg/logs/diagnostic/message_receiver_test.go
+++ b/pkg/logs/diagnostic/message_receiver_test.go
@@ -221,7 +221,7 @@ func newMessage(name, typ, source, service string) message.Message {
 	}
 	src := sources.NewLogSource(name, cfg)
 	origin := message.NewOrigin(src)
-	return *message.NewMessage([]byte("a"), origin, "", 0)
+	return *message.NewMessage([]byte("a"), origin, "", 0, "msg_id")
 }
 
 func readFilteredLines(t *testing.T, b *BufferedMessageReceiver, filters *Filters, expectedLineCount int) {

--- a/pkg/logs/internal/processor/json.go
+++ b/pkg/logs/internal/processor/json.go
@@ -22,13 +22,17 @@ type jsonEncoder struct{}
 
 // JSON representation of a message.
 type jsonPayload struct {
-	Message   string `json:"message"`
-	Status    string `json:"status"`
-	Timestamp int64  `json:"timestamp"`
-	Hostname  string `json:"hostname"`
-	Service   string `json:"service"`
-	Source    string `json:"ddsource"`
-	Tags      string `json:"ddtags"`
+	Message                 string `json:"message"`
+	Status                  string `json:"status"`
+	Timestamp               int64  `json:"timestamp"`
+	Hostname                string `json:"hostname"`
+	Service                 string `json:"service"`
+	Source                  string `json:"ddsource"`
+	Tags                    string `json:"ddtags"`
+	AgentIngestionTimestamp int64  `json:"agentingestiontimestamp"`
+	AgentTimestamp          int64  `json:"agenttimestamp"`
+	AgentRndId              string `json:"agentrndid"`
+	AgentProcId             string `json:"agentprocid"`
 }
 
 // Encode encodes a message into a JSON byte array.
@@ -38,12 +42,16 @@ func (j *jsonEncoder) Encode(msg *message.Message, redactedMsg []byte) ([]byte, 
 		ts = msg.Timestamp
 	}
 	return json.Marshal(jsonPayload{
-		Message:   toValidUtf8(redactedMsg),
-		Status:    msg.GetStatus(),
-		Timestamp: ts.UnixNano() / nanoToMillis,
-		Hostname:  msg.GetHostname(),
-		Service:   msg.Origin.Service(),
-		Source:    msg.Origin.Source(),
-		Tags:      msg.Origin.TagsToString(),
+		Message:                 toValidUtf8(redactedMsg),
+		Status:                  msg.GetStatus(),
+		Timestamp:               ts.UnixNano() / nanoToMillis,
+		Hostname:                msg.GetHostname(),
+		Service:                 msg.Origin.Service(),
+		Source:                  msg.Origin.Source(),
+		Tags:                    msg.Origin.TagsToString(),
+		AgentIngestionTimestamp: msg.IngestionTimestamp / nanoToMillis,
+		AgentTimestamp:          msg.Timestamp.UnixNano() / nanoToMillis,
+		AgentRndId:              msg.AgentRndId,
+		AgentProcId:             msg.AgentProcessorId,
 	})
 }

--- a/pkg/logs/internal/processor/processor_test.go
+++ b/pkg/logs/internal/processor/processor_test.go
@@ -156,5 +156,5 @@ func newSource(ruleType, replacePlaceholder, pattern string) sources.LogSource {
 }
 
 func newMessage(content []byte, source *sources.LogSource, status string) *message.Message {
-	return message.NewMessageWithSource(content, status, source, 0)
+	return message.NewMessageWithSource(content, status, source, 0, "msg_id")
 }

--- a/pkg/logs/internal/tailers/channel/tailer_test.go
+++ b/pkg/logs/internal/tailers/channel/tailer_test.go
@@ -32,7 +32,7 @@ func TestBuildMessageNoLambda(t *testing.T) {
 		IsError:   false,
 	}
 	origin := &message.Origin{}
-	builtMessage := buildMessage(logline, origin)
+	builtMessage := buildMessage(logline, origin, "")
 	assert.Equal(t, "bababang", string(builtMessage.Content))
 	assert.Nil(t, builtMessage.Lambda)
 	assert.Equal(t, message.StatusInfo, builtMessage.GetStatus())
@@ -49,7 +49,7 @@ func TestBuildMessageLambda(t *testing.T) {
 		},
 	}
 	origin := &message.Origin{}
-	builtMessage := buildMessage(logline, origin)
+	builtMessage := buildMessage(logline, origin, "")
 	assert.Equal(t, "bababang", string(builtMessage.Content))
 	assert.Equal(t, "myTestARN", builtMessage.Lambda.ARN)
 	assert.Equal(t, "myTestRequestId", builtMessage.Lambda.RequestID)
@@ -63,7 +63,7 @@ func TestBuildErrorMessage(t *testing.T) {
 		IsError:   true,
 	}
 	origin := &message.Origin{}
-	builtMessage := buildMessage(logline, origin)
+	builtMessage := buildMessage(logline, origin, "")
 	assert.Equal(t, "bababang", string(builtMessage.Content))
 	assert.Equal(t, message.StatusError, builtMessage.GetStatus())
 }

--- a/pkg/logs/internal/tailers/docker/tailer.go
+++ b/pkg/logs/internal/tailers/docker/tailer.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/dockerstream"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/tag"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/util"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 
@@ -310,6 +311,7 @@ func (t *Tailer) forwardMessages() {
 		// the decoder has successfully been flushed
 		t.done <- struct{}{}
 	}()
+	r := util.NewRand()
 	for output := range t.decoder.OutputChan {
 		if len(output.Content) > 0 {
 			origin := message.NewOrigin(t.Source)
@@ -317,7 +319,7 @@ func (t *Tailer) forwardMessages() {
 			t.setLastSince(output.Timestamp)
 			origin.Identifier = t.Identifier()
 			origin.SetTags(t.tagProvider.GetTags())
-			t.outputChan <- message.NewMessage(output.Content, origin, output.Status, output.IngestionTimestamp)
+			t.outputChan <- message.NewMessage(output.Content, origin, output.Status, output.IngestionTimestamp, util.GenID(r))
 		}
 	}
 }

--- a/pkg/logs/internal/tailers/file/rotate_nix.go
+++ b/pkg/logs/internal/tailers/file/rotate_nix.go
@@ -44,9 +44,9 @@ func (t *Tailer) DidRotate() (bool, error) {
 	truncated := fileSize < lastReadOffset
 
 	if recreated {
-		log.Debugf("File rotation detected due to recreation, f1: %+v, f2: %+v", fi1, fi2)
+		log.Infof("File rotation detected due to recreation, f1: %+v, f2: %+v", fi1, fi2)
 	} else if truncated {
-		log.Debugf("File rotation detected due to size change, lastReadOffset=%d, fileSize=%d", lastReadOffset, fileSize)
+		log.Infof("File rotation detected due to size change, lastReadOffset=%d, fileSize=%d", lastReadOffset, fileSize)
 	}
 
 	return recreated || truncated, nil

--- a/pkg/logs/internal/tailers/file/tailer.go
+++ b/pkg/logs/internal/tailers/file/tailer.go
@@ -8,6 +8,7 @@ package file
 import (
 	"context"
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/util"
 	"io"
 	"os"
 	"path/filepath"
@@ -323,6 +324,7 @@ func (t *Tailer) forwardMessages() {
 		t.isFinished.Store(true)
 		close(t.done)
 	}()
+	r := util.NewRand()
 	for output := range t.decoder.OutputChan {
 		offset := t.decodedOffset.Load() + int64(output.RawDataLen)
 		identifier := t.Identifier()
@@ -344,7 +346,7 @@ func (t *Tailer) forwardMessages() {
 		// We don't return directly to keep the same shutdown sequence that in the
 		// normal case.
 		select {
-		case t.outputChan <- message.NewMessage(output.Content, origin, output.Status, output.IngestionTimestamp):
+		case t.outputChan <- message.NewMessage(output.Content, origin, output.Status, output.IngestionTimestamp, util.GenID(r)):
 		case <-t.forwardContext.Done():
 		}
 	}

--- a/pkg/logs/internal/tailers/socket/tailer.go
+++ b/pkg/logs/internal/tailers/socket/tailer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/noop"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/util"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
@@ -64,9 +65,10 @@ func (t *Tailer) forwardMessages() {
 		// the decoder has successfully been flushed
 		t.done <- struct{}{}
 	}()
+	r := util.NewRand()
 	for output := range t.decoder.OutputChan {
 		if len(output.Content) > 0 {
-			t.outputChan <- message.NewMessageWithSource(output.Content, message.StatusInfo, t.source, output.IngestionTimestamp)
+			t.outputChan <- message.NewMessageWithSource(output.Content, message.StatusInfo, t.source, output.IngestionTimestamp, util.GenID(r))
 		}
 	}
 }

--- a/pkg/logs/internal/tailers/windowsevent/tailer.go
+++ b/pkg/logs/internal/tailers/windowsevent/tailer.go
@@ -142,7 +142,7 @@ func (t *Tailer) toMessage(re *richEvent) (*message.Message, error) { //nolint:u
 	}
 	jsonEvent = replaceTextKeyToValue(jsonEvent)
 	log.Debug("Sending JSON:", string(jsonEvent))
-	return message.NewMessageWithSource(jsonEvent, message.StatusInfo, t.source, time.Now().UnixNano()), nil
+	return message.NewMessageWithSourceAndNoId(jsonEvent, message.StatusInfo, t.source, time.Now().UnixNano()), nil
 }
 
 // EventID sometimes comes in like <EventID>7036</EventID>

--- a/pkg/logs/internal/util/rand_id.go
+++ b/pkg/logs/internal/util/rand_id.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package util
+
+import (
+	"math/rand"
+	"time"
+)
+
+const (
+	charset          = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+	randStringLength = 5
+)
+
+func GenID(r *rand.Rand) string {
+	b := make([]byte, randStringLength)
+	for i := range b {
+		b[i] = charset[r.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+func NewRand() *rand.Rand {
+	return rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
+func GenGlobalId() string {
+	b := make([]byte, randStringLength)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(b)
+}

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -37,6 +37,9 @@ type Message struct {
 	// Optional.
 	// Used in the Serverless Agent
 	Lambda *Lambda
+	// Tmp value to give each message a unique ID
+	AgentRndId       string
+	AgentProcessorId string
 }
 
 // Lambda is a struct storing information about the Lambda function and function execution.
@@ -45,18 +48,24 @@ type Lambda struct {
 	RequestID string
 }
 
-// NewMessageWithSource constructs message with content, status and log source.
-func NewMessageWithSource(content []byte, status string, source *sources.LogSource, ingestionTimestamp int64) *Message {
-	return NewMessage(content, NewOrigin(source), status, ingestionTimestamp)
+// NewMessageWithSource constructs message with content, status, log source and msg ID.
+func NewMessageWithSource(content []byte, status string, source *sources.LogSource, ingestionTimestamp int64, msgId string) *Message {
+	return NewMessage(content, NewOrigin(source), status, ingestionTimestamp, msgId)
+}
+
+// NewMessageWithSourceAndNoId constructs message with content, status and log source.
+func NewMessageWithSourceAndNoId(content []byte, status string, source *sources.LogSource, ingestionTimestamp int64) *Message {
+	return NewMessage(content, NewOrigin(source), status, ingestionTimestamp, "")
 }
 
 // NewMessage constructs message with content, status, origin and the ingestion timestamp.
-func NewMessage(content []byte, origin *Origin, status string, ingestionTimestamp int64) *Message {
+func NewMessage(content []byte, origin *Origin, status string, ingestionTimestamp int64, msgId string) *Message {
 	return &Message{
 		Content:            content,
 		Origin:             origin,
 		status:             status,
 		IngestionTimestamp: ingestionTimestamp,
+		AgentRndId:         msgId,
 	}
 }
 

--- a/pkg/logs/sender/batch_strategy_test.go
+++ b/pkg/logs/sender/batch_strategy_test.go
@@ -23,10 +23,10 @@ func TestBatchStrategySendsPayloadWhenBufferIsFull(t *testing.T) {
 	s := NewBatchStrategy(input, output, flushChan, LineSerializer, 100*time.Millisecond, 2, 2, "test", &identityContentType{})
 	s.Start()
 
-	message1 := message.NewMessage([]byte("a"), nil, "", 0)
+	message1 := message.NewMessage([]byte("a"), nil, "", 0, "msg_id")
 	input <- message1
 
-	message2 := message.NewMessage([]byte("b"), nil, "", 0)
+	message2 := message.NewMessage([]byte("b"), nil, "", 0, "msg_id")
 	input <- message2
 
 	expectedPayload := &message.Payload{
@@ -56,7 +56,7 @@ func TestBatchStrategySendsPayloadWhenBufferIsOutdated(t *testing.T) {
 	s.Start()
 
 	for round := 0; round < 3; round++ {
-		m := message.NewMessage([]byte("a"), nil, "", 0)
+		m := message.NewMessage([]byte("a"), nil, "", 0, "msg_id")
 		input <- m
 
 		// it should have flushed in this time
@@ -84,7 +84,7 @@ func TestBatchStrategySendsPayloadWhenClosingInput(t *testing.T) {
 	s := newBatchStrategyWithClock(input, output, flushChan, LineSerializer, 100*time.Millisecond, 2, 2, "test", clk, &identityContentType{})
 	s.Start()
 
-	message := message.NewMessage([]byte("a"), nil, "", 0)
+	message := message.NewMessage([]byte("a"), nil, "", 0, "msg_id")
 	input <- message
 
 	go func() {
@@ -108,7 +108,7 @@ func TestBatchStrategyShouldNotBlockWhenStoppingGracefully(t *testing.T) {
 
 	s := NewBatchStrategy(input, output, flushChan, LineSerializer, 100*time.Millisecond, 2, 2, "test", &identityContentType{})
 	s.Start()
-	message := message.NewMessage([]byte{}, nil, "", 0)
+	message := message.NewMessage([]byte{}, nil, "", 0, "msg_id")
 
 	input <- message
 
@@ -135,9 +135,9 @@ func TestBatchStrategySynchronousFlush(t *testing.T) {
 
 	// all of these messages will get buffered
 	messages := []*message.Message{
-		message.NewMessage([]byte("a"), nil, "", 0),
-		message.NewMessage([]byte("b"), nil, "", 0),
-		message.NewMessage([]byte("c"), nil, "", 0),
+		message.NewMessage([]byte("a"), nil, "", 0, "msg_id"),
+		message.NewMessage([]byte("b"), nil, "", 0, "msg_id"),
+		message.NewMessage([]byte("c"), nil, "", 0, "msg_id"),
 	}
 	for _, m := range messages {
 		input <- m
@@ -180,9 +180,9 @@ func TestBatchStrategyFlushChannel(t *testing.T) {
 
 	// all of these messages will get buffered
 	messages := []*message.Message{
-		message.NewMessage([]byte("a"), nil, "", 0),
-		message.NewMessage([]byte("b"), nil, "", 0),
-		message.NewMessage([]byte("c"), nil, "", 0),
+		message.NewMessage([]byte("a"), nil, "", 0, "msg_id"),
+		message.NewMessage([]byte("b"), nil, "", 0, "msg_id"),
+		message.NewMessage([]byte("c"), nil, "", 0, "msg_id"),
 	}
 	for _, m := range messages {
 		input <- m

--- a/pkg/logs/sender/message_buffer_test.go
+++ b/pkg/logs/sender/message_buffer_test.go
@@ -21,21 +21,21 @@ func TestMessageBufferSize(t *testing.T) {
 	assert.False(t, buffer.IsFull())
 
 	// expect add to success
-	assert.True(t, buffer.AddMessage(message.NewMessage([]byte("a"), nil, "", 0)))
+	assert.True(t, buffer.AddMessage(message.NewMessage([]byte("a"), nil, "", 0, "msg_id")))
 	assert.Len(t, buffer.GetMessages(), 1)
 	assert.False(t, buffer.IsEmpty())
 	assert.False(t, buffer.IsFull())
 	assert.Equal(t, buffer.GetMessages()[0].Content, []byte("a"))
 
 	// expect add to success and buffer to be full
-	assert.True(t, buffer.AddMessage(message.NewMessage([]byte("b"), nil, "", 0)))
+	assert.True(t, buffer.AddMessage(message.NewMessage([]byte("b"), nil, "", 0, "msg_id")))
 	assert.Len(t, buffer.GetMessages(), 2)
 	assert.False(t, buffer.IsEmpty())
 	assert.True(t, buffer.IsFull())
 	assert.Equal(t, buffer.GetMessages()[1].Content, []byte("b"))
 
 	// expect add to success to fail because of buffer full
-	assert.False(t, buffer.AddMessage(message.NewMessage([]byte("c"), nil, "", 0)))
+	assert.False(t, buffer.AddMessage(message.NewMessage([]byte("c"), nil, "", 0, "msg_id")))
 	assert.Len(t, buffer.GetMessages(), 2)
 	assert.False(t, buffer.IsEmpty())
 	assert.True(t, buffer.IsFull())
@@ -56,21 +56,21 @@ func TestMessageBufferContentSize(t *testing.T) {
 	assert.False(t, buffer.IsFull())
 
 	// expect add to success
-	assert.True(t, buffer.AddMessage(message.NewMessage([]byte("a"), nil, "", 0)))
+	assert.True(t, buffer.AddMessage(message.NewMessage([]byte("a"), nil, "", 0, "msg_id")))
 	assert.Len(t, buffer.GetMessages(), 1)
 	assert.False(t, buffer.IsEmpty())
 	assert.False(t, buffer.IsFull())
 	assert.Equal(t, buffer.GetMessages()[0].Content, []byte("a"))
 
 	// expect add to success and buffer to be full
-	assert.True(t, buffer.AddMessage(message.NewMessage([]byte("b"), nil, "", 0)))
+	assert.True(t, buffer.AddMessage(message.NewMessage([]byte("b"), nil, "", 0, "msg_id")))
 	assert.Len(t, buffer.GetMessages(), 2)
 	assert.False(t, buffer.IsEmpty())
 	assert.True(t, buffer.IsFull())
 	assert.Equal(t, buffer.GetMessages()[1].Content, []byte("b"))
 
 	// expect add to success to fail because of buffer full
-	assert.False(t, buffer.AddMessage(message.NewMessage([]byte("c"), nil, "", 0)))
+	assert.False(t, buffer.AddMessage(message.NewMessage([]byte("c"), nil, "", 0, "msg_id")))
 	assert.Len(t, buffer.GetMessages(), 2)
 	assert.False(t, buffer.IsEmpty())
 	assert.True(t, buffer.IsFull())

--- a/pkg/logs/sender/sender_test.go
+++ b/pkg/logs/sender/sender_test.go
@@ -21,7 +21,7 @@ import (
 
 func newMessage(content []byte, source *sources.LogSource, status string) *message.Payload {
 	return &message.Payload{
-		Messages: []*message.Message{message.NewMessageWithSource(content, status, source, 0)},
+		Messages: []*message.Message{message.NewMessageWithSource(content, status, source, 0, "")},
 		Encoded:  content,
 		Encoding: "identity",
 	}

--- a/pkg/logs/sender/serializer_test.go
+++ b/pkg/logs/sender/serializer_test.go
@@ -22,11 +22,11 @@ func TestLineSerializer(t *testing.T) {
 	payload = serializer.Serialize(messages)
 	assert.Len(t, payload, 0)
 
-	messages = []*message.Message{message.NewMessage([]byte("a"), nil, "", 0)}
+	messages = []*message.Message{message.NewMessage([]byte("a"), nil, "", 0, "")}
 	payload = serializer.Serialize(messages)
 	assert.Equal(t, []byte("a"), payload)
 
-	messages = []*message.Message{message.NewMessage([]byte("a"), nil, "", 0), message.NewMessage([]byte("b"), nil, "", 0)}
+	messages = []*message.Message{message.NewMessage([]byte("a"), nil, "", 0, ""), message.NewMessage([]byte("b"), nil, "", 0, "")}
 	payload = serializer.Serialize(messages)
 	assert.Equal(t, []byte("a\nb"), payload)
 }
@@ -40,11 +40,11 @@ func TestArraySerializer(t *testing.T) {
 	payload = serializer.Serialize(messages)
 	assert.Equal(t, []byte("[]"), payload)
 
-	messages = []*message.Message{message.NewMessage([]byte("a"), nil, "", 0)}
+	messages = []*message.Message{message.NewMessage([]byte("a"), nil, "", 0, "")}
 	payload = serializer.Serialize(messages)
 	assert.Equal(t, []byte("[a]"), payload)
 
-	messages = []*message.Message{message.NewMessage([]byte("a"), nil, "", 0), message.NewMessage([]byte("b"), nil, "", 0)}
+	messages = []*message.Message{message.NewMessage([]byte("a"), nil, "", 0, ""), message.NewMessage([]byte("b"), nil, "", 0, "")}
 	payload = serializer.Serialize(messages)
 	assert.Equal(t, []byte("[a,b]"), payload)
 }

--- a/pkg/logs/sender/stream_strategy_test.go
+++ b/pkg/logs/sender/stream_strategy_test.go
@@ -21,7 +21,7 @@ func TestStreamStrategy(t *testing.T) {
 	s.Start()
 
 	content := []byte("a")
-	message1 := message.NewMessage(content, nil, "", 0)
+	message1 := message.NewMessage(content, nil, "", 0, "")
 	input <- message1
 
 	payload := <-output
@@ -30,7 +30,7 @@ func TestStreamStrategy(t *testing.T) {
 	assert.Equal(t, content, payload.Encoded)
 
 	content = []byte("b")
-	message2 := message.NewMessage(content, nil, "", 0)
+	message2 := message.NewMessage(content, nil, "", 0, "")
 	input <- message2
 
 	payload = <-output
@@ -46,7 +46,7 @@ func TestStreamStrategyShouldNotBlockWhenForceStopping(t *testing.T) {
 
 	s := NewStreamStrategy(input, output, IdentityContentType)
 
-	message := message.NewMessage([]byte{}, nil, "", 0)
+	message := message.NewMessage([]byte{}, nil, "", 0, "")
 	go func() {
 		input <- message
 		s.Stop()
@@ -61,7 +61,7 @@ func TestStreamStrategyShouldNotBlockWhenStoppingGracefully(t *testing.T) {
 
 	s := NewStreamStrategy(input, output, IdentityContentType)
 
-	message := message.NewMessage([]byte{}, nil, "", 0)
+	message := message.NewMessage([]byte{}, nil, "", 0, "")
 	go func() {
 		input <- message
 		s.Stop()

--- a/pkg/security/reporter/reporter.go
+++ b/pkg/security/reporter/reporter.go
@@ -30,7 +30,7 @@ func (r *RuntimeReporter) ReportRaw(content []byte, service string, tags ...stri
 	origin := message.NewOrigin(r.logSource)
 	origin.SetTags(tags)
 	origin.SetService(service)
-	msg := message.NewMessage(content, origin, message.StatusInfo, time.Now().UnixNano())
+	msg := message.NewMessage(content, origin, message.StatusInfo, time.Now().UnixNano(), "")
 	r.logChan <- msg
 }
 


### PR DESCRIPTION
Adding an random ID to each log message processed

Adding a processor ID and moving message ID to the tailers.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
