### PR TITLE
usm: disable all irrelevant maps

### DIFF
--- a/pkg/network/ebpf/c/protocols/http/maps.h
+++ b/pkg/network/ebpf/c/protocols/http/maps.h
@@ -5,42 +5,8 @@
 #include "map-defs.h"
 
 #include "protocols/http/types.h"
-#include "protocols/tls/go-tls-types.h"
 
 /* This map is used to keep track of in-flight HTTP transactions for each TCP connection */
 BPF_HASH_MAP(http_in_flight, conn_tuple_t, http_transaction_t, 0)
-
-BPF_LRU_MAP(ssl_sock_by_ctx, void *, ssl_sock_t, 1)
-
-BPF_LRU_MAP(ssl_read_args, u64, ssl_read_args_t, 1024)
-
-BPF_LRU_MAP(ssl_read_ex_args, u64, ssl_read_ex_args_t, 1024)
-
-BPF_LRU_MAP(ssl_write_args, u64, ssl_write_args_t, 1024)
-
-BPF_LRU_MAP(ssl_write_ex_args, u64, ssl_write_ex_args_t, 1024)
-
-BPF_LRU_MAP(bio_new_socket_args, __u64, __u32, 1024)
-
-BPF_LRU_MAP(fd_by_ssl_bio, __u32, void *, 1024)
-
-BPF_LRU_MAP(ssl_ctx_by_pid_tgid, __u64, void *, 1024)
-
-// offsets_data map contains the information about the locations of structs in the inspected binary, mapped by the binary's inode number.
-BPF_HASH_MAP(offsets_data, go_tls_offsets_data_key_t, tls_offsets_data_t, 1024)
-
-/* go_tls_read_args is used to get the read function info when running in the read-return uprobe.
-   The key contains the go routine id and the pid. */
-BPF_LRU_MAP(go_tls_read_args, go_tls_function_args_key_t, go_tls_read_args_data_t, 2048)
-
-/* go_tls_write_args is used to get the read function info when running in the write-return uprobe.
-   The key contains the go routine id and the pid. */
-BPF_LRU_MAP(go_tls_write_args, go_tls_function_args_key_t, go_tls_write_args_data_t, 2048)
-
-/* This map associates crypto/tls.(*Conn) values to the corresponding conn_tuple_t* value.
-   It is used to implement a simplified version of tup_from_ssl_ctx from usm.c
-   Map size is set to 1 as goTLS is optional, this will be overwritten to MaxTrackedConnections
-   if goTLS is enabled. */
-BPF_HASH_MAP(conn_tup_by_go_tls_conn, __u32, conn_tuple_t, 1)
 
 #endif

--- a/pkg/network/ebpf/c/protocols/tls/go-tls-maps.h
+++ b/pkg/network/ebpf/c/protocols/tls/go-tls-maps.h
@@ -1,0 +1,26 @@
+#ifndef __GO_TLS_MAPS_H
+#define __GO_TLS_MAPS_H
+
+#include "bpf_helpers.h"
+#include "map-defs.h"
+
+#include "protocols/tls/go-tls-types.h"
+
+// offsets_data map contains the information about the locations of structs in the inspected binary, mapped by the binary's inode number.
+BPF_HASH_MAP(offsets_data, go_tls_offsets_data_key_t, tls_offsets_data_t, 1024)
+
+/* go_tls_read_args is used to get the read function info when running in the read-return uprobe.
+   The key contains the go routine id and the pid. */
+BPF_LRU_MAP(go_tls_read_args, go_tls_function_args_key_t, go_tls_read_args_data_t, 2048)
+
+/* go_tls_write_args is used to get the read function info when running in the write-return uprobe.
+   The key contains the go routine id and the pid. */
+BPF_LRU_MAP(go_tls_write_args, go_tls_function_args_key_t, go_tls_write_args_data_t, 2048)
+
+/* This map associates crypto/tls.(*Conn) values to the corresponding conn_tuple_t* value.
+   It is used to implement a simplified version of tup_from_ssl_ctx from usm.c
+   Map size is set to 1 as goTLS is optional, this will be overwritten to MaxTrackedConnections
+   if goTLS is enabled. */
+BPF_HASH_MAP(conn_tup_by_go_tls_conn, __u32, conn_tuple_t, 1)
+
+#endif //__GO_TLS_MAPS_H

--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -25,7 +25,9 @@
 #include "protocols/http/maps.h"
 #include "protocols/http/http.h"
 #include "protocols/tls/tags-types.h"
+#include "protocols/tls/native-tls-maps.h"
 #include "protocols/tls/go-tls-types.h"
+#include "protocols/tls/go-tls-maps.h"
 
 #define HTTPS_PORT 443
 

--- a/pkg/network/ebpf/c/protocols/tls/native-tls-maps.h
+++ b/pkg/network/ebpf/c/protocols/tls/native-tls-maps.h
@@ -1,0 +1,22 @@
+#ifndef __NATIVE_TLS_MAPS_H
+#define __NATIVE_TLS_MAPS_H
+
+#include "map-defs.h"
+
+BPF_LRU_MAP(ssl_sock_by_ctx, void *, ssl_sock_t, 1)
+
+BPF_LRU_MAP(ssl_read_args, u64, ssl_read_args_t, 1024)
+
+BPF_LRU_MAP(ssl_read_ex_args, u64, ssl_read_ex_args_t, 1024)
+
+BPF_LRU_MAP(ssl_write_args, u64, ssl_write_args_t, 1024)
+
+BPF_LRU_MAP(ssl_write_ex_args, u64, ssl_write_ex_args_t, 1024)
+
+BPF_LRU_MAP(bio_new_socket_args, __u64, __u32, 1024)
+
+BPF_LRU_MAP(fd_by_ssl_bio, __u32, void *, 1024)
+
+BPF_LRU_MAP(ssl_ctx_by_pid_tgid, __u64, void *, 1024)
+
+#endif

--- a/pkg/network/ebpf/c/protocols/tls/native-tls.h
+++ b/pkg/network/ebpf/c/protocols/tls/native-tls.h
@@ -4,6 +4,8 @@
 #include "ktypes.h"
 #include "bpf_builtins.h"
 
+#include "protocols/tls/native-tls-maps.h"
+
 SEC("uprobe/SSL_do_handshake")
 int uprobe__SSL_do_handshake(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -66,6 +66,15 @@ var Spec = &protocols.ProtocolSpec{
 		{
 			Name: http2IterationsTable,
 		},
+		{
+			Name: "http2_headers_to_process",
+		},
+		{
+			Name: "http2_stream_heap",
+		},
+		{
+			Name: "http2_ctx_heap",
+		},
 	},
 	TailCalls: []manager.TailCallRoute{
 		{

--- a/pkg/network/protocols/kafka/protocol.go
+++ b/pkg/network/protocols/kafka/protocol.go
@@ -33,6 +33,7 @@ const (
 	dispatcherTailCall                       = "socket__protocol_dispatcher_kafka"
 	protocolDispatcherClassificationPrograms = "dispatcher_classification_progs"
 	kafkaLastTCPSeqPerConnectionMap          = "kafka_last_tcp_seq_per_connection"
+	kafkaHeapMap                             = "kafka_heap"
 )
 
 var Spec = &protocols.ProtocolSpec{
@@ -43,6 +44,9 @@ var Spec = &protocols.ProtocolSpec{
 		},
 		{
 			Name: kafkaLastTCPSeqPerConnectionMap,
+		},
+		{
+			Name: kafkaHeapMap,
 		},
 	},
 	TailCalls: []manager.TailCallRoute{

--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -217,6 +217,7 @@ func (p *GoTLSProgram) ConfigureManager(m *errtelemetry.Manager) {
 		{Name: offsetsDataMap},
 		{Name: goTLSReadArgsMap},
 		{Name: goTLSWriteArgsMap},
+		{Name: connectionTupleByGoTLSMap},
 	}...)
 	// Hooks will be added in runtime for each binary
 }

--- a/pkg/network/usm/ebpf_javatls.go
+++ b/pkg/network/usm/ebpf_javatls.go
@@ -84,6 +84,12 @@ var javaTLSSpec = &protocols.ProtocolSpec{
 		{
 			Name: javaTLSConnectionsMap,
 		},
+		{
+			Name: javaDomainsToConnectionsMap,
+		},
+		{
+			Name: eRPCHandlersMap,
+		},
 	},
 	Probes: []*manager.Probe{
 		{

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -241,6 +241,15 @@ var opensslSpec = &protocols.ProtocolSpec{
 			Name: "ssl_read_args",
 		},
 		{
+			Name: "ssl_read_ex_args",
+		},
+		{
+			Name: "ssl_write_args",
+		},
+		{
+			Name: "ssl_write_ex_args",
+		},
+		{
 			Name: "bio_new_socket_args",
 		},
 		{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Adds more maps to disable in case of protocol is not enabled.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Using as small as possible memory
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
In case of https monitoring is disabled - we use 76kb less memory.
the main future achievement will come in goTLS refactor to protocol spec (5MB)

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
