### PR TITLE
pkg/trace/agent: Replace Tags now acts on 'metrics' tags

### DIFF
--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -141,8 +141,8 @@ func TestProcess(t *testing.T) {
 			Type:     "web",
 			Start:    now.Add(-time.Second).UnixNano(),
 			Duration: (500 * time.Millisecond).Nanoseconds(),
-			Metrics:  map[string]float64{"request.zipcode": 12345, "request.secret": 1337},
-			Meta:     map[string]string{},
+			Metrics:  map[string]float64{"request.zipcode": 12345, "request.secret": 1337, "safe.data": 42},
+			Meta:     map[string]string{"keep.me": "very-normal-not-sensitive-data"},
 		}
 		agnt.Process(&api.Payload{
 			TracerPayload: testutil.TracerPayloadWithChunk(testutil.TraceChunkWithSpan(span)),
@@ -151,7 +151,8 @@ func TestProcess(t *testing.T) {
 
 		assert.Equal(t, 5555.0, span.Metrics["request.secret"])
 		assert.Equal(t, "...", span.Meta["request.zipcode"])
-
+		assert.Equal(t, "very-normal-not-sensitive-data", span.Meta["keep.me"])
+		assert.Equal(t, 42.0, span.Metrics["safe.data"])
 	})
 
 	t.Run("Blacklister", func(t *testing.T) {

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -114,6 +114,46 @@ func TestProcess(t *testing.T) {
 		assert.Equal("SELECT name FROM people WHERE age = ? AND extra = ?", span.Meta["sql.query"])
 	})
 
+	t.Run("ReplacerMetrics", func(t *testing.T) {
+		cfg := config.New()
+		cfg.Endpoints[0].APIKey = "test"
+		cfg.ReplaceTags = []*config.ReplaceRule{
+			{
+				Name: "request.zipcode",
+				Re:   regexp.MustCompile(".*"),
+				Repl: "...",
+			},
+			{
+				Name: "*",
+				Re:   regexp.MustCompile("1337"),
+				Repl: "5555",
+			},
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		agnt := NewTestAgent(ctx, cfg, telemetry.NewNoopCollector())
+		defer cancel()
+
+		now := time.Now()
+		span := &pb.Span{
+			TraceID:  1,
+			SpanID:   1,
+			Resource: "resource",
+			Type:     "web",
+			Start:    now.Add(-time.Second).UnixNano(),
+			Duration: (500 * time.Millisecond).Nanoseconds(),
+			Metrics:  map[string]float64{"request.zipcode": 12345, "request.secret": 1337},
+			Meta:     map[string]string{},
+		}
+		agnt.Process(&api.Payload{
+			TracerPayload: testutil.TracerPayloadWithChunk(testutil.TraceChunkWithSpan(span)),
+			Source:        info.NewReceiverStats().GetTagStats(info.Tags{}),
+		})
+
+		assert.Equal(t, 5555.0, span.Metrics["request.secret"])
+		assert.Equal(t, "...", span.Meta["request.zipcode"])
+
+	})
+
 	t.Run("Blacklister", func(t *testing.T) {
 		cfg := config.New()
 		cfg.Endpoints[0].APIKey = "test"

--- a/pkg/trace/filters/replacer.go
+++ b/pkg/trace/filters/replacer.go
@@ -33,17 +33,35 @@ func (f Replacer) Replace(trace pb.Trace) {
 				for k := range s.Meta {
 					s.Meta[k] = re.ReplaceAllString(s.Meta[k], str)
 				}
+				for k := range s.Metrics {
+					replacedValue := re.ReplaceAllString(strconv.FormatFloat(s.Metrics[k], 'f', -1, 64), str)
+					if rf, err := strconv.ParseFloat(replacedValue, 64); err == nil {
+						s.Metrics[k] = rf
+					} else {
+						s.Meta[k] = replacedValue
+						delete(s.Metrics, k)
+					}
+				}
 				s.Resource = re.ReplaceAllString(s.Resource, str)
 			case "resource.name":
 				s.Resource = re.ReplaceAllString(s.Resource, str)
 			default:
-				if s.Meta == nil {
-					continue
+				if s.Meta != nil {
+					if _, ok := s.Meta[key]; ok {
+						s.Meta[key] = re.ReplaceAllString(s.Meta[key], str)
+					}
 				}
-				if _, ok := s.Meta[key]; !ok {
-					continue
+				if s.Metrics != nil {
+					if _, ok := s.Metrics[key]; ok {
+						replacedValue := re.ReplaceAllString(strconv.FormatFloat(s.Metrics[key], 'f', -1, 64), str)
+						if rf, err := strconv.ParseFloat(replacedValue, 64); err == nil {
+							s.Metrics[key] = rf
+						} else {
+							s.Meta[key] = replacedValue
+							delete(s.Metrics, key)
+						}
+					}
 				}
-				s.Meta[key] = re.ReplaceAllString(s.Meta[key], str)
 			}
 		}
 	}

--- a/releasenotes/notes/replace-tags-metrics-31c05b88d3f356f8.yaml
+++ b/releasenotes/notes/replace-tags-metrics-31c05b88d3f356f8.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: DD_APM_REPLACE_TAGS aka apm_config.replace_tags will now properly look for tags with numeric values.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Updates the "replace tags" config option to also look at the `metrics` tags on spans. When the "replaced" value is still a valid float we keep the replaced tag in the `metrics` otherwise it must move to the `meta`. 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The difference between `meta` and `metrics` is an implementation detail of tags. It is not obvious to customers why when setting up replace tags rules that the rules do not work on "number" tags. 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
This adds a bit of extra cost to performing replace_tags, especially if the customer has configured any replace_tags that act on ALL span tags (e.g. `*`). I believe this cost is worth it as the _expected_ behavior of replace tags is to act on all configured tags. 
Additionally it's _possible_ a customer is inadvertently relying on this behavior and when they upgrade they suddenly have tags that are modified by their replace rules, to mitigate this the release notes should be clear.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Unit tests cover this area well and the new unit tests cover this change.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
