### PR TITLE
Fix broken --include and --exclude options for non-local agent diagnose command

### DIFF
--- a/cmd/agent/api/internal/agent/agent.go
+++ b/cmd/agent/api/internal/agent/agent.go
@@ -495,11 +495,6 @@ func getDiagnose(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// No diagnosis to report
-	if len(diagnoses) == 0 {
-		return
-	}
-
 	// Serizalize diagnoses (and implicitly write result to the response)
 	w.Header().Set("Content-Type", "application/json")
 	err = json.NewEncoder(w).Encode(diagnoses)

--- a/cmd/agent/subcommands/diagnose/command.go
+++ b/cmd/agent/subcommands/diagnose/command.go
@@ -9,7 +9,6 @@ package diagnose
 import (
 	"fmt"
 	"os"
-	"regexp"
 
 	"go.uber.org/fx"
 
@@ -147,37 +146,15 @@ This command print the last Inventory metadata payload sent by the Agent. This p
 	return []*cobra.Command{diagnoseCommand}
 }
 
-func strToRegexList(patterns []string) ([]*regexp.Regexp, error) {
-	if len(patterns) > 0 {
-		res := make([]*regexp.Regexp, 0)
-		for _, pattern := range patterns {
-			re, err := regexp.Compile(pattern)
-			if err != nil {
-				return nil, fmt.Errorf("failed to compile regex pattern %s: %s", pattern, err.Error())
-			}
-			res = append(res, re)
-		}
-		return res, nil
-	}
-	return nil, nil
-}
-
 func cmdDiagnose(log log.Component, config config.Component, cliParams *cliParams) error {
 	diagCfg := diagnosis.Config{
 		Verbose:  cliParams.verbose,
 		RunLocal: cliParams.runLocal,
+		Include:  cliParams.include,
+		Exclude:  cliParams.exclude,
 	}
 
-	// prepare include/exclude
-	var err error
-	if diagCfg.Include, err = strToRegexList(cliParams.include); err != nil {
-		return err
-	}
-	if diagCfg.Exclude, err = strToRegexList(cliParams.exclude); err != nil {
-		return err
-	}
-
-	// List command
+	// Is it List command
 	if cliParams.listSuites {
 		pkgdiagnose.ListStdOut(color.Output, diagCfg)
 		return nil

--- a/pkg/diagnose/diagnosis/loader.go
+++ b/pkg/diagnose/diagnosis/loader.go
@@ -6,8 +6,6 @@
 package diagnosis
 
 import (
-	"regexp"
-
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -45,8 +43,8 @@ type Config struct {
 	Verbose               bool
 	RunLocal              bool
 	RunningInAgentProcess bool
-	Include               []*regexp.Regexp
-	Exclude               []*regexp.Regexp
+	Include               []string
+	Exclude               []string
 }
 
 type Result int

--- a/pkg/diagnose/runner.go
+++ b/pkg/diagnose/runner.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"regexp"
 	"sort"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -27,6 +28,12 @@ type counters struct {
 	fail          int
 	warnings      int
 	unexpectedErr int
+}
+
+// diagnose suite filter
+type diagSuiteFilter struct {
+	include []*regexp.Regexp
+	exclude []*regexp.Regexp
 }
 
 // Output summary
@@ -141,20 +148,55 @@ func matchRegExList(regexList []*regexp.Regexp, s string) bool {
 	return false
 }
 
+func strToRegexList(patterns []string) ([]*regexp.Regexp, error) {
+	if len(patterns) > 0 {
+		res := make([]*regexp.Regexp, 0)
+		for _, pattern := range patterns {
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				return nil, fmt.Errorf("failed to compile regex pattern %s: %s", pattern, err.Error())
+			}
+			res = append(res, re)
+		}
+		return res, nil
+	}
+	return nil, nil
+}
+
 // Currently used only to match Diagnose Suite name. In future will be
 // extended to diagnose name or category
-func matchConfigFilters(diagCfg diagnosis.Config, s string) bool {
-	if len(diagCfg.Include) > 0 && len(diagCfg.Exclude) > 0 {
-		return matchRegExList(diagCfg.Include, s) && !matchRegExList(diagCfg.Exclude, s)
-	} else if len(diagCfg.Include) > 0 {
-		return matchRegExList(diagCfg.Include, s)
-	} else if len(diagCfg.Exclude) > 0 {
-		return !matchRegExList(diagCfg.Exclude, s)
+func matchConfigFilters(filter diagSuiteFilter, s string) bool {
+	if len(filter.include) > 0 && len(filter.exclude) > 0 {
+		return matchRegExList(filter.include, s) && !matchRegExList(filter.exclude, s)
+	} else if len(filter.include) > 0 {
+		return matchRegExList(filter.include, s)
+	} else if len(filter.exclude) > 0 {
+		return !matchRegExList(filter.exclude, s)
 	}
 	return true
 }
 
-func getSortedAndFilteredDiagnoseSuites(diagCfg diagnosis.Config) []diagnosis.Suite {
+func getSortedAndFilteredDiagnoseSuites(diagCfg diagnosis.Config) ([]diagnosis.Suite, error) {
+
+	var filter diagSuiteFilter
+	var err error
+
+	if len(diagCfg.Include) > 0 {
+		filter.include, err = strToRegexList(diagCfg.Include)
+		if err != nil {
+			includes := strings.Join(diagCfg.Include, " ")
+			return nil, fmt.Errorf("invalid --include option value(s) provided (%s) compiled with error: %w", includes, err)
+		}
+	}
+
+	if len(diagCfg.Exclude) > 0 {
+		filter.exclude, err = strToRegexList(diagCfg.Exclude)
+		if err != nil {
+			excludes := strings.Join(diagCfg.Exclude, " ")
+			return nil, fmt.Errorf("invalid --exclude option value(s) provided (%s) compiled with error: %w", excludes, err)
+		}
+	}
+
 	sortedSuites := make([]diagnosis.Suite, len(diagnosis.Catalog))
 	copy(sortedSuites, diagnosis.Catalog)
 	sort.Slice(sortedSuites, func(i, j int) bool {
@@ -163,12 +205,12 @@ func getSortedAndFilteredDiagnoseSuites(diagCfg diagnosis.Config) []diagnosis.Su
 
 	var sortedFilteredSuites []diagnosis.Suite
 	for _, ds := range sortedSuites {
-		if matchConfigFilters(diagCfg, ds.SuitName) {
+		if matchConfigFilters(filter, ds.SuitName) {
 			sortedFilteredSuites = append(sortedFilteredSuites, ds)
 		}
 	}
 
-	return sortedFilteredSuites
+	return sortedFilteredSuites, nil
 }
 
 func getSuiteDiagnoses(ds diagnosis.Suite, diagCfg diagnosis.Config) []diagnosis.Diagnosis {
@@ -206,9 +248,13 @@ func ListStdOut(w io.Writer, diagCfg diagnosis.Config) {
 		color.NoColor = true
 	}
 
-	sortedSuites := getSortedAndFilteredDiagnoseSuites(diagCfg)
-
 	fmt.Fprintf(w, "Diagnose suites ...\n")
+
+	sortedSuites, err := getSortedAndFilteredDiagnoseSuites(diagCfg)
+	if err != nil {
+		fmt.Fprintf(w, "Failed to get list of diagnose suites. Validate your command line options. Error: %s\n", err.Error())
+		return
+	}
 
 	count := 0
 	for _, ds := range sortedSuites {
@@ -220,7 +266,10 @@ func ListStdOut(w io.Writer, diagCfg diagnosis.Config) {
 // Enumerate registered Diagnose suites and get their diagnoses
 // for structural output
 func getDiagnosesFromCurrentProcess(diagCfg diagnosis.Config) ([]diagnosis.Diagnoses, error) {
-	suites := getSortedAndFilteredDiagnoseSuites(diagCfg)
+	suites, err := getSortedAndFilteredDiagnoseSuites(diagCfg)
+	if err != nil {
+		return nil, err
+	}
 
 	var suitesDiagnoses []diagnosis.Diagnoses
 	for _, ds := range suites {

--- a/pkg/diagnose/runner_test.go
+++ b/pkg/diagnose/runner_test.go
@@ -6,7 +6,6 @@
 package diagnose
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
@@ -20,9 +19,8 @@ func TestDiagnoseAllBasicRegAndRunNoDiagnoses(t *testing.T) {
 		return nil
 	})
 
-	re, _ := regexp.Compile("TestDiagnoseAllBasicRegAndRunNoDiagnoses")
 	diagCfg := diagnosis.Config{
-		Include:  []*regexp.Regexp{re},
+		Include:  []string{"TestDiagnoseAllBasicRegAndRunNoDiagnoses"},
 		RunLocal: true,
 	}
 	diagnoses, err := Run(diagCfg)
@@ -60,9 +58,8 @@ func TestDiagnoseAllBasicRegAndRunSomeDiagnosis(t *testing.T) {
 	})
 
 	// Include and run
-	reInclude, _ := regexp.Compile("TestDiagnoseAllBasicRegAndRunSomeDiagnosis")
 	diagCfgInclude := diagnosis.Config{
-		Include:  []*regexp.Regexp{reInclude},
+		Include:  []string{"TestDiagnoseAllBasicRegAndRunSomeDiagnosis"},
 		RunLocal: true,
 	}
 	outSuitesDiagnosesInclude, err := Run(diagCfgInclude)
@@ -72,10 +69,9 @@ func TestDiagnoseAllBasicRegAndRunSomeDiagnosis(t *testing.T) {
 	assert.Equal(t, outSuitesDiagnosesInclude[1].SuiteDiagnoses, inDiagnoses)
 
 	// Include and Exclude and run
-	reExclude, _ := regexp.Compile("TestDiagnoseAllBasicRegAndRunSomeDiagnosis-a")
 	diagCfgIncludeExclude := diagnosis.Config{
-		Include:  []*regexp.Regexp{reInclude},
-		Exclude:  []*regexp.Regexp{reExclude},
+		Include:  []string{"TestDiagnoseAllBasicRegAndRunSomeDiagnosis"},
+		Exclude:  []string{"TestDiagnoseAllBasicRegAndRunSomeDiagnosis-a"},
 		RunLocal: true,
 	}
 	outSuitesDiagnosesIncludeExclude, err := Run(diagCfgIncludeExclude)


### PR DESCRIPTION
It would work locally but remote execution with this options would fail there with recoverable panic and agent diagnose will work in the end because it re-execute it locally which would be successful.

The fix is a replacement of compiled RegEx objects as member fields of diagnose config structure on array of string to facilitate its remote (and compiled RegEx before their usage).

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
To get list of diagnose suites run `agent diagnose --list` or `agent diagnose -t`  command. If all diagnoses are successful they will print only ".", to see details of a diagnosis use `--verbose` or `-v` command line option.

Test command line permutation (see next section)
a) with running agent
b) without running agent
c) using --local command line option

Permutations - run agent diagnose command with following command line options 
- `-i` and or `-e` having **matching** regular expression (less number of diagnoses should run and reported)
- `-i` and or `-e` having **mis-matching** regular expression (zero number of diagnoses should run and reported)
- `-i` and or `-e` having **bad (cannot compile e.g. [)** regular expression (error should be reported)
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
