### PR TITLE
trace: Enable DB statement obfuscation in span tags by default

### DIFF
--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -355,6 +355,14 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 		}
 	}
 	{
+		// Obfuscation of database statements will be ON by default. Any new obfuscators should likely be
+		// enabled by default as well. This can be explicitly disabled with the agent config. Any changes
+		// to obfuscation options or defaults must be reflected in the public docs.
+		c.Obfuscation.ES.Enabled = true
+		c.Obfuscation.Mongo.Enabled = true
+		c.Obfuscation.Memcached.Enabled = true
+		c.Obfuscation.Redis.Enabled = true
+
 		// TODO(x): There is an issue with coreconfig.Datadog.IsSet("apm_config.obfuscation"), probably coming from Viper,
 		// where it returns false even is "apm_config.obfuscation.credit_cards.enabled" is set via an environment
 		// variable, so we need a temporary workaround by specifically setting env. var. accessible fields.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1306,7 +1306,7 @@ api_key:
   #
   #     elasticsearch:
   ##        @param DD_APM_OBFUSCATION_ELASTICSEARCH_ENABLED - boolean - optional
-  ##        Enables obfuscation rules for spans of type "elasticsearch". Disabled by default.
+  ##        Enables obfuscation rules for spans of type "elasticsearch". Enabled by default.
   #         enabled: false
   ##        @param DD_APM_OBFUSCATION_ELASTICSEARCH_KEEP_VALUES - object - optional
   ##        List of keys that should not be obfuscated.
@@ -1327,12 +1327,12 @@ api_key:
   #
   #     memcached:
   ##        @param DD_APM_OBFUSCATION_MEMCACHED_ENABLED - boolean - optional
-  ##        Enables obfuscation rules for spans of type "memcached". Disabled by default.
+  ##        Enables obfuscation rules for spans of type "memcached". Enabled by default.
   #         enabled: false
   #
   #     mongodb:
   ##        @param DD_APM_OBFUSCATION_MONGODB_ENABLED - boolean - optional
-  ##        Enables obfuscation rules for spans of type "mongodb". Disabled by default.
+  ##        Enables obfuscation rules for spans of type "mongodb". Enabled by default.
   #         enabled: false
   ##        @param DD_APM_OBFUSCATION_MONGODB_KEEP_VALUES - object - optional
   ##        List of keys that should not be obfuscated.
@@ -1345,7 +1345,7 @@ api_key:
   #
   #     redis:
   ##        @param DD_APM_OBFUSCATION_REDIS_ENABLED - boolean - optional
-  ##        Enables obfuscation rules for spans of type "redis". Disabled by default.
+  ##        Enables obfuscation rules for spans of type "redis". Enabled by default.
   #         enabled: false
   ##        @param DD_APM_OBFUSCATION_REDIS_REMOVE_ALL_ARGS - boolean - optional
   ##        When true, replaces all arguments of a redis command with a single "?". Disabled by default.

--- a/releasenotes/notes/apm-obfuscation-on-by-default-1ccc2e32cdd10ea4.yaml
+++ b/releasenotes/notes/apm-obfuscation-on-by-default-1ccc2e32cdd10ea4.yaml
@@ -1,0 +1,21 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+security:
+  - |
+    APM: In order to improve the default customer experience regarding
+    sensitive data, the Agent now obfuscates database statements within
+    span metadata by default. This includes MongoDB queries,
+    ElasticSearch request bodies, and raw commands from Redis and
+    MemCached. Previously, this setting was off by default.
+    This update could have performance implications, or obfuscate data that
+    is not sensitive, and can be disabled or configured through the
+    `obfuscation` options within the `apm_config`, or with the
+    environment variables prefixed with `DD_APM_OBFUSCATION`. Please read the
+    [Data Security documentation for full details](https://docs.datadoghq.com/tracing/configure_data_security/#trace-obfuscation).
+


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Cherry-pick of https://github.com/DataDog/datadog-agent/pull/19321

Enable DB statement obfuscation for span tags by default which was previously off by default.
This affects MongoDB queries, ElasticSearch request bodies, and raw commands from Redis and MemCached

This change does not affect resource name obfuscation, as that has been and still is on by default.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Improve the default customer experience regarding sensitive data.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

This change could cause a significant increase in CPU or memory usage, or could obfuscate
data that is not sensitive which someone wishes to keep un-obfuscated.
To mitigate this, obfuscation rules can still be fine-tuned or disabled with the Agent config.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Create an instrumented query from one of the frameworks listed above which includes sensitive data,
and verify that this data is obfuscated by the default Agent config.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
