### PR TITLE
[CWS] keep the only one version on the argv

### DIFF
--- a/pkg/security/resolvers/process/resolver_linux.go
+++ b/pkg/security/resolvers/process/resolver_linux.go
@@ -918,19 +918,18 @@ func GetProcessArgv0(pr *model.Process) (string, bool) {
 
 // GetProcessScrubbedArgv returns the scrubbed args of the event as an array
 func (p *Resolver) GetProcessScrubbedArgv(pr *model.Process) ([]string, bool) {
-	if pr.ScrubbedArgvResolved {
-		return pr.ScrubbedArgv, pr.ScrubbedArgsTruncated
+	if pr.ArgsEntry == nil || pr.ScrubbedArgvResolved {
+		return pr.Argv, pr.ArgsTruncated
 	}
 
 	argv, truncated := GetProcessArgv(pr)
 
-	if p.scrubber != nil {
+	if p.scrubber != nil && len(argv) > 0 {
+		// replace with the scrubbed version
 		argv, _ = p.scrubber.ScrubCommand(argv)
+		pr.ArgsEntry.Values = []string{pr.ArgsEntry.Values[0]}
+		pr.ArgsEntry.Values = append(pr.ArgsEntry.Values, argv...)
 	}
-
-	pr.ScrubbedArgv = argv
-	pr.ScrubbedArgsTruncated = truncated
-	pr.ScrubbedArgvResolved = true
 
 	return argv, truncated
 }

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -329,10 +329,8 @@ type Process struct {
 	SymlinkBasenameStr string              `field:"-" json:"-"`
 
 	// cache version
-	ScrubbedArgvResolved  bool           `field:"-" json:"-"`
-	ScrubbedArgv          []string       `field:"-" json:"-"`
-	ScrubbedArgsTruncated bool           `field:"-" json:"-"`
-	Variables             eval.Variables `field:"-" json:"-"`
+	ScrubbedArgvResolved bool           `field:"-" json:"-"`
+	Variables            eval.Variables `field:"-" json:"-"`
 
 	IsThread    bool `field:"is_thread"` // SECLDoc[is_thread] Definition:`Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)`
 	IsExecChild bool `field:"-"`         // Indicates whether the process is an exec child of its parent

--- a/pkg/security/security_profile/activity_tree/activity_tree_proto_dec_v1.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_proto_dec_v1.go
@@ -99,7 +99,6 @@ func protoDecodeProcessNode(p *adproto.ProcessInfo) model.Process {
 		Credentials: protoDecodeCredentials(p.Credentials),
 
 		Argv:          make([]string, len(p.Args)),
-		ScrubbedArgv:  make([]string, len(p.Args)),
 		Argv0:         p.Argv0,
 		ArgsTruncated: p.ArgsTruncated,
 
@@ -108,7 +107,6 @@ func protoDecodeProcessNode(p *adproto.ProcessInfo) model.Process {
 	}
 
 	copy(mp.Argv, p.Args)
-	copy(mp.ScrubbedArgv, p.Args)
 	copy(mp.Envs, p.Envs)
 	return mp
 }

--- a/pkg/security/security_profile/activity_tree/activity_tree_proto_enc_v1.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_proto_enc_v1.go
@@ -97,7 +97,7 @@ func processNodeToProto(p *model.Process) *adproto.ProcessInfo {
 
 		Credentials: credentialsToProto(&p.Credentials),
 
-		Args:          copyAndEscape(p.ScrubbedArgv),
+		Args:          copyAndEscape(p.Argv),
 		Argv0:         escape(p.Argv0),
 		ArgsTruncated: p.ArgsTruncated,
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Prior this PR we were keeping two version of the args, the original one and the scrubbed version

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
