### PR TITLE
[ASCII-737] Add an invoke task to automate go updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -390,6 +390,7 @@
 /tasks/                                 @DataDog/agent-platform
 /tasks/msi.py                           @DataDog/windows-agent
 /tasks/agent.py                         @DataDog/agent-shared-components
+/tasks/update_go.py                     @DataDog/agent-shared-components
 /tasks/cluster_agent_cloudfoundry.py    @DataDog/platform-integrations
 /tasks/new_e2e_tests.py                 @DataDog/agent-e2e-testing
 /tasks/process_agent.py                 @DataDog/processes

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -30,7 +30,6 @@ from . import (
     system_probe,
     systray,
     trace_agent,
-    update_go,
     vscode,
 )
 from .build_tags import audit_tag_impact, print_default_build_tags
@@ -69,6 +68,7 @@ from .test import (
     lint_teamassignment,
     test,
 )
+from .update_go import update_go
 from .utils import generate_config
 from .windows_resources import build_messagetable
 
@@ -95,7 +95,7 @@ ns.add_task(lint_filenames)
 ns.add_task(lint_python)
 ns.add_task(lint_go)
 ns.add_task(show_linters_issues)
-ns.add_task(update_go.update_go)
+ns.add_task(update_go)
 ns.add_task(audit_tag_impact)
 ns.add_task(print_default_build_tags)
 ns.add_task(e2e_tests)

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -30,6 +30,7 @@ from . import (
     system_probe,
     systray,
     trace_agent,
+    update_go,
     vscode,
 )
 from .build_tags import audit_tag_impact, print_default_build_tags
@@ -94,6 +95,7 @@ ns.add_task(lint_filenames)
 ns.add_task(lint_python)
 ns.add_task(lint_go)
 ns.add_task(show_linters_issues)
+ns.add_task(update_go.update_go)
 ns.add_task(audit_tag_impact)
 ns.add_task(print_default_build_tags)
 ns.add_task(e2e_tests)

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -1,7 +1,6 @@
 import re
 from typing import Optional
 
-import semver
 from invoke import Context, exceptions, task
 
 from .go import tidy_all
@@ -30,6 +29,8 @@ def update_go(
     """
     Updates the version of Go and build images.
     """
+    import semver
+
     if not semver.Version.is_valid(version):
         raise exceptions.Exit(f"The version {version} isn't valid.")
 
@@ -126,6 +127,8 @@ def _get_repo_go_version() -> str:
 # extracts the major version from the given string
 # eg. if the string is "1.2.3", returns "1.2"
 def _get_major_version(version: str) -> str:
+    import semver
+
     ver = semver.Version.parse(version)
     return f"{ver.major}.{ver.minor}"
 

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -1,0 +1,179 @@
+import re
+from typing import Optional
+
+from invoke import Context, exceptions, task
+
+from .go import tidy_all
+from .libs.common.color import color_message
+from .modules import DEFAULT_MODULES
+from .pipeline import update_circleci_config, update_gitlab_config
+
+GO_VERSION_FILE = "./.go-version"
+
+
+# replace the given pattern with the given string in the file
+def _update_file(path: str, pattern: str, replace: str, expected_match: int = 1):
+    # newline='' keeps the file's newline character(s)
+    # meaning it keeps '\n' for most files and '\r\n' for windows specific files
+
+    with open(path, "r", newline='') as reader:
+        content = reader.read()
+
+    content, nb_match = re.subn(pattern, replace, content, flags=re.MULTILINE)
+    if nb_match != expected_match:
+        print(
+            color_message(
+                f"WARNING: {path}: '{pattern}': expected {expected_match} matches but go {nb_match}", "orange"
+            )
+        )
+
+    with open(path, "w", newline='') as writer:
+        writer.write(content)
+
+
+# returns the current go version
+def _get_repo_go_version() -> str:
+    with open(GO_VERSION_FILE, "r") as reader:
+        version = reader.read()
+    return version.strip()
+
+
+# extracts the major version from the given string
+# eg. if the string is "1.2.3", returns "1.2"
+def _get_major_version(version: str) -> str:
+    major, _, _ = version.rpartition(".")
+    return major
+
+
+def _update_go_version_file(version: str):
+    _update_file(GO_VERSION_FILE, "[.0-9]+", version)
+
+
+def _update_gdb_dockerfile(version: str):
+    path = "./tools/gdb/Dockerfile"
+    pattern = r'(https://go\.dev/dl/go)[.0-9]+(\.linux-amd64\.tar\.gz)'
+    replace = rf'\g<1>{version}\g<2>'
+    _update_file(path, pattern, replace)
+
+
+def _update_install_devenv(version: str):
+    path = "./devenv/scripts/Install-DevEnv.ps1"
+    _update_file(path, '("Installing go )[.0-9]+"', rf'\g<1>{version}"')
+    _update_file(
+        path,
+        r'(https://dl\.google\.com/go/go)[.0-9]+(\.windows-)',
+        rf'\g<1>{version}\g<2>',
+        2,
+    )
+
+
+def _update_agent_devenv(version: str):
+    path = "./docs/dev/agent_dev_env.md"
+    pattern = r"^(You must \[install Golang\]\(https://golang\.org/doc/install\) version )`[.0-9]+`"
+    replace = rf"\g<1>`{version}`"
+    _update_file(path, pattern, replace)
+
+
+def _update_task_go(version: str):
+    path = "./tasks/go.py"
+    pattern = '("go version go)[.0-9]+( linux/amd64")'
+    replace = rf'\g<1>{version}\g<2>'
+    _update_file(path, pattern, replace)
+
+
+def _update_readme(major: str):
+    path = "./README.md"
+    pattern = r'(\[Go\]\(https://golang\.org/doc/install\) )[.0-9]+( or later)'
+    replace = rf'\g<1>{major}\g<2>'
+    _update_file(path, pattern, replace)
+
+
+def _update_go_mods(major: str):
+    mod_files = [f"./{module}/go.mod" for module in DEFAULT_MODULES]
+    for mod_file in mod_files:
+        _update_file(mod_file, "^go [.0-9]+$", f"go {major}")
+
+
+def _create_releasenote(ctx: Context, version: str):
+    RELEASENOTE_TEMPLATE = """---
+enhancements:
+- |
+    Agents are now built with Go ``{}``.
+"""
+    # hiding stderr too because `reno` displays some warnings about the config
+    res = ctx.run(f'reno new "bump go to {version}"', hide='both')
+    match = re.match("^Created new notes file in (.*)$", res.stdout, flags=re.MULTILINE)
+    if not match:
+        raise exceptions.Exit("Could not get created release note path")
+
+    path = match.group(1)
+    with open(path, "w") as writer:
+        writer.write(RELEASENOTE_TEMPLATE.format(version))
+    return path
+
+
+@task(
+    help={
+        "version": "The version of Go to use",
+        "image_tag": "Tag from buildimages with format v<build_id>_<commit_id>",
+        "test_version": "Whether the image is a test image or not",
+        "force_major": "Whether to apply changes like if it was a major version update",
+    }
+)
+def update_go(
+    ctx: Context,
+    version: str,
+    image_tag: str,
+    test_version: Optional[bool] = False,
+    force_major: Optional[bool] = False,
+):
+    """
+    Updates the version of Go and build images.
+    """
+    if not re.match("[0-9]+.[0-9]+.[0-9]+", version):
+        raise exceptions.Exit(
+            "The version doesn't have an expected format, it should be 3 numbers separated with a dot."
+        )
+
+    # check the installed go version before running `tidy_all`
+    res = ctx.run("go version")
+    if not res.stdout.startswith(f"go version go{version} "):
+        raise exceptions.Exit("The version of your `go` binary doesn't match the requested version")
+
+    current_version = _get_repo_go_version()
+    current_major = _get_major_version(current_version)
+    new_major = _get_major_version(version)
+
+    major_update = current_major != new_major or force_major
+    if major_update:
+        print(color_message("WARNING: this is a change of major version\n", "orange"))
+        _update_readme(new_major)
+        _update_go_mods(new_major)
+
+    update_gitlab_config(".gitlab-ci.yml", image_tag, test_version=test_version)
+    update_circleci_config(".circleci/config.yml", image_tag, test_version=test_version)
+    _update_go_version_file(version)
+    _update_gdb_dockerfile(version)
+    _update_install_devenv(version)
+    _update_agent_devenv(version)
+    _update_task_go(version)
+
+    tidy_all(ctx)
+
+    releasenote_path = _create_releasenote(ctx, version)
+    print(
+        f"A default release note was created at {releasenote_path}, edit it if necessary, for example to list CVEs it fixes."
+    )
+    if major_update:
+        # Examples of major updates with long descriptions:
+        # releasenotes/notes/go1.16.7-4ec8477608022a26.yaml
+        # releasenotes/notes/go1185-fd9d8b88c7c7a12e.yaml
+        print("In particular as this is a major update, the release note should describe user-facing changes.")
+    print()
+
+    print(
+        color_message(
+            "Remember to look for reference to the former version by yourself too, and update this task if you find some.",
+            "green",
+        )
+    )

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -87,11 +87,10 @@ def update_go(
         # releasenotes/notes/go1.16.7-4ec8477608022a26.yaml
         # releasenotes/notes/go1185-fd9d8b88c7c7a12e.yaml
         print("In particular as this is a major update, the release note should describe user-facing changes.")
-    print()
 
     print(
         color_message(
-            "Remember to look for reference to the former version by yourself too, and update this task if you find any.",
+            "\nRemember to look for reference to the former version by yourself too, and update this task if you find any.",
             "green",
         )
     )


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Create an invoke task to automate Go version updates.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Go version updates are long and error prone, having a task to do most of the changes is helpful.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
I was able to check that the task generates the same output as https://github.com/DataDog/datadog-agent-buildimages/pull/439.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
Each file and line to change are hardcoded, so any change could mean having a version not updated, and new references won't be picked up automatically.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
