### PR TITLE
pkg/serverless: set context.Canceled errors log priority to Debug

### DIFF
--- a/pkg/serverless/proxy/transport.go
+++ b/pkg/serverless/proxy/transport.go
@@ -7,6 +7,7 @@ package proxy
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httputil"
@@ -30,7 +31,11 @@ func (p *proxyTransport) RoundTrip(request *http.Request) (*http.Response, error
 
 	response, err := http.DefaultTransport.RoundTrip(request)
 	if err != nil {
-		log.Error("could not forward the request", err)
+		if err == context.Canceled {
+			log.Debug("runtime api proxy: context cancelled:", request.Context().Err())
+		} else {
+			log.Error("runtime api proxy: could not forward the request", err)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
### What does this PR do?

Dial back the log level for context.Canceled errors in the serverless proxy transport from Error to Debug.

### Motivation

Customers have been complaining about log pollution by this message that is logged at the error level, while
it can be safely ignored since it usually is a result of the client app canceling requests (or timeout, but timeout values set by http.DefaultTransport are pretty high). Keeping the log for information but dialling it back to Debug level seems like a reasonable solution.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
