### PR TITLE
[Oracle] Allow unobfuscated plan logging

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -54,7 +54,8 @@ type SharedMemoryConfig struct {
 }
 
 type ExecutionPlansConfig struct {
-	Enabled bool `yaml:"enabled"`
+	Enabled              bool `yaml:"enabled"`
+	LogUnobfuscatedPlans bool `yaml:"log_unobfuscated_plans"`
 }
 
 type AgentSQLTrace struct {

--- a/pkg/collector/corechecks/oracle-dbm/oracle_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_test.go
@@ -14,9 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"testing"
-	"time"
-
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -813,7 +813,7 @@ func (c *Check) StatementMetrics() (int, error) {
 										if c.config.ExecutionPlans.LogUnobfuscatedPlans {
 											stepPayload.AccessPredicates = fmt.Sprintf("%s, unobfuscated filter: %s", stepPayload.AccessPredicates, stepRow.AccessPredicates.String)
 										}
-										log.Errorf(stepPayload.AccessPredicates)
+										log.Error(stepPayload.AccessPredicates)
 									}
 								}
 								if stepRow.FilterPredicates.Valid {
@@ -825,7 +825,7 @@ func (c *Check) StatementMetrics() (int, error) {
 										if c.config.ExecutionPlans.LogUnobfuscatedPlans {
 											stepPayload.FilterPredicates = fmt.Sprintf("%s, unobfuscated filter: %s", stepPayload.FilterPredicates, stepRow.FilterPredicates.String)
 										}
-										log.Errorf(stepPayload.FilterPredicates)
+										log.Error(stepPayload.FilterPredicates)
 									}
 								}
 								if stepRow.Projection.Valid {

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -809,7 +809,12 @@ func (c *Check) StatementMetrics() (int, error) {
 									if err == nil {
 										stepPayload.AccessPredicates = obfuscated.Query
 									} else {
-										stepPayload.AccessPredicates = "obfuscation error"
+										stepPayload.AccessPredicates = "Access obfuscation error"
+										if c.config.ExecutionPlans.LogUnobfuscatedPlans {
+											stepPayload.AccessPredicates = fmt.Sprintf("%s, unobfuscated filter: %s", stepPayload.AccessPredicates, stepRow.AccessPredicates.String)
+										}
+										log.Errorf(stepPayload.FilterPredicates)
+
 										log.Errorf("Access obfuscation error")
 									}
 								}
@@ -818,8 +823,11 @@ func (c *Check) StatementMetrics() (int, error) {
 									if err == nil {
 										stepPayload.FilterPredicates = obfuscated.Query
 									} else {
-										stepPayload.FilterPredicates = "obfuscation error"
-										log.Errorf("Filter obfuscation error")
+										stepPayload.FilterPredicates = "Filter obfuscation error"
+										if c.config.ExecutionPlans.LogUnobfuscatedPlans {
+											stepPayload.FilterPredicates = fmt.Sprintf("%s, unobfuscated filter: %s", stepPayload.FilterPredicates, stepRow.FilterPredicates.String)
+										}
+										log.Errorf(stepPayload.FilterPredicates)
 									}
 								}
 								if stepRow.Projection.Valid {

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -813,9 +813,7 @@ func (c *Check) StatementMetrics() (int, error) {
 										if c.config.ExecutionPlans.LogUnobfuscatedPlans {
 											stepPayload.AccessPredicates = fmt.Sprintf("%s, unobfuscated filter: %s", stepPayload.AccessPredicates, stepRow.AccessPredicates.String)
 										}
-										log.Errorf(stepPayload.FilterPredicates)
-
-										log.Errorf("Access obfuscation error")
+										log.Errorf(stepPayload.AccessPredicates)
 									}
 								}
 								if stepRow.FilterPredicates.Valid {

--- a/releasenotes/notes/oracle-log-unobfuscated-plans-6b7d59214f604192.yaml
+++ b/releasenotes/notes/oracle-log-unobfuscated-plans-6b7d59214f604192.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add a hidden parameter to log unobfuscated execution plan information.


### PR DESCRIPTION
### What does this PR do?

Adding the undocumented parameter `log_unobfuscated_plans` to allow logging of unobfuscated plan information.

https://datadoghq.atlassian.net/browse/DBMON-2788

### Motivation

This is for debugging purposes if a customer hits an obfuscated error.

### Describe how to test/QA your changes

n/a

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
