### PR TITLE
[SNMP] Minimal SNMP traps component

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -205,6 +205,7 @@
 /comp/otelcol @DataDog/opentelemetry
 /comp/process @DataDog/processes
 /comp/remote-config @DataDog/remote-config
+/comp/snmptraps @DataDog/network-device-monitoring
 /comp/systray @DataDog/windows-agent
 /comp/trace @DataDog/agent-apm
 /comp/core/sysprobeconfig @DataDog/ebpf-platform

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -561,8 +561,8 @@ func startAgent(
 	}
 
 	// Start SNMP trap server
-	if traps.IsEnabled() {
-		err = traps.StartServer(hostnameDetected, demux)
+	if traps.IsEnabled(pkgconfig.Datadog) {
+		err = traps.StartServer(hostnameDetected, demux, pkgconfig.Datadog)
 		if err != nil {
 			log.Errorf("Failed to start snmp-traps server: %s", err)
 		}

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -562,7 +562,7 @@ func startAgent(
 
 	// Start SNMP trap server
 	if traps.IsEnabled(pkgconfig.Datadog) {
-		err = traps.StartServer(hostnameDetected, demux, pkgconfig.Datadog)
+		err = traps.StartServer(hostnameDetected, demux, pkgconfig.Datadog, log)
 		if err != nil {
 			log.Errorf("Failed to start snmp-traps server: %s", err)
 		}

--- a/comp/README.md
+++ b/comp/README.md
@@ -182,6 +182,19 @@ supported Datadog intakes.
 
 
 
+## [comp/snmptraps](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/snmptraps) (Component Bundle)
+
+*Datadog Team*: network-device-monitoring
+
+Package snmptraps implements the a server that listens for SNMP trap data
+and sends it to the backend.
+
+### [comp/snmptraps/server](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/snmptraps/server)
+
+Package server implements a component that runs the traps server.
+It listens for SNMP trap messages on a configured port, parses and
+reformats them, and sends the resulting data to the backend.
+
 ## [comp/systray](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/systray) (Component Bundle)
 
 *Datadog Team*: windows-agent

--- a/comp/snmptraps/bundle.go
+++ b/comp/snmptraps/bundle.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package snmptraps implements the a server that listens for SNMP trap data
+// and sends it to the backend.
+package snmptraps
+
+import (
+	"github.com/DataDog/datadog-agent/comp/snmptraps/server"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: network-device-monitoring
+
+// Bundle defines the fx options for this bundle.
+var Bundle = fxutil.Bundle(
+	server.Module,
+)

--- a/comp/snmptraps/server/component.go
+++ b/comp/snmptraps/server/component.go
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package server implements a component that runs the traps server.
+// It listens for SNMP trap messages on a configured port, parses and
+// reformats them, and sends the resulting data to the backend.
+package server
+
+import (
+	"context"
+
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/snmp/traps"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+)
+
+// team: network-device-monitoring
+
+// Component is the component type.
+type Component interface {
+	Start() error
+	Stop()
+}
+
+// Module defines the fx options for this component.
+var Module = fxutil.Component(
+	fx.Provide(newServer),
+)
+
+type server struct {
+	hostname string
+	demux    *aggregator.AgentDemultiplexer
+}
+
+func (s *server) Start() error {
+	return traps.StartServer(s.hostname, s.demux)
+}
+
+func (s *server) Stop() {
+	traps.StopServer()
+}
+
+func newServer(demux *aggregator.AgentDemultiplexer) (Component, error) {
+	name, err := hostname.Get(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return &server{
+		hostname: name,
+		demux:    demux,
+	}, nil
+}

--- a/pkg/snmp/traps/config.go
+++ b/pkg/snmp/traps/config.go
@@ -12,14 +12,14 @@ import (
 
 	"github.com/gosnmp/gosnmp"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
 	"github.com/DataDog/datadog-agent/pkg/snmp/utils"
 )
 
 // IsEnabled returns whether SNMP trap collection is enabled in the Agent configuration.
-func IsEnabled() bool {
-	return config.Datadog.GetBool("network_devices.snmp_traps.enabled")
+func IsEnabled(conf config.Component) bool {
+	return conf.GetBool("network_devices.snmp_traps.enabled")
 }
 
 // UserV3 contains the definition of one SNMPv3 user with its username and its auth
@@ -46,9 +46,9 @@ type Config struct {
 }
 
 // ReadConfig builds and returns configuration from Agent configuration.
-func ReadConfig(agentHostname string) (*Config, error) {
+func ReadConfig(agentHostname string, conf config.Component) (*Config, error) {
 	var c Config
-	err := config.Datadog.UnmarshalKey("network_devices.snmp_traps", &c)
+	err := conf.UnmarshalKey("network_devices.snmp_traps", &c)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func ReadConfig(agentHostname string) (*Config, error) {
 	c.authoritativeEngineID = string(engineID)
 
 	if c.Namespace == "" {
-		c.Namespace = config.Datadog.GetString("network_devices.namespace")
+		c.Namespace = conf.GetString("network_devices.namespace")
 	}
 	c.Namespace, err = utils.NormalizeNamespace(c.Namespace)
 	if err != nil {

--- a/pkg/snmp/traps/config.go
+++ b/pkg/snmp/traps/config.go
@@ -106,16 +106,15 @@ func (c *Config) Addr() string {
 
 // BuildSNMPParams returns a valid GoSNMP params structure from configuration.
 func (c *Config) BuildSNMPParams(logger log.Component) (*gosnmp.GoSNMP, error) {
-	var snmpLogger gosnmp.Logger
-	if logger != nil {
-		snmpLogger = gosnmp.NewLogger(&trapLogger{logger: logger})
+	if logger == nil {
+		return nil, fmt.Errorf("NIL LOGGER?")
 	}
 	if len(c.Users) == 0 {
 		return &gosnmp.GoSNMP{
 			Port:      c.Port,
 			Transport: "udp",
 			Version:   gosnmp.Version2c, // No user configured, let's use Version2 which is enough and doesn't require setting up fake security data.
-			Logger:    snmpLogger,
+			Logger:    gosnmp.NewLogger(&trapLogger{logger: logger}),
 		}, nil
 	}
 	user := c.Users[0]
@@ -150,6 +149,6 @@ func (c *Config) BuildSNMPParams(logger log.Component) (*gosnmp.GoSNMP, error) {
 			PrivacyProtocol:          privProtocol,
 			PrivacyPassphrase:        user.PrivKey,
 		},
-		Logger: snmpLogger,
+		Logger: gosnmp.NewLogger(&trapLogger{logger: logger}),
 	}, nil
 }

--- a/pkg/snmp/traps/config_test.go
+++ b/pkg/snmp/traps/config_test.go
@@ -10,7 +10,9 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	ddconf "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,6 +52,7 @@ func makeConfigWithGlobalNamespace(t *testing.T, trapConfig Config, globalNamesp
 }
 
 func TestFullConfig(t *testing.T) {
+	logger := fxutil.Test[log.Component](t, log.MockModule)
 	rootConfig := makeConfig(t, Config{
 		Port: 1234,
 		Users: []UserV3{
@@ -83,7 +86,7 @@ func TestFullConfig(t *testing.T) {
 		},
 	}, config.Users)
 
-	params, err := config.BuildSNMPParams()
+	params, err := config.BuildSNMPParams(logger)
 	assert.NoError(t, err)
 	assert.Equal(t, uint16(1234), params.Port)
 	assert.Equal(t, gosnmp.Version3, params.Version)
@@ -101,6 +104,7 @@ func TestFullConfig(t *testing.T) {
 }
 
 func TestMinimalConfig(t *testing.T) {
+	logger := fxutil.Test[log.Component](t, log.MockModule)
 	config, err := ReadConfig("", makeConfig(t, Config{}))
 	assert.NoError(t, err)
 	assert.Equal(t, uint16(9162), config.Port)
@@ -110,7 +114,7 @@ func TestMinimalConfig(t *testing.T) {
 	assert.Equal(t, []UserV3{}, config.Users)
 	assert.Equal(t, "default", config.Namespace)
 
-	params, err := config.BuildSNMPParams()
+	params, err := config.BuildSNMPParams(logger)
 	assert.NoError(t, err)
 	assert.Equal(t, uint16(9162), params.Port)
 	assert.Equal(t, gosnmp.Version2c, params.Version)

--- a/pkg/snmp/traps/forwarder.go
+++ b/pkg/snmp/traps/forwarder.go
@@ -8,9 +8,9 @@ package traps
 import (
 	"time"
 
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/epforwarder"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // TrapForwarder consumes from a trapsIn channel, format traps and send them as EventPlatformEvents
@@ -22,21 +22,23 @@ type TrapForwarder struct {
 	formatter Formatter
 	sender    sender.Sender
 	stopChan  chan struct{}
+	logger    log.Component
 }
 
 // NewTrapForwarder creates a simple TrapForwarder instance
-func NewTrapForwarder(formatter Formatter, sender sender.Sender, packets PacketsChannel) (*TrapForwarder, error) {
+func NewTrapForwarder(formatter Formatter, sender sender.Sender, packets PacketsChannel, logger log.Component) (*TrapForwarder, error) {
 	return &TrapForwarder{
 		trapsIn:   packets,
 		formatter: formatter,
 		sender:    sender,
 		stopChan:  make(chan struct{}),
+		logger:    logger,
 	}, nil
 }
 
 // Start the TrapForwarder instance. Need to Stop it manually
 func (tf *TrapForwarder) Start() {
-	log.Info("Starting TrapForwarder")
+	tf.logger.Info("Starting TrapForwarder")
 	go tf.run()
 }
 
@@ -50,7 +52,7 @@ func (tf *TrapForwarder) run() {
 	for {
 		select {
 		case <-tf.stopChan:
-			log.Info("Stopped TrapForwarder")
+			tf.logger.Info("Stopped TrapForwarder")
 			return
 		case packet := <-tf.trapsIn:
 			tf.sendTrap(packet)
@@ -63,10 +65,10 @@ func (tf *TrapForwarder) run() {
 func (tf *TrapForwarder) sendTrap(packet *SnmpPacket) {
 	data, err := tf.formatter.FormatPacket(packet)
 	if err != nil {
-		log.Errorf("failed to format packet: %s", err)
+		tf.logger.Errorf("failed to format packet: %s", err)
 		return
 	}
-	log.Tracef("send trap payload: %s", string(data))
+	tf.logger.Tracef("send trap payload: %s", string(data))
 	tf.sender.Count("datadog.snmp_traps.forwarded", 1, "", packet.getTags())
 	tf.sender.EventPlatformEvent(data, epforwarder.EventTypeSnmpTraps)
 }

--- a/pkg/snmp/traps/forwarder_test.go
+++ b/pkg/snmp/traps/forwarder_test.go
@@ -17,8 +17,10 @@ import (
 	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/epforwarder"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 type DummyFormatter struct{}
@@ -41,11 +43,12 @@ func (f DummyFormatter) FormatPacket(packet *SnmpPacket) ([]byte, error) {
 }
 
 func createForwarder(t *testing.T) (forwarder *TrapForwarder, err error) {
+	logger := fxutil.Test[log.Component](t, log.MockModule)
 	packetsIn := make(PacketsChannel)
 	mockSender := mocksender.NewMockSender("snmp-traps-listener")
 	mockSender.SetupAcceptAll()
 
-	forwarder, err = NewTrapForwarder(&DummyFormatter{}, mockSender, packetsIn)
+	forwarder, err = NewTrapForwarder(&DummyFormatter{}, mockSender, packetsIn, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/snmp/traps/forwarder_test.go
+++ b/pkg/snmp/traps/forwarder_test.go
@@ -96,9 +96,12 @@ func TestV2TrapAreForwarder(t *testing.T) {
 	require.NoError(t, err)
 	sender, ok := forwarder.sender.(*mocksender.MockSender)
 	require.True(t, ok)
-	forwarder.trapsIn <- makeSnmpPacket(NetSNMPExampleHeartbeatNotification)
+	packet := makeSnmpPacket(NetSNMPExampleHeartbeatNotification)
+	rawEvent, err := forwarder.formatter.FormatPacket(packet)
+	require.NoError(t, err)
+	forwarder.trapsIn <- packet
 	forwarder.Stop()
-	sender.AssertEventPlatformEvent(t, []byte("0dee7422f503d972db97b711e39a5003d1995c0d2f718542813acc4c46053ef0"), epforwarder.EventTypeSnmpTraps)
+	sender.AssertEventPlatformEvent(t, rawEvent, epforwarder.EventTypeSnmpTraps)
 }
 
 func TestForwarderTelemetry(t *testing.T) {

--- a/pkg/snmp/traps/forwarder_test.go
+++ b/pkg/snmp/traps/forwarder_test.go
@@ -45,9 +45,6 @@ func createForwarder(t *testing.T) (forwarder *TrapForwarder, err error) {
 	mockSender := mocksender.NewMockSender("snmp-traps-listener")
 	mockSender.SetupAcceptAll()
 
-	config := Config{Port: serverPort, CommunityStrings: []string{"public"}, Namespace: "default"}
-	Configure(t, config)
-
 	forwarder, err = NewTrapForwarder(&DummyFormatter{}, mockSender, packetsIn)
 	if err != nil {
 		return nil, err

--- a/pkg/snmp/traps/listener.go
+++ b/pkg/snmp/traps/listener.go
@@ -7,13 +7,14 @@ package traps
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"net"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+
 	"github.com/gosnmp/gosnmp"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 )
 
 // TrapListener opens an UDP socket and put all received traps in a channel
@@ -23,13 +24,14 @@ type TrapListener struct {
 	packets       PacketsChannel
 	listener      *gosnmp.TrapListener
 	errorsChannel chan error
+	logger        log.Component
 }
 
 // NewTrapListener creates a simple TrapListener instance but does not start it
-func NewTrapListener(config Config, aggregator sender.Sender, packets PacketsChannel) (*TrapListener, error) {
+func NewTrapListener(config Config, aggregator sender.Sender, packets PacketsChannel, logger log.Component) (*TrapListener, error) {
 	var err error
 	gosnmpListener := gosnmp.NewTrapListener()
-	gosnmpListener.Params, err = config.BuildSNMPParams()
+	gosnmpListener.Params, err = config.BuildSNMPParams(logger)
 	if err != nil {
 		return nil, err
 	}
@@ -40,6 +42,7 @@ func NewTrapListener(config Config, aggregator sender.Sender, packets PacketsCha
 		packets:       packets,
 		listener:      gosnmpListener,
 		errorsChannel: errorsChan,
+		logger:        logger,
 	}
 
 	gosnmpListener.OnNewTrap = trapListener.receiveTrap
@@ -48,7 +51,7 @@ func NewTrapListener(config Config, aggregator sender.Sender, packets PacketsCha
 
 // Start the TrapListener instance. Need to be manually Stopped
 func (t *TrapListener) Start() error {
-	log.Infof("Start listening for traps on %s", t.config.Addr())
+	t.logger.Infof("Start listening for traps on %s", t.config.Addr())
 	go t.run()
 	return t.blockUntilReady()
 }
@@ -86,12 +89,12 @@ func (t *TrapListener) receiveTrap(p *gosnmp.SnmpPacket, u *net.UDPAddr) {
 	t.aggregator.Count("datadog.snmp_traps.received", 1, "", tags)
 
 	if err := validatePacket(p, t.config); err != nil {
-		log.Debugf("Invalid credentials from %s on listener %s, dropping traps", u.String(), t.config.Addr())
+		t.logger.Debugf("Invalid credentials from %s on listener %s, dropping traps", u.String(), t.config.Addr())
 		trapsPacketsAuthErrors.Add(1)
 		t.aggregator.Count("datadog.snmp_traps.invalid_packet", 1, "", append(tags, "reason:unknown_community_string"))
 		return
 	}
-	log.Debugf("Packet received from %s on listener %s", u.String(), t.config.Addr())
+	t.logger.Debugf("Packet received from %s on listener %s", u.String(), t.config.Addr())
 	trapsPackets.Add(1)
 	t.packets <- packet
 }

--- a/pkg/snmp/traps/listener_test.go
+++ b/pkg/snmp/traps/listener_test.go
@@ -10,7 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 
 	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/assert"
@@ -23,11 +25,12 @@ var initialTrapsPacketsAuthErrors int64
 const defaultTimeout = 1 * time.Second
 
 func listenerTestSetup(t *testing.T, config Config) (*mocksender.MockSender, *TrapListener) {
+	logger := fxutil.Test[log.Component](t, log.MockModule)
 	mockSender := mocksender.NewMockSender("snmp-traps-telemetry")
 	mockSender.SetupAcceptAll()
 	packetOutChan := make(PacketsChannel, packetsChanSize)
 
-	trapListener, err := startSNMPTrapListener(config, mockSender, packetOutChan)
+	trapListener, err := startSNMPTrapListener(config, mockSender, packetOutChan, logger)
 	require.NoError(t, err)
 
 	// trapsPacketsAuthErrors is global so its value carries over from test to test.  Capture its initial value to determine if it changes during an individual test run.

--- a/pkg/snmp/traps/listener_test.go
+++ b/pkg/snmp/traps/listener_test.go
@@ -7,9 +7,10 @@ package traps
 
 import (
 	"errors"
-	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"testing"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 
 	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/assert"
@@ -25,8 +26,6 @@ func listenerTestSetup(t *testing.T, config Config) (*mocksender.MockSender, *Tr
 	mockSender := mocksender.NewMockSender("snmp-traps-telemetry")
 	mockSender.SetupAcceptAll()
 	packetOutChan := make(PacketsChannel, packetsChanSize)
-
-	Configure(t, config)
 
 	trapListener, err := startSNMPTrapListener(config, mockSender, packetOutChan)
 	require.NoError(t, err)

--- a/pkg/snmp/traps/logging.go
+++ b/pkg/snmp/traps/logging.go
@@ -8,18 +8,19 @@ package traps
 import (
 	"github.com/gosnmp/gosnmp"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/comp/core/log"
 )
 
 // trapLogger is a GoSNMP logger interface implementation.
 type trapLogger struct {
 	gosnmp.Logger
+	logger log.Component
 }
 
 // NOTE: GoSNMP logs show the full content of decoded trap packets. Logging as DEBUG would be too noisy.
 func (logger *trapLogger) Print(v ...interface{}) {
-	log.Trace(v...)
+	logger.logger.Trace(v...)
 }
 func (logger *trapLogger) Printf(format string, v ...interface{}) {
-	log.Tracef(format, v...)
+	logger.logger.Tracef(format, v...)
 }

--- a/pkg/snmp/traps/oid_resolver.go
+++ b/pkg/snmp/traps/oid_resolver.go
@@ -18,7 +18,6 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -53,9 +52,8 @@ type MultiFilesOIDResolver struct {
 
 // NewMultiFilesOIDResolver creates a new MultiFilesOIDResolver instance by loading json or yaml files
 // (optionnally gzipped) located in the directory snmp.d/traps_db/
-func NewMultiFilesOIDResolver() (*MultiFilesOIDResolver, error) {
+func NewMultiFilesOIDResolver(confdPath string) (*MultiFilesOIDResolver, error) {
 	oidResolver := &MultiFilesOIDResolver{traps: make(TrapSpec)}
-	confdPath := config.Datadog.GetString("confd_path")
 	trapsDBRoot := filepath.Join(confdPath, "snmp.d", "traps_db")
 	files, err := os.ReadDir(trapsDBRoot)
 	if err != nil {

--- a/pkg/snmp/traps/oid_resolver_test.go
+++ b/pkg/snmp/traps/oid_resolver_test.go
@@ -12,6 +12,8 @@ import (
 	"io/fs"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
@@ -144,6 +146,7 @@ func TestDecoding(t *testing.T) {
 }
 
 func TestSortFiles(t *testing.T) {
+	logger := fxutil.Test[log.Component](t, log.MockModule)
 	files := []fs.DirEntry{
 		MockedDirEntry{name: "totoro", isDir: false},
 		MockedDirEntry{name: "porco", isDir: false},
@@ -162,7 +165,7 @@ func TestSortFiles(t *testing.T) {
 		MockedDirEntry{name: "dd_traps_db.yaml.gz", isDir: false},
 		MockedDirEntry{name: "dd_traps_db.yaml", isDir: false},
 	}
-	sortedFiles := getSortedFileNames(files)
+	sortedFiles := getSortedFileNames(files, logger)
 	require.EqualValues(t,
 		[]string{
 			"dd_traps_db.json",
@@ -182,7 +185,8 @@ func TestSortFiles(t *testing.T) {
 }
 
 func TestResolverWithNonStandardOIDs(t *testing.T) {
-	resolver := &MultiFilesOIDResolver{traps: make(TrapSpec)}
+	logger := fxutil.Test[log.Component](t, log.MockModule)
+	resolver := &MultiFilesOIDResolver{traps: make(TrapSpec), logger: logger}
 	trapData := trapDBFileContent{
 		Traps: TrapSpec{"1.3.6.1.4.1.8072.2.3.0.1": TrapMetadata{Name: "netSnmpExampleHeartbeat", MIBName: "NET-SNMP-EXAMPLES-MIB"}},
 		Variables: variableSpec{
@@ -210,7 +214,8 @@ func TestResolverWithNonStandardOIDs(t *testing.T) {
 
 }
 func TestResolverWithConflictingTrapOID(t *testing.T) {
-	resolver := &MultiFilesOIDResolver{traps: make(TrapSpec)}
+	logger := fxutil.Test[log.Component](t, log.MockModule)
+	resolver := &MultiFilesOIDResolver{traps: make(TrapSpec), logger: logger}
 	trapDataA := trapDBFileContent{
 		Traps: TrapSpec{"1.3.6.1.4.1.8072.2.3.0.1": TrapMetadata{Name: "foo", MIBName: "FOO-MIB"}},
 	}
@@ -226,7 +231,8 @@ func TestResolverWithConflictingTrapOID(t *testing.T) {
 }
 
 func TestResolverWithConflictingVariables(t *testing.T) {
-	resolver := &MultiFilesOIDResolver{traps: make(TrapSpec)}
+	logger := fxutil.Test[log.Component](t, log.MockModule)
+	resolver := &MultiFilesOIDResolver{traps: make(TrapSpec), logger: logger}
 	trapDataA := trapDBFileContent{
 		Traps: TrapSpec{"1.3.6.1.4.1.8072.2.3.0.1": TrapMetadata{}},
 		Variables: variableSpec{
@@ -256,7 +262,8 @@ func TestResolverWithConflictingVariables(t *testing.T) {
 }
 
 func TestResolverWithSuffixedVariable(t *testing.T) {
-	resolver := &MultiFilesOIDResolver{traps: make(TrapSpec)}
+	logger := fxutil.Test[log.Component](t, log.MockModule)
+	resolver := &MultiFilesOIDResolver{traps: make(TrapSpec), logger: logger}
 	updateResolverWithIntermediateJSONReader(t, resolver, dummyTrapDB)
 
 	data, err := resolver.GetVariableMetadata("1.3.6.1.6.3.1.1.5.4", "1.3.6.1.2.1.2.2.1.1")
@@ -277,7 +284,8 @@ func TestResolverWithSuffixedVariable(t *testing.T) {
 }
 
 func TestResolverWithSuffixedVariableAndNodeConflict(t *testing.T) {
-	resolver := &MultiFilesOIDResolver{traps: make(TrapSpec)}
+	logger := fxutil.Test[log.Component](t, log.MockModule)
+	resolver := &MultiFilesOIDResolver{traps: make(TrapSpec), logger: logger}
 	trapDB := trapDBFileContent{
 		Traps: TrapSpec{
 			"1.3.6.1.6.3.1.1.5.4": TrapMetadata{Name: "linkUp", MIBName: "IF-MIB"},
@@ -314,7 +322,8 @@ func TestResolverWithSuffixedVariableAndNodeConflict(t *testing.T) {
 }
 
 func TestResolverWithNoMatchVariableShouldStopBeforeRoot(t *testing.T) {
-	resolver := &MultiFilesOIDResolver{traps: make(TrapSpec)}
+	logger := fxutil.Test[log.Component](t, log.MockModule)
+	resolver := &MultiFilesOIDResolver{traps: make(TrapSpec), logger: logger}
 	trapDB := trapDBFileContent{
 		Traps: TrapSpec{
 			"1.3.6.1.6.3.1.1.5.4": TrapMetadata{Name: "linkUp", MIBName: "IF-MIB"},

--- a/pkg/snmp/traps/server.go
+++ b/pkg/snmp/traps/server.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -28,8 +29,8 @@ var (
 )
 
 // StartServer starts the global trap server.
-func StartServer(agentHostname string, demux aggregator.Demultiplexer) error {
-	config, err := ReadConfig(agentHostname)
+func StartServer(agentHostname string, demux aggregator.Demultiplexer, conf config.Component) error {
+	config, err := ReadConfig(agentHostname, conf)
 	if err != nil {
 		return err
 	}
@@ -37,7 +38,7 @@ func StartServer(agentHostname string, demux aggregator.Demultiplexer) error {
 	if err != nil {
 		return err
 	}
-	oidResolver, err := NewMultiFilesOIDResolver()
+	oidResolver, err := NewMultiFilesOIDResolver(conf.GetString("confd_path"))
 	if err != nil {
 		return err
 	}

--- a/pkg/snmp/traps/server_test.go
+++ b/pkg/snmp/traps/server_test.go
@@ -21,7 +21,6 @@ func TestStartFailure(t *testing.T) {
 	*/
 
 	config := Config{Port: freePort, CommunityStrings: []string{"public"}}
-	Configure(t, config)
 
 	mockSender := mocksender.NewMockSender("snmp-traps-listener")
 	mockSender.SetupAcceptAll()

--- a/pkg/snmp/traps/server_test.go
+++ b/pkg/snmp/traps/server_test.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 var freePort = getFreePort()
@@ -19,18 +21,19 @@ func TestStartFailure(t *testing.T) {
 	/*
 		Start two servers with the same config to trigger an "address already in use" error.
 	*/
+	logger := fxutil.Test[log.Component](t, log.MockModule)
 
 	config := Config{Port: freePort, CommunityStrings: []string{"public"}}
 
 	mockSender := mocksender.NewMockSender("snmp-traps-listener")
 	mockSender.SetupAcceptAll()
 
-	sucessServer, err := NewTrapServer(config, &DummyFormatter{}, mockSender)
+	sucessServer, err := NewTrapServer(config, &DummyFormatter{}, mockSender, logger)
 	require.NoError(t, err)
 	require.NotNil(t, sucessServer)
 	defer sucessServer.Stop()
 
-	failedServer, err := NewTrapServer(config, &DummyFormatter{}, mockSender)
+	failedServer, err := NewTrapServer(config, &DummyFormatter{}, mockSender, logger)
 	require.Nil(t, failedServer)
 	require.Error(t, err)
 }

--- a/pkg/snmp/traps/traps_test.go
+++ b/pkg/snmp/traps/traps_test.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
-
 	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -82,7 +80,7 @@ var (
 )
 
 func getFreePort() uint16 {
-	sender := mocksender.NewMockSender("")
+	// sender := mocksender.NewMockSender("")
 
 	var port uint16
 	for i := 0; i < 5; i++ {
@@ -95,11 +93,11 @@ func getFreePort() uint16 {
 		if err != nil {
 			continue
 		}
-		listener, err := startSNMPTrapListener(Config{Port: port}, sender, nil)
-		if err != nil {
-			continue
-		}
-		listener.Stop()
+		// listener, err := startSNMPTrapListener(Config{Port: port}, sender, nil, nil)
+		// if err != nil {
+		// 	continue
+		// }
+		// listener.Stop()
 		return port
 	}
 	panic("unable to find free port for starting the trap listener")
@@ -119,7 +117,7 @@ func parsePort(addr string) (uint16, error) {
 }
 
 func sendTestV1GenericTrap(t *testing.T, trapConfig Config, community string) *gosnmp.GoSNMP {
-	params, err := trapConfig.BuildSNMPParams()
+	params, err := trapConfig.BuildSNMPParams(nil)
 	require.NoError(t, err)
 	params.Community = community
 	params.Timeout = 1 * time.Second // Must be non-zero when sending traps.
@@ -137,7 +135,7 @@ func sendTestV1GenericTrap(t *testing.T, trapConfig Config, community string) *g
 }
 
 func sendTestV1SpecificTrap(t *testing.T, trapConfig Config, community string) *gosnmp.GoSNMP {
-	params, err := trapConfig.BuildSNMPParams()
+	params, err := trapConfig.BuildSNMPParams(nil)
 	require.NoError(t, err)
 	params.Community = community
 	params.Timeout = 1 * time.Second // Must be non-zero when sending traps.
@@ -155,7 +153,7 @@ func sendTestV1SpecificTrap(t *testing.T, trapConfig Config, community string) *
 }
 
 func sendTestV2Trap(t *testing.T, trapConfig Config, community string) *gosnmp.GoSNMP {
-	params, err := trapConfig.BuildSNMPParams()
+	params, err := trapConfig.BuildSNMPParams(nil)
 	require.NoError(t, err)
 	params.Community = community
 	params.Timeout = 1 * time.Second // Must be non-zero when sending traps.
@@ -173,7 +171,7 @@ func sendTestV2Trap(t *testing.T, trapConfig Config, community string) *gosnmp.G
 }
 
 func sendTestV3Trap(t *testing.T, trapConfig Config, securityParams *gosnmp.UsmSecurityParameters) *gosnmp.GoSNMP {
-	params, err := trapConfig.BuildSNMPParams()
+	params, err := trapConfig.BuildSNMPParams(nil)
 	require.NoError(t, err)
 	params.MsgFlags = gosnmp.AuthPriv
 	params.SecurityParameters = securityParams

--- a/pkg/snmp/traps/traps_test.go
+++ b/pkg/snmp/traps/traps_test.go
@@ -8,19 +8,16 @@
 package traps
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"net"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 
 	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
-
-	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 // List of variables for a NetSNMP::ExampleHeartBeatNotification trap message.
@@ -119,31 +116,6 @@ func parsePort(addr string) (uint16, error) {
 		return 0, err
 	}
 	return uint16(port), nil
-}
-
-// Configure sets Datadog Agent configuration from a config object.
-func Configure(t *testing.T, trapConfig Config) {
-	ConfigureWithGlobalNamespace(t, trapConfig, "")
-}
-
-// ConfigureWithGlobalNamespace sets Datadog Agent configuration from a config object and a namespace
-func ConfigureWithGlobalNamespace(t *testing.T, trapConfig Config, globalNamespace string) {
-	trapConfig.Enabled = true
-	datadogYaml := map[string]map[string]interface{}{
-		"network_devices": {
-			"snmp_traps": trapConfig,
-		},
-	}
-	if globalNamespace != "" {
-		datadogYaml["network_devices"]["namespace"] = globalNamespace
-	}
-
-	config.Datadog.SetConfigType("yaml")
-	out, err := yaml.Marshal(datadogYaml)
-	require.NoError(t, err)
-
-	err = config.Datadog.ReadConfig(strings.NewReader(string(out)))
-	require.NoError(t, err)
 }
 
 func sendTestV1GenericTrap(t *testing.T, trapConfig Config, community string) *gosnmp.GoSNMP {

--- a/pkg/snmp/traps/traps_test.go
+++ b/pkg/snmp/traps/traps_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -117,7 +119,7 @@ func parsePort(addr string) (uint16, error) {
 }
 
 func sendTestV1GenericTrap(t *testing.T, trapConfig Config, community string) *gosnmp.GoSNMP {
-	params, err := trapConfig.BuildSNMPParams(nil)
+	params, err := trapConfig.BuildSNMPParams(fxutil.Test[log.Component](t, log.MockModule))
 	require.NoError(t, err)
 	params.Community = community
 	params.Timeout = 1 * time.Second // Must be non-zero when sending traps.
@@ -135,7 +137,7 @@ func sendTestV1GenericTrap(t *testing.T, trapConfig Config, community string) *g
 }
 
 func sendTestV1SpecificTrap(t *testing.T, trapConfig Config, community string) *gosnmp.GoSNMP {
-	params, err := trapConfig.BuildSNMPParams(nil)
+	params, err := trapConfig.BuildSNMPParams(fxutil.Test[log.Component](t, log.MockModule))
 	require.NoError(t, err)
 	params.Community = community
 	params.Timeout = 1 * time.Second // Must be non-zero when sending traps.
@@ -153,7 +155,7 @@ func sendTestV1SpecificTrap(t *testing.T, trapConfig Config, community string) *
 }
 
 func sendTestV2Trap(t *testing.T, trapConfig Config, community string) *gosnmp.GoSNMP {
-	params, err := trapConfig.BuildSNMPParams(nil)
+	params, err := trapConfig.BuildSNMPParams(fxutil.Test[log.Component](t, log.MockModule))
 	require.NoError(t, err)
 	params.Community = community
 	params.Timeout = 1 * time.Second // Must be non-zero when sending traps.
@@ -171,7 +173,7 @@ func sendTestV2Trap(t *testing.T, trapConfig Config, community string) *gosnmp.G
 }
 
 func sendTestV3Trap(t *testing.T, trapConfig Config, securityParams *gosnmp.UsmSecurityParameters) *gosnmp.GoSNMP {
-	params, err := trapConfig.BuildSNMPParams(nil)
+	params, err := trapConfig.BuildSNMPParams(fxutil.Test[log.Component](t, log.MockModule))
 	require.NoError(t, err)
 	params.MsgFlags = gosnmp.AuthPriv
 	params.SecurityParameters = securityParams

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -84,7 +84,7 @@ func FormatStatus(data []byte) (string, error) {
 		return nil
 	}
 	snmpTrapFunc := func() error {
-		if traps.IsEnabled() {
+		if traps.IsEnabled(config.Datadog) {
 			return RenderStatusTemplate(b, "/snmp-traps.tmpl", snmpTrapsStats)
 		}
 		return nil


### PR DESCRIPTION
### What does this PR do?

This does the bare minimum work necessary to make the snmp traps server run in a component. It updates the snmp traps server so that it takes the configuration and logger as arguments instead of assuming globals, and creates a tiny component that just invokes the global `traps.StartServer` and `traps.StopServer`.

### Motivation
NDMII-287 - we want the server to be managed by the component system. Originally we wrote a total componentization in #19452, but we decided that this was too many changes at once, so this is the smallest PR that just gets the traps server to be managed by the component lifecycle.

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

See internal instructions for QAing snmp traps. Existing QA should be fine, as the behavior of the traps listener is not expected to change.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
