### PR TITLE
[oracle] Emit zero value for pga_over_allocation

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -60,7 +60,7 @@ type StatementsCache struct {
 	forceMatchingSignatures map[string]StatementsCacheData
 }
 
-type PGAOverAllocationCount struct {
+type pgaOverAllocationCount struct {
 	value float64
 }
 
@@ -93,7 +93,7 @@ type Check struct {
 	connectedToPdb                          bool
 	fqtEmitted                              *cache.Cache
 	planEmitted                             *cache.Cache
-	previousPGAOverAllocationCount          PGAOverAllocationCount
+	previousPGAOverAllocationCount          pgaOverAllocationCount
 }
 
 func handleServiceCheck(c *Check, err error) {

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -60,6 +60,10 @@ type StatementsCache struct {
 	forceMatchingSignatures map[string]StatementsCacheData
 }
 
+type PGAOverAllocationCount struct {
+	value float64
+}
+
 type Check struct {
 	core.CheckBase
 	config                                  *config.CheckConfig
@@ -89,7 +93,7 @@ type Check struct {
 	connectedToPdb                          bool
 	fqtEmitted                              *cache.Cache
 	planEmitted                             *cache.Cache
-	previousAllocationCount                 float64
+	previousPGAOverAllocationCount          PGAOverAllocationCount
 }
 
 func handleServiceCheck(c *Check, err error) {

--- a/pkg/collector/corechecks/oracle-dbm/oracle_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_test.go
@@ -14,9 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"testing"
-	"time"
-
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"

--- a/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
+++ b/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
@@ -160,11 +160,14 @@ func (c *Check) SysMetrics() error {
 	if err != nil {
 		return fmt.Errorf("failed to get PGA over allocation count: %w", err)
 	}
-	if c.previousAllocationCount != 0 {
-		v := overAllocationCount - c.previousAllocationCount
+
+	if c.previousPGAOverAllocationCount == (PGAOverAllocationCount{}) {
+		c.previousPGAOverAllocationCount = PGAOverAllocationCount{value: overAllocationCount}
+	} else {
+		v := overAllocationCount - c.previousPGAOverAllocationCount.value
 		sender.Gauge(fmt.Sprintf("%s.%s", common.IntegrationName, "pga_over_allocation_count"), v, "", c.tags)
+		c.previousPGAOverAllocationCount.value = overAllocationCount
 	}
-	c.previousAllocationCount = overAllocationCount
 
 	sender.Commit()
 	return nil

--- a/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
+++ b/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
@@ -161,8 +161,8 @@ func (c *Check) SysMetrics() error {
 		return fmt.Errorf("failed to get PGA over allocation count: %w", err)
 	}
 
-	if c.previousPGAOverAllocationCount == (PGAOverAllocationCount{}) {
-		c.previousPGAOverAllocationCount = PGAOverAllocationCount{value: overAllocationCount}
+	if c.previousPGAOverAllocationCount == (pgaOverAllocationCount{}) {
+		c.previousPGAOverAllocationCount = pgaOverAllocationCount{value: overAllocationCount}
 	} else {
 		v := overAllocationCount - c.previousPGAOverAllocationCount.value
 		sender.Gauge(fmt.Sprintf("%s.%s", common.IntegrationName, "pga_over_allocation_count"), v, "", c.tags)

--- a/releasenotes/notes/oralce-zero-pga-over-allocation-663866c3070564e1.yaml
+++ b/releasenotes/notes/oralce-zero-pga-over-allocation-663866c3070564e1.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Emit zero value for oracle.pga_over_allocation metric.


### PR DESCRIPTION
### What does this PR do?

Fixing the bug `oracle.pga_over_allocation` not emitted for zero value.

https://datadoghq.atlassian.net/browse/DBMON-2766

### Describe how to test/QA your changes

Check if the metric is being emitted for zero value.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
