### PR TITLE
[utils/ecs/metadata/detection] Use client URL directly

### DIFF
--- a/pkg/util/ecs/metadata/detection_test.go
+++ b/pkg/util/ecs/metadata/detection_test.go
@@ -9,7 +9,6 @@ package metadata
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -33,14 +32,14 @@ func TestLocateECSHTTP(t *testing.T) {
 	)
 	require.Nil(t, err)
 
-	ts, ecsAgentPort, err := ecsinterface.Start()
+	ts, _, err := ecsinterface.Start()
 	require.Nil(t, err)
 	defer ts.Close()
 
-	config.Datadog.SetDefault("ecs_agent_url", fmt.Sprintf("http://localhost:%d/", ecsAgentPort))
+	config.Datadog.SetDefault("ecs_agent_url", ts.URL)
 
 	_, err = newAutodetectedClientV1()
-	assert.Nil(err)
+	require.NoError(t, err)
 
 	select {
 	case r := <-ecsinterface.Requests:
@@ -57,14 +56,14 @@ func TestLocateECSHTTPFail(t *testing.T) {
 	ecsinterface, err := testutil.NewDummyECS()
 	require.Nil(t, err)
 
-	ts, ecsAgentPort, err := ecsinterface.Start()
+	ts, _, err := ecsinterface.Start()
 	require.Nil(t, err)
 	defer ts.Close()
 
-	config.Datadog.SetDefault("ecs_agent_url", fmt.Sprintf("http://localhost:%d/", ecsAgentPort))
+	config.Datadog.SetDefault("ecs_agent_url", ts.URL)
 
 	_, err = newAutodetectedClientV1()
-	assert.NotNil(err)
+	require.Error(t, err)
 
 	select {
 	case r := <-ecsinterface.Requests:


### PR DESCRIPTION

### What does this PR do?

Tries to fix a flaky test in `pkg/util/ecs/metadata/detection_test.go`.
I realized that other tests that use the client URL directly don't seem to be flaky, so I made the same change here.
I've also modified the test to use `require` to avoid continuing with the test when there's an error getting the ecs client.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
