### PR TITLE
[CWS] disable network when CWS is not enabled

### DIFF
--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -38,6 +38,8 @@ var EventMonitor = module.Factory{
 		// adapt options
 		if secconfig.RuntimeSecurity.IsRuntimeEnabled() {
 			secmodule.UpdateEventMonitorOpts(&opts)
+		} else {
+			secmodule.DisableRuntimeSecurity(secconfig)
 		}
 
 		evm, err := eventmonitor.NewEventMonitor(emconfig, secconfig, opts)

--- a/pkg/security/module/cws_linux.go
+++ b/pkg/security/module/cws_linux.go
@@ -19,6 +19,13 @@ func UpdateEventMonitorOpts(opts *eventmonitor.Opts) {
 	opts.ProbeOpts.PathResolutionEnabled = true
 }
 
+// DisableRuntimeSecurity disables all the runtime security features
+func DisableRuntimeSecurity(config *config.Config) {
+	config.Probe.NetworkEnabled = false
+	config.RuntimeSecurity.ActivityDumpEnabled = false
+	config.RuntimeSecurity.SecurityProfileEnabled = false
+}
+
 // platform specific init function
 func (c *CWSConsumer) init(evm *eventmonitor.EventMonitor, config *config.RuntimeSecurityConfig, opts Opts) error {
 	// Activity dumps related

--- a/pkg/security/module/cws_others.go
+++ b/pkg/security/module/cws_others.go
@@ -19,6 +19,9 @@ func getFamilyAddress(config *config.RuntimeSecurityConfig) (string, string) {
 // UpdateEventMonitorOpts adapt the event monitor options
 func UpdateEventMonitorOpts(opts *eventmonitor.Opts) {}
 
+// DisableRuntimeSecurity disables all the runtime security features
+func DisableRuntimeSecurity(config *config.Config) {}
+
 // platform specific init function
 func (c *CWSConsumer) init(evm *eventmonitor.EventMonitor, config *config.RuntimeSecurityConfig, opts Opts) error {
 	return nil


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR force the network feature to be disabled when CWS is not enabled. This should improve the CPU impact for the eventmonitoring.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
