### PR TITLE
usm: tls: Change enable_https_monitoring into new tls tree

### DIFF
--- a/cmd/system-probe/config/adjust_usm.go
+++ b/cmd/system-probe/config/adjust_usm.go
@@ -26,6 +26,7 @@ func adjustUSM(cfg config.Config) {
 
 	deprecateBool(cfg, netNS("enable_http_monitoring"), smNS("enable_http_monitoring"))
 	deprecateBool(cfg, netNS("enable_https_monitoring"), smNS("tls", "native", "enabled"))
+	deprecateBool(cfg, smNS("enable_go_tls_support"), smNS("tls", "go", "enabled"))
 	deprecateGeneric(cfg, netNS("http_replace_rules"), smNS("http_replace_rules"))
 	deprecateInt64(cfg, netNS("max_tracked_http_connections"), smNS("max_tracked_http_connections"))
 	applyDefault(cfg, smNS("max_tracked_http_connections"), 1024)

--- a/cmd/system-probe/config/adjust_usm.go
+++ b/cmd/system-probe/config/adjust_usm.go
@@ -25,6 +25,7 @@ func adjustUSM(cfg config.Config) {
 	}
 
 	deprecateBool(cfg, netNS("enable_http_monitoring"), smNS("enable_http_monitoring"))
+	deprecateBool(cfg, netNS("enable_https_monitoring"), smNS("tls", "native", "enabled"))
 	deprecateGeneric(cfg, netNS("http_replace_rules"), smNS("http_replace_rules"))
 	deprecateInt64(cfg, netNS("max_tracked_http_connections"), smNS("max_tracked_http_connections"))
 	applyDefault(cfg, smNS("max_tracked_http_connections"), 1024)

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -210,7 +210,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnv(join(smNS, "tls", "go", "enabled"))
 
 	cfg.BindEnvAndSetDefault(join(smNS, "enable_http2_monitoring"), false)
-	cfg.BindEnvAndSetDefault(join(smNS, "enable_istio_monitoring"), false)
+	cfg.BindEnvAndSetDefault(join(smNS, "tls", "istio", "enabled"), false)
 	cfg.BindEnvAndSetDefault(join(smjtNS, "enabled"), false)
 	cfg.BindEnvAndSetDefault(join(smjtNS, "debug"), false)
 	cfg.BindEnvAndSetDefault(join(smjtNS, "args"), defaultServiceMonitoringJavaAgentArgs)

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -205,7 +205,9 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnv(join(netNS, "enable_https_monitoring"), "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTPS_MONITORING")
 	cfg.BindEnv(join(smNS, "tls", "native", "enabled"))
 
+	// For backward compatibility
 	cfg.BindEnvAndSetDefault(join(smNS, "enable_go_tls_support"), false)
+	cfg.BindEnv(join(smNS, "tls", "go", "enabled"))
 
 	cfg.BindEnvAndSetDefault(join(smNS, "enable_http2_monitoring"), false)
 	cfg.BindEnvAndSetDefault(join(smNS, "enable_istio_monitoring"), false)

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -25,7 +25,7 @@ const (
 	smNS                         = "service_monitoring_config"
 	dsNS                         = "data_streams_config"
 	evNS                         = "event_monitoring_config"
-	smjtNS                       = smNS + ".java_tls"
+	smjtNS                       = smNS + ".tls.java"
 	diNS                         = "dynamic_instrumentation"
 	defaultConnsMessageBatchSize = 600
 

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -201,7 +201,9 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnv(join(netNS, "enable_http_monitoring"), "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING")
 	cfg.BindEnv(join(smNS, "enable_http_monitoring"))
 
+	// For backward compatibility
 	cfg.BindEnv(join(netNS, "enable_https_monitoring"), "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTPS_MONITORING")
+	cfg.BindEnv(join(smNS, "tls", "native", "enabled"))
 
 	cfg.BindEnvAndSetDefault(join(smNS, "enable_go_tls_support"), false)
 

--- a/pkg/metadata/inventories/README.md
+++ b/pkg/metadata/inventories/README.md
@@ -88,7 +88,7 @@ The payload is a JSON dict with the following fields
     config option).
   - `feature_process_enabled` - **bool**: True if the Process Agent has process collection enabled
      (see: `process_config.process_collection.enabled` config option).
-  - `feature_process_language_detection_enabled` - **bool**: True if process language detection is enabled 
+  - `feature_process_language_detection_enabled` - **bool**: True if process language detection is enabled
      (see: `language_detection,enabled` config option).
   - `feature_processes_container_enabled` - **bool**: True if the Process Agent has container collection enabled
      (see: `process_config.container_collection.enabled`)
@@ -110,7 +110,7 @@ The payload is a JSON dict with the following fields
   - `system_probe_gateway_lookup_enabled` - **bool**: True if gateway lookup is enable in the System Probe (see: `network_config.enable_gateway_lookup` config option in `system-probe.yaml`).
   - `system_probe_root_namespace_enabled` - **bool**: True if the System Probe will run in the root namespace of the host (see: `network_config.enable_root_netns` config option in `system-probe.yaml`).
   - `feature_networks_http_enabled` - **bool**: True if HTTP monitoring is enabled for Network Performance Monitoring (see: `network_config.enable_http_monitoring` config option in `system-probe.yaml`).
-  - `feature_networks_https_enabled` - **bool**: True if HTTPS monitoring is enabled for Network Performance Monitoring (see: `network_config.enable_https_monitoring` config option in `system-probe.yaml`).
+  - `feature_networks_https_enabled` - **bool**: True if HTTPS monitoring is enabled for Universal Service Monitoring (see: `service_monitoring_config.tls.native.enabled` config option in `system-probe.yaml`).
   - `feature_remote_configuration_enabled` - **bool**: True if Remote Configuration is enabled (see: `remote_configuration.enabled` config option).
   - `feature_usm_enabled` - **bool**: True if Universal Service Monitoring is enabled (see: `service_monitoring_config.enabled` config option in `system-probe.yaml`)
   - `feature_usm_http2_enabled` - **bool**: True if HTTP2 monitoring is enabled for Universal Service Monitoring (see: `service_monitoring_config.enable_http2_monitoring` config option in `system-probe.yaml`).

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -474,7 +474,7 @@ func initializeConfig(cfg config.Config) {
 	SetAgentMetadata(AgentRemoteConfigEnabled, cfg.GetBool("remote_configuration.enabled"))
 	SetAgentMetadata(AgentUSMJavaTLSEnabled, config.SystemProbe.GetBool("service_monitoring_config.tls.java.enabled"))
 	SetAgentMetadata(AgentUSMHTTP2Enabled, config.SystemProbe.GetBool("service_monitoring_config.enable_http2_monitoring"))
-	SetAgentMetadata(AgentUSMIstioEnabled, config.SystemProbe.GetBool("service_monitoring_config.enable_istio_monitoring"))
+	SetAgentMetadata(AgentUSMIstioEnabled, config.SystemProbe.GetBool("service_monitoring_config.tls.istio.enabled"))
 	SetAgentMetadata(AgentUSMHTTPStatsByStatusCodeEnabled, config.SystemProbe.GetBool("service_monitoring_config.enable_http_stats_by_status_code"))
 	SetAgentMetadata(AgentUSMGoTLSEnabled, config.SystemProbe.GetBool("service_monitoring_config.tls.go.enabled"))
 	SetAgentMetadata(AgentDIEnabled, config.SystemProbe.GetBool("dynamic_instrumentation.enabled"))

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -468,7 +468,7 @@ func initializeConfig(cfg config.Config) {
 	SetAgentMetadata(AgentProcessesContainerEnabled, cfg.GetBool("process_config.container_collection.enabled"))
 	SetAgentMetadata(AgentNetworksEnabled, config.SystemProbe.GetBool("network_config.enabled"))
 	SetAgentMetadata(AgentNetworksHTTPEnabled, config.SystemProbe.GetBool("service_monitoring_config.enable_http_monitoring"))
-	SetAgentMetadata(AgentNetworksHTTPSEnabled, config.SystemProbe.GetBool("network_config.enable_https_monitoring"))
+	SetAgentMetadata(AgentNetworksHTTPSEnabled, config.SystemProbe.GetBool("service_monitoring_config.tls.native.enabled"))
 	SetAgentMetadata(AgentUSMEnabled, config.SystemProbe.GetBool("service_monitoring_config.enabled"))
 	SetAgentMetadata(AgentUSMKafkaEnabled, config.SystemProbe.GetBool("data_streams_config.enabled"))
 	SetAgentMetadata(AgentRemoteConfigEnabled, cfg.GetBool("remote_configuration.enabled"))

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -476,7 +476,7 @@ func initializeConfig(cfg config.Config) {
 	SetAgentMetadata(AgentUSMHTTP2Enabled, config.SystemProbe.GetBool("service_monitoring_config.enable_http2_monitoring"))
 	SetAgentMetadata(AgentUSMIstioEnabled, config.SystemProbe.GetBool("service_monitoring_config.enable_istio_monitoring"))
 	SetAgentMetadata(AgentUSMHTTPStatsByStatusCodeEnabled, config.SystemProbe.GetBool("service_monitoring_config.enable_http_stats_by_status_code"))
-	SetAgentMetadata(AgentUSMGoTLSEnabled, config.SystemProbe.GetBool("service_monitoring_config.enable_go_tls_support"))
+	SetAgentMetadata(AgentUSMGoTLSEnabled, config.SystemProbe.GetBool("service_monitoring_config.tls.go.enabled"))
 	SetAgentMetadata(AgentDIEnabled, config.SystemProbe.GetBool("dynamic_instrumentation.enabled"))
 	SetAgentMetadata(AgentLogsEnabled, cfg.GetBool("logs_enabled"))
 	SetAgentMetadata(AgentCSPMEnabled, cfg.GetBool("compliance_config.enabled"))

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -472,7 +472,7 @@ func initializeConfig(cfg config.Config) {
 	SetAgentMetadata(AgentUSMEnabled, config.SystemProbe.GetBool("service_monitoring_config.enabled"))
 	SetAgentMetadata(AgentUSMKafkaEnabled, config.SystemProbe.GetBool("data_streams_config.enabled"))
 	SetAgentMetadata(AgentRemoteConfigEnabled, cfg.GetBool("remote_configuration.enabled"))
-	SetAgentMetadata(AgentUSMJavaTLSEnabled, config.SystemProbe.GetBool("service_monitoring_config.enable_java_tls_support"))
+	SetAgentMetadata(AgentUSMJavaTLSEnabled, config.SystemProbe.GetBool("service_monitoring_config.tls.java.enabled"))
 	SetAgentMetadata(AgentUSMHTTP2Enabled, config.SystemProbe.GetBool("service_monitoring_config.enable_http2_monitoring"))
 	SetAgentMetadata(AgentUSMIstioEnabled, config.SystemProbe.GetBool("service_monitoring_config.enable_istio_monitoring"))
 	SetAgentMetadata(AgentUSMHTTPStatsByStatusCodeEnabled, config.SystemProbe.GetBool("service_monitoring_config.enable_http_stats_by_status_code"))

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -83,9 +83,9 @@ type Config struct {
 	// EnableKafkaMonitoring specifies whether the tracer should monitor Kafka traffic
 	EnableKafkaMonitoring bool
 
-	// EnableHTTPSMonitoring specifies whether the tracer should monitor HTTPS traffic
-	// Supported libraries: OpenSSL
-	EnableHTTPSMonitoring bool
+	// EnableNativeTLSMonitoring specifies whether the USM should monitor HTTPS traffic via native libraries.
+	// Supported libraries: OpenSSL, GnuTLS, LibCrypto.
+	EnableNativeTLSMonitoring bool
 
 	// EnableIstioMonitoring specifies whether USM should monitor Istio traffic
 	EnableIstioMonitoring bool
@@ -299,12 +299,12 @@ func New() *Config {
 
 		ProtocolClassificationEnabled: cfg.GetBool(join(netNS, "enable_protocol_classification")),
 
-		EnableHTTPMonitoring:  cfg.GetBool(join(smNS, "enable_http_monitoring")),
-		EnableHTTP2Monitoring: cfg.GetBool(join(smNS, "enable_http2_monitoring")),
-		EnableHTTPSMonitoring: cfg.GetBool(join(netNS, "enable_https_monitoring")),
-		EnableIstioMonitoring: cfg.GetBool(join(smNS, "enable_istio_monitoring")),
-		MaxHTTPStatsBuffered:  cfg.GetInt(join(smNS, "max_http_stats_buffered")),
-		MaxKafkaStatsBuffered: cfg.GetInt(join(smNS, "max_kafka_stats_buffered")),
+		EnableHTTPMonitoring:      cfg.GetBool(join(smNS, "enable_http_monitoring")),
+		EnableHTTP2Monitoring:     cfg.GetBool(join(smNS, "enable_http2_monitoring")),
+		EnableNativeTLSMonitoring: cfg.GetBool(join(smNS, "tls", "native", "enabled")),
+		EnableIstioMonitoring:     cfg.GetBool(join(smNS, "enable_istio_monitoring")),
+		MaxHTTPStatsBuffered:      cfg.GetInt(join(smNS, "max_http_stats_buffered")),
+		MaxKafkaStatsBuffered:     cfg.GetInt(join(smNS, "max_kafka_stats_buffered")),
 
 		MaxTrackedHTTPConnections: cfg.GetInt64(join(smNS, "max_tracked_http_connections")),
 		HTTPNotificationThreshold: cfg.GetInt64(join(smNS, "http_notification_threshold")),

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -302,7 +302,7 @@ func New() *Config {
 		EnableHTTPMonitoring:      cfg.GetBool(join(smNS, "enable_http_monitoring")),
 		EnableHTTP2Monitoring:     cfg.GetBool(join(smNS, "enable_http2_monitoring")),
 		EnableNativeTLSMonitoring: cfg.GetBool(join(smNS, "tls", "native", "enabled")),
-		EnableIstioMonitoring:     cfg.GetBool(join(smNS, "enable_istio_monitoring")),
+		EnableIstioMonitoring:     cfg.GetBool(join(smNS, "tls", "istio", "enabled")),
 		MaxHTTPStatsBuffered:      cfg.GetInt(join(smNS, "max_http_stats_buffered")),
 		MaxKafkaStatsBuffered:     cfg.GetInt(join(smNS, "max_kafka_stats_buffered")),
 

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -340,7 +340,7 @@ func New() *Config {
 		JavaAgentArgs:               cfg.GetString(join(smjtNS, "args")),
 		JavaAgentAllowRegex:         cfg.GetString(join(smjtNS, "allow_regex")),
 		JavaAgentBlockRegex:         cfg.GetString(join(smjtNS, "block_regex")),
-		EnableGoTLSSupport:          cfg.GetBool(join(smNS, "enable_go_tls_support")),
+		EnableGoTLSSupport:          cfg.GetBool(join(smNS, "tls", "go", "enabled")),
 		EnableHTTPStatsByStatusCode: cfg.GetBool(join(smNS, "enable_http_stats_by_status_code")),
 	}
 

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -21,7 +21,7 @@ const (
 	smNS   = "service_monitoring_config"
 	dsNS   = "data_streams_config"
 	evNS   = "event_monitoring_config"
-	smjtNS = smNS + ".java_tls"
+	smjtNS = smNS + ".tls.java"
 
 	defaultUDPTimeoutSeconds       = 30
 	defaultUDPStreamTimeoutSeconds = 120

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -1221,14 +1221,16 @@ func TestIstioMonitoring(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		cfg := configurationFromYAML(t, `
 service_monitoring_config:
-  enable_istio_monitoring: true
+  tls:
+    istio:
+      enabled: true
 `)
 		assert.True(t, cfg.EnableIstioMonitoring)
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_ISTIO_MONITORING", "true")
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_ISTIO_ENABLED", "true")
 
 		cfg := New()
 		assert.True(t, cfg.EnableIstioMonitoring)

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -64,27 +64,6 @@ func TestDisablingProtocolClassification(t *testing.T) {
 	})
 }
 
-func TestEnableGoTLSSupport(t *testing.T) {
-	t.Run("via YAML", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		_, err := sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableGoTLS.yaml")
-		require.NoError(t, err)
-		cfg := New()
-
-		assert.True(t, cfg.EnableGoTLSSupport)
-	})
-
-	t.Run("via ENV variable", func(t *testing.T) {
-		aconfig.ResetSystemProbeConfig(t)
-		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_GO_TLS_SUPPORT", "true")
-		_, err := sysconfig.New("")
-		require.NoError(t, err)
-		cfg := New()
-
-		assert.True(t, cfg.EnableGoTLSSupport)
-	})
-}
-
 func TestEnableHTTPStatsByStatusCode(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
@@ -1331,6 +1310,84 @@ service_monitoring_config:
 		cfg := New()
 		// Default value.
 		require.False(t, cfg.EnableNativeTLSMonitoring)
+	})
+}
+
+func TestUSMTLSGoEnabled(t *testing.T) {
+	t.Run("via deprecated YAML", func(t *testing.T) {
+		aconfig.ResetSystemProbeConfig(t)
+		cfg := configurationFromYAML(t, `
+service_monitoring_config:
+  enable_go_tls_support: true
+`)
+
+		require.True(t, cfg.EnableGoTLSSupport)
+	})
+
+	t.Run("via deprecated ENV variable", func(t *testing.T) {
+		aconfig.ResetSystemProbeConfig(t)
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_GO_TLS_SUPPORT", "true")
+
+		cfg := New()
+
+		require.True(t, cfg.EnableGoTLSSupport)
+	})
+
+	t.Run("via YAML", func(t *testing.T) {
+		aconfig.ResetSystemProbeConfig(t)
+		cfg := configurationFromYAML(t, `
+service_monitoring_config:
+  tls:
+    go:
+      enabled: true
+`)
+		require.True(t, cfg.EnableGoTLSSupport)
+	})
+
+	t.Run("via ENV variable", func(t *testing.T) {
+		aconfig.ResetSystemProbeConfig(t)
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_GO_ENABLED", "true")
+
+		cfg := New()
+
+		require.True(t, cfg.EnableGoTLSSupport)
+	})
+
+	t.Run("Deprecated is enabled, new is disabled", func(t *testing.T) {
+		aconfig.ResetSystemProbeConfig(t)
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_GO_TLS_SUPPORT", "true")
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_GO_ENABLED", "false")
+
+		cfg := New()
+
+		require.False(t, cfg.EnableGoTLSSupport)
+	})
+
+	t.Run("Deprecated is disabled, new is enabled", func(t *testing.T) {
+		aconfig.ResetSystemProbeConfig(t)
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_GO_TLS_SUPPORT", "false")
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_GO_ENABLED", "true")
+
+		cfg := New()
+
+		require.True(t, cfg.EnableGoTLSSupport)
+	})
+
+	t.Run("Both enabled", func(t *testing.T) {
+		aconfig.ResetSystemProbeConfig(t)
+		// Setting a different value
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_GO_TLS_SUPPORT", "true")
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_GO_ENABLED", "true")
+		cfg := New()
+
+		require.True(t, cfg.EnableGoTLSSupport)
+	})
+
+	t.Run("Not enabled", func(t *testing.T) {
+		aconfig.ResetSystemProbeConfig(t)
+		cfg := New()
+		// Default value.
+		require.False(t, cfg.EnableGoTLSSupport)
 	})
 }
 

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -195,24 +195,24 @@ func TestEnableDataStreams(t *testing.T) {
 func TestEnableJavaTLSSupport(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-
-		_, err := sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableJavaTLS.yaml")
-		require.NoError(t, err)
-		cfg := New()
-
-		assert.True(t, cfg.EnableJavaTLSSupport)
+		cfg := configurationFromYAML(t, `
+service_monitoring_config:
+  tls:
+    java:
+      enabled: true
+`)
+		require.True(t, cfg.EnableJavaTLSSupport)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_TLS_JAVA_ENABLED", "true")
 
-		t.Setenv("DD_SERVICE_MONITORING_CONFIG_JAVA_TLS_ENABLED", "true")
-		_, err := sysconfig.New("")
-		require.NoError(t, err)
 		cfg := New()
 
-		assert.True(t, cfg.EnableJavaTLSSupport)
+		require.True(t, cfg.EnableJavaTLSSupport)
 	})
+
 }
 
 func TestEnableHTTP2Monitoring(t *testing.T) {

--- a/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableGoTLS.yaml
+++ b/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableGoTLS.yaml
@@ -1,2 +1,0 @@
-service_monitoring_config:
-  enable_go_tls_support: true

--- a/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableJavaTLS.yaml
+++ b/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableJavaTLS.yaml
@@ -1,3 +1,0 @@
-service_monitoring_config:
-  java_tls:
-    enabled: true

--- a/pkg/network/protocols/http/etw_interface.go
+++ b/pkg/network/protocols/http/etw_interface.go
@@ -28,7 +28,7 @@ func NewEtwInterface(c *config.Config) *EtwInterface {
 	return &EtwInterface{
 		maxEntriesBuffered: c.MaxHTTPStatsBuffered,
 		DataChannel:        make(chan []WinHttpTransaction),
-		captureHTTPS:       c.EnableHTTPSMonitoring,
+		captureHTTPS:       c.EnableNativeTLSMonitoring,
 		captureHTTP:        c.EnableHTTPMonitoring,
 	}
 }

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -143,7 +143,7 @@ func newTracer(cfg *config.Config) (_ *Tracer, reterr error) {
 			log.Warnf("%s. NPM is explicitly enabled, so system-probe will continue with only NPM features enabled.", errStr)
 			cfg.EnableHTTPMonitoring = false
 			cfg.EnableHTTP2Monitoring = false
-			cfg.EnableHTTPSMonitoring = false
+			cfg.EnableNativeTLSMonitoring = false
 		}
 
 		if !http2.Supported() {

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1883,7 +1883,7 @@ func (s *TracerSuite) TestGetHelpersTelemetry() {
 
 	t.Setenv("DD_SYSTEM_PROBE_SERVICE_MONITORING_ENABLED", "true")
 	cfg := testConfig()
-	cfg.EnableHTTPSMonitoring = true
+	cfg.EnableNativeTLSMonitoring = true
 	cfg.EnableHTTPMonitoring = true
 	tr := setupTracer(t, cfg)
 

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -281,7 +281,7 @@ func testHTTPSLibrary(t *testing.T, fetchCmd []string, prefetchLibs []string) {
 	// Start tracer with HTTPS support
 	cfg := testConfig()
 	cfg.EnableHTTPMonitoring = true
-	cfg.EnableHTTPSMonitoring = true
+	cfg.EnableNativeTLSMonitoring = true
 	/* enable protocol classification : TLS */
 	cfg.ProtocolClassificationEnabled = true
 	cfg.CollectTCPv4Conns = true
@@ -392,7 +392,7 @@ func (s *USMSuite) TestOpenSSLVersions() {
 	}
 
 	cfg := testConfig()
-	cfg.EnableHTTPSMonitoring = true
+	cfg.EnableNativeTLSMonitoring = true
 	cfg.EnableHTTPMonitoring = true
 	tr := setupTracer(t, cfg)
 
@@ -453,7 +453,7 @@ func (s *USMSuite) TestOpenSSLVersionsSlowStart() {
 	}
 
 	cfg := testConfig()
-	cfg.EnableHTTPSMonitoring = true
+	cfg.EnableNativeTLSMonitoring = true
 	cfg.EnableHTTPMonitoring = true
 
 	addressOfHTTPPythonServer := "127.0.0.1:8001"
@@ -581,7 +581,7 @@ func (s *USMSuite) TestProtocolClassification() {
 	}
 
 	cfg.EnableGoTLSSupport = true
-	cfg.EnableHTTPSMonitoring = true
+	cfg.EnableNativeTLSMonitoring = true
 	cfg.EnableHTTPMonitoring = true
 	tr, err := NewTracer(cfg)
 	require.NoError(t, err)

--- a/pkg/network/tracer/tracer_windows.go
+++ b/pkg/network/tracer/tracer_windows.go
@@ -253,7 +253,7 @@ func (t *Tracer) DebugDumpProcessCache(ctx context.Context) (interface{}, error)
 }
 
 func newUSMMonitor(c *config.Config, dh driver.Handle) usm.Monitor {
-	if !c.EnableHTTPMonitoring && !c.EnableHTTPSMonitoring {
+	if !c.EnableHTTPMonitoring && !c.EnableNativeTLSMonitoring {
 		return nil
 	}
 	log.Infof("http monitoring has been enabled")

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -412,7 +412,7 @@ type sslProgram struct {
 
 func newSSLProgramProtocolFactory(m *manager.Manager, sockFDMap *ebpf.Map, bpfTelemetry *errtelemetry.EBPFTelemetry) protocols.ProtocolFactory {
 	return func(c *config.Config) (protocols.Protocol, error) {
-		if (!c.EnableHTTPSMonitoring || !http.HTTPSSupported(c)) && !c.EnableIstioMonitoring {
+		if (!c.EnableNativeTLSMonitoring || !http.HTTPSSupported(c)) && !c.EnableIstioMonitoring {
 			return nil, nil
 		}
 
@@ -420,7 +420,7 @@ func newSSLProgramProtocolFactory(m *manager.Manager, sockFDMap *ebpf.Map, bpfTe
 			watcher *sharedlibraries.Watcher
 			err     error
 		)
-		if c.EnableHTTPSMonitoring && http.HTTPSSupported(c) {
+		if c.EnableNativeTLSMonitoring && http.HTTPSSupported(c) {
 			watcher, err = sharedlibraries.NewWatcher(c, bpfTelemetry,
 				sharedlibraries.Rule{
 					Re:           regexp.MustCompile(`libssl.so`),

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -214,7 +214,7 @@ func (m *Monitor) Start() error {
 	}
 
 	// Need to explicitly save the error in `err` so the defer function could save the startup error.
-	if m.cfg.EnableHTTPSMonitoring || m.cfg.EnableGoTLSSupport || m.cfg.EnableJavaTLSSupport || m.cfg.EnableIstioMonitoring {
+	if m.cfg.EnableNativeTLSMonitoring || m.cfg.EnableGoTLSSupport || m.cfg.EnableJavaTLSSupport || m.cfg.EnableIstioMonitoring {
 		err = m.processMonitor.Initialize()
 	}
 

--- a/pkg/network/usm/monitor_windows.go
+++ b/pkg/network/usm/monitor_windows.go
@@ -46,7 +46,7 @@ func NewWindowsMonitor(c *config.Config, dh driver.Handle) (Monitor, error) {
 
 	hei.SetMaxFlows(uint64(c.MaxTrackedConnections))
 	hei.SetMaxRequestBytes(uint64(c.HTTPMaxRequestFragment))
-	hei.SetCapturedProtocols(c.EnableHTTPMonitoring, c.EnableHTTPSMonitoring)
+	hei.SetCapturedProtocols(c.EnableHTTPMonitoring, c.EnableNativeTLSMonitoring)
 
 	telemetry := http.NewTelemetry("http")
 

--- a/releasenotes/notes/deprecating-usm-configuration-values-84128feedad9d345.yaml
+++ b/releasenotes/notes/deprecating-usm-configuration-values-84128feedad9d345.yaml
@@ -8,5 +8,5 @@
 ---
 deprecations:
   - |
-    service_monitoring_config.enable_go_tls_support is deprecated and replaced by service_monitoring_config.tls.go.enabled.
-    network_config.enable_https_monitoring is deprecated and replaced by service_monitoring_config.tls.native.enabled.
+    `service_monitoring_config.enable_go_tls_support` is deprecated and replaced by `service_monitoring_config.tls.go.enabled`.
+    `network_config.enable_https_monitoring` is deprecated and replaced by `service_monitoring_config.tls.native.enabled`.

--- a/releasenotes/notes/deprecating-usm-configuration-values-84128feedad9d345.yaml
+++ b/releasenotes/notes/deprecating-usm-configuration-values-84128feedad9d345.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    service_monitoring_config.enable_go_tls_support is deprecated and replaced by service_monitoring_config.tls.go.enabled.
+    network_config.enable_https_monitoring is deprecated and replaced by service_monitoring_config.tls.native.enabled.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Unifies USM tls configuration under new tls tree.

Old:
```yaml
network_config:
  enable_https_monitoring: true

service_monitoring_config:
  enabled: true
  enable_go_tls_support: true
  java_tls:
    enabled: true
    debug: true
    other configuration values ...
```

New:
```yaml
service_monitoring_config:
  enabled: true
  tls:
    java:
      enabled: true
      other flags....
    go:
      enabled: true
      other flags....
    native:
      enabled: true
      other flags....
```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Making the configuration simpler for users.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Each change (native, go, java) was done in different commits, suggested to review each commit on its on.
For java & istio I didn't add an entry in the release note, as it is still an internal feature.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
