### PR TITLE
[CWS] on-demand SECL Partial

### DIFF
--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -556,9 +556,6 @@ func TestPartial(t *testing.T) {
 		if err != nil {
 			t.Fatalf("error while evaluating `%s`: %s", test.Expr, err)
 		}
-		if err := rule.GenPartials(); err != nil {
-			t.Fatalf("error while evaluating `%s`: %s", test.Expr, err)
-		}
 
 		result, err := rule.PartialEval(ctx, test.Field)
 		if err != nil {
@@ -671,10 +668,6 @@ func TestMacroPartial(t *testing.T) {
 	rule, err := parseRule(expr, model, opts)
 	if err != nil {
 		t.Fatalf("error while evaluating `%s`: %s", expr, err)
-	}
-
-	if err := rule.GenPartials(); err != nil {
-		t.Fatalf("error while generating partials `%s`: %s", expr, err)
 	}
 
 	ctx := NewContext(event)
@@ -952,9 +945,6 @@ func TestRegisterPartial(t *testing.T) {
 
 		rule, err := parseRule(test.Expr, model, opts)
 		if err != nil {
-			t.Fatalf("error while evaluating `%s`: %s", test.Expr, err)
-		}
-		if err := rule.GenPartials(); err != nil {
 			t.Fatalf("error while evaluating `%s`: %s", test.Expr, err)
 		}
 
@@ -1334,9 +1324,6 @@ func TestOpOverridePartials(t *testing.T) {
 		if err != nil {
 			t.Fatalf("error while evaluating `%s`: %s", test.Expr, err)
 		}
-		if err := rule.GenPartials(); err != nil {
-			t.Fatalf("error while evaluating `%s`: %s", test.Expr, err)
-		}
 
 		result, err := rule.PartialEval(ctx, test.Field)
 		if err != nil {
@@ -1530,10 +1517,6 @@ func BenchmarkPartial(b *testing.B) {
 
 	pc := ast.NewParsingContext()
 	if err := rule.GenEvaluator(model, pc); err != nil {
-		b.Fatal(err)
-	}
-
-	if err := rule.GenPartials(); err != nil {
 		b.Fatal(err)
 	}
 

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -267,10 +267,6 @@ func (rs *RuleSet) AddRules(parsingContext *ast.ParsingContext, rules []*RuleDef
 		}
 	}
 
-	if err := rs.generatePartials(); err != nil {
-		result = multierror.Append(result, fmt.Errorf("couldn't generate partials for rule: %w", err))
-	}
-
 	return result
 }
 
@@ -734,21 +730,6 @@ NewFields:
 		}
 		rs.fields = append(rs.fields, newField)
 	}
-}
-
-// generatePartials generates the partials of the ruleset. A partial is a boolean evalution function that only depends
-// on one field. The goal of partial is to determine if a rule depends on a specific field, so that we can decide if
-// we should create an in-kernel filter for that field.
-func (rs *RuleSet) generatePartials() error {
-	// Compute the partials of each rule
-	for _, bucket := range rs.eventRuleBuckets {
-		for _, rule := range bucket.GetRules() {
-			if err := rule.GenPartials(); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 // StopEventCollector stops the event collector


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Generate SECL partial on-demand so that only the discarders used are kept in memory.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
