### PR TITLE
[CWS] increase stability of e2e test by improving log query

### DIFF
--- a/test/e2e/cws-tests/tests/lib/cws/app.py
+++ b/test/e2e/cws-tests/tests/lib/cws/app.py
@@ -35,6 +35,11 @@ from retry.api import retry_call
 
 
 def get_app_log(api_client, query):
+    # in CI ensure that we are filtering the logs from the e2e runs and not
+    # other agents from people doing QA
+    if os.environ["CI"] == "true":
+        query = f"app:agent-e2e-tests host:k8s-e2e-tests-control-plane {query}"
+
     api_instance = logs_api.LogsApi(api_client)
     body = LogsListRequest(
         filter=LogsQueryFilter(

--- a/test/e2e/cws-tests/tests/lib/cws/app.py
+++ b/test/e2e/cws-tests/tests/lib/cws/app.py
@@ -35,10 +35,9 @@ from retry.api import retry_call
 
 
 def get_app_log(api_client, query):
-    # in CI ensure that we are filtering the logs from the e2e runs and not
+    # ensures that we are filtering the logs from the e2e runs and not
     # other agents from people doing QA
-    if os.environ["CI"] == "true":
-        query = f"app:agent-e2e-tests host:k8s-e2e-tests-control-plane {query}"
+    query = f"app:agent-e2e-tests host:k8s-e2e-tests-control-plane {query}"
 
     api_instance = logs_api.LogsApi(api_client)
     body = LogsListRequest(


### PR DESCRIPTION
### What does this PR do?

This PR improves the way we fetch logs from the app in the CWS e2e tests, by ensuring we get logs from e2e runs and not from other agents doing some QA or running there for other reasons.

This additional check is done only in the CI to not impact local work (where the hostname could be different)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
