### PR TITLE
[CWS] LRU based string interning for args and envs values

### DIFF
--- a/pkg/security/resolvers/process/resolver_linux.go
+++ b/pkg/security/resolvers/process/resolver_linux.go
@@ -51,6 +51,7 @@ const (
 const (
 	procResolveMaxDepth              = 16
 	maxParallelArgsEnvs              = 512 // == number of parallel starting processes
+	argsEnvsValueCacheSize           = 8192
 	numAllowedPIDsToResolvePerPeriod = 1
 	procFallbackLimiterPeriod        = 30 * time.Second // proc fallback period by pid
 )
@@ -278,7 +279,7 @@ type argsEnvsCacheEntry struct {
 	truncated bool
 }
 
-var argsEnvsInterner = utils.NewLRUStringInterner(4096)
+var argsEnvsInterner = utils.NewLRUStringInterner(argsEnvsValueCacheSize)
 
 func parseStringArray(data []byte) ([]string, bool) {
 	truncated := false

--- a/pkg/security/resolvers/process/resolver_linux.go
+++ b/pkg/security/resolvers/process/resolver_linux.go
@@ -278,6 +278,8 @@ type argsEnvsCacheEntry struct {
 	truncated bool
 }
 
+var argsEnvsInterner = utils.NewLRUStringInterner(4096)
+
 func parseStringArray(data []byte) ([]string, bool) {
 	truncated := false
 	values, err := model.UnmarshalStringArray(data)
@@ -287,6 +289,8 @@ func parseStringArray(data []byte) ([]string, bool) {
 		}
 		truncated = true
 	}
+
+	argsEnvsInterner.DeduplicateSlice(values)
 	return values, truncated
 }
 

--- a/pkg/security/utils/lru_interner.go
+++ b/pkg/security/utils/lru_interner.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import (
+	"sync"
+
+	"github.com/hashicorp/golang-lru/v2/simplelru"
+)
+
+type LRUStringInterner struct {
+	sync.RWMutex
+	store *simplelru.LRU[string, string]
+}
+
+func NewLRUStringInterner(size int) *LRUStringInterner {
+	store, err := simplelru.NewLRU[string, string](size, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	return &LRUStringInterner{
+		store: store,
+	}
+}
+
+func (si *LRUStringInterner) Deduplicate(value string) string {
+	if res, ok := si.store.Get(value); ok {
+		return res
+	}
+
+	si.store.Add(value, value)
+	return value
+}
+
+func (si *LRUStringInterner) DeduplicateSlice(values []string) {
+	for i := range values {
+		values[i] = si.Deduplicate(values[i])
+	}
+}

--- a/pkg/security/utils/lru_interner.go
+++ b/pkg/security/utils/lru_interner.go
@@ -11,11 +11,14 @@ import (
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 )
 
+// LRUStringInterner is a best-effort LRU-based string deduplicator
 type LRUStringInterner struct {
 	sync.Mutex
 	store *simplelru.LRU[string, string]
 }
 
+// NewLRUStringInterner returns a new LRUStringInterner, with the cache size provided
+// if the cache size is negative this function will panic
 func NewLRUStringInterner(size int) *LRUStringInterner {
 	store, err := simplelru.NewLRU[string, string](size, nil)
 	if err != nil {
@@ -27,6 +30,7 @@ func NewLRUStringInterner(size int) *LRUStringInterner {
 	}
 }
 
+// Deduplicate returns a possibly de-duplicated string
 func (si *LRUStringInterner) Deduplicate(value string) string {
 	si.Lock()
 	defer si.Unlock()
@@ -43,6 +47,7 @@ func (si *LRUStringInterner) deduplicateUnsafe(value string) string {
 	return value
 }
 
+// DeduplicateSlice returns a possibly de-duplicated string slice
 func (si *LRUStringInterner) DeduplicateSlice(values []string) {
 	si.Lock()
 	defer si.Unlock()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR introduces a new layer of deduplication for args and envs values. The goal is to do some layer of deduplication while not allowing the interning cache to grow indefinitely (--> why this PR uses an LRU and not an hashmap). This means that the interning might not be perfect (and we do not use indices or similar as string values).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
