### PR TITLE
Add support for custom contexts to profiling, include system-probe module name

### DIFF
--- a/cmd/system-probe/api/module/common.go
+++ b/cmd/system-probe/api/module/common.go
@@ -28,6 +28,6 @@ type Factory struct {
 type Module interface {
 	GetStats() map[string]interface{}
 	Register(*Router) error
-	RegisterGRPC(*grpc.Server) error
+	RegisterGRPC(grpc.ServiceRegistrar) error
 	Close()
 }

--- a/cmd/system-probe/api/server.go
+++ b/cmd/system-probe/api/server.go
@@ -82,7 +82,7 @@ func StartServer(cfg *config.Config, telemetry telemetry.Component) error {
 
 	go func() {
 		err = srv.Serve(conn.GetListener())
-		if errors.Is(err, http.ErrServerClosed) {
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Errorf("error creating HTTP server: %s", err)
 		}
 	}()

--- a/cmd/system-probe/api/server.go
+++ b/cmd/system-probe/api/server.go
@@ -6,12 +6,17 @@
 package api
 
 import (
+	"context"
+	"errors"
 	"expvar"
 	"fmt"
 	"net/http"
+	"runtime/pprof"
+	"strings"
 
 	gorilla "github.com/gorilla/mux"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/stats"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
@@ -37,7 +42,11 @@ func StartServer(cfg *config.Config, telemetry telemetry.Component) error {
 
 	mux := gorilla.NewRouter()
 	if cfg.GRPCServerEnabled {
-		grpcServer = grpc.NewServer(grpc.MaxRecvMsgSize(maxGRPCServerMessage), grpc.MaxSendMsgSize(maxGRPCServerMessage))
+		grpcServer = grpc.NewServer(
+			grpc.MaxRecvMsgSize(maxGRPCServerMessage),
+			grpc.MaxSendMsgSize(maxGRPCServerMessage),
+			grpc.StatsHandler(&pprofGRPCStatsHandler{}),
+		)
 	}
 
 	err = module.Register(cfg, mux, grpcServer, modules.All)
@@ -47,8 +56,7 @@ func StartServer(cfg *config.Config, telemetry telemetry.Component) error {
 
 	// Register stats endpoint
 	mux.HandleFunc("/debug/stats", utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, func(w http.ResponseWriter, req *http.Request) {
-		stats := module.GetStats()
-		utils.WriteAsJSON(w, stats)
+		utils.WriteAsJSON(w, module.GetStats())
 	}))
 
 	setupConfigHandlers(mux)
@@ -74,7 +82,7 @@ func StartServer(cfg *config.Config, telemetry telemetry.Component) error {
 
 	go func() {
 		err = srv.Serve(conn.GetListener())
-		if err != nil && err != http.ErrServerClosed {
+		if errors.Is(err, http.ErrServerClosed) {
 			log.Errorf("error creating HTTP server: %s", err)
 		}
 	}()
@@ -86,4 +94,29 @@ func init() {
 	expvar.Publish("modules", expvar.Func(func() interface{} {
 		return module.GetStats()
 	}))
+}
+
+type pprofGRPCStatsHandler struct{}
+
+func (p *pprofGRPCStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
+	parts := strings.Split(info.FullMethodName, "/")
+	if len(parts) >= 1 {
+		moduleName := module.NameFromGRPCServiceName(parts[0])
+		if moduleName != "" {
+			return pprof.WithLabels(ctx, pprof.Labels("module", moduleName))
+		}
+	}
+	return ctx
+}
+
+func (p *pprofGRPCStatsHandler) HandleRPC(_ context.Context, _ stats.RPCStats) {
+	// intentionally empty
+}
+
+func (p *pprofGRPCStatsHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+func (p *pprofGRPCStatsHandler) HandleConn(_ context.Context, _ stats.ConnStats) {
+	// intentionally empty
 }

--- a/cmd/system-probe/modules/ebpf.go
+++ b/cmd/system-probe/modules/ebpf.go
@@ -64,6 +64,6 @@ func (o *ebpfModule) GetStats() map[string]interface{} {
 }
 
 // RegisterGRPC register to system probe gRPC server
-func (o *ebpfModule) RegisterGRPC(_ *grpc.Server) error {
+func (o *ebpfModule) RegisterGRPC(_ grpc.ServiceRegistrar) error {
 	return nil
 }

--- a/cmd/system-probe/modules/language_detection.go
+++ b/cmd/system-probe/modules/language_detection.go
@@ -47,7 +47,7 @@ func (l *languageDetectionModule) Register(router *module.Router) error {
 }
 
 // RegisterGRPC register to system probe gRPC server
-func (l *languageDetectionModule) RegisterGRPC(_ *grpc.Server) error {
+func (l *languageDetectionModule) RegisterGRPC(_ grpc.ServiceRegistrar) error {
 	return nil
 }
 

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -87,7 +87,7 @@ func (nt *networkTracer) GetStats() map[string]interface{} {
 }
 
 // RegisterGRPC register system probe grpc server
-func (nt *networkTracer) RegisterGRPC(_ *grpc.Server) error {
+func (nt *networkTracer) RegisterGRPC(_ grpc.ServiceRegistrar) error {
 	return nil
 }
 

--- a/cmd/system-probe/modules/oom_kill_probe.go
+++ b/cmd/system-probe/modules/oom_kill_probe.go
@@ -58,7 +58,7 @@ func (o *oomKillModule) Register(httpMux *module.Router) error {
 }
 
 // RegisterGRPC register to system probe gRPC server
-func (o *oomKillModule) RegisterGRPC(_ *grpc.Server) error {
+func (o *oomKillModule) RegisterGRPC(_ grpc.ServiceRegistrar) error {
 	return nil
 }
 

--- a/cmd/system-probe/modules/process.go
+++ b/cmd/system-probe/modules/process.go
@@ -91,7 +91,7 @@ func (t *process) Register(httpMux *module.Router) error {
 }
 
 // RegisterGRPC register to system probe gRPC server
-func (t *process) RegisterGRPC(_ *grpc.Server) error {
+func (t *process) RegisterGRPC(_ grpc.ServiceRegistrar) error {
 	return nil
 }
 

--- a/cmd/system-probe/modules/tcp_queue_tracer.go
+++ b/cmd/system-probe/modules/tcp_queue_tracer.go
@@ -57,7 +57,7 @@ func (t *tcpQueueLengthModule) Register(httpMux *module.Router) error {
 }
 
 // RegisterGRPC register to system probe gRPC server
-func (t *tcpQueueLengthModule) RegisterGRPC(_ *grpc.Server) error {
+func (t *tcpQueueLengthModule) RegisterGRPC(_ grpc.ServiceRegistrar) error {
 	return nil
 }
 

--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -111,6 +111,7 @@ func (l *ProfilingRuntimeSetting) Set(v interface{}, source Source) error {
 			WithGoroutineProfile: cfg.GetBool(l.ConfigPrefix + "internal_profiling.enable_goroutine_stacktraces"),
 			WithDeltaProfiles:    cfg.GetBool(l.ConfigPrefix + "internal_profiling.delta_profiles"),
 			Tags:                 tags,
+			CustomAttributes:     cfg.GetStringSlice(l.ConfigPrefix + "internal_profiling.custom_attributes"),
 		}
 		err := profiling.Start(settings)
 		if err == nil {

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -122,6 +122,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.block_profile_rate"), 0)
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.enable_goroutine_stacktraces"), false)
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.delta_profiles"), true)
+	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.custom_attributes"), []string{"module"})
 
 	cfg.BindEnvAndSetDefault(join(spNS, "memory_controller.enabled"), false)
 	cfg.BindEnvAndSetDefault(join(spNS, "memory_controller.hierarchy"), "v1")

--- a/pkg/dynamicinstrumentation/module_linux.go
+++ b/pkg/dynamicinstrumentation/module_linux.go
@@ -23,7 +23,7 @@ func (m *Module) Close() {
 }
 
 // RegisterGRPC register to system probe gRPC server
-func (m *Module) RegisterGRPC(_ *grpc.Server) error {
+func (m *Module) RegisterGRPC(_ grpc.ServiceRegistrar) error {
 	return nil
 }
 

--- a/pkg/eventmonitor/eventmonitor.go
+++ b/pkg/eventmonitor/eventmonitor.go
@@ -92,7 +92,7 @@ func (m *EventMonitor) Register(_ *module.Router) error {
 }
 
 // RegisterGRPC register to system probe gRPC server
-func (m *EventMonitor) RegisterGRPC(_ *grpc.Server) error {
+func (m *EventMonitor) RegisterGRPC(_ grpc.ServiceRegistrar) error {
 	return nil
 }
 

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -67,6 +67,14 @@ func Start(settings Settings) error {
 		options = append(options, profiler.BlockProfileRate(settings.BlockProfileRate))
 	}
 
+	if len(settings.CustomAttributes) > 0 {
+		customContextTags := make([]string, len(settings.CustomAttributes))
+		for _, customAttribute := range settings.CustomAttributes {
+			customContextTags = append(customContextTags, "ddprof.custom_ctx:"+customAttribute)
+		}
+		options = append(options, profiler.WithTags(customContextTags...))
+	}
+
 	err := profiler.Start(options...)
 
 	if err == nil {

--- a/pkg/util/profiling/settings.go
+++ b/pkg/util/profiling/settings.go
@@ -40,6 +40,8 @@ type Settings struct {
 	WithDeltaProfiles bool
 	// Tags are the additional tags to attach to profiles.
 	Tags []string
+	// CustomAttributes names of goroutine labels to use as custom attributes in Datadog Profiling UI
+	CustomAttributes []string
 }
 
 func (settings *Settings) String() string {
@@ -64,5 +66,8 @@ func (settings *Settings) applyDefaults() {
 
 	if settings.Tags == nil {
 		settings.Tags = []string{}
+	}
+	if settings.CustomAttributes == nil {
+		settings.CustomAttributes = []string{}
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

- Adds support to the agent profiler for profiler custom contexts.
- Adds `module` for system-probe as a pprof label, including HTTP and gRPC requests that hit modules.

### Motivation

Better module attribution for CPU usage metrics.

### Additional Notes

Constrains system-probe gRPC service names to follow a `datadog.agent.systemprobe.ModuleName` pattern. The PascalCase service name will be converted to snake case before matching, so `NetworkTracer` will match `network_tracer`.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
