### PR TITLE
[e2e] move examples to testify eventually

### DIFF
--- a/test/new-e2e/examples/agentenv_metrics_test.go
+++ b/test/new-e2e/examples/agentenv_metrics_test.go
@@ -6,65 +6,44 @@
 package examples
 
 import (
-	"errors"
 	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-agent/test/fakeintake/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
-	"github.com/cenkalti/backoff/v4"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-type vmSuiteEx5 struct {
+type fakeintakeSuiteMetrics struct {
 	e2e.Suite[e2e.FakeIntakeEnv]
 }
 
 func TestVMSuiteEx5(t *testing.T) {
-	e2e.Run(t, &vmSuiteEx5{}, e2e.FakeIntakeStackDef(nil))
+	e2e.Run(t, &fakeintakeSuiteMetrics{}, e2e.FakeIntakeStackDef(nil))
 }
 
-func (v *vmSuiteEx5) Test1_FakeIntakeReceivesMetrics() {
-	t := v.T()
-	err := backoff.Retry(func() error {
+func (v *fakeintakeSuiteMetrics) Test1_FakeIntakeReceivesMetrics() {
+	v.EventuallyWithT(func(c *assert.CollectT) {
 		metricNames, err := v.Env().Fakeintake.GetMetricNames()
-		if err != nil {
-			return err
-		}
-		if len(metricNames) == 0 {
-			return errors.New("no metrics yet")
-		}
-		return nil
-	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(500*time.Millisecond), 60))
-	require.NoError(t, err)
+		require.NoError(c, err)
+		assert.Greater(c, len(metricNames), 0)
+	}, 5*time.Minute, 10*time.Second)
 }
 
-func (v *vmSuiteEx5) Test2_FakeIntakeReceivesSystemLoadMetric() {
-	t := v.T()
-	err := backoff.Retry(func() error {
+func (v *fakeintakeSuiteMetrics) Test2_FakeIntakeReceivesSystemLoadMetric() {
+	v.EventuallyWithT(func(c *assert.CollectT) {
 		metrics, err := v.Env().Fakeintake.FilterMetrics("system.load.1")
-		if err != nil {
-			return err
-		}
-		if len(metrics) == 0 {
-			return errors.New("no 'system.load.1' metrics yet")
-		}
-		return nil
-	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(500*time.Millisecond), 60))
-	require.NoError(t, err)
+		require.NoError(c, err)
+		assert.Greater(c, len(metrics), 0, "no 'system.load.1' metrics yet")
+	}, 5*time.Minute, 10*time.Second)
 }
 
-func (v *vmSuiteEx5) Test3_FakeIntakeReceivesSystemUptimeHigherThanZero() {
-	t := v.T()
-	err := backoff.Retry(func() error {
+func (v *fakeintakeSuiteMetrics) Test3_FakeIntakeReceivesSystemUptimeHigherThanZero() {
+	v.EventuallyWithT(func(c *assert.CollectT) {
 		metrics, err := v.Env().Fakeintake.FilterMetrics("system.uptime", client.WithMetricValueHigherThan(0))
-		if err != nil {
-			return err
-		}
-		if len(metrics) == 0 {
-			return errors.New("no 'system.uptime' with value higher than 0 yet")
-		}
-		return nil
-	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(500*time.Millisecond), 60))
-	require.NoError(t, err)
+		require.NoError(c, err)
+		assert.Greater(c, len(metrics), 0, "no 'system.uptime' with value higher than 0 yet")
+		assert.Greater(c, len(metrics), 0, "no 'system.load.1' metrics yet")
+	}, 5*time.Minute, 10*time.Second)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Update e2e tests examples with fakeintake to use testify Eventually instead of backoff retry

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

As testify has an API to retry out of the box, there is no need to use additional dependencies. Moreover, the API is cleaner for asserts

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
