### PR TITLE
Remove entries from CreateFolder table

### DIFF
--- a/releasenotes/notes/windows-installer-createfolder-hotfix-6f1e2062856bd5da.yaml
+++ b/releasenotes/notes/windows-installer-createfolder-hotfix-6f1e2062856bd5da.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix issue introduced in 7.47.0 that causes the SE_DACL_AUTO_INHERITED flag to be removed from
+    the installation drive directory when the installer fails and rolls back.

--- a/releasenotes/notes/windows-installer-createfolder-hotfix-6f1e2062856bd5da.yaml
+++ b/releasenotes/notes/windows-installer-createfolder-hotfix-6f1e2062856bd5da.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Fix issue introduced in 7.47.0 that causes the SE_DACL_AUTO_INHERITED flag to be removed from
+    Fix the issue introduced in 7.47.0 that causes the SE_DACL_AUTO_INHERITED flag to be removed from
     the installation drive directory when the installer fails and rolls back.

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -360,6 +360,7 @@ def validate_msi_createfolder_table(db):
     (C:\\Program Files\\) to end up in the CrateFolder MSI table. Then because MSI.dll CreateFolder rollback
     uses the obsolete SetFileSecurityW function the AI DACL flag is removed from those directories
     on rollback.
+    https://github.com/oleg-shilo/wixsharp/issues/1336
 
     If you think you need to add a new directory to this list, perform the following checks:
     * Ensure the directory and its parents are deleted or persisted on uninstall as expected

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -307,8 +307,7 @@ def build(
         )
 
         # And copy it to the final output path as a build artifact
-        msipath = shutil.copy2(os.path.join(build_outdir, msi_name + '.msi'), OUTPUT_PATH)
-        validate_msi(ctx, msipath)
+        shutil.copy2(os.path.join(build_outdir, msi_name + '.msi'), OUTPUT_PATH)
 
     # if the optional upgrade test helper exists then build that too
     optional_name = "datadog-agent-ng-7.43.0~rc.3+git.485.14b9337-1-x86_64"
@@ -320,8 +319,7 @@ def build(
                 build_outdir,
                 optional_name,
             )
-            msipath = shutil.copy2(os.path.join(build_outdir, optional_name + '.msi'), OUTPUT_PATH)
-            validate_msi(ctx, msipath)
+            shutil.copy2(os.path.join(build_outdir, optional_name + '.msi'), OUTPUT_PATH)
 
 
 @task

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -4,7 +4,6 @@ msi namespaced tasks
 
 
 import mmap
-import msilib
 import os
 import shutil
 import sys
@@ -14,6 +13,14 @@ from invoke import task
 from invoke.exceptions import Exit, UnexpectedExit
 
 from tasks.utils import get_version, load_release_versions, timed
+
+# Windows only import
+try:
+    import msilib
+except ImportError:
+    if sys.platform == "win32":
+        raise
+    msilib = None
 
 # constants
 OUTPUT_PATH = os.path.join(os.getcwd(), "omnibus", "pkg")

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -183,7 +183,7 @@ def _build(
 
     # Construct build command line
     cmd = _get_vs_build_command(
-        f'cd {BUILD_SOURCE_DIR} && nuget restore && msbuild {project} /p:Configuration={configuration} /p:Platform="{arch}"',
+        f'cd {BUILD_SOURCE_DIR} && msbuild {project} /restore /p:Configuration={configuration} /p:Platform="{arch}"',
         vstudio_root,
     )
     print(f"Build Command: {cmd}")
@@ -240,8 +240,8 @@ def _build_msi(ctx, env, outdir, name):
     if not succeeded:
         raise Exit("Failed to build the MSI installer.", code=1)
 
-    # sign the MSI
     out_file = os.path.join(outdir, f"{name}.msi")
+    validate_msi(ctx, out_file)
     sign_file(ctx, out_file)
 
 

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -395,7 +395,7 @@ def validate_msi_createfolder_table(db):
 
 
 @task
-def validate_msi(ctx, msi=None):
+def validate_msi(_ctx, msi=None):
     with MsiClosing(msilib.OpenDatabase(msi, msilib.MSIDBOPEN_READONLY)) as db:
         validate_msi_createfolder_table(db)
 

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
@@ -180,6 +180,10 @@ namespace Datadog.CustomActions
             {
                 using var subkey =
                     _registryServices.OpenRegistryKey(Registries.LocalMachine, Constants.DatadogAgentRegistryKey);
+                if (subkey == null)
+                {
+                    throw new Exception("Datadog registry key does not exist");
+                }
                 var domain = subkey.GetValue("installedDomain")?.ToString();
                 var user = subkey.GetValue("installedUser")?.ToString();
                 if (string.IsNullOrEmpty(domain) || string.IsNullOrEmpty(user))

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Interfaces/IRegistryKey.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Interfaces/IRegistryKey.cs
@@ -9,5 +9,6 @@ namespace Datadog.CustomActions.Interfaces
         void SetAccessControl(RegistrySecurity registrySecurity);
         object GetValue(string name);
         void SetValue(string name, object value, RegistryValueKind kind);
+        void DeleteValue(string name);
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Interfaces/IRegistryServices.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Interfaces/IRegistryServices.cs
@@ -6,5 +6,6 @@ namespace Datadog.CustomActions.Interfaces
     {
         IRegistryKey CreateRegistryKey(Registries registry, string path);
         IRegistryKey OpenRegistryKey(Registries registry, string path);
+        IRegistryKey OpenRegistryKey(Registries registry, string path, bool writable);
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/RegistryKey.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/RegistryKey.cs
@@ -28,6 +28,11 @@ namespace Datadog.CustomActions.Native
             _key.SetValue(name, value, kind);
         }
 
+        public void DeleteValue(string name)
+        {
+            _key.DeleteValue(name);
+        }
+
         public void Dispose()
         {
             _key?.Dispose();

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/RegistryServices.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/RegistryServices.cs
@@ -13,7 +13,13 @@ namespace Datadog.CustomActions.Native
                 _ => null
             };
 
-            return new RegistryKey(key.CreateSubKey(path));
+            key = key.CreateSubKey(path);
+            if (key == null)
+            {
+                return null;
+            }
+
+            return new RegistryKey(key);
         }
 
         public IRegistryKey OpenRegistryKey(Registries registry, string path)
@@ -29,7 +35,13 @@ namespace Datadog.CustomActions.Native
                 _ => null
             };
 
-            return new RegistryKey(key.OpenSubKey(path, writable));
+            key = key.OpenSubKey(path, writable);
+            if (key == null)
+            {
+                return null;
+            }
+
+            return new RegistryKey(key);
         }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/RegistryServices.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/RegistryServices.cs
@@ -18,13 +18,18 @@ namespace Datadog.CustomActions.Native
 
         public IRegistryKey OpenRegistryKey(Registries registry, string path)
         {
+            return OpenRegistryKey(registry, path, false);
+        }
+
+        public IRegistryKey OpenRegistryKey(Registries registry, string path, bool writable)
+        {
             var key = registry switch
             {
                 Registries.LocalMachine => Registry.LocalMachine,
                 _ => null
             };
 
-            return new RegistryKey(key.OpenSubKey(path));
+            return new RegistryKey(key.OpenSubKey(path, writable));
         }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
@@ -24,6 +24,8 @@ namespace WixSetup.Datadog
 
         public ManagedAction WriteInstallState { get; }
 
+        public ManagedAction UninstallWriteInstallState { get; }
+
         public ManagedAction ProcessDdAgentUserCredentials { get; }
 
         public ManagedAction ProcessDdAgentUserCredentialsUI { get; }
@@ -476,6 +478,22 @@ namespace WixSetup.Datadog
                 }
                 .SetProperties("DDAGENTUSER_PROCESSED_DOMAIN=[DDAGENTUSER_PROCESSED_DOMAIN], " +
                                "DDAGENTUSER_PROCESSED_NAME=[DDAGENTUSER_PROCESSED_NAME]");
+
+            UninstallWriteInstallState = new CustomAction<InstallStateCustomActions>(
+                    new Id(nameof(UninstallWriteInstallState)),
+                    InstallStateCustomActions.UninstallWriteInstallState,
+                    Return.check,
+                    // Since this CA removes registry values it must run before the built-in RemoveRegistryValues
+                    // so that the built-in registry keys can be removed if they are empty.
+                    When.Before,
+                    Step.RemoveRegistryValues,
+                    // Run only on full uninstall
+                    Conditions.Uninstalling
+                )
+                {
+                    Execute = Execute.deferred,
+                    Impersonate = false
+                };
         }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -114,8 +114,9 @@ namespace WixSetup.Datadog
                     RegistryHive.LocalMachine, @"Software\Datadog\Datadog Agent",
                     // Store these properties in the registry for retrieval by future
                     // installer runs via the ReadInstallState CA.
-                    new RegValue("InstallPath", "[PROJECTLOCATION]") { Win64 = true },
-                    new RegValue("ConfigRoot", "[APPLICATIONDATADIRECTORY]") { Win64 = true }
+                    // Must set KeyPath=yes to ensure WiX# doesn't automatically try to use the parent Directory as the KeyPath
+                    new RegValue("InstallPath", "[PROJECTLOCATION]") { Win64 = true, AttributesDefinition = "KeyPath=yes"},
+                    new RegValue("ConfigRoot", "[APPLICATIONDATADIRECTORY]") { Win64 = true, AttributesDefinition = "KeyPath=yes"}
                 )
                 {
                     Win64 = true

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -515,6 +515,7 @@ namespace WixSetup.Datadog
                 new DirFiles($@"{EtcSource}\*.yaml.example"),
                 new Dir("checks.d"),
                 new Dir("run"),
+                new Dir("logs"),
                 new Dir(new Id("EXAMPLECONFSLOCATION"), "conf.d",
                     new Files($@"{EtcSource}\extra_package_files\EXAMPLECONFSLOCATION\*")
                 ));

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -225,6 +225,11 @@ namespace WixSetup.Datadog
                         value => value.StartsWith("TARGETDIR") ||
                                  value.Equals("ProgramFiles64Folder")))
                     .Remove();
+                document
+                    .FindAll("CreateFolder")
+                    .Where(x => x.Parent.Parent.HasAttribute("Id",
+                        value => value.Equals("ProgramFiles64Folder")))
+                    .Remove();
                 // Windows Installer (MSI.dll) calls the obsolete SetFileSecurityW function during CreateFolder rollback,
                 // this causes directories in the CreateFolder table to have their SE_DACL_AUTO_INHERITED flag removed.
                 // Wix# is auto-adding components for the following directories for some reason, which causes them to be placed

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -222,13 +222,20 @@ namespace WixSetup.Datadog
                 document
                     .FindAll("RemoveFolder")
                     .Where(x => x.HasAttribute("Id",
-                        value => value.StartsWith("TARGETDIR") ||
-                                 value.Equals("ProgramFiles64Folder")))
+                        value => value.Equals("TARGETDIR") ||
+                                 value.Equals("ProgramFiles64Folder") ||
+                                 value.Equals("BIN") ||
+                                 value.Equals("AGENT")))
                     .Remove();
                 document
                     .FindAll("CreateFolder")
                     .Where(x => x.Parent.Parent.HasAttribute("Id",
                         value => value.Equals("ProgramFiles64Folder")))
+                    .Remove();
+                document
+                    .FindAll("CreateFolder")
+                    .Where(x => x.Parent.HasAttribute("Id",
+                        value => value.StartsWith("EventSource")))
                     .Remove();
                 // Windows Installer (MSI.dll) calls the obsolete SetFileSecurityW function during CreateFolder rollback,
                 // this causes directories in the CreateFolder table to have their SE_DACL_AUTO_INHERITED flag removed.

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -119,8 +119,7 @@ namespace WixSetup.Datadog
                 )
                 {
                     Win64 = true
-                },
-                new RemoveRegistryKey(_agentFeatures.MainApplication, @"Software\Datadog\Datadog Agent")
+                }
             );
             project
                 .SetCustomActions(_agentCustomActions)

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -154,7 +154,7 @@ namespace WixSetup.Datadog
                 .AddDirectories(
                     CreateProgramFilesFolder(),
                     CreateAppDataFolder(),
-                    new Dir(@"%ProgramMenu%\Datadog",
+                    new Dir(new Id("ProgramMenuDatadog"), @"%ProgramMenu%\Datadog",
                         new ExeFileShortcut
                         {
                             Name = "Datadog Agent Manager",
@@ -234,14 +234,14 @@ namespace WixSetup.Datadog
                     .Where(x => x.HasAttribute("Id",
                         value => value.Equals("TARGETDIR") ||
                                  value.Equals("ProgramFiles64Folder") ||
-                                 value.Equals("Datadog")))
+                                 value.Equals("DatadogAppRoot")))
                     .Remove();
                 document
                     .FindAll("ComponentRef")
                     .Where(x => x.HasAttribute("Id",
                         value => value.Equals("TARGETDIR") ||
                                  value.Equals("ProgramFiles64Folder") ||
-                                 value.Equals("Datadog")))
+                                 value.Equals("DatadogAppRoot")))
                     .Remove();
                 // END TODO: Wix# adds these automatically
                 document
@@ -346,7 +346,7 @@ namespace WixSetup.Datadog
                 datadogAgentFolder.AddFile(new CompressedDir(this, "embedded2", $@"{InstallerSource}\embedded2"));
             }
 
-            return new Dir("%ProgramFiles%\\Datadog", datadogAgentFolder);
+            return new Dir(new Id("DatadogAppRoot"), "%ProgramFiles%\\Datadog", datadogAgentFolder);
         }
 
         private static PermissionEx DefaultPermissions()

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -467,7 +467,7 @@ namespace WixSetup.Datadog
                     Name = Constants.AgentServiceName,
                     Log = "Application",
                     EventMessageFile = $"[BIN]{Path.GetFileName(_agentBinaries.Agent)}",
-                    AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes"
+                    AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes; KeyPath=yes"
                 },
                 new WixSharp.File(_agentBinaries.LibDatadogAgentThree),
                 new Dir(new Id("AGENT"), "agent",
@@ -481,7 +481,7 @@ namespace WixSetup.Datadog
                         Name = Constants.ProcessAgentServiceName,
                         Log = "Application",
                         EventMessageFile = $"[AGENT]{Path.GetFileName(_agentBinaries.ProcessAgent)}",
-                        AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes"
+                        AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes; KeyPath=yes"
                     },
                     new WixSharp.File(_agentBinaries.SystemProbe, systemProbeService),
                     new EventSource
@@ -489,7 +489,7 @@ namespace WixSetup.Datadog
                         Name = Constants.SystemProbeServiceName,
                         Log = "Application",
                         EventMessageFile = $"[AGENT]{Path.GetFileName(_agentBinaries.SystemProbe)}",
-                        AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes"
+                        AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes; KeyPath=yes"
                     },
                     new WixSharp.File(_agentBinaries.TraceAgent, traceAgentService),
                     new EventSource
@@ -497,7 +497,7 @@ namespace WixSetup.Datadog
                         Name = Constants.TraceAgentServiceName,
                         Log = "Application",
                         EventMessageFile = $"[AGENT]{Path.GetFileName(_agentBinaries.TraceAgent)}",
-                        AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes"
+                        AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes; KeyPath=yes"
                     }
                 )
             );

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -332,7 +332,10 @@ namespace WixSetup.Datadog
                 new DirFiles($@"{InstallerSource}\LICENSE"),
                 new DirFiles($@"{InstallerSource}\*.json"),
                 new DirFiles($@"{InstallerSource}\*.txt"),
-                new CompressedDir(this, "embedded3", $@"{InstallerSource}\embedded3")
+                new CompressedDir(this, "embedded3", $@"{InstallerSource}\embedded3"),
+                // Recursively delete/backup all files/folders in PROJECTLOCATION, they will be restored
+                // on rollback. By default WindowsInstller only removes the files it tracks, and embedded3 isn't tracked
+                new RemoveFolderEx { On = InstallEvent.uninstall, Property = "PROJECTLOCATION" }
             );
             if (_agentPython.IncludePython2)
             {

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -332,10 +332,7 @@ namespace WixSetup.Datadog
                 new DirFiles($@"{InstallerSource}\LICENSE"),
                 new DirFiles($@"{InstallerSource}\*.json"),
                 new DirFiles($@"{InstallerSource}\*.txt"),
-                new CompressedDir(this, "embedded3", $@"{InstallerSource}\embedded3"),
-                // Recursively delete/backup all files/folders in PROJECTLOCATION, they will be restored
-                // on rollback. By default WindowsInstller only removes the files it tracks, and embedded3 isn't tracked
-                new RemoveFolderEx { On = InstallEvent.uninstall, Property = "PROJECTLOCATION" }
+                new CompressedDir(this, "embedded3", $@"{InstallerSource}\embedded3")
             );
             if (_agentPython.IncludePython2)
             {

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -218,6 +218,32 @@ namespace WixSetup.Datadog
                         value => value.StartsWith("APPLICATIONDATADIRECTORY") ||
                                  value.StartsWith("EXAMPLECONFSLOCATION")))
                     .Remove();
+                // TODO: Wix# adds these automatically
+                document
+                    .FindAll("RemoveFolder")
+                    .Where(x => x.HasAttribute("Id",
+                        value => value.StartsWith("TARGETDIR") ||
+                                 value.Equals("ProgramFiles64Folder")))
+                    .Remove();
+                // Windows Installer (MSI.dll) calls the obsolete SetFileSecurityW function during CreateFolder rollback,
+                // this causes directories in the CreateFolder table to have their SE_DACL_AUTO_INHERITED flag removed.
+                // Wix# is auto-adding components for the following directories for some reason, which causes them to be placed
+                // in the CreateFolder table.
+                document
+                    .FindAll("Component")
+                    .Where(x => x.HasAttribute("Id",
+                        value => value.Equals("TARGETDIR") ||
+                                 value.Equals("ProgramFiles64Folder") ||
+                                 value.Equals("Datadog")))
+                    .Remove();
+                document
+                    .FindAll("ComponentRef")
+                    .Where(x => x.HasAttribute("Id",
+                        value => value.Equals("TARGETDIR") ||
+                                 value.Equals("ProgramFiles64Folder") ||
+                                 value.Equals("Datadog")))
+                    .Remove();
+                // END TODO: Wix# adds these automatically
                 document
                     .FindAll("Component")
                     .Where(x => x.Parent.HasAttribute("Id",

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -162,8 +162,7 @@ namespace WixSetup.Datadog
                             Arguments = "\"--launch-gui\"",
                             WorkingDirectory = "AGENT",
                         }
-                    ),
-                    new Dir("logs")
+                    )
                 );
 
             project.SetNetFxPrerequisite(Condition.Net45_Installed,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Removes some of the WiX elements auto-generated by WiX# that are causing directories to be placed in the `CreateFolder` and `RemoveFile` MSI tables. This is a temporary fix while we wait for input from upstream: https://github.com/oleg-shilo/wixsharp/issues/1336

Some of the directories shouldn't ever be in these tables, like `TARGETDIR` (`C:\`) and `ProgramFiles64Folder` (`C:\Program Files\`), which our install shouldn't be trying to modify.
While other directories like `DatadogAppRoot` (`C:\Program Files\Datadog\`), `BIN` (`C:\Program Files\Datadog\Datadog Agent\bin`), and `AGENT` (`C:\Program Files\Datadog\Datadog Agent\bin\agent`) shouldn't need to be as they will be created/removed through the normal course of the install.

This PR also removes the `RemoveRegistryKey` element, which was also contributing to the above behavior. It is replaced with an uninstall custom action that undoes its install counterpart's actions. This allows the normal course of the install to remove the registry key.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
We noticed that the `SE_DACL_AUTO_INHERITED` (`AI`) [DACL flag](https://learn.microsoft.com/en-us/windows-hardware/drivers/ifs/security-descriptor-control) was being removed from `C:\` on rollback. We identified the root cause as the obsolete [`SetFileSecurityW`](https://learn.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-setfilesecurityw) call being made by the built-in MSI [`CreateFolder`](https://learn.microsoft.com/en-us/windows/win32/msi/createfolders-action) rollback action. It seems that any directories listed in the `CreateFolder` MSI table will have this flag removed from their DACL on rollback. There are more details in the linked WixSharp issue.


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
The removal of the `AI` flag causes new child files and directories to be created protected (no inheritance), and also without the `AI` flag. This means that future changes to the parent directories permissions won't propagate to these protected children (or their children).
One odd consequence of this is that depending on the parent DACL, Windows may create the child (via a simple `mkdir <path>`) with a [non-canonical DACL](https://devblogs.microsoft.com/oldnewthing/20070608-00/?p=26503). Notably the C# [FileSystemSecurity](https://learn.microsoft.com/en-us/dotnet/api/system.security.accesscontrol.filesystemsecurity?view=net-7.0) APIs will throw an exception if you attempt to modify a non-canonical DACL.

It also seems that the usual methods of modifying permissions, explorer GUI, PowerShell, and icacls, will restore the `AI` flag. This means that existing children that inherit from the directory won't be affected, as the first attempt to modify permissions will enable inheritance again and trigger propagation.

The `AI` flag can also be removed on the `C:\ProgramData\Datadog` directory on rollback, as `APPLICATIONDATADIRECTORY` is present in the `CreateFolder` table, along with its `logs`, `checks.d`, and `run` subdirs. However since this was present in the OG installer and does not impact the `C:\` issue it isn't going to be addressed in this PR.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
It's possible for future changes to re-introduce this bug by causing new elements to be added to the `CreateFolder` table. To help prevent this I added a new invoke task that checks the `CreateFolder` table against a whitelist. It is run automatically during the `inv msi.build` invoke task. However it uses the msilib package which is now deprecated and will be removed in Python 3.13 [[ref]](https://peps.python.org/pep-0594/#msilib). The PEP and the msilib docs don't offer an alternative.

Example output when run on the v7.47.0 release
```
> inv -e msi.validate-msi --msi .\ddagent-cli-7.47.0.msi
Unexpected directory 'Datadog.1' in MSI CreateFolder table
Unexpected directory 'Datadog' in MSI CreateFolder table
Unexpected directory 'PROJECTLOCATION' in MSI CreateFolder table
Unexpected directory 'AGENT' in MSI CreateFolder table
Unexpected directory 'ProgramFiles64Folder' in MSI CreateFolder table
Unexpected directory 'BIN' in MSI CreateFolder table
Unexpected directory 'TARGETDIR' in MSI CreateFolder table
7 unexpected directories in MSI CreateFolder table
```
### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
#### Rollback test
Run the install with rollback
```
ddagent.msi WIXFAILWHENDEFERRED=1
```
Ensure that `C:\` has DACL flags `PAI`
```
Get-ACL C:\ | fl
```

#### Uninstall test
Install and then uninstall the agent. 
* Ensure the `C:\Program Files\Datadog` directory is removed.
* Ensure the `HKLM\SOFTWAE\Datadog` registry key is removed.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
