### PR TITLE
usm: rework read into buffer fixed pagesize

### DIFF
--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -56,7 +56,7 @@ static __always_inline void https_process(conn_tuple_t *t, void *buffer, size_t 
     http_transaction_t http;
     bpf_memset(&http, 0, sizeof(http));
     bpf_memcpy(&http.tup, t, sizeof(conn_tuple_t));
-    read_into_buffer(http.request_fragment, buffer, len);
+    read_into_user_buffer_http(http.request_fragment, buffer);
     http_process(&http, NULL, tags);
     classify_decrypted_payload(&http.tup, http.request_fragment, len);
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Simplifies `read_into_buffer` to perform max 2 bpf_probe_read calls instead of max 161.
At first we're trying to read the full buffer (HTTP transaction buffer)
In case of failure, we're trying to read until the end of the current page.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Optimization
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Future work:

- automate the manual test below
  - For that we need to run the code inside a docker (as we need gcc, openssl, and other dependencies in the kitchen machines)
  - Currently https monitoring does not hook that scenario
- Read `min(len, HTTP_BUFFER_SIZE)` in the first `bpf_probe_read_user`

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
1. Run USM with https monitoring
2. Compile the test client below using `gcc -o http_get_example main.c -lssl -lcrypto -ldl`
3. Run the test client `./http_get_example httpbin.org 443 /get`
4. Ensure traffic was captured `sudo curl -s --unix /opt/datadog-agent/run/sysprobe.sock http://unix/network_tracer/debug/http_monitoring | jq '.[] | select(.Server.Port==443)'`
```c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>
#include <netdb.h>
#include <malloc.h>
#include <dlfcn.h>
#include <sys/mman.h>
#include <openssl/ssl.h>
#include <openssl/err.h>

#define GET_METHOD "GET "
#define GET_REQUEST1 " HTTP/1.1\r\nHost: "
#define GET_REQUEST2 "\r\nConnection: close\r\n\r\n"

void construct_request_body(char *paged_memory, const char *address, const char *endpoint) {
    // Copy the first string into the buffer
    strcpy(paged_memory, GET_METHOD);
    strcat(paged_memory, endpoint);
    strcat(paged_memory, GET_REQUEST1);
    strcat(paged_memory, address);
    strcat(paged_memory, GET_REQUEST2);
}

long get_request_body_size(const char *address, const char *endpoint) {
    return strlen(GET_METHOD) + strlen(endpoint) + strlen(GET_REQUEST1) + strlen(address) + strlen(GET_REQUEST2) + 1;
}

int main(int argc, char *argv[]) {
    if (argc != 4) {
        fprintf(stderr, "Usage: %s <address> <port> <endpoint>\n", argv[0]);
        return 1;
    }

    // Getting the pagesize.
    const long pagesize = getpagesize();
    const long request_body_size = get_request_body_size(argv[1], argv[3]);
    const long buffer_offset = pagesize - request_body_size;
    // Setting paged memory. Allocating 2 pages so we can pagefault the second page.
    char *paged_memory = memalign(2 * pagesize, pagesize);
    if (paged_memory == NULL) {
        perror("memalign");
        return 1;
    }

    char *request_buffer = &paged_memory[buffer_offset];
    construct_request_body(request_buffer, argv[1], argv[3]);
    printf("%s", request_buffer);

    printf("address of data %p data length %ld\n", request_buffer, request_body_size);

    SSL_CTX *ctx;
    SSL *ssl;
    int sockfd;

    // Initialize OpenSSL
    SSL_library_init();
    SSL_load_error_strings();
    OpenSSL_add_all_algorithms();

    sleep(5);

    // Create an SSL context
    ctx = SSL_CTX_new(SSLv23_client_method());
    if (!ctx) {
        fprintf(stderr, "SSL_CTX_new() failed\n");
        return 1;
    }

    // Create a socket and connect to the server
    struct addrinfo hints, *res;
    memset(&hints, 0, sizeof hints);
    hints.ai_family = AF_UNSPEC;
    hints.ai_socktype = SOCK_STREAM;
    if (getaddrinfo(argv[1], argv[2], &hints, &res) != 0) {
        fprintf(stderr, "getaddrinfo() failed\n");
        return 1;
    }

    sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
    if (sockfd == -1) {
        perror("socket");
        return 1;
    }

    if (connect(sockfd, res->ai_addr, res->ai_addrlen) == -1) {
        perror("connect");
        return 1;
    }

    // Create an SSL object and associate it with the socket
    ssl = SSL_new(ctx);
    if (!ssl) {
        fprintf(stderr, "SSL_new() failed\n");
        return 1;
    }
    SSL_set_fd(ssl, sockfd);

    // Perform the SSL handshake
    if (SSL_connect(ssl) != 1) {
        fprintf(stderr, "SSL_connect() failed\n");
        ERR_print_errors_fp(stderr);
        return 1;
    }

    if (madvise(paged_memory + pagesize, pagesize, MADV_DONTNEED) != 0) {
        perror("madvise");
        return 1;
    }

    // Send the GET request
    if (SSL_write(ssl, request_buffer, request_body_size) <= 0) {
        fprintf(stderr, "SSL_write() failed\n");
        ERR_print_errors_fp(stderr);
        return 1;
    }

    // Receive and print the response
    char out_buffer[1024];
    int bytes_received;
    while ((bytes_received = SSL_read(ssl, out_buffer, sizeof(out_buffer))) > 0) {
        fwrite(out_buffer, 1, bytes_received, stdout);
    }

    // Clean up
    SSL_shutdown(ssl);
    SSL_free(ssl);
    SSL_CTX_free(ctx);
    close(sockfd);
    printf("\npagefault client ended\n");

    return 0;
}
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
