### PR TITLE
[CWS/CSPM] move container utils to `pkg/security/common`

### DIFF
--- a/pkg/security/common/containerutils/utils.go
+++ b/pkg/security/common/containerutils/utils.go
@@ -4,7 +4,6 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Package containerutils holds multiple utils functions around Container IDs and their patterns
-
 package containerutils
 
 import (

--- a/pkg/security/common/containerutils/utils.go
+++ b/pkg/security/common/containerutils/utils.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package containerutils
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"regexp"
+)
+
+// ContainerIDPatternStr is the pattern of a container ID
+var ContainerIDPatternStr = fmt.Sprintf(`([[:xdigit:]]{%v})`, sha256.Size*2)
+
+// containerIDPattern is the pattern of a container ID
+var containerIDPattern = regexp.MustCompile(ContainerIDPatternStr)
+
+// FindContainerID extracts the first sub string that matches the pattern of a container ID
+func FindContainerID(s string) string {
+	return containerIDPattern.FindString(s)
+}

--- a/pkg/security/common/containerutils/utils.go
+++ b/pkg/security/common/containerutils/utils.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package containerutils holds multiple utils functions around Container IDs and their patterns
+
 package containerutils
 
 import (

--- a/pkg/security/secl/model/utils.go
+++ b/pkg/security/secl/model/utils.go
@@ -7,21 +7,7 @@ package model
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"fmt"
-	"regexp"
 )
-
-// ContainerIDPatternStr is the pattern of a container ID
-var ContainerIDPatternStr = fmt.Sprintf(`([[:xdigit:]]{%v})`, sha256.Size*2)
-
-// containerIDPattern is the pattern of a container ID
-var containerIDPattern = regexp.MustCompile(ContainerIDPatternStr)
-
-// FindContainerID extracts the first sub string that matches the pattern of a container ID
-func FindContainerID(s string) string {
-	return containerIDPattern.FindString(s)
-}
 
 // SliceToArray copy src bytes to dst. Destination should have enough space
 func SliceToArray(src []byte, dst []byte) {

--- a/pkg/security/security_profile/activity_tree/paths_reducer.go
+++ b/pkg/security/security_profile/activity_tree/paths_reducer.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/security/common/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
@@ -141,7 +142,7 @@ func getPathsReducerPatterns() []PatternReducer {
 			},
 		},
 		{
-			Pattern: regexp.MustCompile(model.ContainerIDPatternStr), // container ID
+			Pattern: regexp.MustCompile(containerutils.ContainerIDPatternStr), // container ID
 			Callback: func(ctx *callbackContext) {
 				start, end := ctx.getGroup(0)
 				ctx.replaceBy(start, end, "*")

--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -15,7 +15,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/common/containerutils"
 )
 
 // ContainerID is the type holding the container ID
@@ -48,7 +48,7 @@ type ControlGroup struct {
 
 // GetContainerID returns the container id extracted from the path of the control group
 func (cg ControlGroup) GetContainerID() ContainerID {
-	return ContainerID(model.FindContainerID(cg.Path))
+	return ContainerID(containerutils.FindContainerID(cg.Path))
 }
 
 // GetProcControlGroups returns the cgroup membership of the specified task.


### PR DESCRIPTION
### What does this PR do?

This PR moves the container ID utils functions into `pkg/security/common` and out of `pkg/security/secl`. This allows `pkg/compliance` (and also the whole cluster agent) to not depend on the secl pkg and it's enormous model.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
