### PR TITLE
[Oracle] Adding the hosting-type tag

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/activity.go
+++ b/pkg/collector/corechecks/oracle-dbm/activity.go
@@ -331,13 +331,11 @@ func (c *Check) SampleSession() error {
 	var sessionRows []OracleActivityRow
 	sessionSamples := []OracleActivityRowDB{}
 	var activityQuery string
-	var maxSQLTextLength int
-	if c.isRDS || c.isOracleCloud {
-		activityQuery = ACTIVITY_QUERY_DIRECT
-		maxSQLTextLength = MaxSQLFullTextVSQL
-	} else {
+	maxSQLTextLength := MaxSQLFullTextVSQL
+	if c.hostingType.value == SelfManaged {
 		activityQuery = ACTIVITY_QUERY
-		maxSQLTextLength = MaxSQLFullTextVSQLStats
+	} else {
+		activityQuery = ACTIVITY_QUERY_DIRECT
 	}
 
 	if c.config.QuerySamples.IncludeAllSessions {

--- a/pkg/collector/corechecks/oracle-dbm/activity.go
+++ b/pkg/collector/corechecks/oracle-dbm/activity.go
@@ -332,7 +332,7 @@ func (c *Check) SampleSession() error {
 	sessionSamples := []OracleActivityRowDB{}
 	var activityQuery string
 	maxSQLTextLength := MaxSQLFullTextVSQL
-	if c.hostingType.value == SelfManaged {
+	if c.hostingType.value == selfManaged {
 		activityQuery = ACTIVITY_QUERY
 	} else {
 		activityQuery = ACTIVITY_QUERY_DIRECT

--- a/pkg/collector/corechecks/oracle-dbm/connection_handling.go
+++ b/pkg/collector/corechecks/oracle-dbm/connection_handling.go
@@ -144,7 +144,7 @@ func (c *Check) Connect() (*sqlx.DB, error) {
 				ht.value = Oci
 			}
 		}
-		c.tags = append(c.tags, fmt.Sprintf("hosting-type:%s", ht.value))
+		c.tags = append(c.tags, fmt.Sprintf("hosting_type:%s", ht.value))
 		ht.valid = true
 		c.hostingType = ht
 	}

--- a/pkg/collector/corechecks/oracle-dbm/connection_handling.go
+++ b/pkg/collector/corechecks/oracle-dbm/connection_handling.go
@@ -98,7 +98,7 @@ func (c *Check) Connect() (*sqlx.DB, error) {
 	}
 
 	if !c.hostingType.valid {
-		ht := HostingType{value: selfManaged, valid: false}
+		ht := hostingType{value: selfManaged, valid: false}
 
 		// Is RDS?
 		if c.filePath == "" {

--- a/pkg/collector/corechecks/oracle-dbm/connection_handling.go
+++ b/pkg/collector/corechecks/oracle-dbm/connection_handling.go
@@ -98,7 +98,7 @@ func (c *Check) Connect() (*sqlx.DB, error) {
 	}
 
 	if !c.hostingType.valid {
-		ht := HostingType{value: SelfManaged, valid: false}
+		ht := HostingType{value: selfManaged, valid: false}
 
 		// Is RDS?
 		if c.filePath == "" {
@@ -109,7 +109,7 @@ func (c *Check) Connect() (*sqlx.DB, error) {
 				return nil, fmt.Errorf("failed to query path: %w", err)
 			}
 			if path == "/rdsdbdata" {
-				ht.value = Rds
+				ht.value = rds
 			}
 		}
 
@@ -124,7 +124,7 @@ func (c *Check) Connect() (*sqlx.DB, error) {
 			c.connectedToPdb = true
 		}
 
-		if ht.value == SelfManaged {
+		if ht.value == selfManaged {
 			var cloudRows int
 			if c.connectedToPdb {
 				r := db.QueryRow("select 1 from v$pdbs where cloud_identity like '%oraclecloud%' and rownum = 1")
@@ -141,7 +141,7 @@ func (c *Check) Connect() (*sqlx.DB, error) {
 				}
 			}
 			if cloudRows == 1 {
-				ht.value = Oci
+				ht.value = oci
 			}
 		}
 		c.tags = append(c.tags, fmt.Sprintf("hosting_type:%s", ht.value))

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -43,16 +43,16 @@ const (
 	MaxSQLFullTextVSQLStats = 1000
 )
 
-type HostingCode string
+type hostingCode string
 
 const (
-	SelfManaged HostingCode = "self-managed"
-	Rds         HostingCode = "RDS"
-	Oci         HostingCode = "OCI"
+	selfManaged hostingCode = "self-managed"
+	rds         hostingCode = "RDS"
+	oci         hostingCode = "OCI"
 )
 
 type HostingType struct {
-	value HostingCode
+	value hostingCode
 	valid bool
 }
 

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -51,7 +51,7 @@ const (
 	oci         hostingCode = "OCI"
 )
 
-type HostingType struct {
+type hostingType struct {
 	value hostingCode
 	valid bool
 }
@@ -105,7 +105,7 @@ type Check struct {
 	fqtEmitted                              *cache.Cache
 	planEmitted                             *cache.Cache
 	previousPGAOverAllocationCount          pgaOverAllocationCount
-	hostingType                             HostingType
+	hostingType
 }
 
 func handleServiceCheck(c *Check, err error) {

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -43,6 +43,19 @@ const (
 	MaxSQLFullTextVSQLStats = 1000
 )
 
+type HostingCode string
+
+const (
+	SelfManaged HostingCode = "self-managed"
+	Rds         HostingCode = "RDS"
+	Oci         HostingCode = "OCI"
+)
+
+type HostingType struct {
+	value HostingCode
+	valid bool
+}
+
 // The structure is filled by activity sampling and serves as a filter for query metrics
 type StatementsFilter struct {
 	SQLIDs                  map[string]int
@@ -87,13 +100,12 @@ type Check struct {
 	metricLastRun                           time.Time
 	statementsLastRun                       time.Time
 	filePath                                string
-	isRDS                                   bool
-	isOracleCloud                           bool
 	sqlTraceRunsCount                       int
 	connectedToPdb                          bool
 	fqtEmitted                              *cache.Cache
 	planEmitted                             *cache.Cache
 	previousPGAOverAllocationCount          pgaOverAllocationCount
+	hostingType                             HostingType
 }
 
 func handleServiceCheck(c *Check, err error) {

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -75,6 +75,7 @@ type StatementsCache struct {
 
 type pgaOverAllocationCount struct {
 	value float64
+	valid bool
 }
 
 type Check struct {

--- a/pkg/collector/corechecks/oracle-dbm/sql_wrappers.go
+++ b/pkg/collector/corechecks/oracle-dbm/sql_wrappers.go
@@ -51,14 +51,13 @@ func handlePrivilegeError(c *Check, err error) (bool, error) {
 	if !strings.Contains(err.Error(), "ORA-00942") {
 		return isPrivilegeError, err
 	}
-	var link string
-	if c.isRDS {
-		link = "https://docs.datadoghq.com/database_monitoring/setup_oracle/rds/#grant-permissions"
-	} else if c.isOracleCloud {
-		link = "https://docs.datadoghq.com/database_monitoring/setup_oracle/autonomous_database/#grant-permissions"
-	} else {
-		link = "https://docs.datadoghq.com/database_monitoring/setup_oracle/selfhosted/#grant-permissions"
+
+	links := map[HostingCode]string{
+		SelfManaged: "https://docs.datadoghq.com/database_monitoring/setup_oracle/selfhosted/#grant-permissions",
+		Rds:         "https://docs.datadoghq.com/database_monitoring/setup_oracle/rds/#grant-permissions",
+		Oci:         "https://docs.datadoghq.com/database_monitoring/setup_oracle/autonomous_database/#grant-permissions",
 	}
+	link := links[c.hostingType.value]
 	isPrivilegeError = true
 	return isPrivilegeError, fmt.Errorf("Some privileges are missing. Execute the `grant` commands from %s . Error: %w", link, err)
 }

--- a/pkg/collector/corechecks/oracle-dbm/sql_wrappers.go
+++ b/pkg/collector/corechecks/oracle-dbm/sql_wrappers.go
@@ -52,10 +52,10 @@ func handlePrivilegeError(c *Check, err error) (bool, error) {
 		return isPrivilegeError, err
 	}
 
-	links := map[HostingCode]string{
-		SelfManaged: "https://docs.datadoghq.com/database_monitoring/setup_oracle/selfhosted/#grant-permissions",
-		Rds:         "https://docs.datadoghq.com/database_monitoring/setup_oracle/rds/#grant-permissions",
-		Oci:         "https://docs.datadoghq.com/database_monitoring/setup_oracle/autonomous_database/#grant-permissions",
+	links := map[hostingCode]string{
+		selfManaged: "https://docs.datadoghq.com/database_monitoring/setup_oracle/selfhosted/#grant-permissions",
+		rds:         "https://docs.datadoghq.com/database_monitoring/setup_oracle/rds/#grant-permissions",
+		oci:         "https://docs.datadoghq.com/database_monitoring/setup_oracle/autonomous_database/#grant-permissions",
 	}
 	link := links[c.hostingType.value]
 	isPrivilegeError = true

--- a/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
+++ b/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/common"
-	"github.com/DataDog/datadog-agent/pkg/trace/log"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const SYSMETRICS_QUERY = `SELECT 
@@ -160,13 +160,12 @@ func (c *Check) SysMetrics() error {
 	if err != nil {
 		return fmt.Errorf("failed to get PGA over allocation count: %w", err)
 	}
-
-	if c.previousPGAOverAllocationCount == (pgaOverAllocationCount{}) {
-		c.previousPGAOverAllocationCount = pgaOverAllocationCount{value: overAllocationCount}
-	} else {
+	if c.previousPGAOverAllocationCount.valid {
 		v := overAllocationCount - c.previousPGAOverAllocationCount.value
 		sender.Gauge(fmt.Sprintf("%s.%s", common.IntegrationName, "pga_over_allocation_count"), v, "", c.tags)
 		c.previousPGAOverAllocationCount.value = overAllocationCount
+	} else {
+		c.previousPGAOverAllocationCount = pgaOverAllocationCount{value: overAllocationCount, valid: true}
 	}
 
 	sender.Commit()

--- a/releasenotes/notes/oracle-hosting-type-tag-a428756d9af56563.yaml
+++ b/releasenotes/notes/oracle-hosting-type-tag-a428756d9af56563.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add Oracle hosting type, which can be one of the following: `self-managed`, `RDS` or `OCI`.

--- a/releasenotes/notes/oracle-hosting-type-tag-c2ad1ebfc55fb7c9.yaml
+++ b/releasenotes/notes/oracle-hosting-type-tag-c2ad1ebfc55fb7c9.yaml
@@ -8,4 +8,7 @@
 ---
 enhancements:
   - |
-    Add Oracle hosting type, which can be one of the following: `self-managed`, `RDS` or `OCI`.
+    Add ithe `hosting-type` tag, which can have one of the following values: `self-managed`, `RDS` and `OCI`.
+fixes:
+  - |
+    Fix the `failed to query v$pdbs`, which was appearing for RDS databases.

--- a/releasenotes/notes/oracle-hosting-type-tag-c2ad1ebfc55fb7c9.yaml
+++ b/releasenotes/notes/oracle-hosting-type-tag-c2ad1ebfc55fb7c9.yaml
@@ -8,7 +8,7 @@
 ---
 enhancements:
   - |
-    Add ithe `hosting-type` tag, which can have one of the following values: `self-managed`, `RDS` and `OCI`.
+    Add the `hosting-type` tag, which can have one of the following values: `self-managed`, `RDS`, or `OCI`.
 fixes:
   - |
     Fix the `failed to query v$pdbs`, which was appearing for RDS databases.


### PR DESCRIPTION
### What does this PR do?

Adding the `hosting-type` tag, which could take one of the following values: `self-managed`, `RDS` and `OCI`.

Fix the `failed to query v$pdbs`, which was appearing for RDS databases.

### Motivation

Knowing the hosting type is useful for agent troubleshooting.

### Describe how to test/QA your changes

Tests for all three current hosting types (self-hosted, RDS, OCI) :

1. check tags
2. check for any ORA-
3. check activity samples
4. revoke a privilege and see if the correct link to the setup document appears

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
