### PR TITLE
[Windows] add system probe module for windows crash detection.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -266,6 +266,7 @@
 /pkg/collector/corechecks/sbom/         @DataDog/container-integrations
 /pkg/collector/corechecks/snmp/         @DataDog/network-device-monitoring
 /pkg/collector/corechecks/system/                 @DataDog/agent-platform
+/pkg/collector/corechecks/system/wincrashdetect/  @DataDog/windows-kernel-integrations
 /pkg/collector/corechecks/system/**/*_windows*.go @DataDog/agent-platform @DataDog/windows-agent
 /pkg/collector/corechecks/system/winkmem/         @DataDog/windows-agent
 /pkg/collector/corechecks/system/winproc/         @DataDog/windows-agent

--- a/cmd/agent/subcommands/run/dependent_services_windows.go
+++ b/cmd/agent/subcommands/run/dependent_services_windows.go
@@ -53,8 +53,9 @@ var subservices = []Servicedef{
 	{
 		name: "sysprobe",
 		configKeys: map[string]config.Config{
-			"network_config.enabled":      config.SystemProbe,
-			"system_probe_config.enabled": config.SystemProbe,
+			"network_config.enabled":          config.SystemProbe,
+			"system_probe_config.enabled":     config.SystemProbe,
+			"windows_crash_detection.enabled": config.SystemProbe,
 		},
 		serviceName: "datadog-system-probe",
 		serviceInit: sysprobeInit,

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -36,6 +36,7 @@ const (
 	DynamicInstrumentationModule ModuleName = "dynamic_instrumentation"
 	EBPFModule                   ModuleName = "ebpf"
 	LanguageDetectionModule      ModuleName = "language_detection"
+	WindowsCrashDetectModule     ModuleName = "windows_crash_detection"
 )
 
 // Config represents the configuration options for the system-probe
@@ -159,6 +160,17 @@ func load() (*Config, error) {
 	}
 	if cfg.GetBool("system_probe_config.language_detection.enabled") {
 		c.EnabledModules[LanguageDetectionModule] = struct{}{}
+	}
+
+	if cfg.GetBool(wcdNS("enabled")) {
+		c.EnabledModules[WindowsCrashDetectModule] = struct{}{}
+	}
+	if runtime.GOOS == "windows" {
+		if c.ModuleIsEnabled(NetworkTracerModule) {
+			// enable the windows crash detection module if the network tracer
+			// module is enabled, to allow the core agent to detect our own crash
+			c.EnabledModules[WindowsCrashDetectModule] = struct{}{}
+		}
 	}
 
 	c.Enabled = len(c.EnabledModules) > 0

--- a/cmd/system-probe/config/ns.go
+++ b/cmd/system-probe/config/ns.go
@@ -45,3 +45,8 @@ func evNS(k ...string) string {
 func nskey(ns string, pieces ...string) string {
 	return strings.Join(append([]string{ns}, pieces...), ".")
 }
+
+// wcdNS addes 'windows_crash_detection' namespace to config key
+func wcdNS(k ...string) string {
+	return nskey("windows_crash_detection", k...)
+}

--- a/cmd/system-probe/modules/all_windows.go
+++ b/cmd/system-probe/modules/all_windows.go
@@ -20,6 +20,7 @@ import (
 var All = []module.Factory{
 	NetworkTracer,
 	EventMonitor,
+	WinCrashProbe,
 }
 
 func inactivityEventLog(duration time.Duration) {

--- a/cmd/system-probe/modules/crashdetect_windows.go
+++ b/cmd/system-probe/modules/crashdetect_windows.go
@@ -53,7 +53,7 @@ func (wcdm *winCrashDetectModule) Register(httpMux *module.Router) error {
 	return nil
 }
 
-func (wcdm *winCrashDetectModule) RegisterGRPC(_ *grpc.Server) error {
+func (wcdm *winCrashDetectModule) RegisterGRPC(_ grpc.ServiceRegistrar) error {
 	return nil
 }
 

--- a/cmd/system-probe/modules/crashdetect_windows.go
+++ b/cmd/system-probe/modules/crashdetect_windows.go
@@ -15,7 +15,6 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/utils"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/wincrashdetect/probe"
-	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"google.golang.org/grpc"
 )
@@ -26,7 +25,7 @@ var WinCrashProbe = module.Factory{
 	ConfigNamespaces: []string{"windows_crash_detection"},
 	Fn: func(cfg *config.Config) (module.Module, error) {
 		log.Infof("Starting the WinCrashProbe probe")
-		cp, err := probe.NewWinCrashProbe(ebpf.NewConfig())
+		cp, err := probe.NewWinCrashProbe(cfg)
 		if err != nil {
 			return nil, fmt.Errorf("unable to start the Windows Crash Detection probe: %w", err)
 		}

--- a/cmd/system-probe/modules/crashdetect_windows.go
+++ b/cmd/system-probe/modules/crashdetect_windows.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package modules
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	"github.com/DataDog/datadog-agent/cmd/system-probe/utils"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/wincrashdetect/probe"
+	"github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"google.golang.org/grpc"
+)
+
+// WinCrashProbe Factory
+var WinCrashProbe = module.Factory{
+	Name:             config.WindowsCrashDetectModule,
+	ConfigNamespaces: []string{"windows_crash_detection"},
+	Fn: func(cfg *config.Config) (module.Module, error) {
+		log.Infof("Starting the WinCrashProbe probe")
+		cp, err := probe.NewWinCrashProbe(ebpf.NewConfig())
+		if err != nil {
+			return nil, fmt.Errorf("unable to start the Windows Crash Detection probe: %w", err)
+		}
+		return &winCrashDetectModule{
+			WinCrashProbe: cp,
+		}, nil
+	},
+}
+
+var _ module.Module = &winCrashDetectModule{}
+
+type winCrashDetectModule struct {
+	*probe.WinCrashProbe
+}
+
+func (wcdm *winCrashDetectModule) Register(httpMux *module.Router) error {
+	// only ever allow one concurrent check of the blue screen file.
+	httpMux.HandleFunc("/check", utils.WithConcurrencyLimit(1, func(w http.ResponseWriter, req *http.Request) {
+		log.Infof("Got check request in crashDetect")
+		results := wcdm.WinCrashProbe.Get()
+		utils.WriteAsJSON(w, results)
+	}))
+
+	return nil
+}
+
+func (wcdm *winCrashDetectModule) RegisterGRPC(_ *grpc.Server) error {
+	return nil
+}
+
+func (wcdm *winCrashDetectModule) GetStats() map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+func (wcdm *winCrashDetectModule) Close() {
+
+}

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/README.md
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/README.md
@@ -1,0 +1,114 @@
+## How this works, and how to test.
+
+### How this works
+
+Windows provides a limited subset of the debugger functionality with the base OS.  This allows us to execute some (not all) debugger commands when we discover a crash dump file.  But, the output is very
+limited.  It simply dumps the strings that would appear in the debugger.  So we have to parse the string
+to find the parts we're interested.  A sample output is supplied below.
+
+### How to (really) test
+
+Unfortunately, actually testing the parser then requires actual dumps.  Actual dumps require multiple gigabytes of data.  To manually test, in a VM (don't do this on your own machine), install the crasher driver (TBD: linked here).  Start the driver. It will _immediately_ crash.  On reboot there will be a crash dump to parse, and (assuming the agent is installed) the agent will find and report.
+
+## Sample output from debugger callback.
+
+Note that the string below is somewhat formatted.  In practice, the string is sent to the callback
+in chunks, not necessarily, for example, on newline boundaries.
+
+=== cut here ===
+
+Kernel Bitmap Dump File: Kernel address space is available, User address space may not be available.
+
+Symbol search path is: srv*
+Executable search path is:
+*** ERROR: Symbol file could not be found.  Defaulted to export symbols for ntkrnlmp.exe -
+Windows 10 Kernel Version 14393 MP (2 procs) Free x64
+Product: Server, suite: TerminalServer SingleUserTS
+Built by: 14393.5989.amd64fre.GitEnlistment.230602-1907
+Machine Name:
+Kernel base = 0xfffff800`4567f000 PsLoadedModuleList = 0xfffff800`45984cf0
+Debug session time: Mon Jun 26 20:44:49.742 2023 (UTC - 7:00)
+System Uptime: 0 days 0:03:58.449
+*** ERROR: Symbol file could not be found.  Defaulted to export symbols for ntkrnlmp.exe -
+Loading Kernel Symbols
+...............................................................
+................................................................
+........................
+Loading User Symbols
+
+Loading unloaded module list
+...........
+
+************* Symbol Loading Error Summary **************
+Module name            Error
+ntkrnlmp               The system cannot find the file specified
+
+You can troubleshoot most symbol related issues by turning on symbol loading diagnostics (!sym noisy) and repeating the
+command that caused symbols to be loaded.
+You should also verify that your symbol search path (.sympath) is correct.
+Unable to add extension DLL: kdexts
+Unable to add extension DLL: kext
+Unable to add extension DLL: exts
+The call to LoadLibrary(ext) failed, Win32 error 0n2
+    "The system cannot find the file specified."
+Please check your debugger configuration and/or network access.
+The call to LoadLibrary(ext) failed, Win32 error 0n2
+    "The system cannot find the file specified."
+Please check your debugger configuration and/or network access.
+*******************************************************************************
+*                                                                             *
+*                        Bugcheck Analysis                                    *
+*                                                                             *
+*******************************************************************************
+Bugcheck code 0000007E
+Arguments ffffffff`c0000005 fffff806`f7e010e6 ffffb481`789326a8 ffffb481`78931ef0
+
+RetAddr           : Args to Child                                                           : Call Site
+fffff800`457f4db0 : 00000000`0000007e ffffffff`c0000005 fffff806`f7e010e6 ffffb481`789326a8 : nt!KeBugCheckEx
+fffff800`457cb7bf : 00000000`00000004 00000000`00000000 00007fff`ffff0000 ffffc582`1b4e3800 : nt!memset+0x5530
+fffff800`457e602d : ffffb481`78933000 ffffb481`789318c0 00000000`00000000 00000000`00000050 : nt!_C_specific_handler+0x9
+f
+fffff800`457742a1 : ffffb481`78933000 00000000`00000000 ffffb481`7892d000 00000000`00000000 : nt!_chkstk+0x5d
+fffff800`457730c4 : ffffb481`789326a8 ffffb481`789323f0 ffffb481`789326a8 ffffb481`78932570 : nt!KeQuerySystemTimePrecis
+e+0x27d1
+fffff800`457ee482 : 00003c74`00000000 fffff800`458a1d00 00000000`00000000 fffff800`45d940c4 : nt!KeQuerySystemTimePrecis
+e+0x15f4
+fffff800`457eafc0 : 00000000`00000000 fffff800`45a97fe0 ffff8301`2c077220 ffffc582`1bb72c30 : nt!setjmpex+0x7622
+fffff806`f7e010e6 : 00000000`00000001 00000000`00000000 ffffb481`76e2e000 fffff800`456e6511 : nt!setjmpex+0x4160
+*** ERROR: Module load completed but symbols could not be loaded for ddapmcrash.sys
+fffff806`f7e07020 : ffffc582`1bb72c30 ffffc582`19f18000 ffffc582`1bb72c30 ffff3ac8`f399d666 : ddapmcrash+0x10e6
+fffff800`45b338f7 : 00000000`00000000 00000000`00000000 ffffc582`1bb72c30 ffffffff`000001c8 : ddapmcrash+0x7020
+fffff800`45ad140e : 00000000`00000000 00000000`00000000 00000000`00000000 fffff800`45a3e2c0 : nt!FsRtlNotifyVolumeEventE
+x+0x243b
+fffff800`45715dc9 : fffff800`00000000 ffffffff`80000ba4 ffffc582`1b4e3800 fffff800`45a3e2c0 : nt!MmGetPhysicalMemoryRang
+esEx+0xb56
+fffff800`456c6f85 : ffffc582`1b4e3800 00000000`00000080 ffffc582`18a636c0 ffffc582`1b4e3800 : nt!KdPollBreakIn+0x8059
+fffff800`457e4df6 : ffffb481`76e15180 ffffc582`1b4e3800 fffff800`456c6f44 00000000`00000246 : nt!PsGetProcessSessionIdEx
++0x2d5
+00000000`00000000 : ffffb481`78933000 ffffb481`7892d000 00000000`00000000 00000000`00000000 : nt!KeSynchronizeExecution+
+0x7756
+
+RetAddr           : Args to Child                                                           : Call Site
+fffff800`457f4db0 : 00000000`0000007e ffffffff`c0000005 fffff806`f7e010e6 ffffb481`789326a8 : nt!KeBugCheckEx
+fffff800`457cb7bf : 00000000`00000004 00000000`00000000 00007fff`ffff0000 ffffc582`1b4e3800 : nt!memset+0x5530
+fffff800`457e602d : ffffb481`78933000 ffffb481`789318c0 00000000`00000000 00000000`00000050 : nt!_C_specific_handler+0x9
+f
+fffff800`457742a1 : ffffb481`78933000 00000000`00000000 ffffb481`7892d000 00000000`00000000 : nt!_chkstk+0x5d
+fffff800`457730c4 : ffffb481`789326a8 ffffb481`789323f0 ffffb481`789326a8 ffffb481`78932570 : nt!KeQuerySystemTimePrecis
+e+0x27d1
+fffff800`457ee482 : 00003c74`00000000 fffff800`458a1d00 00000000`00000000 fffff800`45d940c4 : nt!KeQuerySystemTimePrecis
+e+0x15f4
+fffff800`457eafc0 : 00000000`00000000 fffff800`45a97fe0 ffff8301`2c077220 ffffc582`1bb72c30 : nt!setjmpex+0x7622
+fffff806`f7e010e6 : 00000000`00000001 00000000`00000000 ffffb481`76e2e000 fffff800`456e6511 : nt!setjmpex+0x4160
+fffff806`f7e07020 : ffffc582`1bb72c30 ffffc582`19f18000 ffffc582`1bb72c30 ffff3ac8`f399d666 : ddapmcrash+0x10e6
+fffff800`45b338f7 : 00000000`00000000 00000000`00000000 ffffc582`1bb72c30 ffffffff`000001c8 : ddapmcrash+0x7020
+fffff800`45ad140e : 00000000`00000000 00000000`00000000 00000000`00000000 fffff800`45a3e2c0 : nt!FsRtlNotifyVolumeEventE
+x+0x243b
+fffff800`45715dc9 : fffff800`00000000 ffffffff`80000ba4 ffffc582`1b4e3800 fffff800`45a3e2c0 : nt!MmGetPhysicalMemoryRang
+esEx+0xb56
+fffff800`456c6f85 : ffffc582`1b4e3800 00000000`00000080 ffffc582`18a636c0 ffffc582`1b4e3800 : nt!KdPollBreakIn+0x8059
+fffff800`457e4df6 : ffffb481`76e15180 ffffc582`1b4e3800 fffff800`456c6f44 00000000`00000246 : nt!PsGetProcessSessionIdEx
++0x2d5
+00000000`00000000 : ffffb481`78933000 ffffb481`7892d000 00000000`00000000 00000000`00000000 : nt!KeSynchronizeExecution+
+0x7756
+PS C:\Users\Administrator>

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/crashdump.cc
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/crashdump.cc
@@ -1,0 +1,114 @@
+#include "crashdump.h"
+#include "_cgo_export.h"
+
+#define INITGUID
+#include "guiddef.h"
+DEFINE_GUID(IID_IDebugControl, 0x5182e668, 0x105e, 0x416e,
+            0xad, 0x92, 0x24, 0xef, 0x80, 0x04, 0x24, 0xba);
+/* 27fe5639-8407-4f47-8364-ee118fb08ac8 */
+DEFINE_GUID(IID_IDebugClient, 0x27fe5639, 0x8407, 0x4f47,
+            0x83, 0x64, 0xee, 0x11, 0x8f, 0xb0, 0x8a, 0xc8);
+
+/* 4bf58045-d654-4c40-b0af-683090f356dc */
+DEFINE_GUID(IID_IDebugOutputCallbacks, 0x4bf58045, 0xd654, 0x4c40,
+            0xb0, 0xaf, 0x68, 0x30, 0x90, 0xf3, 0x56, 0xdc);
+
+class StdioOutputCallbacks : public IDebugOutputCallbacks {
+private:
+    StdioOutputCallbacks();
+    void * ctx;
+public:
+    StdioOutputCallbacks(void *ctx)
+        : ctx(ctx)
+    {};
+    STDMETHOD(QueryInterface)(THIS_ _In_ REFIID ifid, _Out_ PVOID* iface);
+    STDMETHOD_(ULONG, AddRef)(THIS);
+    STDMETHOD_(ULONG, Release)(THIS);
+    STDMETHOD(Output)(THIS_ IN ULONG Mask, IN PCSTR Text);
+};
+STDMETHODIMP
+StdioOutputCallbacks::QueryInterface(THIS_ _In_ REFIID ifid, _Out_ PVOID* iface) {
+    *iface = NULL;
+    if (IsEqualIID(ifid, IID_IDebugOutputCallbacks)) {
+        *iface = (IDebugOutputCallbacks*)this;
+        AddRef();
+        return S_OK;
+    }
+    else {
+        return E_NOINTERFACE;
+    }
+}
+STDMETHODIMP_(ULONG)
+StdioOutputCallbacks::AddRef(THIS) { return 1; }
+STDMETHODIMP_(ULONG)
+StdioOutputCallbacks::Release(THIS) { return 0; }
+STDMETHODIMP StdioOutputCallbacks::Output(THIS_ IN ULONG, IN PCSTR Text) {
+    logLineCallback(this->ctx, Text);
+    return S_OK;
+}
+
+/*
+ * readCrashDump
+ *
+ * the caller of this is calling from `go`.  We can't really log.
+ * so return as the top level error which operation failed (as identified
+ * by the enum), and store the actual hresult in the error parameter
+ *  for logging by the caller
+*/
+READ_CRASH_DUMP_ERROR readCrashDump(char *fname, void *ctx, long * extendedError)
+{
+    IDebugClient* iClient = NULL;
+    IDebugControl* iControl = NULL;
+    StdioOutputCallbacks iOutputCb(ctx);
+    READ_CRASH_DUMP_ERROR ret = RCD_NONE;
+    HRESULT hr = DebugCreate(IID_IDebugClient, (void**)&iClient);
+    if(S_OK != hr) {
+        *extendedError = hr;
+        ret = RCD_DEBUG_CREATE_FAILED;
+        goto rcd_end;
+    }
+    hr = iClient->QueryInterface(IID_IDebugControl, (void**)&iControl);
+    if(S_OK != hr) {
+        *extendedError = hr;
+        ret = RCD_QUERY_INTERFACE_FAILED;
+        goto rcd_release_client;
+    }    
+    
+    
+    hr = iClient->SetOutputCallbacks(&iOutputCb);
+    if(S_OK != hr) {
+        *extendedError = hr;
+        ret = RCD_SET_OUTPUT_CALLBACKS_FAILED;
+        goto rcd_release_control;
+    }
+    hr = iClient->OpenDumpFile(fname);
+    if(S_OK != hr) {
+        *extendedError = hr;
+        ret = RCD_OPEN_DUMP_FILE_FAILED;
+        goto rcd_release_control;
+    }
+    hr = iControl->WaitForEvent(0, INFINITE);
+    if(S_OK != hr) {
+        *extendedError = hr;
+        ret = RCD_WAIT_FOR_EVENT_FAILED;
+        goto rcd_release_control;
+    }
+    hr = iControl->Execute(DEBUG_OUTCTL_THIS_CLIENT, "kb", DEBUG_EXECUTE_DEFAULT);
+    if(S_OK != hr) {
+        *extendedError = hr;
+        ret = RCD_EXECUTE_FAILED;
+        goto rcd_release_control;
+    }
+    // release intentionally left unchecked.
+rcd_release_control:
+    if(iControl){
+        iControl->Release();
+    }
+rcd_release_client:
+    if(iClient){
+        iClient->Release();
+    }
+rcd_end:
+    return ret;
+    
+}

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/crashdump.h
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/crashdump.h
@@ -1,0 +1,29 @@
+
+#ifndef DD_CRASHDUMP_H
+#define DD_CRASHDUMP_H
+
+#include <windows.h>
+#include <winerror.h>
+#include <DbgHelp.h>
+#include <DbgEng.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum _readCrashDumpErrors {
+    RCD_NONE = 0,
+    RCD_DEBUG_CREATE_FAILED = 1,
+    RCD_QUERY_INTERFACE_FAILED = 2,
+    RCD_SET_OUTPUT_CALLBACKS_FAILED = 3,
+    RCD_OPEN_DUMP_FILE_FAILED = 4,
+    RCD_WAIT_FOR_EVENT_FAILED = 5,
+    RCD_EXECUTE_FAILED = 6
+} READ_CRASH_DUMP_ERROR;
+
+READ_CRASH_DUMP_ERROR readCrashDump(char *fname, void *ctx, long * extendedError);
+
+#ifdef __cplusplus
+} // close the extern "C"
+#endif
+#endif /* DD_CRASHDUMP_H */

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse.go
@@ -2,8 +2,8 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021-present Datadog, Inc.
+
 //go:build windows
-// +build windows
 
 package probe
 
@@ -102,7 +102,10 @@ func logLineCallbackGo(ctx *logCallbackContext, line string) {
 
 // this extra layer of indirection so that we can swap out test code which skips the actual debugger.
 func doReadCrashDump(filename string, ctx *logCallbackContext, exterr *uint32) error {
-	err := C.readCrashDump(C.CString(filename), unsafe.Pointer(ctx), (*C.long)(unsafe.Pointer(exterr)))
+	fnasCString := C.CString(filename)
+	err := C.readCrashDump(fnasCString, unsafe.Pointer(ctx), (*C.long)(unsafe.Pointer(exterr)))
+
+	C.free(unsafe.Pointer(fnasCString))
 
 	if err != C.RCD_NONE {
 		return fmt.Errorf("Error reading crash dump file %v", err)

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse.go
@@ -1,0 +1,169 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+//go:build windows
+// +build windows
+
+package probe
+
+/*
+#cgo LDFLAGS: -l dbgeng -static
+#include "crashdump.h"
+*/
+import "C"
+import (
+	"fmt"
+	"strings"
+	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+type logCallbackContext struct {
+	loglines       []string
+	hasSeenRetAddr bool
+	unfinished     string
+}
+
+// maximum number of stack trace lines we'll look through, looking for non-"NT!" lines
+const maxLinesToScan = int(200)
+
+const (
+	bugcheckCodePrefix     = "Bugcheck code"
+	debugSessionTimePrefix = "Debug session time"
+	retAddrPrefix          = "RetAddr"
+	unableToLoadPrefix     = "Unable to"
+	ntBangPrefix           = "nt!"
+)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+//export logLineCallback
+func logLineCallback(voidctx C.PVOID, str C.PCSTR) {
+	var ctx *logCallbackContext
+	ctx = (*logCallbackContext)(unsafe.Pointer(uintptr(voidctx)))
+	line := C.GoString(str)
+	if !strings.Contains(line, "\n") {
+		ctx.unfinished = ctx.unfinished + line
+		return
+	}
+	if len(ctx.unfinished) != 0 {
+		line = ctx.unfinished + line
+		ctx.unfinished = ""
+	}
+	lines := strings.Split(line, "\n")
+	start := int(0)
+	if !ctx.hasSeenRetAddr {
+		for idx, l := range lines {
+			if strings.HasPrefix(l, bugcheckCodePrefix) {
+				ctx.loglines = append(ctx.loglines, l)
+				return
+			}
+			if strings.HasPrefix(l, debugSessionTimePrefix) {
+				ctx.loglines = append(ctx.loglines, l)
+				return
+			}
+			if strings.HasPrefix(l, retAddrPrefix) {
+				ctx.hasSeenRetAddr = true
+				start = idx
+			}
+		}
+		if !ctx.hasSeenRetAddr {
+			return
+		}
+
+	}
+	ctx.loglines = append(ctx.loglines, lines[start:]...)
+}
+func parseCrashDump(wcs *WinCrashStatus) {
+	var ctx logCallbackContext
+	var extendedError uint32
+
+	err := C.readCrashDump(C.CString(wcs.FileName), unsafe.Pointer(&ctx), (*C.long)(unsafe.Pointer(&extendedError)))
+
+	if err != C.RCD_NONE {
+		wcs.Success = false
+		wcs.ErrString = fmt.Sprintf("Failed to load crash dump file %d %x", int(err), extendedError)
+		log.Errorf("Failed to open crash dump %s: %d %x", wcs.FileName, int(err), extendedError)
+		return
+	}
+
+	if len(ctx.loglines) < 2 {
+		wcs.ErrString = fmt.Sprintf("Invalid crash dump file %s", wcs.FileName)
+		wcs.Success = false
+		return
+	}
+
+	// set a maximum of how many lines we'll scan looking for NT!.  The loglinecallback
+	// above should strip off all the lines until the first `RetAddr` line.  So the number of
+	// lines we need to see "should" be on the order of 5.  Set an (arbitrary) max that if
+	// we don't find anything, we're not going to.
+
+	/* expect the lines to look something like:
+	Arguments ffffffff`c0000005 fffff806`f7e010e6 ffffb481`789326a8 ffffb481`78931ef0
+
+	RetAddr           : Args to Child                                                           : Call Site
+	fffff800`457f4db0 : 00000000`0000007e ffffffff`c0000005 fffff806`f7e010e6 ffffb481`789326a8 : nt!KeBugCheckEx
+	fffff800`457cb7bf : 00000000`00000004 00000000`00000000 00007fff`ffff0000 ffffc582`1b4e3800 : nt!memset+0x5530
+	fffff800`457e602d : ffffb481`78933000 ffffb481`789318c0 00000000`00000000 00000000`00000050 : nt!_C_specific_handler+0x9
+	f
+	fffff800`457742a1 : ffffb481`78933000 00000000`00000000 ffffb481`7892d000 00000000`00000000 : nt!_chkstk+0x5d
+	fffff800`457730c4 : ffffb481`789326a8 ffffb481`789323f0 ffffb481`789326a8 ffffb481`78932570 : nt!KeQuerySystemTimePrecis
+	e+0x27d1
+	fffff800`457ee482 : 00003c74`00000000 fffff800`458a1d00 00000000`00000000 fffff800`45d940c4 : nt!KeQuerySystemTimePrecis
+	e+0x15f4
+	fffff800`457eafc0 : 00000000`00000000 fffff800`45a97fe0 ffff8301`2c077220 ffffc582`1bb72c30 : nt!setjmpex+0x7622
+	fffff806`f7e010e6 : 00000000`00000001 00000000`00000000 ffffb481`76e2e000 fffff800`456e6511 : nt!setjmpex+0x4160
+	*** ERROR: Module load completed but symbols could not be loaded for ddapmcrash.sys
+	fffff806`f7e07020 : ffffc582`1bb72c30 ffffc582`19f18000 ffffc582`1bb72c30 ffff3ac8`f399d666 : ddapmcrash+0x10e6
+
+	So, even though the loglinecallback will strip out, we might see the "symbols could not be loaded line".  We could
+	also see additional RetAddr headers.*/
+
+	end := min(len(ctx.loglines)-1, maxLinesToScan)
+	for _, line := range ctx.loglines[:end] {
+
+		if strings.HasPrefix(line, debugSessionTimePrefix) {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 {
+				wcs.DateString = strings.TrimSpace(parts[1])
+			}
+			continue
+		}
+
+		if strings.HasPrefix(line, bugcheckCodePrefix) {
+			codeAsString := strings.TrimSpace(line[len(bugcheckCodePrefix)+1:])
+			wcs.BugCheck = codeAsString
+			continue
+		}
+		// skip lines that start with RetAddr, that's just the header
+		if strings.HasPrefix(line, retAddrPrefix) {
+			continue
+		}
+		// as shown above, there might be a stray "symbols could not be loaded line".  This would then
+		// cause the split on ":" below  to not work, and then things would get worse from there.  so
+		// just skip this line because it's expected.
+		if strings.HasPrefix(line, unableToLoadPrefix) { // "Unable to load image, which is ok
+			continue
+		}
+		parts := strings.Split(line, ":")
+		if len(parts) != 3 {
+			continue
+		}
+		callsite := strings.TrimSpace(parts[2])
+		if strings.HasPrefix(callsite, ntBangPrefix) {
+			// we're still in ntoskernel, keep looking
+			continue
+		}
+		wcs.Offender = callsite
+		break
+	}
+	wcs.Success = true
+	return
+}

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse.go
@@ -46,8 +46,7 @@ func min(a, b int) int {
 
 //export logLineCallback
 func logLineCallback(voidctx C.PVOID, str C.PCSTR) {
-	var ctx *logCallbackContext
-	ctx = (*logCallbackContext)(unsafe.Pointer(uintptr(voidctx)))
+	ctx := (*logCallbackContext)(unsafe.Pointer(uintptr(voidctx)))
 	line := C.GoString(str)
 	if !strings.Contains(line, "\n") {
 		ctx.unfinished = ctx.unfinished + line
@@ -165,5 +164,4 @@ func parseCrashDump(wcs *WinCrashStatus) {
 		break
 	}
 	wcs.Success = true
-	return
 }

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse_test.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse_test.go
@@ -2,8 +2,8 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021-present Datadog, Inc.
+
 //go:build windows
-// +build windows
 
 package probe
 

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse_test.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse_test.go
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+//go:build windows
+// +build windows
+
+package probe
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCrashParser(t *testing.T) {
+
+	wcs := &WinCrashStatus{
+		FileName: "testdata/crashsample1.txt",
+	}
+	// first read in the sample data
+
+	readfn = testCrashReader
+
+	parseCrashDump(wcs)
+
+	assert.True(t, wcs.Success)
+	assert.Empty(t, wcs.ErrString)
+	assert.Equal(t, "Mon Jun 26 20:44:49.742 2023 (UTC - 7:00)", wcs.DateString)
+	before, _, _ := strings.Cut(wcs.Offender, "+")
+	assert.Equal(t, "ddapmcrash", before)
+	assert.Equal(t, "0000007E", wcs.BugCheck)
+
+}

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/testdata/crashsample1.txt
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/testdata/crashsample1.txt
@@ -1,0 +1,94 @@
+Kernel Bitmap Dump File: Kernel address space is available, User address space may not be available.
+
+Symbol search path is: srv*
+Executable search path is:
+*** ERROR: Symbol file could not be found.  Defaulted to export symbols for ntkrnlmp.exe -
+Windows 10 Kernel Version 14393 MP (2 procs) Free x64
+Product: Server, suite: TerminalServer SingleUserTS
+Built by: 14393.5989.amd64fre.GitEnlistment.230602-1907
+Machine Name:
+Kernel base = 0xfffff800`4567f000 PsLoadedModuleList = 0xfffff800`45984cf0
+Debug session time: Mon Jun 26 20:44:49.742 2023 (UTC - 7:00)
+System Uptime: 0 days 0:03:58.449
+*** ERROR: Symbol file could not be found.  Defaulted to export symbols for ntkrnlmp.exe -
+Loading Kernel Symbols
+...............................................................
+................................................................
+........................
+Loading User Symbols
+
+Loading unloaded module list
+...........
+
+************* Symbol Loading Error Summary **************
+Module name            Error
+ntkrnlmp               The system cannot find the file specified
+
+You can troubleshoot most symbol related issues by turning on symbol loading diagnostics (!sym noisy) and repeating the
+command that caused symbols to be loaded.
+You should also verify that your symbol search path (.sympath) is correct.
+Unable to add extension DLL: kdexts
+Unable to add extension DLL: kext
+Unable to add extension DLL: exts
+The call to LoadLibrary(ext) failed, Win32 error 0n2
+    "The system cannot find the file specified."
+Please check your debugger configuration and/or network access.
+The call to LoadLibrary(ext) failed, Win32 error 0n2
+    "The system cannot find the file specified."
+Please check your debugger configuration and/or network access.
+*******************************************************************************
+*                                                                             *
+*                        Bugcheck Analysis                                    *
+*                                                                             *
+*******************************************************************************
+Bugcheck code 0000007E
+Arguments ffffffff`c0000005 fffff806`f7e010e6 ffffb481`789326a8 ffffb481`78931ef0
+
+RetAddr           : Args to Child                                                           : Call Site
+fffff800`457f4db0 : 00000000`0000007e ffffffff`c0000005 fffff806`f7e010e6 ffffb481`789326a8 : nt!KeBugCheckEx
+fffff800`457cb7bf : 00000000`00000004 00000000`00000000 00007fff`ffff0000 ffffc582`1b4e3800 : nt!memset+0x5530
+fffff800`457e602d : ffffb481`78933000 ffffb481`789318c0 00000000`00000000 00000000`00000050 : nt!_C_specific_handler+0x9
+f
+fffff800`457742a1 : ffffb481`78933000 00000000`00000000 ffffb481`7892d000 00000000`00000000 : nt!_chkstk+0x5d
+fffff800`457730c4 : ffffb481`789326a8 ffffb481`789323f0 ffffb481`789326a8 ffffb481`78932570 : nt!KeQuerySystemTimePrecis
+e+0x27d1
+fffff800`457ee482 : 00003c74`00000000 fffff800`458a1d00 00000000`00000000 fffff800`45d940c4 : nt!KeQuerySystemTimePrecis
+e+0x15f4
+fffff800`457eafc0 : 00000000`00000000 fffff800`45a97fe0 ffff8301`2c077220 ffffc582`1bb72c30 : nt!setjmpex+0x7622
+fffff806`f7e010e6 : 00000000`00000001 00000000`00000000 ffffb481`76e2e000 fffff800`456e6511 : nt!setjmpex+0x4160
+*** ERROR: Module load completed but symbols could not be loaded for ddapmcrash.sys
+fffff806`f7e07020 : ffffc582`1bb72c30 ffffc582`19f18000 ffffc582`1bb72c30 ffff3ac8`f399d666 : ddapmcrash+0x10e6
+fffff800`45b338f7 : 00000000`00000000 00000000`00000000 ffffc582`1bb72c30 ffffffff`000001c8 : ddapmcrash+0x7020
+fffff800`45ad140e : 00000000`00000000 00000000`00000000 00000000`00000000 fffff800`45a3e2c0 : nt!FsRtlNotifyVolumeEventE
+x+0x243b
+fffff800`45715dc9 : fffff800`00000000 ffffffff`80000ba4 ffffc582`1b4e3800 fffff800`45a3e2c0 : nt!MmGetPhysicalMemoryRang
+esEx+0xb56
+fffff800`456c6f85 : ffffc582`1b4e3800 00000000`00000080 ffffc582`18a636c0 ffffc582`1b4e3800 : nt!KdPollBreakIn+0x8059
+fffff800`457e4df6 : ffffb481`76e15180 ffffc582`1b4e3800 fffff800`456c6f44 00000000`00000246 : nt!PsGetProcessSessionIdEx
++0x2d5
+00000000`00000000 : ffffb481`78933000 ffffb481`7892d000 00000000`00000000 00000000`00000000 : nt!KeSynchronizeExecution+
+0x7756
+
+RetAddr           : Args to Child                                                           : Call Site
+fffff800`457f4db0 : 00000000`0000007e ffffffff`c0000005 fffff806`f7e010e6 ffffb481`789326a8 : nt!KeBugCheckEx
+fffff800`457cb7bf : 00000000`00000004 00000000`00000000 00007fff`ffff0000 ffffc582`1b4e3800 : nt!memset+0x5530
+fffff800`457e602d : ffffb481`78933000 ffffb481`789318c0 00000000`00000000 00000000`00000050 : nt!_C_specific_handler+0x9
+f
+fffff800`457742a1 : ffffb481`78933000 00000000`00000000 ffffb481`7892d000 00000000`00000000 : nt!_chkstk+0x5d
+fffff800`457730c4 : ffffb481`789326a8 ffffb481`789323f0 ffffb481`789326a8 ffffb481`78932570 : nt!KeQuerySystemTimePrecis
+e+0x27d1
+fffff800`457ee482 : 00003c74`00000000 fffff800`458a1d00 00000000`00000000 fffff800`45d940c4 : nt!KeQuerySystemTimePrecis
+e+0x15f4
+fffff800`457eafc0 : 00000000`00000000 fffff800`45a97fe0 ffff8301`2c077220 ffffc582`1bb72c30 : nt!setjmpex+0x7622
+fffff806`f7e010e6 : 00000000`00000001 00000000`00000000 ffffb481`76e2e000 fffff800`456e6511 : nt!setjmpex+0x4160
+fffff806`f7e07020 : ffffc582`1bb72c30 ffffc582`19f18000 ffffc582`1bb72c30 ffff3ac8`f399d666 : ddapmcrash+0x10e6
+fffff800`45b338f7 : 00000000`00000000 00000000`00000000 ffffc582`1bb72c30 ffffffff`000001c8 : ddapmcrash+0x7020
+fffff800`45ad140e : 00000000`00000000 00000000`00000000 00000000`00000000 fffff800`45a3e2c0 : nt!FsRtlNotifyVolumeEventE
+x+0x243b
+fffff800`45715dc9 : fffff800`00000000 ffffffff`80000ba4 ffffc582`1b4e3800 fffff800`45a3e2c0 : nt!MmGetPhysicalMemoryRang
+esEx+0xb56
+fffff800`456c6f85 : ffffc582`1b4e3800 00000000`00000080 ffffc582`18a636c0 ffffc582`1b4e3800 : nt!KdPollBreakIn+0x8059
+fffff800`457e4df6 : ffffb481`76e15180 ffffc582`1b4e3800 fffff800`456c6f44 00000000`00000246 : nt!PsGetProcessSessionIdEx
++0x2d5
+00000000`00000000 : ffffb481`78933000 ffffb481`7892d000 00000000`00000000 00000000`00000000 : nt!KeSynchronizeExecution+
+0x7756

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/win_crash_types.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/win_crash_types.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+//go:build windows
+// +build windows
+
+package probe
+
+/*
+ * the below represent the REG_DWORD in the registry for the dump type that's
+ * currently configured.  Types are not explicitly documented.  These are
+ * discovered via combination of helpful web searches and trial & error.
+ *
+ * the numbers with explicit comments are validated by trial and error.
+ * remainder found here under the table "Value of CrashDumpEnabled"
+ * https://crashdmp.wordpress.com/crash-mechanism/configuration/
+ *
+ */
+const (
+	DumpTypeUnknown      = int(-1)
+	DumpTypeNone         = int(0) // none
+	DumpTypeFull         = int(1) // complete, active
+	DumpTypeSummary      = int(2) // kernel
+	DumpTypeHeader       = int(3) // small
+	DumpTypeTriage       = int(4)
+	DumpTypeBitmapFull   = int(5)
+	DumpTypeBitmapKernel = int(6)
+	DumpTypeAutomatic    = int(7) // automatic
+)
+
+// WinCrashStatus defines all of the information returned from the system
+// probe to the caller
+type WinCrashStatus struct {
+	Success    bool   `json:"success"`
+	ErrString  string `json:"errstring"`
+	FileName   string `json:"filename"`
+	Type       int    `json:"dumptype"`
+	DateString string `json:"datestring"`
+	Offender   string `json:"offender"`
+	BugCheck   string `json:"buckcheckcode"`
+}

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/win_crash_types.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/win_crash_types.go
@@ -2,8 +2,8 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
+
 //go:build windows
-// +build windows
 
 package probe
 

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/wincrashprobe.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/wincrashprobe.go
@@ -1,0 +1,121 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+//go:build windows
+
+package probe
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
+	"golang.org/x/sys/windows/registry"
+)
+
+type WinCrashProbe struct {
+}
+
+func NewWinCrashProbe(cfg *ebpf.Config) (*WinCrashProbe, error) {
+	return &WinCrashProbe{}, nil
+}
+
+func (p *WinCrashProbe) Get() *WinCrashStatus {
+	wcs := &WinCrashStatus{}
+
+	err := wcs.getCurrentCrashSettings()
+	if err != nil {
+		wcs.ErrString = err.Error()
+		wcs.Success = false
+		return wcs
+	}
+
+	if len(wcs.FileName) == 0 {
+		// no filename means no crash dump
+		wcs.Success = true // we succeeded
+		return wcs
+	}
+	parseCrashDump(wcs)
+
+	return wcs
+}
+func (wcs *WinCrashStatus) getCurrentCrashSettings() error {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE,
+		`SYSTEM\CurrentControlSet\Control\CrashControl`,
+		registry.QUERY_VALUE)
+	if err != nil {
+		return fmt.Errorf("Error opening CrashControl key %v", err)
+	}
+	defer k.Close()
+
+	/// get the dump type
+	v, _, err := k.GetIntegerValue("CrashDumpEnabled")
+	if err != nil {
+		return err
+	}
+	if v > uint64(DumpTypeAutomatic) {
+		// this should never happen.  Unexpected type
+		return fmt.Errorf("Unkknown dump type %d", v)
+	}
+	wcs.Type = int(v)
+
+	// minidump directory (by default), stored in MinidumpDir key
+	//  small,
+	if wcs.Type == DumpTypeHeader {
+		// need to get directory
+		dir, _, err := k.GetStringValue("MinidumpDir")
+		if err != nil {
+			return fmt.Errorf("unable to get minidumpdir %v", err)
+		}
+		dir, err = winutil.ExpandEnvironmentStrings(dir)
+		if err != nil {
+			return fmt.Errorf("error expanding directory string %s %v", dir, err)
+		}
+		// now need to find most recent file
+
+		// since the configuration for small dump files allows only the directory
+		// name, we're assuming it's safe to assume the `.dmp` extension
+		dumpfiles := filepath.Join(dir, "*.dmp")
+
+		var newestfile string
+		var newesttime int64
+		files, _ := filepath.Glob(dumpfiles)
+		for _, fqn := range files {
+			//fqn := filepath.Join(dir, f.Name())
+			exists, err := os.Stat(fqn)
+			if err != nil {
+				// shouldn't happen
+				return fmt.Errorf("Error enumerating dump files %s %v", fqn, err)
+			}
+			thistime := exists.ModTime().Unix()
+			if thistime > newesttime {
+				newesttime = thistime
+				newestfile = fqn
+			}
+		}
+		wcs.FileName = newestfile
+
+	} else if wcs.Type == DumpTypeFull || wcs.Type == DumpTypeSummary || wcs.Type == DumpTypeAutomatic {
+
+		// %systemroot%\memory.dmp (by default) stored in DumpFile key
+		//  kernel, complete, automatic, active
+		fn, _, err := k.GetStringValue("DumpFile")
+		if err != nil {
+			return fmt.Errorf("Error reading dump file name")
+		}
+		fn, err = winutil.ExpandEnvironmentStrings(fn)
+		if err != nil {
+			return fmt.Errorf("Error expanding dump file name %s %v", fn, err)
+		}
+		// check for existence
+		_, err = os.Stat(fn)
+		if err == nil {
+			wcs.FileName = fn
+		}
+
+	}
+	return nil
+}

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/wincrashprobe.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/wincrashprobe.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021-present Datadog, Inc.
+
 //go:build windows
 
 package probe
@@ -61,7 +62,7 @@ func (wcs *WinCrashStatus) getCurrentCrashSettings() error {
 	}
 	if v > uint64(DumpTypeAutomatic) {
 		// this should never happen.  Unexpected type
-		return fmt.Errorf("Unkknown dump type %d", v)
+		return fmt.Errorf("Unknown dump type %d", v)
 	}
 	wcs.Type = int(v)
 

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/wincrashprobe.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/wincrashprobe.go
@@ -16,13 +16,16 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
+// WinCrashProbe has no stored state.
 type WinCrashProbe struct {
 }
 
+// NewWinCrashProbe returns an initialized WinCrashProbe
 func NewWinCrashProbe(cfg *ebpf.Config) (*WinCrashProbe, error) {
 	return &WinCrashProbe{}, nil
 }
 
+// Get returns the current crash, if any
 func (p *WinCrashProbe) Get() *WinCrashStatus {
 	wcs := &WinCrashStatus{}
 

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/wincrashprobe.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/wincrashprobe.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	"golang.org/x/sys/windows/registry"
 )
@@ -21,7 +21,7 @@ type WinCrashProbe struct {
 }
 
 // NewWinCrashProbe returns an initialized WinCrashProbe
-func NewWinCrashProbe(cfg *ebpf.Config) (*WinCrashProbe, error) {
+func NewWinCrashProbe(_ *config.Config) (*WinCrashProbe, error) {
 	return &WinCrashProbe{}, nil
 }
 

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -27,6 +27,7 @@ const (
 	evNS                         = "event_monitoring_config"
 	smjtNS                       = smNS + ".java_tls"
 	diNS                         = "dynamic_instrumentation"
+	wcdNS                        = "windows_crash_detection"
 	defaultConnsMessageBatchSize = 600
 
 	// defaultSystemProbeBPFDir is the default path for eBPF programs
@@ -313,6 +314,9 @@ func InitSystemProbeConfig(cfg Config) {
 
 	// enable/disable use of root net namespace
 	cfg.BindEnvAndSetDefault(join(netNS, "enable_root_netns"), true)
+
+	// Windows crash detection
+	cfg.BindEnvAndSetDefault(join(wcdNS, "enabled"), false)
 
 	initCWSSystemProbeConfig(cfg)
 }

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -112,6 +112,7 @@ const (
 
 	// System Probe general config values
 	AgentSPOOMKillEnabled                AgentMetadataName = "feature_oom_kill_enabled"
+	AgentSPWinCrashEnabled               AgentMetadataName = "feature_windows_crash_detection_enabled"
 	AgentSPTCPQueueLengthEnabled         AgentMetadataName = "feature_tcp_queue_length_enabled"
 	AgentSPTelemetryEnabled              AgentMetadataName = "system_probe_telemetry_enabled"
 	AgentSPCOREEnabled                   AgentMetadataName = "system_probe_core_enabled"
@@ -489,6 +490,7 @@ func initializeConfig(cfg config.Config) {
 	// SystemProbe module level configuration
 	SetAgentMetadata(AgentSPTCPQueueLengthEnabled, config.SystemProbe.GetBool("system_probe_config.enable_tcp_queue_length"))
 	SetAgentMetadata(AgentSPOOMKillEnabled, config.SystemProbe.GetBool("system_probe_config.enable_oom_kill"))
+	SetAgentMetadata(AgentSPWinCrashEnabled, config.SystemProbe.GetBool("windows_crash_detection.enabled"))
 	SetAgentMetadata(AgentSPCOREEnabled, config.SystemProbe.GetBool("system_probe_config.enable_co_re"))
 	SetAgentMetadata(AgentSPRuntimeCompilationEnabled, config.SystemProbe.GetBool("system_probe_config.enable_runtime_compiler"))
 	SetAgentMetadata(AgentSPKernelHeadersDownloadEnabled, config.SystemProbe.GetBool("system_probe_config.enable_kernel_header_download"))

--- a/pkg/process/net/check_windows.go
+++ b/pkg/process/net/check_windows.go
@@ -1,0 +1,68 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package net
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/wincrashdetect/probe"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	checksURL = "http://%s/%s/check"
+)
+
+// GetCheck returns the check output of the specified module
+func (r *RemoteSysProbeUtil) GetCheck(module sysconfig.ModuleName) (interface{}, error) {
+
+	switch module {
+	default:
+		return nil, fmt.Errorf("invalid check name: %s", module)
+	case sysconfig.WindowsCrashDetectModule:
+		// don't need to do anything
+
+		// as additional checks are added, simply add case statements for
+		// newly expected check names.
+	}
+	url := fmt.Sprintf(checksURL, r.path, module)
+	log.Infof("module %s trying url %s", module, url)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("conn request failed: socket %s, url %s, status code: %d", r.path, fmt.Sprintf(checksURL, r.path, module), resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if module == sysconfig.WindowsCrashDetectModule {
+		var data probe.WinCrashStatus
+		err = json.Unmarshal(body, &data)
+		if err != nil {
+			return nil, err
+		}
+		return data, nil
+	}
+
+	return nil, fmt.Errorf("invalid check name: %s", module)
+}

--- a/pkg/process/net/check_windows.go
+++ b/pkg/process/net/check_windows.go
@@ -16,7 +16,6 @@ import (
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/wincrashdetect/probe"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -36,7 +35,6 @@ func (r *RemoteSysProbeUtil) GetCheck(module sysconfig.ModuleName) (interface{},
 		// newly expected check names.
 	}
 	url := fmt.Sprintf(checksURL, r.path, module)
-	log.Infof("module %s trying url %s", module, url)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/process/net/check_windows.go
+++ b/pkg/process/net/check_windows.go
@@ -5,7 +5,7 @@
 
 //go:build windows
 
-// Package net
+// Package net provides local access to system probe
 package net
 
 import (

--- a/pkg/process/net/check_windows.go
+++ b/pkg/process/net/check_windows.go
@@ -5,6 +5,7 @@
 
 //go:build windows
 
+// Package net
 package net
 
 import (

--- a/pkg/util/winutil/winstrings.go
+++ b/pkg/util/winutil/winstrings.go
@@ -63,8 +63,6 @@ func ConvertWindowsString16(winput []uint16) string {
 // provided here because `x/sys/windows` provides a wrapper to the underlying
 // function, but it expects C strings.  This will do the buffer calculation
 // and return the go string everyone wants.
-//
-
 func ExpandEnvironmentStrings(input string) (string, error) {
 
 	asutf16 := windows.StringToUTF16Ptr(input)

--- a/pkg/util/winutil/winstrings.go
+++ b/pkg/util/winutil/winstrings.go
@@ -56,3 +56,29 @@ func ConvertWindowsString(winput []uint8) string {
 func ConvertWindowsString16(winput []uint16) string {
 	return windows.UTF16ToString(winput)
 }
+
+// ExpandEnvironmentStrings returns a string with any environment variables
+// substituted.
+//
+// provided here because `x/sys/windows` provides a wrapper to the underlying
+// function, but it expects C strings.  This will do the buffer calculation
+// and return the go string everyone wants.
+//
+
+func ExpandEnvironmentStrings(input string) (string, error) {
+
+	asutf16 := windows.StringToUTF16Ptr(input)
+
+	sz, err := windows.ExpandEnvironmentStrings(asutf16, nil, 0)
+	if err != nil {
+		return "", err
+	}
+	sz += 2 // leave room for terminating null, and a bonus char
+	target := make([]uint16, sz)
+
+	_, err = windows.ExpandEnvironmentStrings(asutf16, (*uint16)(unsafe.Pointer(&target[0])), sz)
+	if err != nil {
+		return "", err
+	}
+	return windows.UTF16ToString(target), nil
+}


### PR DESCRIPTION
This PR is a replacement for previously reviewed and approved (but not merged) PR #17973 

This PR splits the previous PR into the support module implemented in system probe, and two separate forthcoming PRs.  The forthcoming PRs will each implement a new feature which uses this probe module.

Split into separate PRs to
- decouple the crash parsing module from the consumers
- allow the consumers to be added independently (and in independent order)

### Motivation

Split the previous PR into more manageable chunks.
Make it easier to review by individual code owners.
Make consumers easier to review on their own merits.

### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

QA notes are provided in internal readme

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
