### PR TITLE
[ASCII-717] Avoid using gotest.tools/assert

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,6 +82,9 @@ linters-settings:
       - sync/atomic: "Use go.uber.org/atomic instead; see docs/dev/atomics.md"
       - io/ioutil: "Deprecated since Go 1.16. Use package io or os instead."
       - github.com/golang/glog: "Crashes Windows nanoserver and significantly delays Agent startup on Windows Domain Controllers."
+      # feel free to remove if you really need it as opposed to testify/assert
+      - gotest.tools/assert: "Not really forbidden to use, but it is usually imported by mistake instead of github.com/stretchr/testify/assert"
+
   errcheck:
     # Disable warnings for `fmt`, `log` and `seelog` packages. Also ignore `Write` functions from `net/http` package.
     # Disable warnings for select Windows functions

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,7 +82,10 @@ linters-settings:
       - sync/atomic: "Use go.uber.org/atomic instead; see docs/dev/atomics.md"
       - io/ioutil: "Deprecated since Go 1.16. Use package io or os instead."
       - github.com/golang/glog: "Crashes Windows nanoserver and significantly delays Agent startup on Windows Domain Controllers."
-      # feel free to remove if you really need it as opposed to testify/assert
+      # IDE auto-imports often import `gotest.tools/assert` instead of `testify/assert` by default
+      # feel free to remove the following line if you really need it in several files as opposed to testify/assert
+      # note that if it's just for a single file, you can just add `//nolint:depguard` before the import
+      # the goal is just to limit the risk of accidental imports
       - gotest.tools/assert: "Not really forbidden to use, but it is usually imported by mistake instead of github.com/stretchr/testify/assert"
 
   errcheck:

--- a/cmd/serverless-init/cloudservice/service_test.go
+++ b/cmd/serverless-init/cloudservice/service_test.go
@@ -8,7 +8,7 @@ package cloudservice
 import (
 	"testing"
 
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetCloudServiceType(t *testing.T) {

--- a/cmd/serverless-init/metric/metric_test.go
+++ b/cmd/serverless-init/metric/metric_test.go
@@ -9,10 +9,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"gotest.tools/assert"
 )
 
 func TestAdd(t *testing.T) {

--- a/cmd/system-probe/utils/limiter_test.go
+++ b/cmd/system-probe/utils/limiter_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestWithConcurrencyLimit(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -224,7 +224,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	gopkg.in/zorkian/go-datadog-api.v2 v2.30.0
-	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.27.2
 	k8s.io/apiextensions-apiserver v0.27.2
 	k8s.io/apimachinery v0.27.2

--- a/pkg/logs/launchers/journald/launcher_test.go
+++ b/pkg/logs/launchers/journald/launcher_test.go
@@ -11,6 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coreos/go-systemd/sdjournal"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers"
@@ -19,8 +22,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/tailers"
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/tailers/journald"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
-	"github.com/coreos/go-systemd/sdjournal"
-	"gotest.tools/assert"
 )
 
 type MockJournal struct{}

--- a/pkg/logs/schedulers/cca/scheduler_test.go
+++ b/pkg/logs/schedulers/cca/scheduler_test.go
@@ -8,8 +8,8 @@ package cca
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gotest.tools/assert"
 
 	logsConfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"

--- a/pkg/network/protocols/events/batch_offsets_test.go
+++ b/pkg/network/protocols/events/batch_offsets_test.go
@@ -10,7 +10,7 @@ package events
 import (
 	"testing"
 
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestOffsets(t *testing.T) {

--- a/pkg/serverless/daemon/utils_test.go
+++ b/pkg/serverless/daemon/utils_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestWaitWithTimeoutTimesOut(t *testing.T) {

--- a/pkg/serverless/proc/proc_test.go
+++ b/pkg/serverless/proc/proc_test.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 	"testing"
 
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetPidListInvalid(t *testing.T) {

--- a/pkg/workloadmeta/store_test.go
+++ b/pkg/workloadmeta/store_test.go
@@ -9,8 +9,7 @@ import (
 	"reflect"
 	"testing"
 
-	tassert "github.com/stretchr/testify/assert"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
@@ -595,8 +594,8 @@ func TestSubscribe(t *testing.T) {
 			s.Unsubscribe(ch)
 
 			<-doneCh
-
-			assert.DeepEqual(t, tt.expected, actual)
+			assert.Equal(t, tt.expected, actual)
+			assert.Equal(t, tt.expected, actual)
 		})
 	}
 }
@@ -680,7 +679,7 @@ func TestListContainers(t *testing.T) {
 
 			containers := testStore.ListContainers()
 
-			assert.DeepEqual(t, test.expectedContainers, containers)
+			assert.Equal(t, test.expectedContainers, containers)
 		})
 	}
 }
@@ -723,7 +722,7 @@ func TestListContainersWithFilter(t *testing.T) {
 
 	runningContainers := testStore.ListContainersWithFilter(GetRunningContainers)
 
-	assert.DeepEqual(t, []*Container{runningContainer}, runningContainers)
+	assert.Equal(t, []*Container{runningContainer}, runningContainers)
 }
 
 func TestListProcesses(t *testing.T) {
@@ -764,7 +763,7 @@ func TestListProcesses(t *testing.T) {
 
 			processes := testStore.ListProcesses()
 
-			assert.DeepEqual(t, test.expectedProcesses, processes)
+			assert.Equal(t, test.expectedProcesses, processes)
 		})
 	}
 }
@@ -813,7 +812,7 @@ func TestListProcessesWithFilter(t *testing.T) {
 		}
 	})
 
-	assert.DeepEqual(t, []*Process{javaProcess}, retrievedProcesses)
+	assert.Equal(t, []*Process{javaProcess}, retrievedProcesses)
 }
 
 func TestListImages(t *testing.T) {
@@ -852,7 +851,7 @@ func TestListImages(t *testing.T) {
 			testStore := newTestStore()
 			testStore.handleEvents(test.preEvents)
 
-			assert.DeepEqual(t, test.expectedImages, testStore.ListImages())
+			assert.Equal(t, test.expectedImages, testStore.ListImages())
 		})
 	}
 }
@@ -902,8 +901,8 @@ func TestGetImage(t *testing.T) {
 			if test.expectsError {
 				assert.Error(t, err, errors.NewNotFound(string(KindContainerImageMetadata)).Error())
 			} else {
-				assert.NilError(t, err)
-				assert.DeepEqual(t, test.expectedImage, actualImage)
+				assert.NoError(t, err)
+				assert.Equal(t, test.expectedImage, actualImage)
 			}
 		})
 	}
@@ -1016,7 +1015,7 @@ func TestResetProcesses(t *testing.T) {
 			<-doneCh
 
 			processes := testStore.ListProcesses()
-			tassert.ElementsMatch(t, processes, test.newProcesses)
+			assert.ElementsMatch(t, processes, test.newProcesses)
 		})
 	}
 
@@ -1208,7 +1207,7 @@ func TestReset(t *testing.T) {
 
 			<-doneCh
 
-			assert.DeepEqual(t, test.expectedEventsReceived, actualEventsReceived)
+			assert.Equal(t, test.expectedEventsReceived, actualEventsReceived)
 		})
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Replace uses of `gotest.tools/assert` with `github.com/stretchr/testify/assert`, add `gotest.tools/assert` to the dependency blacklist.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
`testify` is the usual framework in the `datadog-agent` repository, I asked a few teams which were using `gotest.tools` and it was never on purpose, so replacing uses of `gotest.tools` and adding it to the blacklist to avoid this kind of issue.

I can revert (all or part of) the PR if any team really needed `gotest.tools`.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Realized that `gotest.tools/assert` has a `DeepEqual` function which doesn't have a direct equivalent with `testify/assert`, but the `Equal` function from `testify/assert` actually checks a deep equal (it uses `reflect.DeepEqual`) so if the CI passes I think it's ok.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
This change only impacts tests so if the CI passes it should be enough.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
