### PR TITLE
Send additional telemetry headers from the serverless agent

### DIFF
--- a/pkg/trace/api/telemetry.go
+++ b/pkg/trace/api/telemetry.go
@@ -30,6 +30,7 @@ type cloudProvider string
 
 const (
 	awsLambda                     cloudResourceType = "AWS Lambda"
+	awsFargate                    cloudResourceType = "AWS Fargate"
 	cloudRun                      cloudResourceType = "GCP Cloud Run"
 	azureAppService               cloudResourceType = "Azure App Service"
 	azureContainerApp             cloudResourceType = "Azure Container App"
@@ -118,14 +119,14 @@ func (r *HTTPReceiver) telemetryProxyHandler() http.Handler {
 		if containerTags != "" {
 			req.Header.Set("x-datadog-container-tags", containerTags)
 		}
-		if taskArn, ok := extractFargateTask(containerTags); ok {
-			req.Header.Set(cloudProviderHeader, string(aws))
-			req.Header.Set("dd-task-arn", taskArn)
-		}
 		if arn, ok := r.conf.GlobalTags[functionARNKeyTag]; ok {
 			req.Header.Set(cloudProviderHeader, string(aws))
-			req.Header.Set(cloudResourceIdentifierHeader, arn)
 			req.Header.Set(cloudResourceTypeHeader, string(awsLambda))
+			req.Header.Set(cloudResourceIdentifierHeader, arn)
+		} else if taskArn, ok := extractFargateTask(containerTags); ok {
+			req.Header.Set(cloudProviderHeader, string(aws))
+			req.Header.Set(cloudResourceTypeHeader, string(awsFargate))
+			req.Header.Set(cloudResourceIdentifierHeader, taskArn)
 		}
 		if origin, ok := r.conf.GlobalTags[originTag]; ok {
 			if origin == "cloudrun" {

--- a/pkg/trace/api/telemetry.go
+++ b/pkg/trace/api/telemetry.go
@@ -129,19 +129,20 @@ func (r *HTTPReceiver) telemetryProxyHandler() http.Handler {
 			req.Header.Set(cloudResourceIdentifierHeader, taskArn)
 		}
 		if origin, ok := r.conf.GlobalTags[originTag]; ok {
-			if origin == "cloudrun" {
+			switch origin {
+			case "cloudrun":
 				req.Header.Set(cloudProviderHeader, string(gcp))
 				req.Header.Set(cloudResourceTypeHeader, string(cloudRun))
 				if serviceName, found := r.conf.GlobalTags["service_name"]; found {
 					req.Header.Set(cloudResourceIdentifierHeader, serviceName)
 				}
-			} else if origin == "appservice" {
+			case "appservice":
 				req.Header.Set(cloudProviderHeader, string(azure))
 				req.Header.Set(cloudResourceTypeHeader, string(azureAppService))
 				if appName, found := r.conf.GlobalTags["app_name"]; found {
 					req.Header.Set(cloudResourceIdentifierHeader, appName)
 				}
-			} else if origin == "containerapp" {
+			case "containerapp":
 				req.Header.Set(cloudProviderHeader, string(azure))
 				req.Header.Set(cloudResourceTypeHeader, string(azureContainerApp))
 				if appName, found := r.conf.GlobalTags["app_name"]; found {

--- a/pkg/trace/api/telemetry_test.go
+++ b/pkg/trace/api/telemetry_test.go
@@ -78,7 +78,7 @@ func TestTelemetryBasicProxyRequest(t *testing.T) {
 	cfg.Hostname = "test_hostname"
 	cfg.SkipSSLValidation = true
 	cfg.DefaultEnv = "test_env"
-	cfg.GlobalTags[functionARNKey] = "test_ARN"
+	cfg.GlobalTags[functionARNKeyTag] = "test_ARN"
 	recv := newTestReceiverFromConfig(cfg)
 	recv.buildMux().ServeHTTP(rec, req)
 
@@ -132,7 +132,7 @@ func TestTelemetryProxyMultipleEndpoints(t *testing.T) {
 	cfg.Hostname = "test_hostname"
 	cfg.SkipSSLValidation = true
 	cfg.DefaultEnv = "test_env"
-	cfg.GlobalTags[functionARNKey] = "test_ARN"
+	cfg.GlobalTags[functionARNKeyTag] = "test_ARN"
 
 	req, rec := newRequestRecorder(t)
 	recv := newTestReceiverFromConfig(cfg)

--- a/pkg/trace/api/telemetry_test.go
+++ b/pkg/trace/api/telemetry_test.go
@@ -190,8 +190,8 @@ func TestAWSFargate(t *testing.T) {
 
 	srv := assertingServer(t, func(req *http.Request, body []byte) error {
 		assert.Equal("AWS", req.Header.Get("DD-Cloud-Provider"))
-		assert.Equal("", req.Header.Get("DD-Cloud-Resource-Type"))
-		assert.Equal("", req.Header.Get("DD-Cloud-Resource-Identifier"))
+		assert.Equal("AWS Fargate", req.Header.Get("DD-Cloud-Resource-Type"))
+		assert.Equal("test_ARN", req.Header.Get("DD-Cloud-Resource-Identifier"))
 
 		endpointCalled.Inc()
 		return nil

--- a/pkg/trace/api/telemetry_test.go
+++ b/pkg/trace/api/telemetry_test.go
@@ -50,13 +50,13 @@ func recordedResponse(t *testing.T, rec *httptest.ResponseRecorder) string {
 	return string(responseBody)
 }
 
-func getTestConfig(endpointUrl string) *config.AgentConfig {
+func getTestConfig(endpointURL string) *config.AgentConfig {
 	cfg := config.New()
 	cfg.Endpoints[0].APIKey = "test_apikey"
 	cfg.TelemetryConfig.Enabled = true
 	cfg.TelemetryConfig.Endpoints = []*config.Endpoint{{
 		APIKey: "test_apikey",
-		Host:   endpointUrl,
+		Host:   endpointURL,
 	}}
 	cfg.Hostname = "test_hostname"
 	cfg.SkipSSLValidation = true
@@ -173,14 +173,14 @@ func TestAzureContainerApp(t *testing.T) {
 	assert.Equal(uint64(1), endpointCalled.Load())
 }
 
-type testContainerIdProvider struct{}
+type testContainerIDProvider struct{}
 
 // NewIDProvider initializes an IDProvider instance, in non-linux environments the procRoot arg is unused.
-func getTestContainerIdProvider() testContainerIdProvider {
-	return testContainerIdProvider{}
+func getTestContainerIDProvider() testContainerIDProvider {
+	return testContainerIDProvider{}
 }
 
-func (_ testContainerIdProvider) GetContainerID(_ context.Context, _ http.Header) string {
+func (testContainerIDProvider) GetContainerID(_ context.Context, _ http.Header) string {
 	return "test_container_id"
 }
 
@@ -203,7 +203,7 @@ func TestAWSFargate(t *testing.T) {
 		return []string{"task_arn:test_ARN"}, nil
 	}
 	recv := newTestReceiverFromConfig(cfg)
-	recv.containerIDProvider = getTestContainerIdProvider()
+	recv.containerIDProvider = getTestContainerIDProvider()
 	recv.buildMux().ServeHTTP(rec, req)
 
 	assert.Equal("OK", recordedResponse(t, rec))

--- a/pkg/trace/api/telemetry_test.go
+++ b/pkg/trace/api/telemetry_test.go
@@ -6,6 +6,7 @@
 package api
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -49,6 +50,20 @@ func recordedResponse(t *testing.T, rec *httptest.ResponseRecorder) string {
 	return string(responseBody)
 }
 
+func getTestConfig(endpointUrl string) *config.AgentConfig {
+	cfg := config.New()
+	cfg.Endpoints[0].APIKey = "test_apikey"
+	cfg.TelemetryConfig.Enabled = true
+	cfg.TelemetryConfig.Endpoints = []*config.Endpoint{{
+		APIKey: "test_apikey",
+		Host:   endpointUrl,
+	}}
+	cfg.Hostname = "test_hostname"
+	cfg.SkipSSLValidation = true
+	cfg.DefaultEnv = "test_env"
+	return cfg
+}
+
 func TestTelemetryBasicProxyRequest(t *testing.T) {
 	endpointCalled := atomic.NewUint64(0)
 	assert := assert.New(t)
@@ -58,7 +73,9 @@ func TestTelemetryBasicProxyRequest(t *testing.T) {
 		assert.Equal("test_apikey", req.Header.Get("DD-API-KEY"))
 		assert.Equal("test_hostname", req.Header.Get("DD-Agent-Hostname"))
 		assert.Equal("test_env", req.Header.Get("DD-Agent-Env"))
-		assert.Equal("test_ARN", req.Header.Get("DD-Function-ARN"))
+		assert.Equal("AWS", req.Header.Get("DD-Cloud-Provider"))
+		assert.Equal("AWS Lambda", req.Header.Get("DD-Cloud-Resource-Type"))
+		assert.Equal("test_ARN", req.Header.Get("DD-Cloud-Resource-Identifier"))
 		assert.Equal("/path", req.URL.Path)
 		assert.Equal("", req.Header.Get("User-Agent"))
 		assert.Regexp(regexp.MustCompile("trace-agent.*"), req.Header.Get("Via"))
@@ -68,16 +85,7 @@ func TestTelemetryBasicProxyRequest(t *testing.T) {
 	})
 
 	req, rec := newRequestRecorder(t)
-	cfg := config.New()
-	cfg.Endpoints[0].APIKey = "test_apikey"
-	cfg.TelemetryConfig.Enabled = true
-	cfg.TelemetryConfig.Endpoints = []*config.Endpoint{{
-		APIKey: "test_apikey",
-		Host:   srv.URL,
-	}}
-	cfg.Hostname = "test_hostname"
-	cfg.SkipSSLValidation = true
-	cfg.DefaultEnv = "test_env"
+	cfg := getTestConfig(srv.URL)
 	cfg.GlobalTags[functionARNKeyTag] = "test_ARN"
 	recv := newTestReceiverFromConfig(cfg)
 	recv.buildMux().ServeHTTP(rec, req)
@@ -85,6 +93,121 @@ func TestTelemetryBasicProxyRequest(t *testing.T) {
 	assert.Equal("OK", recordedResponse(t, rec))
 	assert.Equal(uint64(1), endpointCalled.Load())
 
+}
+
+func TestGoogleCloudRun(t *testing.T) {
+	endpointCalled := atomic.NewUint64(0)
+	assert := assert.New(t)
+
+	srv := assertingServer(t, func(req *http.Request, body []byte) error {
+		assert.Equal("GCP", req.Header.Get("DD-Cloud-Provider"))
+		assert.Equal("GCP Cloud Run", req.Header.Get("DD-Cloud-Resource-Type"))
+		assert.Equal("test_service", req.Header.Get("DD-Cloud-Resource-Identifier"))
+
+		endpointCalled.Inc()
+		return nil
+	})
+
+	req, rec := newRequestRecorder(t)
+	cfg := getTestConfig(srv.URL)
+	cfg.GlobalTags["service_name"] = "test_service"
+	cfg.GlobalTags["origin"] = "cloudrun"
+	recv := newTestReceiverFromConfig(cfg)
+	recv.buildMux().ServeHTTP(rec, req)
+
+	assert.Equal("OK", recordedResponse(t, rec))
+	assert.Equal(uint64(1), endpointCalled.Load())
+}
+
+func TestAzureAppService(t *testing.T) {
+	endpointCalled := atomic.NewUint64(0)
+	assert := assert.New(t)
+
+	srv := assertingServer(t, func(req *http.Request, body []byte) error {
+		assert.Equal("Azure", req.Header.Get("DD-Cloud-Provider"))
+		assert.Equal("Azure App Service", req.Header.Get("DD-Cloud-Resource-Type"))
+		assert.Equal("test_app", req.Header.Get("DD-Cloud-Resource-Identifier"))
+		assert.Equal("/path", req.URL.Path)
+		assert.Equal("", req.Header.Get("User-Agent"))
+		assert.Regexp(regexp.MustCompile("trace-agent.*"), req.Header.Get("Via"))
+
+		endpointCalled.Inc()
+		return nil
+	})
+
+	req, rec := newRequestRecorder(t)
+	cfg := getTestConfig(srv.URL)
+	cfg.GlobalTags["app_name"] = "test_app"
+	cfg.GlobalTags["origin"] = "appservice"
+	recv := newTestReceiverFromConfig(cfg)
+	recv.buildMux().ServeHTTP(rec, req)
+
+	assert.Equal("OK", recordedResponse(t, rec))
+	assert.Equal(uint64(1), endpointCalled.Load())
+}
+
+func TestAzureContainerApp(t *testing.T) {
+	endpointCalled := atomic.NewUint64(0)
+	assert := assert.New(t)
+
+	srv := assertingServer(t, func(req *http.Request, body []byte) error {
+		assert.Equal("Azure", req.Header.Get("DD-Cloud-Provider"))
+		assert.Equal("Azure Container App", req.Header.Get("DD-Cloud-Resource-Type"))
+		assert.Equal("test_app", req.Header.Get("DD-Cloud-Resource-Identifier"))
+		assert.Equal("/path", req.URL.Path)
+		assert.Equal("", req.Header.Get("User-Agent"))
+		assert.Regexp(regexp.MustCompile("trace-agent.*"), req.Header.Get("Via"))
+
+		endpointCalled.Inc()
+		return nil
+	})
+
+	req, rec := newRequestRecorder(t)
+	cfg := getTestConfig(srv.URL)
+	cfg.GlobalTags["app_name"] = "test_app"
+	cfg.GlobalTags["origin"] = "containerapp"
+	recv := newTestReceiverFromConfig(cfg)
+	recv.buildMux().ServeHTTP(rec, req)
+
+	assert.Equal("OK", recordedResponse(t, rec))
+	assert.Equal(uint64(1), endpointCalled.Load())
+}
+
+type testContainerIdProvider struct{}
+
+// NewIDProvider initializes an IDProvider instance, in non-linux environments the procRoot arg is unused.
+func getTestContainerIdProvider() testContainerIdProvider {
+	return testContainerIdProvider{}
+}
+
+func (_ testContainerIdProvider) GetContainerID(_ context.Context, _ http.Header) string {
+	return "test_container_id"
+}
+
+func TestAWSFargate(t *testing.T) {
+	endpointCalled := atomic.NewUint64(0)
+	assert := assert.New(t)
+
+	srv := assertingServer(t, func(req *http.Request, body []byte) error {
+		assert.Equal("AWS", req.Header.Get("DD-Cloud-Provider"))
+		assert.Equal("", req.Header.Get("DD-Cloud-Resource-Type"))
+		assert.Equal("", req.Header.Get("DD-Cloud-Resource-Identifier"))
+
+		endpointCalled.Inc()
+		return nil
+	})
+
+	req, rec := newRequestRecorder(t)
+	cfg := getTestConfig(srv.URL)
+	cfg.ContainerTags = func(cid string) ([]string, error) {
+		return []string{"task_arn:test_ARN"}, nil
+	}
+	recv := newTestReceiverFromConfig(cfg)
+	recv.containerIDProvider = getTestContainerIdProvider()
+	recv.buildMux().ServeHTTP(rec, req)
+
+	assert.Equal("OK", recordedResponse(t, rec))
+	assert.Equal(uint64(1), endpointCalled.Load())
 }
 
 func TestTelemetryProxyMultipleEndpoints(t *testing.T) {
@@ -98,7 +221,9 @@ func TestTelemetryProxyMultipleEndpoints(t *testing.T) {
 		assert.Equal("test_apikey_1", req.Header.Get("DD-API-KEY"))
 		assert.Equal("test_hostname", req.Header.Get("DD-Agent-Hostname"))
 		assert.Equal("test_env", req.Header.Get("DD-Agent-Env"))
-		assert.Equal("test_ARN", req.Header.Get("DD-Function-ARN"))
+		assert.Equal("AWS", req.Header.Get("DD-Cloud-Provider"))
+		assert.Equal("AWS Lambda", req.Header.Get("DD-Cloud-Resource-Type"))
+		assert.Equal("test_ARN", req.Header.Get("DD-Cloud-Resource-Identifier"))
 
 		endpointCalled.Add(2)
 		return nil
@@ -110,15 +235,16 @@ func TestTelemetryProxyMultipleEndpoints(t *testing.T) {
 		assert.Equal("test_apikey_2", req.Header.Get("DD-API-KEY"))
 		assert.Equal("test_hostname", req.Header.Get("DD-Agent-Hostname"))
 		assert.Equal("test_env", req.Header.Get("DD-Agent-Env"))
-		assert.Equal("test_ARN", req.Header.Get("DD-Function-ARN"))
+		assert.Equal("AWS", req.Header.Get("DD-Cloud-Provider"))
+		assert.Equal("AWS Lambda", req.Header.Get("DD-Cloud-Resource-Type"))
+		assert.Equal("test_ARN", req.Header.Get("DD-Cloud-Resource-Identifier"))
 
 		endpointCalled.Add(3)
 		return nil
 	})
 
-	cfg := config.New()
+	cfg := getTestConfig(mainBackend.URL)
 	cfg.Endpoints[0].APIKey = "test_apikey_1"
-	cfg.TelemetryConfig.Enabled = true
 	cfg.TelemetryConfig.Endpoints = []*config.Endpoint{{
 		APIKey: "test_apikey_1",
 		Host:   mainBackend.URL,
@@ -129,8 +255,6 @@ func TestTelemetryProxyMultipleEndpoints(t *testing.T) {
 		APIKey: "test_apikey_2",
 		Host:   additionalBackend.URL + "/",
 	}}
-	cfg.Hostname = "test_hostname"
-	cfg.SkipSSLValidation = true
 	cfg.DefaultEnv = "test_env"
 	cfg.GlobalTags[functionARNKeyTag] = "test_ARN"
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
[Agent changes to label serverless telemetry for GCP and Azure](https://datadoghq.atlassian.net/browse/AIT-8382)
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This adds three new informational headers to the telemetry messages that the serverless agent sends to the Datadog backend.

- `DD-Cloud-Provider`: the cloud provider the agent is running on. Can either be `AWS`, `GCP` or `Azure`
- `DD-Cloud-Resource-Type`: the compute platform that the agent is running on. Can either be `AWS Lambda`, `GCP Cloud Run`, `Azure App Service` or `Azure Container App`
- `DD-Cloud-Resource-Identifier`: a unique identifier for the resource the agent is running with. This is renamed from `DD-Function-ARN` and `DD-Task-ARN`. For AWS Lambda, this is still the function ARN. For AWS Fargate, this is the task ARN. For GCP Cloud Run, this is the service name, and for Azure App Service or Azure Container App this is the app name.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

For AWS Fargate, I am reporting AWS as the cloud provider and the task ARN as the cloud provider identifier. The task ARN for Fargate will have higher cardinality than for AWS Lambda, as each task will have its own ARN. We will have to make changes on the backend to not save the task ARN into the service_config table to avoid creating too many service configs again.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

I have added unit tests and verified that they pass. I also ran end-to-end tests with GCP and Azure as follows.

## GCP End to End Test

1. Clone [the Datadog Lambda Extension repo](https://github.com/DataDog/datadog-lambda-extension) and [the Datadog Agent repo](https://github.com/DataDog/datadog-agent) into the same parent directory, e.g. `~/dd/`.
2. Before testing, add this line [in telemetry.go](https://github.com/DataDog/datadog-agent/blob/a1a3ea0690901a97360d5941b92f7b0b2cb6b7b8/pkg/trace/api/telemetry.go#L115)
```
req.Header.Set("DD-Telemetry-Debug-Enabled", "true")
```
to enable logging your telemetry messages on the backend.

3. Run `VERSION=0 SERVERLESS_INIT=true ./scripts/build_binary_and_layer_dockerized.sh` in the Datadog Lambda Extension repo to build the serverless agent.
4. Create a "Hello World" serverless application on Google Cloud Run [as described here](https://cloud.google.com/run/docs/quickstarts/build-and-deploy/go).
5. Add a Datadog tracer library to your "Hello World" appliation [as described here](https://docs.datadoghq.com/tracing/trace_collection/library_config/go/)
6. Add a Dockerfile to your application [as described here](https://cloud.google.com/run/docs/building/containers). Note: I used the Cloud Build method, you can use either cloud or local build. My Dockerfile contents are below.
7. Follow [the public instructions](https://docs.datadoghq.com/serverless/google_cloud_run) to add the serverless agent to your "Hello World" application.
8. Copy the binary file that you built to the same location as your Dockerfile:
```
cp datadog-lambda-extension/.layers/datadog_extension-amd64/extensions/datadog-agent ~/workspace/calc-go
```

9. In your Dockerfile, replace
```
COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
```
with
```
COPY datadog-init /app/datadog-init
```
to make it run your local build of the serverless agent with your "Hello World" app. 

10. Deploy your serverless application, and send a request to it (e.g. go to https://calc-go-3ind7pvctq-ue.a.run.app/ ) to start it. Make sure you can see the three new headers (`cloud_provider`, `cloud_resource_type` and `cloud_resource_identifier`) [being reported in the staging logs](https://ddstaging.datadoghq.com/logs?query=service%3Atracer-telemetry-intake%20calc-go%20&cols=host%2Cservice&event=AgAAAYq-sqyrfd9GlAAAAAAAAAAYAAAAAEFZcS1zcTU3QUFCeTY4Q3cxaDV2SVFCRwAAACQAAAAAMDE4YWJlYjItZDRkZC00MjEzLWI4YjctYjQ5MDc3OGYyYmI2&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=time%2Cdesc&viz=stream&from_ts=1677521162227&to_ts=1677524762227&live=true) for `tracer-telemetry-intake`.

Note: I used my own Google Cloud account instead of EU1 for this test.

My Dockerfile for the GCP test:
```
# Copyright 2020 Google LLC
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#    https://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

# [START cloudrun_helloworld_dockerfile]
# [START run_helloworld_dockerfile]

# Use the offical golang image to create a binary.
# This is based on Debian and sets the GOPATH to /go.
# https://hub.docker.com/_/golang
FROM golang:1.19-buster as builder

# Create and change to the app directory.
WORKDIR /app

# Retrieve application dependencies.
# This allows the container build to reuse cached dependencies.
# Expecting to copy go.mod and if present go.sum.
COPY go.* ./
RUN go mod download

# Copy local code to the container image.
COPY . ./

# Build the binary.
RUN go build -v -o server

# Use the official Debian slim image for a lean production container.
# https://hub.docker.com/_/debian
# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
FROM debian:buster-slim
RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
    ca-certificates && \
    rm -rf /var/lib/apt/lists/*

# Copy the binary to the production image from the builder stage.
COPY --from=builder /app/server /app/server

COPY datadog-init /app/datadog-init
ENTRYPOINT ["/app/datadog-init"]

ENV DD_SERVICE=yshapiro-calc-go
ENV DD_ENV=dev
ENV DD_VERSION=12
ENV DD_API_KEY=[my_staging_api_key]
ENV DD_TRACE_ENABLED=true
ENV DD_SITE=datad0g.com
ENV NAME=Yakov

# Run the web service on container startup.
CMD ["/app/server"]

# [END run_helloworld_dockerfile]
# [END cloudrun_helloworld_dockerfile]
```

## Azure End to End Test

Follow the same steps as for GCP, but with the following changes:

- In step 4, [follow these instructions](https://learn.microsoft.com/en-us/azure/container-apps/quickstart-code-to-cloud?tabs=bash%2Cgo&pivots=github-build) to deploy a "Hello World" app to Azure Container Apps.
- For deployment, build your app locally instead of through GitHub as the instructions tell you, using the following command:
```
az containerapp up --name $API_NAME --resource-group $RESOURCE_GROUP --location $LOCATION --environment $ENVIRONMENT --context-path ./src --source .
```
Otherwise if you try to build through GitHub, you will get an error saying you cannot commit your staging API key into a Dockerfile that goes on GitHub. I did not bother going through the recommended song and dance with storing my staging API key in Azure secrets.

[Here are the logs](https://ddstaging.datadoghq.com/logs?query=service%3Atracer-telemetry-intake%20album%20&cols=host%2Cservice&event=AgAAAYq-PeN4F-sNTwAAAAAAAAAYAAAAAEFZcS1QZk8xQUFCYVdGS2Fsc1YxU1FDMQAAACQAAAAAMDE4YWJlNzYtYWUwYi00NDBlLTliNjUtNjg2NzEzYTZiY2Nm&index=%2A&messageDisplay=inline&refresh_mode=sliding&stream_sort=time%2Cdesc&viz=stream&from_ts=1695403458673&to_ts=1695417858673&live=true) I saw at the end of my test with the three new headers.

As with GCP, I used a personal Azure account for testing instead of US3. Here is my Dockerfile for Azure:

```
# Dockerfile References: https://docs.docker.com/engine/reference/builder/

# Start from the latest golang base image
FROM golang:latest

# Set the Current Working Directory inside the container
WORKDIR /app

# Add files to app folder
ADD . /app

# Build the Go app
RUN go build -o main .

# Expose ports to the outside world
EXPOSE 3500

COPY datadog-init /app/datadog-init
ENTRYPOINT ["/app/datadog-init"]

ENV DD_SERVICE=album-api
ENV DD_ENV=dev
ENV DD_VERSION=11
ENV DD_API_KEY=[my_staging_api_key]
ENV DD_TRACE_ENABLED=true
ENV DD_AZURE_SUBSCRIPTION_ID=[my_azure_subscription_id]
ENV DD_AZURE_RESOURCE_GROUP=album-containerapps
ENV DD_SITE=datad0g.com

# Command to run the executable
CMD ["./main"]
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
