### PR TITLE
[ASCII-739] Fix use of deprecated packages and functions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,11 +50,15 @@ issues:
       text: "name will be used as .* by other packages, and that stutters"
     - path: pkg/util/containerd
       text: "name will be used as .* by other packages, and that stutters"
-    # TODO: Needs manual update
+    # Should be replaced by google.golang.org/protobuf but is not a drop-in replacement
     - text: "\"github.com/golang/protobuf/proto\" is deprecated"
       linters: [staticcheck]
+    # Can't rely on getting the same elements after calling Seed because dependencies could be using
+    # it too. Should be replaced by using a local source, but there are too many uses in the repo.
     - text: "rand.Seed has been deprecated since Go 1.20"
       linters: [staticcheck]
+    # net.Error.Temporary() isn't properly defined and was thus deprecated.
+    # We are using it and it's not clear how to replace it.
     - text: "Temporary has been deprecated since Go 1.18"
       linters: [staticcheck]
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,11 @@ issues:
     - path: pkg/util/containerd
       text: "name will be used as .* by other packages, and that stutters"
     # TODO: Needs manual update
-    - text: "package github.com/golang/protobuf/proto is deprecated: .*"
+    - text: "\"github.com/golang/protobuf/proto\" is deprecated"
+      linters: [staticcheck]
+    - text: "rand.Seed has been deprecated since Go 1.20"
+      linters: [staticcheck]
+    - text: "Temporary has been deprecated since Go 1.18"
       linters: [staticcheck]
 
   # We're enabling the revive and the gosimple linters on the whole codebase
@@ -99,7 +103,7 @@ linters-settings:
              # Actual issues that should be fixed eventually
              "-SA6002", # TODO: Fix sync.Pools
              "-SA4025", # TODO: Fix trace unit test
-             "-SA1019", "-SA4011", "-SA4031" # Disabling these to re-enable golanci-lint default tests
+             "-SA4011", "-SA4031" # Disabling these to re-enable golanci-lint default tests
             ]
   govet:
     settings:

--- a/comp/forwarder/defaultforwarder/domain_forwarder.go
+++ b/comp/forwarder/defaultforwarder/domain_forwarder.go
@@ -73,7 +73,7 @@ func newDomainForwarder(
 func (f *domainForwarder) retryTransactions(retryBefore time.Time) {
 	// In case it takes more that flushInterval to sort and retry
 	// transactions we skip a retry.
-	if !f.isRetrying.CAS(false, true) {
+	if !f.isRetrying.CompareAndSwap(false, true) {
 		f.log.Errorf("The forwarder is still retrying Transaction: this should never happens, you might want to lower the 'forwarder_retry_queue_payloads_max_size'")
 		return
 	}

--- a/comp/forwarder/defaultforwarder/internal/retry/telemetry.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/telemetry.go
@@ -9,6 +9,9 @@ import (
 	"expvar"
 	"strings"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 )
@@ -305,10 +308,11 @@ func (t onDiskRetryQueueTelemetry) addDeserializeTransactionsCount(count int) {
 }
 
 func toCamelCase(s string) string {
+	caser := cases.Title(language.English)
 	parts := strings.Split(s, "_")
 	var camelCase string
 	for _, p := range parts {
-		camelCase += strings.Title(p)
+		camelCase += caser.String(p)
 	}
 	return camelCase
 }

--- a/comp/systray/systray/doflare.go
+++ b/comp/systray/systray/doflare.go
@@ -141,7 +141,7 @@ func onFlare(s *systray) {
 	// pass data around.  Don't allow multiple dialogs to be displayed
 
 	// (in go1.18, this could be done with sync.Mutex#TryLock)
-	if !inProgress.CAS(false, true) {
+	if !inProgress.CompareAndSwap(false, true) {
 		s.log.Warn("Dialog already in progress, skipping")
 		return
 	}

--- a/pkg/clusteragent/api/v1/types.go
+++ b/pkg/clusteragent/api/v1/types.go
@@ -27,7 +27,7 @@ import (
 type NamespacesPodsStringsSet map[string]MapStringSet
 
 // MapStringSet maps a set of string by a string key
-type MapStringSet map[string]sets.String
+type MapStringSet map[string]sets.Set[string]
 
 /*
  TODO: we should replace the NamespacesPodsStringsSet struct by the following struct.
@@ -37,7 +37,7 @@ type NamespacesPodsStringsSet struct {
 }
 
 type PodsStringsSet struct {
-	Pods map[string]sets.String `json:"pods"`
+	Pods map[string]sets.Set[string] `json:"pods"`
 }
 */
 
@@ -58,7 +58,7 @@ func (m NamespacesPodsStringsSet) DeepCopy(old *NamespacesPodsStringsSet) Namesp
 		}
 		for pod, svcs := range val1 {
 			if _, ok := m[nsKey][pod]; !ok {
-				m[nsKey][pod] = sets.NewString()
+				m[nsKey][pod] = sets.New[string]()
 			}
 			m[nsKey][pod] = m[nsKey][pod].Union(svcs)
 		}
@@ -81,10 +81,10 @@ func (m NamespacesPodsStringsSet) Get(namespace, podName string) ([]string, bool
 // Set updates strings for a given namespace and pod name.
 func (m NamespacesPodsStringsSet) Set(namespace, podName string, strings ...string) {
 	if _, ok := m[namespace]; !ok {
-		m[namespace] = make(map[string]sets.String)
+		m[namespace] = make(map[string]sets.Set[string])
 	}
 	if _, ok := m[namespace][podName]; !ok {
-		m[namespace][podName] = sets.NewString()
+		m[namespace][podName] = sets.New[string]()
 	}
 	m[namespace][podName].Insert(strings...)
 }

--- a/pkg/clusteragent/api/v1/types_test.go
+++ b/pkg/clusteragent/api/v1/types_test.go
@@ -22,58 +22,58 @@ func TestNamespacesPodsStringsSet_Copy(t *testing.T) {
 		{
 			name: "nil input map",
 			m: NamespacesPodsStringsSet{
-				"foo": map[string]sets.String{"bar": sets.NewString("buz")},
+				"foo": map[string]sets.Set[string]{"bar": sets.New("buz")},
 			},
 			old: nil,
 			want: NamespacesPodsStringsSet{
-				"foo": map[string]sets.String{"bar": sets.NewString("buz")},
+				"foo": map[string]sets.Set[string]{"bar": sets.New("buz")},
 			},
 		},
 		{
 			name: "base case",
 			m:    NamespacesPodsStringsSet{},
 			old: &NamespacesPodsStringsSet{
-				"foo": map[string]sets.String{"bar": sets.NewString("buz")},
+				"foo": map[string]sets.Set[string]{"bar": sets.New("buz")},
 			},
 			want: NamespacesPodsStringsSet{
-				"foo": map[string]sets.String{"bar": sets.NewString("buz")},
+				"foo": map[string]sets.Set[string]{"bar": sets.New("buz")},
 			},
 		},
 		{
 			name: "merge case",
 			m: NamespacesPodsStringsSet{
-				"fuu": map[string]sets.String{"bur": sets.NewString("buz")},
+				"fuu": map[string]sets.Set[string]{"bur": sets.New("buz")},
 			},
 			old: &NamespacesPodsStringsSet{
-				"foo": map[string]sets.String{"bar": sets.NewString("buz")},
+				"foo": map[string]sets.Set[string]{"bar": sets.New("buz")},
 			},
 			want: NamespacesPodsStringsSet{
-				"foo": map[string]sets.String{"bar": sets.NewString("buz")},
-				"fuu": map[string]sets.String{"bur": sets.NewString("buz")},
+				"foo": map[string]sets.Set[string]{"bar": sets.New("buz")},
+				"fuu": map[string]sets.Set[string]{"bur": sets.New("buz")},
 			},
 		},
 		{
 			name: "merge service case",
 			m: NamespacesPodsStringsSet{
-				"foo": map[string]sets.String{"bur": sets.NewString("boz")},
+				"foo": map[string]sets.Set[string]{"bur": sets.New("boz")},
 			},
 			old: &NamespacesPodsStringsSet{
-				"foo": map[string]sets.String{"bar": sets.NewString("buz")},
+				"foo": map[string]sets.Set[string]{"bar": sets.New("buz")},
 			},
 			want: NamespacesPodsStringsSet{
-				"foo": map[string]sets.String{"bar": sets.NewString("buz"), "bur": sets.NewString("boz")},
+				"foo": map[string]sets.Set[string]{"bar": sets.New("buz"), "bur": sets.New("boz")},
 			},
 		},
 		{
 			name: "union case",
 			m: NamespacesPodsStringsSet{
-				"foo": map[string]sets.String{"bur": sets.NewString("boz")},
+				"foo": map[string]sets.Set[string]{"bur": sets.New("boz")},
 			},
 			old: &NamespacesPodsStringsSet{
-				"foo": map[string]sets.String{"bur": sets.NewString("buz")},
+				"foo": map[string]sets.Set[string]{"bur": sets.New("buz")},
 			},
 			want: NamespacesPodsStringsSet{
-				"foo": map[string]sets.String{"bur": sets.NewString("buz", "boz")},
+				"foo": map[string]sets.Set[string]{"bur": sets.New("buz", "boz")},
 			},
 		},
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/node.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/node.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers"
 
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
@@ -209,7 +210,7 @@ func findNodeRoles(nodeLabels map[string]string) []string {
 	labelNodeRolePrefix := "node-role.kubernetes.io/"
 	nodeLabelRole := "kubernetes.io/role"
 
-	roles := sets.NewString()
+	roles := sets.New[string]()
 	for k, v := range nodeLabels {
 		switch {
 		case strings.HasPrefix(k, labelNodeRolePrefix):
@@ -221,5 +222,5 @@ func findNodeRoles(nodeLabels map[string]string) []string {
 			roles.Insert(v)
 		}
 	}
-	return roles.List()
+	return sets.List(roles)
 }

--- a/pkg/collector/corechecks/system/cpu/cpu.go
+++ b/pkg/collector/corechecks/system/cpu/cpu.go
@@ -57,7 +57,9 @@ func (c *Check) Run() error {
 	}
 	t := cpuTimes[0]
 
-	nbCycle := t.Total() / c.nbCPU
+	total := t.User + t.System + t.Idle + t.Nice +
+		t.Iowait + t.Irq + t.Softirq + t.Steal
+	nbCycle := total / c.nbCPU
 
 	if c.lastNbCycle != 0 {
 		// gopsutil return the sum of every CPU

--- a/pkg/collector/runner/runner.go
+++ b/pkg/collector/runner/runner.go
@@ -172,7 +172,7 @@ func (r *Runner) UpdateNumWorkers(numChecks int64) {
 // Stop closes the pending channel so all workers will exit their loop and terminate
 // All publishers to the pending channel need to have stopped before Stop is called
 func (r *Runner) Stop() {
-	if !r.isRunning.CAS(true, false) {
+	if !r.isRunning.CompareAndSwap(true, false) {
 		log.Debugf("Runner %d already stopped, nothing to do here...", r.id)
 		return
 	}

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 	"sync"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -220,7 +223,8 @@ func GetChecksByNameForConfigs(checkName string, configs []integration.Config) [
 		return checks
 	}
 	// try to also match `FooCheck` if `foo` was passed
-	titleCheck := fmt.Sprintf("%s%s", strings.Title(checkName), "Check")
+	titled := cases.Title(language.English).String(checkName)
+	titleCheck := fmt.Sprintf("%s%s", titled, "Check")
 
 	for _, c := range checkScheduler.GetChecksFromConfigs(configs, false) {
 		if checkName == c.String() || titleCheck == c.String() {

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -223,7 +223,7 @@ func GetChecksByNameForConfigs(checkName string, configs []integration.Config) [
 		return checks
 	}
 	// try to also match `FooCheck` if `foo` was passed
-	titled := cases.Title(language.English).String(checkName)
+	titled := cases.Title(language.English, cases.NoLower).String(checkName)
 	titleCheck := fmt.Sprintf("%s%s", titled, "Check")
 
 	for _, c := range checkScheduler.GetChecksFromConfigs(configs, false) {

--- a/pkg/compliance/tools/k8s_types_generator/main.go
+++ b/pkg/compliance/tools/k8s_types_generator/main.go
@@ -30,6 +30,8 @@ import (
 	"unicode"
 
 	"golang.org/x/exp/slices"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 var (
@@ -410,7 +412,8 @@ func printKomponentCode(komp *komponent) string {
 		}
 	}
 
-	goStructName := strings.ReplaceAll(strings.Title(komp.name), "-", "")
+	titled := cases.Title(language.English).String(komp.name)
+	goStructName := strings.ReplaceAll(titled, "-", "")
 	s := ""
 	s += fmt.Sprintf("type K8s%sConfig struct {\n", goStructName)
 	for _, c := range komp.confs {
@@ -555,7 +558,8 @@ func downloadKubeComponentAndExtractFlags(componentName, componentVersion string
 }
 
 func toGoField(s string) string {
-	return strings.ReplaceAll(strings.Title(s), "-", "")
+	caser := cases.Title(language.English)
+	return strings.ReplaceAll(caser.String(s), "-", "")
 }
 
 func toGoJSONTag(s string) string {

--- a/pkg/compliance/tools/k8s_types_generator/main.go
+++ b/pkg/compliance/tools/k8s_types_generator/main.go
@@ -412,7 +412,7 @@ func printKomponentCode(komp *komponent) string {
 		}
 	}
 
-	titled := cases.Title(language.English).String(komp.name)
+	titled := cases.Title(language.English, cases.NoLower).String(komp.name)
 	goStructName := strings.ReplaceAll(titled, "-", "")
 	s := ""
 	s += fmt.Sprintf("type K8s%sConfig struct {\n", goStructName)
@@ -558,7 +558,7 @@ func downloadKubeComponentAndExtractFlags(componentName, componentVersion string
 }
 
 func toGoField(s string) string {
-	caser := cases.Title(language.English)
+	caser := cases.Title(language.English, cases.NoLower)
 	return strings.ReplaceAll(caser.String(s), "-", "")
 }
 

--- a/pkg/ebpf/bytecode/runtime/integrity.go
+++ b/pkg/ebpf/bytecode/runtime/integrity.go
@@ -17,6 +17,9 @@ import (
 	"runtime"
 	"strings"
 	"text/template"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // This program is intended to be called from go generate.
@@ -67,7 +70,9 @@ func genIntegrity(inputFile, outputFile, pkg string) error {
 	defer f.Close()
 
 	base := filepath.Base(inputFile)
-	name := sanitizeFilename(strings.Title(strings.TrimSuffix(base, filepath.Ext(base))))
+
+	caser := cases.Title(language.English)
+	name := sanitizeFilename(caser.String(strings.TrimSuffix(base, filepath.Ext(base))))
 
 	imports := ""
 	packagePrefix := ""

--- a/pkg/ebpf/bytecode/runtime/integrity.go
+++ b/pkg/ebpf/bytecode/runtime/integrity.go
@@ -71,7 +71,7 @@ func genIntegrity(inputFile, outputFile, pkg string) error {
 
 	base := filepath.Base(inputFile)
 
-	caser := cases.Title(language.English)
+	caser := cases.Title(language.English, cases.NoLower)
 	name := sanitizeFilename(caser.String(strings.TrimSuffix(base, filepath.Ext(base))))
 
 	imports := ""

--- a/pkg/network/dns/cache_test.go
+++ b/pkg/network/dns/cache_test.go
@@ -8,6 +8,7 @@
 package dns
 
 import (
+	cryptorand "crypto/rand"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -322,7 +323,7 @@ func randomAddressGen() func() util.Address {
 	b := make([]byte, 4)
 	return func() util.Address {
 		for {
-			if _, err := rand.Read(b); err != nil {
+			if _, err := cryptorand.Read(b); err != nil {
 				continue
 			}
 

--- a/pkg/network/protocols/telemetry/endpoint.go
+++ b/pkg/network/protocols/telemetry/endpoint.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"sort"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/DataDog/datadog-agent/cmd/system-probe/utils"
 )
 
@@ -33,8 +35,8 @@ func (mm MarshableMetric) MarshalJSON() ([]byte, error) {
 	}{
 		Name:  base.name,
 		Type:  fmt.Sprintf("%T", metric),
-		Tags:  base.tags.List(),
-		Opts:  base.opts.List(),
+		Tags:  sets.List(base.tags),
+		Opts:  sets.List(base.opts),
 		Value: base.Get(),
 	})
 }

--- a/pkg/network/protocols/telemetry/metric.go
+++ b/pkg/network/protocols/telemetry/metric.go
@@ -72,8 +72,8 @@ func (g *Gauge) base() *metricBase {
 
 type metricBase struct {
 	name  string
-	tags  sets.String
-	opts  sets.String
+	tags  sets.Set[string]
+	opts  sets.Set[string]
 	value *atomic.Int64
 }
 
@@ -90,7 +90,7 @@ func newMetricBase(name string, tagsAndOptions []string) *metricBase {
 
 // Name of the `Metric` (including tags)
 func (m *metricBase) Name() string {
-	return strings.Join(append([]string{m.name}, m.tags.List()...), ",")
+	return strings.Join(append([]string{m.name}, sets.List(m.tags)...), ",")
 }
 
 // Get value atomically

--- a/pkg/network/protocols/telemetry/prometheus.go
+++ b/pkg/network/protocols/telemetry/prometheus.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	libtelemetry "github.com/DataDog/datadog-agent/pkg/telemetry"
 )
 
@@ -66,7 +68,7 @@ func metricToPrometheus(m metric) any {
 }
 
 func withTag(m *metricBase, fn func(k, v string)) {
-	for _, t := range m.tags.List() {
+	for _, t := range sets.List(m.tags) {
 		pos := strings.IndexByte(t, ':')
 		if pos <= 0 {
 			continue

--- a/pkg/network/protocols/telemetry/registry.go
+++ b/pkg/network/protocols/telemetry/registry.go
@@ -37,7 +37,7 @@ func (r *registry) FindOrCreate(m metric) metric {
 
 // GetMetrics returns all metrics matching a certain criteria
 func (r *registry) GetMetrics(params ...string) []metric {
-	filters := sets.NewString()
+	filters := sets.New[string]()
 	filters.Insert(params...)
 
 	r.Lock()

--- a/pkg/network/protocols/telemetry/reporters.go
+++ b/pkg/network/protocols/telemetry/reporters.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // common prefix used across all statsd metric
@@ -28,7 +29,7 @@ func ReportStatsd() {
 	for _, metric := range metrics {
 		v := previousValues.ValueFor(metric)
 		base := metric.base()
-		tags := base.tags.List()
+		tags := sets.List(base.tags)
 		if _, ok := metric.(*Gauge); ok {
 			client.Gauge(statsdPrefix+base.name, float64(v), tags, 1.0) //nolint:errcheck
 			continue

--- a/pkg/network/protocols/telemetry/utils.go
+++ b/pkg/network/protocols/telemetry/utils.go
@@ -15,12 +15,12 @@ import (
 // The return value will be:
 // {"tag:a", "tag:b", "tag:c"}
 // {"_opt1", "_opt2", "_opt3"}
-func splitTagsAndOptions(all []string) (tags, opts sets.String) {
+func splitTagsAndOptions(all []string) (tags, opts sets.Set[string]) {
 	if len(all) == 0 {
 		return
 	}
-	tags = sets.NewString()
-	opts = sets.NewString()
+	tags = sets.New[string]()
+	opts = sets.New[string]()
 
 	for _, s := range all {
 		if strings.HasPrefix(s, optPrefix) {

--- a/pkg/network/protocols/telemetry/utils_test.go
+++ b/pkg/network/protocols/telemetry/utils_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestSplitTagsAndOpts(t *testing.T) {
@@ -16,13 +17,13 @@ func TestSplitTagsAndOpts(t *testing.T) {
 
 	t.Run("only tags", func(t *testing.T) {
 		tags, opts := splitTagsAndOptions([]string{"tag:a", "tag:c", "tag:b"})
-		assert.Equal([]string{"tag:a", "tag:b", "tag:c"}, tags.List())
+		assert.Equal([]string{"tag:a", "tag:b", "tag:c"}, sets.List(tags))
 		assert.Len(opts, 0)
 	})
 
 	t.Run("only opts", func(t *testing.T) {
 		tags, opts := splitTagsAndOptions([]string{"_opt3", "_opt2", "_opt1"})
-		assert.Equal([]string{"_opt1", "_opt2", "_opt3"}, opts.List())
+		assert.Equal([]string{"_opt1", "_opt2", "_opt3"}, sets.List(opts))
 		assert.Len(tags, 0)
 	})
 
@@ -31,8 +32,8 @@ func TestSplitTagsAndOpts(t *testing.T) {
 			[]string{"_opt3", "tag:a", "_opt2", "tag:b", "_opt1", "tag:c"},
 		)
 
-		assert.Equal([]string{"tag:a", "tag:b", "tag:c"}, tags.List())
-		assert.Equal([]string{"_opt1", "_opt2", "_opt3"}, opts.List())
+		assert.Equal([]string{"tag:a", "tag:b", "tag:c"}, sets.List(tags))
+		assert.Equal([]string{"_opt1", "_opt2", "_opt3"}, sets.List(opts))
 	})
 
 }

--- a/pkg/process/util/log_limit.go
+++ b/pkg/process/util/log_limit.go
@@ -43,7 +43,7 @@ func (l *LogLimit) ShouldLog() bool {
 	n := l.n.Load()
 	if n > 0 {
 		// try to decrement n, doing nothing on concurrent attempts
-		l.n.CAS(n, n-1)
+		l.n.CompareAndSwap(n, n-1)
 		return true
 	}
 
@@ -70,5 +70,5 @@ func (l *LogLimit) resetLoop() {
 func (l *LogLimit) resetCounter() {
 	// c.n == 0, it means we have gotten through the first few logs, and after ticker.T we should
 	// do another log
-	l.n.CAS(0, 1)
+	l.n.CompareAndSwap(0, 1)
 }

--- a/pkg/security/secl/go.mod
+++ b/pkg/security/secl/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20221114191408-850992195362
 	golang.org/x/sys v0.12.0
+	golang.org/x/text v0.4.0
 	golang.org/x/tools v0.13.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/pkg/security/secl/go.sum
+++ b/pkg/security/secl/go.sum
@@ -91,6 +91,7 @@ golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
 golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/pkg/security/secl/model/syscall_table_generator/syscall_table_generator.go
+++ b/pkg/security/secl/model/syscall_table_generator/syscall_table_generator.go
@@ -20,6 +20,9 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 func main() {
@@ -204,10 +207,10 @@ func generateEnumCode(syscalls []*syscallDefinition) (string, error) {
 
 func snakeToCamelCase(snake string) string {
 	parts := strings.Split(snake, "_")
-
+	caser := cases.Title(language.English)
 	var b strings.Builder
 	for _, part := range parts {
-		b.WriteString(strings.Title(part))
+		b.WriteString(caser.String(part))
 	}
 
 	return b.String()

--- a/pkg/status/helpers.go
+++ b/pkg/status/helpers.go
@@ -18,6 +18,8 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"golang.org/x/text/unicode/norm"
 )
 
@@ -196,7 +198,7 @@ func formatTitle(title string) string {
 	title = strings.Join(words, " ")
 
 	// Capitalize the first letter
-	return strings.Title(title)
+	return cases.Title(language.English).String(title)
 }
 
 func status(check map[string]interface{}) string {

--- a/pkg/status/helpers.go
+++ b/pkg/status/helpers.go
@@ -198,7 +198,7 @@ func formatTitle(title string) string {
 	title = strings.Join(words, " ")
 
 	// Capitalize the first letter
-	return cases.Title(language.English).String(title)
+	return cases.Title(language.English, cases.NoLower).String(title)
 }
 
 func status(check map[string]interface{}) string {

--- a/pkg/trace/api/evp_proxy_test.go
+++ b/pkg/trace/api/evp_proxy_test.go
@@ -7,10 +7,10 @@ package api
 
 import (
 	"bytes"
+	"crypto/rand"
 	"fmt"
 	"io"
 	"log"
-	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"

--- a/pkg/trace/api/listener.go
+++ b/pkg/trace/api/listener.go
@@ -239,7 +239,7 @@ func (sl *rateLimitedListener) Accept() (net.Conn, error) {
 
 // Close wraps the Close method of the underlying tcp listener
 func (sl *rateLimitedListener) Close() error {
-	if !sl.closed.CAS(0, 1) {
+	if !sl.closed.CompareAndSwap(0, 1) {
 		// already closed; avoid multiple calls if we're on go1.10
 		// https://golang.org/issue/24803
 		return nil

--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -285,7 +285,7 @@ func (s *sender) sendPayload(p *payload) {
 		for {
 			// interlock with other sends to avoid setting the same value
 			attempt := s.attempt.Load()
-			if s.attempt.CAS(attempt, attempt/2) {
+			if s.attempt.CompareAndSwap(attempt, attempt/2) {
 				break
 			}
 		}

--- a/pkg/util/clusteragent/clusteragent_test.go
+++ b/pkg/util/clusteragent/clusteragent_test.go
@@ -75,18 +75,18 @@ func newDummyClusterAgent() (*dummyClusterAgent, error) {
 				"node1": {
 					Services: apiv1.NamespacesPodsStringsSet{
 						"foo": {
-							"pod-00001": sets.NewString("kube_service:svc1"),
-							"pod-00002": sets.NewString("kube_service:svc1", "kube_service:svc2"),
+							"pod-00001": sets.New("kube_service:svc1"),
+							"pod-00002": sets.New("kube_service:svc1", "kube_service:svc2"),
 						},
 						"bar": {
-							"pod-00004": sets.NewString("kube_service:svc2"),
+							"pod-00004": sets.New("kube_service:svc2"),
 						},
 					},
 				},
 				"node2": {
 					Services: apiv1.NamespacesPodsStringsSet{
 						"foo": {
-							"pod-00003": sets.NewString("kube_service:svc1"),
+							"pod-00003": sets.New("kube_service:svc1"),
 						},
 					},
 				},
@@ -653,11 +653,11 @@ func (suite *clusterAgentSuite) TestGetPodsMetadataForNode() {
 			nodeName: "node1",
 			expectedMetadatas: apiv1.NamespacesPodsStringsSet{
 				"foo": apiv1.MapStringSet{
-					"pod-00001": sets.NewString("kube_service:svc1"),
-					"pod-00002": sets.NewString("kube_service:svc1", "kube_service:svc2"),
+					"pod-00001": sets.New("kube_service:svc1"),
+					"pod-00002": sets.New("kube_service:svc1", "kube_service:svc2"),
 				},
 				"bar": {
-					"pod-00004": sets.NewString("kube_service:svc2"),
+					"pod-00004": sets.New("kube_service:svc2"),
 				},
 			},
 		},
@@ -666,7 +666,7 @@ func (suite *clusterAgentSuite) TestGetPodsMetadataForNode() {
 			nodeName: "node2",
 			expectedMetadatas: apiv1.NamespacesPodsStringsSet{
 				"foo": apiv1.MapStringSet{
-					"pod-00003": sets.NewString("kube_service:svc1"),
+					"pod-00003": sets.New("kube_service:svc1"),
 				},
 			},
 		},
@@ -691,8 +691,8 @@ func (suite *clusterAgentSuite) TestGetPodsMetadataForNode() {
 				require.Equal(t, len(testCase.expectedMetadatas), len(metadatas))
 				for ns, expectedNSValues := range testCase.expectedMetadatas {
 					for podName, expectedMetadatas := range expectedNSValues {
-						for _, elt := range expectedMetadatas.List() {
-							assert.Contains(t, metadatas[ns][podName].List(), elt)
+						for _, elt := range sets.List(expectedMetadatas) {
+							assert.Contains(t, sets.List(metadatas[ns][podName]), elt)
 						}
 					}
 				}

--- a/pkg/util/kubernetes/apiserver/metadata_controller.go
+++ b/pkg/util/kubernetes/apiserver/metadata_controller.go
@@ -213,7 +213,7 @@ func (m *MetadataController) syncEndpoints(key string) error {
 
 // mapEndpoints matches pods to services via endpoint TargetRef objects. It supports Kubernetes 1.4+.
 func (m *MetadataController) mapEndpoints(endpoints *corev1.Endpoints) error {
-	nodeToPods := make(map[string]map[string]sets.String)
+	nodeToPods := make(map[string]map[string]sets.Set[string])
 
 	// Loop over the subsets to create a mapping of nodes to pods running on the node.
 	for _, subset := range endpoints.Subsets {
@@ -243,10 +243,10 @@ func (m *MetadataController) mapEndpoints(endpoints *corev1.Endpoints) error {
 			nodeName := *address.NodeName
 
 			if _, ok := nodeToPods[nodeName]; !ok {
-				nodeToPods[nodeName] = make(map[string]sets.String)
+				nodeToPods[nodeName] = make(map[string]sets.Set[string])
 			}
 			if _, ok := nodeToPods[nodeName][namespace]; !ok {
-				nodeToPods[nodeName][namespace] = sets.NewString()
+				nodeToPods[nodeName][namespace] = sets.New[string]()
 			}
 			nodeToPods[nodeName][namespace].Insert(podName)
 		}

--- a/pkg/util/kubernetes/apiserver/metadata_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/metadata_controller_test.go
@@ -102,12 +102,12 @@ func TestMetadataControllerSyncEndpoints(t *testing.T) {
 			map[string]apiv1.NamespacesPodsStringsSet{
 				"node1": {
 					"default": {
-						"pod1_name": sets.NewString("svc1"),
+						"pod1_name": sets.New("svc1"),
 					},
 				},
 				"node2": {
 					"default": {
-						"pod2_name": sets.NewString("svc1"),
+						"pod2_name": sets.New("svc1"),
 					},
 				},
 			},
@@ -130,13 +130,13 @@ func TestMetadataControllerSyncEndpoints(t *testing.T) {
 			map[string]apiv1.NamespacesPodsStringsSet{
 				"node1": {
 					"default": {
-						"pod1_name": sets.NewString("svc1"),
-						"pod3_name": sets.NewString("svc1"),
+						"pod1_name": sets.New("svc1"),
+						"pod3_name": sets.New("svc1"),
 					},
 				},
 				"node2": {
 					"default": {
-						"pod2_name": sets.NewString("svc1"),
+						"pod2_name": sets.New("svc1"),
 					},
 				},
 			},
@@ -158,12 +158,12 @@ func TestMetadataControllerSyncEndpoints(t *testing.T) {
 			map[string]apiv1.NamespacesPodsStringsSet{
 				"node1": {
 					"default": {
-						"pod1_name": sets.NewString("svc1"),
+						"pod1_name": sets.New("svc1"),
 					},
 				},
 				"node2": {
 					"default": {
-						"pod2_name": sets.NewString("svc1"),
+						"pod2_name": sets.New("svc1"),
 					},
 				},
 			},
@@ -184,12 +184,12 @@ func TestMetadataControllerSyncEndpoints(t *testing.T) {
 			map[string]apiv1.NamespacesPodsStringsSet{
 				"node1": {
 					"default": {
-						"pod1_name": sets.NewString("svc1", "svc2"),
+						"pod1_name": sets.New("svc1", "svc2"),
 					},
 				},
 				"node2": {
 					"default": {
-						"pod2_name": sets.NewString("svc1"),
+						"pod2_name": sets.New("svc1"),
 					},
 				},
 			},
@@ -203,7 +203,7 @@ func TestMetadataControllerSyncEndpoints(t *testing.T) {
 			map[string]apiv1.NamespacesPodsStringsSet{
 				"node1": {
 					"default": {
-						"pod1_name": sets.NewString("svc2"),
+						"pod1_name": sets.New("svc2"),
 					},
 				},
 			},
@@ -223,7 +223,7 @@ func TestMetadataControllerSyncEndpoints(t *testing.T) {
 			map[string]apiv1.NamespacesPodsStringsSet{ // no changes to cluster metadata
 				"node1": {
 					"default": {
-						"pod1_name": sets.NewString("svc2"),
+						"pod1_name": sets.New("svc2"),
 					},
 				},
 			},
@@ -243,7 +243,7 @@ func TestMetadataControllerSyncEndpoints(t *testing.T) {
 			map[string]apiv1.NamespacesPodsStringsSet{ // no changes to cluster metadata
 				"node1": {
 					"default": {
-						"pod1_name": sets.NewString("svc2"),
+						"pod1_name": sets.New("svc2"),
 					},
 				},
 			},

--- a/pkg/util/kubernetes/apiserver/services_kubelet.go
+++ b/pkg/util/kubernetes/apiserver/services_kubelet.go
@@ -28,10 +28,10 @@ func ConvertToServiceMapper(m apiv1.NamespacesPodsStringsSet) serviceMapper { //
 // Set updates services for a given namespace and pod name.
 func (m serviceMapper) Set(namespace, podName string, svcs ...string) {
 	if _, ok := m[namespace]; !ok {
-		m[namespace] = make(map[string]sets.String)
+		m[namespace] = make(map[string]sets.Set[string])
 	}
 	if _, ok := m[namespace][podName]; !ok {
-		m[namespace][podName] = sets.NewString()
+		m[namespace][podName] = sets.New[string]()
 	}
 	m[namespace][podName].Insert(svcs...)
 }

--- a/pkg/util/kubernetes/apiserver/services_kubelet_test.go
+++ b/pkg/util/kubernetes/apiserver/services_kubelet_test.go
@@ -84,7 +84,7 @@ func TestMapServices(t *testing.T) {
 				},
 			},
 			apiv1.NamespacesPodsStringsSet{
-				"foo": {"pod1_name": sets.NewString("svc1")},
+				"foo": {"pod1_name": sets.New("svc1")},
 			},
 		},
 		{
@@ -114,8 +114,8 @@ func TestMapServices(t *testing.T) {
 				},
 			},
 			apiv1.NamespacesPodsStringsSet{
-				"default": {"pod_name": sets.NewString("svc1")},
-				"other":   {"pod_name": sets.NewString("svc2")},
+				"default": {"pod_name": sets.New("svc1")},
+				"other":   {"pod_name": sets.New("svc2")},
 			},
 		},
 		{
@@ -162,8 +162,8 @@ func TestMapServices(t *testing.T) {
 			},
 			apiv1.NamespacesPodsStringsSet{
 				"foo": {
-					"pod1_name": sets.NewString("svc1", "svc3"),
-					"pod3_name": sets.NewString("svc2"),
+					"pod1_name": sets.New("svc1", "svc3"),
+					"pod3_name": sets.New("svc2"),
 				},
 			},
 		},
@@ -173,14 +173,14 @@ func TestMapServices(t *testing.T) {
 	// sure mapping does not affect unlisted services
 	expectedAggregatedMapping := apiv1.NamespacesPodsStringsSet{
 		"foo": {
-			"pod1_name": sets.NewString("svc1", "svc3"),
-			"pod3_name": sets.NewString("svc2"),
+			"pod1_name": sets.New("svc1", "svc3"),
+			"pod3_name": sets.New("svc2"),
 		},
 		"default": {
-			"pod_name": sets.NewString("svc1"),
+			"pod_name": sets.New("svc1"),
 		},
 		"other": {
-			"pod_name": sets.NewString("svc2"),
+			"pod_name": sets.New("svc2"),
 		},
 	}
 

--- a/pkg/util/kubernetes/apiserver/services_test.go
+++ b/pkg/util/kubernetes/apiserver/services_test.go
@@ -26,11 +26,11 @@ func TestNamespacesPodsStringsSet(t *testing.T) {
 	mapper.Set("default", "pod3", "svc2")
 
 	require.Equal(t, 3, len(mapper["default"]))
-	assert.Equal(t, sets.NewString("svc1"), mapper["default"]["pod1"])
+	assert.Equal(t, sets.New("svc1"), mapper["default"]["pod1"])
 
 	mapper.Delete("default", "svc1")
 	require.Equal(t, 1, len(mapper["default"]))
-	assert.Equal(t, sets.NewString("svc2"), mapper["default"]["pod3"])
+	assert.Equal(t, sets.New("svc2"), mapper["default"]["pod3"])
 
 	mapper.Delete("default", "svc2")
 

--- a/pkg/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
+++ b/pkg/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/errors"
@@ -254,7 +256,7 @@ func (c *collector) getMetadata(getPodMetaDataFromAPIServerFunc func(string, str
 
 	if metadataByNsPods != nil {
 		if data, ok := metadataByNsPods[po.Metadata.Namespace][po.Metadata.Name]; ok && data != nil {
-			return data.List(), nil
+			return sets.List(data), nil
 		}
 		return nil, nil
 	}

--- a/pkg/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
+++ b/pkg/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
@@ -230,7 +230,7 @@ func TestKubeMetadataCollector_getMetadata(t *testing.T) {
 				}},
 				metadataByNsPods: apiv1.NamespacesPodsStringsSet{
 					"test": apiv1.MapStringSet{
-						"pod-bar": sets.NewString("foo=bar"),
+						"pod-bar": sets.New("foo=bar"),
 					},
 				},
 			},

--- a/pkg/workloadmeta/collectors/internal/remote/generic.go
+++ b/pkg/workloadmeta/collectors/internal/remote/generic.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/DataDog/datadog-agent/pkg/api/security"
@@ -90,7 +91,7 @@ func (c *GenericCollector) Start(ctx context.Context, store workloadmeta.Store) 
 
 	if c.Insecure {
 		// for test purposes
-		opts = append(opts, grpc.WithInsecure())
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else {
 		// NOTE: we're using InsecureSkipVerify because the gRPC server only
 		// persists its TLS certs in memory, and we currently have no

--- a/test/new-e2e/containers/k8s_test.go
+++ b/test/new-e2e/containers/k8s_test.go
@@ -13,8 +13,6 @@ import (
 	"time"
 
 	"github.com/DataDog/agent-payload/v5/gogen"
-	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
-	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -25,6 +23,9 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
+	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
 )
 
 var GitCommit string
@@ -440,7 +441,7 @@ func (suite *k8sSuite) podExec(namespace, pod, container string, cmd []string) (
 	}
 
 	var stdoutSb, stderrSb strings.Builder
-	err = exec.Stream(remotecommand.StreamOptions{
+	err = exec.StreamWithContext(context.Background(), remotecommand.StreamOptions{
 		Stdout: &stdoutSb,
 		Stderr: &stderrSb,
 	})

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/microVMs/microvms"
 	"github.com/sethvargo/go-retry"
-	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/term"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
@@ -107,7 +106,7 @@ func GetEnv(key, fallback string) string {
 
 func credentials() (string, error) {
 	var fd int
-	if terminal.IsTerminal(syscall.Stdin) {
+	if term.IsTerminal(syscall.Stdin) {
 		fd = syscall.Stdin
 	} else {
 		tty, err := os.Open("/dev/tty")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Stop ignoring the `SA1019` staticcheck lint (which warns about using deprecated functions and packages), fix as much as possible, and ignore the few which would be too hard not to use.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Deprecated functions and packages shouldn't be used, it could bite us someday.
Not ignoring the warning prevents adding more uses of deprecated objects.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Each commit fixes one different warning:
- CAS is deprecated: Use CompareAndSwap
- sets.String is deprecated: use generic Set instead
- strings.Title has been deprecated since Go 1.18
- grpc.WithInsecure is deprecated: use WithTransportCredentials and insecure.NewCredentials() instead
- rand.Read has been deprecated since Go 1.20 because it shouldn't be used
- "golang.org/x/crypto/ssh/terminal" is deprecated: this package moved to golang.org/x/term
- exec.Stream is deprecated: use StreamWithContext instead to avoid possible resource leaks
- t.Total is deprecated: Total returns the total number of seconds in a CPUTimesStat Please do not use this internal function
- ignore remaining deprecation warnings, re-enable deprecation warnings

The ones I couldn't fix are:
- `github.com/golang/protobuf/proto`
- `rand.Seed`
- `net.Error.Temporary`

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Each change should be equivalent, so if the CI passes I would consider it ok. 

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
