### PR TITLE
[omnibus] Update dependencies of OpenSCAP

### DIFF
--- a/omnibus/config/patches/libselinux/ln_no_relative.patch
+++ b/omnibus/config/patches/libselinux/ln_no_relative.patch
@@ -1,6 +1,6 @@
 --- a/src/Makefile
 +++ b/src/Makefile
-@@ -178,12 +178,12 @@
+@@ -184,12 +184,12 @@
  	install -m 755 $(LIBSO) $(DESTDIR)$(SHLIBDIR)
  	test -d $(DESTDIR)$(LIBDIR)/pkgconfig || install -m 755 -d $(DESTDIR)$(LIBDIR)/pkgconfig
  	install -m 644 $(LIBPC) $(DESTDIR)$(LIBDIR)/pkgconfig
@@ -8,7 +8,7 @@
 +	ln -sf $(DESTDIR)$(SHLIBDIR)/$(LIBSO) $(DESTDIR)$(LIBDIR)/$(TARGET)
  
  install-pywrap: pywrap
- 	$(PYTHON) setup.py install --prefix=$(PREFIX) `test -n "$(DESTDIR)" && echo --root $(DESTDIR)` $(PYTHON_SETUP_ARGS)
+ 	$(PYTHON) -m pip install --prefix=$(PREFIX) `test -n "$(DESTDIR)" && echo --root $(DESTDIR) --ignore-installed --no-deps` $(PYTHON_SETUP_ARGS) .
  	install -m 644 $(SWIGPYOUT) $(DESTDIR)$(PYTHONLIBDIR)/selinux/__init__.py
 -	ln -sf --relative $(DESTDIR)$(PYTHONLIBDIR)/selinux/_selinux$(PYCEXT) $(DESTDIR)$(PYTHONLIBDIR)/_selinux$(PYCEXT)
 +	ln -sf $(DESTDIR)$(PYTHONLIBDIR)/selinux/_selinux$(PYCEXT) $(DESTDIR)$(PYTHONLIBDIR)/_selinux$(PYCEXT)

--- a/omnibus/config/patches/rpm/0417-Fix-compiler-error-on-clang.patch
+++ b/omnibus/config/patches/rpm/0417-Fix-compiler-error-on-clang.patch
@@ -1,0 +1,40 @@
+From b960c0b43a080287a7c13533eeb2d9f288db1414 Mon Sep 17 00:00:00 2001
+From: Florian Festi <ffesti@redhat.com>
+Date: Thu, 16 Mar 2023 19:05:04 +0100
+Subject: [PATCH 417/649] Fix compiler error on clang
+
+Turns out variable declarations are not allowed after a label, even in
+C99. And while some compilers don't seem to care others do.
+
+Moving the declaration of mayopen to the start of the function to avoid
+this problem.
+
+Resolves: #2435
+---
+ lib/fsm.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/lib/fsm.c b/lib/fsm.c
+index 5671ac642..183293edb 100644
+--- a/lib/fsm.c
++++ b/lib/fsm.c
+@@ -879,6 +879,7 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
+     int nodigest = (rpmtsFlags(ts) & RPMTRANS_FLAG_NOFILEDIGEST) ? 1 : 0;
+     int nofcaps = (rpmtsFlags(ts) & RPMTRANS_FLAG_NOCAPS) ? 1 : 0;
+     int firstlinkfile = -1;
++    int mayopen = 0;
+     char *tid = NULL;
+     struct filedata_s *fdata = xcalloc(fc, sizeof(*fdata));
+     struct filedata_s *firstlink = NULL;
+@@ -1016,7 +1017,7 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
+ 
+ setmeta:
+ 	    /* Special files require path-based ops */
+-	    int mayopen = S_ISREG(fp->sb.st_mode) || S_ISDIR(fp->sb.st_mode);
++	    mayopen = S_ISREG(fp->sb.st_mode) || S_ISDIR(fp->sb.st_mode);
+ 	    if (!rc && fd == -1 && mayopen) {
+ 		int flags = O_RDONLY;
+ 		/* Only follow safe symlinks, and never on temporary files */
+-- 
+2.34.1
+

--- a/omnibus/config/patches/rpm/0418-Move-variable-to-nearest-available-scope.patch
+++ b/omnibus/config/patches/rpm/0418-Move-variable-to-nearest-available-scope.patch
@@ -1,0 +1,36 @@
+From 8be31c77806604cdca3cf628fb087bc1cc3d5c9e Mon Sep 17 00:00:00 2001
+From: Panu Matilainen <pmatilai@redhat.com>
+Date: Fri, 17 Mar 2023 14:36:26 +0200
+Subject: [PATCH 418/649] Move variable to nearest available scope
+
+Commit b960c0b43a080287a7c13533eeb2d9f288db1414 moved mayopen all the
+way to the function scope when the local if scope would've been enough.
+In a function with complex loops and all, nothing good comes out of having
+variables at unnecessarily wide scope.
+---
+ lib/fsm.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/fsm.c b/lib/fsm.c
+index 183293edb..747ed2b09 100644
+--- a/lib/fsm.c
++++ b/lib/fsm.c
+@@ -879,7 +879,6 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
+     int nodigest = (rpmtsFlags(ts) & RPMTRANS_FLAG_NOFILEDIGEST) ? 1 : 0;
+     int nofcaps = (rpmtsFlags(ts) & RPMTRANS_FLAG_NOCAPS) ? 1 : 0;
+     int firstlinkfile = -1;
+-    int mayopen = 0;
+     char *tid = NULL;
+     struct filedata_s *fdata = xcalloc(fc, sizeof(*fdata));
+     struct filedata_s *firstlink = NULL;
+@@ -940,6 +939,7 @@ int rpmPackageFilesInstall(rpmts ts, rpmte te, rpmfiles files,
+ 	    fp = firstlink;
+ 
+         if (!fp->skip) {
++	    int mayopen = 0;
+ 	    int fd = -1;
+ 	    rc = ensureDir(plugins, rpmfiDN(fi), 0,
+ 			    (fp->action == FA_CREATE), 0, &di.dirfd);
+-- 
+2.34.1
+

--- a/omnibus/config/patches/util-linux/static-assert.patch
+++ b/omnibus/config/patches/util-linux/static-assert.patch
@@ -1,0 +1,13 @@
+--- a/include/xxhash.h
++++ b/include/xxhash.h
+@@ -1549,6 +1549,10 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size)
+ #  define XXH_ASSERT(c)   ((void)0)
+ #endif
+ 
++#ifndef static_assert
++#  define static_assert _Static_assert
++#endif
++
+ /* note: use after variable declarations */
+ #ifndef XXH_STATIC_ASSERT
+ #  if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)    /* C11 */

--- a/omnibus/config/software/apt.rb
+++ b/omnibus/config/software/apt.rb
@@ -6,7 +6,7 @@
 require './lib/cmake.rb'
 
 name 'apt'
-default_version '2.5.5'
+default_version '2.7.3'
 
 dependency 'bzip2'
 dependency 'gnutls'
@@ -22,7 +22,7 @@ license 'GPLv2'
 license_file "COPYING"
 skip_transitive_dependency_licensing true
 
-version("2.5.5") { source sha256: "488d858485bd87369338cdbe3dcd74437379eebea9c9adf272df1e4a05714f3c" }
+version("2.7.3") { source sha256: "67bf0a8f167a4124f9e93d06e17e40a77cce3032b146f6084acf9cc99011fca7" }
 
 ship_source_offer true
 

--- a/omnibus/config/software/dbus.rb
+++ b/omnibus/config/software/dbus.rb
@@ -4,7 +4,7 @@
 # Copyright 2016-present Datadog, Inc.
 
 name "dbus"
-default_version "1.15.4"
+default_version "1.14.10"
 
 dependency "expat"
 dependency "libtool"
@@ -14,7 +14,7 @@ license "AFL-2.1"
 license_file "LICENSES/AFL-2.1.txt"
 skip_transitive_dependency_licensing true
 
-version("1.15.4") { source sha256: "bfe53d9e54a4977ec344928521b031af2e97cf78aea58f5d8e2b85ea0a80028b" }
+version("1.14.10") { source sha256: "ba1f21d2bd9d339da2d4aa8780c09df32fea87998b73da24f49ab9df1e36a50f" }
 
 source url: "https://dbus.freedesktop.org/releases/dbus/dbus-#{version}.tar.xz"
 

--- a/omnibus/config/software/elfutils.rb
+++ b/omnibus/config/software/elfutils.rb
@@ -15,7 +15,7 @@
 #
 
 name "elfutils"
-default_version "0.188"
+default_version "0.189"
 
 dependency 'm4'
 dependency 'zlib'
@@ -26,7 +26,7 @@ license "LGPL-3.0-or-later"
 license_file "COPYING-LGPLV3"
 skip_transitive_dependency_licensing true
 
-version("0.188") { source sha256: "fb8b0e8d0802005b9a309c60c1d8de32dd2951b56f0c3a3cb56d21ce01595dff" }
+version("0.189") { source sha256: "39bd8f1a338e2b7cd4abc3ff11a0eddc6e690f69578a57478d8179b4148708c8" }
 
 ship_source_offer true
 

--- a/omnibus/config/software/file.rb
+++ b/omnibus/config/software/file.rb
@@ -15,7 +15,7 @@
 #
 
 name "file"
-default_version "5.44"
+default_version "5.45"
 
 dependency 'zlib'
 dependency 'bzip2'
@@ -25,7 +25,7 @@ license "BSD"
 license_file "COPYING"
 skip_transitive_dependency_licensing true
 
-version("5.44") { source sha256: "3751c7fba8dbc831cb8d7cc8aff21035459b8ce5155ef8b0880a27d028475f3b" }
+version("5.45") { source sha256: "fc97f51029bb0e2c9f4e3bffefdaf678f0e039ee872b9de5c002a6d09c784d82" }
 
 source url: "http://ftp.astron.com/pub/file/file-#{version}.tar.gz"
 

--- a/omnibus/config/software/glib.rb
+++ b/omnibus/config/software/glib.rb
@@ -15,7 +15,7 @@
 #
 
 name "glib"
-default_version "2.75.2"
+default_version "2.78.0"
 
 license "LGPL-2.1"
 license_file "COPYING"
@@ -25,7 +25,7 @@ dependency "libffi"
 dependency "pcre"
 dependency "elfutils"
 
-version("2.75.2") { source sha256: "4d5aa6c1c491dfe061fea9ee76e21c66e78ccd99fb0f4ae341c4eea5102bef4c" }
+version("2.78.0") { source sha256: "a12ecee4622bc193bf32d683101ac486c74f1918abeb25ed0c8f644eedc5b5d4" }
 
 ship_source_offer true
 

--- a/omnibus/config/software/gmp.rb
+++ b/omnibus/config/software/gmp.rb
@@ -15,7 +15,7 @@
 #
 
 name "gmp"
-default_version "6.2.1"
+default_version "6.3.0"
 
 dependency 'nettle'
 
@@ -23,7 +23,7 @@ license "LGPL-3.0-or-late"
 license_file "COPYING.LESSERv3"
 skip_transitive_dependency_licensing true
 
-version("6.2.1") { source sha256: "fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2" }
+version("6.3.0") { source sha256: "a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898" }
 
 ship_source_offer true
 

--- a/omnibus/config/software/gnutls.rb
+++ b/omnibus/config/software/gnutls.rb
@@ -15,7 +15,7 @@
 #
 
 name "gnutls"
-default_version "3.7.8"
+default_version "3.7.10"
 
 dependency 'nettle'
 dependency 'gmp'
@@ -25,7 +25,7 @@ license "LGPL-2.1"
 license_file "doc/COPYING.LESSER"
 skip_transitive_dependency_licensing true
 
-version("3.7.8") { source sha256: "c58ad39af0670efe6a8aee5e3a8b2331a1200418b64b7c51977fb396d4617114" }
+version("3.7.10") { source sha256: "b6e4e8bac3a950a3a1b7bdb0904979d4ab420a81e74de8636dd50b467d36f5a9" }
 
 ship_source_offer true
 

--- a/omnibus/config/software/libgcrypt.rb
+++ b/omnibus/config/software/libgcrypt.rb
@@ -15,7 +15,7 @@
 #
 
 name "libgcrypt"
-default_version "1.10.1"
+default_version "1.10.2"
 
 license "LGPL-2.1"
 license_file "COPYING.LIB"
@@ -23,7 +23,7 @@ skip_transitive_dependency_licensing true
 
 dependency "libgpg-error"
 
-version("1.10.1") { source sha256: "ef14ae546b0084cd84259f61a55e07a38c3b53afc0f546bffcef2f01baffe9de" }
+version("1.10.2") { source sha256: "3b9c02a004b68c256add99701de00b383accccf37177e0d6c58289664cce0c03" }
 
 ship_source_offer true
 

--- a/omnibus/config/software/libgpg-error.rb
+++ b/omnibus/config/software/libgpg-error.rb
@@ -15,13 +15,13 @@
 #
 
 name "libgpg-error"
-default_version "1.46"
+default_version "1.47"
 
 license "LGPL-2.1"
 license_file "COPYING.LIB"
 skip_transitive_dependency_licensing true
 
-version("1.46") { source sha256: "b7e11a64246bbe5ef37748de43b245abd72cfcd53c9ae5e7fc5ca59f1c81268d" }
+version("1.47") { source sha256: "9e3c670966b96ecc746c28c2c419541e3bcb787d1a73930f5e5f5e1bcbbb9bdb" }
 
 ship_source_offer true
 

--- a/omnibus/config/software/libselinux.rb
+++ b/omnibus/config/software/libselinux.rb
@@ -15,7 +15,7 @@
 #
 
 name "libselinux"
-default_version "3.4"
+default_version "3.5"
 
 dependency 'pcre2'
 dependency 'libsepol'
@@ -24,7 +24,7 @@ license "Public-Domain"
 license_file "LICENSE"
 skip_transitive_dependency_licensing true
 
-version("3.4") { source sha256: "77c294a927e6795c2e98f74b5c3adde9c8839690e9255b767c5fca6acff9b779" }
+version("3.5") { source sha256: "9a3a3705ac13a2ccca2de6d652b6356fead10f36fb33115c185c5ccdf29eec19" }
 
 source url: "https://github.com/SELinuxProject/selinux/releases/download/#{version}/libselinux-#{version}.tar.gz"
 

--- a/omnibus/config/software/libsepol.rb
+++ b/omnibus/config/software/libsepol.rb
@@ -15,13 +15,13 @@
 #
 
 name "libsepol"
-default_version "3.4"
+default_version "3.5"
 
 license "LGPL-2.1"
 license_file "COPYING"
 skip_transitive_dependency_licensing true
 
-version("3.4") { source sha256: "fc277ac5b52d59d2cd81eec8b1cccd450301d8b54d9dd48a993aea0577cf0336" }
+version("3.5") { source sha256: "78fdaf69924db780bac78546e43d9c44074bad798c2c415d0b9bb96d065ee8a2" }
 
 ship_source_offer true
 

--- a/omnibus/config/software/libxxhash.rb
+++ b/omnibus/config/software/libxxhash.rb
@@ -15,13 +15,13 @@
 #
 
 name "libxxhash"
-default_version "0.8.1"
+default_version "0.8.2"
 
 license "BSD-2-Clause"
 license_file "LICENSE"
 skip_transitive_dependency_licensing true
 
-version("0.8.1") { source sha256: "3bb6b7d6f30c591dd65aaaff1c8b7a5b94d81687998ca9400082c739a690436c" }
+version("0.8.2") { source sha256: "baee0c6afd4f03165de7a4e67988d16f0f2b257b51d0e3cb91909302a26a79c4" }
 
 source url: "https://github.com/Cyan4973/xxHash/archive/refs/tags/v#{version}.tar.gz"
 

--- a/omnibus/config/software/lua.rb
+++ b/omnibus/config/software/lua.rb
@@ -15,9 +15,9 @@
 #
 
 name "lua"
-default_version "5.4.4"
+default_version "5.4.6"
 
-version("5.4.4") { source sha256: "164c7849653b80ae67bec4b7473b884bf5cc8d2dca05653475ec2ed27b9ebf61" }
+version("5.4.6") { source sha256: "7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88" }
 
 license "MIT"
 license_file "https://www.lua.org/license.html"

--- a/omnibus/config/software/nettle.rb
+++ b/omnibus/config/software/nettle.rb
@@ -15,13 +15,13 @@
 #
 
 name "nettle"
-default_version "3.8.1"
+default_version "3.9.1"
 
 license "LGPL-3.0-or-later"
 license_file "COPYING.LESSERv3"
 skip_transitive_dependency_licensing true
 
-version("3.8.1") { source sha256: "364f3e2b77cd7dcde83fd7c45219c834e54b0c75e428b6f894a23d12dd41cbfe" }
+version("3.9.1") { source sha256: "ccfeff981b0ca71bbd6fbcb054f407c60ffb644389a5be80d6716d5b550c6ce3" }
 
 ship_source_offer true
 

--- a/omnibus/config/software/rpm.rb
+++ b/omnibus/config/software/rpm.rb
@@ -15,7 +15,7 @@
 #
 
 name "rpm"
-default_version "4.18.0"
+default_version "4.18.1"
 
 license "LGPLv2"
 license_file "COPYING"
@@ -34,9 +34,9 @@ dependency "lua"
 
 ship_source_offer true
 
-version "4.18.0" do
+version "4.18.1" do
   source url: "http://ftp.rpm.org/releases/rpm-4.18.x/rpm-#{version}.tar.bz2",
-         sha256: "2a17152d7187ab30edf2c2fb586463bdf6388de7b5837480955659e5e9054554"
+         sha256: "37f3b42c0966941e2ad3f10fde3639824a6591d07197ba8fd0869ca0779e1f56"
 end
 
 relative_path "rpm-#{version}"
@@ -50,6 +50,10 @@ build do
 
   patch source: "0001-Include-fcntl.patch", env: env # fix build
   patch source: "rpmdb-no-create.patch", env: env # don't create db if it doesn't exist already
+
+  # Build fixes since 4.18.1.
+  patch source: "0417-Fix-compiler-error-on-clang.patch", env: env
+  patch source: "0418-Move-variable-to-nearest-available-scope.patch", env: env
 
   update_config_guess
   

--- a/omnibus/config/software/sqlite.rb
+++ b/omnibus/config/software/sqlite.rb
@@ -15,7 +15,7 @@
 #
 
 name "sqlite"
-default_version "3.40.1"
+default_version "3.43.1"
 
 dependency 'libedit'
 dependency 'zlib'
@@ -23,12 +23,12 @@ dependency 'zlib'
 license "Public-Domain"
 skip_transitive_dependency_licensing true
 
-version("3.40.1") do
-  source url: "https://www.sqlite.org/2022/sqlite-autoconf-3400100.tar.gz",
-         sha256: "2c5dea207fa508d765af1ef620b637dcb06572afa6f01f0815bd5bbf864b33d9"
+version("3.43.1") do
+  source url: "https://www.sqlite.org/2023/sqlite-autoconf-3430101.tar.gz",
+         sha256: "098984eb36a684c90bc01c0eb7bda3273c327cbc3673d7d0bc195028c19fb7b0"
 end
 
-relative_path "sqlite-autoconf-3400100"
+relative_path "sqlite-autoconf-3430100"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/omnibus/config/software/util-linux.rb
+++ b/omnibus/config/software/util-linux.rb
@@ -15,7 +15,7 @@
 #
 
 name "util-linux"
-default_version "2.38.1"
+default_version "2.39.2"
 
 license "GPLv2"
 license_file "COPYING"
@@ -23,15 +23,17 @@ skip_transitive_dependency_licensing true
 
 ship_source_offer true
 
-version '2.38.1' do
-  source url: "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.38/util-linux-#{version}.tar.gz",
-         sha256: '0820eb8eea90408047e3715424bc6be771417047f683950fecb4bdd2e2cbbc6e'
+version '2.39.2' do
+  source url: "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.39/util-linux-#{version}.tar.gz",
+         sha256: 'c8e1a11dd5879a2788973c73589fbcf08606e85aeec095e516162495ead8ba68'
 end
 
 relative_path "util-linux-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+
+  patch source: "static-assert.patch", env: env # define static_assert in xxhash.h, since it's not defined in our old glibc's assert.h
 
   configure_options = [
     "--disable-nls",

--- a/omnibus/config/software/xmlsec.rb
+++ b/omnibus/config/software/xmlsec.rb
@@ -15,7 +15,7 @@
 #
 
 name "xmlsec"
-default_version "1.2.37"
+default_version "1.3.1"
 
 license "MIT"
 license_file "Copyright"
@@ -28,15 +28,16 @@ dependency "libgcrypt"
 dependency "gnutls"
 dependency ENV["OMNIBUS_OPENSSL_SOFTWARE"] || "openssl"
 
-version("1.2.37") { source sha256: "5f8dfbcb6d1e56bddd0b5ec2e00a3d0ca5342a9f57c24dffde5c796b2be2871c" }
+version("1.3.1") { source sha256: "10f48384d4fd1afc05fea545b74fbf7c152582f0a895c189f164d55270400c63" }
 
-source url: "https://github.com/lsh123/xmlsec/releases/download/xmlsec-1_2_37/xmlsec1-#{version}.tar.gz"
+source url: "https://github.com/lsh123/xmlsec/releases/download/xmlsec_1_3_1/xmlsec1-#{version}.tar.gz"
 
 relative_path "xmlsec1-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  env["CC"] = "/opt/gcc-#{ENV['GCC_VERSION']}/bin/gcc"
   env["CFLAGS"] << " -fPIC"
   env["CFLAGS"] << " -std=c99"
 

--- a/omnibus/config/software/zstd.rb
+++ b/omnibus/config/software/zstd.rb
@@ -17,7 +17,7 @@
 require './lib/cmake.rb'
 
 name "zstd"
-default_version "1.5.2"
+default_version "1.5.5"
 
 license "BSD"
 license_file "LICENSE"
@@ -25,7 +25,7 @@ skip_transitive_dependency_licensing true
 
 dependency "libarchive"
 
-version("1.5.2") { source sha256: "7c42d56fac126929a6a85dbc73ff1db2411d04f104fae9bdea51305663a83fd0" }
+version("1.5.5") { source sha256: "9c4396cc829cfae319a6e2615202e82aad41372073482fce286fac78646d3ee4" }
 
 source url: "https://github.com/facebook/zstd/releases/download/v#{version}/zstd-#{version}.tar.gz"
 


### PR DESCRIPTION
### What does this PR do?

This change updates dependencies of OpenSCAP.
It includes the following software definitions:

 - apt
 - dbus
 - elfutils
 - file
 - glib
 - gmp
 - gnutls
 - libgcrypt
 - libgpg-error
 - libselinux
 - libsepol
 - libxxhash
 - lua
 - nettle
 - rpm
 - sqlite
 - util-linux
 - xmlsec
 - zstd

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
