### PR TITLE
[gitlab] Remove use of `$CI_PROJECT_DIR` in artifact sections

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,15 +100,18 @@ variables:
   OMNIBUS_BASE_DIR: /omnibus
   # Directory in which we put the artifacts after the build
   # Must be in $CI_PROJECT_DIR
-  OMNIBUS_PACKAGE_DIR: $CI_PROJECT_DIR/omnibus/pkg/
+  OMNIBUS_PACKAGE_DIR_SUFFIX: omnibus/pkg/
+  OMNIBUS_PACKAGE_DIR: $CI_PROJECT_DIR/$OMNIBUS_PACKAGE_DIR_SUFFIX
   # Directory in which we put the SUSE artifacts after the SUSE build
   # Must be in $CI_PROJECT_DIR
   # RPM builds and SUSE RPM builds create artifacts with the same name.
   # To differentiate them, we put them in different folders. That also
   # avoids accidentally overwriting files when downloading artifacts from
   # both RPM and SUSE rpm jobs.
-  OMNIBUS_PACKAGE_DIR_SUSE: $CI_PROJECT_DIR/omnibus/suse/pkg
-  DD_AGENT_TESTING_DIR: $CI_PROJECT_DIR/test/kitchen
+  OMNIBUS_PACKAGE_DIR_SUSE_SUFFIX: omnibus/suse/pkg
+  OMNIBUS_PACKAGE_DIR_SUSE: $CI_PROJECT_DIR/$OMNIBUS_PACKAGE_DIR_SUSE_SUFFIX
+  DD_AGENT_TESTING_DIR_SUFFIX: test/kitchen
+  DD_AGENT_TESTING_DIR: $CI_PROJECT_DIR/$DD_AGENT_TESTING_DIR_SUFFIX
   STATIC_BINARIES_DIR: bin/static
   DOGSTATSD_BINARIES_DIR: bin/dogstatsd
   AGENT_BINARIES_DIR: bin/agent

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,18 +100,15 @@ variables:
   OMNIBUS_BASE_DIR: /omnibus
   # Directory in which we put the artifacts after the build
   # Must be in $CI_PROJECT_DIR
-  OMNIBUS_PACKAGE_DIR_SUFFIX: omnibus/pkg/
-  OMNIBUS_PACKAGE_DIR: $CI_PROJECT_DIR/$OMNIBUS_PACKAGE_DIR_SUFFIX
+  OMNIBUS_PACKAGE_DIR: $CI_PROJECT_DIR/omnibus/pkg
   # Directory in which we put the SUSE artifacts after the SUSE build
   # Must be in $CI_PROJECT_DIR
   # RPM builds and SUSE RPM builds create artifacts with the same name.
   # To differentiate them, we put them in different folders. That also
   # avoids accidentally overwriting files when downloading artifacts from
   # both RPM and SUSE rpm jobs.
-  OMNIBUS_PACKAGE_DIR_SUSE_SUFFIX: omnibus/suse/pkg
-  OMNIBUS_PACKAGE_DIR_SUSE: $CI_PROJECT_DIR/$OMNIBUS_PACKAGE_DIR_SUSE_SUFFIX
-  DD_AGENT_TESTING_DIR_SUFFIX: test/kitchen
-  DD_AGENT_TESTING_DIR: $CI_PROJECT_DIR/$DD_AGENT_TESTING_DIR_SUFFIX
+  OMNIBUS_PACKAGE_DIR_SUSE: $CI_PROJECT_DIR/omnibus/suse/pkg
+  DD_AGENT_TESTING_DIR: $CI_PROJECT_DIR/test/kitchen
   STATIC_BINARIES_DIR: bin/static
   DOGSTATSD_BINARIES_DIR: bin/dogstatsd
   AGENT_BINARIES_DIR: bin/agent

--- a/.gitlab/binary_build/cluster_agent_cloudfoundry.yml
+++ b/.gitlab/binary_build/cluster_agent_cloudfoundry.yml
@@ -9,7 +9,7 @@ cluster_agent_cloudfoundry-build_amd64:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR
+      - $OMNIBUS_PACKAGE_DIR_SUFFIX
   variables:
     ARCH: amd64
   before_script:

--- a/.gitlab/binary_build/cluster_agent_cloudfoundry.yml
+++ b/.gitlab/binary_build/cluster_agent_cloudfoundry.yml
@@ -9,7 +9,7 @@ cluster_agent_cloudfoundry-build_amd64:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR_SUFFIX
+      - omnibus/pkg
   variables:
     ARCH: amd64
   before_script:

--- a/.gitlab/binary_build/serverless.yml
+++ b/.gitlab/binary_build/serverless.yml
@@ -18,7 +18,7 @@ build_serverless-deb_x64:
   artifacts:
     expire_in: 1 day
     paths:
-      - $CI_PROJECT_DIR/cmd/serverless
+      - cmd/serverless
 
 build_serverless-deb_arm64:
   extends: .build_serverless_common

--- a/.gitlab/deps_build.yml
+++ b/.gitlab/deps_build.yml
@@ -62,8 +62,8 @@
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $CI_PROJECT_DIR/.tmp/clang
-      - $CI_PROJECT_DIR/.tmp/llc
+      - .tmp/clang
+      - .tmp/llc
 
 build_clang_x64:
   extends: .build_clang_common

--- a/.gitlab/deps_fetch.yml
+++ b/.gitlab/deps_fetch.yml
@@ -21,6 +21,7 @@ go_deps:
     - inv -e deps --verbose
     - cd $GOPATH/pkg/mod/ && tar czf $CI_PROJECT_DIR/modcache.tar.gz .
     - ls -la . || true
+    - ls -la $CI_PROJECT_DIR || true
   artifacts:
     expire_in: 1 day
     paths:
@@ -33,7 +34,7 @@ test:
   tags: ["arch:amd64"]
   needs: ["setup_agent_version"]
   script:
-    - echo "test" > test
+    - echo "test" > $CI_PROJECT_DIR/test
   artifacts:
     expire_in: 1 day
     paths:

--- a/.gitlab/deps_fetch.yml
+++ b/.gitlab/deps_fetch.yml
@@ -20,25 +20,10 @@ go_deps:
     - source /root/.bashrc
     - inv -e deps --verbose
     - cd $GOPATH/pkg/mod/ && tar czf $CI_PROJECT_DIR/modcache.tar.gz .
-    - ls -la . || true
-    - ls -la $CI_PROJECT_DIR || true
   artifacts:
     expire_in: 1 day
     paths:
-      - $CI_PROJECT_DIR/modcache.tar.gz
-  retry: 1
-
-test:
-  stage: deps_fetch
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["arch:amd64"]
-  needs: ["setup_agent_version"]
-  script:
-    - echo "test" > $CI_PROJECT_DIR/test
-  artifacts:
-    expire_in: 1 day
-    paths:
-      - $CI_PROJECT_DIR/test
+      - modcache.tar.gz
   retry: 1
 
 go_tools_deps:
@@ -53,5 +38,5 @@ go_tools_deps:
   artifacts:
     expire_in: 1 day
     paths:
-      - $CI_PROJECT_DIR/modcache_tools.tar.gz
+      - modcache_tools.tar.gz
   retry: 1

--- a/.gitlab/deps_fetch.yml
+++ b/.gitlab/deps_fetch.yml
@@ -20,10 +20,24 @@ go_deps:
     - source /root/.bashrc
     - inv -e deps --verbose
     - cd $GOPATH/pkg/mod/ && tar czf $CI_PROJECT_DIR/modcache.tar.gz .
+    - ls -la . || true
   artifacts:
     expire_in: 1 day
     paths:
       - $CI_PROJECT_DIR/modcache.tar.gz
+  retry: 1
+
+test:
+  stage: deps_fetch
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs: ["setup_agent_version"]
+  script:
+    - echo "test" > test
+  artifacts:
+    expire_in: 1 day
+    paths:
+      - $CI_PROJECT_DIR/test
   retry: 1
 
 go_tools_deps:

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -30,7 +30,7 @@
     expire_in: 2 weeks
     when: always
     paths:
-      - $DD_AGENT_TESTING_DIR/kitchen-junit-*.tar.gz
+      - $DD_AGENT_TESTING_DIR_SUFFIX/kitchen-junit-*.tar.gz
 
 kitchen_test_security_agent_x64:
   extends:

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -30,7 +30,7 @@
     expire_in: 2 weeks
     when: always
     paths:
-      - $DD_AGENT_TESTING_DIR_SUFFIX/kitchen-junit-*.tar.gz
+      - test/kitchen/kitchen-junit-*.tar.gz
 
 kitchen_test_security_agent_x64:
   extends:

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -29,9 +29,9 @@
     expire_in: 2 weeks
     when: always
     paths:
-      - $DD_AGENT_TESTING_DIR/kitchen-junit-*.tar.gz
-      - $DD_AGENT_TESTING_DIR/testjson
-      - $CI_PROJECT_DIR/kitchen_logs
+      - $DD_AGENT_TESTING_DIR_SUFFIX/kitchen-junit-*.tar.gz
+      - $DD_AGENT_TESTING_DIR_SUFFIX/testjson
+      - kitchen_logs
 
 .retrieve_test_dockers:
   - mkdir -p $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
@@ -71,6 +71,7 @@ kitchen_test_system_probe_linux_x64_ec2:
     KITCHEN_EC2_INSTANCE_TYPE: "t2.xlarge"
     KITCHEN_CI_MOUNT_PATH: "/mnt/ci"
     KITCHEN_CI_ROOT_PATH: "/tmp/ci"
+    KITCHEN_DOCKERS_SUFFIX: $DD_AGENT_TESTING_DIR_SUFFIX/kitchen-dockers-$ARCH
     KITCHEN_DOCKERS: $DD_AGENT_TESTING_DIR/kitchen-dockers-$ARCH
   before_script:
     - !reference [.retrieve_test_dockers]
@@ -135,6 +136,7 @@ kitchen_test_system_probe_linux_arm64:
     KITCHEN_EC2_INSTANCE_TYPE: "t4g.xlarge"
     KITCHEN_CI_MOUNT_PATH: "/mnt/ci"
     KITCHEN_CI_ROOT_PATH: "/tmp/ci"
+    KITCHEN_DOCKERS_SUFFIX: $DD_AGENT_TESTING_DIR_SUFFIX/kitchen-dockers-$ARCH
     KITCHEN_DOCKERS: $DD_AGENT_TESTING_DIR/kitchen-dockers-$ARCH
   before_script:
     - !reference [.retrieve_test_dockers]

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -29,8 +29,8 @@
     expire_in: 2 weeks
     when: always
     paths:
-      - $DD_AGENT_TESTING_DIR_SUFFIX/kitchen-junit-*.tar.gz
-      - $DD_AGENT_TESTING_DIR_SUFFIX/testjson
+      - test/kitchen/kitchen-junit-*.tar.gz
+      - test/kitchen/testjson
       - kitchen_logs
 
 .retrieve_test_dockers:
@@ -71,7 +71,6 @@ kitchen_test_system_probe_linux_x64_ec2:
     KITCHEN_EC2_INSTANCE_TYPE: "t2.xlarge"
     KITCHEN_CI_MOUNT_PATH: "/mnt/ci"
     KITCHEN_CI_ROOT_PATH: "/tmp/ci"
-    KITCHEN_DOCKERS_SUFFIX: $DD_AGENT_TESTING_DIR_SUFFIX/kitchen-dockers-$ARCH
     KITCHEN_DOCKERS: $DD_AGENT_TESTING_DIR/kitchen-dockers-$ARCH
   before_script:
     - !reference [.retrieve_test_dockers]
@@ -136,7 +135,6 @@ kitchen_test_system_probe_linux_arm64:
     KITCHEN_EC2_INSTANCE_TYPE: "t4g.xlarge"
     KITCHEN_CI_MOUNT_PATH: "/mnt/ci"
     KITCHEN_CI_ROOT_PATH: "/tmp/ci"
-    KITCHEN_DOCKERS_SUFFIX: $DD_AGENT_TESTING_DIR_SUFFIX/kitchen-dockers-$ARCH
     KITCHEN_DOCKERS: $DD_AGENT_TESTING_DIR/kitchen-dockers-$ARCH
   before_script:
     - !reference [.retrieve_test_dockers]

--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -15,8 +15,9 @@
   artifacts:
     expire_in: 1 day
     paths:
-      - $KITCHEN_DOCKERS
+      - $KITCHEN_DOCKERS_SUFFIX
   variables:
+    KITCHEN_DOCKERS_SUFFIX: $DD_AGENT_TESTING_DIR_SUFFIX/kitchen-dockers-$ARCH
     KITCHEN_DOCKERS: $DD_AGENT_TESTING_DIR/kitchen-dockers-$ARCH
 
 pull_test_dockers_x64:
@@ -90,6 +91,7 @@ pull_test_dockers_arm64:
     - scp -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE $DD_AGENT_TESTING_DIR/$ARCHIVE_NAME ubuntu@$INSTANCE_IP:/opt/kernel-version-testing/
   variables:
     DEPENDENCIES: $DD_AGENT_TESTING_DIR/$ARCH/dependencies
+    KITCHEN_DOCKERS_SUFFIX: $DD_AGENT_TESTING_DIR_SUFFIX/kitchen-dockers-$ARCH
     KITCHEN_DOCKERS: $DD_AGENT_TESTING_DIR/kitchen-dockers-$ARCH
     AWS_EC2_SSH_KEY_FILE: $CI_PROJECT_DIR/ssh_key
 
@@ -291,7 +293,7 @@ kernel_matrix_testing_setup_env:
       - $LibvirtSSHKeyARM
       - $LibvirtSSHKeyARM.pub
       - $STACK_DIR
-      - $CI_PROJECT_DIR/stack.outputs
+      - stack.outputs
 
 .kernel_matrix_testing_run_tests:
   stage: kernel_matrix_testing

--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -15,9 +15,8 @@
   artifacts:
     expire_in: 1 day
     paths:
-      - $KITCHEN_DOCKERS_SUFFIX
+      - test/kitchen/kitchen-dockers-$ARCH
   variables:
-    KITCHEN_DOCKERS_SUFFIX: $DD_AGENT_TESTING_DIR_SUFFIX/kitchen-dockers-$ARCH
     KITCHEN_DOCKERS: $DD_AGENT_TESTING_DIR/kitchen-dockers-$ARCH
 
 pull_test_dockers_x64:
@@ -91,7 +90,6 @@ pull_test_dockers_arm64:
     - scp -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE $DD_AGENT_TESTING_DIR/$ARCHIVE_NAME ubuntu@$INSTANCE_IP:/opt/kernel-version-testing/
   variables:
     DEPENDENCIES: $DD_AGENT_TESTING_DIR/$ARCH/dependencies
-    KITCHEN_DOCKERS_SUFFIX: $DD_AGENT_TESTING_DIR_SUFFIX/kitchen-dockers-$ARCH
     KITCHEN_DOCKERS: $DD_AGENT_TESTING_DIR/kitchen-dockers-$ARCH
     AWS_EC2_SSH_KEY_FILE: $CI_PROJECT_DIR/ssh_key
 

--- a/.gitlab/kitchen_common/testing.yml
+++ b/.gitlab/kitchen_common/testing.yml
@@ -7,7 +7,7 @@
     expire_in: 2 weeks
     when: always
     paths:
-      - $CI_PROJECT_DIR/kitchen_logs
+      - kitchen_logs
   retry: 1
 
 .kitchen_common_with_junit:
@@ -23,7 +23,7 @@
     expire_in: 2 weeks
     when: always
     paths:
-      - $CI_PROJECT_DIR/kitchen_logs
+      - kitchen_logs
       - "**/kitchen-rspec-common-${CI_JOB_NAME}.tar.gz"
 
 # Kitchen: providers

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -72,7 +72,7 @@
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR_SUFFIX
+      - omnibus/pkg
 
 agent_deb-x64-a6:
   extends: .agent_build_common_deb
@@ -169,7 +169,7 @@ agent_deb-arm64-a7:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR_SUFFIX
+      - omnibus/pkg
 
 iot_agent_deb-x64:
   extends: .iot_agent_build_common_deb
@@ -234,7 +234,7 @@ dogstatsd_deb-x64:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR_SUFFIX
+      - omnibus/pkg
 
 dogstatsd_deb-arm64:
   rules:
@@ -261,7 +261,7 @@ dogstatsd_deb-arm64:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR_SUFFIX
+      - omnibus/pkg
 
 agent_heroku_deb-x64-a6:
   extends: agent_deb-x64-a6

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -72,7 +72,7 @@
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR
+      - $OMNIBUS_PACKAGE_DIR_SUFFIX
 
 agent_deb-x64-a6:
   extends: .agent_build_common_deb
@@ -169,7 +169,7 @@ agent_deb-arm64-a7:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR
+      - $OMNIBUS_PACKAGE_DIR_SUFFIX
 
 iot_agent_deb-x64:
   extends: .iot_agent_build_common_deb
@@ -234,7 +234,7 @@ dogstatsd_deb-x64:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR
+      - $OMNIBUS_PACKAGE_DIR_SUFFIX
 
 dogstatsd_deb-arm64:
   rules:
@@ -261,7 +261,7 @@ dogstatsd_deb-arm64:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR
+      - $OMNIBUS_PACKAGE_DIR_SUFFIX
 
 agent_heroku_deb-x64-a6:
   extends: agent_deb-x64-a6

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -18,7 +18,7 @@
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR_SUFFIX
+      - omnibus/pkg
 
 agent_dmg-x64-a7:
   extends: .agent_build_common_dmg

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -18,7 +18,7 @@
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR
+      - $OMNIBUS_PACKAGE_DIR_SUFFIX
 
 agent_dmg-x64-a7:
   extends: .agent_build_common_dmg

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -67,7 +67,7 @@
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR
+      - $OMNIBUS_PACKAGE_DIR_SUFFIX
 
 # build Agent package for rpm-x64
 agent_rpm-x64-a6:
@@ -167,7 +167,7 @@ agent_rpm-arm64-a7:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR
+      - $OMNIBUS_PACKAGE_DIR_SUFFIX
 
 iot_agent_rpm-x64:
   extends: .iot_agent_build_common_rpm
@@ -230,4 +230,4 @@ dogstatsd_rpm-x64:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR
+      - $OMNIBUS_PACKAGE_DIR_SUFFIX

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -67,7 +67,7 @@
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR_SUFFIX
+      - omnibus/pkg
 
 # build Agent package for rpm-x64
 agent_rpm-x64-a6:
@@ -167,7 +167,7 @@ agent_rpm-arm64-a7:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR_SUFFIX
+      - omnibus/pkg
 
 iot_agent_rpm-x64:
   extends: .iot_agent_build_common_rpm
@@ -230,4 +230,4 @@ dogstatsd_rpm-x64:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR_SUFFIX
+      - omnibus/pkg

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -69,7 +69,7 @@
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR_SUSE
+      - $OMNIBUS_PACKAGE_DIR_SUSE_SUFFIX
 
 # build Agent package for suse-x64
 agent_suse-x64-a6:
@@ -140,7 +140,7 @@ iot_agent_suse-x64:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR_SUSE
+      - $OMNIBUS_PACKAGE_DIR_SUSE_SUFFIX
 
 dogstatsd_suse-x64:
   rules:
@@ -174,4 +174,4 @@ dogstatsd_suse-x64:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR_SUSE
+      - $OMNIBUS_PACKAGE_DIR_SUSE_SUFFIX

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -69,7 +69,7 @@
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR_SUSE_SUFFIX
+      - omnibus/suse/pkg
 
 # build Agent package for suse-x64
 agent_suse-x64-a6:
@@ -140,7 +140,7 @@ iot_agent_suse-x64:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR_SUSE_SUFFIX
+      - omnibus/suse/pkg
 
 dogstatsd_suse-x64:
   rules:
@@ -174,4 +174,4 @@ dogstatsd_suse-x64:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR_SUSE_SUFFIX
+      - omnibus/suse/pkg

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -80,7 +80,7 @@
   artifacts:
     when: always
     paths:
-      - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files
+      - $DD_AGENT_TESTING_DIR_SUFFIX/site-cookbooks/dd-system-probe-check/files
 
 tests_ebpf_x64:
   extends: .tests_linux_ebpf
@@ -104,9 +104,9 @@ tests_ebpf_arm64:
   artifacts:
     when: always
     paths:
-      - $CI_PROJECT_DIR/.tmp/binary-ebpf
-      - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files
-      - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files
+      - .tmp/binary-ebpf
+      - $DD_AGENT_TESTING_DIR_SUFFIX/site-cookbooks/dd-security-agent-check/files
+      - $DD_AGENT_TESTING_DIR_SUFFIX/site-cookbooks/dd-system-probe-check/files
   before_script:
     - !reference [.retrieve_linux_go_deps]
     - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf/co-re

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -80,7 +80,7 @@
   artifacts:
     when: always
     paths:
-      - $DD_AGENT_TESTING_DIR_SUFFIX/site-cookbooks/dd-system-probe-check/files
+      - test/kitchen/site-cookbooks/dd-system-probe-check/files
 
 tests_ebpf_x64:
   extends: .tests_linux_ebpf
@@ -105,8 +105,8 @@ tests_ebpf_arm64:
     when: always
     paths:
       - .tmp/binary-ebpf
-      - $DD_AGENT_TESTING_DIR_SUFFIX/site-cookbooks/dd-security-agent-check/files
-      - $DD_AGENT_TESTING_DIR_SUFFIX/site-cookbooks/dd-system-probe-check/files
+      - test/kitchen/site-cookbooks/dd-security-agent-check/files
+      - test/kitchen/site-cookbooks/dd-system-probe-check/files
   before_script:
     - !reference [.retrieve_linux_go_deps]
     - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf/co-re


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Removes `$CI_PROJECT_DIR` from the Gitlab artifact paths. Some other variables used in artifacts were referencing it, so I created duplicates of them without the `$CI_PROJECT_DIR` prefix.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Gitlab runner 15.6 -> 15.12 upgrade broke the Gitlab pipeline because of this - the `go_deps` job that is supposed to upload an archive containing all our go dependencies didn't work anymore.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Check that the datadog-agent Gitlab pipeline passes.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
