### PR TITLE
Tweak Worload Checks metadata

### DIFF
--- a/.gitlab/functional_test/workload_checks.yml
+++ b/.gitlab/functional_test/workload_checks.yml
@@ -33,6 +33,7 @@ single-machine-performance-workload-checks:
     # Download smp binary and prepare it for use
     - aws --profile single-machine-performance s3 cp s3://smp-cli-releases/v${SMP_VERSION}/x86_64-unknown-linux-gnu/smp smp
     - chmod +x smp
+    - CURRENT_DATE=$(date --utc '+%Y_%m_%d')
     - TARGET_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:nightly-${CI_COMMIT_BRANCH}-${CI_COMMIT_SHA}-7-amd64
     # Copy the TARGET_IMAGE to SMP for debugging purposes later
     - RUST_LOG="info,aws_config::profile::credentials=error"
@@ -49,7 +50,7 @@ single-machine-performance-workload-checks:
             --target-name datadog-agent
             --target-command "/bin/entrypoint.sh"
             --target-environment-variables "DD_HOSTNAME=smp-workload-checks,DD_DD_URL=http://127.0.0.1:9092,DD_API_KEY=00000001"
-            --tags status=nightly,commit_time="${CI_COMMIT_TIME}"
+            --tags smp_status=nightly,client_team="agent",tag_date="${CURRENT_DATE}"
             --submission-metadata submission-metadata
     # Wait for job to complete.
     - RUST_BACKTRACE=1 RUST_LOG="${RUST_LOG_DEBUG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE}


### PR DESCRIPTION
### What does this PR do?

This commit adjusts the metadata present in the image and passed labels, required to drive our internal dashboards. We have made adjustments in this commit to run per-PR but these will not be merged up, as this workflow is intended to be nightly-only.

REF SMP-673
