### PR TITLE
[process-agent] Add workloadmeta extractor stats to status output

### DIFF
--- a/pkg/process/util/status/status.go
+++ b/pkg/process/util/status/status.go
@@ -93,6 +93,9 @@ type ProcessExpvars struct {
 	DropCheckPayloads               []string            `json:"drop_check_payloads"`
 	SystemProbeProcessModuleEnabled bool                `json:"system_probe_process_module_enabled"`
 	LanguageDetectionEnabled        bool                `json:"language_detection_enabled"`
+	WlmExtractorCacheSize           int                 `json:"workloadmeta_extractor_cache_size"`
+	WlmExtractorStaleDiffs          int                 `json:"workloadmeta_extractor_stale_diffs"`
+	WlmExtractorDiffsDropped        int                 `json:"workloadmeta_extractor_diffs_dropped"`
 }
 
 // Status holds runtime information from process-agent

--- a/pkg/process/util/status/status_test.go
+++ b/pkg/process/util/status/status_test.go
@@ -67,6 +67,9 @@ func TestGetStatus(t *testing.T) {
 		PodQueueBytes:                   4 * 1024,
 		SystemProbeProcessModuleEnabled: true,
 		LanguageDetectionEnabled:        true,
+		WlmExtractorCacheSize:           36,
+		WlmExtractorStaleDiffs:          1,
+		WlmExtractorDiffsDropped:        2,
 	}
 
 	// Feature detection needs to run before host methods are called. During runtime, feature detection happens

--- a/pkg/status/templates/process-agent.tmpl
+++ b/pkg/status/templates/process-agent.tmpl
@@ -60,4 +60,14 @@ Process Agent
     Event Bytes enqueued: {{.expvars.event_queue_bytes}}
     Pod Bytes enqueued: {{.expvars.pod_queue_bytes}}
     Drop Check Payloads: {{.expvars.drop_check_payloads}}
+
+  ==========
+  Extractors
+  ==========
+
+    Workloadmeta
+    ============
+      Cache size: {{.expvars.workloadmeta_extractor_cache_size}}
+      Stale diffs discarded: {{.expvars.workloadmeta_extractor_stale_diffs}}
+      Diffs dropped: {{.expvars.workloadmeta_extractor_diffs_dropped}}
 {{- end }}

--- a/releasenotes/notes/extractor-metrics-60e1402928422cee.yaml
+++ b/releasenotes/notes/extractor-metrics-60e1402928422cee.yaml
@@ -1,0 +1,10 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - Add metrics for the workloadmeta extractor to process-agent status output 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

* Add the existing WorkloadMetaExtractor stats to the process-agent status output
* Rename `old_diffs_dropped` and `diff_chan_full` to `stale_diffs` and `diffs_dropped`, respectively
* Remove unused `StatusInfo` type

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

https://datadoghq.atlassian.net/browse/PROCS-1545

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. Ensure that the generated Datadog metrics are populated (note that the last two are likely 0, but they should still be emitted)
    - `datadog.process_agent.WorkloadMetaExtractor.cache_size`
    - `datadog.process_agent.WorkloadMetaExtractor.stale_diffs`
    - `datadog.process_agent.WorkloadMetaExtractor.diffs_dropped`
2. Ensure that the process-agent status output includes a new section for the WorkloadMetaExtractor
```
/opt/datadog-agent/embedded/bin/process-agent status
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
