### PR TITLE
[CWS][SEC-10575] Change `security_profiles` and `secprofs_syscalls` LRU maps to hashmaps

### DIFF
--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -33,6 +33,8 @@ BPF_HASH_MAP(basename_approvers, struct basename_t, struct basename_filter_t, 25
 BPF_HASH_MAP(register_netdevice_cache, u64, struct register_netdevice_cache_t, 1024)
 BPF_HASH_MAP(netdevice_lookup_cache, u64, struct device_ifindex_t, 1024)
 BPF_HASH_MAP(fd_link_pid, u8, u32, 1)
+BPF_HASH_MAP(security_profiles, struct container_context_t, struct security_profile_t, 1) // max entries will be overriden at runtime
+BPF_HASH_MAP(secprofs_syscalls, u64, struct security_profile_syscalls_t, 1) // max entries will be overriden at runtime
 
 BPF_LRU_MAP(activity_dump_rate_limiters, u64, struct activity_dump_rate_limiter_ctx, 1) // max entries will be overridden at runtime
 BPF_LRU_MAP(mount_ref, u32, struct mount_ref_t, 64000)
@@ -58,8 +60,6 @@ BPF_LRU_MAP(veth_device_name_to_ifindex, struct device_name_t, struct device_ifi
 BPF_LRU_MAP(exec_file_cache, u64, struct file_t, 4096)
 BPF_LRU_MAP(syscall_monitor, u32, struct syscall_monitor_entry_t, 2048)
 BPF_LRU_MAP(syscall_table, struct syscall_table_key_t, u8, 50)
-BPF_LRU_MAP(security_profiles, struct container_context_t, struct security_profile_t, 1) // max entries will be overriden at runtime
-BPF_LRU_MAP(secprofs_syscalls, u64, struct security_profile_syscalls_t, 1) // max entries will be overriden at runtime
 
 BPF_LRU_MAP_FLAGS(tasks_in_coredump, u64, u8, 64, BPF_F_NO_COMMON_LRU)
 BPF_LRU_MAP_FLAGS(syscalls, u64, struct syscall_cache_t, 1, BPF_F_NO_COMMON_LRU) // max entries will be overridden at runtime

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -212,6 +212,13 @@ var (
 	// MetricActivityDumpNotYetProfiledWorkload is the name of the metric used to report the count of workload not yet profiled
 	// Tags: -
 	MetricActivityDumpNotYetProfiledWorkload = newAgentMetric(".activity_dump.not_yet_profiled_workload")
+	// MetricActivityDumpLocalStorageCount is the name of the metric used to count the number of dumps stored locally
+	// Tags: -
+	MetricActivityDumpLocalStorageCount = newAgentMetric(".activity_dump.local_storage.count")
+	// MetricActivityDumpLocalStorageDeleted is the name of the metric used to track the deletion of workload entries in
+	// the local storage.
+	// Tags: -
+	MetricActivityDumpLocalStorageDeleted = newAgentMetric(".activity_dump.local_storage.deleted")
 
 	// SBOM resolver metrics
 
@@ -251,6 +258,10 @@ var (
 	// MetricSecurityProfileEventFiltering is the name of the metric used to report the count of Security Profile event filtered
 	// Tags: event_type, profile_state ('no_profile', 'unstable', 'unstable_event_type', 'stable', 'auto_learning', 'workload_warmup'), in_profile ('true', 'false' or none)
 	MetricSecurityProfileEventFiltering = newRuntimeMetric(".security_profile.evaluation.hit")
+	// MetricSecurityProfileDirectoryProviderCount is the name of the metric used to track the count of profiles in the cache
+	// of the Profile directory provider
+	// Tags: -
+	MetricSecurityProfileDirectoryProviderCount = newAgentMetric(".activity_dump.directory_provider.count")
 
 	// Hash resolver metrics
 

--- a/pkg/security/rconfig/profiles.go
+++ b/pkg/security/rconfig/profiles.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	proto "github.com/DataDog/agent-payload/v5/cws/dumpsv1"
+	"github.com/DataDog/datadog-go/v5/statsd"
 
 	"github.com/DataDog/datadog-agent/pkg/config/remote"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
@@ -127,6 +128,11 @@ func (r *RCProfileProvider) UpdateWorkloadSelectors(selectors []cgroupModel.Work
 // SetOnNewProfileCallback sets the onNewProfileCallback function
 func (r *RCProfileProvider) SetOnNewProfileCallback(onNewProfileCallback func(selector cgroupModel.WorkloadSelector, profile *proto.SecurityProfile)) {
 	r.onNewProfileCallback = onNewProfileCallback
+}
+
+// SendStats sends the metrics of the directory provider
+func (r *RCProfileProvider) SendStats(_ statsd.ClientInterface) error {
+	return nil
 }
 
 // NewRCProfileProvider returns a new Remote Config based policy provider

--- a/pkg/security/security_profile/activity_tree/activity_tree_test.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_test.go
@@ -3714,8 +3714,8 @@ var activityTreeInsertExecEventTestCases = []struct {
 	//         |         | (exec)                  |                        |             | (exec)
 	//       python    uwsgi                      bash                   python        ddtrace
 	//                                             |                                      | (exec)
-	//                                           ddtrace                                  tools
-	//                                             | (exec                               | (exec)
+	//                                           ddtrace                                tools
+	//                                             | (exec)                               | (exec)
 	//                                           tools                                  utils
 	//                                             | (exec)                               | (exec)
 	//                                           utils                                  uwsgi

--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -45,6 +45,7 @@ type ActivityDumpHandler interface {
 // SecurityProfileManager is a generic interface used to communicate with the Security Profile manager
 type SecurityProfileManager interface {
 	FetchSilentWorkloads() map[cgroupModel.WorkloadSelector][]*cgroupModel.CacheEntry
+	OnLocalStorageCleanup(files []string)
 }
 
 // ActivityDumpManager is used to manage ActivityDumps
@@ -285,7 +286,7 @@ func NewActivityDumpManager(config *config.Config, statsdClient statsd.ClientInt
 		pathsReducer:           activity_tree.NewPathsReducer(),
 	}
 
-	adm.storage, err = NewActivityDumpStorageManager(config, statsdClient, adm)
+	adm.storage, err = NewActivityDumpStorageManager(config, statsdClient, adm, adm)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't instantiate the activity dump storage manager: %w", err)
 	}

--- a/pkg/security/security_profile/dump/storage_manager.go
+++ b/pkg/security/security_profile/dump/storage_manager.go
@@ -66,7 +66,7 @@ func NewSecurityAgentCommandStorageManager(cfg *config.Config) (*ActivityDumpSto
 		storages: make(map[config.StorageType]ActivityDumpStorage),
 	}
 
-	storage, err := NewActivityDumpLocalStorage(cfg)
+	storage, err := NewActivityDumpLocalStorage(cfg, nil)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't instantiate storage: %w", err)
 	}
@@ -83,13 +83,13 @@ func NewSecurityAgentCommandStorageManager(cfg *config.Config) (*ActivityDumpSto
 }
 
 // NewActivityDumpStorageManager returns a new instance of ActivityDumpStorageManager
-func NewActivityDumpStorageManager(cfg *config.Config, statsdClient statsd.ClientInterface, handler ActivityDumpHandler) (*ActivityDumpStorageManager, error) {
+func NewActivityDumpStorageManager(cfg *config.Config, statsdClient statsd.ClientInterface, handler ActivityDumpHandler, m *ActivityDumpManager) (*ActivityDumpStorageManager, error) {
 	manager := &ActivityDumpStorageManager{
 		storages:     make(map[config.StorageType]ActivityDumpStorage),
 		statsdClient: statsdClient,
 	}
 
-	storage, err := NewActivityDumpLocalStorage(cfg)
+	storage, err := NewActivityDumpLocalStorage(cfg, m)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't instantiate storage: %w", err)
 	}

--- a/pkg/security/security_profile/profile/manager.go
+++ b/pkg/security/security_profile/profile/manager.go
@@ -603,7 +603,7 @@ func (m *SecurityProfileManager) loadProfile(profile *SecurityProfile) error {
 
 	// push kernel space filters
 	if err := m.securityProfileSyscallsMap.Put(profile.profileCookie, profile.generateSyscallsFilters()); err != nil {
-		return fmt.Errorf("couldn't push syscalls filter: %w", err)
+		return fmt.Errorf("couldn't push syscalls filter (check map size limit ?): %w", err)
 	}
 
 	// TODO: load generated programs
@@ -627,7 +627,7 @@ func (m *SecurityProfileManager) unloadProfile(profile *SecurityProfile) {
 // linkProfile (thread unsafe) updates the kernel space mapping between a workload and its profile
 func (m *SecurityProfileManager) linkProfile(profile *SecurityProfile, workload *cgroupModel.CacheEntry) {
 	if err := m.securityProfileMap.Put([]byte(workload.ID), profile.generateKernelSecurityProfileDefinition()); err != nil {
-		seclog.Errorf("couldn't link workload %s (selector: %s) with profile %s: %v", workload.ID, workload.WorkloadSelector.String(), profile.Metadata.Name, err)
+		seclog.Errorf("couldn't link workload %s (selector: %s) with profile %s (check map size limit ?): %v", workload.ID, workload.WorkloadSelector.String(), profile.Metadata.Name, err)
 		return
 	}
 	seclog.Infof("workload %s (selector: %s) successfully linked to profile %s", workload.ID, workload.WorkloadSelector.String(), profile.Metadata.Name)

--- a/pkg/security/security_profile/profile/profile_provider.go
+++ b/pkg/security/security_profile/profile/profile_provider.go
@@ -12,6 +12,8 @@ import (
 	"context"
 
 	proto "github.com/DataDog/agent-payload/v5/cws/dumpsv1"
+	"github.com/DataDog/datadog-go/v5/statsd"
+
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
 )
 
@@ -21,6 +23,8 @@ type Provider interface {
 	Start(ctx context.Context) error
 	// Stop closes the profile provider
 	Stop() error
+	// SendStats sends the metrics of the profile provider
+	SendStats(statsdClient statsd.ClientInterface) error
 
 	// UpdateWorkloadSelectors updates the selectors used to query profiles
 	UpdateWorkloadSelectors(selectors []cgroupModel.WorkloadSelector)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR changes 2 kernel space eBPF LRU maps to hashmaps to prevent un controlled deletions. If we ever reach the 400 security profiles loaded (default threshold for `runtime_security_config.security_profile.max_count`), we should log an error (on map Put) instead of randomly loosing coverage on one of the containers.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This PR should prevent the generation of hundreds of deletion error logs in case entries are removed in kernel space before the workload profile is unloaded in user space. If logs still appear, then we know that the default 400 profiles limit is too low and we'll need to bump it up a bit.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Checkout the logs in staging, and look for patterns like `couldn't unlink workload * key does not exist` or `couldn't remove syscalls filter * key does not exist`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
