### PR TITLE
Avoid heap inflation from packet pool

### DIFF
--- a/comp/dogstatsd/packets/pool.go
+++ b/comp/dogstatsd/packets/pool.go
@@ -25,6 +25,8 @@ type Pool struct {
 	pool sync.Pool
 	// telemetry
 	tlmEnabled bool
+	// packet size for this buffer
+	bufferSize int
 }
 
 // NewPool creates a new pool with a specified buffer size
@@ -42,6 +44,7 @@ func NewPool(bufferSize int) *Pool {
 		},
 		// telemetry
 		tlmEnabled: utils.IsTelemetryEnabled(),
+		bufferSize: bufferSize,
 	}
 }
 
@@ -68,6 +71,11 @@ func (p *Pool) Put(x interface{}) {
 	if p.tlmEnabled {
 		tlmPoolPut.Inc()
 		tlmPool.Dec()
+	}
+	if len(packet.Buffer) > p.bufferSize {
+		tlmPoolDrops.Inc()
+		// free packet if the buffer has been increased
+		return
 	}
 	p.pool.Put(packet)
 }

--- a/comp/dogstatsd/packets/telemetry.go
+++ b/comp/dogstatsd/packets/telemetry.go
@@ -28,6 +28,8 @@ var (
 		nil, "Count of get done in the packet pool")
 	tlmPoolPut = telemetry.NewCounter("dogstatsd", "packet_pool_put",
 		nil, "Count of put done in the packet pool")
+	tlmPoolDrops = telemetry.NewCounter("dogstatsd", "packet_pool_drop",
+		nil, "Count of packets dropped in the packet pool")
 	tlmPool = telemetry.NewGauge("dogstatsd", "packet_pool",
 		nil, "Usage of the packet pool in dogstatsd")
 )

--- a/comp/dogstatsd/server/parse.go
+++ b/comp/dogstatsd/server/parse.go
@@ -239,7 +239,10 @@ func (p *parser) parseFloat64List(rawFloats []byte) ([]float64, error) {
 
 // extractContainerID parses the value of the container ID field.
 func (p *parser) extractContainerID(rawContainerIDField []byte) []byte {
-	return rawContainerIDField[len(containerIDFieldPrefix):]
+	containerIdRef := rawContainerIDField[len(containerIDFieldPrefix):]
+	containerId := make([]byte, len(containerIdRef))
+	copy(containerId, containerIdRef)
+	return containerId
 }
 
 // the std API does not have methods to do []byte => float parsing

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -630,9 +630,6 @@ func (s *server) parsePackets(batcher *batcher, parser *parser, packets []*packe
 				}
 			}
 		}
-		packet.Buffer = nil
-		packet.Contents = nil
-		packet.Origin = ""
 		s.sharedPacketPoolManager.Put(packet)
 	}
 	batcher.flush()

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -630,6 +630,9 @@ func (s *server) parsePackets(batcher *batcher, parser *parser, packets []*packe
 				}
 			}
 		}
+		packet.Buffer = nil
+		packet.Contents = nil
+		packet.Origin = ""
 		s.sharedPacketPoolManager.Put(packet)
 	}
 	batcher.flush()

--- a/comp/dogstatsd/server/server_worker.go
+++ b/comp/dogstatsd/server/server_worker.go
@@ -56,6 +56,9 @@ func (w *worker) run() {
 		case <-w.server.serverlessFlushChan:
 			w.batcher.flush()
 		case packets := <-w.server.packetsIn:
+			for k := range w.samples {
+				w.samples[k] = metrics.MetricSample{}
+			}
 			w.samples = w.samples[0:0]
 			// we return the samples in case the slice was extended
 			// when parsing the packets


### PR DESCRIPTION
Looking at the UDS packet pool [here](https://app.datadoghq.com/profiling/search?query=env%3Asingle-machine-performance%20service%3Adatadog-agent%20version%3A%2A00c7869%2A%20experiment%3Auds_dogstatsd_to_api%20&group_by=line&my_code=disabled&op_filter=ignore_from%28function%3A%22%28%2AtimeSamplerWorker%29.run%20%28time_sampler_worker.go%29%22%29%20ignore_from%28function%3A%22%28%2AsparseStore%29.Cols%20%28store.go%29%22%29&profile_type=heap-live-size&viz=flame_graph&start=1694106254519&end=1694122664303&paused=true).

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
