### PR TITLE
usm: tls: introduce tls process

### DIFF
--- a/pkg/network/ebpf/c/protocols/classification/defs.h
+++ b/pkg/network/ebpf/c/protocols/classification/defs.h
@@ -143,7 +143,8 @@ typedef enum {
 
 typedef enum {
     TLS_PROG_UNKNOWN = 0,
-    // Add TLS uprobe tail calls here
+    TLS_HTTP_PROCESS,
+    TLS_HTTP_TERMINATION,
     TLS_PROG_MAX,
 } tls_prog_t;
 

--- a/pkg/network/ebpf/c/protocols/classification/dispatcher-maps.h
+++ b/pkg/network/ebpf/c/protocols/classification/dispatcher-maps.h
@@ -29,4 +29,6 @@ BPF_PROG_ARRAY(dispatcher_classification_progs, DISPATCHER_PROG_MAX)
 // A per-cpu array to share conn_tuple and skb_info between the dispatcher and the tail-calls.
 BPF_PERCPU_ARRAY_MAP(dispatcher_arguments, __u32, dispatcher_arguments_t, 1)
 
+BPF_PERCPU_ARRAY_MAP(tls_dispatcher_arguments, __u32, tls_dispatcher_arguments_t, 1)
+
 #endif

--- a/pkg/network/ebpf/c/protocols/classification/structs.h
+++ b/pkg/network/ebpf/c/protocols/classification/structs.h
@@ -23,4 +23,10 @@ typedef struct {
     skb_info_t skb_info;
 } dispatcher_arguments_t;
 
+typedef struct {
+    conn_tuple_t tup;
+    __u64 tags;
+    char *buffer_ptr;
+} tls_dispatcher_arguments_t;
+
 #endif

--- a/pkg/network/ebpf/c/protocols/http/buffer.h
+++ b/pkg/network/ebpf/c/protocols/http/buffer.h
@@ -28,6 +28,7 @@
     }                                                                                                                   \
 
 READ_INTO_USER_BUFFER(http, HTTP_BUFFER_SIZE)
+READ_INTO_USER_BUFFER(classification, CLASSIFICATION_MAX_BUFFER)
 
 READ_INTO_BUFFER(skb, HTTP_BUFFER_SIZE, BLK_SIZE)
 

--- a/pkg/network/ebpf/c/protocols/tls/tls-maps.h
+++ b/pkg/network/ebpf/c/protocols/tls/tls-maps.h
@@ -1,0 +1,10 @@
+#ifndef __TLS_MAPS_H
+#define __TLS_MAPS_H
+
+#include "map-defs.h"
+
+#include "protocols/classification/defs.h"
+
+BPF_PERCPU_ARRAY_MAP(tls_classification_heap, __u32, char[CLASSIFICATION_MAX_BUFFER], 1)
+
+#endif

--- a/pkg/network/protocols/ebpf.go
+++ b/pkg/network/protocols/ebpf.go
@@ -86,5 +86,8 @@ func toProtocolType(protoNum uint8, layerBit uint16) ProtocolType {
 type TLSProgramType C.tls_prog_t
 
 const (
-// Add TLS prog constants here
+	// ProgramTLSHTTPProcess is tail call to process http traffic.
+	ProgramTLSHTTPProcess ProgramType = C.TLS_HTTP_PROCESS
+	// ProgramTLSHTTPTermination is tail call to process http termination.
+	ProgramTLSHTTPTermination ProgramType = C.TLS_HTTP_TERMINATION
 )

--- a/pkg/network/protocols/http/protocol.go
+++ b/pkg/network/protocols/http/protocol.go
@@ -36,9 +36,11 @@ type protocol struct {
 }
 
 const (
-	inFlightMap    = "http_in_flight"
-	filterTailCall = "socket__http_filter"
-	eventStream    = "http"
+	inFlightMap            = "http_in_flight"
+	filterTailCall         = "socket__http_filter"
+	tlsProcessTailCall     = "uprobe__http_process"
+	tlsTerminationTailCall = "uprobe__http_termination"
+	eventStream            = "http"
 )
 
 var Spec = &protocols.ProtocolSpec{
@@ -52,6 +54,20 @@ var Spec = &protocols.ProtocolSpec{
 			Key:           uint32(protocols.ProgramHTTP),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				EBPFFuncName: filterTailCall,
+			},
+		},
+		{
+			ProgArrayName: protocols.TLSDispatcherProgramsMap,
+			Key:           uint32(protocols.ProgramTLSHTTPProcess),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: tlsProcessTailCall,
+			},
+		},
+		{
+			ProgArrayName: protocols.TLSDispatcherProgramsMap,
+			Key:           uint32(protocols.ProgramTLSHTTPTermination),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: tlsTerminationTailCall,
 			},
 		},
 	},

--- a/pkg/network/protocols/protocols.go
+++ b/pkg/network/protocols/protocols.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 )
 
-// Programs maps used for tail valls
+// Programs maps used for tail calls
 const (
 	ProtocolDispatcherProgramsMap = "protocols_progs"
 	TLSDispatcherProgramsMap      = "tls_process_progs"

--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -108,6 +108,7 @@ type subprogram interface {
 func newEBPFProgram(c *config.Config, sockFD, connectionProtocolMap *ebpf.Map, bpfTelemetry *errtelemetry.EBPFTelemetry) (*ebpfProgram, error) {
 	mgr := &manager.Manager{
 		Maps: []*manager.Map{
+			{Name: protocols.TLSDispatcherProgramsMap},
 			{Name: protocols.ProtocolDispatcherProgramsMap},
 			{Name: connectionStatesMap},
 		},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Introduces the baseline for future protocols capturing over TLS traffic.
New aditions:
* Running classification on TLS (http and http2)
* Moving https process into 2 tail calls (http process and http termination)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Setting the baseline for gRPC-TLS processing.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

The PR also reduces stack pressure (often revealed in javaTLS eRPC handlers) due to stack allocations of `http_transaction_t` by using a per-cpu array as heap.

The PR should reduce the processing USM is doing on TLS payload if those are not HTTP.

Memory impact - 
24 bytes per cpu - classification per-cpu heap
assuming upper limit of 96 cores - additional 2.3KB

no performance impact - 
WSS
![image](https://github.com/DataDog/datadog-agent/assets/17148247/23e9ad14-01da-4d9e-9f76-ed744b61f5c4)

RSS
![image](https://github.com/DataDog/datadog-agent/assets/17148247/69b64ae4-00fd-48aa-be10-891c967d65fd)

CPU 
![image](https://github.com/DataDog/datadog-agent/assets/17148247/a370c495-ee34-447f-9eea-45a4f70de9c2)


<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
