### PR TITLE
feat: add CONTAINER_APP_REPLICA_NAME in spans #18136

### DIFF
--- a/cmd/serverless-init/cloudservice/containerapp.go
+++ b/cmd/serverless-init/cloudservice/containerapp.go
@@ -19,9 +19,10 @@ type ContainerApp struct {
 }
 
 const (
-	ContainerAppNameEnvVar = "CONTAINER_APP_NAME"
-	ContainerAppDNSSuffix  = "CONTAINER_APP_ENV_DNS_SUFFIX"
-	ContainerAppRevision   = "CONTAINER_APP_REVISION"
+	ContainerAppNameEnvVar        = "CONTAINER_APP_NAME"
+	ContainerAppReplicaNameEnvVar = "CONTAINER_APP_REPLICA_NAME"
+	ContainerAppDNSSuffix         = "CONTAINER_APP_ENV_DNS_SUFFIX"
+	ContainerAppRevision          = "CONTAINER_APP_REVISION"
 
 	AzureSubscriptionIdEnvVar = "DD_AZURE_SUBSCRIPTION_ID"
 	AzureResourceGroupEnvVar  = "DD_AZURE_RESOURCE_GROUP"
@@ -30,6 +31,7 @@ const (
 // GetTags returns a map of Azure-related tags
 func (c *ContainerApp) GetTags() map[string]string {
 	appName := os.Getenv(ContainerAppNameEnvVar)
+	replicaName := os.Getenv(ContainerAppReplicaNameEnvVar)
 	appDNSSuffix := os.Getenv(ContainerAppDNSSuffix)
 
 	appDNSSuffixTokens := strings.Split(appDNSSuffix, ".")
@@ -38,11 +40,12 @@ func (c *ContainerApp) GetTags() map[string]string {
 	revision := os.Getenv(ContainerAppRevision)
 
 	tags := map[string]string{
-		"app_name":   appName,
-		"region":     region,
-		"revision":   revision,
-		"origin":     c.GetOrigin(),
-		"_dd.origin": c.GetOrigin(),
+		"app_name":     appName,
+		"replica_name": replicaName,
+		"region":       region,
+		"revision":     revision,
+		"origin":       c.GetOrigin(),
+		"_dd.origin":   c.GetOrigin(),
 	}
 
 	if c.SubscriptionId != "" {

--- a/cmd/serverless-init/cloudservice/containerapp_test.go
+++ b/cmd/serverless-init/cloudservice/containerapp_test.go
@@ -17,6 +17,7 @@ func TestGetContainerAppTags(t *testing.T) {
 	service := &ContainerApp{}
 
 	t.Setenv("CONTAINER_APP_NAME", "test_app_name")
+	t.Setenv("CONTAINER_APP_REPLICA_NAME", "test_app_name--klc9ksi-dd757dc46-zwqk8")
 	t.Setenv("CONTAINER_APP_ENV_DNS_SUFFIX", "test.bluebeach.eastus.azurecontainerapps.io")
 	t.Setenv("CONTAINER_APP_REVISION", "test_revision")
 
@@ -26,11 +27,12 @@ func TestGetContainerAppTags(t *testing.T) {
 	tags := service.GetTags()
 
 	assert.Equal(t, map[string]string{
-		"app_name":   "test_app_name",
-		"origin":     "containerapp",
-		"region":     "eastus",
-		"revision":   "test_revision",
-		"_dd.origin": "containerapp",
+		"app_name":     "test_app_name",
+		"replica_name": "test_app_name--klc9ksi-dd757dc46-zwqk8",
+		"origin":       "containerapp",
+		"region":       "eastus",
+		"revision":     "test_revision",
+		"_dd.origin":   "containerapp",
 	}, tags)
 }
 
@@ -38,6 +40,7 @@ func TestGetContainerAppTagsWithOptionalEnvVars(t *testing.T) {
 	service := NewContainerApp()
 
 	t.Setenv("CONTAINER_APP_NAME", "test_app_name")
+	t.Setenv("CONTAINER_APP_REPLICA_NAME", "test_app_name--klc9ksi-dd757dc46-zwqk8")
 	t.Setenv("CONTAINER_APP_ENV_DNS_SUFFIX", "test.bluebeach.eastus.azurecontainerapps.io")
 	t.Setenv("CONTAINER_APP_REVISION", "test_revision")
 
@@ -51,6 +54,7 @@ func TestGetContainerAppTagsWithOptionalEnvVars(t *testing.T) {
 
 	assert.Equal(t, map[string]string{
 		"app_name":        "test_app_name",
+		"replica_name":    "test_app_name--klc9ksi-dd757dc46-zwqk8",
 		"origin":          "containerapp",
 		"region":          "eastus",
 		"revision":        "test_revision",
@@ -67,6 +71,7 @@ func TestInitHasErrorsWhenMissingSubscriptionId(t *testing.T) {
 	service := NewContainerApp()
 	if os.Getenv("SERVERLESS_TEST") == "true" {
 		t.Setenv("CONTAINER_APP_NAME", "test_app_name")
+		t.Setenv("CONTAINER_APP_REPLICA_NAME", "test_app_name--klc9ksi-dd757dc46-zwqk8")
 		t.Setenv("CONTAINER_APP_ENV_DNS_SUFFIX", "test.bluebeach.eastus.azurecontainerapps.io")
 		t.Setenv("CONTAINER_APP_REVISION", "test_revision")
 
@@ -91,6 +96,7 @@ func TestInitHasErrorsWhenMissingResourceGroup(t *testing.T) {
 	service := NewContainerApp()
 	if os.Getenv("SERVERLESS_TEST") == "true" {
 		t.Setenv("CONTAINER_APP_NAME", "test_app_name")
+		t.Setenv("CONTAINER_APP_REPLICA_NAME", "test_app_name--klc9ksi-dd757dc46-zwqk8")
 		t.Setenv("CONTAINER_APP_ENV_DNS_SUFFIX", "test.bluebeach.eastus.azurecontainerapps.io")
 		t.Setenv("CONTAINER_APP_REVISION", "test_revision")
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

* Add `CONTAINER_APP_REPLICA_NAME` env variable to spans for Azure

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

* This information is useful to find which container has an issue or is impacted
* [Issue 18136](https://github.com/DataDog/datadog-agent/issues/18136)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
