### PR TITLE
[utils/ecs/metadata/testutil/dummy_ecs] Simplify Start()

### DIFF
--- a/pkg/util/ecs/metadata/detection_test.go
+++ b/pkg/util/ecs/metadata/detection_test.go
@@ -32,8 +32,7 @@ func TestLocateECSHTTP(t *testing.T) {
 	)
 	require.Nil(t, err)
 
-	ts, _, err := ecsinterface.Start()
-	require.Nil(t, err)
+	ts := ecsinterface.Start()
 	defer ts.Close()
 
 	config.Datadog.SetDefault("ecs_agent_url", ts.URL)
@@ -56,8 +55,7 @@ func TestLocateECSHTTPFail(t *testing.T) {
 	ecsinterface, err := testutil.NewDummyECS()
 	require.Nil(t, err)
 
-	ts, _, err := ecsinterface.Start()
-	require.Nil(t, err)
+	ts := ecsinterface.Start()
 	defer ts.Close()
 
 	config.Datadog.SetDefault("ecs_agent_url", ts.URL)

--- a/pkg/util/ecs/metadata/testutil/dummy_ecs.go
+++ b/pkg/util/ecs/metadata/testutil/dummy_ecs.go
@@ -9,9 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
-	"strconv"
 )
 
 // DummyECS allows tests to mock ECS metadata server responses
@@ -78,15 +76,6 @@ func (d *DummyECS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // Start starts the HTTP server
-func (d *DummyECS) Start() (*httptest.Server, int, error) {
-	ts := httptest.NewServer(d)
-	ecsAgentURL, err := url.Parse(ts.URL)
-	if err != nil {
-		return nil, 0, err
-	}
-	ecsAgentPort, err := strconv.Atoi(ecsAgentURL.Port())
-	if err != nil {
-		return nil, 0, err
-	}
-	return ts, ecsAgentPort, nil
+func (d *DummyECS) Start() *httptest.Server {
+	return httptest.NewServer(d)
 }

--- a/pkg/util/ecs/metadata/v1/client_test.go
+++ b/pkg/util/ecs/metadata/v1/client_test.go
@@ -26,10 +26,9 @@ func TestGetInstance(t *testing.T) {
 	ecsinterface, err := testutil.NewDummyECS(
 		testutil.FileHandlerOption("/v1/metadata", "./testdata/instance.json"),
 	)
+	require.Nil(t, err)
 
-	require.Nil(t, err)
-	ts, _, err := ecsinterface.Start()
-	require.Nil(t, err)
+	ts := ecsinterface.Start()
 	defer ts.Close()
 
 	expected := &Instance{
@@ -57,10 +56,9 @@ func TestGetTasks(t *testing.T) {
 	ecsinterface, err := testutil.NewDummyECS(
 		testutil.FileHandlerOption("/v1/tasks", "./testdata/tasks.json"),
 	)
+	require.Nil(t, err)
 
-	require.Nil(t, err)
-	ts, _, err := ecsinterface.Start()
-	require.Nil(t, err)
+	ts := ecsinterface.Start()
 	defer ts.Close()
 
 	expected := []Task{
@@ -106,10 +104,9 @@ func TestGetTasksFail(t *testing.T) {
 	ecsinterface, err := testutil.NewDummyECS(
 		testutil.RawHandlerOption("/v1/tasks", ""),
 	)
+	require.Nil(t, err)
 
-	require.Nil(t, err)
-	ts, _, err := ecsinterface.Start()
-	require.Nil(t, err)
+	ts := ecsinterface.Start()
 	defer ts.Close()
 
 	var expected []Task

--- a/pkg/util/ecs/metadata/v2/client_test.go
+++ b/pkg/util/ecs/metadata/v2/client_test.go
@@ -27,8 +27,7 @@ func TestGetTask(t *testing.T) {
 	)
 	require.Nil(t, err)
 
-	ts, _, err := ecsinterface.Start()
-	require.Nil(t, err)
+	ts := ecsinterface.Start()
 	defer ts.Close()
 
 	expected := &Task{
@@ -128,8 +127,7 @@ func TestGetTaskWithTags(t *testing.T) {
 	)
 	require.Nil(t, err)
 
-	ts, _, err := ecsinterface.Start()
-	require.Nil(t, err)
+	ts := ecsinterface.Start()
 	defer ts.Close()
 
 	expected := &Task{
@@ -451,8 +449,7 @@ func TestGetContainerStats(t *testing.T) {
 			)
 			require.Nil(t, err)
 
-			ts, _, err := ecsinterface.Start()
-			require.Nil(t, err)
+			ts := ecsinterface.Start()
 			defer ts.Close()
 
 			metadata, err := NewClient(ts.URL).GetContainerStats(ctx, test.containerID)


### PR DESCRIPTION
### What does this PR do?

Small cleanup. Simplifies the ECS tests by removing the port returned in the `Start` func of `pkg/util/ecs/metadata/testutil/dummy_ecs.go` because it's not used anywhere.


### Describe how to test/QA your changes

Skip.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
