### PR TITLE
[CWS][SEC-10593] Add siblings rebase test case and fix non-"isExecChild" node stuttering

### DIFF
--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -46,8 +46,6 @@ var (
 var (
 	// ErrBrokenLineage is returned when the given process don't have a full lineage
 	ErrBrokenLineage = errors.New("broken lineage")
-	// ErrContainerIDNotEqual is returnet when the given process don't have the same container ID as the tree
-	ErrContainerIDNotEqual = errors.New("ContainerIDs are different")
 	// ErrNotValidRootNode is returned when trying to insert a process with an invalide root node
 	ErrNotValidRootNode = errors.New("root node not valid")
 )
@@ -102,6 +100,11 @@ func (cs *cookieSelector) isSet() bool {
 	return cs.execTime != 0 && cs.cookie != 0
 }
 
+func (cs *cookieSelector) fillFromEntry(entry *model.ProcessCacheEntry) {
+	cs.execTime = entry.ExecTime.UnixNano()
+	cs.cookie = entry.Cookie
+}
+
 // ActivityTree contains a process tree and its activities. This structure has no locks.
 type ActivityTree struct {
 	Stats *Stats
@@ -137,6 +140,27 @@ func NewActivityTree(validator Owner, pathsReducer *PathsReducer, treeType strin
 		SyscallsMask:        make(map[int]int),
 		DNSNames:            utils.NewStringKeys(nil),
 	}
+}
+
+// GetChildren returns the list of root ProcessNodes from the ActivityTree
+func (at *ActivityTree) GetChildren() *[]*ProcessNode {
+	return &at.ProcessNodes
+}
+
+// GetSiblings returns the list of siblings of the current node
+func (at *ActivityTree) GetSiblings() *[]*ProcessNode {
+	return nil
+}
+
+// AppendChild appends a new root node in the ActivityTree
+func (at *ActivityTree) AppendChild(node *ProcessNode) {
+	at.ProcessNodes = append(at.ProcessNodes, node)
+	node.Parent = at
+}
+
+// GetParent returns nil for the ActivityTree
+func (at *ActivityTree) GetParent() ProcessNodeParent {
+	return nil
 }
 
 // ComputeSyscallsList computes the top level list of syscalls
@@ -243,7 +267,7 @@ func (at *ActivityTree) isEventValid(event *model.Event, dryRun bool) (bool, err
 
 // Insert inserts the event in the activity tree
 func (at *ActivityTree) Insert(event *model.Event, generationType NodeGenerationType, resolvers *resolvers.Resolvers) (bool, error) {
-	newEntry, err := at.insert(event, false, generationType, resolvers)
+	newEntry, err := at.insertEvent(event, false, generationType, resolvers)
 	if newEntry {
 		// this doesn't count the exec events which are counted separately
 		at.Stats.addedCount[event.GetEventType()][generationType].Inc()
@@ -253,12 +277,12 @@ func (at *ActivityTree) Insert(event *model.Event, generationType NodeGeneration
 
 // Contains looks up the event in the activity tree
 func (at *ActivityTree) Contains(event *model.Event, generationType NodeGenerationType, resolvers *resolvers.Resolvers) (bool, error) {
-	newEntry, err := at.insert(event, true, generationType, resolvers)
+	newEntry, err := at.insertEvent(event, true, generationType, resolvers)
 	return !newEntry, err
 }
 
 // insert inserts the event in the activity tree, returns true if the event generated a new entry in the tree
-func (at *ActivityTree) insert(event *model.Event, dryRun bool, generationType NodeGenerationType, resolvers *resolvers.Resolvers) (bool, error) {
+func (at *ActivityTree) insertEvent(event *model.Event, dryRun bool, generationType NodeGenerationType, resolvers *resolvers.Resolvers) (bool, error) {
 	// sanity check
 	if generationType == Unknown || generationType > MaxNodeGenerationType {
 		return false, fmt.Errorf("invalid generation type: %v", generationType)
@@ -269,7 +293,7 @@ func (at *ActivityTree) insert(event *model.Event, dryRun bool, generationType N
 		return false, fmt.Errorf("invalid event: %s", err)
 	}
 
-	node, _, newProcessNode, err := at.CreateProcessNode(event.ProcessCacheEntry, nil, generationType, dryRun, resolvers)
+	node, newProcessNode, err := at.CreateProcessNode(event.ProcessCacheEntry, generationType, dryRun, resolvers)
 	if err != nil {
 		return false, err
 	}
@@ -376,157 +400,193 @@ func eventHaveValidCookie(entry *model.ProcessCacheEntry) bool {
 	return !entry.ExecTime.IsZero() && entry.Cookie != 0
 }
 
-// CreateProcessNode finds or a create a new process activity node in the activity dump if the entry
-// matches the activity dump selector.
-func (at *ActivityTree) CreateProcessNode(entry *model.ProcessCacheEntry, branch []*model.ProcessCacheEntry, generationType NodeGenerationType, dryRun bool, resolvers *resolvers.Resolvers) (node *ProcessNode, siblings *[]*ProcessNode, newProcessNode bool, err error) {
-	if entry == nil {
-		return nil, nil, false, nil
+// buildBranchAndLookupCookies iterates over the ancestors of entry with 2 intentions in mind:
+//   - check if one of the ancestors of entry is already in the tree and has a shortcut thanks to its cookie
+//   - creates the list of ancestors "we care about" for the tree, i.e. the chain of ancestors created by calling
+//     "GetNextAncestorBinaryOrArgv0" and that match the tree selector.
+func (at *ActivityTree) buildBranchAndLookupCookies(entry *model.ProcessCacheEntry) ([]*model.ProcessCacheEntry, *ProcessNode, error) {
+	var cs cookieSelector
+	var fastMatch *ProcessNode
+	var found bool
+	var branch []*model.ProcessCacheEntry
+	nextAncestor := entry
+
+	for nextAncestor != nil {
+		// look for the current ancestor
+		cs.fillFromEntry(nextAncestor)
+		if cs.isSet() {
+			fastMatch, found = at.CookieToProcessNode.Get(cs)
+			if found {
+				return branch, fastMatch, nil
+			}
+		}
+
+		// check if the next ancestor matches the tree selector
+		if !at.validator.MatchesSelector(nextAncestor) {
+			// When the first ancestor that doesn't match the tree selector is reached, we can return early because we
+			// know that none of its parents will match the selector
+			break
+		}
+
+		// append current ancestor to the branch
+		branch = append(branch, nextAncestor)
+		nextAncestor = GetNextAncestorBinaryOrArgv0(&nextAncestor.ProcessContext)
+	}
+	if len(branch) == 0 {
+		return nil, nil, nil
 	}
 
-	if !entry.HasCompleteLineage() {
-		return nil, nil, false, ErrBrokenLineage
-	}
-
-	// look for a ProcessActivityNode by process cookie
-	cs := cookieSelector{}
-	if eventHaveValidCookie(entry) {
-		cs = cookieSelector{
-			execTime: entry.ExecTime.UnixNano(),
-			cookie:   entry.Cookie,
-		}
-		var found bool
-		node, found = at.CookieToProcessNode.Get(cs)
-		if found {
-			return node, nil, false, nil
-		}
-	}
-
-	defer func() {
-		// if a node was found, and if the entry has a valid cookie, insert a cookie shortcut
-		if cs.isSet() && node != nil {
-			at.CookieToProcessNode.Add(cs, node)
-		}
-	}()
-
-	branch = append(branch, entry)
-
-	// find or create a ProcessActivityNode for the parent of the input ProcessCacheEntry. If the parent is a fork entry,
-	// jump immediately to the next ancestor.
-	parentNode, siblings, newProcessNode, err := at.CreateProcessNode(GetNextAncestorBinaryOrArgv0(&entry.ProcessContext), branch, Snapshot, dryRun, resolvers)
-	if err == nil && newProcessNode && dryRun {
-		// Explanation of (newProcessNode && dryRun): when dryRun is on, we can return as soon as we
-		// see something new in the tree.
-		return parentNode, siblings, newProcessNode, err
-	}
-
-	// if parentNode is nil, the parent of the current node is out of tree (either because the parent is null, or it
-	// doesn't match the dump tags).
-	if parentNode == nil {
-
-		// since the parent of the current entry wasn't inserted, we need to know if the current entry needs to be inserted.
-		if !at.validator.MatchesSelector(entry) {
-			return nil, nil, false, ErrContainerIDNotEqual
-		}
-
-		// go through the root nodes and check if one of them matches the input ProcessCacheEntry:
-		if branchRoot, newChildNode := at.findBranch(&at.ProcessNodes, nil, branch, dryRun, generationType, resolvers); branchRoot != nil {
-			return branchRoot, &at.ProcessNodes, newChildNode, nil
-		}
-
-		// we're about to add a root process node, make sure this root node passes the root node sanitizer
-		if !isValidRootNode(&entry.ProcessContext) {
-			return nil, nil, false, ErrNotValidRootNode
-		}
-
-		// if it doesn't, create a new ProcessActivityNode for the input ProcessCacheEntry
-		if !dryRun {
-			node = NewProcessNode(entry, generationType, resolvers)
-			// insert in the list of root entries
-			at.ProcessNodes = append(at.ProcessNodes, node)
-			at.Stats.ProcessNodes++
-		}
-
-	} else {
-		// if parentNode wasn't nil, then (at least) the parent is part of the activity dump. This means that we need
-		// to add the current entry no matter if it matches the selector or not. Go through the root children of the
-		// parent node and check if one of them matches the input ProcessCacheEntry.
-		branchRoot, newChildNode := at.findBranch(&parentNode.Children, siblings, branch, dryRun, generationType, resolvers)
-		if branchRoot != nil {
-			return branchRoot, &parentNode.Children, newChildNode || newProcessNode, nil
-		}
-
-		// we haven't found anything, create a new ProcessActivityNode for the input processCacheEntry
-		if !dryRun {
-			node = NewProcessNode(entry, generationType, resolvers)
-			// insert in the list of children
-			parentNode.Children = append(parentNode.Children, node)
-			at.Stats.ProcessNodes++
+	// make sure the branch has a valid root node
+	for i := len(branch) - 1; i >= 0; i-- {
+		if isValidRootNode(&branch[i].ProcessContext) {
+			return branch[:i+1], nil, nil
 		}
 	}
 
-	// count new entry
-	if !dryRun {
-		at.Stats.addedCount[model.ExecEventType][generationType].Inc()
-		// propagate the entry matching process cache entry
-		at.validator.NewProcessNodeCallback(node)
-	}
-
-	var nextSiblings *[]*ProcessNode
-	if parentNode != nil {
-		nextSiblings = &parentNode.Children
-	}
-	return node, nextSiblings, true, nil
+	return branch, nil, ErrNotValidRootNode
 }
 
-// findBranch looks for the provided branch in the list of children. Returns the node that matches the
+// CreateProcessNode looks up or inserts the provided entry in the tree
+func (at *ActivityTree) CreateProcessNode(entry *model.ProcessCacheEntry, generationType NodeGenerationType, dryRun bool, resolvers *resolvers.Resolvers) (*ProcessNode, bool, error) {
+	if entry == nil {
+		return nil, false, nil
+	}
+
+	// check the lineage now, we have to do it only once
+	if !entry.HasCompleteLineage() {
+		return nil, false, ErrBrokenLineage
+	}
+
+	// Check if entry or one of its parents cookies are in CookieToProcessNode while building the branch we're trying to
+	// insert.
+	branchToInsert, quickMatch, err := at.buildBranchAndLookupCookies(entry)
+	if err != nil {
+		return nil, false, err
+	}
+	if quickMatch != nil && len(branchToInsert) == 0 {
+		// we can return immediately, we've found a direct hit from the cookie of the input entry
+		return quickMatch, false, nil
+	}
+
+	var parent ProcessNodeParent
+
+	// At this point, we want to insert "branchToInsert" below "firstMatch" in the tree
+	if quickMatch == nil {
+		// we didn't find a shortcut to the tree, this means we'll have to attempt the insertion from the top
+		parent = at
+	} else {
+		// we have a shortcut to the tree, populate tree, siblings and parent accordingly
+		parent = quickMatch
+	}
+
+	return at.insertBranch(parent, branchToInsert, generationType, dryRun, resolvers)
+}
+
+func (at *ActivityTree) insertBranch(parent ProcessNodeParent, branchToInsert []*model.ProcessCacheEntry, generationType NodeGenerationType, dryRun bool, r *resolvers.Resolvers) (*ProcessNode, bool, error) {
+	var matchingNode *ProcessNode
+	var branchIncrement int
+	var newNode, newNodeFromRebase bool
+	i := len(branchToInsert) - 1
+
+	for i >= 0 {
+		matchingNode, branchIncrement, newNodeFromRebase = at.findBranch(parent, branchToInsert[:i+1], dryRun, generationType, r)
+		if newNodeFromRebase {
+			newNode = true
+			if dryRun {
+				// early return in case of a dry run
+				return nil, newNodeFromRebase, nil
+			}
+		}
+		if matchingNode != nil {
+			parent = matchingNode
+			i -= branchIncrement
+			continue
+		}
+
+		// we've found a new node in the branch which doesn't exist in the tree
+		if dryRun {
+			// exit early in case of a dry run
+			return nil, true, nil
+		}
+
+		// we can safely insert the rest of the branch since they automatically all be new
+		for j := i; j >= 0; j-- {
+			// create the node
+			matchingNode = NewProcessNode(branchToInsert[j], generationType, r)
+			parent.AppendChild(matchingNode)
+
+			// insert the new node in the list of children
+			at.Stats.addedCount[model.ExecEventType][generationType].Inc()
+			at.Stats.ProcessNodes++
+
+			parent = matchingNode
+		}
+
+		// if we reach this point, we can safely return the last inserted entry and indicate that the tree was modified
+		return matchingNode, true, nil
+	}
+
+	// if we reach this point, we've successfully found the matching node in the tree without modifying the tree
+	return matchingNode, newNode, nil
+}
+
+// findBranch2 looks for the provided branch in the list of children. Returns the node that matches the
 // first node of the branch and true if a new entry was inserted.
-func (at *ActivityTree) findBranch(children *[]*ProcessNode, siblings *[]*ProcessNode, branch []*model.ProcessCacheEntry, dryRun bool, generationType NodeGenerationType, resolvers *resolvers.Resolvers) (*ProcessNode, bool) {
+func (at *ActivityTree) findBranch(parent ProcessNodeParent, branch []*model.ProcessCacheEntry, dryRun bool, generationType NodeGenerationType, resolvers *resolvers.Resolvers) (*ProcessNode, int, bool) {
 	for i := len(branch) - 1; i >= 0; i-- {
 		branchCursor := branch[i]
 
 		// look for branchCursor in the children
-		matchingNode, treeNodeToRebaseIndex := at.findProcessCacheEntryInTree(*children, branchCursor)
+		matchingNode, treeNodeToRebaseIndex := at.findProcessCacheEntryInTree(*parent.GetChildren(), branchCursor)
 
 		if matchingNode != nil {
-			// if this is the first iteration, we've just identified a direct match without looking for execs, return now
+			// if this is the first iteration, we've just identified a direct match without looking for execs in the event.
+			// This means we have nothing to rebase, return now.
 			if i == len(branch)-1 {
-				return matchingNode, false
+				return matchingNode, 1, false
 			}
 
 			// we're about to rebase part of the tree, exit early if this is a dry run
 			if dryRun {
-				return nil, true
+				return nil, len(branch) - i, true
 			}
 
-			// here is the current state of the tree:
-			//   parent (owner of "children") -> treeNodeToRebase -> [...] -> matchingNode
-			// here is what we want:
-			//   parent (owner of "children") -> branch[i+1:] -> treeNodeToRebase -> [...] -> matchingNode
-			newNodesRoot := at.rebaseTree(children, treeNodeToRebaseIndex, children, branch[i+1:], generationType, resolvers)
+			// make sure we properly update the isExecChild status
+			matchingNode.Process.IsExecChild = matchingNode.Process.IsExecChild || branchCursor.IsExecChild
 
-			// we need to return the node that matched branch[0]
-			return newNodesRoot, true
+			// here is the current state of the tree:
+			//   parent -> treeNodeToRebase -> [...] -> matchingNode
+			// here is what we want:
+			//   parent -> { result of branch[i+1:].insert(treeNodeToRebase) } -> matchingNode
+			at.rebaseTree(parent, treeNodeToRebaseIndex, parent, branch[i:], generationType, resolvers)
+
+			return matchingNode, len(branch) - i, true
+
 		}
 		// are we looking for an exec child ?
-		if branchCursor.IsExecChild && siblings != nil {
+		if siblings := parent.GetSiblings(); branchCursor.IsExecChild && siblings != nil {
+
 			// if yes, then look for branchCursor in the siblings of the parent of children
 			matchingNode, treeNodeToRebaseIndex = at.findProcessCacheEntryInTree(*siblings, branchCursor)
 			if treeNodeToRebaseIndex >= 0 {
 
-				// we're about to rebase part of the tree, exit early if this is a dry run
+				// We're about to rebase part of the tree, exit early if this is a dry run.
+				// The "i < len(branch)-1" check is used in case we'll rebase a node without adding a new one, which
+				// should be allowed in a dryRun.
 				if i < len(branch)-1 && dryRun {
-					return nil, true
+					return nil, len(branch) - i, true
 				}
 
-				// rebase the siblings node below the branch
-				newNodesRoot := at.rebaseTree(siblings, treeNodeToRebaseIndex, children, branch[i+1:], generationType, resolvers)
+				// make sure we properly update the isExecChild status
+				matchingNode.Process.IsExecChild = matchingNode.Process.IsExecChild || branchCursor.IsExecChild
 
-				// we need to return the node that matched branch[0]
-				if i == len(branch)-1 {
-					return matchingNode, false
-				}
+				// here is the current state of the tree:
+				//   parent of parent -> treeNodeToRebase -> [...] -> matchingNode
+				// here is what we want:
+				//   parent -> { result of branch[i+1:].insert(treeNodeToRebase) } -> matchingNode
+				at.rebaseTree(parent.GetParent(), treeNodeToRebaseIndex, parent, branch[i:], generationType, resolvers)
 
-				return newNodesRoot, true
+				return matchingNode, len(branch) - i, i < len(branch)-1
 			}
 		}
 
@@ -542,24 +602,44 @@ func (at *ActivityTree) findBranch(children *[]*ProcessNode, siblings *[]*Proces
 		// directly exec-ed
 		break
 	}
-	return nil, false
+	return nil, 0, false
 }
 
 // rebaseTree rebases the node identified by "nodeIndexToRebase" in the input "tree" onto a newly created branch made of
 // "branchToInsert" and appended to "treeToRebaseOnto". New nodes will be tagged with the input "generationType".
 // This function returns the top level node, owner of the newly inserted branch that lead to the rebased node
-func (at *ActivityTree) rebaseTree(tree *[]*ProcessNode, treeIndexToRebase int, treeToRebaseOnto *[]*ProcessNode, branchToInsert []*model.ProcessCacheEntry, generationType NodeGenerationType, resolvers *resolvers.Resolvers) *ProcessNode {
+func (at *ActivityTree) rebaseTree(parent ProcessNodeParent, childIndexToRebase int, newParent ProcessNodeParent, branchToInsert []*model.ProcessCacheEntry, generationType NodeGenerationType, resolvers *resolvers.Resolvers) *ProcessNode {
+	if len(branchToInsert) > 1 {
+		// We know that the entries in "branch" are all "isExecChild = true" nodes, except the top level entry that might be
+		// a "isExecChild = false" node. Similarly, all the nodes below parent.GetChildren()[childIndexToRebase] must be non
+		// matching "isExecChild = true" nodes, except parent.GetChildren()[childIndexToRebase] that might be a "isExecChild
+		// = false" node. To be safe, check if the 2 top level nodes match if one of them is an "isExecChild = true" node.
+		childToRebase := (*parent.GetChildren())[childIndexToRebase]
+		if topLevelNode := branchToInsert[len(branchToInsert)-1]; !topLevelNode.IsExecChild || !childToRebase.Process.IsExecChild {
+			if childToRebase.Matches(&topLevelNode.Process, at.differentiateArgs) {
+				// ChildNodeToRebase and topLevelNode match and need to be merged, rebase the one in the profile, and insert
+				// the remaining nodes of the branch on top of it
+				newRebasedChild := at.rebaseTree(parent, childIndexToRebase, newParent, nil, generationType, resolvers)
+				output, _, _ := at.insertBranch(newRebasedChild, branchToInsert[:len(branchToInsert)-1], generationType, false, resolvers)
+
+				if output == nil {
+					return newRebasedChild
+				}
+				return output
+			}
+		}
+	}
 
 	// create the new branch
 	var rebaseRoot, childrenCursor *ProcessNode
-	for i := len(branchToInsert) - 1; i >= 0; i-- {
+	for i := len(branchToInsert) - 1; i >= 1; i-- {
 		eventExecChildTmp := branchToInsert[i]
 		n := NewProcessNode(eventExecChildTmp, generationType, resolvers)
 		if i == len(branchToInsert)-1 {
 			rebaseRoot = n
 		}
 		if childrenCursor != nil {
-			childrenCursor.Children = append(childrenCursor.Children, n)
+			childrenCursor.AppendChild(n)
 		}
 		at.Stats.ProcessNodes++
 		at.Stats.addedCount[model.ExecEventType][generationType].Inc()
@@ -568,22 +648,22 @@ func (at *ActivityTree) rebaseTree(tree *[]*ProcessNode, treeIndexToRebase int, 
 	}
 
 	// mark the rebased node as an exec child
-	(*tree)[treeIndexToRebase].Process.IsExecChild = true
+	(*parent.GetChildren())[childIndexToRebase].Process.IsExecChild = true
 
 	if rebaseRoot == nil {
-		rebaseRoot = (*tree)[treeIndexToRebase]
+		rebaseRoot = (*parent.GetChildren())[childIndexToRebase]
 	}
 
 	if childrenCursor != nil {
-		// attach the head of  to the last newly inserted child
-		childrenCursor.Children = append(childrenCursor.Children, (*tree)[treeIndexToRebase])
+		// attach the head of to the last newly inserted child
+		childrenCursor.Children = append(childrenCursor.Children, (*parent.GetChildren())[childIndexToRebase])
 	}
 
 	// rebase the node onto treeToRebaseOnto
-	*treeToRebaseOnto = append(*treeToRebaseOnto, rebaseRoot)
+	*newParent.GetChildren() = append(*newParent.GetChildren(), rebaseRoot)
 
-	// break the link between parent and the node to rebase
-	*tree = append((*tree)[0:treeIndexToRebase], (*tree)[treeIndexToRebase+1:]...)
+	// break the link between the parent and the node to rebase
+	*parent.GetChildren() = append((*parent.GetChildren())[0:childIndexToRebase], (*parent.GetChildren())[childIndexToRebase+1:]...)
 
 	// now that the tree is ready, call the validator on the first node
 	at.validator.NewProcessNodeCallback(rebaseRoot)

--- a/pkg/security/security_profile/activity_tree/activity_tree_test.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_test.go
@@ -71,10 +71,22 @@ func TestInsertFileEvent(t *testing.T) {
 	assert.Equal(t, expectedDebugOuput, debugOutput)
 }
 
+func setParentRelationship(parent ProcessNodeParent, node *ProcessNode) {
+	node.Parent = parent
+	for _, child := range node.Children {
+		setParentRelationship(node, child)
+	}
+}
+
 func TestActivityTree_InsertExecEvent(t *testing.T) {
 	for _, tt := range activityTreeInsertExecEventTestCases {
 		t.Run(tt.name, func(t *testing.T) {
-			node, _, newEntry, err := tt.tree.CreateProcessNode(tt.inputEvent.ProcessCacheEntry, nil, Runtime, false, nil)
+			// prepare parent links in the input tree
+			for _, rootNode := range tt.tree.ProcessNodes {
+				setParentRelationship(tt.tree, rootNode)
+			}
+
+			node, newEntry, err := tt.tree.CreateProcessNode(tt.inputEvent.ProcessCacheEntry, Runtime, false, nil)
 			if tt.wantErr != nil {
 				if !tt.wantErr(t, err, fmt.Sprintf("unexpected error: %v", err)) {
 					return
@@ -3422,12 +3434,13 @@ var activityTreeInsertExecEventTestCases = []struct {
 	},
 
 	// exec/21
-	// ---------------                                                          /bin/4
-	//                                                                             | (exec)
-	//       bin/1--------        /bin/4  +   systemd                ==>>       /bin/1 -------
-	//         |         |                    |- /bin/4 -> /bin/2                  | (exec)  | (exec)
-	//      /bin/2    /bin/3                                                    /bin/2    /bin/3
-	//         | (exec)  | (exec)
+	// ---------------
+	//
+	//       bin/1------------           /bin/4          +        systemd                   ==>>        /bin/4
+	//         | (exec)      | (exec)                                |- /bin/4 -> /bin/2                   | (exec)
+	//      /bin/2         /bin/3                                                                       /bin/1 -------------
+	//                                                                                                    | (exec)         | (exec)
+	//                                                                                                  /bin/2          /bin/3
 	//
 	{
 		name: "exec/21",
@@ -3549,12 +3562,11 @@ var activityTreeInsertExecEventTestCases = []struct {
 
 	// exec/22
 	// ---------------
-	//      /bin/0                                                 /bin/0
-	//         |                                                      |
-	//      /bin/1--------         +       systemd      ==>>       /bin/1 -------         /bin/4
-	//         |         |                 |- /bin/4 -> /bin/2        | (exec)  | (exec)     | (exec)
-	//      /bin/2    /bin/3                                       /bin/2    /bin/3       /bin/2
-	//         | (exec)  | (exec)
+	//      /bin/0                          +       systemd                      ==>>         /bin/0                          /bin/4
+	//         |                                       |- /bin/4 -> /bin/2                       |                               | (exec)
+	//      /bin/1---------------                                                             /bin/1 -----------              /bin/2
+	//         | (exec)         | (exec)                                                         | (exec)      | (exec)
+	//      /bin/2            /bin/3                                                          /bin/2         /bin/3
 	//
 	{
 		name: "exec/22",
@@ -3685,6 +3697,224 @@ var activityTreeInsertExecEventTestCases = []struct {
 								IsExecChild: true,
 								FileEvent: model.FileEvent{
 									PathnameStr: "/bin/2",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// exec/23
+	// ---------------
+	//        dash---------            +        systemd             ==>    dash
+	//         |          |                        |                        |
+	//        bash     ddtrace                    dash                     bash------------
+	//         |         | (exec)                  |                        |             | (exec)
+	//       python    uwsgi                      bash                   python        ddtrace
+	//                                             |                                      | (exec)
+	//                                           ddtrace                                  tools
+	//                                             | (exec                               | (exec)
+	//                                           tools                                  utils
+	//                                             | (exec)                               | (exec)
+	//                                           utils                                  uwsgi
+	//                                             | (exec)
+	//                                           uwsgi
+	//
+	{
+		name: "exec/23",
+		tree: &ActivityTree{
+			validator: activityTreeInsertTestValidator{},
+			Stats:     NewActivityTreeNodeStats(),
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						FileEvent: model.FileEvent{
+							PathnameStr: "dash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								FileEvent: model.FileEvent{
+									PathnameStr: "bash",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										FileEvent: model.FileEvent{
+											PathnameStr: "python",
+										},
+									},
+								},
+							},
+						},
+						{
+							Process: model.Process{
+								IsExecChild: false,
+								FileEvent: model.FileEvent{
+									PathnameStr: "ddtrace",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										IsExecChild: true,
+										FileEvent: model.FileEvent{
+											PathnameStr: "uwsgi",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		inputEvent: newExecTestEventWithAncestors([]model.Process{
+			{
+				IsExecChild: false,
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "dash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 1,
+						},
+					},
+				},
+			},
+			{
+				IsExecChild: false,
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "bash",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 2,
+						},
+					},
+				},
+			},
+			{
+				IsExecChild: false,
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "ddtrace",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 3,
+						},
+					},
+				},
+			},
+			{
+				IsExecChild: true,
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "tools",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 4,
+						},
+					},
+				},
+			},
+			{
+				IsExecChild: true,
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "utils",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 5,
+						},
+					},
+				},
+			},
+			{
+				IsExecChild: true,
+				ContainerID: "123",
+				FileEvent: model.FileEvent{
+					PathnameStr: "uwsgi",
+					FileFields: model.FileFields{
+						PathKey: model.PathKey{
+							Inode: 6,
+						},
+					},
+				},
+			},
+		}),
+		wantNode: &ProcessNode{
+			Process: model.Process{
+				FileEvent: model.FileEvent{
+					PathnameStr: "uwsgi",
+				},
+			},
+		},
+		wantNewEntry: true,
+		wantTree: &ActivityTree{
+			ProcessNodes: []*ProcessNode{
+				{
+					Process: model.Process{
+						FileEvent: model.FileEvent{
+							PathnameStr: "dash",
+						},
+					},
+					Children: []*ProcessNode{
+						{
+							Process: model.Process{
+								FileEvent: model.FileEvent{
+									PathnameStr: "bash",
+								},
+							},
+							Children: []*ProcessNode{
+								{
+									Process: model.Process{
+										FileEvent: model.FileEvent{
+											PathnameStr: "python",
+										},
+									},
+								},
+								{
+									Process: model.Process{
+										IsExecChild: true,
+										FileEvent: model.FileEvent{
+											PathnameStr: "ddtrace",
+										},
+									},
+									Children: []*ProcessNode{
+										{
+											Process: model.Process{
+												IsExecChild: true,
+												FileEvent: model.FileEvent{
+													PathnameStr: "tools",
+												},
+											},
+											Children: []*ProcessNode{
+												{
+													Process: model.Process{
+														IsExecChild: true,
+														FileEvent: model.FileEvent{
+															PathnameStr: "utils",
+														},
+													},
+													Children: []*ProcessNode{
+														{
+															Process: model.Process{
+																IsExecChild: true,
+																FileEvent: model.FileEvent{
+																	PathnameStr: "uwsgi",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
 								},
 							},
 						},

--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -633,7 +633,7 @@ func (adm *ActivityDumpManager) SearchTracedProcessCacheEntryCallback(ad *Activi
 		}
 
 		for _, parent = range ancestors {
-			_, _, _, err := ad.ActivityTree.CreateProcessNode(parent, nil, activity_tree.Snapshot, false, adm.resolvers)
+			_, _, err := ad.ActivityTree.CreateProcessNode(parent, activity_tree.Snapshot, false, adm.resolvers)
 			if err != nil {
 				// if one of the parents wasn't inserted, leave now
 				break

--- a/pkg/security/security_profile/tests/activity_tree_test.go
+++ b/pkg/security/security_profile/tests/activity_tree_test.go
@@ -163,7 +163,7 @@ func TestActivityTree_CreateProcessNode(t *testing.T) {
 			differentContainerID:  true,
 			resultNodeShouldBeNil: true,
 			resultNewProcessNode:  false,
-			resultErr:             activity_tree.ErrContainerIDNotEqual,
+			resultErr:             nil,
 			resultTree:            map[string][]string{},
 		},
 
@@ -697,7 +697,7 @@ func TestActivityTree_CreateProcessNode(t *testing.T) {
 
 						process := craftFakeProcess(defaultContainerID, &ti)
 
-						node, _, newProcessNode, err := at.CreateProcessNode(process, []*model.ProcessCacheEntry{}, gentype, dryRun, nil)
+						node, newProcessNode, err := at.CreateProcessNode(process, gentype, dryRun, nil)
 
 						assert.Equal(t, ti.resultErr, err)
 						assert.Equal(t, ti.resultNewProcessNode, newProcessNode)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

 This PR introduces a new "siblings" rebase test case in the `ActivityTree` algorithm. This new test put the spotlight on an edge case of the merge algorithm where a non-"IsExecChild" could, on rebase, stutter if it execed into a node that matches an input event. This PR fixes this stuttering (see the test case number 23, in the old version of the algorithm, the `ddtrace` node would stutter).

This PR also refactors the algorithm to get rid of the top level recursion in the `ActivityTree.CreateProcessNode` function.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This PR was motivated by a real world example where a rebase would badly alter a profile and make it invalid for further evaluations.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Getting rid of the recursion helped simplify some checks performed on the input event. This new version of the algorithm should therefore be faster than the previous one.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
