### PR TITLE
[CWS] ensure network context is scoped to DNS events

### DIFF
--- a/docs/cloud-workload-security/agent_expressions.md
+++ b/docs/cloud-workload-security/agent_expressions.md
@@ -173,15 +173,6 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`container.tags`](#container-tags-doc) | Tags of the container |
 | [`event.async`](#event-async-doc) | True if the syscall was asynchronous |
 | [`event.timestamp`](#event-timestamp-doc) | Timestamp of the event |
-| [`network.destination.ip`](#common-ipportcontext-ip-doc) | IP address |
-| [`network.destination.port`](#common-ipportcontext-port-doc) | Port number |
-| [`network.device.ifindex`](#network-device-ifindex-doc) | interface ifindex |
-| [`network.device.ifname`](#network-device-ifname-doc) | interface ifname |
-| [`network.l3_protocol`](#network-l3_protocol-doc) | l3 protocol of the network packet |
-| [`network.l4_protocol`](#network-l4_protocol-doc) | l4 protocol of the network packet |
-| [`network.size`](#network-size-doc) | size in bytes of the network packet |
-| [`network.source.ip`](#common-ipportcontext-ip-doc) | IP address |
-| [`network.source.port`](#common-ipportcontext-port-doc) | Port number |
 | [`process.ancestors.args`](#common-process-args-doc) | Arguments of the process (as a string, excluding argv0) |
 | [`process.ancestors.args_flags`](#common-process-args_flags-doc) | Flags in the process arguments |
 | [`process.ancestors.args_options`](#common-process-args_options-doc) | Argument of the process as options |
@@ -510,6 +501,15 @@ A DNS request was sent
 | [`dns.question.name`](#dns-question-name-doc) | the queried domain name |
 | [`dns.question.name.length`](#common-string-length-doc) | Length of the corresponding string |
 | [`dns.question.type`](#dns-question-type-doc) | a two octet code which specifies the DNS question type |
+| [`network.destination.ip`](#common-ipportcontext-ip-doc) | IP address |
+| [`network.destination.port`](#common-ipportcontext-port-doc) | Port number |
+| [`network.device.ifindex`](#network-device-ifindex-doc) | interface ifindex |
+| [`network.device.ifname`](#network-device-ifname-doc) | interface ifname |
+| [`network.l3_protocol`](#network-l3_protocol-doc) | l3 protocol of the network packet |
+| [`network.l4_protocol`](#network-l4_protocol-doc) | l4 protocol of the network packet |
+| [`network.size`](#network-size-doc) | size in bytes of the network packet |
+| [`network.source.ip`](#common-ipportcontext-ip-doc) | IP address |
+| [`network.source.port`](#common-ipportcontext-port-doc) | Port number |
 
 ### Event `exec`
 

--- a/docs/cloud-workload-security/secl.json
+++ b/docs/cloud-workload-security/secl.json
@@ -33,51 +33,6 @@
           "property_doc_link": "event-timestamp-doc"
         },
         {
-          "name": "network.destination.ip",
-          "definition": "IP address",
-          "property_doc_link": "common-ipportcontext-ip-doc"
-        },
-        {
-          "name": "network.destination.port",
-          "definition": "Port number",
-          "property_doc_link": "common-ipportcontext-port-doc"
-        },
-        {
-          "name": "network.device.ifindex",
-          "definition": "interface ifindex",
-          "property_doc_link": "network-device-ifindex-doc"
-        },
-        {
-          "name": "network.device.ifname",
-          "definition": "interface ifname",
-          "property_doc_link": "network-device-ifname-doc"
-        },
-        {
-          "name": "network.l3_protocol",
-          "definition": "l3 protocol of the network packet",
-          "property_doc_link": "network-l3_protocol-doc"
-        },
-        {
-          "name": "network.l4_protocol",
-          "definition": "l4 protocol of the network packet",
-          "property_doc_link": "network-l4_protocol-doc"
-        },
-        {
-          "name": "network.size",
-          "definition": "size in bytes of the network packet",
-          "property_doc_link": "network-size-doc"
-        },
-        {
-          "name": "network.source.ip",
-          "definition": "IP address",
-          "property_doc_link": "common-ipportcontext-ip-doc"
-        },
-        {
-          "name": "network.source.port",
-          "definition": "Port number",
-          "property_doc_link": "common-ipportcontext-port-doc"
-        },
-        {
           "name": "process.ancestors.args",
           "definition": "Arguments of the process (as a string, excluding argv0)",
           "property_doc_link": "common-process-args-doc"
@@ -1560,6 +1515,51 @@
           "name": "dns.question.type",
           "definition": "a two octet code which specifies the DNS question type",
           "property_doc_link": "dns-question-type-doc"
+        },
+        {
+          "name": "network.destination.ip",
+          "definition": "IP address",
+          "property_doc_link": "common-ipportcontext-ip-doc"
+        },
+        {
+          "name": "network.destination.port",
+          "definition": "Port number",
+          "property_doc_link": "common-ipportcontext-port-doc"
+        },
+        {
+          "name": "network.device.ifindex",
+          "definition": "interface ifindex",
+          "property_doc_link": "network-device-ifindex-doc"
+        },
+        {
+          "name": "network.device.ifname",
+          "definition": "interface ifname",
+          "property_doc_link": "network-device-ifname-doc"
+        },
+        {
+          "name": "network.l3_protocol",
+          "definition": "l3 protocol of the network packet",
+          "property_doc_link": "network-l3_protocol-doc"
+        },
+        {
+          "name": "network.l4_protocol",
+          "definition": "l4 protocol of the network packet",
+          "property_doc_link": "network-l4_protocol-doc"
+        },
+        {
+          "name": "network.size",
+          "definition": "size in bytes of the network packet",
+          "property_doc_link": "network-size-doc"
+        },
+        {
+          "name": "network.source.ip",
+          "definition": "IP address",
+          "property_doc_link": "common-ipportcontext-ip-doc"
+        },
+        {
+          "name": "network.source.port",
+          "definition": "Port number",
+          "property_doc_link": "common-ipportcontext-port-doc"
         }
       ]
     },

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -22198,23 +22198,23 @@ func (ev *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "mprotect.vm_protection":
 		return "mprotect", nil
 	case "network.destination.ip":
-		return "*", nil
+		return "dns", nil
 	case "network.destination.port":
-		return "*", nil
+		return "dns", nil
 	case "network.device.ifindex":
-		return "*", nil
+		return "dns", nil
 	case "network.device.ifname":
-		return "*", nil
+		return "dns", nil
 	case "network.l3_protocol":
-		return "*", nil
+		return "dns", nil
 	case "network.l4_protocol":
-		return "*", nil
+		return "dns", nil
 	case "network.size":
-		return "*", nil
+		return "dns", nil
 	case "network.source.ip":
-		return "*", nil
+		return "dns", nil
 	case "network.source.port":
-		return "*", nil
+		return "dns", nil
 	case "open.file.change_time":
 		return "open", nil
 	case "open.file.destination.mode":

--- a/pkg/security/secl/model/field_handlers_unix.go
+++ b/pkg/security/secl/model/field_handlers_unix.go
@@ -27,7 +27,6 @@ func (ev *Event) resolveFields(forADs bool) {
 	}
 	_ = ev.FieldHandlers.ResolveAsync(ev)
 	_ = ev.FieldHandlers.ResolveEventTimestamp(ev, &ev.BaseEvent)
-	_ = ev.FieldHandlers.ResolveNetworkDeviceIfName(ev, &ev.BaseEvent.NetworkContext.Device)
 	_ = ev.FieldHandlers.ResolveProcessArgs(ev, &ev.BaseEvent.ProcessContext.Process)
 	_ = ev.FieldHandlers.ResolveProcessArgsTruncated(ev, &ev.BaseEvent.ProcessContext.Process)
 	_ = ev.FieldHandlers.ResolveProcessArgv(ev, &ev.BaseEvent.ProcessContext.Process)
@@ -222,6 +221,7 @@ func (ev *Event) resolveFields(forADs bool) {
 		_ = ev.FieldHandlers.ResolveChownUID(ev, &ev.Chown)
 		_ = ev.FieldHandlers.ResolveChownGID(ev, &ev.Chown)
 	case "dns":
+		_ = ev.FieldHandlers.ResolveNetworkDeviceIfName(ev, &ev.BaseEvent.NetworkContext.Device)
 	case "exec":
 		if ev.Exec.Process.IsNotKworker() {
 			_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.Exec.Process.FileEvent.FileFields)

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -169,7 +169,7 @@ type BaseEvent struct {
 	SpanContext            SpanContext            `field:"-" json:"-"`
 	ProcessContext         *ProcessContext        `field:"process" event:"*"`
 	ContainerContext       *ContainerContext      `field:"container" event:"*"`
-	NetworkContext         NetworkContext         `field:"network" event:"*"`
+	NetworkContext         NetworkContext         `field:"network" event:"dns"`
 	SecurityProfileContext SecurityProfileContext `field:"-"`
 
 	// internal usage


### PR DESCRIPTION
### What does this PR do?

Network context is NOT available in all events, which makes the current documentation VERY confusing. This PR fixes this by tagging network context as only scoped to DNS events (it should be scoped to all network events, but it's only DNS for now).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
