### PR TITLE
Fix `agent.hacky_dev_image_build` invoke task

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -110,6 +110,7 @@ def build(
     exclude_rtloader=False,
     go_mod="mod",
     windows_sysprobe=False,
+    cmake_options='',
 ):
     """
     Build the agent. If the bits to include in the build are not specified,
@@ -123,7 +124,7 @@ def build(
     if not exclude_rtloader and not flavor.is_iot():
         # If embedded_path is set, we should give it to rtloader as it should install the headers/libs
         # in the embedded path folder because that's what is used in get_build_flags()
-        rtloader_make(ctx, python_runtimes=python_runtimes, install_prefix=embedded_path)
+        rtloader_make(ctx, python_runtimes=python_runtimes, install_prefix=embedded_path, cmake_options=cmake_options)
         rtloader_install(ctx)
 
     ldflags, gcflags, env = get_build_flags(
@@ -346,13 +347,6 @@ def hacky_dev_image_build(
     push=False,
     signed_pull=False,
 ):
-    os.environ["DELVE"] = "1"
-    build(ctx)
-    if process_agent:
-        process_agent_build(ctx)
-    if trace_agent:
-        trace_agent_build(ctx)
-
     if base_image is None:
         import requests
         import semver
@@ -369,6 +363,28 @@ def hacky_dev_image_build(
             if ver > latest_release:
                 latest_release = ver
         base_image = f"gcr.io/datadoghq/agent:{latest_release}"
+
+    # Extract the python library of the docker image
+    with tempfile.TemporaryDirectory() as extracted_python_dir:
+        ctx.run(
+            f"docker run --rm '{base_image}' bash -c 'tar --create /opt/datadog-agent/embedded/{{bin,lib,include}}/*python*' | tar --directory '{extracted_python_dir}' --extract"
+        )
+
+        os.environ["DELVE"] = "1"
+        os.environ["LD_LIBRARY_PATH"] = (
+            os.environ.get("LD_LIBRARY_PATH", "") + f":{extracted_python_dir}/opt/datadog-agent/embedded/lib"
+        )
+        build(
+            ctx,
+            cmake_options=f'-DPython3_ROOT_DIR={extracted_python_dir}/opt/datadog-agent/embedded -DPython3_FIND_STRATEGY=LOCATION',
+        )
+        ctx.run(
+            f'perl -0777 -pe \'s|{extracted_python_dir}(/opt/datadog-agent/embedded/lib/python\\d+\\.\\d+/../..)|substr $1."\\0"x length$&,0,length$&|e or die "pattern not found"\' -i dev/lib/libdatadog-agent-three.so'
+        )
+        if process_agent:
+            process_agent_build(ctx)
+        if trace_agent:
+            trace_agent_build(ctx)
 
     copy_extra_agents = ""
     if process_agent:
@@ -391,9 +407,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y patchelf
 
-COPY bin/agent/agent /opt/datadog-agent/bin/agent/agent
+COPY bin/agent/agent                            /opt/datadog-agent/bin/agent/agent
+COPY dev/lib/libdatadog-agent-rtloader.so.0.1.0 /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.0.1.0
+COPY dev/lib/libdatadog-agent-three.so          /opt/datadog-agent/embedded/lib/libdatadog-agent-three.so
 
 RUN patchelf --set-rpath /opt/datadog-agent/embedded/lib /opt/datadog-agent/bin/agent/agent
+RUN patchelf --set-rpath /opt/datadog-agent/embedded/lib /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.0.1.0
+RUN patchelf --set-rpath /opt/datadog-agent/embedded/lib /opt/datadog-agent/embedded/lib/libdatadog-agent-three.so
 
 FROM golang:latest AS dlv
 
@@ -407,11 +427,13 @@ RUN apt-get update && \
     apt-get clean
 
 ENV DELVE_PAGER=less
+#ENV PYTHONPATH=/opt/datadog-agent/embedded/lib/python3.9
 
 COPY --from=dlv /go/bin/dlv /usr/local/bin/dlv
 COPY --from=src /usr/src/datadog-agent {os.getcwd()}
-COPY --from=bin /opt/datadog-agent/bin/agent/agent /opt/datadog-agent/bin/agent/agent
-COPY dev/lib/libdatadog-agent-* /opt/datadog-agent/embedded/lib/
+COPY --from=bin /opt/datadog-agent/bin/agent/agent                                 /opt/datadog-agent/bin/agent/agent
+COPY --from=bin /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.0.1.0 /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.0.1.0
+COPY --from=bin /opt/datadog-agent/embedded/lib/libdatadog-agent-three.so          /opt/datadog-agent/embedded/lib/libdatadog-agent-three.so
 {copy_extra_agents}
 RUN agent completion bash > /usr/share/bash-completion/completions/agent
 


### PR DESCRIPTION
### What does this PR do?

The goal of the `agent.hacky-dev-image-build` invoke task is to rebuild the agent from the local git working directory and to ship it in a docker image ready to be tested without having to wait 3 hours for the CI to complete all the steps required to build the docker image the “clean” way.

It achieves that goal that by:
* re-compiling (only) the `agent` binary;
* patching an already existing agent docker image (by default the latest official released one) by overriding the `agent` binary.

The issue is that the `agent` binary depends on the `libdatadog-agent-rtloader.so` the ABI of which isn’t stable.
So, we need to rebuild the exact same version of this library as the version of the agent and to override it in the final docker image.
The `libdatadog-agent-three.so` also depends on `libdatadog-agent-rtloader.so`, so it also needs to be re-built and copied in the final docker image.

The current issue is that the resulting `libdatadog-agent-three.so` depends on the version of the `libpython` that is present in the build environment, which may not be the same version as the one present in the docker image.

As a consequence, when an agent built with `agent.hacky-dev-image-build` starts, it fails to load `libdatadog-agent-three.so` because the `libpython…` dependency cannot be resolved inside the docker image.

The visible symptom is:
```
$ agent status

[…]
=========
Collector
=========
  Error initializing Python
  =========================
    - could not load runtime python for version 3: Unable to open three library: libdatadog-agent-three.so: cannot open shared object file: No such file or directory
[…]
```

In the logs:
```
2023-09-07 15:33:02 UTC | CORE | ERROR | (/home/lenaic/doc/devel/DataDog/datadog-agent.main/pkg/collector/embed_python.go:18 in pySetup) | Could not initialize Python: could not load runtime python for version 3: Unable to open three library: libdatadog-agent-three.so: cannot open shared object file: No such file or directory
```

In order to address this issue, this PR is extracting the Python found inside the docker image and forces the `rtloader` build to use that one instead of the system one thanks to the [`Python3_ROOT_DIR` CMake parameter](https://cmake.org/cmake/help/latest/module/FindPython.html#hints).

### Motivation

Fix python checks with image built with `inv agent.hacky_dev_image_build`.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Create an agent docker image with `inv agent.hacky_dev_image_build` and validate that the agent in the resulting docker image can execute the python checks.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
