### PR TITLE
[Oracle] Detect missing privileges

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/sql_wrappers.go
+++ b/pkg/collector/corechecks/oracle-dbm/sql_wrappers.go
@@ -42,7 +42,7 @@ func handleError(c *Check, db **sqlx.DB, err error) error {
 func handlePrivilegeError(c *Check, err error) (bool, error) {
 	var isPrivilegeError bool
 	if err == nil {
-		return nil, isPrivilegeError
+		return isPrivilegeError, err
 	}
 	if !strings.Contains(err.Error(), "ORA-00942") {
 		return isPrivilegeError, err

--- a/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
+++ b/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
@@ -156,7 +156,7 @@ func (c *Check) SysMetrics() error {
 	}
 
 	var overAllocationCount float64
-	err = c.db.Get(&overAllocationCount, "SELECT value FROM v$pgastat WHERE name = 'over allocation count'")
+	err = getWrapper(c, &overAllocationCount, "SELECT value FROM v$pgastat WHERE name = 'over allocation count'")
 	if err != nil {
 		return fmt.Errorf("failed to get PGA over allocation count: %w", err)
 	}

--- a/releasenotes/notes/oracle-privilege-info-f66e19ac7c8aff57.yaml
+++ b/releasenotes/notes/oracle-privilege-info-f66e19ac7c8aff57.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add the information about missing privileges with the link to the `grant` commands.

--- a/releasenotes/notes/oracle-privilege-info-f66e19ac7c8aff57.yaml
+++ b/releasenotes/notes/oracle-privilege-info-f66e19ac7c8aff57.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Add the information about missing privileges with the link to the `grant` commands.
+    Add information about missing privileges with the link to the `grant` commands.


### PR DESCRIPTION
### What does this PR do?

Detect that the Agent data collection is failing on missing privileges, and point to the `grant` commands for customer's database hosting type.

### Motivation

Beforehand, only the native error message was logged: `ORA-00942: table or view does not exist`, so customers were asking for support in such cases. As we grant on the need-to-have basis, we are continuously adding new privileges with every agent release, so we expect that some customers might forget to run the `grant privilege` commands. The additional information should reduce the number of support cases.

New message logged in the agent log file:

`Some privileges are missing. Execute the `grant` commands from https://docs.datadoghq.com/database_monitoring/setup_oracle/selfhosted/#grant-permissions . Error: ORA-00942: table or view does not exist`

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
