### PR TITLE
[ebpf] ensure the BTF kernel spec is not copied multiple times for no reason

### DIFF
--- a/cmd/system-probe/api/server.go
+++ b/cmd/system-probe/api/server.go
@@ -54,6 +54,10 @@ func StartServer(cfg *config.Config, telemetry telemetry.Component) error {
 		return fmt.Errorf("failed to create system probe: %s", err)
 	}
 
+	if err := modules.PostRegisterCleanup(); err != nil {
+		log.Errorf("failed to run post-register cleanup callack: %v", err)
+	}
+
 	// Register stats endpoint
 	mux.HandleFunc("/debug/stats", utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, func(w http.ResponseWriter, req *http.Request) {
 		utils.WriteAsJSON(w, module.GetStats())

--- a/cmd/system-probe/modules/cleanup_linux_ebpf.go
+++ b/cmd/system-probe/modules/cleanup_linux_ebpf.go
@@ -11,6 +11,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 )
 
+// PostRegisterCleanup is a function that will be called after modules are registered, it should run cleanup code
+// that is common to most system probe modules
 func PostRegisterCleanup() error {
 	ebpf.FlushKernelSpecCache()
 	return nil

--- a/cmd/system-probe/modules/cleanup_linux_ebpf.go
+++ b/cmd/system-probe/modules/cleanup_linux_ebpf.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && linux_bpf
+
+package modules
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/ebpf"
+)
+
+func PostRegisterCleanup() error {
+	ebpf.FlushKernelSpecCache()
+	return nil
+}

--- a/cmd/system-probe/modules/cleanup_unsupported.go
+++ b/cmd/system-probe/modules/cleanup_unsupported.go
@@ -7,6 +7,8 @@
 
 package modules
 
+// PostRegisterCleanup is a function that will be called after modules are registered, it should run cleanup code
+// that is common to most system probe modules
 func PostRegisterCleanup() error {
 	return nil
 }

--- a/cmd/system-probe/modules/cleanup_unsupported.go
+++ b/cmd/system-probe/modules/cleanup_unsupported.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !(linux && linux_bpf)
+
+package modules
+
+func PostRegisterCleanup() error {
+	return nil
+}

--- a/pkg/ebpf/btf.go
+++ b/pkg/ebpf/btf.go
@@ -168,5 +168,6 @@ func ReleaseKernelSpecCache() {
 	if kernelSpecCache.refCount <= 0 {
 		kernelSpecCache.spec = nil
 		btf.FlushKernelSpec()
+		kernelSpecCache.refCount = 0
 	}
 }

--- a/pkg/ebpf/btf.go
+++ b/pkg/ebpf/btf.go
@@ -144,6 +144,9 @@ func GetKernelSpec() (*btf.Spec, error) {
 		return kernelSpecCache.spec, nil
 	}
 
+	// re-sync refCount
+	kernelSpecCache.refCount = 0
+
 	spec, err := btf.LoadKernelSpec()
 	if err != nil {
 		return nil, err

--- a/pkg/ebpf/co_re.go
+++ b/pkg/ebpf/co_re.go
@@ -36,7 +36,7 @@ func LoadCOREAsset(cfg *Config, filename string, startFn func(bytecode.AssetRead
 	if btfData == nil {
 		return fmt.Errorf("could not find BTF data on host")
 	}
-	defer KernelSpecFlushCache()
+	defer ReleaseKernelSpecCache()
 
 	buf, err := bytecode.GetReader(filepath.Join(cfg.BPFDir, "co-re"), filename)
 	if err != nil {

--- a/pkg/ebpf/co_re.go
+++ b/pkg/ebpf/co_re.go
@@ -36,7 +36,7 @@ func LoadCOREAsset(cfg *Config, filename string, startFn func(bytecode.AssetRead
 	if btfData == nil {
 		return fmt.Errorf("could not find BTF data on host")
 	}
-	defer btf.FlushKernelSpec()
+	defer KernelSpecFlushCache()
 
 	buf, err := bytecode.GetReader(filepath.Join(cfg.BPFDir, "co-re"), filename)
 	if err != nil {

--- a/pkg/ebpf/co_re.go
+++ b/pkg/ebpf/co_re.go
@@ -36,7 +36,6 @@ func LoadCOREAsset(cfg *Config, filename string, startFn func(bytecode.AssetRead
 	if btfData == nil {
 		return fmt.Errorf("could not find BTF data on host")
 	}
-	defer ReleaseKernelSpecCache()
 
 	buf, err := bytecode.GetReader(filepath.Join(cfg.BPFDir, "co-re"), filename)
 	if err != nil {

--- a/pkg/security/probe/constantfetch/available_unsupported.go
+++ b/pkg/security/probe/constantfetch/available_unsupported.go
@@ -20,10 +20,6 @@ import (
 func GetAvailableConstantFetchers(config *config.Config, kv *kernel.Version, statsdClient statsd.ClientInterface) []ConstantFetcher {
 	fetchers := make([]ConstantFetcher, 0)
 
-	if coreFetcher, err := NewBTFConstantFetcherFromCurrentKernel(); err == nil {
-		fetchers = append(fetchers, coreFetcher)
-	}
-
 	btfhubFetcher, err := NewBTFHubConstantFetcher(kv)
 	if err != nil {
 		seclog.Debugf("failed to create btfhub constant fetcher: %v", err)

--- a/pkg/security/probe/constantfetch/btfhub/main.go
+++ b/pkg/security/probe/constantfetch/btfhub/main.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
+//go:build linux && linux_bpf
 
 // Package main holds main related files
 package main

--- a/pkg/security/probe/constantfetch/core.go
+++ b/pkg/security/probe/constantfetch/core.go
@@ -48,7 +48,7 @@ func NewBTFConstantFetcherFromCurrentKernel() (*BTFConstantFetcher, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer ebpf.KernelSpecFlushCache()
+	defer ebpf.ReleaseKernelSpecCache()
 	return NewBTFConstantFetcherFromSpec(spec), nil
 }
 

--- a/pkg/security/probe/constantfetch/core.go
+++ b/pkg/security/probe/constantfetch/core.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
+//go:build linux && linux_bpf
 
 // Package constantfetch holds constantfetch related files
 package constantfetch
@@ -14,6 +14,8 @@ import (
 	"strings"
 
 	"github.com/cilium/ebpf/btf"
+
+	"github.com/DataDog/datadog-agent/pkg/ebpf"
 )
 
 // BTFConstantFetcher is a constant fetcher based on BTF data (from file or current kernel)
@@ -42,11 +44,11 @@ func NewBTFConstantFetcherFromReader(btfReader io.ReaderAt) (*BTFConstantFetcher
 
 // NewBTFConstantFetcherFromCurrentKernel creates a BTFConstantFetcher, reading BTF from current kernel
 func NewBTFConstantFetcherFromCurrentKernel() (*BTFConstantFetcher, error) {
-	spec, err := btf.LoadKernelSpec()
+	spec, err := ebpf.GetKernelSpec()
 	if err != nil {
 		return nil, err
 	}
-	defer btf.FlushKernelSpec()
+	defer ebpf.KernelSpecFlushCache()
 	return NewBTFConstantFetcherFromSpec(spec), nil
 }
 

--- a/pkg/security/probe/constantfetch/core.go
+++ b/pkg/security/probe/constantfetch/core.go
@@ -48,7 +48,6 @@ func NewBTFConstantFetcherFromCurrentKernel() (*BTFConstantFetcher, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer ebpf.ReleaseKernelSpecCache()
 	return NewBTFConstantFetcherFromSpec(spec), nil
 }
 

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -604,7 +604,7 @@ def generate_btfhub_constants(ctx, archive_path, force_refresh=False):
     output_path = "./pkg/security/probe/constantfetch/btfhub/constants.json"
     force_refresh_opt = "-force-refresh" if force_refresh else ""
     ctx.run(
-        f"go run ./pkg/security/probe/constantfetch/btfhub/ -archive-root {archive_path} -output {output_path} {force_refresh_opt}",
+        f"go run -tags linux_bpf ./pkg/security/probe/constantfetch/btfhub/ -archive-root {archive_path} -output {output_path} {force_refresh_opt}",
     )
 
 


### PR DESCRIPTION
### What does this PR do?

`btf.LoadKernelSpec` does a deep copy every time it's called, allocating a lot of memory. Since we call it once for each system probe module it ends up being quite costly. This PR "solves" this issue by only calling it once and sharing this copy between system probe users. The cache is kept until after all modules are registered when we actually do the `FlushKernelSpec` operation. 

This also has the advantage of reducing CPU at startup as well since the BTF copy operation is CPU intensive

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
