### PR TITLE
[CWS] Enable Hash resolver by default

### DIFF
--- a/pkg/config/system_probe_cws.go
+++ b/pkg/config/system_probe_cws.go
@@ -76,7 +76,7 @@ func initCWSSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.anomaly_detection.tag_rules.enabled", true)
 
 	// CWS - Hash algorithms
-	cfg.BindEnvAndSetDefault("runtime_security_config.hash_resolver.enabled", false)
+	cfg.BindEnvAndSetDefault("runtime_security_config.hash_resolver.enabled", true)
 	cfg.BindEnvAndSetDefault("runtime_security_config.hash_resolver.event_types", []string{"exec", "open"})
 	cfg.BindEnvAndSetDefault("runtime_security_config.hash_resolver.max_file_size", (1<<20)*10) // 10 MB
 	cfg.BindEnvAndSetDefault("runtime_security_config.hash_resolver.max_hash_rate", 500)

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -410,12 +410,14 @@ const (
 	PathnameResolutionError
 	// FileTooBig means that the underlying file is larger than the hash resolver file size limit
 	FileTooBig
+	// FileEmpty means that the underlying file is empty
+	FileEmpty
+	// FileOpenError is a generic hash state to say that we couldn't open the file
+	FileOpenError
 	// EventTypeNotConfigured means that the event type prevents a hash from being computed
 	EventTypeNotConfigured
 	// HashWasRateLimited means that the hash will be tried again later, it was rate limited
 	HashWasRateLimited
-	// UnknownHashError means that we couldn't hash the file and we don't know why
-	UnknownHashError
 	// MaxHashState is used for initializations
 	MaxHashState
 )

--- a/pkg/security/secl/model/model_string.go
+++ b/pkg/security/secl/model/model_string.go
@@ -13,15 +13,16 @@ func _() {
 	_ = x[FileNotFound-2]
 	_ = x[PathnameResolutionError-3]
 	_ = x[FileTooBig-4]
-	_ = x[EventTypeNotConfigured-5]
-	_ = x[HashWasRateLimited-6]
-	_ = x[UnknownHashError-7]
-	_ = x[MaxHashState-8]
+	_ = x[FileEmpty-5]
+	_ = x[FileOpenError-6]
+	_ = x[EventTypeNotConfigured-7]
+	_ = x[HashWasRateLimited-8]
+	_ = x[MaxHashState-9]
 }
 
-const _HashState_name = "NoHashDoneFileNotFoundPathnameResolutionErrorFileTooBigEventTypeNotConfiguredHashWasRateLimitedUnknownHashErrorMaxHashState"
+const _HashState_name = "NoHashDoneFileNotFoundPathnameResolutionErrorFileTooBigFileEmptyFileOpenErrorEventTypeNotConfiguredHashWasRateLimitedMaxHashState"
 
-var _HashState_index = [...]uint8{0, 6, 10, 22, 45, 55, 77, 95, 111, 123}
+var _HashState_index = [...]uint8{0, 6, 10, 22, 45, 55, 64, 77, 99, 117, 129}
 
 func (i HashState) String() string {
 	if i < 0 || i >= HashState(len(_HashState_index)-1) {

--- a/releasenotes/notes/runtime-security-hash-resolver-1ac399bb564284ff.yaml
+++ b/releasenotes/notes/runtime-security-hash-resolver-1ac399bb564284ff.yaml
@@ -1,0 +1,10 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - CWS now computes hashes for all the files involved in the generation of a Security Profile and an Anomaly Detection Event


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR enables the hash resolver feature (introduced in https://github.com/DataDog/datadog-agent/pull/16799) by default.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This feature is now ready to be enabled by default.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Start a new dump and check if it contains hashes.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
