### PR TITLE
usm: http: minimize http_transaction struct by reorder the inner fields

### DIFF
--- a/pkg/network/ebpf/c/protocols/http/types.h
+++ b/pkg/network/ebpf/c/protocols/http/types.h
@@ -43,16 +43,14 @@ typedef enum
 typedef struct {
     conn_tuple_t tup;
     __u64 request_started;
-    __u8  request_method;
-    __u16 response_status_code;
     __u64 response_last_seen;
-    char request_fragment[HTTP_BUFFER_SIZE] __attribute__ ((aligned (8)));
-
+    __u64 tags;
     // this field is used to disambiguate segments in the context of keep-alives
     // we populate it with the TCP seq number of the request and then the response segments
     __u32 tcp_seq;
-
-    __u64 tags;
+    __u16 response_status_code;
+    __u8  request_method;
+    char request_fragment[HTTP_BUFFER_SIZE] __attribute__ ((aligned (8)));
 } http_transaction_t;
 
 // OpenSSL types

--- a/pkg/network/protocols/http/types_linux.go
+++ b/pkg/network/protocols/http/types_linux.go
@@ -27,12 +27,13 @@ type SslReadArgs struct {
 type EbpfTx struct {
 	Tup                  ConnTuple
 	Request_started      uint64
-	Request_method       uint8
-	Response_status_code uint16
 	Response_last_seen   uint64
-	Request_fragment     [160]byte
-	Tcp_seq              uint32
 	Tags                 uint64
+	Tcp_seq              uint32
+	Response_status_code uint16
+	Request_method       uint8
+	Pad_cgo_0            [1]byte
+	Request_fragment     [160]byte
 }
 
 const (


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Spares 1MB from USM WSS by reordering the inner fields of `http_transaction_t`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Memory efficiency

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Before the change:
```
4485: hash  name http_in_flight  flags 0x0
	key 48B  value 248B  max_entries 65536  memlock 19398656B
	btf_id 44166
```

After the change:
```
4385: hash  name http_in_flight  flags 0x0
	key 48B  value 240B  max_entries 65536  memlock 18874368B
	btf_id 43957
```

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
