### PR TITLE
[prometheus_scrape] Add support for multiple Openmetrics V2 parameters

### DIFF
--- a/pkg/autodiscovery/common/types/prometheus.go
+++ b/pkg/autodiscovery/common/types/prometheus.go
@@ -100,6 +100,7 @@ type OpenmetricsInstance struct {
 	RenameLabels                     map[string]string            `mapstructure:"rename_labels" yaml:"rename_labels,omitempty" json:"rename_labels,omitempty"`                                           // Supersedes `labels_mapper`
 	ShareLabels                      map[string]ShareLabelsConfig `mapstructure:"share_labels" yaml:"share_labels,omitempty" json:"share_labels,omitempty"`                                              // Supersedes `label_joins`
 	CacheSharedLabels                bool                         `mapstructure:"cache_shared_labels" yaml:"cache_shared_labels,omitempty" json:"cache_shared_labels,omitempty"`
+	RawLineFilters                   []string                     `mapstructure:"raw_line_filters" yaml:"raw_line_filters,omitempty" json:"raw_line_filters,omitempty"`
 	CollectHistogramBuckets          *bool                        `mapstructure:"collect_histogram_buckets" yaml:"collect_histogram_buckets,omitempty" json:"collect_histogram_buckets,omitempty"` // Supersedes `send_histograms_buckets`
 	NonCumulativeHistogramBuckets    *bool                        `mapstructure:"non_cumulative_histogram_buckets" yaml:"non_cumulative_histogram_buckets,omitempty" json:"non_cumulative_histogram_buckets,omitempty"`
 	HistogramBucketsAsDistributions  bool                         `mapstructure:"histogram_buckets_as_distributions" yaml:"histogram_buckets_as_distributions,omitempty" json:"histogram_buckets_as_distributions,omitempty"` // Supersedes `send_distribution_buckets`
@@ -111,6 +112,7 @@ type OpenmetricsInstance struct {
 	Telemetry                        *bool                        `mapstructure:"telemetry" yaml:"telemetry,omitempty" json:"telemetry,omitempty"`
 	IgnoreConnectionErrors           *bool                        `mapstructure:"ignore_connection_errors" yaml:"ignore_connection_errors,omitempty" json:"ignore_connection_errors,omitempty"`
 	RequestSize                      int                          `mapstructure:"request_size" yaml:"request_size,omitempty" json:"request_size,omitempty"`
+	LogRequests                      *bool                        `mapstructure:"log_requests" yaml:"log_requests,omitempty" json:"log_requests,omitempty"`
 	PersistConnections               *bool                        `mapstructure:"persist_connections" yaml:"persist_connections,omitempty" json:"persist_connections,omitempty"`
 	AllowRedirects                   bool                         `mapstructure:"allow_redirects" yaml:"allow_redirects,omitempty" json:"allow_redirects,omitempty"`
 	AuthToken                        map[string]interface{}       `mapstructure:"auth_token" yaml:"auth_token,omitempty" json:"auth_token,omitempty"`

--- a/pkg/autodiscovery/common/types/prometheus.go
+++ b/pkg/autodiscovery/common/types/prometheus.go
@@ -91,15 +91,29 @@ type OpenmetricsInstance struct {
 	TagByEndpoint                 *bool                       `mapstructure:"tag_by_endpoint" yaml:"tag_by_endpoint,omitempty" json:"tag_by_endpoint,omitempty"`
 
 	// openmetrics v2 specific fields
-	OpenMetricsEndpoint              string                       `mapstructure:"openmetrics_endpoint" yaml:"openmetrics_endpoint,omitempty" json:"openmetrics_endpoint,omitempty"`                                           // Supersedes `prometheus_url`
-	ExcludeMetrics                   []string                     `mapstructure:"exclude_metrics" yaml:"exclude_metrics,omitempty" json:"exclude_metrics,omitempty"`                                                          // Supersedes `ignore_metrics`
-	RawPrefix                        string                       `mapstructure:"raw_metric_prefix" yaml:"raw_metric_prefix,omitempty" json:"raw_metric_prefix,omitempty"`                                                    // Supersedes `prometheus_metrics_prefix`
-	EnableHealthCheck                *bool                        `mapstructure:"enable_health_service_check" yaml:"enable_health_service_check,omitempty" json:"enable_health_service_check,omitempty"`                      // Supersedes `health_service_check`
-	RenameLabels                     map[string]string            `mapstructure:"rename_labels" yaml:"rename_labels,omitempty" json:"rename_labels,omitempty"`                                                                // Supersedes `labels_mapper`
-	ShareLabels                      map[string]ShareLabelsConfig `mapstructure:"share_labels" yaml:"share_labels,omitempty" json:"share_labels,omitempty"`                                                                   // Supersedes `label_joins`
-	CollectHistogramBuckets          *bool                        `mapstructure:"collect_histogram_buckets" yaml:"collect_histogram_buckets,omitempty" json:"collect_histogram_buckets,omitempty"`                            // Supersedes `send_histograms_buckets`
+	OpenMetricsEndpoint              string                       `mapstructure:"openmetrics_endpoint" yaml:"openmetrics_endpoint,omitempty" json:"openmetrics_endpoint,omitempty"`                // Supersedes `prometheus_url`
+	ExcludeMetrics                   []string                     `mapstructure:"exclude_metrics" yaml:"exclude_metrics,omitempty" json:"exclude_metrics,omitempty"`                               // Supersedes `ignore_metrics`
+	ExcludeMetricsByLabels           map[string]interface{}       `mapstructure:"exclude_metrics_by_labels" yaml:"exclude_metrics_by_labels,omitempty" json:"exclude_metrics_by_labels,omitempty"` // Supersedes `ignore_metrics_by_labels`
+	IncludeLabels                    []string                     `mapstructure:"include_labels" yaml:"include_labels,omitempty" json:"include_labels,omitempty"`
+	RawPrefix                        string                       `mapstructure:"raw_metric_prefix" yaml:"raw_metric_prefix,omitempty" json:"raw_metric_prefix,omitempty"`                               // Supersedes `prometheus_metrics_prefix`
+	EnableHealthCheck                *bool                        `mapstructure:"enable_health_service_check" yaml:"enable_health_service_check,omitempty" json:"enable_health_service_check,omitempty"` // Supersedes `health_service_check`
+	RenameLabels                     map[string]string            `mapstructure:"rename_labels" yaml:"rename_labels,omitempty" json:"rename_labels,omitempty"`                                           // Supersedes `labels_mapper`
+	ShareLabels                      map[string]ShareLabelsConfig `mapstructure:"share_labels" yaml:"share_labels,omitempty" json:"share_labels,omitempty"`                                              // Supersedes `label_joins`
+	CacheSharedLabels                bool                         `mapstructure:"cache_shared_labels" yaml:"cache_shared_labels,omitempty" json:"cache_shared_labels,omitempty"`
+	CollectHistogramBuckets          *bool                        `mapstructure:"collect_histogram_buckets" yaml:"collect_histogram_buckets,omitempty" json:"collect_histogram_buckets,omitempty"` // Supersedes `send_histograms_buckets`
+	NonCumulativeHistogramBuckets    *bool                        `mapstructure:"non_cumulative_histogram_buckets" yaml:"non_cumulative_histogram_buckets,omitempty" json:"non_cumulative_histogram_buckets,omitempty"`
 	HistogramBucketsAsDistributions  bool                         `mapstructure:"histogram_buckets_as_distributions" yaml:"histogram_buckets_as_distributions,omitempty" json:"histogram_buckets_as_distributions,omitempty"` // Supersedes `send_distribution_buckets`
 	CollectCountersWithDistributions bool                         `mapstructure:"collect_counters_with_distributions" yaml:"collect_counters_with_distributions,omitempty" json:"collect_counters_with_distributions,omitempty"`
+	UseProcessStartTime              *bool                        `mapstructure:"use_process_start_time" yaml:"use_process_start_time,omitempty" json:"use_process_start_time,omitempty"`
+	HostnameLabel                    string                       `mapstructure:"hostname_label" yaml:"hostname_label,omitempty" json:"hostname_label,omitempty"`
+	HostnameFormat                   string                       `mapstructure:"hostname_format" yaml:"hostname_format,omitempty" json:"hostname_format,omitempty"`
+	CacheMetricWildcards             bool                         `mapstructure:"cache_metric_wildcards" yaml:"cache_metric_wildcards,omitempty" json:"cache_metric_wildcards,omitempty"`
+	Telemetry                        *bool                        `mapstructure:"telemetry" yaml:"telemetry,omitempty" json:"telemetry,omitempty"`
+	IgnoreConnectionErrors           *bool                        `mapstructure:"ignore_connection_errors" yaml:"ignore_connection_errors,omitempty" json:"ignore_connection_errors,omitempty"`
+	RequestSize                      int                          `mapstructure:"request_size" yaml:"request_size,omitempty" json:"request_size,omitempty"`
+	PersistConnections               *bool                        `mapstructure:"persist_connections" yaml:"persist_connections,omitempty" json:"persist_connections,omitempty"`
+	AllowRedirects                   bool                         `mapstructure:"allow_redirects" yaml:"allow_redirects,omitempty" json:"allow_redirects,omitempty"`
+	AuthToken                        map[string]interface{}       `mapstructure:"auth_token" yaml:"auth_token,omitempty" json:"auth_token,omitempty"`
 }
 
 // LabelJoinsConfig contains the label join configuration fields

--- a/releasenotes/notes/prometheus-scrape-openmetrics-v2-mirror-features-80af416849bf32d1.yaml
+++ b/releasenotes/notes/prometheus-scrape-openmetrics-v2-mirror-features-80af416849bf32d1.yaml
@@ -8,7 +8,7 @@
 ---
 enhancements:
   - |
-    prometheus_scrape: Adds support for multiple Openmetrics V2 features in the ``prometheus_scrape.checks[].configurations[]`` items :
+    prometheus_scrape: Adds support for multiple OpenMetrics V2 features in the ``prometheus_scrape.checks[].configurations[]`` items:
       * ``exclude_metrics_by_labels``
       * ``cache_shared_labels``
       * ``use_process_start_time``

--- a/releasenotes/notes/prometheus-scrape-openmetrics-v2-mirror-features-80af416849bf32d1.yaml
+++ b/releasenotes/notes/prometheus-scrape-openmetrics-v2-mirror-features-80af416849bf32d1.yaml
@@ -1,0 +1,23 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    prometheus_scrape: Adds support for multiple Openmetrics V2 features in the ``prometheus_scrape.checks[].configurations[]`` items :
+      * ``exclude_metrics_by_labels``
+      * ``cache_shared_labels``
+      * ``use_process_start_time``
+      * ``hostname_label``
+      * ``hostname_format``
+      * ``telemetry``
+      * ``ignore_connection_errors``
+      * ``request_size``
+      * ``persist_connections``
+      * ``allow_redirects``
+      * ``auth_token``
+    For the description of each option, refer to the sample configuration : https://github.com/DataDog/integrations-core/blob/master/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example

--- a/releasenotes/notes/prometheus-scrape-openmetrics-v2-mirror-features-80af416849bf32d1.yaml
+++ b/releasenotes/notes/prometheus-scrape-openmetrics-v2-mirror-features-80af416849bf32d1.yaml
@@ -10,6 +10,7 @@ enhancements:
   - |
     prometheus_scrape: Adds support for multiple Openmetrics V2 features in the ``prometheus_scrape.checks[].configurations[]`` items :
       * ``exclude_metrics_by_labels``
+      * ``raw_line_filters``
       * ``cache_shared_labels``
       * ``use_process_start_time``
       * ``hostname_label``
@@ -17,6 +18,7 @@ enhancements:
       * ``telemetry``
       * ``ignore_connection_errors``
       * ``request_size``
+      * ``log_requests``
       * ``persist_connections``
       * ``allow_redirects``
       * ``auth_token``

--- a/releasenotes/notes/prometheus-scrape-openmetrics-v2-mirror-features-80af416849bf32d1.yaml
+++ b/releasenotes/notes/prometheus-scrape-openmetrics-v2-mirror-features-80af416849bf32d1.yaml
@@ -20,4 +20,4 @@ enhancements:
       * ``persist_connections``
       * ``allow_redirects``
       * ``auth_token``
-    For the description of each option, refer to the sample configuration : https://github.com/DataDog/integrations-core/blob/master/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+    For a description of each option, refer to the sample configuration in https://github.com/DataDog/integrations-core/blob/master/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example.


### PR DESCRIPTION
### What does this PR do?

* This PR adds support for multiple parameters available in Openmetrics V2 configurations (e.g. via annotations) within the `prometheus_scrape` feature to get the same behaviour as with Datadog annotations
* Due to the addition of some options, the formatting of previous existing options is also changed, but not the behaviour/functionality, such as `OpenMetricsEndpoint` line

### Motivation

* Recent support case where the customer wanted to use features such as `exclude_metrics_by_labels` (mimicking the existing `ignore_metrics_by_labels` in Prometheus
* Follow-up to https://github.com/DataDog/datadog-agent/pull/14805 where we did not add all possible parameters due to time constraints

### Possible Drawbacks / Trade-offs

* The following behaviour is not specific to this PR, it was already the case before : With the JSON encoding of the Go struct, some characters in strings are encoded to their unicode counterpart (e.g. `<`, `>`, `&`). Therefore, even if this PR aims to align `prometheus_scrape` with all the features of Openmetrics V2, some specific/niche use cases might still require the use of annotations/Openmetrics configuration files.

### Describe how to test/QA your changes

* Deploy the following Prometheus example chart : 
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: prometheus-deployment
  namespace: default
  labels:
    app: prometheus
    purpose: example
spec:
  replicas: 1
  selector:
    matchLabels:
      app: prometheus
      purpose: example
  template:
    metadata:
      labels:
        app: prometheus
        purpose: example
      annotations:
        prometheus.datadog.io/scrape: "true"
        prometheus.io/port: "9090"
        ad.datadoghq.com/prom.checks: |
          {
            "openmetrics": {
              "init_config": {},
              "instances": [
                {
                  "openmetrics_endpoint": "http://%%host%%:9090/metrics",
                  "namespace": "omv2",
                  "metrics": [".*"],
                  "exclude_metrics_by_labels": {
                    "handler": [
                      "/version"
                    ]
                  },
                  "telemetry": true
                }
              ]
            }
          }
    spec:
      containers:
      - name: prom
        image: prom/prometheus
        ports:
          - containerPort: 9090
```
* Deploy the Agent with Helm/Operator with an advanced `prometheus_scrape` configuration : 
```yaml
# Operator variant
    prometheusScrape:
      enabled: true
      additionalConfigs: |-
        - autodiscovery:
            kubernetes_annotations:
              include:
                prometheus.datadog.io/scrape: "true"
          configurations:
          - metrics:
            - .*
            openmetrics_endpoint: http://%%host%%:9090/metrics
            namespace: promscrape
            exclude_metrics_by_labels:
              handler:
              - "/version"
            telemetry: true
```
* Ensure the new parameters are now present in `agent configcheck` when the Configuration source is `Configuration Source: prometheus_pods:containerd://<CONTAINER ID>` with their desired value.
* The code afterwards ran is the Openmetrics python integration, so the functionality is governed by it. Nonetheless, you can deepen the test by evaluating if the parameter is behaving as expected :
    * Ensure the `handler=/version` tag is not present in metric tags such as `promscrape.prometheus_http_requests.count`
    * Ensure `promscrape.telemetry.*` metrics are collected
**Note** : you can do the comparison with `omv2.*` metrics, collected thanks to the Openmetrics V2 annotation
* Other added parameters could also be tested functionally, for instance the `auth_token` can be used to check the connection to the kubelet endpoint (node internal IP from `kubectl get nodes -owide`) which requires authentication : 
```yaml
    prometheusScrape:
      enabled: true
      additionalConfigs: |-
        - autodiscovery:
            kubernetes_annotations:
              include:
                prometheus.datadog.io/scrape: "true"
          configurations:
          - metrics:
            - .*
            openmetrics_endpoint: https://<REPLACE_ME>:10250/metrics/cadvisor
            namespace: promscrape
            auth_token:
              reader:
                type: file
                path: /var/run/secrets/kubernetes.io/serviceaccount/token
              writer:
                type: header
                name: Authorization
                value: Bearer TOKEN
                placeholder: TOKEN
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
