### PR TITLE
Add initialization debug logs to DSM pipeline_stats handler in Datadog agent

### DIFF
--- a/pkg/trace/api/pipeline_stats.go
+++ b/pkg/trace/api/pipeline_stats.go
@@ -33,6 +33,7 @@ func pipelineStatsEndpoints(cfg *config.AgentConfig) (urls []*url.URL, apiKeys [
 	}
 	for _, e := range cfg.Endpoints {
 		urlStr := e.Host + pipelineStatsURLSuffix
+		log.Debug("[pipeline_stats] Intake URL " + urlStr)
 		url, err := url.Parse(urlStr)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error parsing pipeline stats intake URL %q: %v", urlStr, err)
@@ -45,9 +46,10 @@ func pipelineStatsEndpoints(cfg *config.AgentConfig) (urls []*url.URL, apiKeys [
 
 // pipelineStatsProxyHandler returns a new HTTP handler which will proxy requests to the pipeline stats intake.
 func (r *HTTPReceiver) pipelineStatsProxyHandler() http.Handler {
+	log.Debug("[pipeline_stats] Creating proxy handler")
 	urls, apiKeys, err := pipelineStatsEndpoints(r.conf)
 	if err != nil {
-		log.Errorf("Failed to start pipeline stats proxy handler: %v", err)
+		log.Errorf("[pipeline_stats] Failed to start pipeline stats proxy handler: %v", err)
 		return pipelineStatsErrorHandler(err)
 	}
 	tags := fmt.Sprintf("host:%s,default_env:%s,agent_version:%s", r.conf.Hostname, r.conf.DefaultEnv, r.conf.AgentVersion)
@@ -68,6 +70,7 @@ func pipelineStatsErrorHandler(err error) http.Handler {
 // newPipelineStatsProxy creates an http.ReverseProxy which forwards requests to the pipeline stats intake.
 // The tags will be added as a header to all proxied requests.
 func newPipelineStatsProxy(conf *config.AgentConfig, urls []*url.URL, apiKeys []string, tags string) *httputil.ReverseProxy {
+	log.Debug("[pipeline_stats] Creating reverse proxy")
 	cidProvider := NewIDProvider(conf.ContainerProcRoot)
 	director := func(req *http.Request) {
 		req.Header.Set("Via", fmt.Sprintf("trace-agent %s", conf.AgentVersion))

--- a/pkg/trace/api/pipeline_stats.go
+++ b/pkg/trace/api/pipeline_stats.go
@@ -117,7 +117,7 @@ func (m *multiDataStreamsTransport) RoundTrip(req *http.Request) (rresp *http.Re
 		setTarget(req, m.targets[0], m.keys[0])
 		rresp, rerr = m.rt.RoundTrip(req)
 		if rerr != nil {
-			log.Error(rerr)
+			log.Errorf("[pipeline_stats] RoundTrip failed: %v", rerr)
 		} else {
 			log.Debugf("[pipeline_stats] Returned status: %s, from host: %s, path: %s", rresp.Status, m.targets[0].Host, m.targets[0].Path)
 		}
@@ -137,7 +137,7 @@ func (m *multiDataStreamsTransport) RoundTrip(req *http.Request) (rresp *http.Re
 			// will be the first one called, we return its response and error
 			rresp, rerr = m.rt.RoundTrip(newreq)
 			if rerr != nil {
-				log.Error(rerr)
+				log.Errorf("[pipeline_stats] RoundTrip failed: %v", rerr)
 			} else {
 				log.Debugf("[pipeline_stats] Returned status: %s, from host: %s, path: %s", rresp.Status, m.targets[0].Host, m.targets[0].Path)
 			}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Add debug logs during initialization of the Data Streams Monitoring `pipeline_stats` handler to help with support and debugging cases where DSM data is not properly received by the backend.

### Motivation

Improve support and debugging experience for the DSM product.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
