### PR TITLE
TestE2E GetCollectedTimeByName

### DIFF
--- a/test/fakeintake/aggregator/checkRunAggregator.go
+++ b/test/fakeintake/aggregator/checkRunAggregator.go
@@ -7,17 +7,19 @@ package aggregator
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/DataDog/datadog-agent/test/fakeintake/api"
 )
 
 type CheckRun struct {
-	Check     string   `json:"check"`
-	HostName  string   `json:"host_name"`
-	Timestamp int      `json:"timestamp"`
-	Status    int      `json:"status"`
-	Message   string   `json:"message"`
-	Tags      []string `json:"tags"`
+	collectedTime time.Time
+	Check         string   `json:"check"`
+	HostName      string   `json:"host_name"`
+	Timestamp     int      `json:"timestamp"`
+	Status        int      `json:"status"`
+	Message       string   `json:"message"`
+	Tags          []string `json:"tags"`
 }
 
 func (cr *CheckRun) name() string {
@@ -28,6 +30,10 @@ func (cr *CheckRun) GetTags() []string {
 	return cr.Tags
 }
 
+func (cr *CheckRun) GetCollectedTime() time.Time {
+	return cr.collectedTime
+}
+
 func ParseCheckRunPayload(payload api.Payload) (checks []*CheckRun, err error) {
 	enflated, err := enflate(payload.Data, payload.Encoding)
 	if err != nil {
@@ -35,6 +41,12 @@ func ParseCheckRunPayload(payload api.Payload) (checks []*CheckRun, err error) {
 	}
 	checks = []*CheckRun{}
 	err = json.Unmarshal(enflated, &checks)
+	if err != nil {
+		return nil, err
+	}
+	for _, c := range checks {
+		c.collectedTime = payload.Timestamp
+	}
 	return checks, err
 }
 

--- a/test/fakeintake/aggregator/checkRunAggregator.go
+++ b/test/fakeintake/aggregator/checkRunAggregator.go
@@ -26,14 +26,17 @@ func (cr *CheckRun) name() string {
 	return cr.Check
 }
 
+// GetTags return the tags from a payload
 func (cr *CheckRun) GetTags() []string {
 	return cr.Tags
 }
 
+// GetCollectedTime return the time when the payload has been collected by the fakeintake server
 func (cr *CheckRun) GetCollectedTime() time.Time {
 	return cr.collectedTime
 }
 
+// ParseCheckRunPayload return the parsed checkRun from payload
 func ParseCheckRunPayload(payload api.Payload) (checks []*CheckRun, err error) {
 	enflated, err := enflate(payload.Data, payload.Encoding)
 	if err != nil {

--- a/test/fakeintake/aggregator/common.go
+++ b/test/fakeintake/aggregator/common.go
@@ -42,6 +42,7 @@ func newAggregator[P PayloadItem](parse parseFunc[P]) Aggregator[P] {
 	}
 }
 
+// UnmarshallPayloads aggregate the payloads
 func (agg *Aggregator[P]) UnmarshallPayloads(payloads []api.Payload) error {
 	// reset map
 	agg.Reset()
@@ -64,11 +65,13 @@ func (agg *Aggregator[P]) UnmarshallPayloads(payloads []api.Payload) error {
 	return nil
 }
 
+// ContainsPayloadName return true if name match one of the payloads
 func (agg *Aggregator[P]) ContainsPayloadName(name string) bool {
 	_, found := agg.payloadsByName[name]
 	return found
 }
 
+// ContainsPayloadNameAndTags return true if the payload name exist and on of the payloads contains all the tags
 func (agg *Aggregator[P]) ContainsPayloadNameAndTags(name string, tags []string) bool {
 	payloads, found := agg.payloadsByName[name]
 	if !found {
@@ -84,6 +87,7 @@ func (agg *Aggregator[P]) ContainsPayloadNameAndTags(name string, tags []string)
 	return false
 }
 
+// GetNames return the names of the payloads
 func (agg *Aggregator[P]) GetNames() []string {
 	names := []string{}
 	for name := range agg.payloadsByName {
@@ -118,18 +122,23 @@ func getReadCloserForEncoding(payload []byte, encoding string) (rc io.ReadCloser
 	return rc, err
 }
 
+// GetPayloadsByName return the payloads for the resource name
 func (agg *Aggregator[P]) GetPayloadsByName(name string) []P {
 	return agg.payloadsByName[name]
 }
 
+// GetCollectedTimeByName return the timestamp when the payloads has been collected for the resource name
 func (agg *Aggregator[P]) GetCollectedTimeByName(name string) []time.Time {
 	return agg.collectedAtByName[name]
 }
 
+// Reset the aggregation
 func (agg *Aggregator[P]) Reset() {
 	agg.payloadsByName = map[string][]P{}
+	agg.collectedAtByName = map[string][]time.Time{}
 }
 
+// FilterByTags return the payloads that match all the tags
 func FilterByTags[P PayloadItem](payloads []P, tags []string) []P {
 	ret := []P{}
 	for _, p := range payloads {
@@ -140,6 +149,7 @@ func FilterByTags[P PayloadItem](payloads []P, tags []string) []P {
 	return ret
 }
 
+// AreTagsSubsetOfOtherTags return true is all tags are in otherTags
 func AreTagsSubsetOfOtherTags(tags, otherTags []string) bool {
 	otherTagsSet := tagsToSet(otherTags)
 	for _, tag := range tags {

--- a/test/fakeintake/aggregator/logAggregator.go
+++ b/test/fakeintake/aggregator/logAggregator.go
@@ -27,14 +27,17 @@ func (l *Log) name() string {
 	return l.Service
 }
 
+// GetTags return the tags from a payload
 func (l *Log) GetTags() []string {
 	return l.Tags
 }
 
+// GetCollectedTime return the time when the payload has been collected by the fakeintake server
 func (l *Log) GetCollectedTime() time.Time {
 	return l.collectedTime
 }
 
+// ParseLogPayload return the parsed logs from payload
 func ParseLogPayload(payload api.Payload) (logs []*Log, err error) {
 	if len(payload.Data) == 0 {
 		// logs can submit with empty data

--- a/test/fakeintake/aggregator/logAggregator.go
+++ b/test/fakeintake/aggregator/logAggregator.go
@@ -7,18 +7,20 @@ package aggregator
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/DataDog/datadog-agent/test/fakeintake/api"
 )
 
 type Log struct {
-	Message   string   `json:"message"`
-	Status    string   `json:"status"`
-	Timestamp int      `json:"timestamp"`
-	HostName  string   `json:"hostname"`
-	Service   string   `json:"service"`
-	Source    string   `json:"source"`
-	Tags      []string `json:"tags"`
+	collectedTime time.Time
+	Message       string   `json:"message"`
+	Status        string   `json:"status"`
+	Timestamp     int      `json:"timestamp"`
+	HostName      string   `json:"hostname"`
+	Service       string   `json:"service"`
+	Source        string   `json:"source"`
+	Tags          []string `json:"tags"`
 }
 
 func (l *Log) name() string {
@@ -27,6 +29,10 @@ func (l *Log) name() string {
 
 func (l *Log) GetTags() []string {
 	return l.Tags
+}
+
+func (l *Log) GetCollectedTime() time.Time {
+	return l.collectedTime
 }
 
 func ParseLogPayload(payload api.Payload) (logs []*Log, err error) {
@@ -42,6 +48,9 @@ func ParseLogPayload(payload api.Payload) (logs []*Log, err error) {
 	err = json.Unmarshal(enflated, &logs)
 	if err != nil {
 		return nil, err
+	}
+	for _, l := range logs {
+		l.collectedTime = payload.Timestamp
 	}
 	return logs, err
 }

--- a/test/fakeintake/aggregator/metricAggregator.go
+++ b/test/fakeintake/aggregator/metricAggregator.go
@@ -6,6 +6,8 @@
 package aggregator
 
 import (
+	"time"
+
 	metricspb "github.com/DataDog/agent-payload/v5/gogen"
 	"github.com/DataDog/datadog-agent/test/fakeintake/api"
 )
@@ -13,6 +15,8 @@ import (
 type MetricSeries struct {
 	// embed proto Metric Series struct
 	metricspb.MetricPayload_MetricSeries
+
+	collectedTime time.Time
 }
 
 func (mp *MetricSeries) name() string {
@@ -21,6 +25,10 @@ func (mp *MetricSeries) name() string {
 
 func (mp *MetricSeries) GetTags() []string {
 	return mp.Tags
+}
+
+func (mp *MetricSeries) GetCollectedTime() time.Time {
+	return mp.collectedTime
 }
 
 func ParseMetricSeries(payload api.Payload) (metrics []*MetricSeries, err error) {
@@ -36,7 +44,7 @@ func ParseMetricSeries(payload api.Payload) (metrics []*MetricSeries, err error)
 
 	metrics = []*MetricSeries{}
 	for _, serie := range metricsPayload.Series {
-		metrics = append(metrics, &MetricSeries{MetricPayload_MetricSeries: *serie})
+		metrics = append(metrics, &MetricSeries{MetricPayload_MetricSeries: *serie, collectedTime: payload.Timestamp})
 	}
 
 	return metrics, err

--- a/test/fakeintake/aggregator/metricAggregator.go
+++ b/test/fakeintake/aggregator/metricAggregator.go
@@ -23,14 +23,17 @@ func (mp *MetricSeries) name() string {
 	return mp.Metric
 }
 
+// GetTags return the tags from a payload
 func (mp *MetricSeries) GetTags() []string {
 	return mp.Tags
 }
 
+// GetCollectedTime return the time when the payload has been collected by the fakeintake server
 func (mp *MetricSeries) GetCollectedTime() time.Time {
 	return mp.collectedTime
 }
 
+// ParseMetricSeries return the parsed metrics from payload
 func ParseMetricSeries(payload api.Payload) (metrics []*MetricSeries, err error) {
 	enflated, err := enflate(payload.Data, payload.Encoding)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Return the timestamp when the payloads has been collected aim to check if it was received as expected.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
