### PR TITLE
[serverless] Fix flaky logs_collector unit test

### DIFF
--- a/pkg/serverless/logs/logs_test.go
+++ b/pkg/serverless/logs/logs_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -802,25 +803,31 @@ func TestProcessMultipleLogMessagesTimeoutLogFromReportLog(t *testing.T) {
 			createStringRecordForReportLog(lc.invocationStartTime, lc.invocationEndTime, &reportLogMessageTwo),
 		},
 	}
-	expectedErrors := map[string][]bool{
-		"myRequestID-1": {false, true},
-		"myRequestID-2": {false},
-	}
 
-	for reqId, logsSlice := range expectedLogs {
-		for i := 0; i < len(logsSlice); i++ {
-			select {
-			case received := <-logChannel:
-				assert.NotNil(t, received)
-				assert.Equal(t, "my-arn", received.Lambda.ARN)
-				assert.Equal(t, reqId, received.Lambda.RequestID)
-				assert.Equal(t, logsSlice[i], string(received.Content))
-				assert.Equal(t, expectedErrors[reqId][i], received.IsError)
-			case <-time.After(100 * time.Millisecond):
-				assert.Fail(t, "We should have received logs")
+	for i := 0; i < 3; i++ {
+		select {
+		case received := <-logChannel:
+			assert.NotNil(t, received)
+			logs := expectedLogs[received.Lambda.RequestID]
+			assert.NotEmpty(t, logs)
+			logMatch := false
+			for _, logString := range logs {
+				if logString == string(received.Content) {
+					logMatch = true
+				}
 			}
+			assert.True(t, logMatch)
+			assert.Equal(t, "my-arn", received.Lambda.ARN)
+			if strings.Contains(string(received.Content), "Task timed out") {
+				assert.True(t, received.IsError)
+			} else {
+				assert.False(t, received.IsError)
+			}
+		case <-time.After(100 * time.Millisecond):
+			assert.Fail(t, "We should have received logs")
 		}
 	}
+
 }
 
 func TestProcessLogMessagesOutOfMemoryError(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fixes flaky unit test due to iterating over an unordered map. Keeps the same functionality of the test.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Test is flaky

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
