### PR TITLE
[Backport][7.47.x] Remove entries from CreateFolder table #19298

### DIFF
--- a/releasenotes/notes/windows-installer-createfolder-hotfix-6f1e2062856bd5da.yaml
+++ b/releasenotes/notes/windows-installer-createfolder-hotfix-6f1e2062856bd5da.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix the issue introduced in 7.47.0 that causes the SE_DACL_AUTO_INHERITED flag to be removed from
+    the installation drive directory when the installer fails and rolls back.

--- a/releasenotes/notes/windows-installer-createfolder-hotfix-6f1e2062856bd5da.yaml
+++ b/releasenotes/notes/windows-installer-createfolder-hotfix-6f1e2062856bd5da.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Fix the issue introduced in 7.47.0 that causes the SE_DACL_AUTO_INHERITED flag to be removed from
+    Fix the issue introduced in `7.47.0` that causes the `SE_DACL_AUTO_INHERITED` flag to be removed from
     the installation drive directory when the installer fails and rolls back.

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -7,11 +7,20 @@ import mmap
 import os
 import shutil
 import sys
+from contextlib import contextmanager
 
 from invoke import task
 from invoke.exceptions import Exit, UnexpectedExit
 
 from tasks.utils import get_version, load_release_versions, timed
+
+# Windows only import
+try:
+    import msilib
+except ImportError:
+    if sys.platform == "win32":
+        raise
+    msilib = None
 
 # constants
 OUTPUT_PATH = os.path.join(os.getcwd(), "omnibus", "pkg")
@@ -174,7 +183,7 @@ def _build(
 
     # Construct build command line
     cmd = _get_vs_build_command(
-        f'cd {BUILD_SOURCE_DIR} && nuget restore && msbuild {project} /p:Configuration={configuration} /p:Platform="{arch}"',
+        f'cd {BUILD_SOURCE_DIR} && msbuild {project} /restore /p:Configuration={configuration} /p:Platform="{arch}"',
         vstudio_root,
     )
     print(f"Build Command: {cmd}")
@@ -231,8 +240,8 @@ def _build_msi(ctx, env, outdir, name):
     if not succeeded:
         raise Exit("Failed to build the MSI installer.", code=1)
 
-    # sign the MSI
     out_file = os.path.join(outdir, f"{name}.msi")
+    validate_msi(ctx, out_file)
     sign_file(ctx, out_file)
 
 
@@ -346,3 +355,55 @@ def test(
 
     if not ctx.run(f'dotnet test {build_outdir}\\WixSetup.Tests.dll', warn=True, env=env):
         raise Exit(code=1)
+
+
+def validate_msi_createfolder_table(db):
+    """
+    Checks that the CreateFolder MSI table only contains certain directories.
+
+    We found that WiX# was causing directories like TARGETDIR (C:\\) and ProgramFiles64Folder
+    (C:\\Program Files\\) to end up in the CrateFolder MSI table. Then because MSI.dll CreateFolder rollback
+    uses the obsolete SetFileSecurityW function the AI DACL flag is removed from those directories
+    on rollback.
+    https://github.com/oleg-shilo/wixsharp/issues/1336
+
+    If you think you need to add a new directory to this list, perform the following checks:
+    * Ensure the directory and its parents are deleted or persisted on uninstall as expected
+    * If the directory may be persisted after rollback, check if AI flag is removed and consider if that's okay or not
+
+    TODO: We don't want the AI flag to be removed from the directories in the allow list either, but
+          this behavior was also present in the original installer so leave them for now.
+    """
+    allowlist = ["APPLICATIONDATADIRECTORY", "checks.d", "run", "logs", "ProgramMenuDatadog"]
+
+    with MsiClosing(db.OpenView("Select Directory_ FROM CreateFolder")) as view:
+        view.Execute(None)
+        record = view.Fetch()
+        unexpected = set()
+        while record:
+            directory = record.GetString(1)
+            if directory not in allowlist:
+                unexpected.add(directory)
+            record = view.Fetch()
+
+    if unexpected:
+        for directory in unexpected:
+            print(f"Unexpected directory '{directory}' in MSI CreateFolder table")
+        raise Exit(f"{len(unexpected)} unexpected directories in MSI CreateFolder table")
+
+
+@task
+def validate_msi(_ctx, msi=None):
+    with MsiClosing(msilib.OpenDatabase(msi, msilib.MSIDBOPEN_READONLY)) as db:
+        validate_msi_createfolder_table(db)
+
+
+@contextmanager
+def MsiClosing(obj):
+    """
+    The MSI objects use Close() instead of close() so we can't use the built-in closing()
+    """
+    try:
+        yield obj
+    finally:
+        obj.Close()

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
@@ -180,6 +180,10 @@ namespace Datadog.CustomActions
             {
                 using var subkey =
                     _registryServices.OpenRegistryKey(Registries.LocalMachine, Constants.DatadogAgentRegistryKey);
+                if (subkey == null)
+                {
+                    throw new Exception("Datadog registry key does not exist");
+                }
                 var domain = subkey.GetValue("installedDomain")?.ToString();
                 var user = subkey.GetValue("installedUser")?.ToString();
                 if (string.IsNullOrEmpty(domain) || string.IsNullOrEmpty(user))

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Interfaces/IRegistryKey.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Interfaces/IRegistryKey.cs
@@ -9,5 +9,6 @@ namespace Datadog.CustomActions.Interfaces
         void SetAccessControl(RegistrySecurity registrySecurity);
         object GetValue(string name);
         void SetValue(string name, object value, RegistryValueKind kind);
+        void DeleteValue(string name);
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Interfaces/IRegistryServices.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Interfaces/IRegistryServices.cs
@@ -6,5 +6,6 @@ namespace Datadog.CustomActions.Interfaces
     {
         IRegistryKey CreateRegistryKey(Registries registry, string path);
         IRegistryKey OpenRegistryKey(Registries registry, string path);
+        IRegistryKey OpenRegistryKey(Registries registry, string path, bool writable);
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/RegistryKey.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/RegistryKey.cs
@@ -28,6 +28,11 @@ namespace Datadog.CustomActions.Native
             _key.SetValue(name, value, kind);
         }
 
+        public void DeleteValue(string name)
+        {
+            _key.DeleteValue(name);
+        }
+
         public void Dispose()
         {
             _key?.Dispose();

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Native/RegistryServices.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Native/RegistryServices.cs
@@ -13,10 +13,21 @@ namespace Datadog.CustomActions.Native
                 _ => null
             };
 
-            return new RegistryKey(key.CreateSubKey(path));
+            key = key.CreateSubKey(path);
+            if (key == null)
+            {
+                return null;
+            }
+
+            return new RegistryKey(key);
         }
 
         public IRegistryKey OpenRegistryKey(Registries registry, string path)
+        {
+            return OpenRegistryKey(registry, path, false);
+        }
+
+        public IRegistryKey OpenRegistryKey(Registries registry, string path, bool writable)
         {
             var key = registry switch
             {
@@ -24,7 +35,13 @@ namespace Datadog.CustomActions.Native
                 _ => null
             };
 
-            return new RegistryKey(key.OpenSubKey(path));
+            key = key.OpenSubKey(path, writable);
+            if (key == null)
+            {
+                return null;
+            }
+
+            return new RegistryKey(key);
         }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
@@ -24,6 +24,8 @@ namespace WixSetup.Datadog
 
         public ManagedAction WriteInstallState { get; }
 
+        public ManagedAction UninstallWriteInstallState { get; }
+
         public ManagedAction ProcessDdAgentUserCredentials { get; }
 
         public ManagedAction ProcessDdAgentUserCredentialsUI { get; }
@@ -476,6 +478,22 @@ namespace WixSetup.Datadog
                 }
                 .SetProperties("DDAGENTUSER_PROCESSED_DOMAIN=[DDAGENTUSER_PROCESSED_DOMAIN], " +
                                "DDAGENTUSER_PROCESSED_NAME=[DDAGENTUSER_PROCESSED_NAME]");
+
+            UninstallWriteInstallState = new CustomAction<InstallStateCustomActions>(
+                    new Id(nameof(UninstallWriteInstallState)),
+                    InstallStateCustomActions.UninstallWriteInstallState,
+                    Return.check,
+                    // Since this CA removes registry values it must run before the built-in RemoveRegistryValues
+                    // so that the built-in registry keys can be removed if they are empty.
+                    When.Before,
+                    Step.RemoveRegistryValues,
+                    // Run only on full uninstall
+                    Conditions.Uninstalling
+                )
+                {
+                    Execute = Execute.deferred,
+                    Impersonate = false
+                };
         }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -114,13 +114,14 @@ namespace WixSetup.Datadog
                     RegistryHive.LocalMachine, @"Software\Datadog\Datadog Agent",
                     // Store these properties in the registry for retrieval by future
                     // installer runs via the ReadInstallState CA.
-                    new RegValue("InstallPath", "[PROJECTLOCATION]") { Win64 = true },
-                    new RegValue("ConfigRoot", "[APPLICATIONDATADIRECTORY]") { Win64 = true }
+                    // Must set KeyPath=yes to ensure WiX# doesn't automatically try to use the parent Directory as the KeyPath,
+                    // which can cause the directory to be added to the CreateFolder table.
+                    new RegValue("InstallPath", "[PROJECTLOCATION]") { Win64 = true, AttributesDefinition = "KeyPath=yes"},
+                    new RegValue("ConfigRoot", "[APPLICATIONDATADIRECTORY]") { Win64 = true, AttributesDefinition = "KeyPath=yes"}
                 )
                 {
                     Win64 = true
-                },
-                new RemoveRegistryKey(_agentFeatures.MainApplication, @"Software\Datadog\Datadog Agent")
+                }
             );
             project
                 .SetCustomActions(_agentCustomActions)
@@ -154,7 +155,7 @@ namespace WixSetup.Datadog
                 .AddDirectories(
                     CreateProgramFilesFolder(),
                     CreateAppDataFolder(),
-                    new Dir(@"%ProgramMenu%\Datadog",
+                    new Dir(new Id("ProgramMenuDatadog"), @"%ProgramMenu%\Datadog",
                         new ExeFileShortcut
                         {
                             Name = "Datadog Agent Manager",
@@ -162,8 +163,7 @@ namespace WixSetup.Datadog
                             Arguments = "\"--launch-gui\"",
                             WorkingDirectory = "AGENT",
                         }
-                    ),
-                    new Dir("logs")
+                    )
                 );
 
             project.SetNetFxPrerequisite(Condition.Net45_Installed,
@@ -213,12 +213,33 @@ namespace WixSetup.Datadog
                     .Select("Wix/Product")
                     .AddElement("MediaTemplate",
                         "CabinetTemplate=cab{0}.cab; CompressionLevel=high; EmbedCab=yes; MaximumUncompressedMediaSize=2");
+
+                // Windows Installer (MSI.dll) calls the obsolete SetFileSecurityW function during CreateFolder rollback,
+                // this causes directories in the CreateFolder table to have their SE_DACL_AUTO_INHERITED flag removed.
+                // Also, since folders created by CreateFolder aren't removed on uninstall then it can cause empty directories
+                // to be left behind on uninstall.
+                document.FindAll("CreateFolder")
+                    .ForEach(x => x.Remove());
+                document.FindAll("RemoveFolder")
+                    .ForEach(x => x.Remove());
+
+                // Wix# is auto-adding components for the following directories for some reason, which causes them to be placed
+                // in the CreateFolder table.
                 document
-                    .FindAll("RemoveFolder")
+                    .FindAll("Component")
                     .Where(x => x.HasAttribute("Id",
-                        value => value.StartsWith("APPLICATIONDATADIRECTORY") ||
-                                 value.StartsWith("EXAMPLECONFSLOCATION")))
+                        value => value.Equals("TARGETDIR") ||
+                                 value.Equals("ProgramFiles64Folder") ||
+                                 value.Equals("DatadogAppRoot")))
                     .Remove();
+                document
+                    .FindAll("ComponentRef")
+                    .Where(x => x.HasAttribute("Id",
+                        value => value.Equals("TARGETDIR") ||
+                                 value.Equals("ProgramFiles64Folder") ||
+                                 value.Equals("DatadogAppRoot")))
+                    .Remove();
+                // END TODO: Wix# adds these automatically
                 document
                     .FindAll("Component")
                     .Where(x => x.Parent.HasAttribute("Id",
@@ -321,7 +342,7 @@ namespace WixSetup.Datadog
                 datadogAgentFolder.AddFile(new CompressedDir(this, "embedded2", $@"{InstallerSource}\embedded2"));
             }
 
-            return new Dir("%ProgramFiles%\\Datadog", datadogAgentFolder);
+            return new Dir(new Id("DatadogAppRoot"), "%ProgramFiles%\\Datadog", datadogAgentFolder);
         }
 
         private static PermissionEx DefaultPermissions()
@@ -437,12 +458,15 @@ namespace WixSetup.Datadog
 
             var targetBinFolder = new Dir(new Id("BIN"), "bin",
                 new WixSharp.File(_agentBinaries.Agent, agentService),
+                // Each EventSource must have KeyPath=yes to avoid having the parent directory placed in the CreateFolder table.
+                // The EventSource supports being a KeyPath.
+                // https://wixtoolset.org/docs/v3/xsd/util/eventsource/
                 new EventSource
                 {
                     Name = Constants.AgentServiceName,
                     Log = "Application",
                     EventMessageFile = $"[BIN]{Path.GetFileName(_agentBinaries.Agent)}",
-                    AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes"
+                    AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes; KeyPath=yes"
                 },
                 new WixSharp.File(_agentBinaries.LibDatadogAgentThree),
                 new Dir(new Id("AGENT"), "agent",
@@ -456,7 +480,7 @@ namespace WixSetup.Datadog
                         Name = Constants.ProcessAgentServiceName,
                         Log = "Application",
                         EventMessageFile = $"[AGENT]{Path.GetFileName(_agentBinaries.ProcessAgent)}",
-                        AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes"
+                        AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes; KeyPath=yes"
                     },
                     new WixSharp.File(_agentBinaries.SystemProbe, systemProbeService),
                     new EventSource
@@ -464,7 +488,7 @@ namespace WixSetup.Datadog
                         Name = Constants.SystemProbeServiceName,
                         Log = "Application",
                         EventMessageFile = $"[AGENT]{Path.GetFileName(_agentBinaries.SystemProbe)}",
-                        AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes"
+                        AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes; KeyPath=yes"
                     },
                     new WixSharp.File(_agentBinaries.TraceAgent, traceAgentService),
                     new EventSource
@@ -472,7 +496,7 @@ namespace WixSetup.Datadog
                         Name = Constants.TraceAgentServiceName,
                         Log = "Application",
                         EventMessageFile = $"[AGENT]{Path.GetFileName(_agentBinaries.TraceAgent)}",
-                        AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes"
+                        AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes; KeyPath=yes"
                     }
                 )
             );
@@ -490,6 +514,7 @@ namespace WixSetup.Datadog
                 new DirFiles($@"{EtcSource}\*.yaml.example"),
                 new Dir("checks.d"),
                 new Dir("run"),
+                new Dir("logs"),
                 new Dir(new Id("EXAMPLECONFSLOCATION"), "conf.d",
                     new Files($@"{EtcSource}\extra_package_files\EXAMPLECONFSLOCATION\*")
                 ));


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Backport #19298 to 7.47.x

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
