### PR TITLE
[usm] Add debugging endpoint for listing USM traced programs

### DIFF
--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -30,6 +30,7 @@ import (
 	kafkadebugging "github.com/DataDog/datadog-agent/pkg/network/protocols/kafka/debugging"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer"
+	usm "github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -245,6 +246,7 @@ func (nt *networkTracer) Register(httpMux *module.Router) error {
 	})
 
 	httpMux.HandleFunc("/debug/usm_telemetry", telemetry.Handler)
+	httpMux.HandleFunc("/debug/usm_traced_programs", usm.TracedProgramsEndpoint)
 
 	// Convenience logging if nothing has made any requests to the system-probe in some time, let's log something.
 	// This should be helpful for customers + support to debug the underlying issue.

--- a/pkg/network/usm/sharedlibraries/testutil/testutil.go
+++ b/pkg/network/usm/sharedlibraries/testutil/testutil.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux_bpf && test
+//go:build linux && test
 
 package testutil
 

--- a/pkg/network/usm/utils/debugger.go
+++ b/pkg/network/usm/utils/debugger.go
@@ -3,8 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux_bpf
+//go:build linux
 
+// Package utils contains common code shared across the USM codebase
 package utils
 
 import (
@@ -14,7 +15,18 @@ import (
 	otherutils "github.com/DataDog/datadog-agent/cmd/system-probe/utils"
 )
 
-func TracedProgramsEndpoint(w http.ResponseWriter, req *http.Request) {
+// TracedProgram represents an active uprobe-based program and its used
+// for the purposes of generating JSON content in our debugging endpoint
+type TracedProgram struct {
+	ProgramType string
+	FilePath    string
+	PIDs        []uint32
+}
+
+// TracedProgramsEndpoint generates a summary of all active uprobe-based
+// programs along with their file paths and PIDs.
+// This is used for debugging purposes only.
+func TracedProgramsEndpoint(w http.ResponseWriter, _ *http.Request) {
 	otherutils.WriteAsJSON(w, debugger.GetTracedPrograms())
 }
 
@@ -30,12 +42,6 @@ func (d *fileRegistryDebugger) Add(r *FileRegistry) {
 	defer d.mux.Unlock()
 
 	d.instances = append(d.instances, r)
-}
-
-type TracedProgram struct {
-	ProgramType string
-	FilePath    string
-	PIDs        []uint32
 }
 
 func (d *fileRegistryDebugger) GetTracedPrograms() []TracedProgram {

--- a/pkg/network/usm/utils/debugger.go
+++ b/pkg/network/usm/utils/debugger.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package utils
+
+import (
+	"net/http"
+	"sync"
+
+	otherutils "github.com/DataDog/datadog-agent/cmd/system-probe/utils"
+)
+
+func TracedProgramsEndpoint(w http.ResponseWriter, req *http.Request) {
+	otherutils.WriteAsJSON(w, debugger.GetTracedPrograms())
+}
+
+var debugger *fileRegistryDebugger
+
+type fileRegistryDebugger struct {
+	mux       sync.Mutex
+	instances []*FileRegistry
+}
+
+func (d *fileRegistryDebugger) Add(r *FileRegistry) {
+	d.mux.Lock()
+	defer d.mux.Unlock()
+
+	d.instances = append(d.instances, r)
+}
+
+type TracedProgram struct {
+	ProgramType string
+	FilePath    string
+	PIDs        []uint32
+}
+
+func (d *fileRegistryDebugger) GetTracedPrograms() []TracedProgram {
+	d.mux.Lock()
+	defer d.mux.Unlock()
+
+	var all []TracedProgram
+
+	// Iterate over each `FileRegistry` instance:
+	// Examples of this would be: "shared_libraries", "istio", "goTLS" etc
+	for _, registry := range d.instances {
+		programType := registry.telemetry.programName
+		tracedProgramsByID := make(map[PathIdentifier]*TracedProgram)
+
+		registry.m.Lock()
+		// First, "aggregate" PathIDs by PIDs
+		for pid, pathSet := range registry.byPID {
+			for pathID := range pathSet {
+				tracedProgram, ok := tracedProgramsByID[pathID]
+				if !ok {
+					tracedProgram = new(TracedProgram)
+					tracedProgramsByID[pathID] = tracedProgram
+				}
+
+				tracedProgram.PIDs = append(tracedProgram.PIDs, pid)
+			}
+		}
+
+		// Then, enhance each PathID with a sample file path and the program type
+		for pathID, program := range tracedProgramsByID {
+			registration, ok := registry.byID[pathID]
+			if !ok {
+				continue
+			}
+
+			program.ProgramType = programType
+			program.FilePath = registration.sampleFilePath
+		}
+		registry.m.Unlock()
+
+		// Finally, add everything to a slice that is transformed in JSON
+		// content by the endpoint handler
+		for _, program := range tracedProgramsByID {
+			all = append(all, *program)
+		}
+	}
+
+	return all
+}
+
+func init() {
+	debugger = new(fileRegistryDebugger)
+}

--- a/pkg/network/usm/utils/debugger_windows.go
+++ b/pkg/network/usm/utils/debugger_windows.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+// Package utils contains common code shared across the USM codebase
+package utils
+
+import "net/http"
+
+// TracedProgramsEndpoint is not supported on Windows
+func TracedProgramsEndpoint(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(404)
+}

--- a/pkg/network/usm/utils/ebpfoptions.go
+++ b/pkg/network/usm/utils/ebpfoptions.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux_bpf
+//go:build linux
 
 package utils
 

--- a/pkg/network/usm/utils/ebpfoptions.go
+++ b/pkg/network/usm/utils/ebpfoptions.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
+//go:build linux_bpf
 
 package utils
 

--- a/pkg/network/usm/utils/ebpfoptions_test.go
+++ b/pkg/network/usm/utils/ebpfoptions_test.go
@@ -3,13 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux_bpf
+//go:build linux
 
 package utils
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	manager "github.com/DataDog/ebpf-manager"
 )

--- a/pkg/network/usm/utils/ebpfoptions_test.go
+++ b/pkg/network/usm/utils/ebpfoptions_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
+//go:build linux_bpf
 
 package utils
 

--- a/pkg/network/usm/utils/file_registry.go
+++ b/pkg/network/usm/utils/file_registry.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux_bpf
+//go:build linux
 
 package utils
 

--- a/pkg/network/usm/utils/file_registry.go
+++ b/pkg/network/usm/utils/file_registry.go
@@ -84,13 +84,19 @@ func NewFileRegistry(programName string) *FileRegistry {
 		log.Warnf("running without block cache list, creation error: %s", err)
 		blocklistByID = nil
 	}
-	return &FileRegistry{
+	r := &FileRegistry{
 		procRoot:      kernel.ProcFSRoot(),
 		byID:          make(map[PathIdentifier]*registration),
 		byPID:         make(map[uint32]pathIdentifierSet),
 		blocklistByID: blocklistByID,
 		telemetry:     newRegistryTelemetry(programName),
 	}
+
+	// Add self to the debugger so we can inspect internal state of this
+	// FileRegistry using our debugging endpoint
+	debugger.Add(r)
+
+	return r
 }
 
 // Register inserts or updates a new file registration within to the `FileRegistry`;
@@ -159,7 +165,7 @@ func (r *FileRegistry) Register(namespacedPath string, pid uint32, activationCB,
 		return
 	}
 
-	reg := r.newRegistration(deactivationCB)
+	reg := r.newRegistration(namespacedPath, deactivationCB)
 	r.byID[pathID] = reg
 	if len(r.byPID[pid]) == 0 {
 		r.byPID[pid] = pathIdentifierSet{}
@@ -239,11 +245,12 @@ func (r *FileRegistry) Clear() {
 	r.stopped = true
 }
 
-func (r *FileRegistry) newRegistration(deactivationCB callback) *registration {
+func (r *FileRegistry) newRegistration(sampleFilePath string, deactivationCB callback) *registration {
 	return &registration{
 		deactivationCB:       deactivationCB,
 		uniqueProcessesCount: atomic.NewInt32(1),
 		telemetry:            &r.telemetry,
+		sampleFilePath:       sampleFilePath,
 	}
 }
 
@@ -253,6 +260,13 @@ type registration struct {
 
 	// we are sharing the telemetry from FileRegistry
 	telemetry *registryTelemetry
+
+	// Note about the motivation for this field:
+	// a registration is tied to a PathIdentifier which is a global "identifier"
+	// to a file (dev, inode). Multiple file paths can point to the same
+	// underlying (dev, inode), so the `pathSample` here happens to be simply
+	// *one* of these file paths and use this mostly for debugging purposes
+	sampleFilePath string
 }
 
 // unregister return true if there are no more reference to this registration

--- a/pkg/network/usm/utils/file_registry.go
+++ b/pkg/network/usm/utils/file_registry.go
@@ -262,10 +262,11 @@ type registration struct {
 	telemetry *registryTelemetry
 
 	// Note about the motivation for this field:
-	// a registration is tied to a PathIdentifier which is a global "identifier"
-	// to a file (dev, inode). Multiple file paths can point to the same
-	// underlying (dev, inode), so the `pathSample` here happens to be simply
-	// *one* of these file paths and use this mostly for debugging purposes
+	// a registration is tied to a PathIdentifier which is basically a global
+	// identifier to a file (dev, inode). Multiple file paths can point to the
+	// same underlying (dev, inode), so the `sampleFilePath` here happens to be
+	// simply *one* of these file paths and we use this only for debugging
+	// purposes.
 	sampleFilePath string
 }
 

--- a/pkg/network/usm/utils/file_registry_test.go
+++ b/pkg/network/usm/utils/file_registry_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux_bpf
+//go:build linux
 
 package utils
 

--- a/pkg/network/usm/utils/path_identifier.go
+++ b/pkg/network/usm/utils/path_identifier.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux_bpf
+//go:build linux
 
 package utils
 

--- a/pkg/network/usm/utils/testutils.go
+++ b/pkg/network/usm/utils/testutils.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux_bpf && test
+//go:build linux && test
 
 package utils
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Add a debugging endpoint for the purposes of listing all traced USM programs and their PIDs.

### Motivation

Improve debugging workflow for uprobe-based programs.

### Additional Notes

Sample output:

``` 
[
  {
    "ProgramType": "shared_libraries",
    "FilePath": "/usr/lib/aarch64-linux-gnu/libcrypto.so.3",
    "PIDs": [
      759,
      36353,
      512,
      1386,
      2118,
      36350,
      42671,
      442,
      764,
      36354,
      36363,
      42667,
      45775,
      1,
      687,
      726,
      806
    ]
  },
  {
    "ProgramType": "shared_libraries",
    "FilePath": "/usr/lib/aarch64-linux-gnu/libgnutls.so.30.31.0",
    "PIDs": [
      2118,
      45775,
      726
    ]
  },
  {
    "ProgramType": "shared_libraries",
    "FilePath": "/lib/aarch64-linux-gnu/libssl.so.3",
    "PIDs": [
      45775
    ]
  }
]
```



### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
