### PR TITLE
[Orchestrator] Run orchestrator_pod check by default

### DIFF
--- a/cmd/agent/dist/conf.d/orchestrator_pod.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/orchestrator_pod.d/conf.yaml.default
@@ -1,0 +1,4 @@
+init_config:
+instances:
+  -
+

--- a/cmd/agent/dist/conf.d/orchestrator_pod.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/orchestrator_pod.d/conf.yaml.default
@@ -1,2 +1,4 @@
+ad_identifiers:
+  - _kube_orchestrator
 instances:
   - {}

--- a/cmd/agent/dist/conf.d/orchestrator_pod.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/orchestrator_pod.d/conf.yaml.default
@@ -1,4 +1,2 @@
-init_config:
 instances:
-  -
-
+  - {}

--- a/pkg/collector/corechecks/orchestrator/pod/pod.go
+++ b/pkg/collector/corechecks/orchestrator/pod/pod.go
@@ -80,7 +80,7 @@ func (c *Check) Configure(
 		return err
 	}
 	if !c.config.CoreCheck {
-		log.Warn("The corecheck version for pods is currently disabled. See the changelog.")
+		log.Warn("The Node Agent version for pods is currently disabled. See the changelog.")
 		return nil
 	}
 	if !c.config.OrchestrationCollectionEnabled {

--- a/pkg/collector/corechecks/orchestrator/pod/pod.go
+++ b/pkg/collector/corechecks/orchestrator/pod/pod.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const checkName = "orchestrator_pod"
@@ -80,10 +81,12 @@ func (c *Check) Configure(
 	}
 
 	if !c.config.OrchestrationCollectionEnabled {
-		return errors.New("orchestrator check is configured but the feature is disabled")
+		log.Warn("orchestrator pod check is configured but the feature is disabled")
+		return nil
 	}
 	if !c.config.CoreCheck {
-		return errors.New("the corecheck version for pods is currently disabled")
+		log.Warn("the corecheck version for pods is currently disabled")
+		return nil
 	}
 	if c.config.KubeClusterName == "" {
 		return errors.New("orchestrator check is configured but the cluster name is empty")
@@ -111,6 +114,11 @@ func (c *Check) Configure(
 
 // Run executes the check
 func (c *Check) Run() error {
+
+	if !c.config.CoreCheck {
+		return nil
+	}
+
 	if c.clusterID == "" {
 		clusterID, err := clustername.GetClusterID()
 		if err != nil {

--- a/pkg/collector/corechecks/orchestrator/pod/pod.go
+++ b/pkg/collector/corechecks/orchestrator/pod/pod.go
@@ -79,13 +79,12 @@ func (c *Check) Configure(
 	if err != nil {
 		return err
 	}
-
-	if !c.config.OrchestrationCollectionEnabled {
-		log.Warn("orchestrator pod check is configured but the feature is disabled")
+	if !c.config.CoreCheck {
+		log.Warn("The corecheck version for pods is currently disabled. See the changelog.")
 		return nil
 	}
-	if !c.config.CoreCheck {
-		log.Warn("the corecheck version for pods is currently disabled")
+	if !c.config.OrchestrationCollectionEnabled {
+		log.Warn("orchestrator pod check is configured but the feature is disabled")
 		return nil
 	}
 	if c.config.KubeClusterName == "" {

--- a/pkg/process/checks/pod.go
+++ b/pkg/process/checks/pod.go
@@ -57,9 +57,9 @@ func (c *PodCheck) IsEnabled() bool {
 	if coreCheck {
 		log.Info("Skipping pod check on process agent")
 		return false
-	} else {
-		log.Warn("This check will be deprecated in 7.51.0 and move to corechecks")
 	}
+
+	log.Warn("This check will be deprecated in 7.51.0 and move to corechecks")
 
 	if kubeClusterName == "" {
 		_ = log.Warnf("Failed to auto-detect a Kubernetes cluster name. Pod collection will not start. To fix this, set it manually via the cluster_name config option")

--- a/pkg/process/checks/pod.go
+++ b/pkg/process/checks/pod.go
@@ -57,6 +57,8 @@ func (c *PodCheck) IsEnabled() bool {
 	if coreCheck {
 		log.Info("Skipping pod check on process agent")
 		return false
+	} else {
+		log.Warn("This check will be deprecated in 7.51.0 and move to corechecks")
 	}
 
 	if kubeClusterName == "" {

--- a/pkg/process/checks/pod.go
+++ b/pkg/process/checks/pod.go
@@ -59,7 +59,7 @@ func (c *PodCheck) IsEnabled() bool {
 		return false
 	}
 
-	log.Warn("This check will be deprecated in 7.51.0 and move to corechecks")
+	log.Warn("This Process Agent check will be deprecated in 7.51.0 and moved to the Node Agent")
 
 	if kubeClusterName == "" {
 		_ = log.Warnf("Failed to auto-detect a Kubernetes cluster name. Pod collection will not start. To fix this, set it manually via the cluster_name config option")

--- a/releasenotes/notes/AddPodCheck-355c270d2179d511.yaml
+++ b/releasenotes/notes/AddPodCheck-355c270d2179d511.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    Introducing the new orchestrator pod check that will now reside in corechecks. In the next release, this new check will replace the current pod check in the process agent. You can start using this new check now by manually setting the environment variable `DD_ORCHESTRATOR_EXPLORER_RUN_ON_NODE_AGENT` to true.
+    Introducing the new orchestrator pod check that now resides in corechecks. In the next release, this new check will replace the current pod check in the Process Agent. You can start using this new check now by manually setting the environment variable `DD_ORCHESTRATOR_EXPLORER_RUN_ON_NODE_AGENT` to `true`.

--- a/releasenotes/notes/AddPodCheck-355c270d2179d511.yaml
+++ b/releasenotes/notes/AddPodCheck-355c270d2179d511.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Introducing the new orchestrator pod check that will now reside in corechecks. In the next release, this new check will replace the current pod check in the process agent. You can start using this new check now by manually setting the environment variable `DD_ORCHESTRATOR_EXPLORER_RUN_ON_NODE_AGENT` to true.

--- a/releasenotes/notes/AddPodCheck-355c270d2179d511.yaml
+++ b/releasenotes/notes/AddPodCheck-355c270d2179d511.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    The orchestrator check is moving from the Process Agent to the Core Agent. In the next release, this new check will replace the current pod check in the Process Agent. You can start using this new check now by manually setting the environment variable ``DD_ORCHESTRATOR_EXPLORER_RUN_ON_NODE_AGENT`` to ``true``.
+    The orchestrator check is moving from the Process Agent to the Node Agent. In the next release, this new check will replace the current pod check in the Process Agent. You can start using this new check now by manually setting the environment variable ``DD_ORCHESTRATOR_EXPLORER_RUN_ON_NODE_AGENT`` to ``true``.

--- a/releasenotes/notes/AddPodCheck-355c270d2179d511.yaml
+++ b/releasenotes/notes/AddPodCheck-355c270d2179d511.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    The orchestrator check is moving from the Process Agent to the Core Agent. In the next release, this new check will replace the current pod check in the Process Agent. You can start using this new check now by manually setting the environment variable `DD_ORCHESTRATOR_EXPLORER_RUN_ON_NODE_AGENT` to `true`.
+    The orchestrator check is moving from the Process Agent to the Core Agent. In the next release, this new check will replace the current pod check in the Process Agent. You can start using this new check now by manually setting the environment variable ``DD_ORCHESTRATOR_EXPLORER_RUN_ON_NODE_AGENT`` to ``true``.

--- a/releasenotes/notes/AddPodCheck-355c270d2179d511.yaml
+++ b/releasenotes/notes/AddPodCheck-355c270d2179d511.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    Introducing the new orchestrator pod check that now resides in corechecks. In the next release, this new check will replace the current pod check in the Process Agent. You can start using this new check now by manually setting the environment variable `DD_ORCHESTRATOR_EXPLORER_RUN_ON_NODE_AGENT` to `true`.
+    The orchestrator check is moving from the Process Agent to the Core Agent. In the next release, this new check will replace the current pod check in the Process Agent. You can start using this new check now by manually setting the environment variable `DD_ORCHESTRATOR_EXPLORER_RUN_ON_NODE_AGENT` to `true`.

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -68,6 +68,7 @@ AGENT_CORECHECKS = [
     "uptime",
     "winproc",
     "jetson",
+    "orchestrator_pod",
 ]
 
 WINDOWS_CORECHECKS = [


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Follow up to https://github.com/DataDog/datadog-agent/pull/18740 that creates the configuration to run the check by default

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
