### PR TITLE
[CWS][SEC-10574] Fix Activity Dump local storage race with Security Profile directory provider

### DIFF
--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -212,6 +212,13 @@ var (
 	// MetricActivityDumpNotYetProfiledWorkload is the name of the metric used to report the count of workload not yet profiled
 	// Tags: -
 	MetricActivityDumpNotYetProfiledWorkload = newAgentMetric(".activity_dump.not_yet_profiled_workload")
+	// MetricActivityDumpLocalStorageCount is the name of the metric used to count the number of dumps stored locally
+	// Tags: -
+	MetricActivityDumpLocalStorageCount = newAgentMetric(".activity_dump.local_storage.count")
+	// MetricActivityDumpLocalStorageDeleted is the name of the metric used to track the deletion of workload entries in
+	// the local storage.
+	// Tags: -
+	MetricActivityDumpLocalStorageDeleted = newAgentMetric(".activity_dump.local_storage.deleted")
 
 	// SBOM resolver metrics
 
@@ -251,6 +258,10 @@ var (
 	// MetricSecurityProfileEventFiltering is the name of the metric used to report the count of Security Profile event filtered
 	// Tags: event_type, profile_state ('no_profile', 'unstable', 'unstable_event_type', 'stable', 'auto_learning', 'workload_warmup'), in_profile ('true', 'false' or none)
 	MetricSecurityProfileEventFiltering = newRuntimeMetric(".security_profile.evaluation.hit")
+	// MetricSecurityProfileDirectoryProviderCount is the name of the metric used to track the count of profiles in the cache
+	// of the Profile directory provider
+	// Tags: -
+	MetricSecurityProfileDirectoryProviderCount = newAgentMetric(".activity_dump.directory_provider.count")
 
 	// Hash resolver metrics
 

--- a/pkg/security/rconfig/profiles.go
+++ b/pkg/security/rconfig/profiles.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	proto "github.com/DataDog/agent-payload/v5/cws/dumpsv1"
+	"github.com/DataDog/datadog-go/v5/statsd"
 
 	"github.com/DataDog/datadog-agent/pkg/config/remote"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
@@ -127,6 +128,11 @@ func (r *RCProfileProvider) UpdateWorkloadSelectors(selectors []cgroupModel.Work
 // SetOnNewProfileCallback sets the onNewProfileCallback function
 func (r *RCProfileProvider) SetOnNewProfileCallback(onNewProfileCallback func(selector cgroupModel.WorkloadSelector, profile *proto.SecurityProfile)) {
 	r.onNewProfileCallback = onNewProfileCallback
+}
+
+// SendStats sends the metrics of the directory provider
+func (r *RCProfileProvider) SendStats(_ statsd.ClientInterface) error {
+	return nil
 }
 
 // NewRCProfileProvider returns a new Remote Config based policy provider

--- a/pkg/security/security_profile/activity_tree/activity_tree_test.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_test.go
@@ -3714,8 +3714,8 @@ var activityTreeInsertExecEventTestCases = []struct {
 	//         |         | (exec)                  |                        |             | (exec)
 	//       python    uwsgi                      bash                   python        ddtrace
 	//                                             |                                      | (exec)
-	//                                           ddtrace                                  tools
-	//                                             | (exec                               | (exec)
+	//                                           ddtrace                                tools
+	//                                             | (exec)                               | (exec)
 	//                                           tools                                  utils
 	//                                             | (exec)                               | (exec)
 	//                                           utils                                  uwsgi

--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -45,6 +45,7 @@ type ActivityDumpHandler interface {
 // SecurityProfileManager is a generic interface used to communicate with the Security Profile manager
 type SecurityProfileManager interface {
 	FetchSilentWorkloads() map[cgroupModel.WorkloadSelector][]*cgroupModel.CacheEntry
+	OnLocalStorageCleanup(files []string)
 }
 
 // ActivityDumpManager is used to manage ActivityDumps
@@ -285,7 +286,7 @@ func NewActivityDumpManager(config *config.Config, statsdClient statsd.ClientInt
 		pathsReducer:           activity_tree.NewPathsReducer(),
 	}
 
-	adm.storage, err = NewActivityDumpStorageManager(config, statsdClient, adm)
+	adm.storage, err = NewActivityDumpStorageManager(config, statsdClient, adm, adm)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't instantiate the activity dump storage manager: %w", err)
 	}

--- a/pkg/security/security_profile/dump/storage_manager.go
+++ b/pkg/security/security_profile/dump/storage_manager.go
@@ -66,7 +66,7 @@ func NewSecurityAgentCommandStorageManager(cfg *config.Config) (*ActivityDumpSto
 		storages: make(map[config.StorageType]ActivityDumpStorage),
 	}
 
-	storage, err := NewActivityDumpLocalStorage(cfg)
+	storage, err := NewActivityDumpLocalStorage(cfg, nil)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't instantiate storage: %w", err)
 	}
@@ -83,13 +83,13 @@ func NewSecurityAgentCommandStorageManager(cfg *config.Config) (*ActivityDumpSto
 }
 
 // NewActivityDumpStorageManager returns a new instance of ActivityDumpStorageManager
-func NewActivityDumpStorageManager(cfg *config.Config, statsdClient statsd.ClientInterface, handler ActivityDumpHandler) (*ActivityDumpStorageManager, error) {
+func NewActivityDumpStorageManager(cfg *config.Config, statsdClient statsd.ClientInterface, handler ActivityDumpHandler, m *ActivityDumpManager) (*ActivityDumpStorageManager, error) {
 	manager := &ActivityDumpStorageManager{
 		storages:     make(map[config.StorageType]ActivityDumpStorage),
 		statsdClient: statsdClient,
 	}
 
-	storage, err := NewActivityDumpLocalStorage(cfg)
+	storage, err := NewActivityDumpLocalStorage(cfg, m)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't instantiate storage: %w", err)
 	}

--- a/pkg/security/security_profile/profile/profile_provider.go
+++ b/pkg/security/security_profile/profile/profile_provider.go
@@ -12,6 +12,8 @@ import (
 	"context"
 
 	proto "github.com/DataDog/agent-payload/v5/cws/dumpsv1"
+	"github.com/DataDog/datadog-go/v5/statsd"
+
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
 )
 
@@ -21,6 +23,8 @@ type Provider interface {
 	Start(ctx context.Context) error
 	// Stop closes the profile provider
 	Stop() error
+	// SendStats sends the metrics of the profile provider
+	SendStats(statsdClient statsd.ClientInterface) error
 
 	// UpdateWorkloadSelectors updates the selectors used to query profiles
 	UpdateWorkloadSelectors(selectors []cgroupModel.WorkloadSelector)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR fixes a race between the Activity Dump local storage and the Security Profile directory provider: once the `config.RuntimeSecurity.ActivityDumpLocalStorageMaxDumpsCount` limit is reached by the Activity Dump local storage, it will start deleting old entries to prevent leaking files on the file system - this deletion wasn't synchronized with the Security Profile directory provider which would expected the deleted files to exist on the file system. This PR ensures that the Security Profile directory provider is notified by the local storage before any file is deleted.

This PR also introduces new metrics to better track the state of the local storage and the directory provider:
- `datadog.runtime_security.activity_dump.directory_provider.count` is the name of the metric used to track the count of profiles in the cache of the Profile directory provider
- `datadog.runtime_security.activity_dump.local_storage.count` is the name of the metric used to count the number of dumps stored locally
- `datadog.runtime_security.activity_dump.local_storage.deleted` is the name of the metric used to track the local storage deletions

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Given enough time, this race generates a log of system-probe error logs.

### Describe how to test/QA your changes

Check the levels of the 3 metrics in staging and make sure they make sense.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
