### PR TITLE
[CWS] Cross generate SECL files for linux and windows

### DIFF
--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:generate go run github.com/DataDog/datadog-agent/pkg/security/secl/compiler/generators/operators -output eval_operators.go
+//go:generate operators -output eval_operators.go
 
 // Package eval holds eval related files
 package eval

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:generate go run golang.org/x/tools/cmd/stringer -type=HashState -linecomment -output model_string.go
+//go:generate stringer -type=HashState -linecomment -output model_string.go
 
 // Package model holds model related files
 package model

--- a/pkg/security/secl/model/model_windows.go
+++ b/pkg/security/secl/model/model_windows.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:generate go run github.com/DataDog/datadog-agent/pkg/security/secl/compiler/generators/accessors -tags windows -types-file model.go -output accessors_windows.go -field-handlers field_handlers_windows.go -field-accessors-output field_accessors_windows.go
+//go:generate accessors -tags windows -types-file model.go -output accessors_windows.go -field-handlers field_handlers_windows.go -field-accessors-output field_accessors_windows.go
 
 // Package model holds model related files
 package model

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -569,7 +569,15 @@ def generate_cws_documentation(ctx, go_generate=False):
 
 @task
 def cws_go_generate(ctx):
+    ctx.run("go install golang.org/x/tools/cmd/stringer")
+    ctx.run("go install github.com/mailru/easyjson/easyjson")
+    ctx.run("go install github.com/DataDog/datadog-agent/pkg/security/secl/compiler/generators/accessors@v0.49.0-rc.2")
+    ctx.run("go install github.com/DataDog/datadog-agent/pkg/security/secl/compiler/generators/operators@v0.49.0-rc.2")
     with ctx.cd("./pkg/security/secl"):
+        if sys.platform == "linux":
+            ctx.run("GOOS=windows go generate ./...")
+        elif sys.platform == "win32":
+            ctx.run("GOOS=linux go generate ./...")
         ctx.run("go generate ./...")
 
     if sys.platform == "win32":


### PR DESCRIPTION
### What does this PR do?

This PR will cross generate windows SECL files on linux, and vice versa.
It's a first step because there is also the serializers to be cross generated (which should come on another PR)

### Motivation

Be able to modify the models without having to run windows

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
