### PR TITLE
[CWS] use a single empty process cache entry

### DIFF
--- a/pkg/security/probe/field_handlers.go
+++ b/pkg/security/probe/field_handlers.go
@@ -117,7 +117,7 @@ func (fh *FieldHandlers) ResolveContainerTags(ev *model.Event, e *model.Containe
 // ResolveProcessCacheEntry queries the ProcessResolver to retrieve the ProcessContext of the event
 func (fh *FieldHandlers) ResolveProcessCacheEntry(ev *model.Event) (*model.ProcessCacheEntry, bool) {
 	if ev.PIDContext.IsKworker {
-		return model.NewEmptyProcessCacheEntry(ev.PIDContext.Pid, ev.PIDContext.Tid, true), false
+		return model.GetPlaceholderProcessCacheEntry(ev.PIDContext.Pid, ev.PIDContext.Tid, true), false
 	}
 
 	if ev.ProcessCacheEntry == nil && ev.PIDContext.Pid != 0 {
@@ -125,7 +125,7 @@ func (fh *FieldHandlers) ResolveProcessCacheEntry(ev *model.Event) (*model.Proce
 	}
 
 	if ev.ProcessCacheEntry == nil {
-		ev.ProcessCacheEntry = model.NewEmptyProcessCacheEntry(ev.PIDContext.Pid, ev.PIDContext.Tid, false)
+		ev.ProcessCacheEntry = model.GetPlaceholderProcessCacheEntry(ev.PIDContext.Pid, ev.PIDContext.Tid, false)
 		return ev.ProcessCacheEntry, false
 	}
 

--- a/pkg/security/probe/field_handlers_linux.go
+++ b/pkg/security/probe/field_handlers_linux.go
@@ -250,7 +250,7 @@ func (fh *FieldHandlers) ResolveSELinuxBoolName(ev *model.Event, e *model.SELinu
 func (fh *FieldHandlers) GetProcessCacheEntry(ev *model.Event) (*model.ProcessCacheEntry, bool) {
 	ev.ProcessCacheEntry = fh.resolvers.ProcessResolver.Resolve(ev.PIDContext.Pid, ev.PIDContext.Tid, ev.PIDContext.ExecInode, false)
 	if ev.ProcessCacheEntry == nil {
-		ev.ProcessCacheEntry = model.NewEmptyProcessCacheEntry(ev.PIDContext.Pid, ev.PIDContext.Tid, false)
+		ev.ProcessCacheEntry = model.GetPlaceholderProcessCacheEntry(ev.PIDContext.Pid, ev.PIDContext.Tid, false)
 		return ev.ProcessCacheEntry, false
 	}
 	return ev.ProcessCacheEntry, true

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -753,7 +753,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 			pce = p.resolvers.ProcessResolver.Resolve(event.PTrace.PID, event.PTrace.PID, 0, false)
 		}
 		if pce == nil {
-			pce = model.NewEmptyProcessCacheEntry(event.PTrace.PID, event.PTrace.PID, false)
+			pce = model.NewPlaceholderProcessCacheEntry(event.PTrace.PID, event.PTrace.PID, false)
 		}
 		event.PTrace.Tracee = &pce.ProcessContext
 	case model.MMapEventType:
@@ -798,7 +798,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 			pce = p.resolvers.ProcessResolver.Resolve(event.Signal.PID, event.Signal.PID, 0, false)
 		}
 		if pce == nil {
-			pce = model.NewEmptyProcessCacheEntry(event.Signal.PID, event.Signal.PID, false)
+			pce = model.NewPlaceholderProcessCacheEntry(event.Signal.PID, event.Signal.PID, false)
 		}
 		event.Signal.Target = &pce.ProcessContext
 	case model.SpliceEventType:

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -24,6 +24,7 @@ type Model struct {
 	ExtraValidateFieldFnc func(field eval.Field, fieldValue eval.FieldValue) error
 }
 
+var processContextZero = ProcessCacheEntry{}
 var eventZero = Event{BaseEvent: BaseEvent{ContainerContext: &ContainerContext{}}}
 var containerContextZero ContainerContext
 

--- a/pkg/security/secl/model/process_cache_entry_unix.go
+++ b/pkg/security/secl/model/process_cache_entry_unix.go
@@ -106,17 +106,28 @@ func (pc *ProcessCacheEntry) Equals(entry *ProcessCacheEntry) bool {
 		pc.EnvsEntry.Equals(entry.EnvsEntry))
 }
 
-// NewEmptyProcessCacheEntry returns an empty process cache entry for kworker events or failed process resolutions
-func NewEmptyProcessCacheEntry(pid uint32, tid uint32, isKworker bool) *ProcessCacheEntry {
-	entry := &ProcessCacheEntry{ProcessContext: ProcessContext{Process: Process{PIDContext: PIDContext{Pid: pid, Tid: tid, IsKworker: isKworker}}}}
-
+func (pc *ProcessCacheEntry) markFileEventAsResovled() {
 	// mark file path as resolved
-	entry.FileEvent.SetPathnameStr("")
-	entry.FileEvent.SetBasenameStr("")
+	pc.FileEvent.SetPathnameStr("")
+	pc.FileEvent.SetBasenameStr("")
 
 	// mark interpreter as resolved too
-	entry.LinuxBinprm.FileEvent.SetPathnameStr("")
-	entry.LinuxBinprm.FileEvent.SetBasenameStr("")
+	pc.LinuxBinprm.FileEvent.SetPathnameStr("")
+	pc.LinuxBinprm.FileEvent.SetBasenameStr("")
+}
 
+// NewPlaceholderProcessCacheEntry returns a new empty process cache entry for failed process resolutions
+func NewPlaceholderProcessCacheEntry(pid uint32, tid uint32, isKworker bool) *ProcessCacheEntry {
+	entry := &ProcessCacheEntry{ProcessContext: ProcessContext{Process: Process{PIDContext: PIDContext{Pid: pid, Tid: tid, IsKworker: isKworker}}}}
+	entry.markFileEventAsResovled()
 	return entry
+}
+
+// GetPlaceholderProcessCacheEntry returns an empty process cache entry for failed process resolutions
+func GetPlaceholderProcessCacheEntry(pid uint32, tid uint32, isKworker bool) *ProcessCacheEntry {
+	processContextZero.Pid = pid
+	processContextZero.Tid = tid
+	processContextZero.IsKworker = isKworker
+	processContextZero.markFileEventAsResovled()
+	return &processContextZero
 }

--- a/pkg/security/secl/model/process_cache_entry_windows.go
+++ b/pkg/security/secl/model/process_cache_entry_windows.go
@@ -5,7 +5,15 @@
 
 package model
 
-// NewEmptyProcessCacheEntry returns an empty process cache entry for kworker events or failed process resolutions
-func NewEmptyProcessCacheEntry(pid uint32, tid uint32, isKworker bool) *ProcessCacheEntry {
+// NewPlaceholderProcessCacheEntry returns an empty process cache entry for failed process resolutions
+func NewPlaceholderProcessCacheEntry(pid uint32, tid uint32, isKworker bool) *ProcessCacheEntry {
 	return &ProcessCacheEntry{ProcessContext: ProcessContext{Process: Process{PIDContext: PIDContext{Pid: pid, Tid: tid, IsKworker: isKworker}}}}
+}
+
+// GetPlaceholderProcessCacheEntry returns an empty process cache entry for failed process resolutions
+func GetPlaceholderProcessCacheEntry(pid uint32, tid uint32, isKworker bool) *ProcessCacheEntry {
+	processContextZero.Pid = pid
+	processContextZero.Tid = tid
+	processContextZero.IsKworker = isKworker
+	return &processContextZero
 }

--- a/pkg/security/security_profile/profile/manager_test.go
+++ b/pkg/security/security_profile/profile/manager_test.go
@@ -46,7 +46,7 @@ func craftFakeEvent(t0 time.Time, ti *testIteration, defaultContainerID string) 
 	event.Timestamp = t0.Add(ti.eventTimestampRaw)
 
 	// setting process
-	event.ProcessCacheEntry = model.NewEmptyProcessCacheEntry(42, 42, false)
+	event.ProcessCacheEntry = model.NewPlaceholderProcessCacheEntry(42, 42, false)
 	event.ProcessCacheEntry.ContainerID = defaultContainerID
 	event.ProcessCacheEntry.FileEvent.PathnameStr = ti.eventProcessPath
 	event.ProcessCacheEntry.FileEvent.Inode = 42
@@ -66,7 +66,7 @@ func craftFakeEvent(t0 time.Time, ti *testIteration, defaultContainerID string) 
 	}
 
 	// setting process ancestor
-	event.ProcessCacheEntry.Ancestor = model.NewEmptyProcessCacheEntry(1, 1, false)
+	event.ProcessCacheEntry.Ancestor = model.NewPlaceholderProcessCacheEntry(1, 1, false)
 	event.ProcessCacheEntry.Ancestor.FileEvent.PathnameStr = "systemd"
 	event.ProcessCacheEntry.Ancestor.FileEvent.Inode = 41
 	event.ProcessCacheEntry.Ancestor.Args = "foo"

--- a/pkg/security/security_profile/tests/activity_tree_test.go
+++ b/pkg/security/security_profile/tests/activity_tree_test.go
@@ -83,7 +83,7 @@ func matchResultTree(at *activity_tree.ActivityTree, toMatch map[string][]string
 
 func craftFakeProcess(containerID string, test *testIteration) *model.ProcessCacheEntry {
 	// setting process
-	process := model.NewEmptyProcessCacheEntry(42, 42, false)
+	process := model.NewPlaceholderProcessCacheEntry(42, 42, false)
 	process.ContainerID = containerID
 	process.FileEvent.PathnameStr = test.processPath
 	process.FileEvent.BasenameStr = filepath.Base(test.processPath)
@@ -98,7 +98,7 @@ func craftFakeProcess(containerID string, test *testIteration) *model.ProcessCac
 	}
 
 	// setting process ancestor
-	process.Ancestor = model.NewEmptyProcessCacheEntry(41, 41, false)
+	process.Ancestor = model.NewPlaceholderProcessCacheEntry(41, 41, false)
 	process.Ancestor.ContainerID = containerID
 	process.Ancestor.FileEvent.PathnameStr = test.parentProcessPath
 	process.Ancestor.FileEvent.BasenameStr = filepath.Base(test.parentProcessPath)
@@ -119,9 +119,9 @@ func craftFakeProcess(containerID string, test *testIteration) *model.ProcessCac
 
 	// setting process granpa
 	if test.completeLineage {
-		process.Ancestor.Ancestor = model.NewEmptyProcessCacheEntry(1, 1, false)
+		process.Ancestor.Ancestor = model.NewPlaceholderProcessCacheEntry(1, 1, false)
 	} else {
-		process.Ancestor.Ancestor = model.NewEmptyProcessCacheEntry(40, 40, false)
+		process.Ancestor.Ancestor = model.NewPlaceholderProcessCacheEntry(40, 40, false)
 	}
 	process.Ancestor.Ancestor.FileEvent.PathnameStr = "/usr/bin/systemd"
 	process.Ancestor.Ancestor.FileEvent.BasenameStr = "systemd"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

reuse the same instance for the empty process cache entry in order to limit the allocations

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

We need to validate that the activity dumps can't be corrupted and we need to ensure the place holder is not kept by another entity.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
