### PR TITLE
[Oracle] Add network disruption handling

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/connection_handling.go
+++ b/pkg/collector/corechecks/oracle-dbm/connection_handling.go
@@ -61,10 +61,12 @@ func (c *Check) Connect() (*sqlx.DB, error) {
 
 	db, err := sqlx.Open(oracleDriver, connStr)
 	if err != nil {
+		_, err := handleRefusedConnection(c, db, err)
 		return nil, fmt.Errorf("failed to connect to oracle instance: %w", err)
 	}
 	err = db.Ping()
 	if err != nil {
+		_, err := handleRefusedConnection(c, db, err)
 		return nil, fmt.Errorf("failed to ping oracle instance: %w", err)
 	}
 

--- a/pkg/collector/corechecks/oracle-dbm/sql_wrappers.go
+++ b/pkg/collector/corechecks/oracle-dbm/sql_wrappers.go
@@ -77,10 +77,7 @@ func isConnectionError(err error) bool {
 }
 
 func isConnectionRefused(err error) bool {
-	if strings.Contains(err.Error(), "connect: connection refused") {
-		return true
-	}
-	return false
+	return strings.Contains(err.Error(), "connect: connection refused")
 }
 
 func handleRefusedConnection(c *Check, db *sqlx.DB, err error) (bool, error) {
@@ -93,8 +90,7 @@ func handleRefusedConnection(c *Check, db *sqlx.DB, err error) (bool, error) {
 The network connection between the Agent and the database server is disrupted. Run one of the following commands on the machine where the Agent is running to test the network connection: 
 nc -v dbserver port
 telnet dbserver port
-curl dbserver:port
-`,
+curl dbserver:port`,
 			err)
 	}
 	return false, err

--- a/releasenotes/notes/oracle-handling-refused-connection-8606661daa27952c.yaml
+++ b/releasenotes/notes/oracle-handling-refused-connection-8606661daa27952c.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Add refused connection handling.
+    Add connection refused handling.

--- a/releasenotes/notes/oracle-handling-refused-connection-8606661daa27952c.yaml
+++ b/releasenotes/notes/oracle-handling-refused-connection-8606661daa27952c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add refused connection handling.


### PR DESCRIPTION
### What does this PR do?

Adding network disruption handling. The error message is parsed, and in the case of network disruption (`connection refused`) the Agent logs basic diagnostic steps.

### Motivation

In the case of a network disruption on the client site, the Agent won't be able to get the metrics from the database. The native error message might not be clear to everyone, which could result in unnecessary support tickets - we can't do anything in such a case. The goal is to emphasize that the underlying error is in the network infrastructure, and point the user to some basic diagnostic steps.

https://datadoghq.atlassian.net/browse/DBMON-2781

### Describe how to test/QA your changes

Misconfigure the port and observe if the new message appears in the log file.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
