### PR TITLE
[containerd] Add support for image pull metrics in containerd check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -317,6 +317,7 @@
 /pkg/util/kubernetes/                   @DataDog/container-integrations @DataDog/container-app
 /pkg/util/orchestrator/                 @DataDog/container-app
 /pkg/util/podman/                       @DataDog/container-integrations
+/pkg/util/prometheus                    @DataDog/container-integrations
 /pkg/util/trivy/                        @DataDog/container-integrations @DataDog/agent-security
 /pkg/util/cgroups/                      @DataDog/container-integrations
 /pkg/util/retry/                        @DataDog/container-integrations

--- a/cmd/agent/dist/conf.d/containerd.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/containerd.d/conf.yaml.default
@@ -30,3 +30,8 @@ instances:
     ## Set to `false` if you want to deactivate the event collection for the containerd check
     #
     collect_events: true
+
+    ## @param openmetrics_endpoint - openmetrics endpoint on which containerd runtime exposes metrics
+    #  Learn more about exposing containerd openmetrics endpoint: https://github.com/containerd/containerd/blob/main/docs/ops.md
+    #
+    openmetrics_endpoint: http://127.0.0.1:1338

--- a/pkg/collector/corechecks/containers/containerd/check.go
+++ b/pkg/collector/corechecks/containers/containerd/check.go
@@ -196,10 +196,12 @@ func (c *ContainerdCheck) collectImagePullMetrics(sender sender.Sender) error {
 			continue
 		}
 
-		metricName := fmt.Sprintf("containerd.image.pull.%s", toSnakeCase(string(grpcCode)))
-		metricTags := []string{fmt.Sprintf("grpc_service:%s", metric["grpc_service"])}
+		metricTags := []string{
+			fmt.Sprintf("grpc_service:%s", metric["grpc_service"]),
+			fmt.Sprintf("grpc_code:%s", toSnakeCase(string(grpcCode))),
+		}
 
-		sender.MonotonicCount(metricName, float64(sample.Value), "", metricTags)
+		sender.MonotonicCount("containerd.image.pull", float64(sample.Value), "", metricTags)
 	}
 
 	return nil

--- a/pkg/collector/corechecks/containers/containerd/check.go
+++ b/pkg/collector/corechecks/containers/containerd/check.go
@@ -199,7 +199,7 @@ func (c *ContainerdCheck) collectImagePullMetrics(sender sender.Sender) error {
 		metricName := fmt.Sprintf("containerd.image.pull.%s", toSnakeCase(string(grpcCode)))
 		metricTags := []string{fmt.Sprintf("grpc_service:%s", metric["grpc_service"])}
 
-		sender.Counter(metricName, float64(sample.Value), "", metricTags)
+		sender.MonotonicCount(metricName, float64(sample.Value), "", metricTags)
 	}
 
 	return nil

--- a/pkg/collector/corechecks/containers/containerd/check_test.go
+++ b/pkg/collector/corechecks/containers/containerd/check_test.go
@@ -129,7 +129,7 @@ func TestContainerdCheckGenericPart(t *testing.T) {
 	mockSender.AssertMetric(t, "Rate", "containerd.blkio.service_recursive_bytes", 200, "", barWriteTags)
 	mockSender.AssertMetric(t, "Rate", "containerd.blkio.serviced_recursive", 20, "", barWriteTags)
 
-	check.collectImagePullMetrics(mockSender)
+	check.scrapeOpenmetricsEndpoint(mockSender)
 	mockSender.AssertMetric(t, "MonotonicCount", "containerd.image.pull", 72, "", []string{"grpc_service:runtime.v1alpha2.ImageService", "grpc_code:ok"})
 	mockSender.AssertMetric(t, "MonotonicCount", "containerd.image.pull", 0, "", []string{"grpc_service:runtime.v1alpha2.ImageService", "grpc_code:invalid_argument"})
 	mockSender.AssertMetric(t, "MonotonicCount", "containerd.image.pull", 0, "", []string{"grpc_service:runtime.v1.ImageService", "grpc_code:not_found"})

--- a/pkg/collector/corechecks/containers/containerd/check_test.go
+++ b/pkg/collector/corechecks/containers/containerd/check_test.go
@@ -130,10 +130,10 @@ func TestContainerdCheckGenericPart(t *testing.T) {
 	mockSender.AssertMetric(t, "Rate", "containerd.blkio.serviced_recursive", 20, "", barWriteTags)
 
 	check.collectImagePullMetrics(mockSender)
-	mockSender.AssertMetric(t, "Counter", "containerd.image.pull.ok", 72, "", []string{"grpc_service:runtime.v1alpha2.ImageService"})
-	mockSender.AssertMetric(t, "Counter", "containerd.image.pull.invalid_argument", 0, "", []string{"grpc_service:runtime.v1alpha2.ImageService"})
-	mockSender.AssertMetric(t, "Counter", "containerd.image.pull.not_found", 0, "", []string{"grpc_service:runtime.v1.ImageService"})
-	mockSender.AssertMetric(t, "Counter", "containerd.image.pull.not_found", 16559, "", []string{"grpc_service:runtime.v1alpha2.ImageService"})
+	mockSender.AssertMetric(t, "MonotonicCount", "containerd.image.pull", 72, "", []string{"grpc_service:runtime.v1alpha2.ImageService", "grpc_code:ok"})
+	mockSender.AssertMetric(t, "MonotonicCount", "containerd.image.pull", 0, "", []string{"grpc_service:runtime.v1alpha2.ImageService", "grpc_code:invalid_argument"})
+	mockSender.AssertMetric(t, "MonotonicCount", "containerd.image.pull", 0, "", []string{"grpc_service:runtime.v1.ImageService", "grpc_code:not_found"})
+	mockSender.AssertMetric(t, "MonotonicCount", "containerd.image.pull", 16559, "", []string{"grpc_service:runtime.v1alpha2.ImageService", "grpc_code:not_found"})
 
 	mockSender.AssertMetric(t, "Gauge", "containerd.proc.open_fds", 200, "", expectedTags)
 }

--- a/pkg/collector/corechecks/containers/containerd/check_test.go
+++ b/pkg/collector/corechecks/containers/containerd/check_test.go
@@ -22,21 +22,28 @@ import (
 )
 
 func TestToSnakeCaseConversion(t *testing.T) {
-
-	mockString := ""
-	expectedOutput := ""
-	actualOutput := toSnakeCase(mockString)
-
-	if expectedOutput != actualOutput {
-		t.Errorf("got %s, wanted %s", actualOutput, expectedOutput)
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "Full",
+			input:    "SomeMetricLabel",
+			expected: "some_metric_label",
+		},
 	}
 
-	mockString = "SomeMetricLabel"
-	expectedOutput = "some_metric_label"
-	actualOutput = toSnakeCase(mockString)
-
-	if expectedOutput != actualOutput {
-		t.Errorf("got %s, wanted empty string", actualOutput)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := toSnakeCase(tt.input)
+			assert.Equal(t, tt.expected, actual)
+		})
 	}
 }
 

--- a/pkg/collector/corechecks/containers/containerd/containerd_transformers.go
+++ b/pkg/collector/corechecks/containers/containerd/containerd_transformers.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+//go:build containerd
+
+package containerd
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/prometheus/common/model"
+)
+
+// metricTransformerFunc is used to tweak or generate new metrics from a given containerd metric
+type metricTransformerFunc = func(sender.Sender, string, model.Sample)
+
+var defaultContainerdOpenmetricsTransformers = map[string]metricTransformerFunc{
+	"grpc_server_handled_total": grpcServerHandlerTransformer,
+}
+
+func grpcServerHandlerTransformer(s sender.Sender, name string, sample model.Sample) {
+	metric := sample.Metric
+
+	grpcMethod, ok := metric["grpc_method"]
+	if !ok {
+		return
+	}
+
+	switch grpcMethod {
+	case pullImageGrpcMethod:
+		imagePullMetricTransformer(s, name, sample)
+	}
+}
+
+func imagePullMetricTransformer(s sender.Sender, name string, sample model.Sample) {
+	metric := sample.Metric
+
+	grpcCode, ok := metric["grpc_code"]
+
+	if !ok {
+		return
+	}
+
+	metricTags := []string{
+		fmt.Sprintf("grpc_service:%s", metric["grpc_service"]),
+		fmt.Sprintf("grpc_code:%s", toSnakeCase(string(grpcCode))),
+	}
+
+	s.MonotonicCount("containerd.image.pull", float64(sample.Value), "", metricTags)
+}

--- a/pkg/collector/corechecks/containers/kubelet/provider/prometheus/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/prometheus/provider.go
@@ -8,20 +8,18 @@
 package prometheus
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"regexp"
 	"strings"
 
-	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
-	"golang.org/x/exp/maps"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/common"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/prometheus"
 )
 
 // TransformerFunc outlines the function signature for any transformers which will be used with the prometheus Provider
@@ -132,7 +130,7 @@ func (p *Provider) Provide(kc kubelet.KubeUtilInterface, sender sender.Sender) e
 		return nil
 	}
 
-	metrics, err := ParseMetrics(data)
+	metrics, err := prometheus.ParseMetrics(data)
 	if err != nil {
 		return err
 	}
@@ -184,23 +182,4 @@ func (p *Provider) submitMetric(metric *model.Sample, metricName string, sender 
 	tags := p.Config.Tags
 
 	sender.Gauge(nameWithNamespace, float64(metric.Value), "", tags)
-}
-
-// ParseMetrics parses prometheus-formatted metrics from the input data.
-func ParseMetrics(data []byte) (model.Vector, error) {
-	// the prometheus TextParser does not support windows line separators, so we need to explicitly remove them
-	data = bytes.Replace(data, []byte("\r"), []byte(""), -1)
-
-	reader := bytes.NewReader(data)
-	var parser expfmt.TextParser
-	mf, err := parser.TextToMetricFamilies(reader)
-	if err != nil {
-		return nil, err
-	}
-
-	metrics, err := expfmt.ExtractSamples(&expfmt.DecodeOptions{Timestamp: model.Now()}, maps.Values(mf)...)
-	if err != nil {
-		return nil, err
-	}
-	return metrics, nil
 }

--- a/pkg/util/prometheus/parse.go
+++ b/pkg/util/prometheus/parse.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+/*
+Package prometheus provides utility functions to deal with prometheus endpoints
+*/
+package prometheus
+
+import (
+	"bytes"
+
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"golang.org/x/exp/maps"
+)
+
+// ParseMetrics parses prometheus-formatted metrics from the input data.
+func ParseMetrics(data []byte) (model.Vector, error) {
+	// the prometheus TextParser does not support windows line separators, so we need to explicitly remove them
+	data = bytes.Replace(data, []byte("\r"), []byte(""), -1)
+
+	reader := bytes.NewReader(data)
+	var parser expfmt.TextParser
+	mf, err := parser.TextToMetricFamilies(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	metrics, err := expfmt.ExtractSamples(&expfmt.DecodeOptions{Timestamp: model.Now()}, maps.Values(mf)...)
+	if err != nil {
+		return nil, err
+	}
+	return metrics, nil
+}

--- a/pkg/util/prometheus/parse_test.go
+++ b/pkg/util/prometheus/parse_test.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package prometheus
+
+import (
+	"testing"
+)
+
+func TestParseMetrics(t *testing.T) {
+
+	mockOpenmetricsData := `
+	grpc_server_msg_received_total{grpc_method="PullImage",grpc_service="runtime.v1.ImageService",grpc_type="unary"} 0
+	grpc_server_msg_received_total{grpc_method="PullImage",grpc_service="runtime.v1alpha2.ImageService",grpc_type="unary"} 16631
+	grpc_server_msg_sent_total{grpc_method="PullImage",grpc_service="runtime.v1.ImageService",grpc_type="unary"} 0
+	grpc_server_msg_sent_total{grpc_method="PullImage",grpc_service="runtime.v1alpha2.ImageService",grpc_type="unary"} 72
+	grpc_server_started_total{grpc_method="PullImage",grpc_service="runtime.v1.ImageService",grpc_type="unary"} 0
+	grpc_server_started_total{grpc_method="PullImage",grpc_service="runtime.v1alpha2.ImageService",grpc_type="unary"} 16631
+	`
+
+	parsedMetrics, err := ParseMetrics([]byte(mockOpenmetricsData))
+
+	if err != nil {
+		t.Errorf("parsing metrics failed with %s", err)
+	}
+
+	expectedNumberOfMetrics := 6
+	actualNumberOfMetrics := parsedMetrics.Len()
+
+	if actualNumberOfMetrics != expectedNumberOfMetrics {
+		t.Errorf("expected %d reported metrics, got %d reported metrics", expectedNumberOfMetrics, actualNumberOfMetrics)
+	}
+
+}

--- a/releasenotes/notes/add-image-pull-metrics-to-containerd-check-de6dcb700830df0c.yaml
+++ b/releasenotes/notes/add-image-pull-metrics-to-containerd-check-de6dcb700830df0c.yaml
@@ -9,6 +9,3 @@
 features:
   - |
     Add support for image pull metrics in the containerd check.
-enhancements:
-  - |
-    Refactor ParseMetrics function into `pkg/util/prometheus` to parse response from the Prometheus endpoint.

--- a/releasenotes/notes/add-image-pull-metrics-to-containerd-check-de6dcb700830df0c.yaml
+++ b/releasenotes/notes/add-image-pull-metrics-to-containerd-check-de6dcb700830df0c.yaml
@@ -8,7 +8,7 @@
 ---
 features:
   - |
-    Add support for image pull metrics in containerd check
+    Add support for image pull metrics in the containerd check.
 enhancements:
   - |
     Refactor ParseMetrics function into `pkg/util/prometheus` to parse response from prometheus endpoint

--- a/releasenotes/notes/add-image-pull-metrics-to-containerd-check-de6dcb700830df0c.yaml
+++ b/releasenotes/notes/add-image-pull-metrics-to-containerd-check-de6dcb700830df0c.yaml
@@ -11,4 +11,4 @@ features:
     Add support for image pull metrics in the containerd check.
 enhancements:
   - |
-    Refactor ParseMetrics function into `pkg/util/prometheus` to parse response from prometheus endpoint
+    Refactor ParseMetrics function into `pkg/util/prometheus` to parse response from the Prometheus endpoint.

--- a/releasenotes/notes/add-image-pull-metrics-to-containerd-check-de6dcb700830df0c.yaml
+++ b/releasenotes/notes/add-image-pull-metrics-to-containerd-check-de6dcb700830df0c.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add support for image pull metrics in containerd check
+enhancements:
+  - |
+    Refactor ParseMetrics function into `pkg/util/prometheus` to parse response from prometheus endpoint


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR adds support for collecting image pull metrics from containerd runtime exposed openmetrics endpoint.

### Motivation
As containerd user, I would like to use Datadog to monitor and investigate container image pull issues.

The agent already provide an integration with the containerd container runtime to expose container metrics (CPU/Memory/IO…), containerd events and other container image metadata extraction for autodiscovery and other features.

Currently all the containerd metrics are generated thanks to cgroup parsing or thanks to some GRPC services exposed by the containerd socket.
But the containerd image pull event metrics are exposed thanks to the openmetrics containerd endpoint. 

### Changes Made
- Added an http client to the containerd core check in order to get metrics from the openmetrics endpoint exposed by containerd runtime
- Added `openmetrics_endpoint` configuration parameter to containerd conf.d (defaulted to `http://127.0.0.1:1338`)
- Refactored the code of the kubelet check in order to extract the `ParseMetrics` function that parses prometheus data from the openmetrics endpoint so it can be used by several packages. 

### Testing
- Unit testing:
   - Unit tests are implemented to test the collection of the image pull metrics using a mock http server and sample prometheus data.
   - Unit tests are implemented to test the util functions `toSnakeCase` and `ParseMetrics`
- Manual testing:
   - Built custom image of the agent
   - Deployed the agent locally on minikube with containerd runtime
   - Created several containers with existing and non-existing images and checked that the image pull metrics are correctly collected  

### Additional Notes
The containerd runtime exposes metrics on the openmetrics endpoint as such:
```
grpc_server_handled_total{grpc_code="InvalidArgument",grpc_method="PullImage",grpc_service="runtime.v1alpha2.ImageService",grpc_type="unary"} 0
grpc_server_handled_total{grpc_code="NotFound",grpc_method="PullImage",grpc_service="runtime.v1.ImageService",grpc_type="unary"} 0
grpc_server_handled_total{grpc_code="NotFound",grpc_method="PullImage",grpc_service="runtime.v1alpha2.ImageService",grpc_type="unary"} 16559
grpc_server_handled_total{grpc_code="OK",grpc_method="PullImage",grpc_service="runtime.v1alpha2.ImageService",grpc_type="unary"} 72
```

The `grpc_code` can take the values listed [here](https://pkg.go.dev/google.golang.org/grpc/codes).

The reported metrics are under the format: `containerd.image.pull`.

The `grpc_code` is reported as a tag along with the reported metric.

The containerd integration documentation will be updated in a separate PR to document the newly added metrics and indicate the new configuration parameter `openmetrics_endpoint`


### Describe how to test/QA your changes
- Start a kubernetes cluster with containerd as a container runtime (you can use minikube by running the command: `minikube start --container-runtime=containerd --nodes 1`)
- Verify that the containerd runtime is exposing metrics on the openmetrics endpoint by doing the following:
   - ssh into the host node
   - navigate into `/etc/containerd/config.toml` and open the file
   - check that the metrics configuration includes a non-empty tcp address such as:
   ```# metrics configuration
    [metrics]
    # tcp address!
    address = "127.0.0.1:1338"
   ```
   - If the address is empty, add `127.0.0.1:1338` as the address, save the file, and restart the containerd runtime with `systemctl restart containerd`
- Create some pods on the node exposing openmetrics containerd metrics (use valid images for some pods and invalid ones for others). For example:
   - `kubectl run redis-1 --image=redis`
   - `kubectl run redis-2 --image=redis:non-existing`
   - `kubectl run nginx-1 --image=nginx`
   - `kubectl run nginx-2 --image=nginx:non-existing`
- Check the reported metrics on the DD app:
   - Filter by the cluster name (host)
   - Show the `containerd.image.pull` metric
   - Sum by `grpc_code`
   - You should see something similar to the following:
![image](https://github.com/DataDog/datadog-agent/assets/41540817/f88bfe4c-5b67-4224-8d64-fe249fd18178)


Notes on QA:

You could also test setting the `openmetrics_endpoint` in the conf.d configuration of the containerd check. In the steps explained above, we didn't have to do so because if we don't specify the endpoint in conf.d, it will be defaulted to `http://127.0.0.1:1338`
   
   
### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
