### PR TITLE
include CWS functional tests in slack messages even if allowed to fail

### DIFF
--- a/tasks/libs/pipeline_data.py
+++ b/tasks/libs/pipeline_data.py
@@ -132,13 +132,17 @@ def truncate_job_name(job_name, max_char_per_job=48):
     return truncated_job_name
 
 
+# those jobs are `allow_failure: true` but still needs to be included
+# in fail reports
+jobs_allowed_to_fails_but_need_report = [re.compile(r'kitchen_test_security_agent.*')]
+
+
 def should_include_failed_job(job_name, allow_failure):
     if not allow_failure:
         return True
 
-    # the security agent team wants their jobs to be "allowed to fail",
-    # but at the same time to appear in the slack messages
-    if job_name.startswith("kitchen_test_security_agent"):
-        return True
+    for job_to_include in jobs_allowed_to_fails_but_need_report:
+        if job_to_include.fullmatch(job_name):
+            return True
 
     return False

--- a/tasks/libs/pipeline_data.py
+++ b/tasks/libs/pipeline_data.py
@@ -48,7 +48,7 @@ def get_failed_jobs(project_name, pipeline_id):
         }
 
         # Also exclude jobs allowed to fail
-        if final_status["status"] == "failed" and should_include_failed_job(job_name, final_status["allow_failure"]):
+        if final_status["status"] == "failed" and should_report_job(job_name, final_status["allow_failure"]):
             final_failed_jobs.append(final_status)
 
     return final_failed_jobs
@@ -137,12 +137,5 @@ def truncate_job_name(job_name, max_char_per_job=48):
 jobs_allowed_to_fails_but_need_report = [re.compile(r'kitchen_test_security_agent.*')]
 
 
-def should_include_failed_job(job_name, allow_failure):
-    if not allow_failure:
-        return True
-
-    for job_to_include in jobs_allowed_to_fails_but_need_report:
-        if job_to_include.fullmatch(job_name):
-            return True
-
-    return False
+def should_report_job(job_name, allow_failure):
+    return not allow_failure or any(pattern.fullmatch(job_name) for pattern in jobs_allowed_to_fails_but_need_report)

--- a/tasks/libs/pipeline_data.py
+++ b/tasks/libs/pipeline_data.py
@@ -48,7 +48,7 @@ def get_failed_jobs(project_name, pipeline_id):
         }
 
         # Also exclude jobs allowed to fail
-        if final_status["status"] == "failed" and not final_status["allow_failure"]:
+        if final_status["status"] == "failed" and should_include_failed_job(job_name, final_status["allow_failure"]):
             final_failed_jobs.append(final_status)
 
     return final_failed_jobs
@@ -130,3 +130,15 @@ def truncate_job_name(job_name, max_char_per_job=48):
     # We also want to avoid it being too long
     truncated_job_name = truncated_job_name[:max_char_per_job]
     return truncated_job_name
+
+
+def should_include_failed_job(job_name, allow_failure):
+    if not allow_failure:
+        return True
+
+    # the security agent team wants their jobs to be "allowed to fail",
+    # but at the same time to appear in the slack messages
+    if job_name.startswith("kitchen_test_security_agent"):
+        return True
+
+    return False


### PR DESCRIPTION
### What does this PR do?

We would like to include the CWS functional tests failure in the Gitlab slack messages even for those that are allowed to fail. This PR adds a new check when including failing jobs in the list of jobs to include in the message body.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
