### PR TITLE
Add new metricskube_pod_container_status_last_terminated_reason

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -33,6 +33,7 @@ func defaultMetricTransformers() map[string]metricTransformerFunc {
 		"kube_pod_status_phase":                         podPhaseTransformer,
 		"kube_pod_container_status_waiting_reason":      containerWaitingReasonTransformer,
 		"kube_pod_container_status_terminated_reason":   containerTerminatedReasonTransformer,
+		"kube_pod_container_status_last_terminated_reason":   containerLastTerminatedReasonTransformer,
 		"kube_pod_container_extended_resource_requests": containerResourceRequestsTransformer,
 		"kube_pod_container_resource_requests":          containerResourceRequestsTransformer,
 		"kube_pod_container_resource_limits":            containerResourceLimitsTransformer,
@@ -205,12 +206,24 @@ var allowedTerminatedReasons = map[string]struct{}{
 	"error":              {},
 }
 
-// containerTerminatedReasonTransformer validates the container waiting reasons for metric kube_pod_container_status_terminated_reason
+// containerTerminatedReasonTransformer validates the container terminated reasons for metric kube_pod_container_status_terminated_reason
 func containerTerminatedReasonTransformer(s sender.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	if reason, found := metric.Labels["reason"]; found {
 		// Filtering according to the reason here is paramount to limit cardinality
 		if _, allowed := allowedTerminatedReasons[strings.ToLower(reason)]; allowed {
 			s.Gauge(ksmMetricPrefix+"container.status_report.count.terminated", metric.Val, hostname, tags)
+		}
+	}
+}
+
+// containerLastTerminatedReasonTransformer validates the container terminated reasons for metric kube_pod_container_status_last_terminated_reason
+func containerLastTerminatedReasonTransformer(s sender.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
+	log.Debugf("TEST containerLastTerminatedReasonTransformer '%s'", name)
+	log.Debugf("TEST value '%v', reason '%s', tags '%s'",  metric.Val, metric.Labels["reason"], tags)
+	if reason, found := metric.Labels["reason"]; found {
+		// Filtering according to the reason here is paramount to limit cardinality
+		if _, allowed := allowedTerminatedReasons[strings.ToLower(reason)]; allowed {
+			s.Gauge(ksmMetricPrefix+"container.status_report.count.last_terminated", metric.Val, hostname, tags)
 		}
 	}
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -218,8 +218,6 @@ func containerTerminatedReasonTransformer(s sender.Sender, name string, metric k
 
 // containerLastTerminatedReasonTransformer validates the container terminated reasons for metric kube_pod_container_status_last_terminated_reason
 func containerLastTerminatedReasonTransformer(s sender.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
-	log.Debugf("TEST containerLastTerminatedReasonTransformer '%s'", name)
-	log.Debugf("TEST value '%v', reason '%s', tags '%s'",  metric.Val, metric.Labels["reason"], tags)
 	if reason, found := metric.Labels["reason"]; found {
 		// Filtering according to the reason here is paramount to limit cardinality
 		if _, allowed := allowedTerminatedReasons[strings.ToLower(reason)]; allowed {

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers_test.go
@@ -1169,7 +1169,7 @@ func Test_containerLastTerminatedReasonTransformer(t *testing.T) {
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
 			currentTime := time.Now()
-			containerTerminatedReasonTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
+			containerLastTerminatedReasonTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
 				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.args.tags)
 				s.AssertNumberOfCalls(t, "Gauge", 1)


### PR DESCRIPTION
`kube_pod_container_status_last_terminated_reason` is added as a improvement of `kube_pod_container_status_terminated_reason`
This is not yet collected in Datadog

Ref: https://github.com/kubernetes/kube-state-metrics/issues/570 

Please let me know if there's any feedback