### PR TITLE
Sls 3243 add circuit breaker backoff to retries from the extension

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -121,7 +121,7 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 	if !hasApiKey() {
 		log.Errorf("Can't start the Datadog extension as no API Key has been detected, or API Key could not be decrypted. Data will not be sent to Datadog.")
 		// we still need to register the extension but let's return after (no-op)
-		id, _, registrationError := registration.RegisterExtension(os.Getenv(runtimeAPIEnvVar), extensionRegistrationRoute, extensionRegistrationTimeout)
+		id, _, registrationError := registration.RegisterExtension(extensionRegistrationRoute, extensionRegistrationTimeout)
 		if registrationError != nil {
 			log.Errorf("Can't register as a serverless agent: %s", registrationError)
 		}
@@ -146,7 +146,7 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 	// ----------------
 
 	// extension registration
-	serverlessID, functionArn, err := registration.RegisterExtension(os.Getenv(runtimeAPIEnvVar), extensionRegistrationRoute, extensionRegistrationTimeout)
+	serverlessID, functionArn, err := registration.RegisterExtension(extensionRegistrationRoute, extensionRegistrationTimeout)
 	if err != nil {
 		// at this point, we were not even able to register, thus, we don't have
 		// any ID assigned, thus, we can't report an error to the init error route

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1227,7 +1227,6 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("serverless.trace_enabled", false, "DD_TRACE_ENABLED")
 	config.BindEnvAndSetDefault("serverless.trace_managed_services", true, "DD_TRACE_MANAGED_SERVICES")
 	config.BindEnvAndSetDefault("serverless.service_mapping", nil, "DD_SERVICE_MAPPING")
-	config.BindEnvAndSetDefault("serverless.constant_backoff_interval", 100*time.Millisecond)
 
 	// trace-agent's evp_proxy
 	config.BindEnv("evp_proxy_config.enabled")

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
-	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
@@ -112,20 +111,13 @@ func newDestination(endpoint config.Endpoint,
 	if maxConcurrentBackgroundSends <= 0 {
 		maxConcurrentBackgroundSends = 1
 	}
-	var policy backoff.Policy
-	if endpoint.Origin == config.ServerlessIntakeOrigin {
-		policy = backoff.NewConstantBackoffPolicy(
-			coreConfig.Datadog.GetDuration("serverless.constant_backoff_interval"),
-		)
-	} else {
-		policy = backoff.NewExpBackoffPolicy(
-			endpoint.BackoffFactor,
-			endpoint.BackoffBase,
-			endpoint.BackoffMax,
-			endpoint.RecoveryInterval,
-			endpoint.RecoveryReset,
-		)
-	}
+	policy := backoff.NewExpBackoffPolicy(
+		endpoint.BackoffFactor,
+		endpoint.BackoffBase,
+		endpoint.BackoffMax,
+		endpoint.RecoveryInterval,
+		endpoint.RecoveryReset,
+	)
 
 	expVars := &expvar.Map{}
 	expVars.AddFloat(expVarIdleMsMapKey, 0)

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -117,7 +117,6 @@ func newDestination(endpoint config.Endpoint,
 		policy = backoff.NewConstantBackoffPolicy(
 			coreConfig.Datadog.GetDuration("serverless.constant_backoff_interval"),
 		)
-		shouldRetry = false
 	} else {
 		policy = backoff.NewExpBackoffPolicy(
 			endpoint.BackoffFactor,

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -117,6 +117,7 @@ func newDestination(endpoint config.Endpoint,
 		policy = backoff.NewConstantBackoffPolicy(
 			coreConfig.Datadog.GetDuration("serverless.constant_backoff_interval"),
 		)
+		shouldRetry = false
 	} else {
 		policy = backoff.NewExpBackoffPolicy(
 			endpoint.BackoffFactor,

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 
@@ -323,12 +322,4 @@ func TestBackoffDelayDisabled(t *testing.T) {
 
 	assert.Equal(t, 0, server.Destination.nbErrors)
 	server.Stop()
-}
-
-func TestBackoffShouldBeConstantServerless(t *testing.T) {
-	dest := NewDestination(config.Endpoint{
-		Origin: "lambda-extension",
-	}, "", nil, 0, true, "")
-
-	assert.Equal(t, dest.backoff.GetBackoffDuration(0), coreConfig.Datadog.GetDuration("serverless.constant_backoff_interval"))
 }

--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -248,9 +248,10 @@ func (d *Daemon) TriggerFlush(isLastFlushBeforeShutdown bool) {
 	timedOut := waitWithTimeout(&wg, FlushTimeout)
 	if timedOut {
 		log.Debug("Timed out while flushing")
-		d.flushStrategy.IncrementFailure(time.Now())
+		d.flushStrategy.Failure(time.Now())
 	} else {
 		log.Debug("Finished flushing")
+		d.flushStrategy.Success()
 	}
 	cancel()
 

--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -248,6 +248,7 @@ func (d *Daemon) TriggerFlush(isLastFlushBeforeShutdown bool) {
 	timedOut := waitWithTimeout(&wg, FlushTimeout)
 	if timedOut {
 		log.Debug("Timed out while flushing")
+		d.flushStrategy.IncrementFailure(time.Now())
 		d.flushStrategy.Failure(time.Now())
 	} else {
 		log.Debug("Finished flushing")

--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -151,7 +151,7 @@ func wrapOtlpError(handle http.Handler) http.Handler {
 // HandleRuntimeDone should be called when the runtime is done handling the current invocation. It will tell the daemon
 // that the runtime is done, and may also flush telemetry.
 func (d *Daemon) HandleRuntimeDone() {
-	if !d.ShouldFlush(flush.Stopping, time.Now()) {
+	if !d.ShouldFlush(flush.Stopping) {
 		log.Debugf("The flush strategy %s has decided to not flush at moment: %s", d.GetFlushStrategy(), flush.Stopping)
 		d.TellDaemonRuntimeDone()
 		return
@@ -173,8 +173,10 @@ func (d *Daemon) HandleRuntimeDone() {
 }
 
 // ShouldFlush indicated whether or a flush is needed
-func (d *Daemon) ShouldFlush(moment flush.Moment, t time.Time) bool {
-	return d.flushStrategy.ShouldFlush(moment, t)
+func (d *Daemon) ShouldFlush(moment flush.Moment) bool {
+	d.FlushLock.Lock()
+	defer d.FlushLock.Unlock()
+	return d.flushStrategy.ShouldFlush(moment, time.Now())
 }
 
 // GetFlushStrategy returns the flush strategy
@@ -330,7 +332,7 @@ func (d *Daemon) Stop() {
 
 	// Once the HTTP server is shut down, it is safe to shut down the agents
 	// Otherwise, we might try to handle API calls after the agent has already been shut down
-	if d.ShouldFlush(flush.Stopping, time.Now()) {
+	if d.ShouldFlush(flush.Stopping) {
 		d.TriggerFlush(true)
 	}
 
@@ -395,7 +397,7 @@ func (d *Daemon) WaitForDaemon() {
 	// If we are flushing at the end of the invocation, we need to wait for the invocation itself to end
 	// before we finish handling it. Otherwise, the daemon does not actually need to wait for the runtime to
 	// complete the invocation before it is done.
-	if d.flushStrategy.ShouldFlush(flush.Stopping, time.Now()) {
+	if d.ShouldFlush(flush.Stopping) {
 		d.RuntimeWg.Wait()
 	}
 }

--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -330,7 +330,7 @@ func (d *Daemon) Stop() {
 
 	// Once the HTTP server is shut down, it is safe to shut down the agents
 	// Otherwise, we might try to handle API calls after the agent has already been shut down
-	if !d.ShouldFlush(flush.Stopping, time.Now()) {
+	if d.ShouldFlush(flush.Stopping, time.Now()) {
 		d.TriggerFlush(true)
 	}
 

--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -248,7 +248,6 @@ func (d *Daemon) TriggerFlush(isLastFlushBeforeShutdown bool) {
 	timedOut := waitWithTimeout(&wg, FlushTimeout)
 	if timedOut {
 		log.Debug("Timed out while flushing")
-		d.flushStrategy.IncrementFailure(time.Now())
 		d.flushStrategy.Failure(time.Now())
 	} else {
 		log.Debug("Finished flushing")

--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -174,8 +174,6 @@ func (d *Daemon) HandleRuntimeDone() {
 
 // ShouldFlush indicated whether or a flush is needed
 func (d *Daemon) ShouldFlush(moment flush.Moment) bool {
-	d.FlushLock.Lock()
-	defer d.FlushLock.Unlock()
 	return d.flushStrategy.ShouldFlush(moment, time.Now())
 }
 

--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -330,7 +330,9 @@ func (d *Daemon) Stop() {
 
 	// Once the HTTP server is shut down, it is safe to shut down the agents
 	// Otherwise, we might try to handle API calls after the agent has already been shut down
-	d.TriggerFlush(true)
+	if !d.ShouldFlush(flush.Stopping, time.Now()) {
+		d.TriggerFlush(true)
+	}
 
 	log.Debug("Shutting down agents")
 

--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -177,7 +177,7 @@ func (d *Daemon) ShouldFlush(moment flush.Moment, t time.Time) bool {
 	return d.flushStrategy.ShouldFlush(moment, t)
 }
 
-// GetFlushStrategy returns the flush stategy
+// GetFlushStrategy returns the flush strategy
 func (d *Daemon) GetFlushStrategy() string {
 	return d.flushStrategy.String()
 }

--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -248,6 +248,7 @@ func (d *Daemon) TriggerFlush(isLastFlushBeforeShutdown bool) {
 	timedOut := waitWithTimeout(&wg, FlushTimeout)
 	if timedOut {
 		log.Debug("Timed out while flushing")
+		d.flushStrategy.IncrementFailure(time.Now())
 	} else {
 		log.Debug("Finished flushing")
 	}

--- a/pkg/serverless/flush/strategy.go
+++ b/pkg/serverless/flush/strategy.go
@@ -45,7 +45,6 @@ const (
 //   - end
 //   - periodically[,milliseconds]
 func StrategyFromString(str string) (Strategy, error) {
-	retries = 0
 	switch str {
 	case "end":
 		return &AtTheEnd{}, nil
@@ -102,7 +101,6 @@ type Periodically struct {
 
 // NewPeriodically returns an initialized Periodically flush strategy.
 func NewPeriodically(interval time.Duration) *Periodically {
-	retries = 0
 	return &Periodically{interval: interval}
 }
 

--- a/pkg/serverless/flush/strategy.go
+++ b/pkg/serverless/flush/strategy.go
@@ -12,6 +12,7 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -24,6 +25,14 @@ type Strategy interface {
 	Failure(t time.Time)
 	Success()
 }
+
+type retryState struct {
+	lastFail time.Time
+	retries  uint64
+	lock     sync.Mutex
+}
+
+var globalRetryState = retryState{}
 
 // Moment represents at which moment we're asking the flush strategy if we
 // should flush or not.
@@ -76,7 +85,7 @@ func (s *AtTheEnd) String() string { return "end" }
 
 // ShouldFlush returns true if this strategy want to flush at the given moment.
 func (s *AtTheEnd) ShouldFlush(moment Moment, t time.Time) bool {
-	if shouldWaitBackoff(t) {
+	if globalRetryState.shouldWaitBackoff(t) {
 		return false
 	}
 	return moment == Stopping
@@ -84,12 +93,12 @@ func (s *AtTheEnd) ShouldFlush(moment Moment, t time.Time) bool {
 
 // Failure modify state to keep track of failure
 func (s *AtTheEnd) Failure(t time.Time) {
-	incrementFailure(t)
+	globalRetryState.incrementFailure(t)
 }
 
 // Success reset the state when a flush is successful
 func (s *AtTheEnd) Success() {
-	reset()
+	globalRetryState.reset()
 }
 
 // Periodically is the strategy flushing at least every N [nano/micro/milli]seconds
@@ -110,7 +119,7 @@ func (s *Periodically) String() string {
 
 // ShouldFlush returns true if this strategy want to flush at the given moment.
 func (s *Periodically) ShouldFlush(moment Moment, t time.Time) bool {
-	if moment == Starting && !shouldWaitBackoff(t) {
+	if moment == Starting && !globalRetryState.shouldWaitBackoff(t) {
 		// Periodically strategy will not flush anyway if the s.interval didn't pass
 		if s.lastFlush.Add(s.interval).Before(t) {
 			s.lastFlush = t
@@ -122,38 +131,41 @@ func (s *Periodically) ShouldFlush(moment Moment, t time.Time) bool {
 
 // Failure modify state to keep track of failure
 func (s *Periodically) Failure(t time.Time) {
-	incrementFailure(t)
+	globalRetryState.incrementFailure(t)
 }
 
 // Success reset the state when a flush is successful
 func (s *Periodically) Success() {
-	reset()
+	globalRetryState.reset()
 }
 
-var lastFail time.Time
-var retries uint64
-
-func shouldWaitBackoff(now time.Time) bool {
-	if retries > 0 {
-		maxRetryBackoff := math.Min(float64(retries), 10) // no need to go higher and risk overflow in the power op
+func (r *retryState) shouldWaitBackoff(now time.Time) bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if r.retries > 0 {
+		maxRetryBackoff := math.Min(float64(r.retries), 10) // no need to go higher and risk overflow in the power op
 		spreadRetrySeconds := float64(rand.Int31n(1_000)) / 1_000
 		ignoreWindowSeconds := int(math.Min(math.Pow(2, maxRetryBackoff)+spreadRetrySeconds, maxBackoffRetrySeconds))
 
-		whenAcceptingFlush := lastFail.Add(time.Duration(ignoreWindowSeconds * 1e9))
+		whenAcceptingFlush := r.lastFail.Add(time.Duration(ignoreWindowSeconds * 1e9))
 
 		timeLeft := int(math.Max(float64(whenAcceptingFlush.Second()-now.Second()), 0))
 
-		log.Debugf("Flush failed %d times, flushes will be prevented for %d seconds (%d left)", retries, ignoreWindowSeconds, timeLeft)
+		log.Debugf("Flush failed %d times, flushes will be prevented for %d seconds (%d left)", r.retries, ignoreWindowSeconds, timeLeft)
 		return now.Before(whenAcceptingFlush)
 	}
 	return false
 }
 
-func incrementFailure(t time.Time) {
-	retries++
-	lastFail = t
+func (r *retryState) incrementFailure(t time.Time) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.retries++
+	r.lastFail = t
 }
 
-func reset() {
-	retries = 0
+func (r *retryState) reset() {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.retries = 0
 }

--- a/pkg/serverless/flush/strategy.go
+++ b/pkg/serverless/flush/strategy.go
@@ -45,6 +45,7 @@ const (
 //   - end
 //   - periodically[,milliseconds]
 func StrategyFromString(str string) (Strategy, error) {
+	retries = 0
 	switch str {
 	case "end":
 		return &AtTheEnd{}, nil
@@ -101,6 +102,7 @@ type Periodically struct {
 
 // NewPeriodically returns an initialized Periodically flush strategy.
 func NewPeriodically(interval time.Duration) *Periodically {
+	retries = 0
 	return &Periodically{interval: interval}
 }
 

--- a/pkg/serverless/flush/strategy.go
+++ b/pkg/serverless/flush/strategy.go
@@ -21,9 +21,7 @@ const maxBackoffRetrySeconds = 5 * 60
 type Strategy interface {
 	String() string
 	ShouldFlush(moment Moment, t time.Time) bool
-	// Failure modify state to keep track of failure
 	Failure(t time.Time)
-	// Success reset the state when a flush is successful
 	Success()
 }
 
@@ -84,9 +82,12 @@ func (s *AtTheEnd) ShouldFlush(moment Moment, t time.Time) bool {
 	return moment == Stopping
 }
 
+// Failure modify state to keep track of failure
 func (s *AtTheEnd) Failure(t time.Time) {
 	incrementFailure(t)
 }
+
+// Success reset the state when a flush is successful
 func (s *AtTheEnd) Success() {
 	reset()
 }
@@ -119,10 +120,12 @@ func (s *Periodically) ShouldFlush(moment Moment, t time.Time) bool {
 	return false
 }
 
+// Failure modify state to keep track of failure
 func (s *Periodically) Failure(t time.Time) {
 	incrementFailure(t)
 }
 
+// Success reset the state when a flush is successful
 func (s *Periodically) Success() {
 	reset()
 }

--- a/pkg/serverless/flush/strategy.go
+++ b/pkg/serverless/flush/strategy.go
@@ -111,6 +111,7 @@ func (s *Periodically) String() string {
 // ShouldFlush returns true if this strategy want to flush at the given moment.
 func (s *Periodically) ShouldFlush(moment Moment, t time.Time) bool {
 	if moment == Starting && !s.lastFailure.tooEarly(t) {
+		// Periodically strategy will not flush anyway if the s.interval didn't pass
 		if s.lastFlush.Add(s.interval).Before(t) {
 			s.lastFlush = t
 			return true
@@ -136,7 +137,7 @@ func (f *failedAttempt) tooEarly(now time.Time) bool {
 	if f.retries > 0 {
 		spreadRetrySeconds := float64(rand.Int31n(1_000)) / 1_000
 		ignoreWindowSeconds := int(math.Min(math.Pow(2, float64(f.retries))+spreadRetrySeconds, maxBackoffRetrySeconds))
-		log.Debug("Flush failed, retry number %s will happen in %s seconds", f.retries, ignoreWindowSeconds)
+		log.Debugf("Flush failed, retry number %d will happen after at least %d seconds", f.retries, ignoreWindowSeconds)
 		return now.Before(f.lastFail.Add(time.Duration(ignoreWindowSeconds * 1e9)))
 	} else {
 		return false

--- a/pkg/serverless/flush/strategy.go
+++ b/pkg/serverless/flush/strategy.go
@@ -138,7 +138,7 @@ func (f *failedAttempt) tooEarly(now time.Time) bool {
 		maxRetryBackoff := math.Min(float64(f.retries), 10) // no need to go higher and risk overflow in the power op
 		spreadRetrySeconds := float64(rand.Int31n(1_000)) / 1_000
 		ignoreWindowSeconds := int(math.Min(math.Pow(2, maxRetryBackoff)+spreadRetrySeconds, maxBackoffRetrySeconds))
-		log.Debugf("Flush failed, retry number %d will happen after at least %d seconds", f.retries, ignoreWindowSeconds)
+		log.Debugf("Flush failed %d times, flushes will be prevented for %d seconds", f.retries, ignoreWindowSeconds)
 		return now.Before(f.lastFail.Add(time.Duration(ignoreWindowSeconds * 1e9)))
 	} else {
 		return false

--- a/pkg/serverless/flush/strategy_test.go
+++ b/pkg/serverless/flush/strategy_test.go
@@ -96,7 +96,7 @@ func TestSkipAfterFailure(t *testing.T) {
 
 }
 
-func TestSkipMaxBackoff(t *testing.T) {
+func TestMaxBackoff(t *testing.T) {
 	assert := assert.New(t)
 
 	now := time.Now()
@@ -109,6 +109,6 @@ func TestSkipMaxBackoff(t *testing.T) {
 		sEnd.Failure(now)
 	}
 	assert.False(sEnd.ShouldFlush(Stopping, afterLessThanRetryTimeout), "it should not flush because it failed right away")
-	assert.True(sEnd.ShouldFlush(Stopping, afterMoreThanRetryTimeout), "it flush because enough time has passed since failure")
+	assert.True(sEnd.ShouldFlush(Stopping, afterMoreThanRetryTimeout), "it flush because more than max backoff passed")
 
 }

--- a/pkg/serverless/flush/strategy_test.go
+++ b/pkg/serverless/flush/strategy_test.go
@@ -80,18 +80,35 @@ func TestSkipAfterFailure(t *testing.T) {
 
 	sEnd := &AtTheEnd{}
 	assert.True(sEnd.ShouldFlush(Stopping, now), "it should flush because it's not the end of the function invocation")
-	for i := 1; i <= 10; i++ {
-		sEnd.IncrementFailure(now)
+	for i := 1; i <= 5; i++ {
+		sEnd.Failure(now)
 	}
 	assert.False(sEnd.ShouldFlush(Stopping, afterLessThanRetryTimeout), "it should not flush because it failed right away")
 	assert.True(sEnd.ShouldFlush(Stopping, afterMoreThanRetryTimeout), "it flush because enough time has passed since failure")
 
 	sPeriodic := &Periodically{}
 	assert.True(sPeriodic.ShouldFlush(Starting, now), "it should flush because it's not the end of the function invocation")
-	for i := 1; i <= 10; i++ {
-		sPeriodic.IncrementFailure(now)
+	for i := 1; i <= 5; i++ {
+		sPeriodic.Failure(now)
 	}
 	assert.False(sPeriodic.ShouldFlush(Starting, afterLessThanRetryTimeout), "it should not flush because it failed right away")
 	assert.True(sPeriodic.ShouldFlush(Starting, afterMoreThanRetryTimeout), "it flush because enough time has passed since failure")
+
+}
+
+func TestSkipMaxBackoff(t *testing.T) {
+	assert := assert.New(t)
+
+	now := time.Now()
+	afterLessThanRetryTimeout := now.Add(4 * time.Minute)
+	afterMoreThanRetryTimeout := now.Add(maxBackoffRetrySeconds * time.Second)
+
+	sEnd := &AtTheEnd{}
+	assert.True(sEnd.ShouldFlush(Stopping, now), "it should flush because it's not the end of the function invocation")
+	for i := 1; i <= 500; i++ {
+		sEnd.Failure(now)
+	}
+	assert.False(sEnd.ShouldFlush(Stopping, afterLessThanRetryTimeout), "it should not flush because it failed right away")
+	assert.True(sEnd.ShouldFlush(Stopping, afterMoreThanRetryTimeout), "it flush because enough time has passed since failure")
 
 }

--- a/pkg/serverless/flush/strategy_test.go
+++ b/pkg/serverless/flush/strategy_test.go
@@ -70,3 +70,28 @@ func TestStrategyFromString(t *testing.T) {
 	assert.Equal("end", s.String())
 	assert.Error(err, "parsing this string should fail")
 }
+
+func TestSkipAfterFailure(t *testing.T) {
+	assert := assert.New(t)
+
+	now := time.Now()
+	afterLessThanRetryTimeout := now.Add(30 * time.Second)
+	afterMoreThanRetryTimeout := now.Add(2 * time.Minute)
+
+	sEnd := &AtTheEnd{}
+	assert.True(sEnd.ShouldFlush(Stopping, now), "it should flush because it's not the end of the function invocation")
+	for i := 1; i <= 10; i++ {
+		sEnd.IncrementFailure(now)
+	}
+	assert.False(sEnd.ShouldFlush(Stopping, afterLessThanRetryTimeout), "it should not flush because it failed right away")
+	assert.True(sEnd.ShouldFlush(Stopping, afterMoreThanRetryTimeout), "it flush because enough time has passed since failure")
+
+	sPeriodic := &Periodically{}
+	assert.True(sPeriodic.ShouldFlush(Starting, now), "it should flush because it's not the end of the function invocation")
+	for i := 1; i <= 10; i++ {
+		sPeriodic.IncrementFailure(now)
+	}
+	assert.False(sPeriodic.ShouldFlush(Starting, afterLessThanRetryTimeout), "it should not flush because it failed right away")
+	assert.True(sPeriodic.ShouldFlush(Starting, afterMoreThanRetryTimeout), "it flush because enough time has passed since failure")
+
+}

--- a/pkg/serverless/flush/strategy_test.go
+++ b/pkg/serverless/flush/strategy_test.go
@@ -80,18 +80,35 @@ func TestSkipAfterFailure(t *testing.T) {
 
 	sEnd := &AtTheEnd{}
 	assert.True(sEnd.ShouldFlush(Stopping, now), "it should flush because it's not the end of the function invocation")
-	for i := 1; i <= 10; i++ {
-		sEnd.IncrementFailure(now)
+	for i := 1; i <= 5; i++ {
+		sEnd.Failure(now)
 	}
 	assert.False(sEnd.ShouldFlush(Stopping, afterLessThanRetryTimeout), "it should not flush because it failed right away")
 	assert.True(sEnd.ShouldFlush(Stopping, afterMoreThanRetryTimeout), "it flush because enough time has passed since failure")
 
 	sPeriodic := &Periodically{}
 	assert.True(sPeriodic.ShouldFlush(Starting, now), "it should flush because it's not the end of the function invocation")
-	for i := 1; i <= 10; i++ {
-		sPeriodic.IncrementFailure(now)
+	for i := 1; i <= 5; i++ {
+		sPeriodic.Failure(now)
 	}
 	assert.False(sPeriodic.ShouldFlush(Starting, afterLessThanRetryTimeout), "it should not flush because it failed right away")
 	assert.True(sPeriodic.ShouldFlush(Starting, afterMoreThanRetryTimeout), "it flush because enough time has passed since failure")
+
+}
+
+func TestMaxBackoff(t *testing.T) {
+	assert := assert.New(t)
+
+	now := time.Now()
+	afterLessThanRetryTimeout := now.Add(4 * time.Minute)
+	afterMoreThanRetryTimeout := now.Add(maxBackoffRetrySeconds * time.Second)
+
+	sEnd := &AtTheEnd{}
+	assert.True(sEnd.ShouldFlush(Stopping, now), "it should flush because it's not the end of the function invocation")
+	for i := 1; i <= 500; i++ {
+		sEnd.Failure(now)
+	}
+	assert.False(sEnd.ShouldFlush(Stopping, afterLessThanRetryTimeout), "it should not flush because it failed right away")
+	assert.True(sEnd.ShouldFlush(Stopping, afterMoreThanRetryTimeout), "it flush because more than max backoff passed")
 
 }

--- a/pkg/serverless/flush/strategy_test.go
+++ b/pkg/serverless/flush/strategy_test.go
@@ -80,35 +80,18 @@ func TestSkipAfterFailure(t *testing.T) {
 
 	sEnd := &AtTheEnd{}
 	assert.True(sEnd.ShouldFlush(Stopping, now), "it should flush because it's not the end of the function invocation")
-	for i := 1; i <= 5; i++ {
-		sEnd.Failure(now)
+	for i := 1; i <= 10; i++ {
+		sEnd.IncrementFailure(now)
 	}
 	assert.False(sEnd.ShouldFlush(Stopping, afterLessThanRetryTimeout), "it should not flush because it failed right away")
 	assert.True(sEnd.ShouldFlush(Stopping, afterMoreThanRetryTimeout), "it flush because enough time has passed since failure")
 
 	sPeriodic := &Periodically{}
 	assert.True(sPeriodic.ShouldFlush(Starting, now), "it should flush because it's not the end of the function invocation")
-	for i := 1; i <= 5; i++ {
-		sPeriodic.Failure(now)
+	for i := 1; i <= 10; i++ {
+		sPeriodic.IncrementFailure(now)
 	}
 	assert.False(sPeriodic.ShouldFlush(Starting, afterLessThanRetryTimeout), "it should not flush because it failed right away")
 	assert.True(sPeriodic.ShouldFlush(Starting, afterMoreThanRetryTimeout), "it flush because enough time has passed since failure")
-
-}
-
-func TestMaxBackoff(t *testing.T) {
-	assert := assert.New(t)
-
-	now := time.Now()
-	afterLessThanRetryTimeout := now.Add(4 * time.Minute)
-	afterMoreThanRetryTimeout := now.Add(maxBackoffRetrySeconds * time.Second)
-
-	sEnd := &AtTheEnd{}
-	assert.True(sEnd.ShouldFlush(Stopping, now), "it should flush because it's not the end of the function invocation")
-	for i := 1; i <= 500; i++ {
-		sEnd.Failure(now)
-	}
-	assert.False(sEnd.ShouldFlush(Stopping, afterLessThanRetryTimeout), "it should not flush because it failed right away")
-	assert.True(sEnd.ShouldFlush(Stopping, afterMoreThanRetryTimeout), "it flush because more than max backoff passed")
 
 }

--- a/pkg/serverless/registration/extension_api.go
+++ b/pkg/serverless/registration/extension_api.go
@@ -34,11 +34,11 @@ const (
 // RegisterExtension registers the serverless daemon and subscribe to INVOKE and SHUTDOWN messages.
 // Returns either (the serverless ID assigned by the serverless daemon + the api key as read from
 // the environment) or an error.
-func RegisterExtension(runtimeURL string, registrationRoute string, timeout time.Duration) (ID, FunctionARN, error) { //nolint:revive // TODO fix revive unused-parameter
-	extesionRegistrationURL := BuildURL(registrationRoute)
+func RegisterExtension(registrationRoute string, timeout time.Duration) (ID, FunctionARN, error) {
+	extesnionRegistrationURL := BuildURL(registrationRoute)
 	payload := createRegistrationPayload()
 
-	request, err := buildRegisterRequest(extesionRegistrationURL, payload)
+	request, err := buildRegisterRequest(extesnionRegistrationURL, payload)
 	if err != nil {
 		return "", "", fmt.Errorf("registerExtension: can't create the POST register request: %v", err)
 	}

--- a/pkg/serverless/registration/extension_api.go
+++ b/pkg/serverless/registration/extension_api.go
@@ -35,10 +35,10 @@ const (
 // Returns either (the serverless ID assigned by the serverless daemon + the api key as read from
 // the environment) or an error.
 func RegisterExtension(registrationRoute string, timeout time.Duration) (ID, FunctionARN, error) {
-	extesnionRegistrationURL := BuildURL(registrationRoute)
+	extensionRegistrationURL := BuildURL(registrationRoute)
 	payload := createRegistrationPayload()
 
-	request, err := buildRegisterRequest(extesnionRegistrationURL, payload)
+	request, err := buildRegisterRequest(extensionRegistrationURL, payload)
 	if err != nil {
 		return "", "", fmt.Errorf("registerExtension: can't create the POST register request: %v", err)
 	}

--- a/pkg/serverless/registration/extension_api_test.go
+++ b/pkg/serverless/registration/extension_api_test.go
@@ -111,7 +111,7 @@ func TestRegisterSuccess(t *testing.T) {
 
 	baseRuntime := strings.Replace(ts.URL, "http://", "", 1)
 	t.Setenv("AWS_LAMBDA_RUNTIME_API", baseRuntime)
-	id, functionArn, err := RegisterExtension(baseRuntime, "/myRoute", registerExtensionTimeout)
+	id, functionArn, err := RegisterExtension("/myRoute", registerExtensionTimeout)
 
 	assert.Equal(t, expectedId, id.String())
 	assert.Equal(t, expectedFunctionARN, string(functionArn))
@@ -129,7 +129,7 @@ func TestRegisterErrorNoExtensionId(t *testing.T) {
 	defer ts.Close()
 
 	t.Setenv("AWS_LAMBDA_RUNTIME_API", ts.URL)
-	id, functionArn, err := RegisterExtension(strings.Replace(ts.URL, "http://", "", 1), "", registerExtensionTimeout)
+	id, functionArn, err := RegisterExtension("", registerExtensionTimeout)
 
 	assert.Empty(t, id.String())
 	assert.Empty(t, string(functionArn))
@@ -144,7 +144,7 @@ func TestRegisterErrorHttp(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	id, functionArn, err := RegisterExtension(strings.Replace(ts.URL, "http://", "", 1), "", registerExtensionTimeout)
+	id, functionArn, err := RegisterExtension("", registerExtensionTimeout)
 
 	assert.Empty(t, id.String())
 	assert.Empty(t, string(functionArn))
@@ -152,7 +152,7 @@ func TestRegisterErrorHttp(t *testing.T) {
 }
 
 func TestRegisterErrorTimeout(t *testing.T) {
-	id, functionArn, err := RegisterExtension(":invalidURL:", "", registerExtensionTimeout)
+	id, functionArn, err := RegisterExtension("", registerExtensionTimeout)
 	assert.Empty(t, id.String())
 	assert.Empty(t, string(functionArn))
 	assert.NotNil(t, err)
@@ -166,7 +166,7 @@ func TestRegisterErrorBuildRequest(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	id, functionArn, err := RegisterExtension(ts.URL, "", registerExtensionTimeout)
+	id, functionArn, err := RegisterExtension("", registerExtensionTimeout)
 
 	assert.Empty(t, id.String())
 	assert.Empty(t, string(functionArn))
@@ -174,7 +174,7 @@ func TestRegisterErrorBuildRequest(t *testing.T) {
 }
 
 func TestRegisterInvalidUrl(t *testing.T) {
-	id, functionArn, err := RegisterExtension(":inv al id:", "", registerExtensionTimeout)
+	id, functionArn, err := RegisterExtension("", registerExtensionTimeout)
 	assert.Empty(t, id.String())
 	assert.Empty(t, string(functionArn))
 	assert.NotNil(t, err)

--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -186,7 +186,7 @@ func handleInvocation(doneChannel chan bool, daemon *daemon.Daemon, arn string, 
 	}
 
 	// immediately check if we should flush data
-	if daemon.ShouldFlush(flush.Starting, time.Now()) {
+	if daemon.ShouldFlush(flush.Starting) {
 		log.Debugf("The flush strategy %s has decided to flush at moment: %s", daemon.GetFlushStrategy(), flush.Starting)
 		daemon.TriggerFlush(false)
 	} else {

--- a/pkg/serverless/tags/testGetRuntimeRetries/13/environ
+++ b/pkg/serverless/tags/testGetRuntimeRetries/13/environ
@@ -1,0 +1,1 @@
+AWS_EXECUTION_ENV=nodejs14.x

--- a/pkg/serverless/tags/testGetRuntimeRetries/13/environ
+++ b/pkg/serverless/tags/testGetRuntimeRetries/13/environ
@@ -1,1 +1,0 @@
-AWS_EXECUTION_ENV=nodejs14.x


### PR DESCRIPTION
This PR adds an exponential backoff timer to the serverless agent during the metrics/logs/traces flush.
The last attempts are stored in a global variable to keep track of them across different invocations in the same sandbox.

The low level retry logic is also disabled, preventing the extension to hang on retrying until the lambda timeout occurs