### PR TITLE
Use string interning in statskeeper for the endpoint path

### DIFF
--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -15,6 +15,8 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/util/intern"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -283,7 +285,7 @@ func testSerialization(t *testing.T, aggregateByStatusCode bool) {
 				util.AddressFromString("20.1.1.1"),
 				40000,
 				80,
-				"/testpath",
+				[]byte("/testpath"),
 				true,
 				http.MethodGet,
 			): httpReqStats,
@@ -313,7 +315,7 @@ func testSerialization(t *testing.T, aggregateByStatusCode bool) {
 				util.AddressFromString("10.2.2.2"),
 				1000,
 				9000,
-				"/testpath",
+				[]byte("/testpath"),
 				true,
 				http.MethodGet,
 			): httpReqStats,
@@ -540,7 +542,7 @@ func testHTTPSerializationWithLocalhostTraffic(t *testing.T, aggregateByStatusCo
 				localhost,
 				clientPort,
 				serverPort,
-				"/testpath",
+				[]byte("/testpath"),
 				true,
 				http.MethodGet,
 			): httpReqStats,
@@ -558,7 +560,7 @@ func testHTTPSerializationWithLocalhostTraffic(t *testing.T, aggregateByStatusCo
 			localhost,
 			serverPort,
 			clientPort,
-			"/testpath",
+			[]byte("/testpath"),
 			true,
 			http.MethodGet,
 		)
@@ -681,7 +683,7 @@ func testHTTP2SerializationWithLocalhostTraffic(t *testing.T, aggregateByStatusC
 				localhost,
 				clientPort,
 				serverPort,
-				"/testpath",
+				[]byte("/testpath"),
 				true,
 				http.MethodPost,
 			): http2ReqStats,
@@ -699,7 +701,7 @@ func testHTTP2SerializationWithLocalhostTraffic(t *testing.T, aggregateByStatusC
 			localhost,
 			serverPort,
 			clientPort,
-			"/testpath",
+			[]byte("/testpath"),
 			true,
 			http.MethodPost,
 		)
@@ -760,7 +762,7 @@ func TestPooledObjectGarbageRegression(t *testing.T) {
 		util.AddressFromString("172.217.10.45"),
 		60000,
 		8080,
-		"",
+		nil,
 		true,
 		http.MethodGet,
 	)
@@ -800,7 +802,7 @@ func TestPooledObjectGarbageRegression(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		if (i % 2) == 0 {
 			httpKey.Path = http.Path{
-				Content:  fmt.Sprintf("/path-%d", i),
+				Content:  intern.Interner.GetString(fmt.Sprintf("/path-%d", i)),
 				FullPath: true,
 			}
 			in.HTTP = map[http.Key]*http.RequestStats{httpKey: {}}
@@ -808,7 +810,7 @@ func TestPooledObjectGarbageRegression(t *testing.T) {
 
 			require.NotNil(t, out)
 			require.Len(t, out.EndpointAggregations, 1)
-			require.Equal(t, httpKey.Path.Content, out.EndpointAggregations[0].Path)
+			require.Equal(t, httpKey.Path.Content.Get(), out.EndpointAggregations[0].Path)
 		} else {
 			// No HTTP data in this payload, so we should never get HTTP data back after the serialization
 			in.HTTP = nil
@@ -826,7 +828,7 @@ func TestPooledHTTP2ObjectGarbageRegression(t *testing.T) {
 		util.AddressFromString("172.217.10.45"),
 		60000,
 		8080,
-		"",
+		nil,
 		true,
 		http.MethodGet,
 	)
@@ -866,7 +868,7 @@ func TestPooledHTTP2ObjectGarbageRegression(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		if (i % 2) == 0 {
 			httpKey.Path = http.Path{
-				Content:  fmt.Sprintf("/path-%d", i),
+				Content:  intern.Interner.GetString(fmt.Sprintf("/path-%d", i)),
 				FullPath: true,
 			}
 			in.HTTP2 = map[http.Key]*http.RequestStats{httpKey: {}}
@@ -874,7 +876,7 @@ func TestPooledHTTP2ObjectGarbageRegression(t *testing.T) {
 
 			require.NotNil(t, out)
 			require.Len(t, out.EndpointAggregations, 1)
-			require.Equal(t, httpKey.Path.Content, out.EndpointAggregations[0].Path)
+			require.Equal(t, httpKey.Path.Content.Get(), out.EndpointAggregations[0].Path)
 		} else {
 			// No HTTP2 data in this payload, so we should never get HTTP2 data back after the serialization
 			in.HTTP2 = nil

--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -15,8 +15,6 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/util/intern"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -802,7 +800,7 @@ func TestPooledObjectGarbageRegression(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		if (i % 2) == 0 {
 			httpKey.Path = http.Path{
-				Content:  intern.Interner.GetString(fmt.Sprintf("/path-%d", i)),
+				Content:  http.Interner.GetString(fmt.Sprintf("/path-%d", i)),
 				FullPath: true,
 			}
 			in.HTTP = map[http.Key]*http.RequestStats{httpKey: {}}
@@ -868,7 +866,7 @@ func TestPooledHTTP2ObjectGarbageRegression(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		if (i % 2) == 0 {
 			httpKey.Path = http.Path{
-				Content:  intern.Interner.GetString(fmt.Sprintf("/path-%d", i)),
+				Content:  http.Interner.GetString(fmt.Sprintf("/path-%d", i)),
 				FullPath: true,
 			}
 			in.HTTP2 = map[http.Key]*http.RequestStats{httpKey: {}}

--- a/pkg/network/encoding/http.go
+++ b/pkg/network/encoding/http.go
@@ -65,7 +65,7 @@ func (e *httpEncoder) encodeData(connectionData *USMConnectionData[http.Key, *ht
 			key := kvPair.Key
 			stats := kvPair.Value
 
-			httpStatsBuilder.SetPath(key.Path.Content)
+			httpStatsBuilder.SetPath(key.Path.Content.Get())
 			httpStatsBuilder.SetFullPath(key.Path.FullPath)
 			httpStatsBuilder.SetMethod(uint64(model.HTTPMethod(key.Method)))
 

--- a/pkg/network/encoding/http2.go
+++ b/pkg/network/encoding/http2.go
@@ -86,7 +86,7 @@ func (e *http2Encoder) encodeData(connectionData *USMConnectionData[http.Key, *h
 		stats := kvPair.Value
 
 		ms := http2StatsPool.Get().(*model.HTTPStats)
-		ms.Path = key.Path.Content
+		ms.Path = key.Path.Content.Get()
 		ms.FullPath = key.Path.FullPath
 		ms.Method = model.HTTPMethod(key.Method)
 		ms.StatsByStatusCode = e.getDataMap(stats.Data)

--- a/pkg/network/encoding/http2_test.go
+++ b/pkg/network/encoding/http2_test.go
@@ -9,8 +9,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/util/intern"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
@@ -67,7 +65,7 @@ func testFormatHTTP2Stats(t *testing.T, aggregateByStatusCode bool) {
 
 	httpKey2 := httpKey1
 	httpKey2.Path = http.Path{
-		Content:  intern.Interner.GetString("/testpath-2"),
+		Content:  http.Interner.GetString("/testpath-2"),
 		FullPath: true,
 	}
 	http2Stats2 := http.NewRequestStats(aggregateByStatusCode)

--- a/pkg/network/encoding/http2_test.go
+++ b/pkg/network/encoding/http2_test.go
@@ -9,6 +9,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/util/intern"
+
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
@@ -54,7 +56,7 @@ func testFormatHTTP2Stats(t *testing.T, aggregateByStatusCode bool) {
 		localhost,
 		clientPort,
 		serverPort,
-		"/testpath-1",
+		[]byte("/testpath-1"),
 		true,
 		http.MethodGet,
 	)
@@ -65,7 +67,7 @@ func testFormatHTTP2Stats(t *testing.T, aggregateByStatusCode bool) {
 
 	httpKey2 := httpKey1
 	httpKey2.Path = http.Path{
-		Content:  "/testpath-2",
+		Content:  intern.Interner.GetString("/testpath-2"),
 		FullPath: true,
 	}
 	http2Stats2 := http.NewRequestStats(aggregateByStatusCode)
@@ -154,7 +156,7 @@ func testFormatHTTP2StatsByPath(t *testing.T, aggregateByStatusCode bool) {
 		util.AddressFromString("10.2.2.2"),
 		60000,
 		80,
-		"/testpath",
+		[]byte("/testpath"),
 		true,
 		http.MethodGet,
 	)
@@ -238,7 +240,7 @@ func testHTTP2IDCollisionRegression(t *testing.T, aggregateByStatusCode bool) {
 		util.AddressFromString("2.2.2.2"),
 		60000,
 		80,
-		"/",
+		[]byte("/"),
 		true,
 		http.MethodGet,
 	)
@@ -305,7 +307,7 @@ func testHTTP2LocalhostScenario(t *testing.T, aggregateByStatusCode bool) {
 		util.AddressFromString("127.0.0.1"),
 		cliport,
 		serverport,
-		"/",
+		[]byte("/"),
 		true,
 		http.MethodGet,
 	)
@@ -331,7 +333,7 @@ func testHTTP2LocalhostScenario(t *testing.T, aggregateByStatusCode bool) {
 			util.AddressFromString("127.0.0.1"),
 			serverport,
 			cliport,
-			"/",
+			[]byte("/"),
 			true,
 			http.MethodGet,
 		)

--- a/pkg/network/encoding/http_test.go
+++ b/pkg/network/encoding/http_test.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/util/intern"
+
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/sketches-go/ddsketch"
 	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
@@ -44,7 +46,7 @@ func testFormatHTTPStats(t *testing.T, aggregateByStatusCode bool) {
 		localhost,
 		clientPort,
 		serverPort,
-		"/testpath-1",
+		[]byte("/testpath-1"),
 		true,
 		http.MethodGet,
 	)
@@ -55,7 +57,7 @@ func testFormatHTTPStats(t *testing.T, aggregateByStatusCode bool) {
 
 	httpKey2 := httpKey1
 	httpKey2.Path = http.Path{
-		Content:  "/testpath-2",
+		Content:  intern.Interner.GetString("/testpath-2"),
 		FullPath: true,
 	}
 	httpStats2 := http.NewRequestStats(aggregateByStatusCode)
@@ -146,7 +148,7 @@ func testFormatHTTPStatsByPath(t *testing.T, aggregateByStatusCode bool) {
 		util.AddressFromString("10.2.2.2"),
 		60000,
 		80,
-		"/testpath",
+		[]byte("/testpath"),
 		true,
 		http.MethodGet,
 	)
@@ -229,7 +231,7 @@ func testIDCollisionRegression(t *testing.T, aggregateByStatusCode bool) {
 		util.AddressFromString("2.2.2.2"),
 		60000,
 		80,
-		"/",
+		[]byte("/"),
 		true,
 		http.MethodGet,
 	)
@@ -297,7 +299,7 @@ func testLocalhostScenario(t *testing.T, aggregateByStatusCode bool) {
 		util.AddressFromString("127.0.0.1"),
 		60000,
 		80,
-		"/",
+		[]byte("/"),
 		true,
 		http.MethodGet,
 	)
@@ -323,7 +325,7 @@ func testLocalhostScenario(t *testing.T, aggregateByStatusCode bool) {
 			util.AddressFromString("127.0.0.1"),
 			80,
 			60000,
-			"/",
+			[]byte("/"),
 			true,
 			http.MethodGet,
 		)
@@ -417,7 +419,7 @@ func generateBenchMarkPayload(sourcePortsMax, destPortsMax uint16) network.Conne
 				localhost,
 				sport+1,
 				dport+1,
-				fmt.Sprintf("/api/%d-%d", sport+1, dport+1),
+				[]byte(fmt.Sprintf("/api/%d-%d", sport+1, dport+1)),
 				true,
 				http.MethodGet,
 			)] = httpStats

--- a/pkg/network/encoding/http_test.go
+++ b/pkg/network/encoding/http_test.go
@@ -10,8 +10,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/util/intern"
-
 	model "github.com/DataDog/agent-payload/v5/process"
 	"github.com/DataDog/sketches-go/ddsketch"
 	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
@@ -57,7 +55,7 @@ func testFormatHTTPStats(t *testing.T, aggregateByStatusCode bool) {
 
 	httpKey2 := httpKey1
 	httpKey2.Path = http.Path{
-		Content:  intern.Interner.GetString("/testpath-2"),
+		Content:  http.Interner.GetString("/testpath-2"),
 		FullPath: true,
 	}
 	httpStats2 := http.NewRequestStats(aggregateByStatusCode)

--- a/pkg/network/encoding/usm_test.go
+++ b/pkg/network/encoding/usm_test.go
@@ -22,7 +22,7 @@ func TestGroupByConnection(t *testing.T) {
 		util.AddressFromString("2.2.2.2"),
 		60000,
 		80,
-		"/connection-1-path-1",
+		[]byte("/connection-1-path-1"),
 		true,
 		http.MethodGet,
 	)
@@ -34,7 +34,7 @@ func TestGroupByConnection(t *testing.T) {
 		util.AddressFromString("2.2.2.2"),
 		60000,
 		80,
-		"/connection-1-path-2",
+		[]byte("/connection-1-path-2"),
 		true,
 		http.MethodGet,
 	)
@@ -47,7 +47,7 @@ func TestGroupByConnection(t *testing.T) {
 		util.AddressFromString("4.4.4.4"),
 		60000,
 		80,
-		"/connection-2-path-1",
+		[]byte("/connection-2-path-1"),
 		true,
 		http.MethodGet,
 	)
@@ -59,7 +59,7 @@ func TestGroupByConnection(t *testing.T) {
 		util.AddressFromString("4.4.4.4"),
 		60000,
 		80,
-		"/connection-2-path-2",
+		[]byte("/connection-2-path-2"),
 		true,
 		http.MethodGet,
 	)

--- a/pkg/network/protocols/grpc/monitor_test.go
+++ b/pkg/network/protocols/grpc/monitor_test.go
@@ -14,8 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/intern"
-
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc/metadata"
@@ -109,7 +107,7 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
-					Path:   http.Path{Content: intern.Interner.GetString("/helloworld.Greeter/SayHello")},
+					Path:   http.Path{Content: http.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
 				}: 1000,
 			},
@@ -125,11 +123,11 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
-					Path:   http.Path{Content: intern.Interner.GetString("/helloworld.Greeter/SayHello")},
+					Path:   http.Path{Content: http.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
 				}: 2,
 				{
-					Path:   http.Path{Content: intern.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
+					Path:   http.Path{Content: http.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
 					Method: http.MethodPost,
 				}: 1,
 			},
@@ -146,11 +144,11 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
-					Path:   http.Path{Content: intern.Interner.GetString("/helloworld.Greeter/SayHello")},
+					Path:   http.Path{Content: http.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
 				}: 2,
 				{
-					Path:   http.Path{Content: intern.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
+					Path:   http.Path{Content: http.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
 					Method: http.MethodPost,
 				}: 2,
 			},
@@ -167,11 +165,11 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
-					Path:   http.Path{Content: intern.Interner.GetString("/helloworld.Greeter/SayHello")},
+					Path:   http.Path{Content: http.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
 				}: 2,
 				{
-					Path:   http.Path{Content: intern.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
+					Path:   http.Path{Content: http.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
 					Method: http.MethodPost,
 				}: 2,
 			},
@@ -188,7 +186,7 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
-					Path:   http.Path{Content: intern.Interner.GetString("/protobuf.Math/Max")},
+					Path:   http.Path{Content: http.Interner.GetString("/protobuf.Math/Max")},
 					Method: http.MethodPost,
 				}: 25,
 			},
@@ -205,11 +203,11 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
-					Path:   http.Path{Content: intern.Interner.GetString("/protobuf.Math/Max")},
+					Path:   http.Path{Content: http.Interner.GetString("/protobuf.Math/Max")},
 					Method: http.MethodPost,
 				}: 2,
 				{
-					Path:   http.Path{Content: intern.Interner.GetString("/helloworld.Greeter/SayHello")},
+					Path:   http.Path{Content: http.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
 				}: 2,
 			},
@@ -235,11 +233,11 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
-					Path:   http.Path{Content: intern.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
+					Path:   http.Path{Content: http.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
 					Method: http.MethodPost,
 				}: 2,
 				{
-					Path:   http.Path{Content: intern.Interner.GetString("/helloworld.Greeter/SayHello")},
+					Path:   http.Path{Content: http.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
 				}: 2,
 			},
@@ -266,11 +264,11 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
-					Path:   http.Path{Content: intern.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
+					Path:   http.Path{Content: http.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
 					Method: http.MethodPost,
 				}: 2,
 				{
-					Path:   http.Path{Content: intern.Interner.GetString("/helloworld.Greeter/SayHello")},
+					Path:   http.Path{Content: http.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
 				}: 2,
 			},
@@ -373,7 +371,7 @@ func (s *USMgRPCSuite) TestLargeBodiesGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]captureRange{
 				{
-					Path:   http.Path{Content: intern.Interner.GetString("/helloworld.Greeter/SayHello")},
+					Path:   http.Path{Content: http.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
 				}: {
 					lower: 4,
@@ -395,14 +393,14 @@ func (s *USMgRPCSuite) TestLargeBodiesGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]captureRange{
 				{
-					Path:   http.Path{Content: intern.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
+					Path:   http.Path{Content: http.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
 					Method: http.MethodPost,
 				}: {
 					lower: 2,
 					upper: 2,
 				},
 				{
-					Path:   http.Path{Content: intern.Interner.GetString("/helloworld.Greeter/SayHello")},
+					Path:   http.Path{Content: http.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
 				}: {
 					lower: 1,

--- a/pkg/network/protocols/grpc/monitor_test.go
+++ b/pkg/network/protocols/grpc/monitor_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/util/intern"
+
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc/metadata"
@@ -107,7 +109,7 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
-					Path:   http.Path{Content: "/helloworld.Greeter/SayHello"},
+					Path:   http.Path{Content: intern.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
 				}: 1000,
 			},
@@ -123,11 +125,11 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
-					Path:   http.Path{Content: "/helloworld.Greeter/SayHello"},
+					Path:   http.Path{Content: intern.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
 				}: 2,
 				{
-					Path:   http.Path{Content: "/routeguide.RouteGuide/GetFeature"},
+					Path:   http.Path{Content: intern.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
 					Method: http.MethodPost,
 				}: 1,
 			},
@@ -144,11 +146,11 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
-					Path:   http.Path{Content: "/helloworld.Greeter/SayHello"},
+					Path:   http.Path{Content: intern.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
 				}: 2,
 				{
-					Path:   http.Path{Content: "/routeguide.RouteGuide/GetFeature"},
+					Path:   http.Path{Content: intern.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
 					Method: http.MethodPost,
 				}: 2,
 			},
@@ -165,11 +167,11 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
-					Path:   http.Path{Content: "/helloworld.Greeter/SayHello"},
+					Path:   http.Path{Content: intern.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
 				}: 2,
 				{
-					Path:   http.Path{Content: "/routeguide.RouteGuide/GetFeature"},
+					Path:   http.Path{Content: intern.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
 					Method: http.MethodPost,
 				}: 2,
 			},
@@ -186,7 +188,7 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
-					Path:   http.Path{Content: "/protobuf.Math/Max"},
+					Path:   http.Path{Content: intern.Interner.GetString("/protobuf.Math/Max")},
 					Method: http.MethodPost,
 				}: 25,
 			},
@@ -203,11 +205,11 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
-					Path:   http.Path{Content: "/protobuf.Math/Max"},
+					Path:   http.Path{Content: intern.Interner.GetString("/protobuf.Math/Max")},
 					Method: http.MethodPost,
 				}: 2,
 				{
-					Path:   http.Path{Content: "/helloworld.Greeter/SayHello"},
+					Path:   http.Path{Content: intern.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
 				}: 2,
 			},
@@ -233,11 +235,11 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
-					Path:   http.Path{Content: "/routeguide.RouteGuide/GetFeature"},
+					Path:   http.Path{Content: intern.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
 					Method: http.MethodPost,
 				}: 2,
 				{
-					Path:   http.Path{Content: "/helloworld.Greeter/SayHello"},
+					Path:   http.Path{Content: intern.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
 				}: 2,
 			},
@@ -264,11 +266,11 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]int{
 				{
-					Path:   http.Path{Content: "/routeguide.RouteGuide/GetFeature"},
+					Path:   http.Path{Content: intern.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
 					Method: http.MethodPost,
 				}: 2,
 				{
-					Path:   http.Path{Content: "/helloworld.Greeter/SayHello"},
+					Path:   http.Path{Content: intern.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
 				}: 2,
 			},
@@ -371,7 +373,7 @@ func (s *USMgRPCSuite) TestLargeBodiesGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]captureRange{
 				{
-					Path:   http.Path{Content: "/helloworld.Greeter/SayHello"},
+					Path:   http.Path{Content: intern.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
 				}: {
 					lower: 4,
@@ -393,14 +395,14 @@ func (s *USMgRPCSuite) TestLargeBodiesGRPCScenarios() {
 			},
 			expectedEndpoints: map[http.Key]captureRange{
 				{
-					Path:   http.Path{Content: "/routeguide.RouteGuide/GetFeature"},
+					Path:   http.Path{Content: intern.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
 					Method: http.MethodPost,
 				}: {
 					lower: 2,
 					upper: 2,
 				},
 				{
-					Path:   http.Path{Content: "/helloworld.Greeter/SayHello"},
+					Path:   http.Path{Content: intern.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
 				}: {
 					lower: 1,

--- a/pkg/network/protocols/http/debugging/debugging.go
+++ b/pkg/network/protocols/http/debugging/debugging.go
@@ -56,7 +56,7 @@ func HTTP(stats map[http.Key]*http.RequestStats, dns map[util.Address][]dns.Host
 				Port: k.DstPort,
 			},
 			DNS:      getDNS(dns, serverAddr),
-			Path:     k.Path.Content,
+			Path:     k.Path.Content.Get(),
 			Method:   k.Method.String(),
 			ByStatus: make(map[uint16]Stats),
 		}

--- a/pkg/network/protocols/http/statkeeper.go
+++ b/pkg/network/protocols/http/statkeeper.go
@@ -110,7 +110,7 @@ func (h *StatKeeper) add(tx Transaction) {
 		return
 	}
 
-	key := h.newKey(tx, path, fullPath)
+	key := NewKeyWithConnection(tx.ConnTuple(), path, fullPath, tx.Method())
 	stats, ok := h.stats[*key]
 	if !ok {
 		if len(h.stats) >= h.maxEntries {
@@ -123,10 +123,6 @@ func (h *StatKeeper) add(tx Transaction) {
 	}
 
 	stats.AddRequest(tx.StatusCode(), latency, tx.StaticTags(), tx.DynamicTags())
-}
-
-func (h *StatKeeper) newKey(tx Transaction, path []byte, fullPath bool) *Key {
-	return NewKeyWithConnection(tx.ConnTuple(), path, fullPath, tx.Method())
 }
 
 func pathIsMalformed(fullPath []byte) bool {

--- a/pkg/network/protocols/http/statkeeper.go
+++ b/pkg/network/protocols/http/statkeeper.go
@@ -105,7 +105,7 @@ func (h *StatKeeper) add(tx Transaction) {
 	}
 
 	key := NewKeyWithConnection(tx.ConnTuple(), path, fullPath, tx.Method())
-	stats, ok := h.stats[*key]
+	stats, ok := h.stats[key]
 	if !ok {
 		if len(h.stats) >= h.maxEntries {
 			h.telemetry.dropped.Add(1)
@@ -113,7 +113,7 @@ func (h *StatKeeper) add(tx Transaction) {
 		}
 		h.telemetry.aggregations.Add(1)
 		stats = NewRequestStats(h.enableStatusCodeAggregation)
-		h.stats[*key] = stats
+		h.stats[key] = stats
 	}
 
 	stats.AddRequest(tx.StatusCode(), latency, tx.StaticTags(), tx.DynamicTags())

--- a/pkg/network/protocols/http/statkeeper.go
+++ b/pkg/network/protocols/http/statkeeper.go
@@ -31,10 +31,6 @@ type StatKeeper struct {
 	// http path buffer
 	buffer []byte
 
-	// map containing interned path strings
-	// this is rotated  with the stats map
-	interned map[string]string
-
 	oversizedLogLimit *util.LogLimit
 }
 
@@ -46,7 +42,6 @@ func NewStatkeeper(c *config.Config, telemetry *Telemetry) *StatKeeper {
 		replaceRules:                c.HTTPReplaceRules,
 		enableStatusCodeAggregation: c.EnableHTTPStatsByStatusCode,
 		buffer:                      make([]byte, getPathBufferSize(c)),
-		interned:                    make(map[string]string),
 		telemetry:                   telemetry,
 		oversizedLogLimit:           util.NewLogLimit(10, time.Minute*10),
 	}
@@ -74,7 +69,6 @@ func (h *StatKeeper) GetAndResetAllStats() map[Key]*RequestStats {
 
 	ret := h.stats // No deep copy needed since `h.stats` gets reset
 	h.stats = make(map[Key]*RequestStats)
-	h.interned = make(map[string]string)
 	return ret
 }
 

--- a/pkg/network/protocols/http/statkeeper_test.go
+++ b/pkg/network/protocols/http/statkeeper_test.go
@@ -160,7 +160,7 @@ func TestPathProcessing(t *testing.T) {
 
 		require.Len(t, stats, 1)
 		for key := range stats {
-			assert.Equal(t, "/foobar", key.Path.Content)
+			assert.Equal(t, "/foobar", key.Path.Content.Get())
 		}
 	})
 

--- a/pkg/network/protocols/http/statkeeper_test.go
+++ b/pkg/network/protocols/http/statkeeper_test.go
@@ -49,7 +49,7 @@ func TestProcessHTTPTransactions(t *testing.T) {
 	assert.Equal(t, 0, len(sk.stats))
 	assert.Equal(t, numPaths, len(stats))
 	for key, stats := range stats {
-		assert.Equal(t, "/testpath", key.Path.Content[:9])
+		assert.Equal(t, "/testpath", key.Path.Content.Get()[:9])
 		for i := 0; i < 5; i++ {
 			s := stats.Data[uint16((i+1)*100)]
 			require.NotNil(t, s)
@@ -151,7 +151,7 @@ func TestPathProcessing(t *testing.T) {
 
 		require.Len(t, stats, 1)
 		for key, metrics := range stats {
-			assert.Equal(t, "/prefix/users/?", key.Path.Content)
+			assert.Equal(t, "/prefix/users/?", key.Path.Content.Get())
 			s := metrics.Data[uint16(statusCode)]
 			require.NotNil(t, s)
 			assert.Equal(t, 3, s.Count)
@@ -182,7 +182,7 @@ func TestPathProcessing(t *testing.T) {
 
 		require.Len(t, stats, 1)
 		for key, metrics := range stats {
-			assert.Equal(t, "/users/?/payment/?", key.Path.Content)
+			assert.Equal(t, "/users/?/payment/?", key.Path.Content.Get())
 			s := metrics.Data[uint16(statusCode)]
 			require.NotNil(t, s)
 			assert.Equal(t, 2, s.Count)

--- a/pkg/network/protocols/http/statkeeper_test.go
+++ b/pkg/network/protocols/http/statkeeper_test.go
@@ -88,7 +88,7 @@ func BenchmarkProcessHTTPTransactions(b *testing.B) {
 		for p := 0; p < numPaths; p++ {
 			b.StopTimer()
 			//we use subset of unique endpoints, but those will occur over and over again like in regular target application
-			path := "/testpath" + strconv.Itoa(p%uniqPaths)
+			path := "/testpath/blablabla/dsadas/isdaasd/asdasadsadasd" + strconv.Itoa(p%uniqPaths)
 			//we simulate different conn tuples by increasing the port number
 			newSourcePort := sourcePort + (p % 30)
 			statusCode := (i%5 + 1) * 100

--- a/pkg/network/protocols/http/stats.go
+++ b/pkg/network/protocols/http/stats.go
@@ -14,6 +14,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// Interner is used to intern strings to save memory allocations.
+var Interner = intern.NewStringInterner()
+
 // Method is the type used to represent HTTP request methods
 type Method uint8
 
@@ -82,7 +85,7 @@ func NewKey(saddr, daddr util.Address, sport, dport uint16, path []byte, fullPat
 	return Key{
 		ConnectionKey: types.NewConnectionKey(saddr, daddr, sport, dport),
 		Path: Path{
-			Content:  intern.Interner.Get(path),
+			Content:  Interner.Get(path),
 			FullPath: fullPath,
 		},
 		Method: method,
@@ -94,7 +97,7 @@ func NewKeyWithConnection(connKey types.ConnectionKey, path []byte, fullPath boo
 	return Key{
 		ConnectionKey: connKey,
 		Path: Path{
-			Content:  intern.Interner.Get(path),
+			Content:  Interner.Get(path),
 			FullPath: fullPath,
 		},
 		Method: method,

--- a/pkg/network/protocols/http/stats.go
+++ b/pkg/network/protocols/http/stats.go
@@ -90,8 +90,8 @@ func NewKey(saddr, daddr util.Address, sport, dport uint16, path []byte, fullPat
 }
 
 // NewKeyWithConnection generates a new Key with a given connection tuple
-func NewKeyWithConnection(connKey types.ConnectionKey, path []byte, fullPath bool, method Method) *Key {
-	return &Key{
+func NewKeyWithConnection(connKey types.ConnectionKey, path []byte, fullPath bool, method Method) Key {
+	return Key{
 		ConnectionKey: connKey,
 		Path: Path{
 			Content:  intern.Interner.Get(path),

--- a/pkg/network/protocols/http/stats.go
+++ b/pkg/network/protocols/http/stats.go
@@ -6,11 +6,11 @@
 package http
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/util/intern"
 	"github.com/DataDog/sketches-go/ddsketch"
 
 	"github.com/DataDog/datadog-agent/pkg/network/types"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/DataDog/datadog-agent/pkg/util/intern"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -82,14 +82,7 @@ type Key struct {
 
 // NewKey generates a new Key
 func NewKey(saddr, daddr util.Address, sport, dport uint16, path []byte, fullPath bool, method Method) Key {
-	return Key{
-		ConnectionKey: types.NewConnectionKey(saddr, daddr, sport, dport),
-		Path: Path{
-			Content:  Interner.Get(path),
-			FullPath: fullPath,
-		},
-		Method: method,
-	}
+	return NewKeyWithConnection(types.NewConnectionKey(saddr, daddr, sport, dport), path, fullPath, method)
 }
 
 // NewKeyWithConnection generates a new Key with a given connection tuple

--- a/pkg/network/protocols/http/stats.go
+++ b/pkg/network/protocols/http/stats.go
@@ -6,6 +6,7 @@
 package http
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/util/intern"
 	"github.com/DataDog/sketches-go/ddsketch"
 
 	"github.com/DataDog/datadog-agent/pkg/network/types"
@@ -64,7 +65,7 @@ func (m Method) String() string {
 
 // Path represents the HTTP path
 type Path struct {
-	Content  string
+	Content  *intern.StringValue
 	FullPath bool
 }
 
@@ -77,11 +78,23 @@ type Key struct {
 }
 
 // NewKey generates a new Key
-func NewKey(saddr, daddr util.Address, sport, dport uint16, path string, fullPath bool, method Method) Key {
+func NewKey(saddr, daddr util.Address, sport, dport uint16, path []byte, fullPath bool, method Method) Key {
 	return Key{
 		ConnectionKey: types.NewConnectionKey(saddr, daddr, sport, dport),
 		Path: Path{
-			Content:  path,
+			Content:  intern.Interner.Get(path),
+			FullPath: fullPath,
+		},
+		Method: method,
+	}
+}
+
+// NewKeyWithConnection generates a new Key with a given connection tuple
+func NewKeyWithConnection(connKey types.ConnectionKey, path []byte, fullPath bool, method Method) Key {
+	return Key{
+		ConnectionKey: connKey,
+		Path: Path{
+			Content:  intern.Interner.Get(path),
 			FullPath: fullPath,
 		},
 		Method: method,

--- a/pkg/network/protocols/http/stats.go
+++ b/pkg/network/protocols/http/stats.go
@@ -90,8 +90,8 @@ func NewKey(saddr, daddr util.Address, sport, dport uint16, path []byte, fullPat
 }
 
 // NewKeyWithConnection generates a new Key with a given connection tuple
-func NewKeyWithConnection(connKey types.ConnectionKey, path []byte, fullPath bool, method Method) Key {
-	return Key{
+func NewKeyWithConnection(connKey types.ConnectionKey, path []byte, fullPath bool, method Method) *Key {
+	return &Key{
 		ConnectionKey: connKey,
 		Path: Path{
 			Content:  intern.Interner.Get(path),

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -1391,7 +1391,7 @@ func testHTTPStats(t *testing.T, aggregateByStatusCode bool) {
 		DPort:  80,
 	}
 
-	key := http.NewKey(c.Source, c.Dest, c.SPort, c.DPort, "/testpath", true, http.MethodGet)
+	key := http.NewKey(c.Source, c.Dest, c.SPort, c.DPort, []byte("/testpath"), true, http.MethodGet)
 
 	httpStats := make(map[http.Key]*http.RequestStats)
 	httpStats[key] = http.NewRequestStats(aggregateByStatusCode)
@@ -1429,7 +1429,7 @@ func testHTTP2Stats(t *testing.T, aggregateByStatusCode bool) {
 	}
 
 	getStats := func(path string) map[protocols.ProtocolType]interface{} {
-		key := http.NewKey(c.Source, c.Dest, c.SPort, c.DPort, path, true, http.MethodGet)
+		key := http.NewKey(c.Source, c.Dest, c.SPort, c.DPort, []byte(path), true, http.MethodGet)
 
 		http2Stats := make(map[http.Key]*http.RequestStats)
 		http2Stats[key] = http.NewRequestStats(aggregateByStatusCode)
@@ -1471,7 +1471,7 @@ func testHTTPStatsWithMultipleClients(t *testing.T, aggregateByStatusCode bool) 
 
 	getStats := func(path string) map[protocols.ProtocolType]interface{} {
 		httpStats := make(map[http.Key]*http.RequestStats)
-		key := http.NewKey(c.Source, c.Dest, c.SPort, c.DPort, path, true, http.MethodGet)
+		key := http.NewKey(c.Source, c.Dest, c.SPort, c.DPort, []byte(path), true, http.MethodGet)
 		httpStats[key] = http.NewRequestStats(aggregateByStatusCode)
 
 		usmStats := make(map[protocols.ProtocolType]interface{})
@@ -1543,7 +1543,7 @@ func testHTTP2StatsWithMultipleClients(t *testing.T, aggregateByStatusCode bool)
 
 	getStats := func(path string) map[protocols.ProtocolType]interface{} {
 		http2Stats := make(map[http.Key]*http.RequestStats)
-		key := http.NewKey(c.Source, c.Dest, c.SPort, c.DPort, path, true, http.MethodGet)
+		key := http.NewKey(c.Source, c.Dest, c.SPort, c.DPort, []byte(path), true, http.MethodGet)
 		http2Stats[key] = http.NewRequestStats(aggregateByStatusCode)
 
 		usmStats := make(map[protocols.ProtocolType]interface{})

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -143,7 +143,7 @@ func testHTTPStats(t *testing.T, aggregateByStatusCode bool) {
 	require.Eventuallyf(t, func() bool {
 		payload := getConnections(t, tr)
 		for key, stats := range payload.HTTP {
-			if key.Method == http.MethodGet && key.Path.Content == "/test" && (key.SrcPort == 8080 || key.DstPort == 8080) {
+			if key.Method == http.MethodGet && key.Path.Content.Get() == "/test" && (key.SrcPort == 8080 || key.DstPort == 8080) {
 				currentStats := stats.Data[stats.NormalizeStatusCode(204)]
 				if currentStats != nil && currentStats.Count == 1 {
 					return true
@@ -318,7 +318,7 @@ func testHTTPSLibrary(t *testing.T, fetchCmd []string, prefetchLibs []string) {
 		allConnections = append(allConnections, payload.Conns...)
 		found := false
 		for key, stats := range payload.HTTP {
-			if key.Path.Content != "/200/foobar" {
+			if key.Path.Content.Get() != "/200/foobar" {
 				continue
 			}
 			req, exists := stats.Data[200]
@@ -562,7 +562,7 @@ func simpleGetRequestsGenerator(t *testing.T, targetAddr string) (*nethttp.Clien
 func isRequestIncluded(allStats map[http.Key]*http.RequestStats, req *nethttp.Request) bool {
 	expectedStatus := testutil.StatusFromPath(req.URL.Path)
 	for key, stats := range allStats {
-		if key.Path.Content != req.URL.Path {
+		if key.Path.Content.Get() != req.URL.Path {
 			continue
 		}
 		if requests, exists := stats.Data[expectedStatus]; exists && requests.Count > 0 {
@@ -882,7 +882,7 @@ func (s *USMSuite) TestJavaInjection() {
 				require.Eventuallyf(t, func() bool {
 					payload := getConnections(t, tr)
 					for key, stats := range payload.HTTP {
-						if key.Path.Content == "/200/anything/java-tls-request" {
+						if key.Path.Content.Get() == "/200/anything/java-tls-request" {
 							t.Log("path content found")
 							// socket filter is not supported on fentry tracer
 							if tr.ebpfTracer.Type() == connection.TracerTypeFentry {
@@ -1229,7 +1229,7 @@ func countRequestsOccurrences(t *testing.T, conns *network.Connections, reqs map
 			}
 
 			expectedStatus := testutil.StatusFromPath(req.URL.Path)
-			if key.Path.Content != req.URL.Path {
+			if key.Path.Content.Get() != req.URL.Path {
 				continue
 			}
 			if requests, exists := stats.Data[expectedStatus]; exists && requests.Count > 0 {
@@ -1327,7 +1327,7 @@ func testHTTPSClassification(t *testing.T, tr *Tracer, clientHost, targetHost, s
 
 					httpData := getConnections(t, tr).HTTP
 					for httpKey := range httpData {
-						if httpKey.Path.Content == resp.Request.URL.Path {
+						if httpKey.Path.Content.Get() == resp.Request.URL.Path {
 							return true
 						}
 					}

--- a/pkg/network/usm/monitor_test.go
+++ b/pkg/network/usm/monitor_test.go
@@ -445,7 +445,7 @@ func (s *HTTPTestSuite) TestUnknownMethodRegression() {
 					t.Error("detected HTTP request with method unknown")
 				}
 				// we just want our requests
-				if strings.Contains(key.Path.Content, "/request-") &&
+				if strings.Contains(key.Path.Content.Get(), "/request-") &&
 					key.DstPort == 8080 &&
 					util.FromLowHigh(key.DstIPLow, key.DstIPHigh) == serverAddrIP {
 					requestsSum++
@@ -754,7 +754,7 @@ func countRequestOccurrences(allStats map[http.Key]*http.RequestStats, req *neth
 	expectedStatus := testutil.StatusFromPath(req.URL.Path)
 	occurrences := 0
 	for key, stats := range allStats {
-		if key.Path.Content != req.URL.Path {
+		if key.Path.Content.Get() != req.URL.Path {
 			continue
 		}
 		if requests, exists := stats.Data[expectedStatus]; exists && requests.Count > 0 {

--- a/pkg/util/intern/string.go
+++ b/pkg/util/intern/string.go
@@ -78,7 +78,6 @@ func NewStringInterner() *StringInterner {
 // The returned pointer will be the same for GetString(v) and GetString(v2)
 // if and only if v == v2. The returned pointer will also be the same
 // for a byte slice with same contents as the string.
-//
 //go:nocheckptr
 func (s *StringInterner) GetString(k string) *StringValue {
 	s.mu.Lock()
@@ -103,7 +102,6 @@ func (s *StringInterner) GetString(k string) *StringValue {
 // The returned pointer will be the same for Get(v) and Get(v2)
 // if and only if v == v2. The returned pointer will also be the same
 // for a string with same contents as the byte slice.
-//
 //go:nocheckptr
 func (s *StringInterner) Get(k []byte) *StringValue {
 	s.mu.Lock()

--- a/pkg/util/intern/string.go
+++ b/pkg/util/intern/string.go
@@ -46,8 +46,6 @@ import (
 	"unsafe"
 )
 
-var Interner = NewStringInterner()
-
 // A StringValue pointer is the handle to the underlying string value.
 // See Get how Value pointers may be used.
 type StringValue struct {

--- a/pkg/util/intern/string.go
+++ b/pkg/util/intern/string.go
@@ -46,6 +46,8 @@ import (
 	"unsafe"
 )
 
+var Interner = NewStringInterner()
+
 // A StringValue pointer is the handle to the underlying string value.
 // See Get how Value pointers may be used.
 type StringValue struct {
@@ -78,6 +80,7 @@ func NewStringInterner() *StringInterner {
 // The returned pointer will be the same for GetString(v) and GetString(v2)
 // if and only if v == v2. The returned pointer will also be the same
 // for a byte slice with same contents as the string.
+//
 //go:nocheckptr
 func (s *StringInterner) GetString(k string) *StringValue {
 	s.mu.Lock()
@@ -102,6 +105,7 @@ func (s *StringInterner) GetString(k string) *StringValue {
 // The returned pointer will be the same for Get(v) and Get(v2)
 // if and only if v == v2. The returned pointer will also be the same
 // for a string with same contents as the byte slice.
+//
 //go:nocheckptr
 func (s *StringInterner) Get(k []byte) *StringValue {
 	s.mu.Lock()


### PR DESCRIPTION
### What does this PR do?

Replaced `Path.Content` field to use string interning, that way we can save some memory allocations when similar endpoints are hit again and again

### Motivation

Reduce memory usage and optimize temporary allocations

### Additional Notes

Load tests: 
_(all tests are re-using the connections and don't create new connections, which should reduce the number of total entries in  StatsKeeper's map)_

to run:

`inv -e usm-load-test.http-scenario --env val-string-intern --api-key <api_key> --compare-docker-repo 601427279990.dkr.ecr.us-east-1.amazonaws.com/usm-agent/valeri.pliskin --compare-agent string_intern --scenarios medium_volume_client --base-docker-repo 601427279990.dkr.ecr.us-east-1.amazonaws.com/usm-agent/valeri.pliskin --base-agent no_string_intern`

performance dashboards:

- medium load [dashboard](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=val-string-intern-base&tpl_var_client-service%5B0%5D=http-k6-client&tpl_var_compare_agent-env%5B0%5D=val-string-intern-new&tpl_var_kube_cluster_name%5B0%5D=usm-test-env-sso&tpl_var_server-service%5B0%5D=golang-httpbin&from_ts=1695026623170&to_ts=1695030342314&live=false)
      - [profiler](https://dddev.datadoghq.com/profiling/comparison?query=agent-env%3Aval-string-intern-new%20&compare_end_A=1695030300000&compare_end_B=1695030300000&compare_facet=log_prof_go_lifetime_heap_bytes&compare_query_A=agent-env%3Aval-string-intern-base&compare_query_B=agent-env%3Aval-string-intern-new&compare_start_A=1695026580000&compare_start_B=1695026580000&compareValuesMode=absolute&comparisonViz=flamegraph&my_code=enabled&op_filter=focus_on%28function%3A%22%28%2AStatKeeper%29.Process%20%28statkeeper.go%29%22%29&profile_type=heap-live-size&viz=stream&start=1694678791000&end=1694679391000&paused=true)


- production load [dashboard](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=val-string-intern-base&tpl_var_client-service%5B0%5D=http-k6-client&tpl_var_compare_agent-env%5B0%5D=val-string-intern-new&tpl_var_kube_cluster_name%5B0%5D=%2A&tpl_var_server-service%5B0%5D=golang-httpbin&from_ts=1694692800000&to_ts=1694706000000&live=false)

#### Benchmarks:

paths: 10000
unique paths: 50
unique conn tuples = 30

**BASELINE (no intern)**

```
goos: linux
goarch: amd64
pkg: github.com/DataDog/datadog-agent/pkg/network/protocols/http
cpu: 11th Gen Intel(R) Core(TM) i9-11950H @ 2.60GHz
BenchmarkProcessHTTPTransactions
BenchmarkProcessHTTPTransactions-16    	      10	   5087173 ns/op	  148880 B/op	    1179 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   4352453 ns/op	  148518 B/op	    1178 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   4424486 ns/op	  148540 B/op	    1178 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   4163176 ns/op	  148409 B/op	    1178 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   5086082 ns/op	  148729 B/op	    1179 allocs/op
```

**String Interning**

```
goos: linux
goarch: amd64
pkg: github.com/DataDog/datadog-agent/pkg/network/protocols/http
cpu: 11th Gen Intel(R) Core(TM) i9-11950H @ 2.60GHz
BenchmarkProcessHTTPTransactions
BenchmarkProcessHTTPTransactions-16    	      10	   4842102 ns/op	  147274 B/op	    1174 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   4388956 ns/op	  146602 B/op	    1172 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   4215041 ns/op	  146823 B/op	    1173 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   4332209 ns/op	  146663 B/op	    1172 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   4996685 ns/op	  146775 B/op	    1172 allocs/op
```

------------------------------------

paths: 10000
unique paths: 50
unique conn tuples  = 1000


**BASELINE (no intern)**

```
goos: linux
goarch: amd64
pkg: github.com/DataDog/datadog-agent/pkg/network/protocols/http
cpu: 11th Gen Intel(R) Core(TM) i9-11950H @ 2.60GHz
BenchmarkProcessHTTPTransactions
BenchmarkProcessHTTPTransactions-16    	      10	   3351261 ns/op	  478958 B/op	    5309 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   3734514 ns/op	  479131 B/op	    5309 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   3479820 ns/op	  478724 B/op	    5309 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   3833522 ns/op	  478708 B/op	    5308 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   3441786 ns/op	  478596 B/op	    5308 allocs/op
```

**String Interning**

```
goos: linux
goarch: amd64
pkg: github.com/DataDog/datadog-agent/pkg/network/protocols/http
cpu: 11th Gen Intel(R) Core(TM) i9-11950H @ 2.60GHz
BenchmarkProcessHTTPTransactions
BenchmarkProcessHTTPTransactions-16    	      10	   4117142 ns/op	  473944 B/op	    5304 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   3508454 ns/op	  473823 B/op	    5303 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   3387072 ns/op	  473765 B/op	    5303 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   3685999 ns/op	  474501 B/op	    5305 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   3466970 ns/op	  474069 B/op	    5304 allocs/op
```
------------------------------------

paths: 10000
unique path: 50
always new port 

**BASELINE (no intern)**

```
goos: linux
goarch: amd64
pkg: github.com/DataDog/datadog-agent/pkg/network/protocols/http
cpu: 11th Gen Intel(R) Core(TM) i9-11950H @ 2.60GHz
BenchmarkProcessHTTPTransactions
BenchmarkProcessHTTPTransactions-16    	      10	   9349743 ns/op	 2460779 B/op	   38023 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   8121694 ns/op	 2458891 B/op	   38020 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   8077411 ns/op	 2461560 B/op	   38025 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   7985048 ns/op	 2460225 B/op	   38023 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   8391819 ns/op	 2460705 B/op	   38024 allocs/op
```

**String Interning**

```
goos: linux
goarch: amd64
pkg: github.com/DataDog/datadog-agent/pkg/network/protocols/http
cpu: 11th Gen Intel(R) Core(TM) i9-11950H @ 2.60GHz
BenchmarkProcessHTTPTransactions
BenchmarkProcessHTTPTransactions-16    	      10	   7681500 ns/op	 2430674 B/op	   38019 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   8330516 ns/op	 2429461 B/op	   38017 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   8590826 ns/op	 2430293 B/op	   38018 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   7929292 ns/op	 2429698 B/op	   38017 allocs/op
BenchmarkProcessHTTPTransactions-16    	      10	   9083679 ns/op	 2429864 B/op	   38018 allocs/op
```


### Possible Drawbacks / Trade-offs

string interner pkg is a thread safe pkg and using a mutex for each access

### Describe how to test/QA your changes

usm-load-test env
use `BenchmarkProcessHTTPTransactions` benchmark test with different values to compare vs the base version (without string interning)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
