### PR TITLE
Revert "allow failure of CWS e2e tests"

### DIFF
--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -79,7 +79,6 @@ k8s-e2e-cws-dev:
 k8s-e2e-cws-main:
   extends: .k8s_e2e_template
   rules: !reference [.on_main]
-  allow_failure: true
   # needs:
   #   - dev_master-a6
   #   - dev_master-a7


### PR DESCRIPTION
Reverts DataDog/datadog-agent#19341, the tests should be fixed now