### PR TITLE
[Oracle] Fix large SQL text truncation

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/oracle_dictionary.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_dictionary.go
@@ -17,6 +17,10 @@ import (
 )
 
 func getFullSQLText(c *Check, SQLStatement *string, key string, value string) error {
+	/*
+	 * Due to the Oracle bug "V$SQLSTATS.SQL_FULLTEXT does not show full of sql statements (Doc ID 2398100.1)
+	 * we must retrieve `sql_fulltext` from `v$sql`.
+	 */
 	var err error
 	var sql string
 	switch c.driver {

--- a/pkg/collector/corechecks/oracle-dbm/oracle_dictionary.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_dictionary.go
@@ -32,7 +32,7 @@ func getFullSQLText(c *Check, SQLStatement *string, key string, value string) er
 		var sqlFullText go_ora.Clob
 		sql = fmt.Sprintf("BEGIN SELECT /* DD */ sql_fulltext INTO :sql_fulltext FROM v$sql WHERE %s = :v AND rownum = 1; END;", key)
 		_, err = c.connection.Exec(sql, go_ora.Out{Dest: &sqlFullText, Size: 8000}, value)
-		if err == nil && sqlFullText.Valid && sqlFullText.String != "" {
+		if err == nil && sqlFullText.String != "" {
 			*SQLStatement = sqlFullText.String
 		} else if err != nil {
 			if !isConnectionError(err) {

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -663,16 +663,10 @@ func (c *Check) StatementMetrics() (int, error) {
 			queryRow := QueryRow{}
 			var SQLStatement string
 
-			if statementMetricRow.SQLTextLength == 1000 {
+			if statementMetricRow.SQLTextLength == MaxSQLFullTextVSQLStats {
 				err := getFullSQLText(c, &SQLStatement, "sql_id", statementMetricRow.SQLID)
 				if err != nil {
 					log.Errorf("%s failed to get the full text %s for sql_id %s", c.logPrompt, err, statementMetricRow.SQLID)
-				}
-				if SQLStatement == "" && statementMetricRow.ForceMatchingSignature != "" {
-					err := getFullSQLText(c, &SQLStatement, "force_matching_signature", statementMetricRow.ForceMatchingSignature)
-					if err != nil {
-						log.Errorf("%s failed to get the full text %s for force_matching_signature %s", c.logPrompt, err, statementMetricRow.ForceMatchingSignature)
-					}
 				}
 				if SQLStatement != "" {
 					statementMetricRow.SQLText = SQLStatement

--- a/releasenotes/notes/oracle-full-text-ed705522f73e6139.yaml
+++ b/releasenotes/notes/oracle-full-text-ed705522f73e6139.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix truncation of SQL text for large statements.


### PR DESCRIPTION
### What does this PR do?

Fix truncated SQL text for large statements.

### Additional Notes

For statements larger than 1000 characters we have to execute another query to get the text from the LOB `sql_fulltext` column. The procedure executing the query was always returning the empty string.

### Describe how to test/QA your changes

Check if the activity sampling query is truncated.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
