### PR TITLE
[Oracle] Fix agent crash on a failed database connection

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/connection_handling.go
+++ b/pkg/collector/corechecks/oracle-dbm/connection_handling.go
@@ -9,6 +9,7 @@ package oracle
 
 import (
 	"fmt"
+
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/jmoiron/sqlx"
 	go_ora "github.com/sijms/go-ora/v2"
@@ -181,6 +182,9 @@ func connectGoOra(c *Check) (*go_ora.Connection, error) {
 }
 
 func closeGoOraConnection(c *Check) {
+	if c.connection == nil {
+		return
+	}
 	err := c.connection.Close()
 	if err != nil {
 		log.Warnf("failed to close go-ora connection | server=[%s]: %s", c.config.Server, err.Error())

--- a/pkg/collector/corechecks/oracle-dbm/connection_handling_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/connection_handling_test.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle_test
+
+package oracle
+
+import (
+	"testing"
+)
+
+func TestFailingConnection(t *testing.T) {
+	chk, _ := initCheck(t, "localhost", 1523, "a", "a", "a")
+	chk.Run()
+}

--- a/pkg/collector/corechecks/oracle-dbm/testutil.go
+++ b/pkg/collector/corechecks/oracle-dbm/testutil.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle_test
+
+package oracle
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/stretchr/testify/require"
+)
+
+func initCheck(t *testing.T, server string, port int, user string, password string, serviceName string) (Check, error) {
+	c := Check{}
+	rawInstanceConfig := []byte(fmt.Sprintf(`
+server: %s
+port: %d
+username: %s
+password: %s
+service_name: %s
+`, server, port, user, password, serviceName))
+	err := c.Configure(aggregator.GetSenderManager(), integration.FakeConfigHash, rawInstanceConfig, []byte(``), "oracle_test")
+	require.NoError(t, err)
+	initAndStartAgentDemultiplexer(t)
+
+	return c, err
+}


### PR DESCRIPTION
### What does this PR do?

Bug fix for the agent crash on failed database connection.

### Additional Notes

https://datadoghq.atlassian.net/browse/DBMON-2749

Error stack:

```
2023-09-11 06:39:57 UTC | CORE | ERROR | (pkg/collector/corechecks/oracle-dbm/oracle.go:94 in handleServiceCheck) | failed to connect: failed to ping oracle instance: dial tcp 127.0.0.1:1521: connect: connection refused
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x57c5403]

goroutine 514 [running]:
github.com/sijms/go-ora/v2.(*Connection).Close(0x0)
	/go/pkg/mod/github.com/sijms/go-ora/v2@v2.7.6/connection.go:617 +0x43
github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm.closeGoOraConnection(0xc001f0a000)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/connection_handling.go:183 +0x2c
github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm.(*Check).Teardown(0xc001f0a000)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/oracle.go:226 +0x45
github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm.(*Check).Run(0xc001f0a000)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/oracle.go:115 +0x772
github.com/DataDog/datadog-agent/pkg/collector/internal/middleware.(*CheckWrapper).Run(0xc000894180?)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/internal/middleware/check_wrapper.go:42 +0xc4
github.com/DataDog/datadog-agent/pkg/collector/worker.(*Worker).Run(0xc001057d10)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/worker/worker.go:138 +0x364
github.com/DataDog/datadog-agent/pkg/collector/runner.(*Runner).newWorker.func1()
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/runner/runner.go:128 +0x6d
created by github.com/DataDog/datadog-agent/pkg/collector/runner.(*Runner).newWorker
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/runner/runner.go:125 +0x1cd
AGENT EXITED WITH CODE 2, SIGNAL 0, KILLING CONTAINER
```

The segmentation fault is due to attempting to close the `Connection` was never initialized. A nil pointer check was edded before closing. The problem was introduced with https://github.com/DataDog/datadog-agent/pull/19260 .

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Create a faulty database configuration and check if the agent is crashing.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
