### PR TITLE
Adding a mock to the resources comp

### DIFF
--- a/comp/metadata/resources/component_mock.go
+++ b/comp/metadata/resources/component_mock.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package resources
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"go.uber.org/fx"
+)
+
+// MockParams defines the parameter for the mock resources metadata providers.
+// It is designed to be used with `fx.Supply` and allows to set the return value for the resources mock.
+//
+//	fx.Supply(resourcesComponent.MockParams{Data: someData})
+type MockParams struct {
+	// Overrides is a parameter used to override values of the config
+	Data map[string]interface{}
+}
+
+// Mock implements mock-specific methods for the resources component.
+//
+// Usage:
+//
+//	fxutil.Test[dependencies](
+//	   t,
+//	   resources.MockModule,
+//	   fx.Replace(resources.MockParams{Data: someData}),
+//	)
+type Mock interface {
+	Component
+}
+
+// MockModule defines the fx options for the mock component.
+var MockModule = fxutil.Component(
+	fx.Provide(newMock),
+	fx.Supply(MockParams{}),
+)

--- a/comp/metadata/resources/resources_mock.go
+++ b/comp/metadata/resources/resources_mock.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package resources
+
+import (
+	"testing"
+
+	"go.uber.org/fx"
+)
+
+type mockDependencies struct {
+	fx.In
+
+	Params MockParams
+}
+
+type mock struct {
+	data map[string]interface{}
+}
+
+func (m *mock) Get() map[string]interface{} {
+	return m.data
+}
+
+func newMock(deps mockDependencies, t testing.TB) Component {
+	return &mock{
+		data: deps.Params.Data,
+	}
+}

--- a/comp/metadata/resources/resources_test.go
+++ b/comp/metadata/resources/resources_test.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
+	testifyMock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
@@ -84,7 +84,7 @@ func TestCollect(t *testing.T) {
 
 	s := &serializer.MockSerializer{}
 	s.On("SendProcessesMetadata",
-		mock.MatchedBy(func(payload map[string]interface{}) bool {
+		testifyMock.MatchedBy(func(payload map[string]interface{}) bool {
 			jsonPayload, err := json.Marshal(payload)
 			require.NoError(t, err)
 			assert.Equal(t, expectedPayload, string(jsonPayload))


### PR DESCRIPTION
### What does this PR do?

Adding a mock to the resources comp. This builds the way to the host payload which embed the resources payload.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
