### PR TITLE
Create minimal netflow component.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -202,6 +202,7 @@
 /comp/forwarder @DataDog/agent-shared-components
 /comp/logs @DataDog/agent-metrics-logs
 /comp/metadata @DataDog/agent-shared-components
+/comp/netflow @DataDog/network-device-monitoring
 /comp/process @DataDog/processes
 /comp/remote-config @DataDog/remote-config
 /comp/systray @DataDog/windows-agent

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -51,7 +51,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/metadata"
 	"github.com/DataDog/datadog-agent/comp/metadata/runner"
 	"github.com/DataDog/datadog-agent/comp/netflow"
-	"github.com/DataDog/datadog-agent/comp/netflow/server"
+	netflowServer "github.com/DataDog/datadog-agent/comp/netflow/server"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/api/healthprobe"
@@ -182,7 +182,7 @@ func run(log log.Component,
 	sharedSerializer serializer.MetricSerializer,
 	cliParams *cliParams,
 	logsAgent util.Optional[logsAgent.Component],
-	_ server.Component,
+	_ netflowServer.Component,
 ) error {
 	defer func() {
 		stopAgent(cliParams, server)
@@ -258,7 +258,7 @@ func StartAgentWithDefaults(ctxChan <-chan context.Context) (<-chan error, error
 			logsAgent util.Optional[logsAgent.Component],
 			metadataRunner runner.Component,
 			sharedSerializer serializer.MetricSerializer,
-			_ server.Component,
+			_ netflowServer.Component,
 		) error {
 
 			defer StopAgentWithDefaults(server)

--- a/comp/README.md
+++ b/comp/README.md
@@ -98,6 +98,20 @@ Package runner implements a component to generate the 'resources' metadata paylo
 
 Package runner implements a component to generate metadata payload at the right interval.
 
+## [comp/netflow](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/netflow) (Component Bundle)
+
+*Datadog Team*: network-device-monitoring
+
+Package netflow implements the "netflow" bundle, which listens for netflow
+packets, processes them, and forwards relevant data to the backend.
+
+### [comp/netflow/server](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/netflow/server)
+
+Package server implements a component that runs the netflow server.
+When running, it listens for network traffic according to configured
+listeners and aggregates traffic data to send to the backend.
+It does not expose any public methods.
+
 ## [comp/process](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/process) (Component Bundle)
 
 *Datadog Team*: processes

--- a/comp/netflow/bundle.go
+++ b/comp/netflow/bundle.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package netflow implements the "netflow" bundle, which listens for netflow
+// packets, processes them, and forwards relevant data to the backend.
+package netflow
+
+import (
+	"github.com/DataDog/datadog-agent/comp/netflow/server"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: network-device-monitoring
+
+// Bundle defines the fx options for this bundle.
+var Bundle = fxutil.Bundle(
+	server.Module,
+)

--- a/comp/netflow/server/component.go
+++ b/comp/netflow/server/component.go
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package server implements a component that runs the netflow server.
+// When running, it listens for network traffic according to configured
+// listeners and aggregates traffic data to send to the backend.
+// It does not expose any public methods.
+package server
+
+import (
+	"context"
+
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/netflow"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: network-device-monitoring
+
+// Component is the component type.
+type Component interface {
+	Start() error
+	Stop()
+}
+
+// Module defines the fx options for this component.
+var Module = fxutil.Component(
+	fx.Provide(newServer),
+)
+
+type dependencies struct {
+	fx.In
+	Demux  *aggregator.AgentDemultiplexer
+	Conf   config.Component
+	Logger log.Component
+}
+
+func newServer(lc fx.Lifecycle, dep dependencies) (Component, error) {
+	epForwarder, err := dep.Demux.GetEventPlatformForwarder()
+	if err != nil {
+		return nil, err
+	}
+
+	sender, err := dep.Demux.GetDefaultSender()
+	if err != nil {
+		return nil, err
+	}
+	server, err := netflow.NewNetflowServer(sender, epForwarder, dep.Conf, dep.Logger)
+	if err != nil {
+		return nil, err
+	}
+	if netflow.IsEnabled(dep.Conf) {
+		lc.Append(fx.Hook{
+			OnStart: func(ctx context.Context) error {
+				return server.Start()
+			},
+			OnStop: func(ctx context.Context) error {
+				server.Stop()
+				return nil
+			},
+		})
+	}
+	return server, nil
+}

--- a/pkg/netflow/server_integration_test.go
+++ b/pkg/netflow/server_integration_test.go
@@ -52,7 +52,7 @@ network_devices:
 
 	ctrl := gomock.NewController(t)
 	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
-	server, err := NewNetflowServer(sender, epForwarder, config.Datadog, logger)
+	server, err := NewRunningNetflowServer(sender, epForwarder, config.Datadog, logger)
 	require.NoError(t, err, "cannot start Netflow Server")
 	assert.NotNil(t, server)
 
@@ -105,7 +105,7 @@ network_devices:
 
 	ctrl := gomock.NewController(t)
 	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
-	server, err := NewNetflowServer(sender, epForwarder, config.Datadog, logger)
+	server, err := NewRunningNetflowServer(sender, epForwarder, config.Datadog, logger)
 	require.NoError(t, err, "cannot start Netflow Server")
 	assert.NotNil(t, server)
 
@@ -152,7 +152,7 @@ network_devices:
 
 	ctrl := gomock.NewController(t)
 	epForwarder := epforwarder.NewMockEventPlatformForwarder(ctrl)
-	server, err := NewNetflowServer(sender, epForwarder, config.Datadog, logger)
+	server, err := NewRunningNetflowServer(sender, epForwarder, config.Datadog, logger)
 	require.NoError(t, err, "cannot start Netflow Server")
 	assert.NotNil(t, server)
 

--- a/pkg/netflow/server_test.go
+++ b/pkg/netflow/server_test.go
@@ -84,14 +84,14 @@ network_devices:
 	sender, err := demux.GetDefaultSender()
 	require.NoError(t, err, "cannot get default sender")
 
-	server, err := NewNetflowServer(sender, nil, config.Datadog, logger)
+	server, err := NewRunningNetflowServer(sender, nil, config.Datadog, logger)
 	require.NoError(t, err, "cannot start Netflow Server")
 	assert.NotNil(t, server)
 
 	flowProcessor := replaceWithDummyFlowProcessor(server, port)
 
 	// Stops server
-	server.stop()
+	server.Stop()
 
 	// Assert logs present
 	assert.Equal(t, flowProcessor.stopped, true)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This does the bare minimum work necessary to make the netflow server run in a component. It leaves nearly all of netflow unchanged in `/pkg/netflow`, creating a tiny component that just invokes the existing server code.

The only changes to netflow itself are to split out the actual starting of the server from the `NewNetflowServer` method, so that we can create the component without immediately starting it.

### Motivation
This is for [NDMII-772](https://datadoghq.atlassian.net/browse/NDMII-772) (formerly NDM-2470); feedback on #19140 was that it was doing too much in one PR, so this is a tremendously stripped-down first step towards the end product designed there.

### Possible Drawbacks / Trade-offs

Behavior should not change.

Note that we inject the server by making it an argument to the `run` method instead of using an `fx.Invoke` block because using `Invoke` breaks the tests for `./cmd/agent/subcommands/run` by forcing them to load the dependencies for the server, not all of which are available (it fails trying to find the datadog configuration file in `/opt/datadog-agent/etc`).

### Describe how to test/QA your changes

QA should follow the [instructions documented on Confluence for general netflow QA](https://datadoghq.atlassian.net/wiki/spaces/II/pages/2522810587/NetFlow+QA+Testing+Tips). This PR changes how the server is launched, but should not change the actual behavior at all, so the standard QA checks should all function normally.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.


[NDMII-772]: https://datadoghq.atlassian.net/browse/NDMII-772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ