### PR TITLE
Delimit in place

### DIFF
--- a/pkg/logs/client/tcp/delimiter.go
+++ b/pkg/logs/client/tcp/delimiter.go
@@ -34,6 +34,7 @@ func NewDelimiter(useProto bool) Delimiter {
 type lengthPrefixDelimiter struct{}
 
 func (l lengthPrefixDelimiter) delimit(content []byte) ([]byte, error) {
+	content = append(content, 0, 0, 0, 0)
 	copy(content[4:], content)
 	binary.BigEndian.PutUint32(content[:4], uint32(len(content)))
 	return content, nil

--- a/pkg/logs/client/tcp/delimiter.go
+++ b/pkg/logs/client/tcp/delimiter.go
@@ -34,10 +34,9 @@ func NewDelimiter(useProto bool) Delimiter {
 type lengthPrefixDelimiter struct{}
 
 func (l lengthPrefixDelimiter) delimit(content []byte) ([]byte, error) {
-	buf := make([]byte, 4+len(content))
-	binary.BigEndian.PutUint32(buf[:4], uint32(len(content)))
-	copy(buf[4:], content)
-	return buf, nil
+	copy(content[4:], content)
+	binary.BigEndian.PutUint32(content[:4], uint32(len(content)))
+	return content, nil
 }
 
 // lineBreakDelimiter is a delimiter that appends a line break after each message.

--- a/pkg/logs/client/tcp/delimiter.go
+++ b/pkg/logs/client/tcp/delimiter.go
@@ -34,9 +34,10 @@ func NewDelimiter(useProto bool) Delimiter {
 type lengthPrefixDelimiter struct{}
 
 func (l lengthPrefixDelimiter) delimit(content []byte) ([]byte, error) {
+	len := len(content)
 	content = append(content, 0, 0, 0, 0)
 	copy(content[4:], content)
-	binary.BigEndian.PutUint32(content[:4], uint32(len(content)))
+	binary.BigEndian.PutUint32(content[:4], uint32(len))
 	return content, nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Run the length-prefix delimiter in place on the provided list rather than allocating a new list and copying. This will use existing capacity when possible and reduces work for the garbage collector.

### Motivation

Improve performance for log forwarding.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

Modifying this list in place could have side effects if other pieces of code depend on it being static.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
