### PR TITLE
[gitlab] Remove use of $CI_PROJECT_DIR in artifact sections

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,7 +102,7 @@ variables:
   OMNIBUS_BASE_DIR: /omnibus
   # Directory in which we put the artifacts after the build
   # Must be in $CI_PROJECT_DIR
-  OMNIBUS_PACKAGE_DIR: $CI_PROJECT_DIR/omnibus/pkg/
+  OMNIBUS_PACKAGE_DIR: $CI_PROJECT_DIR/omnibus/pkg
   # Directory in which we put the SUSE artifacts after the SUSE build
   # Must be in $CI_PROJECT_DIR
   # RPM builds and SUSE RPM builds create artifacts with the same name.

--- a/.gitlab/binary_build/cluster_agent_cloudfoundry.yml
+++ b/.gitlab/binary_build/cluster_agent_cloudfoundry.yml
@@ -9,7 +9,7 @@ cluster_agent_cloudfoundry-build_amd64:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR
+      - omnibus/pkg
   variables:
     ARCH: amd64
   before_script:

--- a/.gitlab/binary_build/serverless.yml
+++ b/.gitlab/binary_build/serverless.yml
@@ -18,7 +18,7 @@ build_serverless-deb_x64:
   artifacts:
     expire_in: 1 day
     paths:
-      - $CI_PROJECT_DIR/cmd/serverless
+      - cmd/serverless
 
 build_serverless-deb_arm64:
   extends: .build_serverless_common

--- a/.gitlab/deps_build.yml
+++ b/.gitlab/deps_build.yml
@@ -62,8 +62,8 @@
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $CI_PROJECT_DIR/.tmp/clang
-      - $CI_PROJECT_DIR/.tmp/llc
+      - .tmp/clang
+      - .tmp/llc
 
 build_clang_x64:
   extends: .build_clang_common

--- a/.gitlab/deps_fetch.yml
+++ b/.gitlab/deps_fetch.yml
@@ -23,7 +23,7 @@ go_deps:
   artifacts:
     expire_in: 1 day
     paths:
-      - $CI_PROJECT_DIR/modcache.tar.gz
+      - modcache.tar.gz
   retry: 1
 
 go_tools_deps:
@@ -38,5 +38,5 @@ go_tools_deps:
   artifacts:
     expire_in: 1 day
     paths:
-      - $CI_PROJECT_DIR/modcache_tools.tar.gz
+      - modcache_tools.tar.gz
   retry: 1

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -30,7 +30,7 @@
     expire_in: 2 weeks
     when: always
     paths:
-      - $DD_AGENT_TESTING_DIR/kitchen-junit-*.tar.gz
+      - test/kitchen/kitchen-junit-*.tar.gz
 
 kitchen_test_security_agent_x64:
   extends:

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -29,9 +29,9 @@
     expire_in: 2 weeks
     when: always
     paths:
-      - $DD_AGENT_TESTING_DIR/kitchen-junit-*.tar.gz
-      - $DD_AGENT_TESTING_DIR/testjson
-      - $CI_PROJECT_DIR/kitchen_logs
+      - test/kitchen/kitchen-junit-*.tar.gz
+      - test/kitchen/testjson
+      - kitchen_logs
 
 .retrieve_test_dockers:
   - mkdir -p $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers

--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -15,7 +15,7 @@
   artifacts:
     expire_in: 1 day
     paths:
-      - $KITCHEN_DOCKERS
+      - test/kitchen/kitchen-dockers-$ARCH
   variables:
     KITCHEN_DOCKERS: $DD_AGENT_TESTING_DIR/kitchen-dockers-$ARCH
 
@@ -291,7 +291,7 @@ kernel_matrix_testing_setup_env:
       - $LibvirtSSHKeyARM
       - $LibvirtSSHKeyARM.pub
       - $STACK_DIR
-      - $CI_PROJECT_DIR/stack.outputs
+      - stack.outputs
 
 .kernel_matrix_testing_run_tests:
   stage: kernel_matrix_testing

--- a/.gitlab/kitchen_common/testing.yml
+++ b/.gitlab/kitchen_common/testing.yml
@@ -7,7 +7,7 @@
     expire_in: 2 weeks
     when: always
     paths:
-      - $CI_PROJECT_DIR/kitchen_logs
+      - kitchen_logs
   retry: 1
 
 .kitchen_common_with_junit:
@@ -23,7 +23,7 @@
     expire_in: 2 weeks
     when: always
     paths:
-      - $CI_PROJECT_DIR/kitchen_logs
+      - kitchen_logs
       - "**/kitchen-rspec-common-${CI_JOB_NAME}.tar.gz"
 
 # Kitchen: providers

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -72,7 +72,7 @@
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR
+      - omnibus/pkg
 
 agent_deb-x64-a6:
   extends: .agent_build_common_deb
@@ -169,7 +169,7 @@ agent_deb-arm64-a7:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR
+      - omnibus/pkg
 
 iot_agent_deb-x64:
   extends: .iot_agent_build_common_deb
@@ -234,7 +234,7 @@ dogstatsd_deb-x64:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR
+      - omnibus/pkg
 
 dogstatsd_deb-arm64:
   rules:
@@ -261,7 +261,7 @@ dogstatsd_deb-arm64:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR
+      - omnibus/pkg
 
 agent_heroku_deb-x64-a6:
   extends: agent_deb-x64-a6

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -18,7 +18,7 @@
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR
+      - omnibus/pkg
 
 agent_dmg-x64-a7:
   extends: .agent_build_common_dmg

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -67,7 +67,7 @@
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR
+      - omnibus/pkg
 
 # build Agent package for rpm-x64
 agent_rpm-x64-a6:
@@ -167,7 +167,7 @@ agent_rpm-arm64-a7:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR
+      - omnibus/pkg
 
 iot_agent_rpm-x64:
   extends: .iot_agent_build_common_rpm
@@ -230,4 +230,4 @@ dogstatsd_rpm-x64:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR
+      - omnibus/pkg

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -69,7 +69,7 @@
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR_SUSE
+      - omnibus/suse/pkg
 
 # build Agent package for suse-x64
 agent_suse-x64-a6:
@@ -140,7 +140,7 @@ iot_agent_suse-x64:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR_SUSE
+      - omnibus/suse/pkg
 
 dogstatsd_suse-x64:
   rules:
@@ -174,4 +174,4 @@ dogstatsd_suse-x64:
   artifacts:
     expire_in: 2 weeks
     paths:
-      - $OMNIBUS_PACKAGE_DIR_SUSE
+      - omnibus/suse/pkg

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -82,7 +82,7 @@
   artifacts:
     when: always
     paths:
-      - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files
+      - test/kitchen/site-cookbooks/dd-system-probe-check/files
 
 tests_ebpf_x64:
   extends: .tests_linux_ebpf
@@ -106,9 +106,9 @@ tests_ebpf_arm64:
   artifacts:
     when: always
     paths:
-      - $CI_PROJECT_DIR/.tmp/binary-ebpf
-      - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files
-      - $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files
+      - .tmp/binary-ebpf
+      - test/kitchen/site-cookbooks/dd-security-agent-check/files
+      - test/kitchen/site-cookbooks/dd-system-probe-check/files
   before_script:
     - !reference [.retrieve_linux_go_deps]
     - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf/co-re


### PR DESCRIPTION
New version of gitlab runner does not accept this

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Backport https://github.com/DataDog/datadog-agent/pull/19370 to 7.48.x
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
