### PR TITLE
pkg/trace: ensure the sql.query tag always contains the obfuscated value

### DIFF
--- a/pkg/trace/agent/obfuscate.go
+++ b/pkg/trace/agent/obfuscate.go
@@ -39,24 +39,14 @@ func (a *Agent) obfuscateSpan(span *pb.Span) {
 		if err != nil {
 			// we have an error, discard the SQL to avoid polluting user resources.
 			log.Debugf("Error parsing SQL query: %v. Resource: %q", err, span.Resource)
-			if span.Meta == nil {
-				span.Meta = make(map[string]string, 1)
-			}
-			if _, ok := span.Meta[tagSQLQuery]; !ok {
-				span.Meta[tagSQLQuery] = textNonParsable
-			}
 			span.Resource = textNonParsable
+			traceutil.SetMeta(span, tagSQLQuery, textNonParsable)
 			return
 		}
 
 		span.Resource = oq.Query
-
 		if len(oq.Metadata.TablesCSV) > 0 {
 			traceutil.SetMeta(span, "sql.tables", oq.Metadata.TablesCSV)
-		}
-		if span.Meta != nil && span.Meta[tagSQLQuery] != "" {
-			// "sql.query" tag already set by user, do not change it.
-			return
 		}
 		traceutil.SetMeta(span, tagSQLQuery, oq.Query)
 	case "redis":

--- a/releasenotes/notes/apm-obfuscation-sql-query-8db35fd42138d57b.yaml
+++ b/releasenotes/notes/apm-obfuscation-sql-query-8db35fd42138d57b.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+security:
+  - |
+   This update ensures the `sql.query` tag is always obfuscated by the Datadog Agent
+    even if this tag was already set by a tracer or manually by a user.
+    This is to prevent potentially sensitive data from being sent to Datadog.
+    If you wish to have a raw, unobfuscated query within a span, then
+    manually add a span tag of a different name (for example, `sql.rawquery`).


### PR DESCRIPTION
Cherry pick of https://github.com/DataDog/datadog-agent/pull/19354

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

The trace-agent will always set the `sql.query` tag to an obfuscated value to avoid exposing sensitive data. This is a change from the previous behavior where the trace-agent would not change the sql.query tag if it was already set.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

It's safer for the trace-agent to always obfuscate this tag, instead of assuming that the tracers that send this tag will have already done obfuscation of the tags beforehand. There is no known reason why we would need to leave the raw query as-is.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

If for some reason someone wants the unobfuscated query, and was relying on the `sql.query` tag to be unobfuscated in their setup, then this would be a behavior change for them.  However, if a customer really needs the unobfuscated query, then they can create another manual tag with a different name (e.g. `sql.raw.query`) which won't be obfuscated by the agent.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- Create a span with a manual `sql.query` tag and ensure that the tag is present obfuscated in the Datadog UI.
- Create a span of type `sql` and ensure that the trace-agent adds the obfuscated `sql.query` tag.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
