### PR TITLE
Fixed cluster-agent broken buid caused by PR 19178 (#19293)

### DIFF
--- a/cmd/cluster-agent/subcommands/diagnose/command.go
+++ b/cmd/cluster-agent/subcommands/diagnose/command.go
@@ -9,8 +9,6 @@
 package diagnose
 
 import (
-	"regexp"
-
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -51,11 +49,10 @@ func run(log log.Component, config config.Component) error {
 	//                  diagnose suite as it was done in this agent for
 	//                  a while. Most likely need to relax or add more
 	//                  diagnose suites in the future
-	reAutoDiscovery, _ := regexp.Compile("connectivity-datadog-autodiscovery")
 	diagCfg := diagnosis.Config{
 		Verbose:  true, // show details
 		RunLocal: true, // do not attept to run in actual runnin agent (may need to implement it in future)
-		Include:  []*regexp.Regexp{reAutoDiscovery},
+		Include:  []string{"connectivity-datadog-autodiscovery"},
 	}
 	return diagnose.RunStdOut(color.Output, diagCfg)
 }

--- a/pkg/flare/diagnose.go
+++ b/pkg/flare/diagnose.go
@@ -14,9 +14,17 @@ import (
 
 // GetClusterAgentDiagnose dumps the connectivity checks diagnose to the writer
 func GetClusterAgentDiagnose(w io.Writer) error {
+	// Verbose:  true - to show details like if was done a while ago
+	// RunLocal: true - do not attept to run in actual running agent but
+	//                  may need to implement it in future
+	// Include: connectivity-datadog-autodiscovery - limit to a single
+	//                  diagnose suite as it was done in this agent for
+	//                  a while. Most likely need to relax or add more
+	//                  diagnose suites in the future
 	diagCfg := diagnosis.Config{
-		Verbose:  false,
-		RunLocal: false,
+		Verbose:  true,
+		RunLocal: true,
+		Include:  []string{"connectivity-datadog-autodiscovery"},
 	}
 	return diagnose.RunStdOut(w, diagCfg)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Fixed cluster-agent broken build caused by [Fix broken --include and --exclude options for non-local agent diagnose command #19178](https://github.com/DataDog/datadog-agent/pull/19178)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
* cluster-agent should be built
* cluster-agent flare command should succeed
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
