### PR TITLE
Add stats summary to datadog-agent kubelet check 

### DIFF
--- a/pkg/collector/corechecks/containers/kubelet/common/config.go
+++ b/pkg/collector/corechecks/containers/kubelet/common/config.go
@@ -21,6 +21,8 @@ const (
 type KubeletConfig struct {
 	ProbesMetricsEndpoint *string `yaml:"probes_metrics_endpoint,omitempty"`
 	types.OpenmetricsInstance
+	EnabledRates            []string `yaml:"enabled_rates,omitempty"`
+	UseStatsSummaryAsSource *bool    `yaml:"use_stats_summary_as_source,omitempty"`
 }
 
 func (c *KubeletConfig) Parse(data []byte) error {

--- a/pkg/collector/corechecks/containers/kubelet/common/config.go
+++ b/pkg/collector/corechecks/containers/kubelet/common/config.go
@@ -19,10 +19,10 @@ const (
 
 // KubeletConfig is the config of the Kubelet.
 type KubeletConfig struct {
-	ProbesMetricsEndpoint *string `yaml:"probes_metrics_endpoint,omitempty"`
-	types.OpenmetricsInstance
+	ProbesMetricsEndpoint   *string  `yaml:"probes_metrics_endpoint,omitempty"`
 	EnabledRates            []string `yaml:"enabled_rates,omitempty"`
 	UseStatsSummaryAsSource *bool    `yaml:"use_stats_summary_as_source,omitempty"`
+	types.OpenmetricsInstance
 }
 
 func (c *KubeletConfig) Parse(data []byte) error {

--- a/pkg/collector/corechecks/containers/kubelet/kubelet.go
+++ b/pkg/collector/corechecks/containers/kubelet/kubelet.go
@@ -59,12 +59,6 @@ func NewKubeletCheck(base core.CheckBase, instance *common.KubeletConfig) *Kubel
 }
 
 func initProviders(filter *containers.Filter, config *common.KubeletConfig) []Provider {
-	if len(config.EnabledRates) == 0 {
-		config.EnabledRates = []string{
-			"diskio.io_service_bytes.stats.total",
-			"network[\\.].._bytes",
-			"cpu[\\.].*[\\.]total"} //default metrics
-	}
 	podProvider := pod.NewProvider(filter, config)
 	// nodeProvider collects from the /spec endpoint, which was hidden by default in k8s 1.18 and removed in k8s 1.19.
 	// It is here for backwards compatibility.

--- a/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go
@@ -64,7 +64,7 @@ func (p *Provider) Provide(kc kubelet.KubeUtilInterface, sender sender.Sender) e
 		return err
 	}
 
-	var useStatsAsSource bool = false
+	useStatsAsSource := false
 	if p.config.UseStatsSummaryAsSource == nil {
 		if runtime.GOOS == "windows" {
 			useStatsAsSource = true

--- a/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go
@@ -31,6 +31,7 @@ type Provider struct {
 	store  workloadmeta.Store
 }
 
+// Create a new provider by filter, config and workloadmeta
 func NewProvider(filter *containers.Filter,
 	config *common.KubeletConfig,
 	store workloadmeta.Store) *Provider {
@@ -76,6 +77,7 @@ func reportFsMetric(sender sender.Sender,
 	}
 }
 
+// Process metrics and report
 func (p *Provider) Provide(kc kubelet.KubeUtilInterface, sender sender.Sender) error {
 	statsSummary, err := kc.GetLocalStatsSummary(context.TODO())
 	if err != nil || statsSummary == nil {

--- a/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go
@@ -165,27 +165,27 @@ func (p *Provider) processPodStats(sender sender.Sender,
 		report_metric(sender.Gauge, "ephemeral_storage.usage",
 			ephemeralStorage.UsedBytes, podTags)
 	}
-	if useStatsAsSource == false {
+	if !useStatsAsSource {
 		return
 	}
 	podNetwork := podStats.Network
 	if podNetwork == nil {
 		return
 	}
-	var rx_bytes, tx_bytes *uint64
-	rx_bytes = podNetwork.InterfaceStats.RxBytes
-	tx_bytes = podNetwork.InterfaceStats.TxBytes
+	var rxBytes, txBytes *uint64
+	rxBytes = podNetwork.InterfaceStats.RxBytes
+	txBytes = podNetwork.InterfaceStats.TxBytes
 
 	// if config has "network.*"" in "enabled_rates"
 	for i, _ := range p.config.EnabledRates {
 		pattern := &p.config.EnabledRates[i]
 		matched, error := regexp.MatchString(*pattern, txBytesMetricName)
-		if tx_bytes != nil && error == nil && matched {
-			report_metric(sender.Rate, txBytesMetricName, tx_bytes, podTags)
+		if txBytes != nil && error == nil && matched {
+			report_metric(sender.Rate, txBytesMetricName, txBytes, podTags)
 		}
 		matched, error = regexp.MatchString(*pattern, rxBytesMetricName)
-		if rx_bytes != nil && error == nil && matched {
-			report_metric(sender.Rate, rxBytesMetricName, rx_bytes, podTags)
+		if rxBytes != nil && error == nil && matched {
+			report_metric(sender.Rate, rxBytesMetricName, rxBytes, podTags)
 		}
 	}
 }
@@ -197,7 +197,7 @@ func (p *Provider) processContainerStats(sender sender.Sender,
 	if podStats == nil ||
 		len(podStats.Containers) == 0 ||
 		podData == nil ||
-		useStatsAsSource == false {
+		!useStatsAsSource {
 		return
 	}
 	containerData := make(map[string]*workloadmeta.OrchestratorContainer)

--- a/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go
@@ -55,8 +55,8 @@ func NewProvider(filter *containers.Filter,
 
 	rateFilterList := []*regexp.Regexp{
 		regexp.MustCompile("diskio.io_service_bytes.stats.total"),
-		regexp.MustCompile("network[\\.].._bytes"),
-		regexp.MustCompile("cpu[\\.].*[\\.]total"),
+		regexp.MustCompile("network[.].._bytes"),
+		regexp.MustCompile("cpu[.].*[.]total"),
 	} //default enabled_rates
 	if len(config.EnabledRates) > 0 {
 		rateFilterList = []*regexp.Regexp{}

--- a/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go
@@ -1,0 +1,245 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubelet
+
+package summary
+
+import (
+	"context"
+	"regexp"
+	"runtime"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/common"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	kubeletv1alpha1 "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+)
+
+// Provider provides the data collected from the `/stats/summary` Kubelet endpoint
+type Provider struct {
+	filter *containers.Filter
+	config *common.KubeletConfig
+	store  workloadmeta.Store
+}
+
+func NewProvider(filter *containers.Filter,
+	config *common.KubeletConfig,
+	store workloadmeta.Store) *Provider {
+	return &Provider{
+		filter: filter,
+		config: config,
+		store:  store,
+	}
+}
+
+const (
+	txBytesMetricName = "network.tx_bytes"
+	rxBytesMetricName = "network.rx_bytes"
+)
+
+func report_metric[T float64 | uint64](senderFunc func(string, float64, string, []string),
+	metricName string, value *T, tags []string) {
+	if value == nil {
+		return
+	}
+	if metricName != "" {
+		senderFunc(common.KubeletMetricsPrefix+metricName, float64(*value), "", tags)
+	}
+}
+
+func report_fs_metric(sender sender.Sender,
+	fsStats *kubeletv1alpha1.FsStats,
+	metricPrefix string,
+	tags []string) {
+	if fsStats == nil {
+		return
+	}
+	report_metric(sender.Gauge,
+		metricPrefix+"filesystem.usage",
+		fsStats.UsedBytes,
+		tags)
+	if fsStats.UsedBytes != nil && fsStats.CapacityBytes != nil && *fsStats.CapacityBytes != 0 {
+		usage_pct := float64(*fsStats.UsedBytes) / float64(*fsStats.CapacityBytes)
+		report_metric(sender.Gauge,
+			metricPrefix+"filesystem.usage_pct",
+			&usage_pct,
+			tags)
+	}
+}
+
+func (p *Provider) Provide(kc kubelet.KubeUtilInterface, sender sender.Sender) error {
+	statsSummary, err := kc.GetLocalStatsSummary(context.TODO())
+	if err != nil || statsSummary == nil {
+		return err
+	}
+
+	p.processSystemStats(sender, statsSummary)
+	useStatsAsSource := false
+	if p.config.UseStatsSummaryAsSource == nil {
+		if runtime.GOOS == "windows" {
+			useStatsAsSource = true
+		}
+	} else {
+		useStatsAsSource = *p.config.UseStatsSummaryAsSource
+	}
+	for i, _ := range statsSummary.Pods {
+		podStats := &statsSummary.Pods[i]
+		if len(podStats.Containers) == 0 {
+
+			continue
+		}
+		if len(podStats.PodRef.Namespace) == 0 || len(podStats.PodRef.Name) == 0 || len(podStats.PodRef.UID) == 0 {
+			log.Warnf("Got incomplete pod data from '/stats/summary', podNamespace = %s, podName = %s, podUid = %s",
+				podStats.PodRef.Namespace, podStats.PodRef.Name, podStats.PodRef.UID)
+			continue
+		}
+		//  Query to check whether a Kubernetes namespace should be excluded.
+		if p.filter.IsExcluded(nil, "", "", podStats.PodRef.Namespace) {
+			continue
+		}
+
+		podData, err := p.store.GetKubernetesPod(podStats.PodRef.UID) //from workloadmeta store
+		if err != nil || podData == nil {
+			log.Warnf("Couldn't get pod data from workloadmeta store, error = %v ", err)
+			continue
+		}
+		if podData.Phase == "Running" {
+			p.processPodStats(sender, podStats, useStatsAsSource)
+			p.processContainerStats(sender, podStats, podData, useStatsAsSource)
+		}
+	}
+	return nil
+}
+
+func (p *Provider) processSystemStats(sender sender.Sender,
+	statsSummary *kubeletv1alpha1.Summary) {
+	//System metrics
+	report_fs_metric(sender, statsSummary.Node.Fs, "node.", p.config.Tags)
+	if statsSummary.Node.Runtime != nil {
+		report_fs_metric(sender, statsSummary.Node.Runtime.ImageFs, "node.image.", p.config.Tags)
+	}
+
+	for _, ctr := range statsSummary.Node.SystemContainers {
+		if ctr.Name == "runtime" || ctr.Name == "kubelet" {
+			if ctr.Memory != nil {
+				report_metric(sender.Gauge, ctr.Name+".memory.rss",
+					ctr.Memory.RSSBytes, p.config.Tags)
+				report_metric(sender.Gauge, ctr.Name+".memory.usage",
+					ctr.Memory.UsageBytes, p.config.Tags)
+			}
+			if ctr.CPU != nil {
+				report_metric(sender.Gauge, ctr.Name+".cpu.usage",
+					ctr.CPU.UsageNanoCores, p.config.Tags)
+			}
+		}
+	}
+}
+
+func (p *Provider) processPodStats(sender sender.Sender,
+	podStats *kubeletv1alpha1.PodStats, useStatsAsSource bool) {
+	if podStats == nil {
+		return
+	}
+
+	podTags, _ := tagger.Tag(kubelet.PodUIDToTaggerEntityName(podStats.PodRef.UID),
+		collectors.OrchestratorCardinality)
+
+	if len(podTags) == 0 {
+		log.Infof("Tags not found for pod: %s/%s - no metrics will be sent",
+			podStats.PodRef.Namespace, podStats.PodRef.Name)
+		return
+	}
+
+	podTags = utils.ConcatenateTags(podTags, p.config.Tags)
+	ephemeralStorage := podStats.EphemeralStorage
+	if ephemeralStorage != nil {
+		report_metric(sender.Gauge, "ephemeral_storage.usage",
+			ephemeralStorage.UsedBytes, podTags)
+	}
+	if useStatsAsSource == false {
+		return
+	}
+	podNetwork := podStats.Network
+	if podNetwork == nil {
+		return
+	}
+	var rx_bytes, tx_bytes *uint64
+	rx_bytes = podNetwork.InterfaceStats.RxBytes
+	tx_bytes = podNetwork.InterfaceStats.TxBytes
+
+	// if config has "network.*"" in "enabled_rates"
+	for i, _ := range p.config.EnabledRates {
+		pattern := &p.config.EnabledRates[i]
+		matched, error := regexp.MatchString(*pattern, txBytesMetricName)
+		if tx_bytes != nil && error == nil && matched {
+			report_metric(sender.Rate, txBytesMetricName, tx_bytes, podTags)
+		}
+		matched, error = regexp.MatchString(*pattern, rxBytesMetricName)
+		if rx_bytes != nil && error == nil && matched {
+			report_metric(sender.Rate, rxBytesMetricName, rx_bytes, podTags)
+		}
+	}
+}
+
+func (p *Provider) processContainerStats(sender sender.Sender,
+	podStats *kubeletv1alpha1.PodStats,
+	podData *workloadmeta.KubernetesPod,
+	useStatsAsSource bool) {
+	if podStats == nil ||
+		len(podStats.Containers) == 0 ||
+		podData == nil ||
+		useStatsAsSource == false {
+		return
+	}
+	containerData := make(map[string]*workloadmeta.OrchestratorContainer)
+	for i, _ := range podData.Containers {
+		containerData[podData.Containers[i].Name] = &podData.Containers[i]
+	}
+	for idx, _ := range podStats.Containers {
+		containerStats := &podStats.Containers[idx]
+		containerName := containerStats.Name
+		if len(containerName) == 0 {
+			log.Warnf("Kubelet reported stats without container name for pod: %s/%s",
+				podStats.PodRef.Namespace, podStats.PodRef.Name)
+			continue
+		}
+		ctr, found := containerData[containerName]
+		if !found || ctr == nil && ctr.ID == "" {
+			log.Debugf(
+				"Container id not found from /pods for container: %s/%s/%s - no metrics will be sent",
+				podStats.PodRef.Namespace, podStats.PodRef.Name, containerName)
+			continue
+		}
+		if p.filter.IsExcluded(nil,
+			containerName,
+			ctr.Image.Name,
+			podStats.PodRef.Namespace) {
+			continue
+		}
+		tags, err := tagger.Tag(containers.BuildTaggerEntityName(ctr.ID), collectors.HighCardinality)
+		if err != nil || len(tags) == 0 {
+			log.Debugf("Tags not found for container: %s/%s/%s:%s - no metrics will be sent",
+				podStats.PodRef.Namespace, podStats.PodRef.Name, containerName, ctr.ID)
+			continue
+		}
+		tags = utils.ConcatenateTags(tags, p.config.Tags)
+		//collecting metric
+		if containerStats.CPU != nil {
+			report_metric(sender.Rate, "cpu.usage.total", containerStats.CPU.UsageCoreNanoSeconds, tags)
+		}
+		if containerStats.Memory != nil {
+			report_metric(sender.Rate, "memory.working_set", containerStats.Memory.WorkingSetBytes, tags)
+			report_metric(sender.Rate, "memory.usage", containerStats.Memory.UsageBytes, tags)
+		}
+		report_fs_metric(sender, containerStats.Rootfs, "", tags)
+	}
+}

--- a/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go
@@ -54,7 +54,7 @@ func NewProvider(filter *containers.Filter,
 	}
 
 	rateFilterList := []*regexp.Regexp{
-		regexp.MustCompile("diskio.io_service_bytes.stats.total"),
+		regexp.MustCompile("diskio[.]io_service_bytes[.]stats[.]total"),
 		regexp.MustCompile("network[.].._bytes"),
 		regexp.MustCompile("cpu[.].*[.]total"),
 	} //default enabled_rates

--- a/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go
@@ -5,6 +5,7 @@
 
 //go:build kubelet
 
+// Package summary contains all metrics from the /stats/summary endpoint
 package summary
 
 import (
@@ -31,7 +32,7 @@ type Provider struct {
 	store  workloadmeta.Store
 }
 
-// Create a new provider by filter, config and workloadmeta
+// NewProvider is created by filter, config and workloadmeta
 func NewProvider(filter *containers.Filter,
 	config *common.KubeletConfig,
 	store workloadmeta.Store) *Provider {
@@ -77,7 +78,7 @@ func reportFsMetric(sender sender.Sender,
 	}
 }
 
-// Process metrics and report
+// Provide processes metrics and reports
 func (p *Provider) Provide(kc kubelet.KubeUtilInterface, sender sender.Sender) error {
 	statsSummary, err := kc.GetLocalStatsSummary(context.TODO())
 	if err != nil || statsSummary == nil {
@@ -93,7 +94,7 @@ func (p *Provider) Provide(kc kubelet.KubeUtilInterface, sender sender.Sender) e
 	} else {
 		useStatsAsSource = *p.config.UseStatsSummaryAsSource
 	}
-	for i, _ := range statsSummary.Pods {
+	for i := range statsSummary.Pods {
 		podStats := &statsSummary.Pods[i]
 		if len(podStats.Containers) == 0 {
 
@@ -179,7 +180,7 @@ func (p *Provider) processPodStats(sender sender.Sender,
 	txBytes = podNetwork.InterfaceStats.TxBytes
 
 	// if config has "network.*"" in "enabled_rates"
-	for i, _ := range p.config.EnabledRates {
+	for i := range p.config.EnabledRates {
 		pattern := &p.config.EnabledRates[i]
 		matched, error := regexp.MatchString(*pattern, txBytesMetricName)
 		if txBytes != nil && error == nil && matched {
@@ -203,10 +204,10 @@ func (p *Provider) processContainerStats(sender sender.Sender,
 		return
 	}
 	containerData := make(map[string]*workloadmeta.OrchestratorContainer)
-	for i, _ := range podData.Containers {
+	for i := range podData.Containers {
 		containerData[podData.Containers[i].Name] = &podData.Containers[i]
 	}
-	for idx, _ := range podStats.Containers {
+	for idx := range podStats.Containers {
 		containerStats := &podStats.Containers[idx]
 		containerName := containerStats.Name
 		if len(containerName) == 0 {

--- a/pkg/collector/corechecks/containers/kubelet/provider/summary/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/summary/provider_test.go
@@ -368,7 +368,3 @@ func setFakeStatsSummary(t *testing.T, kubeletMock *mock.KubeletMock, rc int, er
 		Error:        err,
 	}
 }
-
-func clearFakeStatsSummary(kubeletMock *mock.KubeletMock) {
-	delete(kubeletMock.MockReplies, "/stats/summary")
-}

--- a/pkg/collector/corechecks/containers/kubelet/provider/summary/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/summary/provider_test.go
@@ -8,362 +8,364 @@
 package summary
 
 import (
-    "errors"
-    "os"
-    "reflect"
-    "testing"
+	"errors"
+	"os"
+	"reflect"
+	"testing"
 
-    "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 
-    "github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
-    "github.com/DataDog/datadog-agent/pkg/autodiscovery/common/types"
-    checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
-    "github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/common"
-    "github.com/DataDog/datadog-agent/pkg/tagger"
-    "github.com/DataDog/datadog-agent/pkg/tagger/local"
-    "github.com/DataDog/datadog-agent/pkg/util/containers"
-    "github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet/mock"
-    "github.com/DataDog/datadog-agent/pkg/workloadmeta"
-    workloadmetatesting "github.com/DataDog/datadog-agent/pkg/workloadmeta/testing"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common/types"
+	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/common"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/local"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet/mock"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	workloadmetatesting "github.com/DataDog/datadog-agent/pkg/workloadmeta/testing"
 )
 
 var (
-    //entity id: [fake tags]
-    entityTags = map[string][]string{
-        //pod name in summary: datadog-agent-linux-hn9f2
-        "kubernetes_pod_uid://foobar": {
-            "app:datadog-agent",
-        },
-        "container_id://agent-01": {
-            "kube_namespace:datadog-agent-helm",
-            "pod_name:datadog-agent-linux-hn9f2",
-            "kube_container_name:agent",
-        },
-        "container_id://agent-02": {
-            "kube_namespace:datadog-agent-helm",
-            "pod_name:datadog-agent-linux-hn9f2",
-            "kube_container_name:process-agent",
-        },
-        "container_id://agent-03": {
-            "kube_namespace:datadog-agent-helm",
-            "pod_name:datadog-agent-linux-hn9f2",
-            "kube_container_name:security-agent",
-        },
-        "container_id://agent-04": {
-            "kube_namespace:datadog-agent-helm",
-            "pod_name:datadog-agent-linux-hn9f2",
-            "kube_container_name:non-existing-in-summary",
-        },
-    }
+	//entity id: [fake tags]
+	entityTags = map[string][]string{
+		//pod name in summary: datadog-agent-linux-hn9f2
+		"kubernetes_pod_uid://foobar": {
+			"app:datadog-agent",
+		},
+		"container_id://agent-01": {
+			"kube_namespace:datadog-agent-helm",
+			"pod_name:datadog-agent-linux-hn9f2",
+			"kube_container_name:agent",
+		},
+		"container_id://agent-02": {
+			"kube_namespace:datadog-agent-helm",
+			"pod_name:datadog-agent-linux-hn9f2",
+			"kube_container_name:process-agent",
+		},
+		"container_id://agent-03": {
+			"kube_namespace:datadog-agent-helm",
+			"pod_name:datadog-agent-linux-hn9f2",
+			"kube_container_name:security-agent",
+		},
+		"container_id://agent-04": {
+			"kube_namespace:datadog-agent-helm",
+			"pod_name:datadog-agent-linux-hn9f2",
+			"kube_container_name:non-existing-in-summary",
+		},
+	}
 )
 
 func TestProvider_Provide(t *testing.T) {
-    useStatsSummaryAsSource := true
+	useStatsSummaryAsSource := true
 
-    type metrics struct {
-        name  string
-        value float64
-        tags  []string
-    }
+	type metrics struct {
+		name  string
+		value float64
+		tags  []string
+	}
 
-    type response struct {
-        code int
-        err  error
-    }
-    type want struct {
-        gaugeMetrics []metrics
-        rateMetrics  []metrics
-        err          error
-    }
-    tests := []struct {
-        name     string
-        response response
-        want     want
-    }{
-        {
-            name: "endpoint 404 error",
-            response: response{
-                code: 404,
-                err:  errors.New("Unable to fetch stats summary from Kubelet, rc: 404"),
-            },
-            want: want{
-                gaugeMetrics: nil,
-                rateMetrics:  nil,
-                err:          errors.New("Unable to fetch stats summary from Kubelet, rc: 404"),
-            },
-        },
-        {
-            name: "endpoint no error",
-            response: response{
-                code: 200,
-                err:  nil,
-            },
-            want: want{
-                gaugeMetrics: []metrics{
-                    {
-                        name:  common.KubeletMetricsPrefix + "node.filesystem.usage",
-                        value: 14517391360,
-                        tags:  []string{"instance_tag:something"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "node.filesystem.usage_pct",
-                        value: 0.13977132820196123,
-                        tags:  []string{"instance_tag:something"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "node.image.filesystem.usage",
-                        value: 10980311040,
-                        tags:  []string{"instance_tag:something"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "node.image.filesystem.usage_pct",
-                        value: 0.10571683438666064,
-                        tags:  []string{"instance_tag:something"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "kubelet.memory.rss",
-                        value: 77819904,
-                        tags:  []string{"instance_tag:something"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "kubelet.memory.usage",
-                        value: 147464192,
-                        tags:  []string{"instance_tag:something"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "kubelet.cpu.usage",
-                        value: 42549809,
-                        tags:  []string{"instance_tag:something"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "runtime.memory.rss",
-                        value: 219836416,
-                        tags:  []string{"instance_tag:something"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "runtime.memory.usage",
-                        value: 1521729536,
-                        tags:  []string{"instance_tag:something"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "runtime.cpu.usage",
-                        value: 58035303,
-                        tags:  []string{"instance_tag:something"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "ephemeral_storage.usage",
-                        value: 17596416,
-                        tags:  []string{"instance_tag:something", "app:datadog-agent"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "filesystem.usage",
-                        value: 94208,
-                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "filesystem.usage_pct",
-                        value: 9.070208938178244e-07,
-                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "filesystem.usage",
-                        value: 102400,
-                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "filesystem.usage_pct",
-                        value: 9.858922758889397e-07,
-                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "filesystem.usage",
-                        value: 69632,
-                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "filesystem.usage_pct",
-                        value: 6.704067476044789e-07,
-                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
-                    },
-                },
-                rateMetrics: []metrics{
-                    {
-                        name:  common.KubeletMetricsPrefix + "network.tx_bytes",
-                        value: 958986495,
-                        tags:  []string{"instance_tag:something", "app:datadog-agent"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "network.rx_bytes",
-                        value: 870160903,
-                        tags:  []string{"instance_tag:something", "app:datadog-agent"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "cpu.usage.total",
-                        value: 45241120000,
-                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "memory.working_set",
-                        value: 80461824,
-                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "memory.usage",
-                        value: 85618688,
-                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "cpu.usage.total",
-                        value: 6361765000,
-                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "memory.working_set",
-                        value: 52338688,
-                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "memory.usage",
-                        value: 52842496,
-                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "cpu.usage.total",
-                        value: 6903135000,
-                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "memory.working_set",
-                        value: 68685824,
-                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
-                    },
-                    {
-                        name:  common.KubeletMetricsPrefix + "memory.usage",
-                        value: 69447680,
-                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
-                    },
-                },
-                err: nil,
-            },
-        },
-    }
+	type response struct {
+		code int
+		err  error
+	}
+	type want struct {
+		gaugeMetrics []metrics
+		rateMetrics  []metrics
+		err          error
+	}
+	tests := []struct {
+		name     string
+		response response
+		want     want
+	}{
+		{
+			name: "endpoint 404 error",
+			response: response{
+				code: 404,
+				err:  errors.New("Unable to fetch stats summary from Kubelet, rc: 404"),
+			},
+			want: want{
+				gaugeMetrics: nil,
+				rateMetrics:  nil,
+				err:          errors.New("Unable to fetch stats summary from Kubelet, rc: 404"),
+			},
+		},
+		{
+			name: "endpoint no error",
+			response: response{
+				code: 200,
+				err:  nil,
+			},
+			want: want{
+				gaugeMetrics: []metrics{
+					{
+						name:  common.KubeletMetricsPrefix + "node.filesystem.usage",
+						value: 14517391360,
+						tags:  []string{"instance_tag:something"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "node.filesystem.usage_pct",
+						value: 0.13977132820196123,
+						tags:  []string{"instance_tag:something"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "node.image.filesystem.usage",
+						value: 10980311040,
+						tags:  []string{"instance_tag:something"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "node.image.filesystem.usage_pct",
+						value: 0.10571683438666064,
+						tags:  []string{"instance_tag:something"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "kubelet.memory.rss",
+						value: 77819904,
+						tags:  []string{"instance_tag:something"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "kubelet.memory.usage",
+						value: 147464192,
+						tags:  []string{"instance_tag:something"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "kubelet.cpu.usage",
+						value: 42549809,
+						tags:  []string{"instance_tag:something"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "runtime.memory.rss",
+						value: 219836416,
+						tags:  []string{"instance_tag:something"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "runtime.memory.usage",
+						value: 1521729536,
+						tags:  []string{"instance_tag:something"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "runtime.cpu.usage",
+						value: 58035303,
+						tags:  []string{"instance_tag:something"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "ephemeral_storage.usage",
+						value: 17596416,
+						tags:  []string{"instance_tag:something", "app:datadog-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "filesystem.usage",
+						value: 94208,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "filesystem.usage_pct",
+						value: 9.070208938178244e-07,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "filesystem.usage",
+						value: 102400,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "filesystem.usage_pct",
+						value: 9.858922758889397e-07,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "filesystem.usage",
+						value: 69632,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "filesystem.usage_pct",
+						value: 6.704067476044789e-07,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
+					},
+				},
+				rateMetrics: []metrics{
+					{
+						name:  common.KubeletMetricsPrefix + "network.tx_bytes",
+						value: 958986495,
+						tags:  []string{"instance_tag:something", "app:datadog-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "network.rx_bytes",
+						value: 870160903,
+						tags:  []string{"instance_tag:something", "app:datadog-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "cpu.usage.total",
+						value: 45241120000,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "memory.working_set",
+						value: 80461824,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "memory.usage",
+						value: 85618688,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "cpu.usage.total",
+						value: 6361765000,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "memory.working_set",
+						value: 52338688,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "memory.usage",
+						value: 52842496,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "cpu.usage.total",
+						value: 6903135000,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "memory.working_set",
+						value: 68685824,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "memory.usage",
+						value: 69447680,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
+					},
+				},
+				err: nil,
+			},
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            var err error
-            mockSender := mocksender.NewMockSender(checkid.ID(t.Name()))
-            mockSender.SetupAcceptAll()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			mockSender := mocksender.NewMockSender(checkid.ID(t.Name()))
+			mockSender.SetupAcceptAll()
 
-            fakeTagger := local.NewFakeTagger()
-            for entity, tags := range entityTags {
-                fakeTagger.SetTags(entity, "foo", tags, nil, nil, nil)
-            }
-            tagger.SetDefaultTagger(fakeTagger)
-            store := creatFakeStore()
-            kubeletMock := mock.NewKubeletMock()
-            setFakeStatsSummary(t, kubeletMock, tt.response.code, tt.response.err)
+			fakeTagger := local.NewFakeTagger()
+			for entity, tags := range entityTags {
+				fakeTagger.SetTags(entity, "foo", tags, nil, nil, nil)
+			}
+			tagger.SetDefaultTagger(fakeTagger)
+			store := creatFakeStore()
+			kubeletMock := mock.NewKubeletMock()
+			setFakeStatsSummary(t, kubeletMock, tt.response.code, tt.response.err)
 
-            config := &common.KubeletConfig{
-                OpenmetricsInstance: types.OpenmetricsInstance{
-                    Tags: []string{"instance_tag:something"},
-                },
-                EnabledRates: []string{ //default
-                    "diskio.io_service_bytes.stats.total",
-                    "network[\\.].._bytes",
-                    "cpu[\\.].*[\\.]total"},
-                UseStatsSummaryAsSource: &useStatsSummaryAsSource,
-            }
+			config := &common.KubeletConfig{
+				OpenmetricsInstance: types.OpenmetricsInstance{
+					Tags: []string{"instance_tag:something"},
+				},
+				EnabledRates: []string{ //default
+					"diskio.io_service_bytes.stats.total",
+					"network[\\.].._bytes",
+					"cpu[\\.].*[\\.]total",
+					"+cpu[\\.].*[\\.]total", //invalid regexp, should be skipped in NewProvider.
+				},
+				UseStatsSummaryAsSource: &useStatsSummaryAsSource,
+			}
 
-            p := NewProvider(
-                &containers.Filter{
-                    Enabled: true,
-                },
-                config,
-                store,
-            )
-            assert.NoError(t, err)
+			p := NewProvider(
+				&containers.Filter{
+					Enabled: true,
+				},
+				config,
+				store,
+			)
+			assert.NoError(t, err)
 
-            err = p.Provide(kubeletMock, mockSender)
-            if !reflect.DeepEqual(err, tt.want.err) {
-                t.Errorf("Collect() error = %v, wantErr %v", err, tt.want.err)
-                return
-            }
-            mockSender.AssertNumberOfCalls(t, "Gauge", len(tt.want.gaugeMetrics))
-            mockSender.AssertNumberOfCalls(t, "Rate", len(tt.want.rateMetrics))
-            for _, metric := range tt.want.gaugeMetrics {
-                mockSender.AssertMetric(t, "Gauge", metric.name, metric.value, "", metric.tags)
-            }
-            for _, metric := range tt.want.rateMetrics {
-                mockSender.AssertMetric(t, "Rate", metric.name, metric.value, "", metric.tags)
-            }
-        })
-    }
+			err = p.Provide(kubeletMock, mockSender)
+			if !reflect.DeepEqual(err, tt.want.err) {
+				t.Errorf("Collect() error = %v, wantErr %v", err, tt.want.err)
+				return
+			}
+			mockSender.AssertNumberOfCalls(t, "Gauge", len(tt.want.gaugeMetrics))
+			mockSender.AssertNumberOfCalls(t, "Rate", len(tt.want.rateMetrics))
+			for _, metric := range tt.want.gaugeMetrics {
+				mockSender.AssertMetric(t, "Gauge", metric.name, metric.value, "", metric.tags)
+			}
+			for _, metric := range tt.want.rateMetrics {
+				mockSender.AssertMetric(t, "Rate", metric.name, metric.value, "", metric.tags)
+			}
+		})
+	}
 }
 
 func creatFakeStore() *workloadmetatesting.Store {
-    store := workloadmetatesting.NewStore()
-    podEntityID := workloadmeta.EntityID{
-        Kind: workloadmeta.KindKubernetesPod,
-        ID:   "foobar",
-    }
-    pod := &workloadmeta.KubernetesPod{
-        EntityID: podEntityID,
-        EntityMeta: workloadmeta.EntityMeta{
-            Name:      "datadog-agent-1234",
-            Namespace: "default",
-        },
-        Containers: []workloadmeta.OrchestratorContainer{
-            {
-                ID:   "agent-01",
-                Name: "agent",
-            },
-            {
-                ID:   "agent-02",
-                Name: "process-agent",
-            },
-            {
-                ID:   "agent-03",
-                Name: "security-agent",
-            },
-            {
-                ID:   "agent-04",
-                Name: "non-existing-in-summary",
-            },
-        },
-        Ready:         true,
-        Phase:         "Running",
-        IP:            "127.0.0.1",
-        PriorityClass: "some_priority",
-        QOSClass:      "guaranteed",
-    }
-    store.Set(pod)
-    return store
+	store := workloadmetatesting.NewStore()
+	podEntityID := workloadmeta.EntityID{
+		Kind: workloadmeta.KindKubernetesPod,
+		ID:   "foobar",
+	}
+	pod := &workloadmeta.KubernetesPod{
+		EntityID: podEntityID,
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:      "datadog-agent-1234",
+			Namespace: "default",
+		},
+		Containers: []workloadmeta.OrchestratorContainer{
+			{
+				ID:   "agent-01",
+				Name: "agent",
+			},
+			{
+				ID:   "agent-02",
+				Name: "process-agent",
+			},
+			{
+				ID:   "agent-03",
+				Name: "security-agent",
+			},
+			{
+				ID:   "agent-04",
+				Name: "non-existing-in-summary",
+			},
+		},
+		Ready:         true,
+		Phase:         "Running",
+		IP:            "127.0.0.1",
+		PriorityClass: "some_priority",
+		QOSClass:      "guaranteed",
+	}
+	store.Set(pod)
+	return store
 }
 
 func setFakeStatsSummary(t *testing.T, kubeletMock *mock.KubeletMock, rc int, err error) {
-    filePath := "../../testdata/summary.json"
-    content, fileErr := os.ReadFile(filePath)
-    if fileErr != nil {
-        t.Errorf("unable to read test file at: %s, err: %v", filePath, fileErr)
-    }
-    kubeletMock.MockReplies["/stats/summary"] = &mock.HTTPReplyMock{
-        Data:         content,
-        ResponseCode: rc,
-        Error:        err,
-    }
+	filePath := "../../testdata/summary.json"
+	content, fileErr := os.ReadFile(filePath)
+	if fileErr != nil {
+		t.Errorf("unable to read test file at: %s, err: %v", filePath, fileErr)
+	}
+	kubeletMock.MockReplies["/stats/summary"] = &mock.HTTPReplyMock{
+		Data:         content,
+		ResponseCode: rc,
+		Error:        err,
+	}
 }

--- a/pkg/collector/corechecks/containers/kubelet/provider/summary/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/summary/provider_test.go
@@ -8,363 +8,363 @@
 package summary
 
 import (
-	"errors"
-	"os"
-	"reflect"
-	"testing"
+    "errors"
+    "os"
+    "reflect"
+    "testing"
 
-	"github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common/types"
-	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/common"
-	"github.com/DataDog/datadog-agent/pkg/tagger"
-	"github.com/DataDog/datadog-agent/pkg/tagger/local"
-	"github.com/DataDog/datadog-agent/pkg/util/containers"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet/mock"
-	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
-	workloadmetatesting "github.com/DataDog/datadog-agent/pkg/workloadmeta/testing"
+    "github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+    "github.com/DataDog/datadog-agent/pkg/autodiscovery/common/types"
+    checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
+    "github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/common"
+    "github.com/DataDog/datadog-agent/pkg/tagger"
+    "github.com/DataDog/datadog-agent/pkg/tagger/local"
+    "github.com/DataDog/datadog-agent/pkg/util/containers"
+    "github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet/mock"
+    "github.com/DataDog/datadog-agent/pkg/workloadmeta"
+    workloadmetatesting "github.com/DataDog/datadog-agent/pkg/workloadmeta/testing"
 )
 
 var (
-	//entity id: [fake tags]
-	entityTags = map[string][]string{
-		//pod name in summary: datadog-agent-linux-hn9f2
-		"kubernetes_pod_uid://foobar": {
-			"app:datadog-agent",
-		},
-		"container_id://agent-01": {
-			"kube_namespace:datadog-agent-helm",
-			"pod_name:datadog-agent-linux-hn9f2",
-			"kube_container_name:agent",
-		},
-		"container_id://agent-02": {
-			"kube_namespace:datadog-agent-helm",
-			"pod_name:datadog-agent-linux-hn9f2",
-			"kube_container_name:process-agent",
-		},
-		"container_id://agent-03": {
-			"kube_namespace:datadog-agent-helm",
-			"pod_name:datadog-agent-linux-hn9f2",
-			"kube_container_name:security-agent",
-		},
-		"container_id://agent-04": {
-			"kube_namespace:datadog-agent-helm",
-			"pod_name:datadog-agent-linux-hn9f2",
-			"kube_container_name:non-existing-in-summary",
-		},
-	}
+    //entity id: [fake tags]
+    entityTags = map[string][]string{
+        //pod name in summary: datadog-agent-linux-hn9f2
+        "kubernetes_pod_uid://foobar": {
+            "app:datadog-agent",
+        },
+        "container_id://agent-01": {
+            "kube_namespace:datadog-agent-helm",
+            "pod_name:datadog-agent-linux-hn9f2",
+            "kube_container_name:agent",
+        },
+        "container_id://agent-02": {
+            "kube_namespace:datadog-agent-helm",
+            "pod_name:datadog-agent-linux-hn9f2",
+            "kube_container_name:process-agent",
+        },
+        "container_id://agent-03": {
+            "kube_namespace:datadog-agent-helm",
+            "pod_name:datadog-agent-linux-hn9f2",
+            "kube_container_name:security-agent",
+        },
+        "container_id://agent-04": {
+            "kube_namespace:datadog-agent-helm",
+            "pod_name:datadog-agent-linux-hn9f2",
+            "kube_container_name:non-existing-in-summary",
+        },
+    }
 )
 
 func TestProvider_Provide(t *testing.T) {
-	useStatsSummaryAsSource := true
+    useStatsSummaryAsSource := true
 
-	type metrics struct {
-		name  string
-		value float64
-		tags  []string
-	}
+    type metrics struct {
+        name  string
+        value float64
+        tags  []string
+    }
 
-	type response struct {
-		code int
-		err  error
-	}
-	type want struct {
-		gaugeMetrics []metrics
-		rateMetrics  []metrics
-		err          error
-	}
-	tests := []struct {
-		name     string
-		response response
-		want     want
-	}{
-		{
-			name: "endpoint 404 error",
-			response: response{
-				code: 404,
-				err:  errors.New("Unable to fetch stats summary from Kubelet, rc: 404"),
-			},
-			want: want{
-				gaugeMetrics: nil,
-				rateMetrics:  nil,
-				err:          errors.New("Unable to fetch stats summary from Kubelet, rc: 404"),
-			},
-		},
-		{
-			name: "endpoint no error",
-			response: response{
-				code: 200,
-				err:  nil,
-			},
-			want: want{
-				gaugeMetrics: []metrics{
-					{
-						name:  common.KubeletMetricsPrefix + "node.filesystem.usage",
-						value: 14517391360,
-						tags:  []string{"instance_tag:something"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "node.filesystem.usage_pct",
-						value: 0.13977132820196123,
-						tags:  []string{"instance_tag:something"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "node.image.filesystem.usage",
-						value: 10980311040,
-						tags:  []string{"instance_tag:something"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "node.image.filesystem.usage_pct",
-						value: 0.10571683438666064,
-						tags:  []string{"instance_tag:something"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "kubelet.memory.rss",
-						value: 77819904,
-						tags:  []string{"instance_tag:something"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "kubelet.memory.usage",
-						value: 147464192,
-						tags:  []string{"instance_tag:something"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "kubelet.cpu.usage",
-						value: 42549809,
-						tags:  []string{"instance_tag:something"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "runtime.memory.rss",
-						value: 219836416,
-						tags:  []string{"instance_tag:something"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "runtime.memory.usage",
-						value: 1521729536,
-						tags:  []string{"instance_tag:something"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "runtime.cpu.usage",
-						value: 58035303,
-						tags:  []string{"instance_tag:something"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "ephemeral_storage.usage",
-						value: 17596416,
-						tags:  []string{"instance_tag:something", "app:datadog-agent"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "filesystem.usage",
-						value: 94208,
-						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "filesystem.usage_pct",
-						value: 9.070208938178244e-07,
-						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "filesystem.usage",
-						value: 102400,
-						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "filesystem.usage_pct",
-						value: 9.858922758889397e-07,
-						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "filesystem.usage",
-						value: 69632,
-						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "filesystem.usage_pct",
-						value: 6.704067476044789e-07,
-						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
-					},
-				},
-				rateMetrics: []metrics{
-					{
-						name:  common.KubeletMetricsPrefix + "network.tx_bytes",
-						value: 958986495,
-						tags:  []string{"instance_tag:something", "app:datadog-agent"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "network.rx_bytes",
-						value: 870160903,
-						tags:  []string{"instance_tag:something", "app:datadog-agent"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "cpu.usage.total",
-						value: 45241120000,
-						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "memory.working_set",
-						value: 80461824,
-						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "memory.usage",
-						value: 85618688,
-						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "cpu.usage.total",
-						value: 6361765000,
-						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "memory.working_set",
-						value: 52338688,
-						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "memory.usage",
-						value: 52842496,
-						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "cpu.usage.total",
-						value: 6903135000,
-						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "memory.working_set",
-						value: 68685824,
-						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
-					},
-					{
-						name:  common.KubeletMetricsPrefix + "memory.usage",
-						value: 69447680,
-						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
-							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
-					},
-				},
-				err: nil,
-			},
-		},
-	}
+    type response struct {
+        code int
+        err  error
+    }
+    type want struct {
+        gaugeMetrics []metrics
+        rateMetrics  []metrics
+        err          error
+    }
+    tests := []struct {
+        name     string
+        response response
+        want     want
+    }{
+        {
+            name: "endpoint 404 error",
+            response: response{
+                code: 404,
+                err:  errors.New("Unable to fetch stats summary from Kubelet, rc: 404"),
+            },
+            want: want{
+                gaugeMetrics: nil,
+                rateMetrics:  nil,
+                err:          errors.New("Unable to fetch stats summary from Kubelet, rc: 404"),
+            },
+        },
+        {
+            name: "endpoint no error",
+            response: response{
+                code: 200,
+                err:  nil,
+            },
+            want: want{
+                gaugeMetrics: []metrics{
+                    {
+                        name:  common.KubeletMetricsPrefix + "node.filesystem.usage",
+                        value: 14517391360,
+                        tags:  []string{"instance_tag:something"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "node.filesystem.usage_pct",
+                        value: 0.13977132820196123,
+                        tags:  []string{"instance_tag:something"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "node.image.filesystem.usage",
+                        value: 10980311040,
+                        tags:  []string{"instance_tag:something"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "node.image.filesystem.usage_pct",
+                        value: 0.10571683438666064,
+                        tags:  []string{"instance_tag:something"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "kubelet.memory.rss",
+                        value: 77819904,
+                        tags:  []string{"instance_tag:something"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "kubelet.memory.usage",
+                        value: 147464192,
+                        tags:  []string{"instance_tag:something"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "kubelet.cpu.usage",
+                        value: 42549809,
+                        tags:  []string{"instance_tag:something"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "runtime.memory.rss",
+                        value: 219836416,
+                        tags:  []string{"instance_tag:something"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "runtime.memory.usage",
+                        value: 1521729536,
+                        tags:  []string{"instance_tag:something"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "runtime.cpu.usage",
+                        value: 58035303,
+                        tags:  []string{"instance_tag:something"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "ephemeral_storage.usage",
+                        value: 17596416,
+                        tags:  []string{"instance_tag:something", "app:datadog-agent"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "filesystem.usage",
+                        value: 94208,
+                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "filesystem.usage_pct",
+                        value: 9.070208938178244e-07,
+                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "filesystem.usage",
+                        value: 102400,
+                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "filesystem.usage_pct",
+                        value: 9.858922758889397e-07,
+                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "filesystem.usage",
+                        value: 69632,
+                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "filesystem.usage_pct",
+                        value: 6.704067476044789e-07,
+                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
+                    },
+                },
+                rateMetrics: []metrics{
+                    {
+                        name:  common.KubeletMetricsPrefix + "network.tx_bytes",
+                        value: 958986495,
+                        tags:  []string{"instance_tag:something", "app:datadog-agent"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "network.rx_bytes",
+                        value: 870160903,
+                        tags:  []string{"instance_tag:something", "app:datadog-agent"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "cpu.usage.total",
+                        value: 45241120000,
+                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "memory.working_set",
+                        value: 80461824,
+                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "memory.usage",
+                        value: 85618688,
+                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "cpu.usage.total",
+                        value: 6361765000,
+                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "memory.working_set",
+                        value: 52338688,
+                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "memory.usage",
+                        value: 52842496,
+                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "cpu.usage.total",
+                        value: 6903135000,
+                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "memory.working_set",
+                        value: 68685824,
+                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
+                    },
+                    {
+                        name:  common.KubeletMetricsPrefix + "memory.usage",
+                        value: 69447680,
+                        tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+                            "pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
+                    },
+                },
+                err: nil,
+            },
+        },
+    }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var err error
-			mockSender := mocksender.NewMockSender(checkid.ID(t.Name()))
-			mockSender.SetupAcceptAll()
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            var err error
+            mockSender := mocksender.NewMockSender(checkid.ID(t.Name()))
+            mockSender.SetupAcceptAll()
 
-			fakeTagger := local.NewFakeTagger()
-			for entity, tags := range entityTags {
-				fakeTagger.SetTags(entity, "foo", tags, nil, nil, nil)
-			}
-			tagger.SetDefaultTagger(fakeTagger)
-			store := creatFakeStore()
-			kubeletMock := mock.NewKubeletMock()
-			setFakeStatsSummary(t, kubeletMock, tt.response.code, tt.response.err)
+            fakeTagger := local.NewFakeTagger()
+            for entity, tags := range entityTags {
+                fakeTagger.SetTags(entity, "foo", tags, nil, nil, nil)
+            }
+            tagger.SetDefaultTagger(fakeTagger)
+            store := creatFakeStore()
+            kubeletMock := mock.NewKubeletMock()
+            setFakeStatsSummary(t, kubeletMock, tt.response.code, tt.response.err)
 
-			config := &common.KubeletConfig{
-				OpenmetricsInstance: types.OpenmetricsInstance{
-					Tags: []string{"instance_tag:something"},
-				},
-				EnabledRates: []string{ //default
-					"diskio.io_service_bytes.stats.total",
-					"network[\\.].._bytes",
-					"cpu[\\.].*[\\.]total"},
-				UseStatsSummaryAsSource: &useStatsSummaryAsSource,
-			}
+            config := &common.KubeletConfig{
+                OpenmetricsInstance: types.OpenmetricsInstance{
+                    Tags: []string{"instance_tag:something"},
+                },
+                EnabledRates: []string{ //default
+                    "diskio.io_service_bytes.stats.total",
+                    "network[\\.].._bytes",
+                    "cpu[\\.].*[\\.]total"},
+                UseStatsSummaryAsSource: &useStatsSummaryAsSource,
+            }
 
-			p := NewProvider(
-				&containers.Filter{
-					Enabled: true,
-				},
-				config,
-				store,
-			)
-			assert.NoError(t, err)
+            p := NewProvider(
+                &containers.Filter{
+                    Enabled: true,
+                },
+                config,
+                store,
+            )
+            assert.NoError(t, err)
 
-			err = p.Provide(kubeletMock, mockSender)
-			if !reflect.DeepEqual(err, tt.want.err) {
-				t.Errorf("Collect() error = %v, wantErr %v", err, tt.want.err)
-				return
-			}
-			mockSender.AssertNumberOfCalls(t, "Gauge", len(tt.want.gaugeMetrics))
-			mockSender.AssertNumberOfCalls(t, "Rate", len(tt.want.rateMetrics))
-			for _, metric := range tt.want.gaugeMetrics {
-				mockSender.AssertMetric(t, "Gauge", metric.name, metric.value, "", metric.tags)
-			}
-			for _, metric := range tt.want.rateMetrics {
-				mockSender.AssertMetric(t, "Rate", metric.name, metric.value, "", metric.tags)
-			}
-		})
-	}
+            err = p.Provide(kubeletMock, mockSender)
+            if !reflect.DeepEqual(err, tt.want.err) {
+                t.Errorf("Collect() error = %v, wantErr %v", err, tt.want.err)
+                return
+            }
+            mockSender.AssertNumberOfCalls(t, "Gauge", len(tt.want.gaugeMetrics))
+            mockSender.AssertNumberOfCalls(t, "Rate", len(tt.want.rateMetrics))
+            for _, metric := range tt.want.gaugeMetrics {
+                mockSender.AssertMetric(t, "Gauge", metric.name, metric.value, "", metric.tags)
+            }
+            for _, metric := range tt.want.rateMetrics {
+                mockSender.AssertMetric(t, "Rate", metric.name, metric.value, "", metric.tags)
+            }
+        })
+    }
 }
 
 func creatFakeStore() *workloadmetatesting.Store {
-	store := workloadmetatesting.NewStore()
-	podEntityID := workloadmeta.EntityID{
-		Kind: workloadmeta.KindKubernetesPod,
-		ID:   "foobar",
-	}
-	pod := &workloadmeta.KubernetesPod{
-		EntityID: podEntityID,
-		EntityMeta: workloadmeta.EntityMeta{
-			Name:      "datadog-agent-1234",
-			Namespace: "default",
-		},
-		Containers: []workloadmeta.OrchestratorContainer{
-			{
-				ID:   "agent-01",
-				Name: "agent",
-			},
-			{
-				ID:   "agent-02",
-				Name: "process-agent",
-			},
-			{
-				ID:   "agent-03",
-				Name: "security-agent",
-			},
-			{
-				ID:   "agent-04",
-				Name: "non-existing-in-summary",
-			},
-		},
-		Ready:         true,
-		Phase:         "Running",
-		IP:            "127.0.0.1",
-		PriorityClass: "some_priority",
-		QOSClass:      "guaranteed",
-	}
-	store.Set(pod)
-	return store
+    store := workloadmetatesting.NewStore()
+    podEntityID := workloadmeta.EntityID{
+        Kind: workloadmeta.KindKubernetesPod,
+        ID:   "foobar",
+    }
+    pod := &workloadmeta.KubernetesPod{
+        EntityID: podEntityID,
+        EntityMeta: workloadmeta.EntityMeta{
+            Name:      "datadog-agent-1234",
+            Namespace: "default",
+        },
+        Containers: []workloadmeta.OrchestratorContainer{
+            {
+                ID:   "agent-01",
+                Name: "agent",
+            },
+            {
+                ID:   "agent-02",
+                Name: "process-agent",
+            },
+            {
+                ID:   "agent-03",
+                Name: "security-agent",
+            },
+            {
+                ID:   "agent-04",
+                Name: "non-existing-in-summary",
+            },
+        },
+        Ready:         true,
+        Phase:         "Running",
+        IP:            "127.0.0.1",
+        PriorityClass: "some_priority",
+        QOSClass:      "guaranteed",
+    }
+    store.Set(pod)
+    return store
 }
 
 func setFakeStatsSummary(t *testing.T, kubeletMock *mock.KubeletMock, rc int, err error) {
-	filePath := "../../testdata/summary.json"
-	var content []byte
-	content, err = os.ReadFile(filePath)
-	if err != nil {
-		t.Errorf("unable to read test file at: %s, err: %v", filePath, err)
-	}
-	kubeletMock.MockReplies["/stats/summary"] = &mock.HTTPReplyMock{
-		Data:         content,
-		ResponseCode: rc,
-		Error:        err,
-	}
+    filePath := "../../testdata/summary.json"
+    var content []byte
+    content, err = os.ReadFile(filePath)
+    if err != nil {
+        t.Errorf("unable to read test file at: %s, err: %v", filePath, err)
+    }
+    kubeletMock.MockReplies["/stats/summary"] = &mock.HTTPReplyMock{
+        Data:         content,
+        ResponseCode: rc,
+        Error:        err,
+    }
 }

--- a/pkg/collector/corechecks/containers/kubelet/provider/summary/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/summary/provider_test.go
@@ -1,0 +1,374 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubelet
+
+package summary
+
+import (
+	"errors"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common/types"
+	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/common"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/local"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet/mock"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	workloadmetatesting "github.com/DataDog/datadog-agent/pkg/workloadmeta/testing"
+)
+
+var (
+	//entity id: [fake tags]
+	entityTags = map[string][]string{
+		//pod name in summary: datadog-agent-linux-hn9f2
+		"kubernetes_pod_uid://foobar": {
+			"app:datadog-agent",
+		},
+		"container_id://agent-01": {
+			"kube_namespace:datadog-agent-helm",
+			"pod_name:datadog-agent-linux-hn9f2",
+			"kube_container_name:agent",
+		},
+		"container_id://agent-02": {
+			"kube_namespace:datadog-agent-helm",
+			"pod_name:datadog-agent-linux-hn9f2",
+			"kube_container_name:process-agent",
+		},
+		"container_id://agent-03": {
+			"kube_namespace:datadog-agent-helm",
+			"pod_name:datadog-agent-linux-hn9f2",
+			"kube_container_name:security-agent",
+		},
+		"container_id://agent-04": {
+			"kube_namespace:datadog-agent-helm",
+			"pod_name:datadog-agent-linux-hn9f2",
+			"kube_container_name:non-existing-in-summary",
+		},
+	}
+)
+
+func TestProvider_Provide(t *testing.T) {
+	useStatsSummaryAsSource := true
+
+	type metrics struct {
+		name  string
+		value float64
+		tags  []string
+	}
+
+	type response struct {
+		code int
+		err  error
+	}
+	type want struct {
+		gaugeMetrics []metrics
+		rateMetrics  []metrics
+		err          error
+	}
+	tests := []struct {
+		name     string
+		response response
+		want     want
+	}{
+		{
+			name: "endpoint 404 error",
+			response: response{
+				code: 404,
+				err:  errors.New("Unable to fetch stats summary from Kubelet, rc: 404"),
+			},
+			want: want{
+				gaugeMetrics: nil,
+				rateMetrics:  nil,
+				err:          errors.New("Unable to fetch stats summary from Kubelet, rc: 404"),
+			},
+		},
+		{
+			name: "endpoint no error",
+			response: response{
+				code: 200,
+				err:  nil,
+			},
+			want: want{
+				gaugeMetrics: []metrics{
+					{
+						name:  common.KubeletMetricsPrefix + "node.filesystem.usage",
+						value: 14517391360,
+						tags:  []string{"instance_tag:something"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "node.filesystem.usage_pct",
+						value: 0.13977132820196123,
+						tags:  []string{"instance_tag:something"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "node.image.filesystem.usage",
+						value: 10980311040,
+						tags:  []string{"instance_tag:something"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "node.image.filesystem.usage_pct",
+						value: 0.10571683438666064,
+						tags:  []string{"instance_tag:something"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "kubelet.memory.rss",
+						value: 77819904,
+						tags:  []string{"instance_tag:something"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "kubelet.memory.usage",
+						value: 147464192,
+						tags:  []string{"instance_tag:something"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "kubelet.cpu.usage",
+						value: 42549809,
+						tags:  []string{"instance_tag:something"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "runtime.memory.rss",
+						value: 219836416,
+						tags:  []string{"instance_tag:something"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "runtime.memory.usage",
+						value: 1521729536,
+						tags:  []string{"instance_tag:something"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "runtime.cpu.usage",
+						value: 58035303,
+						tags:  []string{"instance_tag:something"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "ephemeral_storage.usage",
+						value: 17596416,
+						tags:  []string{"instance_tag:something", "app:datadog-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "filesystem.usage",
+						value: 94208,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "filesystem.usage_pct",
+						value: 9.070208938178244e-07,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "filesystem.usage",
+						value: 102400,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "filesystem.usage_pct",
+						value: 9.858922758889397e-07,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "filesystem.usage",
+						value: 69632,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "filesystem.usage_pct",
+						value: 6.704067476044789e-07,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
+					},
+				},
+				rateMetrics: []metrics{
+					{
+						name:  common.KubeletMetricsPrefix + "network.tx_bytes",
+						value: 958986495,
+						tags:  []string{"instance_tag:something", "app:datadog-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "network.rx_bytes",
+						value: 870160903,
+						tags:  []string{"instance_tag:something", "app:datadog-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "cpu.usage.total",
+						value: 45241120000,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "memory.working_set",
+						value: 80461824,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "memory.usage",
+						value: 85618688,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "cpu.usage.total",
+						value: 6361765000,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "memory.working_set",
+						value: 52338688,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "memory.usage",
+						value: 52842496,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:security-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "cpu.usage.total",
+						value: 6903135000,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "memory.working_set",
+						value: 68685824,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
+					},
+					{
+						name:  common.KubeletMetricsPrefix + "memory.usage",
+						value: 69447680,
+						tags: []string{"instance_tag:something", "kube_namespace:datadog-agent-helm",
+							"pod_name:datadog-agent-linux-hn9f2", "kube_container_name:process-agent"},
+					},
+				},
+				err: nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			mockSender := mocksender.NewMockSender(checkid.ID(t.Name()))
+			mockSender.SetupAcceptAll()
+
+			fakeTagger := local.NewFakeTagger()
+			for entity, tags := range entityTags {
+				fakeTagger.SetTags(entity, "foo", tags, nil, nil, nil)
+			}
+			tagger.SetDefaultTagger(fakeTagger)
+			store := creatFakeStore()
+			kubeletMock := mock.NewKubeletMock()
+			setFakeStatsSummary(t, kubeletMock, tt.response.code, tt.response.err)
+
+			config := &common.KubeletConfig{
+				OpenmetricsInstance: types.OpenmetricsInstance{
+					Tags: []string{"instance_tag:something"},
+				},
+				EnabledRates: []string{
+					"diskio.io_service_bytes.stats.total",
+					"network[\\.].._bytes",
+					"cpu[\\.].*[\\.]total"},
+				UseStatsSummaryAsSource: &useStatsSummaryAsSource,
+			}
+
+			p := NewProvider(
+				&containers.Filter{
+					Enabled: true,
+				},
+				config,
+				store,
+			)
+			assert.NoError(t, err)
+
+			err = p.Provide(kubeletMock, mockSender)
+			if !reflect.DeepEqual(err, tt.want.err) {
+				t.Errorf("Collect() error = %v, wantErr %v", err, tt.want.err)
+				return
+			}
+			mockSender.AssertNumberOfCalls(t, "Gauge", len(tt.want.gaugeMetrics))
+			mockSender.AssertNumberOfCalls(t, "Rate", len(tt.want.rateMetrics))
+			for _, metric := range tt.want.gaugeMetrics {
+				mockSender.AssertMetric(t, "Gauge", metric.name, metric.value, "", metric.tags)
+			}
+			for _, metric := range tt.want.rateMetrics {
+				mockSender.AssertMetric(t, "Rate", metric.name, metric.value, "", metric.tags)
+			}
+		})
+	}
+}
+
+func creatFakeStore() *workloadmetatesting.Store {
+	store := workloadmetatesting.NewStore()
+	podEntityID := workloadmeta.EntityID{
+		Kind: workloadmeta.KindKubernetesPod,
+		ID:   "foobar",
+	}
+	pod := &workloadmeta.KubernetesPod{
+		EntityID: podEntityID,
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:      "datadog-agent-1234",
+			Namespace: "default",
+		},
+		Containers: []workloadmeta.OrchestratorContainer{
+			{
+				ID:   "agent-01",
+				Name: "agent",
+			},
+			{
+				ID:   "agent-02",
+				Name: "process-agent",
+			},
+			{
+				ID:   "agent-03",
+				Name: "security-agent",
+			},
+			{
+				ID:   "agent-04",
+				Name: "non-existing-in-summary",
+			},
+		},
+		Ready:         true,
+		Phase:         "Running",
+		IP:            "127.0.0.1",
+		PriorityClass: "some_priority",
+		QOSClass:      "guaranteed",
+	}
+	store.Set(pod)
+	return store
+}
+
+func setFakeStatsSummary(t *testing.T, kubeletMock *mock.KubeletMock, rc int, err error) {
+	filePath := "../../testdata/summary.json"
+	var content []byte
+	content, err = os.ReadFile(filePath)
+	if err != nil {
+		t.Errorf("unable to read test file at: %s, err: %v", filePath, err)
+	}
+	kubeletMock.MockReplies["/stats/summary"] = &mock.HTTPReplyMock{
+		Data:         content,
+		ResponseCode: rc,
+		Error:        err,
+	}
+}
+
+func clearFakeStatsSummary(kubeletMock *mock.KubeletMock) {
+	delete(kubeletMock.MockReplies, "/stats/summary")
+}

--- a/pkg/collector/corechecks/containers/kubelet/provider/summary/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/summary/provider_test.go
@@ -282,7 +282,7 @@ func TestProvider_Provide(t *testing.T) {
 				OpenmetricsInstance: types.OpenmetricsInstance{
 					Tags: []string{"instance_tag:something"},
 				},
-				EnabledRates: []string{
+				EnabledRates: []string{ //default
 					"diskio.io_service_bytes.stats.total",
 					"network[\\.].._bytes",
 					"cpu[\\.].*[\\.]total"},

--- a/pkg/collector/corechecks/containers/kubelet/provider/summary/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/summary/provider_test.go
@@ -357,10 +357,9 @@ func creatFakeStore() *workloadmetatesting.Store {
 
 func setFakeStatsSummary(t *testing.T, kubeletMock *mock.KubeletMock, rc int, err error) {
     filePath := "../../testdata/summary.json"
-    var content []byte
-    content, err = os.ReadFile(filePath)
-    if err != nil {
-        t.Errorf("unable to read test file at: %s, err: %v", filePath, err)
+    content, fileErr := os.ReadFile(filePath)
+    if fileErr != nil {
+        t.Errorf("unable to read test file at: %s, err: %v", filePath, fileErr)
     }
     kubeletMock.MockReplies["/stats/summary"] = &mock.HTTPReplyMock{
         Data:         content,

--- a/pkg/collector/corechecks/containers/kubelet/testdata/summary.json
+++ b/pkg/collector/corechecks/containers/kubelet/testdata/summary.json
@@ -1,0 +1,737 @@
+{
+    "node": {
+        "nodeName": "gke-minyi-test-gke-ubuntu-containerd-178fd335-w4wq",
+        "systemContainers": [
+            {
+                "name": "kubelet",
+                "startTime": "2023-08-26T07:43:23Z",
+                "cpu": {
+                    "time": "2023-09-06T05:07:22Z",
+                    "usageNanoCores": 42549809,
+                    "usageCoreNanoSeconds": 46995115702000
+                },
+                "memory": {
+                    "time": "2023-09-06T05:07:22Z",
+                    "usageBytes": 147464192,
+                    "workingSetBytes": 125190144,
+                    "rssBytes": 77819904,
+                    "pageFaults": 33443506,
+                    "majorPageFaults": 1463
+                }
+            },
+            {
+                "name": "runtime",
+                "startTime": "2023-08-26T07:43:22Z",
+                "cpu": {
+                    "time": "2023-09-06T05:07:10Z",
+                    "usageNanoCores": 58035303,
+                    "usageCoreNanoSeconds": 67836824833000
+                },
+                "memory": {
+                    "time": "2023-09-06T05:07:10Z",
+                    "usageBytes": 1521729536,
+                    "workingSetBytes": 1024487424,
+                    "rssBytes": 219836416,
+                    "pageFaults": 870178114,
+                    "majorPageFaults": 2781
+                }
+            },
+            {
+                "name": "pods",
+                "startTime": "2023-08-26T07:43:23Z",
+                "cpu": {
+                    "time": "2023-09-06T05:07:14Z",
+                    "usageNanoCores": 183616682,
+                    "usageCoreNanoSeconds": 224982637962000
+                },
+                "memory": {
+                    "time": "2023-09-06T05:07:14Z",
+                    "availableBytes": 5007962112,
+                    "usageBytes": 1576058880,
+                    "workingSetBytes": 1404874752,
+                    "rssBytes": 917598208,
+                    "pageFaults": 793623725,
+                    "majorPageFaults": 19988
+                }
+            }
+        ],
+        "startTime": "2023-08-26T07:42:33Z",
+        "cpu": {
+            "time": "2023-09-06T05:07:14Z",
+            "usageNanoCores": 301840475,
+            "usageCoreNanoSeconds": 339715566254000
+        },
+        "memory": {
+            "time": "2023-09-06T05:07:14Z",
+            "availableBytes": 4921966592,
+            "usageBytes": 4277596160,
+            "workingSetBytes": 3398230016,
+            "rssBytes": 1335762944,
+            "pageFaults": 2121142812,
+            "majorPageFaults": 32404
+        },
+        "network": {
+            "time": "2023-09-06T05:07:14Z",
+            "name": "",
+            "interfaces": [
+                {
+                    "name": "ens4",
+                    "rxBytes": 34885750476,
+                    "rxErrors": 0,
+                    "txBytes": 47832988857,
+                    "txErrors": 0
+                },
+                {
+                    "name": "gkefa54d372f0c",
+                    "rxBytes": 628,
+                    "rxErrors": 0,
+                    "txBytes": 446,
+                    "txErrors": 0
+                },
+                {
+                    "name": "cilium_net",
+                    "rxBytes": 360,
+                    "rxErrors": 0,
+                    "txBytes": 360,
+                    "txErrors": 0
+                },
+                {
+                    "name": "cilium_host",
+                    "rxBytes": 360,
+                    "rxErrors": 0,
+                    "txBytes": 360,
+                    "txErrors": 0
+                },
+                {
+                    "name": "gke9500533e9ab",
+                    "rxBytes": 355299146,
+                    "rxErrors": 0,
+                    "txBytes": 118571325,
+                    "txErrors": 0
+                },
+                {
+                    "name": "gke9cc9e5bf6fd",
+                    "rxBytes": 827659605,
+                    "rxErrors": 0,
+                    "txBytes": 2096086174,
+                    "txErrors": 0
+                },
+                {
+                    "name": "gkedbd70c5edd9",
+                    "rxBytes": 34967090,
+                    "rxErrors": 0,
+                    "txBytes": 36707488,
+                    "txErrors": 0
+                },
+                {
+                    "name": "gke95994f8b32d",
+                    "rxBytes": 218842908,
+                    "rxErrors": 0,
+                    "txBytes": 96753653,
+                    "txErrors": 0
+                },
+                {
+                    "name": "gkeb2d74f759f1",
+                    "rxBytes": 73645992,
+                    "rxErrors": 0,
+                    "txBytes": 11765964,
+                    "txErrors": 0
+                },
+                {
+                    "name": "gkef7994d042a0",
+                    "rxBytes": 30378277,
+                    "rxErrors": 0,
+                    "txBytes": 134804348,
+                    "txErrors": 0
+                },
+                {
+                    "name": "gkec784dcb3c92",
+                    "rxBytes": 958975826,
+                    "rxErrors": 0,
+                    "txBytes": 870151495,
+                    "txErrors": 0
+                },
+                {
+                    "name": "gked363f704a81",
+                    "rxBytes": 84690924,
+                    "rxErrors": 0,
+                    "txBytes": 66816859,
+                    "txErrors": 0
+                },
+                {
+                    "name": "gke0c68a261717",
+                    "rxBytes": 1223405205,
+                    "rxErrors": 0,
+                    "txBytes": 529111059,
+                    "txErrors": 0
+                },
+                {
+                    "name": "gkeed9cbbb3ffc",
+                    "rxBytes": 963060005,
+                    "rxErrors": 0,
+                    "txBytes": 937334172,
+                    "txErrors": 0
+                },
+                {
+                    "name": "gke494c34fa349",
+                    "rxBytes": 33428303,
+                    "rxErrors": 0,
+                    "txBytes": 289333780,
+                    "txErrors": 0
+                },
+                {
+                    "name": "gkec194322284e",
+                    "rxBytes": 1223614605,
+                    "rxErrors": 0,
+                    "txBytes": 528508685,
+                    "txErrors": 0
+                },
+                {
+                    "name": "gke06a668dd215",
+                    "rxBytes": 33230719,
+                    "rxErrors": 0,
+                    "txBytes": 256681560,
+                    "txErrors": 0
+                },
+                {
+                    "name": "gke4afaa6d8e17",
+                    "rxBytes": 1030832485,
+                    "rxErrors": 0,
+                    "txBytes": 8157681016,
+                    "txErrors": 0
+                },
+                {
+                    "name": "gke4bb1269ee3e",
+                    "rxBytes": 77581888,
+                    "rxErrors": 0,
+                    "txBytes": 69199499,
+                    "txErrors": 0
+                },
+                {
+                    "name": "gke8d9f2ff9f73",
+                    "rxBytes": 43773216,
+                    "rxErrors": 0,
+                    "txBytes": 36011623,
+                    "txErrors": 0
+                },
+                {
+                    "name": "gkee88dabfde74",
+                    "rxBytes": 296800,
+                    "rxErrors": 0,
+                    "txBytes": 3032905,
+                    "txErrors": 0
+                },
+                {
+                    "name": "gke646c291431c",
+                    "rxBytes": 1538939,
+                    "rxErrors": 0,
+                    "txBytes": 6090111,
+                    "txErrors": 0
+                }
+            ]
+        },
+        "fs": {
+            "time": "2023-09-06T05:07:14Z",
+            "availableBytes": 89331134464,
+            "capacityBytes": 103865303040,
+            "usedBytes": 14517391360,
+            "inodesFree": 12618076,
+            "inodes": 12902400,
+            "inodesUsed": 284324
+        },
+        "runtime": {
+            "imageFs": {
+                "time": "2023-09-06T05:07:22Z",
+                "availableBytes": 89331134464,
+                "capacityBytes": 103865303040,
+                "usedBytes": 10980311040,
+                "inodesFree": 12618076,
+                "inodes": 12902400,
+                "inodesUsed": 204550
+            }
+        },
+        "rlimit": {
+            "time": "2023-09-06T05:07:24Z",
+            "maxpid": 4194304,
+            "curproc": 959
+        }
+    },
+    "pods": [
+        {
+            "podRef": {
+                "name": "datadog-agent-linux-hn9f2",
+                "namespace": "datadog-agent-helm",
+                "uid": "foobar"
+            },
+            "startTime": "2023-09-06T04:58:47Z",
+            "containers": [
+                {
+                    "name": "security-agent",
+                    "startTime": "2023-09-06T04:59:07Z",
+                    "cpu": {
+                        "time": "2023-09-06T05:07:16Z",
+                        "usageNanoCores": 7627601,
+                        "usageCoreNanoSeconds": 6361765000
+                    },
+                    "memory": {
+                        "time": "2023-09-06T05:07:16Z",
+                        "usageBytes": 52842496,
+                        "workingSetBytes": 52338688,
+                        "rssBytes": 49000448,
+                        "pageFaults": 28317,
+                        "majorPageFaults": 46
+                    },
+                    "rootfs": {
+                        "time": "2023-09-06T05:07:22Z",
+                        "availableBytes": 89331134464,
+                        "capacityBytes": 103865303040,
+                        "usedBytes": 102400,
+                        "inodesFree": 12618076,
+                        "inodes": 12902400,
+                        "inodesUsed": 23
+                    },
+                    "logs": {
+                        "time": "2023-09-06T05:07:24Z",
+                        "availableBytes": 89331134464,
+                        "capacityBytes": 103865303040,
+                        "usedBytes": 40960,
+                        "inodesFree": 12618076,
+                        "inodes": 12902400,
+                        "inodesUsed": 1
+                    }
+                },
+                {
+                    "name": "process-agent",
+                    "startTime": "2023-09-06T04:59:05Z",
+                    "cpu": {
+                        "time": "2023-09-06T05:07:23Z",
+                        "usageNanoCores": 10012658,
+                        "usageCoreNanoSeconds": 6903135000
+                    },
+                    "memory": {
+                        "time": "2023-09-06T05:07:23Z",
+                        "usageBytes": 69447680,
+                        "workingSetBytes": 68685824,
+                        "rssBytes": 65081344,
+                        "pageFaults": 29901,
+                        "majorPageFaults": 32
+                    },
+                    "rootfs": {
+                        "time": "2023-09-06T05:07:22Z",
+                        "availableBytes": 89331134464,
+                        "capacityBytes": 103865303040,
+                        "usedBytes": 69632,
+                        "inodesFree": 12618076,
+                        "inodes": 12902400,
+                        "inodesUsed": 17
+                    },
+                    "logs": {
+                        "time": "2023-09-06T05:07:24Z",
+                        "availableBytes": 89331134464,
+                        "capacityBytes": 103865303040,
+                        "usedBytes": 20480,
+                        "inodesFree": 12618076,
+                        "inodes": 12902400,
+                        "inodesUsed": 1
+                    }
+                },
+                {
+                    "name": "agent",
+                    "startTime": "2023-09-06T04:59:03Z",
+                    "cpu": {
+                        "time": "2023-09-06T05:07:17Z",
+                        "usageNanoCores": 80001759,
+                        "usageCoreNanoSeconds": 45241120000
+                    },
+                    "memory": {
+                        "time": "2023-09-06T05:07:17Z",
+                        "usageBytes": 85618688,
+                        "workingSetBytes": 80461824,
+                        "rssBytes": 78069760,
+                        "pageFaults": 62963,
+                        "majorPageFaults": 13
+                    },
+                    "rootfs": {
+                        "time": "2023-09-06T05:07:22Z",
+                        "availableBytes": 89331134464,
+                        "capacityBytes": 103865303040,
+                        "usedBytes": 94208,
+                        "inodesFree": 12618076,
+                        "inodes": 12902400,
+                        "inodesUsed": 23
+                    },
+                    "logs": {
+                        "time": "2023-09-06T05:07:24Z",
+                        "availableBytes": 89331134464,
+                        "capacityBytes": 103865303040,
+                        "usedBytes": 4145152,
+                        "inodesFree": 12618076,
+                        "inodes": 12902400,
+                        "inodesUsed": 1
+                    }
+                },
+                {
+                    "name": "trace-agent",
+                    "startTime": "2023-09-06T04:59:04Z",
+                    "cpu": {
+                        "time": "2023-09-06T05:07:19Z",
+                        "usageNanoCores": 2715247,
+                        "usageCoreNanoSeconds": 1782682000
+                    },
+                    "memory": {
+                        "time": "2023-09-06T05:07:19Z",
+                        "usageBytes": 20754432,
+                        "workingSetBytes": 20459520,
+                        "rssBytes": 18153472,
+                        "pageFaults": 19923,
+                        "majorPageFaults": 22
+                    },
+                    "rootfs": {
+                        "time": "2023-09-06T05:07:22Z",
+                        "availableBytes": 89331134464,
+                        "capacityBytes": 103865303040,
+                        "usedBytes": 61440,
+                        "inodesFree": 12618076,
+                        "inodes": 12902400,
+                        "inodesUsed": 14
+                    },
+                    "logs": {
+                        "time": "2023-09-06T05:07:24Z",
+                        "availableBytes": 89331134464,
+                        "capacityBytes": 103865303040,
+                        "usedBytes": 4096,
+                        "inodesFree": 12618076,
+                        "inodes": 12902400,
+                        "inodesUsed": 1
+                    }
+                },
+                {
+                    "name": "system-probe",
+                    "startTime": "2023-09-06T04:59:06Z",
+                    "cpu": {
+                        "time": "2023-09-06T05:07:14Z",
+                        "usageNanoCores": 21046877,
+                        "usageCoreNanoSeconds": 22024600000
+                    },
+                    "memory": {
+                        "time": "2023-09-06T05:07:14Z",
+                        "usageBytes": 170057728,
+                        "workingSetBytes": 169213952,
+                        "rssBytes": 84545536,
+                        "pageFaults": 43501,
+                        "majorPageFaults": 72
+                    },
+                    "rootfs": {
+                        "time": "2023-09-06T05:07:22Z",
+                        "availableBytes": 89331134464,
+                        "capacityBytes": 103865303040,
+                        "usedBytes": 81920,
+                        "inodesFree": 12618076,
+                        "inodes": 12902400,
+                        "inodesUsed": 20
+                    },
+                    "logs": {
+                        "time": "2023-09-06T05:07:24Z",
+                        "availableBytes": 89331134464,
+                        "capacityBytes": 103865303040,
+                        "usedBytes": 20480,
+                        "inodesFree": 12618076,
+                        "inodes": 12902400,
+                        "inodesUsed": 1
+                    }
+                }
+            ],
+            "cpu": {
+                "time": "2023-09-06T05:07:17Z",
+                "usageNanoCores": 117128141,
+                "usageCoreNanoSeconds": 82453966000
+            },
+            "memory": {
+                "time": "2023-09-06T05:07:17Z",
+                "usageBytes": 410988544,
+                "workingSetBytes": 393912320,
+                "rssBytes": 294862848,
+                "pageFaults": 193712,
+                "majorPageFaults": 194
+            },
+            "network": {
+                "time": "2023-09-06T05:07:13Z",
+                "name": "eth0",
+                "rxBytes": 870160903,
+                "rxErrors": 0,
+                "txBytes": 958986495,
+                "txErrors": 0,
+                "interfaces": [
+                    {
+                        "name": "ens4",
+                        "rxBytes": 34885726327,
+                        "rxErrors": 0,
+                        "txBytes": 47832975365,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "gkefa54d372f0c",
+                        "rxBytes": 628,
+                        "rxErrors": 0,
+                        "txBytes": 446,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "cilium_net",
+                        "rxBytes": 360,
+                        "rxErrors": 0,
+                        "txBytes": 360,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "cilium_host",
+                        "rxBytes": 360,
+                        "rxErrors": 0,
+                        "txBytes": 360,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "gke9500533e9ab",
+                        "rxBytes": 355299146,
+                        "rxErrors": 0,
+                        "txBytes": 118571325,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "gke9cc9e5bf6fd",
+                        "rxBytes": 827658413,
+                        "rxErrors": 0,
+                        "txBytes": 2096084255,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "gkedbd70c5edd9",
+                        "rxBytes": 34967090,
+                        "rxErrors": 0,
+                        "txBytes": 36707488,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "gke95994f8b32d",
+                        "rxBytes": 218842908,
+                        "rxErrors": 0,
+                        "txBytes": 96753653,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "gkeb2d74f759f1",
+                        "rxBytes": 73645992,
+                        "rxErrors": 0,
+                        "txBytes": 11765964,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "gkef7994d042a0",
+                        "rxBytes": 30378277,
+                        "rxErrors": 0,
+                        "txBytes": 134804348,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "gkec784dcb3c92",
+                        "rxBytes": 958974253,
+                        "rxErrors": 0,
+                        "txBytes": 870151274,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "gked363f704a81",
+                        "rxBytes": 84690924,
+                        "rxErrors": 0,
+                        "txBytes": 66816859,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "gke0c68a261717",
+                        "rxBytes": 1223405139,
+                        "rxErrors": 0,
+                        "txBytes": 529110450,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "gkeed9cbbb3ffc",
+                        "rxBytes": 963059873,
+                        "rxErrors": 0,
+                        "txBytes": 937334040,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "gke494c34fa349",
+                        "rxBytes": 33428303,
+                        "rxErrors": 0,
+                        "txBytes": 289333780,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "gkec194322284e",
+                        "rxBytes": 1223614539,
+                        "rxErrors": 0,
+                        "txBytes": 528508076,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "gke06a668dd215",
+                        "rxBytes": 33230719,
+                        "rxErrors": 0,
+                        "txBytes": 256681560,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "gke4afaa6d8e17",
+                        "rxBytes": 1030832380,
+                        "rxErrors": 0,
+                        "txBytes": 8157680845,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "gke4bb1269ee3e",
+                        "rxBytes": 77581213,
+                        "rxErrors": 0,
+                        "txBytes": 69198890,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "gke8d9f2ff9f73",
+                        "rxBytes": 43773216,
+                        "rxErrors": 0,
+                        "txBytes": 36011623,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "gkee88dabfde74",
+                        "rxBytes": 296800,
+                        "rxErrors": 0,
+                        "txBytes": 3032905,
+                        "txErrors": 0
+                    },
+                    {
+                        "name": "gke646c291431c",
+                        "rxBytes": 1534237,
+                        "rxErrors": 0,
+                        "txBytes": 6084399,
+                        "txErrors": 0
+                    }
+                ]
+            },
+            "volume": [
+                {
+                    "time": "2023-09-06T05:06:18Z",
+                    "availableBytes": 89332064256,
+                    "capacityBytes": 103865303040,
+                    "usedBytes": 12288,
+                    "inodesFree": 12618076,
+                    "inodes": 12902400,
+                    "inodesUsed": 5,
+                    "name": "installinfo"
+                },
+                {
+                    "time": "2023-09-06T05:06:18Z",
+                    "availableBytes": 89332064256,
+                    "capacityBytes": 103865303040,
+                    "usedBytes": 12288,
+                    "inodesFree": 12618076,
+                    "inodes": 12902400,
+                    "inodesUsed": 5,
+                    "name": "confd"
+                },
+                {
+                    "time": "2023-09-06T05:06:18Z",
+                    "availableBytes": 89332064256,
+                    "capacityBytes": 103865303040,
+                    "usedBytes": 9625600,
+                    "inodesFree": 12618076,
+                    "inodes": 12902400,
+                    "inodesUsed": 678,
+                    "name": "config"
+                },
+                {
+                    "time": "2023-09-06T05:06:18Z",
+                    "availableBytes": 89332064256,
+                    "capacityBytes": 103865303040,
+                    "usedBytes": 16384,
+                    "inodesFree": 12618076,
+                    "inodes": 12902400,
+                    "inodesUsed": 5,
+                    "name": "datadog-agent-security"
+                },
+                {
+                    "time": "2023-09-06T05:06:18Z",
+                    "availableBytes": 89332064256,
+                    "capacityBytes": 103865303040,
+                    "usedBytes": 8192,
+                    "inodesFree": 12618076,
+                    "inodes": 12902400,
+                    "inodesUsed": 2,
+                    "name": "auth-token"
+                },
+                {
+                    "time": "2023-09-06T05:06:18Z",
+                    "availableBytes": 89332064256,
+                    "capacityBytes": 103865303040,
+                    "usedBytes": 3248128,
+                    "inodesFree": 12618076,
+                    "inodes": 12902400,
+                    "inodesUsed": 6,
+                    "name": "logdatadog"
+                },
+                {
+                    "time": "2023-09-06T05:06:18Z",
+                    "availableBytes": 89332064256,
+                    "capacityBytes": 103865303040,
+                    "usedBytes": 12288,
+                    "inodesFree": 12618076,
+                    "inodes": 12902400,
+                    "inodesUsed": 5,
+                    "name": "sysprobe-config"
+                },
+                {
+                    "time": "2023-09-06T05:06:18Z",
+                    "availableBytes": 89332064256,
+                    "capacityBytes": 103865303040,
+                    "usedBytes": 4096,
+                    "inodesFree": 12618076,
+                    "inodes": 12902400,
+                    "inodesUsed": 3,
+                    "name": "sysprobe-socket-dir"
+                },
+                {
+                    "time": "2023-09-06T05:06:18Z",
+                    "availableBytes": 89332064256,
+                    "capacityBytes": 103865303040,
+                    "usedBytes": 12288,
+                    "inodesFree": 12618076,
+                    "inodes": 12902400,
+                    "inodesUsed": 4,
+                    "name": "tmpdir"
+                },
+                {
+                    "time": "2023-09-06T05:06:18Z",
+                    "availableBytes": 6307966976,
+                    "capacityBytes": 6307979264,
+                    "usedBytes": 12288,
+                    "inodesFree": 1015640,
+                    "inodes": 1015649,
+                    "inodesUsed": 9,
+                    "name": "kube-api-access-g665w"
+                }
+            ],
+            "ephemeral-storage": {
+                "time": "2023-09-06T05:07:24Z",
+                "availableBytes": 89331134464,
+                "capacityBytes": 103865303040,
+                "usedBytes": 17596416,
+                "inodesFree": 12618076,
+                "inodes": 12902400,
+                "inodesUsed": 816
+            },
+            "process_stats": {
+                "process_count": 0
+            }
+        }
+    ]
+}

--- a/releasenotes/notes/add-kubelet-stats-summary-check-0d8761db7f20b6d1.yaml
+++ b/releasenotes/notes/add-kubelet-stats-summary-check-0d8761db7f20b6d1.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add kubelet stats.summary check (kubernetes_core.kubelet.*) to the Agent's core checks to replace the old kubernetes.kubelet check generated from Python.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Port over the logic and metrics for the /stats/summary endpoint, refactoring the existing Kubelet call which is used for the containers corecheck

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Currently, the existing kubelet check is implemented in the integrations-core repo, and is written in python. This current implementation poses several challenges as it relates to maintaining or adding new metrics. Ideally, we would like to improve on these problem areas by re-writing the check as a corecheck in the main agent repo.

/stats/summary is part of this improvement. 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
currently, if the agent is able to communicate with the cadvisor endpoint, the stats/summary is not used.
Therefore to force the agent to use the stats/summary a secret option exist in the check config:use_stats_summary_as_source
```
datadog:
  confd:
    kubelet_core.yaml: |
      init_config:
      instances:
        - min_collection_interval: 20
           use_stats_summary_as_source: true
```

Metrics added are
```
System level
kubernetes_core.node.filesystem.usage
kubernetes_core.node.filesystem.usage_pct
kubernetes_core.node.image.filesystem.usage
kubernetes_core.node.image.filesystem.usage
kubernetes_core.kubelet.memory.rss
kubernetes_core.kubelet.memory.usage
kubernetes_core.kubelet.cpu.usage
kubernetes_core.runtime.cpu.usage
kubernetes_core.runtime.memory.rss
kubernetes_core.runtime.memory.usage

Pod level
kubernetes_core.ephemeral_storage.usage
kubernetes_core.network.tx_bytes
kubernetes_core.network.rx_bytes

Container level
kubernetes_core.cpu.usage.total
kubernetes_core.memory.working_set
kubernetes_core.runtime.memory.usage
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
