### PR TITLE
Revert "usm: fix incomplete buffer timestamp parameter (#18928)"

### DIFF
--- a/pkg/network/protocols/http/incomplete_stats.go
+++ b/pkg/network/protocols/http/incomplete_stats.go
@@ -109,10 +109,11 @@ func (b *incompleteBuffer) Add(tx Transaction) {
 	}
 }
 
-func (b *incompleteBuffer) Flush(nowNano int64) []Transaction {
+func (b *incompleteBuffer) Flush(now time.Time) []Transaction {
 	var (
 		joined   []Transaction
 		previous = b.data
+		nowUnix  = now.UnixNano()
 	)
 
 	b.data = make(map[types.ConnectionKey]*txParts)
@@ -145,7 +146,7 @@ func (b *incompleteBuffer) Flush(nowNano int64) []Transaction {
 		// now that we have finished matching requests and responses
 		// we check if we should keep orphan requests a little longer
 		for i < len(parts.requests) {
-			if b.shouldKeep(parts.requests[i], nowNano) {
+			if b.shouldKeep(parts.requests[i], nowUnix) {
 				keep := parts.requests[i:]
 				parts := newTXParts()
 				parts.requests = append(parts.requests, keep...)

--- a/pkg/network/protocols/http/incomplete_stats_windows.go
+++ b/pkg/network/protocols/http/incomplete_stats_windows.go
@@ -8,6 +8,8 @@
 package http
 
 import (
+	"time"
+
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 )
 
@@ -19,5 +21,5 @@ func newIncompleteBuffer(c *config.Config, telemetry *Telemetry) *incompleteBuff
 	return &incompleteBuffer{}
 }
 
-func (b *incompleteBuffer) Add(tx Transaction)            {}
-func (b *incompleteBuffer) Flush(now int64) []Transaction { return nil }
+func (b *incompleteBuffer) Add(tx Transaction)                {}
+func (b *incompleteBuffer) Flush(now time.Time) []Transaction { return nil }

--- a/pkg/network/protocols/http/statkeeper.go
+++ b/pkg/network/protocols/http/statkeeper.go
@@ -68,7 +68,7 @@ func (h *StatKeeper) GetAndResetAllStats() map[Key]*RequestStats {
 	h.mux.Lock()
 	defer h.mux.Unlock()
 
-	for _, tx := range h.incomplete.Flush(getCurrentNanoSeconds()) {
+	for _, tx := range h.incomplete.Flush(time.Now()) {
 		h.add(tx)
 	}
 

--- a/pkg/network/protocols/http/statkeeper_linux.go
+++ b/pkg/network/protocols/http/statkeeper_linux.go
@@ -8,22 +8,9 @@
 package http
 
 import (
-	"time"
-
-	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func getPathBufferSize(c *config.Config) int {
 	return int(BufferSize)
-}
-
-func getCurrentNanoSeconds() int64 {
-	now, err := ebpf.NowNanoseconds()
-	if err != nil {
-		log.Warnf("couldn't get monotonic clock, using realtime clock instead: %s", err)
-		now = time.Now().UnixNano()
-	}
-	return now
 }

--- a/pkg/network/protocols/http/statkeeper_windows.go
+++ b/pkg/network/protocols/http/statkeeper_windows.go
@@ -8,15 +8,9 @@
 package http
 
 import (
-	"time"
-
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 )
 
 func getPathBufferSize(c *config.Config) int {
 	return int(c.HTTPMaxRequestFragment)
-}
-
-func getCurrentNanoSeconds() int64 {
-	return time.Now().UnixNano()
 }


### PR DESCRIPTION

### What does this PR do?

Revert #18928

### Motivation

The changes currently reverted has inadvertently caused more datapoints to be accumulated inside the `incompleteBuffer`, which is causing an increase in memory usage for certain workloads.

### Additional Notes

We intend to ship #18928 in 7.49 alongside with a another change improving how buffer limits are enforced.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
