### PR TITLE
[Oracle] Add `lookback` config parameter to query metrics

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -35,6 +35,7 @@ type QueryMetricsConfig struct {
 	DBRowsLimit        int   `yaml:"db_rows_limit"`
 	PlanCacheRetention int   `yaml:"plan_cache_retention"`
 	DisableLastActive  bool  `yaml:"disable_last_active"`
+	Lookback           int64 `yaml:"lookback"`
 }
 
 type SysMetricsConfig struct {

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -514,11 +514,19 @@ func (c *Check) StatementMetrics() (int, error) {
 		} else {
 			sql = queryForceMatchingSignatureLastActive
 		}
+
+		var lookback int64
+		if c.config.QueryMetrics.Lookback != 0 {
+			lookback = c.config.QueryMetrics.Lookback
+		} else {
+			lookback = 2 * c.config.QueryMetrics.CollectionInterval
+		}
+
 		err := selectWrapper(
 			c,
 			&statementMetrics,
 			sql,
-			2*c.config.QueryMetrics.CollectionInterval,
+			lookback,
 			c.config.QueryMetrics.DBRowsLimit,
 		)
 		if err != nil {


### PR DESCRIPTION
### What does this PR do?

Add the `lookback` parameter to query metrics. The `lookback` parameter determines how far do we look back when loading query metrics into the Datadog Agent cache. 

### Motivation

The purpose of this parameter is to increase the probability of capturing query metrics for some specific workloads. 

The parameter will also come in handy during testing, where we can shorten the collection interval without losing query metrics data - by setting `lookback` to a larger value. (The default value for `lookback` is `2 * collection_interval`). 

### Additional Notes

The agent calculates query metrics only for the statements that were captured in two consecutive snapshots. The statement that doesn't appear in the next snapshot, but then shows up again in one of the subsequent snapshots, won't be captured. This can be resolved by increasing the `lookback`

Here's an example where the default settings weren't sufficient for capturing the statements of a specific workload: https://datadoghq.atlassian.net/browse/SDBM-597. The escalation is for SQL Server, but the algorithm is exactly the same, so the problem is also relevant for the Oracle integration.

### Possible Drawbacks / Trade-offs

Increasing `lookback` will require large cache. Therefore, the parameter remains hidden for now. 

### Describe how to test/QA your changes

Set `collection_interval to 1`. Compare the number of captured statements with  `lookback` not set, and then set to a large value.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
