### PR TITLE
Split flarehelpers interface from implementation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,7 +85,7 @@ linters-settings:
   errcheck:
     # Disable warnings for `fmt`, `log` and `seelog` packages. Also ignore `Write` functions from `net/http` package.
     # Disable warnings for select Windows functions
-    ignore: fmt:.*,github.com/DataDog/datadog-agent/pkg/util/log:.*,github.com/DataDog/datadog-agent/comp/core/log:.*,github.com/cihub/seelog:.*,net/http:Write,github.com/DataDog/datadog-agent/pkg/trace/metrics:.*,github.com/DataDog/datadog-agent/pkg/collector/corechecks:Warnf?,golang.org/x/sys/windows:(CloseHandle|FreeLibrary|FreeSid|RegCloseKey|SetEvent|LocalFree),syscall:CloseHandle,golang.org/x/sys/windows/svc/mgr:Disconnect,golang.org/x/sys/windows/svc/debug:(Close|Error|Info|Warning),github.com/lxn/walk:Dispose,github.com/DataDog/datadog-agent/comp/core/flare/helpers:(AddFile.*|CopyDir.*|CopyFile.*),golang.org/x/sys/windows/registry:Close
+    ignore: fmt:.*,github.com/DataDog/datadog-agent/pkg/util/log:.*,github.com/DataDog/datadog-agent/comp/core/log:.*,github.com/cihub/seelog:.*,net/http:Write,github.com/DataDog/datadog-agent/pkg/trace/metrics:.*,github.com/DataDog/datadog-agent/pkg/collector/corechecks:Warnf?,golang.org/x/sys/windows:(CloseHandle|FreeLibrary|FreeSid|RegCloseKey|SetEvent|LocalFree),syscall:CloseHandle,golang.org/x/sys/windows/svc/mgr:Disconnect,golang.org/x/sys/windows/svc/debug:(Close|Error|Info|Warning),github.com/lxn/walk:Dispose,github.com/DataDog/datadog-agent/comp/core/flare/types:(AddFile.*|CopyDir.*|CopyFile.*),golang.org/x/sys/windows/registry:Close
   staticcheck:
     checks: ["all",
              "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", # These ones are disabled by default on staticcheck

--- a/comp/core/flare/flare.go
+++ b/comp/core/flare/flare.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/flare/helpers"
-	flarehelpers "github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	"github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -32,14 +32,14 @@ type dependencies struct {
 	Log       log.Component
 	Config    config.Component
 	Params    Params
-	Providers []helpers.FlareProvider `group:"flare"`
+	Providers []types.FlareProvider `group:"flare"`
 }
 
 type flare struct {
 	log       log.Component
 	config    config.Component
 	params    Params
-	providers []helpers.FlareProvider
+	providers []types.FlareProvider
 }
 
 func newFlare(deps dependencies) (Component, rcclient.ListenerProvider, error) {
@@ -112,11 +112,11 @@ func (f *flare) Create(pdata ProfileData, ipcError error) (string, error) {
 	// Adding legacy and internal providers. Registering then as FlareProvider through FX create cycle dependencies.
 	providers := append(
 		f.providers,
-		helpers.FlareProvider{Callback: func(fb flarehelpers.FlareBuilder) error {
+		types.FlareProvider{Callback: func(fb types.FlareBuilder) error {
 			return pkgFlare.CompleteFlare(fb, aggregator.GetSenderManager())
 		}},
-		helpers.FlareProvider{Callback: f.collectLogsFiles},
-		helpers.FlareProvider{Callback: f.collectConfigFiles},
+		types.FlareProvider{Callback: f.collectLogsFiles},
+		types.FlareProvider{Callback: f.collectConfigFiles},
 	)
 
 	for _, p := range providers {

--- a/comp/core/flare/helpers/builder.go
+++ b/comp/core/flare/helpers/builder.go
@@ -14,12 +14,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mholt/archiver/v3"
+
+	"github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
-	"github.com/mholt/archiver/v3"
 )
 
 const (
@@ -76,7 +78,7 @@ func newBuilder(root string, hostname string, localFlare bool) (*builder, error)
 // NewFlareBuilder returns a new FlareBuilder ready to be used. You need to call the Save method to archive all the data
 // pushed to the flare as well as cleanup the temporary directories created. Not calling 'Save' after NewFlareBuilder
 // will leave temporary directory on the file system.
-func NewFlareBuilder(localFlare bool) (FlareBuilder, error) {
+func NewFlareBuilder(localFlare bool) (types.FlareBuilder, error) {
 	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return nil, fmt.Errorf("Could not create temp dir for flare: %s", err)

--- a/comp/core/flare/helpers/builder_mock.go
+++ b/comp/core/flare/helpers/builder_mock.go
@@ -12,10 +12,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/flare/types"
 )
 
 type FlareBuilderMock struct {
-	Fb   FlareBuilder
+	Fb   types.FlareBuilder
 	Root string
 	t    *testing.T
 }

--- a/comp/core/flare/providers.go
+++ b/comp/core/flare/providers.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"strings"
 
-	flarehelpers "github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	"github.com/DataDog/datadog-agent/comp/core/flare/types"
 )
 
 var (
@@ -22,7 +22,7 @@ func getFirstSuffix(s string) string {
 	return filepath.Ext(strings.TrimSuffix(s, filepath.Ext(s)))
 }
 
-func (f *flare) collectLogsFiles(fb flarehelpers.FlareBuilder) error {
+func (f *flare) collectLogsFiles(fb types.FlareBuilder) error {
 	logFile := f.config.GetString("log_file")
 	if logFile == "" {
 		logFile = f.params.defaultLogFile
@@ -52,7 +52,7 @@ func (f *flare) collectLogsFiles(fb flarehelpers.FlareBuilder) error {
 	return nil
 }
 
-func (f *flare) collectConfigFiles(fb flarehelpers.FlareBuilder) error {
+func (f *flare) collectConfigFiles(fb types.FlareBuilder) error {
 	confSearchPaths := map[string]string{
 		"":        f.config.GetString("confd_path"),
 		"dist":    filepath.Join(f.params.distPath, "conf.d"),

--- a/comp/core/flare/types/types.go
+++ b/comp/core/flare/types/types.go
@@ -3,7 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package helpers
+// Package types contains all the types needed by FlareProviders without the underlying implementation and dependencies.
+// This allows components to offer flare capabilities without linking to the flare dependencies when the flare feature
+// is not built in the binary.
+package types
 
 import (
 	"go.uber.org/fx"

--- a/docs/components/migrating-to-components.md
+++ b/docs/components/migrating-to-components.md
@@ -15,7 +15,7 @@ Then, migrate the code related to your component's domain from `pkg/flare` to yo
 
 To add data to a flare you will first need to register a callback, aka a `FlareBuilder`.
 
-Within your component create a method with the following signature `func (c *yourComp) fillFlare(fb flarehelpers.FlareBuilder) error`.
+Within your component create a method with the following signature `func (c *yourComp) fillFlare(fb flaretypes.FlareBuilder) error`.
 
 This function is called every time the Agent generates a flare, either from the CLI or from the running Agent. This
 callback receives a `comp/core/flare/helpers:FlareBuilder`. The `FlareBuilder` interface provides all the
@@ -27,10 +27,10 @@ Example:
 import (
 	yaml "gopkg.in/yaml.v2"
 
-	flarehelpers "github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 )
 
-func (c *myComponent) fillFlare(fb flarehelpers.FlareBuilder) error {
+func (c *myComponent) fillFlare(fb flaretypes.FlareBuilder) error {
 	fb.AddFileFromFunc(
 		"runtime_config_dump.yaml",
 		func () ([]byte, error) {
@@ -59,14 +59,14 @@ need to provide a new `comp/core/flare/helpers:Provider`. Use `comp/core/flare/h
 Example:
 ```golang
 import (
-	flarehelpers "github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 )
 
 type provides struct {
 	fx.Out
 
 	// [...]
-	FlareProvider flarehelpers.Provider // Your component will provides a new FlareProvider
+	FlareProvider flaretypes.Provider // Your component will provides a new FlareProvider
 	// [...]
 }
 
@@ -74,7 +74,7 @@ func newComponent(deps dependencies) (provides, error) {
 	// [...]
 	return provides{
 		// [...]
-		FlareProvider: flarehelpers.NewProvider(myComponent.fillFlare), // NewProvider will wrap your callback in order to be use as a 'FlareProvider'
+		FlareProvider: flaretypes.NewProvider(myComponent.fillFlare), // NewProvider will wrap your callback in order to be use as a 'FlareProvider'
 		// [...]
 	}, nil
 }
@@ -84,6 +84,6 @@ func newComponent(deps dependencies) (provides, error) {
 
 Now migrate the require code from `pkg/flare` to you component callback. The code in `pkg/flare` already uses the
 `FlareBuilder` interface, simplifying migration. Don't forget to migrate the tests too and expand them (most of the
-flare features are not tested). `flarehelpers.NewFlareBuilderMock` will provides helpers for your tests.
+flare features are not tested). `comp/core/flare/helpers::NewFlareBuilderMock` will provides helpers for your tests.
 
 Keep in mind that the goal is to delete `pkg/flare` once the migration to component is done.

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"time"
 
-	flarehelpers "github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
@@ -50,7 +50,7 @@ type searchPaths map[string]string
 
 // CompleteFlare packages up the files with an already created builder. This is aimed to be used by the flare
 // component while we migrate to a component architecture.
-func CompleteFlare(fb flarehelpers.FlareBuilder, senderManager sender.SenderManager) error {
+func CompleteFlare(fb flaretypes.FlareBuilder, senderManager sender.SenderManager) error {
 	/** WARNING
 	 *
 	 * When adding data to flares, carefully analyze what is being added and ensure that it contains no credentials
@@ -121,11 +121,11 @@ func CompleteFlare(fb flarehelpers.FlareBuilder, senderManager sender.SenderMana
 	return nil
 }
 
-func getVersionHistory(fb flarehelpers.FlareBuilder) {
+func getVersionHistory(fb flaretypes.FlareBuilder) {
 	fb.CopyFile(filepath.Join(config.Datadog.GetString("run_path"), "version-history.json"))
 }
 
-func getRegistryJSON(fb flarehelpers.FlareBuilder) {
+func getRegistryJSON(fb flaretypes.FlareBuilder) {
 	fb.CopyFile(filepath.Join(config.Datadog.GetString("logs_config.run_path"), "registry.json"))
 }
 
@@ -142,7 +142,7 @@ func getMetadataV5() ([]byte, error) {
 	return data, nil
 }
 
-func getLogFiles(fb flarehelpers.FlareBuilder, logFileDir string) {
+func getLogFiles(fb flaretypes.FlareBuilder, logFileDir string) {
 	log.Flush()
 
 	fb.CopyDirToWithoutScrubbing(filepath.Dir(logFileDir), "logs", func(path string) bool {
@@ -153,7 +153,7 @@ func getLogFiles(fb flarehelpers.FlareBuilder, logFileDir string) {
 	})
 }
 
-func getExpVar(fb flarehelpers.FlareBuilder) error {
+func getExpVar(fb flaretypes.FlareBuilder) error {
 	variables := make(map[string]interface{})
 	expvar.Do(func(kv expvar.KeyValue) {
 		variable := make(map[string]interface{})
@@ -224,7 +224,7 @@ func getProcessAgentFullConfig() ([]byte, error) {
 	return cfgB, nil
 }
 
-func getConfigFiles(fb flarehelpers.FlareBuilder, confSearchPaths map[string]string) {
+func getConfigFiles(fb flaretypes.FlareBuilder, confSearchPaths map[string]string) {
 	for prefix, filePath := range confSearchPaths {
 		fb.CopyDirTo(filePath, filepath.Join("etc", "confd", prefix), func(path string) bool {
 			// ignore .example file
@@ -266,7 +266,7 @@ func getSecrets() ([]byte, error) {
 	return functionOutputToBytes(fct), nil
 }
 
-func getProcessChecks(fb flarehelpers.FlareBuilder, getAddressPort func() (url string, err error)) {
+func getProcessChecks(fb flaretypes.FlareBuilder, getAddressPort func() (url string, err error)) {
 	addressPort, err := getAddressPort()
 	if err != nil {
 		log.Errorf("Could not zip process agent checks: wrong configuration to connect to process-agent: %s", err.Error())

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 
 	flarehelpers "github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/custommetrics"
@@ -40,7 +41,7 @@ func CreateDCAArchive(local bool, distPath, logFilePath string, senderManager se
 	return fb.Save()
 }
 
-func createDCAArchive(fb flarehelpers.FlareBuilder, confSearchPaths map[string]string, logFilePath string, senderManager sender.SenderManager) {
+func createDCAArchive(fb flaretypes.FlareBuilder, confSearchPaths map[string]string, logFilePath string, senderManager sender.SenderManager) {
 	// If the request against the API does not go through we don't collect the status log.
 	if fb.IsLocal() {
 		fb.AddFile("local", nil)
@@ -84,7 +85,7 @@ func QueryDCAMetrics() ([]byte, error) {
 	return io.ReadAll(r.Body)
 }
 
-func getMetadataMap(fb flarehelpers.FlareBuilder) error {
+func getMetadataMap(fb flaretypes.FlareBuilder) error {
 	metaList := apiv1.NewMetadataResponse()
 	cl, err := apiserver.GetAPIClient()
 	if err != nil {
@@ -110,7 +111,7 @@ func getMetadataMap(fb flarehelpers.FlareBuilder) error {
 	return fb.AddFile("cluster-agent-metadatamapper.log", []byte(str))
 }
 
-func getClusterAgentClusterChecks(fb flarehelpers.FlareBuilder) error {
+func getClusterAgentClusterChecks(fb flaretypes.FlareBuilder) error {
 	var b bytes.Buffer
 
 	writer := bufio.NewWriter(&b)
@@ -120,7 +121,7 @@ func getClusterAgentClusterChecks(fb flarehelpers.FlareBuilder) error {
 	return fb.AddFile("clusterchecks.log", b.Bytes())
 }
 
-func getHPAStatus(fb flarehelpers.FlareBuilder) error {
+func getHPAStatus(fb flaretypes.FlareBuilder) error {
 	stats := make(map[string]interface{})
 	apiCl, err := apiserver.GetAPIClient()
 	if err != nil {
@@ -141,7 +142,7 @@ func getHPAStatus(fb flarehelpers.FlareBuilder) error {
 	return fb.AddFile("custommetricsprovider.log", []byte(str))
 }
 
-func getClusterAgentConfigCheck(fb flarehelpers.FlareBuilder) error {
+func getClusterAgentConfigCheck(fb flaretypes.FlareBuilder) error {
 	var b bytes.Buffer
 
 	writer := bufio.NewWriter(&b)
@@ -151,7 +152,7 @@ func getClusterAgentConfigCheck(fb flarehelpers.FlareBuilder) error {
 	return fb.AddFile("config-check.log", b.Bytes())
 }
 
-func getClusterAgentDiagnose(fb flarehelpers.FlareBuilder, senderManager sender.SenderManager) error {
+func getClusterAgentDiagnose(fb flaretypes.FlareBuilder, senderManager sender.SenderManager) error {
 	var b bytes.Buffer
 
 	writer := bufio.NewWriter(&b)

--- a/pkg/flare/archive_linux.go
+++ b/pkg/flare/archive_linux.go
@@ -17,22 +17,22 @@ import (
 
 	"github.com/DataDog/ebpf-manager/tracefs"
 
-	flarehelpers "github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
-func addSystemProbePlatformSpecificEntries(fb flarehelpers.FlareBuilder) {
+func addSystemProbePlatformSpecificEntries(fb flaretypes.FlareBuilder) {
 	sysprobeSocketLocation := config.SystemProbe.GetString("system_probe_config.sysprobe_socket")
 	if sysprobeSocketLocation != "" {
 		fb.RegisterDirPerm(filepath.Dir(sysprobeSocketLocation))
 	}
 }
 
-func getLinuxKernelSymbols(fb flarehelpers.FlareBuilder) error {
+func getLinuxKernelSymbols(fb flaretypes.FlareBuilder) error {
 	return fb.CopyFile("/proc/kallsyms")
 }
 
-func getLinuxKprobeEvents(fb flarehelpers.FlareBuilder) error {
+func getLinuxKprobeEvents(fb flaretypes.FlareBuilder) error {
 	traceFSPath, err := tracefs.Root()
 	if err != nil {
 		return err
@@ -40,7 +40,7 @@ func getLinuxKprobeEvents(fb flarehelpers.FlareBuilder) error {
 	return fb.CopyFile(filepath.Join(traceFSPath, "kprobe_events"))
 }
 
-func getLinuxPid1MountInfo(fb flarehelpers.FlareBuilder) error {
+func getLinuxPid1MountInfo(fb flaretypes.FlareBuilder) error {
 	return fb.CopyFile("/proc/1/mountinfo")
 }
 
@@ -88,7 +88,7 @@ func parseDmesg(buffer []byte) (string, error) {
 	return result, nil
 }
 
-func getLinuxDmesg(fb flarehelpers.FlareBuilder) error {
+func getLinuxDmesg(fb flaretypes.FlareBuilder) error {
 	dmesg, err := readAllDmesg()
 	if err != nil {
 		return err
@@ -102,7 +102,7 @@ func getLinuxDmesg(fb flarehelpers.FlareBuilder) error {
 	return fb.AddFile("dmesg", []byte(content))
 }
 
-func getLinuxTracingAvailableEvents(fb flarehelpers.FlareBuilder) error {
+func getLinuxTracingAvailableEvents(fb flaretypes.FlareBuilder) error {
 	traceFSPath, err := tracefs.Root()
 	if err != nil {
 		return err
@@ -110,7 +110,7 @@ func getLinuxTracingAvailableEvents(fb flarehelpers.FlareBuilder) error {
 	return fb.CopyFile(filepath.Join(traceFSPath, "available_events"))
 }
 
-func getLinuxTracingAvailableFilterFunctions(fb flarehelpers.FlareBuilder) error {
+func getLinuxTracingAvailableFilterFunctions(fb flaretypes.FlareBuilder) error {
 	traceFSPath, err := tracefs.Root()
 	if err != nil {
 		return err

--- a/pkg/flare/archive_nix.go
+++ b/pkg/flare/archive_nix.go
@@ -8,7 +8,7 @@
 package flare
 
 import (
-	flarehelpers "github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 )
 
-func getWindowsData(fb flarehelpers.FlareBuilder) {}
+func getWindowsData(fb flaretypes.FlareBuilder) {}

--- a/pkg/flare/archive_nolinux.go
+++ b/pkg/flare/archive_nolinux.go
@@ -8,31 +8,31 @@
 package flare
 
 import (
-	flarehelpers "github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 )
 
-func addSystemProbePlatformSpecificEntries(fb flarehelpers.FlareBuilder) {}
+func addSystemProbePlatformSpecificEntries(fb flaretypes.FlareBuilder) {}
 
-func getLinuxKernelSymbols(fb flarehelpers.FlareBuilder) error {
+func getLinuxKernelSymbols(fb flaretypes.FlareBuilder) error {
 	return nil
 }
 
-func getLinuxKprobeEvents(fb flarehelpers.FlareBuilder) error {
+func getLinuxKprobeEvents(fb flaretypes.FlareBuilder) error {
 	return nil
 }
 
-func getLinuxDmesg(fb flarehelpers.FlareBuilder) error {
+func getLinuxDmesg(fb flaretypes.FlareBuilder) error {
 	return nil
 }
 
-func getLinuxPid1MountInfo(fb flarehelpers.FlareBuilder) error {
+func getLinuxPid1MountInfo(fb flaretypes.FlareBuilder) error {
 	return nil
 }
 
-func getLinuxTracingAvailableEvents(fb flarehelpers.FlareBuilder) error {
+func getLinuxTracingAvailableEvents(fb flaretypes.FlareBuilder) error {
 	return nil
 }
 
-func getLinuxTracingAvailableFilterFunctions(fb flarehelpers.FlareBuilder) error {
+func getLinuxTracingAvailableFilterFunctions(fb flaretypes.FlareBuilder) error {
 	return nil
 }

--- a/pkg/flare/archive_security.go
+++ b/pkg/flare/archive_security.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	flarehelpers "github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -29,7 +30,7 @@ func CreateSecurityAgentArchive(local bool, logFilePath string, runtimeStatus, c
 }
 
 // createSecurityAgentArchive packages up the files
-func createSecurityAgentArchive(fb flarehelpers.FlareBuilder, logFilePath string, runtimeStatus, complianceStatus map[string]interface{}) {
+func createSecurityAgentArchive(fb flaretypes.FlareBuilder, logFilePath string, runtimeStatus, complianceStatus map[string]interface{}) {
 	// If the request against the API does not go through we don't collect the status log.
 	if fb.IsLocal() {
 		fb.AddFile("local", []byte(""))
@@ -59,7 +60,7 @@ func createSecurityAgentArchive(fb flarehelpers.FlareBuilder, logFilePath string
 	getLinuxTracingAvailableFilterFunctions(fb) //nolint:errcheck
 }
 
-func getComplianceFiles(fb flarehelpers.FlareBuilder) error {
+func getComplianceFiles(fb flaretypes.FlareBuilder) error {
 	compDir := config.Datadog.GetString("compliance_config.dir")
 
 	return fb.CopyDirTo(compDir, "compliance.d", func(path string) bool {
@@ -71,7 +72,7 @@ func getComplianceFiles(fb flarehelpers.FlareBuilder) error {
 	})
 }
 
-func getRuntimeFiles(fb flarehelpers.FlareBuilder) error {
+func getRuntimeFiles(fb flaretypes.FlareBuilder) error {
 	runtimeDir := config.SystemProbe.GetString("runtime_security_config.policies.dir")
 
 	return fb.CopyDirTo(runtimeDir, "runtime-security.d", func(path string) bool {

--- a/pkg/flare/archive_security_test.go
+++ b/pkg/flare/archive_security_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	flarehelpers "github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/pkg/config"
 
 	// Required to initialize the "dogstatsd" expvar
@@ -25,10 +26,10 @@ func TestCreateSecurityAgentArchive(t *testing.T) {
 	logFilePath := "./test/logs/agent.log"
 
 	// Mock getLinuxKernelSymbols. It can take a long time to scrub when creating a flare.
-	defer func(f func(flarehelpers.FlareBuilder) error) {
+	defer func(f func(flaretypes.FlareBuilder) error) {
 		linuxKernelSymbols = f
 	}(getLinuxKernelSymbols)
-	linuxKernelSymbols = func(fb flarehelpers.FlareBuilder) error {
+	linuxKernelSymbols = func(fb flaretypes.FlareBuilder) error {
 		fb.AddFile("kallsyms", []byte("some kernel symbol"))
 		return nil
 	}

--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -19,7 +19,7 @@ import (
 
 	"golang.org/x/sys/windows"
 
-	flarehelpers "github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 )
@@ -40,7 +40,7 @@ const (
 	evtExportLogChannelPath uint32 = 0x1
 )
 
-func getCounterStrings(fb flarehelpers.FlareBuilder) error {
+func getCounterStrings(fb flaretypes.FlareBuilder) error {
 	return fb.AddFileFromFunc("counter_strings.txt",
 		func() ([]byte, error) {
 			bufferIncrement := uint32(1024)
@@ -80,7 +80,7 @@ func getCounterStrings(fb flarehelpers.FlareBuilder) error {
 	)
 }
 
-func getTypeperfData(fb flarehelpers.FlareBuilder) error {
+func getTypeperfData(fb flaretypes.FlareBuilder) error {
 	cancelctx, cancelfunc := context.WithTimeout(context.Background(), execTimeout)
 	defer cancelfunc()
 
@@ -96,7 +96,7 @@ func getTypeperfData(fb flarehelpers.FlareBuilder) error {
 	return fb.AddFile("typeperf.txt", out.Bytes())
 }
 
-func getLodctrOutput(fb flarehelpers.FlareBuilder) error {
+func getLodctrOutput(fb flaretypes.FlareBuilder) error {
 	cancelctx, cancelfunc := context.WithTimeout(context.Background(), execTimeout)
 	defer cancelfunc()
 
@@ -116,7 +116,7 @@ func getLodctrOutput(fb flarehelpers.FlareBuilder) error {
 }
 
 // getWindowsEventLogs exports Windows event logs.
-func getWindowsEventLogs(fb flarehelpers.FlareBuilder) error {
+func getWindowsEventLogs(fb flaretypes.FlareBuilder) error {
 	var err error
 
 	for eventLogChannel := range eventLogChannelsToExport {
@@ -143,7 +143,7 @@ func getWindowsEventLogs(fb flarehelpers.FlareBuilder) error {
 
 // exportWindowsEventLog exports one event log file to the temporary location.
 // destFileName might contain a path.
-func exportWindowsEventLog(fb flarehelpers.FlareBuilder, eventLogChannel, eventLogQuery, destFileName string) error {
+func exportWindowsEventLog(fb flaretypes.FlareBuilder, eventLogChannel, eventLogQuery, destFileName string) error {
 	// Put all event logs under "eventlog" folder
 	destFullFileName, err := fb.PrepareFilePath(filepath.Join("eventlog", destFileName))
 	if err != nil {
@@ -178,7 +178,7 @@ func exportWindowsEventLog(fb flarehelpers.FlareBuilder, eventLogChannel, eventL
 	return err
 }
 
-func getServiceStatus(fb flarehelpers.FlareBuilder) error {
+func getServiceStatus(fb flaretypes.FlareBuilder) error {
 	return fb.AddFileFromFunc(
 		"servicestatus.txt",
 		func() ([]byte, error) {
@@ -259,7 +259,7 @@ func getServiceStatus(fb flarehelpers.FlareBuilder) error {
 // The implementation is based on the invoking Windows built-in reg.exe command, which does all
 // heavy lifting (instead of relying on explicit and recursive Registry API calls).
 // More technical details can be found in the PR https://github.com/DataDog/datadog-agent/pull/11290
-func getDatadogRegistry(fb flarehelpers.FlareBuilder) error {
+func getDatadogRegistry(fb flaretypes.FlareBuilder) error {
 	// Generate raw exported registry file which we will scrub just in case
 	rawf, err := fb.PrepareFilePath("datadog-raw.reg")
 	if err != nil {
@@ -289,7 +289,7 @@ func getDatadogRegistry(fb flarehelpers.FlareBuilder) error {
 	return fb.AddFile("datadog.reg", data)
 }
 
-func getWindowsData(fb flarehelpers.FlareBuilder) {
+func getWindowsData(fb flaretypes.FlareBuilder) {
 	getTypeperfData(fb)     //nolint:errcheck
 	getLodctrOutput(fb)     //nolint:errcheck
 	getCounterStrings(fb)   //nolint:errcheck

--- a/pkg/flare/remote_config.go
+++ b/pkg/flare/remote_config.go
@@ -16,7 +16,7 @@ import (
 	"sort"
 	"strings"
 
-	flarehelpers "github.com/DataDog/datadog-agent/comp/core/flare/helpers"
+	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
@@ -28,7 +28,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-func exportRemoteConfig(fb flarehelpers.FlareBuilder) error {
+func exportRemoteConfig(fb flaretypes.FlareBuilder) error {
 	// Dump the DB
 	if err := getRemoteConfigDB(fb); err != nil {
 		return err
@@ -78,7 +78,7 @@ func hashRCTargets(raw []byte) []byte {
 	return []byte(s)
 }
 
-func getRemoteConfigDB(fb flarehelpers.FlareBuilder) error {
+func getRemoteConfigDB(fb flaretypes.FlareBuilder) error {
 	dstPath, _ := fb.PrepareFilePath("remote-config.db")
 	tempPath, _ := fb.PrepareFilePath("remote-config.temp.db")
 	srcPath := filepath.Join(config.Datadog.GetString("run_path"), "remote-config.db")


### PR DESCRIPTION
### What does this PR do?

A component that supports adding information to a flare will not longer pull all the flare dependencies when included in a binary that doesn't support flare creation.

### Describe how to test/QA your changes

Try creating and sending a flare from the core agent. The content and behavior should be the same.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
