### PR TITLE
[oracle] Improve SQL text collection for activity samples

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/activity.go
+++ b/pkg/collector/corechecks/oracle-dbm/activity.go
@@ -471,7 +471,7 @@ func (c *Check) SampleSession() error {
 			statement = sample.Module.String
 			obfuscate = false
 		} else {
-			log.Warnf("activity sql text empty for %#v \n", sample)
+			log.Debugf("activity sql text empty for %#v \n", sample)
 		}
 
 		if hasRealSQLText {

--- a/pkg/collector/corechecks/oracle-dbm/activity.go
+++ b/pkg/collector/corechecks/oracle-dbm/activity.go
@@ -465,8 +465,8 @@ func (c *Check) SampleSession() error {
 		} else if commandName != "" {
 			statement = commandName
 		} else if sessionType == "BACKGROUND" {
-			// The program name can contain an IP address, so we have to obfuscate it
 			statement = program
+			obfuscate = false
 		} else if sample.Module.Valid && sample.Module.String == "DBMS_SCHEDULER" {
 			statement = sample.Module.String
 			obfuscate = false

--- a/pkg/collector/corechecks/oracle-dbm/sql/setup.sql
+++ b/pkg/collector/corechecks/oracle-dbm/sql/setup.sql
@@ -1,82 +1,58 @@
-set verify off
-
-accept password hide prompt password:
-
-CREATE USER c##datadog IDENTIFIED BY &password CONTAINER = ALL ;
-
-ALTER USER c##datadog SET CONTAINER_DATA=ALL CONTAINER=CURRENT;
-
-grant create session to c##datadog ;
-grant select on v_$session to c##datadog ;
-grant select on v_$database to c##datadog ;
-grant select on v_$containers to c##datadog;
-grant select on v_$sqlstats to c##datadog ;
-grant select on v_$instance to c##datadog ;
-grant select on v_$sql_plan_statistics_all to c##datadog ;
-grant select on dba_feature_usage_statistics to c##datadog ;
-grant select on v_$datafile to c##datadog ;
-grant select on v_$con_sysmetric to c##datadog ;
-grant select on v_$sysmetric to c##datadog ;
-grant select on cdb_tablespace_usage_metrics to c##datadog ;
-grant select on cdb_tablespaces to c##datadog ;
-grant select on v_$process to c##datadog ;
-grant select on v_$sgainfo to c##datadog ;
-
 CREATE OR REPLACE VIEW dd_session AS
-SELECT 
-    s.indx as sid,
-    s.ksuseser as serial#,
-    s.ksuudlna as username,
-    DECODE(BITAND(s.ksuseidl, 9), 1, 'ACTIVE', 0, DECODE(BITAND(s.ksuseflg, 4096), 0, 'INACTIVE', 'CACHED'), 'KILLED') as status,
-    s.ksuseunm as osuser,
-    s.ksusepid as process,
-    s.ksusemnm as machine,
-    s.ksusemnp as port,
-    s.ksusepnm as program,
-    DECODE(BITAND(s.ksuseflg, 19), 17, 'BACKGROUND', 1, 'USER', 2, 'RECURSIVE', '?') as type,
-    s.ksusesqi as sql_id,
-    sq.force_matching_signature as force_matching_signature,
-    s.ksusesph as sql_plan_hash_value,
-    s.ksusesesta as sql_exec_start,
-    s.ksusesql as sql_address,
-    CASE WHEN BITAND(s.ksusstmbv, POWER(2, 04)) = POWER(2, 04) THEN 'Y' ELSE 'N' END as in_parse,
-    CASE WHEN BITAND(s.ksusstmbv, POWER(2, 07)) = POWER(2, 07) THEN 'Y' ELSE 'N' END as in_hard_parse,
-    s.ksusepsi as prev_sql_id,
-    s.ksusepha as prev_sql_plan_hash_value,
-    s.ksusepesta as prev_sql_exec_start,
-    sq_prev.force_matching_signature as prev_force_matching_signature,
-    s.ksusepsq as prev_sql_address,
-    s.ksuseapp as module,
+SELECT
+  s.indx as sid,
+  s.ksuseser as serial#,
+  s.ksuudlna as username,
+  DECODE(BITAND(s.ksuseidl, 9), 1, 'ACTIVE', 0, DECODE(BITAND(s.ksuseflg, 4096), 0, 'INACTIVE', 'CACHED'), 'KILLED') as status,
+  s.ksuseunm as osuser,
+  s.ksusepid as process,
+  s.ksusemnm as machine,
+  s.ksusemnp as port,
+  s.ksusepnm as program,
+  DECODE(BITAND(s.ksuseflg, 19), 17, 'BACKGROUND', 1, 'USER', 2, 'RECURSIVE', '?') as type,
+  s.ksusesqi as sql_id,
+  sq.force_matching_signature as force_matching_signature,
+  s.ksusesph as sql_plan_hash_value,
+  s.ksusesesta as sql_exec_start,
+  s.ksusesql as sql_address,
+  CASE WHEN BITAND(s.ksusstmbv, POWER(2, 04)) = POWER(2, 04) THEN 'Y' ELSE 'N' END as in_parse,
+  CASE WHEN BITAND(s.ksusstmbv, POWER(2, 07)) = POWER(2, 07) THEN 'Y' ELSE 'N' END as in_hard_parse,
+  s.ksusepsi as prev_sql_id,
+  s.ksusepha as prev_sql_plan_hash_value,
+  s.ksusepesta as prev_sql_exec_start,
+  sq_prev.force_matching_signature as prev_force_matching_signature,
+  s.ksusepsq as prev_sql_address,
+  s.ksuseapp as module,
     s.ksuseact as action,
     s.ksusecli as client_info,
     s.ksuseltm as logon_time,
     s.ksuseclid as client_identifier,
     s.ksusstmbv as op_flags,
-    decode(s.ksuseblocker, 
-        4294967295, 'UNKNOWN', 4294967294, 'UNKNOWN', 4294967293, 'UNKNOWN', 4294967292, 'NO HOLDER', 4294967291, 'NOT IN WAIT', 
+    decode(s.ksuseblocker,
+        4294967295, 'UNKNOWN', 4294967294, 'UNKNOWN', 4294967293, 'UNKNOWN', 4294967292, 'NO HOLDER', 4294967291, 'NOT IN WAIT',
         'VALID'
     ) as blocking_session_status,
-    DECODE(s.ksuseblocker, 
-        4294967295, TO_NUMBER(NULL), 4294967294, TO_NUMBER(NULL), 4294967293, TO_NUMBER(NULL), 
+    DECODE(s.ksuseblocker,
+        4294967295, TO_NUMBER(NULL), 4294967294, TO_NUMBER(NULL), 4294967293, TO_NUMBER(NULL),
         4294967292, TO_NUMBER(NULL), 4294967291, TO_NUMBER(NULL), BITAND(s.ksuseblocker, 2147418112) / 65536
     ) as blocking_instance,
-    DECODE(s.ksuseblocker, 
-        4294967295, TO_NUMBER(NULL), 4294967294, TO_NUMBER(NULL), 4294967293, TO_NUMBER(NULL), 
+    DECODE(s.ksuseblocker,
+        4294967295, TO_NUMBER(NULL), 4294967294, TO_NUMBER(NULL), 4294967293, TO_NUMBER(NULL),
         4294967292, TO_NUMBER(NULL), 4294967291, TO_NUMBER(NULL), BITAND(s.ksuseblocker, 65535)
     ) as blocking_session,
-    DECODE(s.ksusefblocker, 
+    DECODE(s.ksusefblocker,
         4294967295, 'UNKNOWN', 4294967294, 'UNKNOWN', 4294967293, 'UNKNOWN', 4294967292, 'NO HOLDER', 4294967291, 'NOT IN WAIT', 'VALID'
     ) as final_blocking_session_status,
-    DECODE(s.ksusefblocker, 
-        4294967295, TO_NUMBER(NULL), 4294967294, TO_NUMBER(NULL), 4294967293, TO_NUMBER(NULL), 4294967292, TO_NUMBER(NULL), 
+    DECODE(s.ksusefblocker,
+        4294967295, TO_NUMBER(NULL), 4294967294, TO_NUMBER(NULL), 4294967293, TO_NUMBER(NULL), 4294967292, TO_NUMBER(NULL),
         4294967291, TO_NUMBER(NULL), BITAND(s.ksusefblocker, 2147418112) / 65536
     ) as final_blocking_instance,
-    DECODE(s.ksusefblocker, 
-        4294967295, TO_NUMBER(NULL), 4294967294, TO_NUMBER(NULL), 4294967293, TO_NUMBER(NULL), 4294967292, TO_NUMBER(NULL), 
+    DECODE(s.ksusefblocker,
+        4294967295, TO_NUMBER(NULL), 4294967294, TO_NUMBER(NULL), 4294967293, TO_NUMBER(NULL), 4294967292, TO_NUMBER(NULL),
         4294967291, TO_NUMBER(NULL), BITAND(s.ksusefblocker, 65535)
     ) as final_blocking_session,
-    DECODE(w.kslwtinwait, 
-        1, 'WAITING', decode(bitand(w.kslwtflags, 256), 0, 'WAITED UNKNOWN TIME', 
+    DECODE(w.kslwtinwait,
+        1, 'WAITING', decode(bitand(w.kslwtflags, 256), 0, 'WAITED UNKNOWN TIME',
         decode(round(w.kslwtstime / 10000), 0, 'WAITED SHORT TIME', 'WAITED KNOWN TIME'))
     ) as STATE,
     e.kslednam as event,
@@ -87,26 +63,26 @@ SELECT
     sq.sql_fulltext as sql_fulltext,
     sq_prev.sql_fulltext as prev_sql_fulltext,
     comm.command_name
-  FROM
-    x$ksuse s,
-    x$kslwt w, 
-    x$ksled e,
-    v$sqlstats sq,
-    v$sqlstats sq_prev,
-    v$containers c,
-    v$sqlcommand comm
-  WHERE
-    BITAND(s.ksspaflg, 1) != 0
-    AND BITAND(s.ksuseflg, 1) != 0
-    AND s.inst_id = USERENV('Instance')
-    AND s.indx = w.kslwtsid
-    AND w.kslwtevt = e.indx
-    AND s.ksusesqi = sq.sql_id(+)
-    AND s.ksusesph = sq.plan_hash_value(+)
-    AND s.ksusepsi = sq_prev.sql_id(+)
-    AND s.ksusepha = sq_prev.plan_hash_value(+)
-    AND s.con_id = c.con_id(+)
-    AND s.ksuudoct = comm.command_type(+)
+FROM
+  x$ksuse s,
+  x$kslwt w,
+  x$ksled e,
+  v$sql sq,
+  v$sql sq_prev,
+  v$containers c,
+  v$sqlcommand comm
+WHERE
+  BITAND(s.ksspaflg, 1) != 0
+  AND BITAND(s.ksuseflg, 1) != 0
+  AND s.inst_id = USERENV('Instance')
+  AND s.indx = w.kslwtsid
+  AND w.kslwtevt = e.indx
+  AND s.ksusesqi = sq.sql_id(+)
+  AND decode(s.ksusesch, 65535, TO_NUMBER(NULL), s.ksusesch) = sq.child_number(+)
+  AND s.ksusepsi = sq_prev.sql_id(+)
+  AND decode(s.ksusepch, 65535, TO_NUMBER(NULL), s.ksusepch) = sq_prev.child_number(+)
+  AND s.con_id = c.con_id(+)
+  AND s.ksuudoct = comm.command_type(+)
 ;
 
 GRANT SELECT ON dd_session TO c##datadog ;

--- a/releasenotes/notes/oracle-enrich-sqltext-aa778da34a8eb4ed.yaml
+++ b/releasenotes/notes/oracle-enrich-sqltext-aa778da34a8eb4ed.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Improve SQL text collection for self-managed installations. We are selecting text from `V$SQL` instead of `V$SQLSTATS`. If it isn't possible to query the text, we try to identify the context, such as parsing, or closing cursor, and put it in the SQL text.
+    Improve SQL text collection for self-managed installations. We are selecting text from `V$SQL` instead of `V$SQLSTATS`. If it isn't possible to query the text, we try to identify the context, such as parsing or closing cursor, and put it in the SQL text.

--- a/releasenotes/notes/oracle-enrich-sqltext-aa778da34a8eb4ed.yaml
+++ b/releasenotes/notes/oracle-enrich-sqltext-aa778da34a8eb4ed.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Improve SQL text collection.

--- a/releasenotes/notes/oracle-enrich-sqltext-aa778da34a8eb4ed.yaml
+++ b/releasenotes/notes/oracle-enrich-sqltext-aa778da34a8eb4ed.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Improve SQL text collection for self-managed installations. We are selecting text from `V$SQL` instead of `V$SQLSTATS`. If it isn't possible to query the text, we try to identify the context, such as parsing or closing cursor, and put it in the SQL text.
+    Improve SQL text collection for self-managed installations. The Agent selects text from `V$SQL` instead of `V$SQLSTATS`. If it isn't possible to query the text, the Agent tries to identify the context, such as parsing or closing cursor, and put it in the SQL text.

--- a/releasenotes/notes/oracle-enrich-sqltext-aa778da34a8eb4ed.yaml
+++ b/releasenotes/notes/oracle-enrich-sqltext-aa778da34a8eb4ed.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Improve SQL text collection.
+    Improve SQL text collection for self-managed installations. We are selecting text from `V$SQL` instead of `V$SQLSTATS`. If it isn't possible to query the text, we try to identify the context, such as parsing, or closing cursor, and put it in the SQL text.


### PR DESCRIPTION
### What does this PR do?

We are increasing the likelihood of capturing SQL statement text. In the cases where that's not possible, we are providing additional information about what the active session is doing, i.e. parsing, connection management, closing cursor.

### Additional Notes

The activity view is changed to collect SQL text from `V$SQL` instead of `V$SQLSTATS`, which is populated with delay, so we are more likely to capture SQL text. `V#SQL` is optimally accessed via `FIXED INDEX`:

![image](https://github.com/DataDog/datadog-agent/assets/18366081/b222a241-9701-4eb0-a1c6-79d860c6d8c7)

Further, since during parsing a statement isn't loaded into the cache yet, so we can't get obtain the text. In such cases, we detect that the session is in parsing, and we are writing this information into the SQL text.

https://datadoghq.atlassian.net/browse/DBMON-2725

### Describe how to test/QA your changes

Generate load and check activity samples for empty text.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
