### PR TITLE
Update jira project ids to reflect company managed project conversion

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -9,7 +9,7 @@ ignored_labels = [
 ]
 
 [teams."Agent Metrics Logs"]
-jira_project = "AML"
+jira_project = "AMLII"
 jira_issue_type = "Task"
 jira_statuses = [
   "To Do",
@@ -21,7 +21,7 @@ github_labels = ["team/agent-metrics-logs"]
 exclude_members = ["olivielpeau"]
 
 [teams."Agent Shared Components"]
-jira_project = "ASC"
+jira_project = "ASCII"
 jira_issue_type = "QA"
 jira_statuses = [
   "To Do",
@@ -33,7 +33,7 @@ github_labels = ["team/agent-shared-components"]
 exclude_members = ["olivielpeau", "sgnn7"]
 
 [teams."Agent Platform"]
-jira_project = "AP"
+jira_project = "APL"
 jira_issue_type = "QA"
 jira_statuses = [
   "To Do",
@@ -45,7 +45,7 @@ github_labels = ["team/agent-platform"]
 exclude_members = ["olivielpeau"]
 
 [teams."Universal Service Monitoring"]
-jira_project = "USMO"
+jira_project = "USMON"
 jira_issue_type = "Task"
 jira_statuses = [
   "To Do",
@@ -56,7 +56,7 @@ github_team = "universal-service-monitoring"
 github_labels = ["team/usm"]
 
 [teams."Network Device Monitoring"]
-jira_project = "NDM"
+jira_project = "NDMII"
 jira_issue_type = "Task"
 jira_statuses = [
   "To Do",
@@ -67,7 +67,7 @@ github_team = "network-device-monitoring"
 github_labels = ["team/network-device-monitoring"]
 
 [teams."Network Performance Monitoring"]
-jira_project = "NET"
+jira_project = "NPM"
 jira_issue_type = "Task"
 jira_statuses = [
   "Backlog",
@@ -114,7 +114,7 @@ exclude_members = [
 ]
 
 [teams."Platform Integrations"]
-jira_project = "PINT"
+jira_project = "PLINT"
 jira_issue_type = "Task"
 jira_statuses = [
   "To Do",
@@ -140,7 +140,7 @@ github_team = "apm-go"
 github_labels = ["team/agent-apm"]
 
 [teams."Remote Config"]
-jira_project = "RCM"
+jira_project = "RC"
 jira_issue_type = "QA"
 jira_statuses = [
   "To Do",
@@ -151,7 +151,7 @@ github_team = "remote-config"
 github_labels = ["team/remote-config"]
 
 [teams."Container Integrations"]
-jira_project = "CONT"
+jira_project = "CONTINT"
 jira_issue_type = "Task"
 jira_statuses = [
   "To Do",
@@ -198,7 +198,7 @@ github_team = "agent-cspm"
 github_labels = ["team/agent-cspm"]
 
 [teams."Processes"]
-jira_project = "PROC"
+jira_project = "PROCS"
 jira_issue_type = "Task"
 jira_statuses = [
   "TRIAGE",
@@ -231,7 +231,7 @@ github_team = "windows-kernel-integrations"
 github_labels = ["team/windows-kernel-integrations"]
 
 [teams."Database Monitoring"]
-jira_project = "DBM"
+jira_project = "DBMII"
 jira_issue_type = "Task"
 jira_statuses = [
   "Eventually",


### PR DESCRIPTION
### What does this PR do?
Update jira project ids to reflect company managed project conversion

### Motivation
Create jira tickets for 7.48.0-rc.4 QA

### Additional Notes
[Agent OKRs in jira tracking](https://docs.google.com/spreadsheets/d/1IMgAQvNe5A50idA5KkJNip-gnG3IfBTwMy3UcGTYc9w/edit#gid=1473884811)

**Status as of 2023-09-07:**
|Jira Project Name|Current PID|Newly Migrated C|Type|Status|Support Ticket|
|:----|:----|:----|:----|:----|:----|
|Agent Metrics Logs|AML|AMLII|Team-managed Project|In progress|SR-363141|
|Agent Shared Components|ASC|ASCII|Team-managed Project|Done|SR-360974|
|Agent Platform|AP|APL|Team-managed Project|In progress|SR-365451|
|Release Management|AGENTR|AGNTR|Team-managed Project|In progress|365419|
|Windows Agent|WA| |Team-managed Project|In progress| |
|Vector|VEC|VEK|Company-managed Project|In progress|NA|
|Container Apps|CAP board|CAP2|Team-managed Project|In progress|SR-361486|
|Container Integrations|CONT|CONTINT|Team-managed Project|In progress|SR-369479|
|Container Ecosystems|CONTECO| |Team-managed Project|Not started|SR-367675|
|Processes|PROC|PROCS|Team-managed Project|Not started|SR-366507|
|Agent Integrations|AI|NA|Company-managed Project|Done|SR-365001|
|Platform Integrations|PINT|PLINT|Team-managed Project|Done|SR-360169|
|Remote Configuration|RCM|RC|Team-managed Project|In progress|SR-365436|
|eBPF Platform|EBPF|NA|Company-managed Project|In progress|SR-369007|
|Network performance monitoring |NET|NPM|Team-managed Project|In progress|SR-361524|
|USM|USMO|USMON|Team-managed Project|Not started|SR-367851|
|Windows kernel integrations|WKIT| |Team-managed Project|Not started|SR-367814|
|NDM|NDM|NDMII|Team-managed Project|In progress|SR-368239|
|Serverless Agent|SLS|SVLS|Team-managed Project|Not started|SR-366500|
|Cloud Workload Security (CWS)|SEC|NA|Company-managed Project|Not started| |
|APM Core Go |AIT|NA|Company-managed Project|Not started| |
|APM Database Monitoring|DBM|DBMON|Team-managed Project|Not started| |
|APM OTEL|OTEL|NA|Company-managed Project|Not started| |
|Agent Integrations Tools |AITOOLS|AITS|Team-managed Project|In progress|SR-368242|
|Agent Guild|AGNTGLT|AGTGLT |Team-managed Project|In progress|SR-372319|
|End2End testing squad|AETT| |Team-managed Project|Not started| |

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
