### PR TITLE
usm: Improve performance of group by connection

### DIFF
--- a/pkg/network/encoding/http.go
+++ b/pkg/network/encoding/http.go
@@ -28,7 +28,7 @@ func newHTTPEncoder(httpPayloads map[http.Key]*http.RequestStats) *httpEncoder {
 
 	return &httpEncoder{
 		httpAggregationsBuilder: model.NewHTTPAggregationsBuilder(nil),
-		byConnection: GroupByConnection("http", httpPayloads, func(key http.Key) types.ConnectionKey {
+		byConnection: GroupByConnection("http", httpPayloads, func(key http.Key) *types.ConnectionKey {
 			return key.ConnectionKey
 		}),
 	}

--- a/pkg/network/encoding/http2.go
+++ b/pkg/network/encoding/http2.go
@@ -55,7 +55,7 @@ func newHTTP2Encoder(http2Payloads map[http.Key]*http.RequestStats) *http2Encode
 	}
 
 	return &http2Encoder{
-		byConnection: GroupByConnection("http2", http2Payloads, func(key http.Key) types.ConnectionKey {
+		byConnection: GroupByConnection("http2", http2Payloads, func(key http.Key) *types.ConnectionKey {
 			return key.ConnectionKey
 		}),
 		aggregations: new(model.HTTP2Aggregations),

--- a/pkg/network/encoding/http_test.go
+++ b/pkg/network/encoding/http_test.go
@@ -383,7 +383,7 @@ func generateBenchMarkPayload(sourcePortsMax, destPortsMax uint16) network.Conne
 
 	payload := network.Connections{
 		BufferedData: network.BufferedData{
-			Conns: make([]network.ConnectionStats, sourcePortsMax*destPortsMax),
+			Conns: make([]network.ConnectionStats, uint32(sourcePortsMax)*uint32(destPortsMax)),
 		},
 		HTTP: make(map[http.Key]*http.RequestStats),
 	}
@@ -397,7 +397,7 @@ func generateBenchMarkPayload(sourcePortsMax, destPortsMax uint16) network.Conne
 
 	for sport := uint16(0); sport < sourcePortsMax; sport++ {
 		for dport := uint16(0); dport < destPortsMax; dport++ {
-			index := sport*sourcePortsMax + dport
+			index := uint32(sport)*uint32(sourcePortsMax) + uint32(dport)
 
 			payload.Conns[index].Dest = localhost
 			payload.Conns[index].Source = localhost

--- a/pkg/network/encoding/kafka.go
+++ b/pkg/network/encoding/kafka.go
@@ -44,7 +44,7 @@ func newKafkaEncoder(kafkaPayloads map[kafka.Key]*kafka.RequestStat) *kafkaEncod
 			// `GetKafkaAggregations`
 			KafkaAggregations: make([]*model.KafkaAggregation, 0, 10),
 		},
-		byConnection: GroupByConnection("kafka", kafkaPayloads, func(key kafka.Key) types.ConnectionKey {
+		byConnection: GroupByConnection("kafka", kafkaPayloads, func(key kafka.Key) *types.ConnectionKey {
 			return key.ConnectionKey
 		}),
 	}

--- a/pkg/network/encoding/usm.go
+++ b/pkg/network/encoding/usm.go
@@ -17,8 +17,8 @@ import (
 
 // USMConnectionIndex provides a generic container for USM data pre-aggregated by connection
 type USMConnectionIndex[K comparable, V any] struct {
-	lookupFn func(network.ConnectionStats, map[types.ConnectionKey]*USMConnectionData[K, V]) *USMConnectionData[K, V]
-	data     map[types.ConnectionKey]*USMConnectionData[K, V]
+	lookupFn func(network.ConnectionStats, map[*types.ConnectionKey]*USMConnectionData[K, V]) *USMConnectionData[K, V]
+	data     map[*types.ConnectionKey]*USMConnectionData[K, V]
 	protocol string
 	once     sync.Once
 }
@@ -43,7 +43,7 @@ type USMKeyValue[K comparable, V any] struct {
 // GroupByConnection generates a `USMConnectionIndex` from a generic `map[K]V` data structure.
 // In addition to the `data` argument the caller must provide a `keyGen` function that
 // essentially translates `K` to a `types.ConnectionKey` and a `protocol` name.
-func GroupByConnection[K comparable, V any](protocol string, data map[K]V, keyGen func(K) types.ConnectionKey) *USMConnectionIndex[K, V] {
+func GroupByConnection[K comparable, V any](protocol string, data map[K]V, keyGen func(K) *types.ConnectionKey) *USMConnectionIndex[K, V] {
 	byConnection := &USMConnectionIndex[K, V]{
 		protocol: protocol,
 		lookupFn: USMLookup[K, V],
@@ -51,7 +51,7 @@ func GroupByConnection[K comparable, V any](protocol string, data map[K]V, keyGe
 
 	// The map intended to calculate how many entries we actually need in byConnection.data, and for each entry
 	// how many elements it has in it.
-	entriesSizeMap := make(map[types.ConnectionKey]int)
+	entriesSizeMap := make(map[*types.ConnectionKey]int)
 
 	// In the first pass we instantiate the map and calculate the number of
 	// USM aggregation objects per connection
@@ -59,7 +59,7 @@ func GroupByConnection[K comparable, V any](protocol string, data map[K]V, keyGe
 		entriesSizeMap[keyGen(key)]++
 	}
 
-	byConnection.data = make(map[types.ConnectionKey]*USMConnectionData[K, V], len(entriesSizeMap))
+	byConnection.data = make(map[*types.ConnectionKey]*USMConnectionData[K, V], len(entriesSizeMap))
 
 	// In the second pass we create a slice for each `USMConnectionData` entry
 	// in the map using the pre-determined sizes from the previous iteration and

--- a/pkg/network/encoding/usm_lookup.go
+++ b/pkg/network/encoding/usm_lookup.go
@@ -14,7 +14,7 @@ import (
 
 // USMLookup determines the strategy for associating a given connection to USM
 // In the context of Linux we may perform up to 4 lookups as described below
-func USMLookup[K comparable, V any](c network.ConnectionStats, data map[types.ConnectionKey]*USMConnectionData[K, V]) *USMConnectionData[K, V] {
+func USMLookup[K comparable, V any](c network.ConnectionStats, data map[*types.ConnectionKey]*USMConnectionData[K, V]) *USMConnectionData[K, V] {
 	var connectionData *USMConnectionData[K, V]
 
 	// WithKey will attempt 4 lookups in total
@@ -23,7 +23,7 @@ func USMLookup[K comparable, V any](c network.ConnectionStats, data map[types.Co
 	// 3) (translated(A), translated(B))
 	// 3) (translated(B), translated(A))
 	// The callback API is used to avoid allocating a slice of all pre-computed keys
-	network.WithKey(c, func(key types.ConnectionKey) (stopIteration bool) {
+	network.WithKey(c, func(key *types.ConnectionKey) (stopIteration bool) {
 		val, ok := data[key]
 		if !ok {
 			return false

--- a/pkg/network/encoding/usm_lookup_test.go
+++ b/pkg/network/encoding/usm_lookup_test.go
@@ -29,7 +29,7 @@ func TestUSMLookup(t *testing.T) {
 		// We only want to make sure that this object is returned during lookups
 		val := new(USMConnectionData[struct{}, any])
 
-		data := make(map[types.ConnectionKey]*USMConnectionData[struct{}, any])
+		data := make(map[*types.ConnectionKey]*USMConnectionData[struct{}, any])
 		data[key] = val
 
 		// Assert that c1 and c2 (which are symmetrical) "link" to the same aggregation
@@ -59,7 +59,7 @@ func TestUSMLookup(t *testing.T) {
 		)
 
 		val := new(USMConnectionData[struct{}, any])
-		data := make(map[types.ConnectionKey]*USMConnectionData[struct{}, any])
+		data := make(map[*types.ConnectionKey]*USMConnectionData[struct{}, any])
 		data[key] = val
 
 		// Assert that c1 and c2 (which are symmetrical) "link" to the same aggregation

--- a/pkg/network/event_linux_test.go
+++ b/pkg/network/event_linux_test.go
@@ -39,14 +39,14 @@ func TestKeyTuplesFromConn(t *testing.T) {
 	keyTuples := ConnectionKeysFromConnectionStats(connectionStats)
 
 	assert.Len(t, keyTuples, 2, "Expected different number of key tuples")
-	assert.True(t, slices.ContainsFunc(keyTuples, func(keyTuple types.ConnectionKey) bool {
+	assert.True(t, slices.ContainsFunc(keyTuples, func(keyTuple *types.ConnectionKey) bool {
 		sourceAddressLow, sourceAddressHigh := util.ToLowHigh(sourceAddress)
 		destinationAddressLow, destinationAddressHigh := util.ToLowHigh(destinationAddress)
 		return (keyTuple.SrcIPLow == sourceAddressLow) && (keyTuple.SrcIPHigh == sourceAddressHigh) &&
 			(keyTuple.DstIPLow == destinationAddressLow) && (keyTuple.DstIPHigh == destinationAddressHigh) &&
 			(keyTuple.SrcPort == sourcePort) && (keyTuple.DstPort == destinationPort)
 	}), "Missing original connection")
-	assert.True(t, slices.ContainsFunc(keyTuples, func(keyTuple types.ConnectionKey) bool {
+	assert.True(t, slices.ContainsFunc(keyTuples, func(keyTuple *types.ConnectionKey) bool {
 		sourceAddressLow, sourceAddressHigh := util.ToLowHigh(sourceAddress)
 		destinationAddressLow, destinationAddressHigh := util.ToLowHigh(destinationAddress)
 		return (keyTuple.SrcIPLow == destinationAddressLow) && (keyTuple.SrcIPHigh == destinationAddressHigh) &&
@@ -83,14 +83,14 @@ func TestKeyTuplesFromConnNAT(t *testing.T) {
 	// Expecting 2 non NAT'd keys and 2 NAT'd keys
 	assert.Len(t, keyTuples, 4, "Expected different number of key tuples")
 
-	assert.True(t, slices.ContainsFunc(keyTuples, func(keyTuple types.ConnectionKey) bool {
+	assert.True(t, slices.ContainsFunc(keyTuples, func(keyTuple *types.ConnectionKey) bool {
 		sourceAddressLow, sourceAddressHigh := util.ToLowHigh(sourceAddress)
 		destinationAddressLow, destinationAddressHigh := util.ToLowHigh(destinationAddress)
 		return (keyTuple.SrcIPLow == sourceAddressLow) && (keyTuple.SrcIPHigh == sourceAddressHigh) &&
 			(keyTuple.DstIPLow == destinationAddressLow) && (keyTuple.DstIPHigh == destinationAddressHigh) &&
 			(keyTuple.SrcPort == sourcePort) && (keyTuple.DstPort == destinationPort)
 	}), "Missing original connection")
-	assert.True(t, slices.ContainsFunc(keyTuples, func(keyTuple types.ConnectionKey) bool {
+	assert.True(t, slices.ContainsFunc(keyTuples, func(keyTuple *types.ConnectionKey) bool {
 		sourceAddressLow, sourceAddressHigh := util.ToLowHigh(sourceAddress)
 		destinationAddressLow, destinationAddressHigh := util.ToLowHigh(destinationAddress)
 		return (keyTuple.SrcIPLow == destinationAddressLow) && (keyTuple.SrcIPHigh == destinationAddressHigh) &&
@@ -98,14 +98,14 @@ func TestKeyTuplesFromConnNAT(t *testing.T) {
 			(keyTuple.SrcPort == destinationPort) && (keyTuple.DstPort == sourcePort)
 	}), "Missing flipped connection")
 
-	assert.True(t, slices.ContainsFunc(keyTuples, func(keyTuple types.ConnectionKey) bool {
+	assert.True(t, slices.ContainsFunc(keyTuples, func(keyTuple *types.ConnectionKey) bool {
 		sourceAddressLow, sourceAddressHigh := util.ToLowHigh(natSourceAddress)
 		destinationAddressLow, destinationAddressHigh := util.ToLowHigh(natDestinationAddress)
 		return (keyTuple.SrcIPLow == sourceAddressLow) && (keyTuple.SrcIPHigh == sourceAddressHigh) &&
 			(keyTuple.DstIPLow == destinationAddressLow) && (keyTuple.DstIPHigh == destinationAddressHigh) &&
 			(keyTuple.SrcPort == natSourcePort) && (keyTuple.DstPort == natDestinationPort)
 	}), "Missing NAT'd connection")
-	assert.True(t, slices.ContainsFunc(keyTuples, func(keyTuple types.ConnectionKey) bool {
+	assert.True(t, slices.ContainsFunc(keyTuples, func(keyTuple *types.ConnectionKey) bool {
 		sourceAddressLow, sourceAddressHigh := util.ToLowHigh(natSourceAddress)
 		destinationAddressLow, destinationAddressHigh := util.ToLowHigh(natDestinationAddress)
 		return (keyTuple.SrcIPLow == destinationAddressLow) && (keyTuple.SrcIPHigh == destinationAddressHigh) &&

--- a/pkg/network/protocols/http/model.go
+++ b/pkg/network/protocols/http/model.go
@@ -13,7 +13,7 @@ import (
 
 type Transaction interface {
 	RequestLatency() float64
-	ConnTuple() types.ConnectionKey
+	ConnTuple() *types.ConnectionKey
 	Method() Method
 	SetRequestMethod(Method)
 	StatusCode() uint16

--- a/pkg/network/protocols/http/model_linux.go
+++ b/pkg/network/protocols/http/model_linux.go
@@ -61,8 +61,8 @@ func (tx *EbpfTx) Incomplete() bool {
 	return tx.Request_started == 0 || tx.Response_status_code == 0
 }
 
-func (tx *EbpfTx) ConnTuple() types.ConnectionKey {
-	return types.ConnectionKey{
+func (tx *EbpfTx) ConnTuple() *types.ConnectionKey {
+	return &types.ConnectionKey{
 		SrcIPHigh: tx.Tup.Saddr_h,
 		SrcIPLow:  tx.Tup.Saddr_l,
 		DstIPHigh: tx.Tup.Daddr_h,

--- a/pkg/network/protocols/http/model_windows.go
+++ b/pkg/network/protocols/http/model_windows.go
@@ -70,8 +70,8 @@ func (tx *WinHttpTransaction) RequestLatency() float64 {
 	return requestLatency(tx.Txn.ResponseLastSeen, tx.Txn.RequestStarted)
 }
 
-func (tx *WinHttpTransaction) ConnTuple() types.ConnectionKey {
-	return types.ConnectionKey{
+func (tx *WinHttpTransaction) ConnTuple() *types.ConnectionKey {
+	return &types.ConnectionKey{
 		SrcIPHigh: srcIPHigh(&tx.Txn.Tup),
 		SrcIPLow:  srcIPLow(&tx.Txn.Tup),
 		DstIPHigh: dstIPHigh(&tx.Txn.Tup),

--- a/pkg/network/protocols/http/stats.go
+++ b/pkg/network/protocols/http/stats.go
@@ -72,7 +72,7 @@ type Path struct {
 type Key struct {
 	// this field order is intentional to help the GC pointer tracking
 	Path Path
-	types.ConnectionKey
+	*types.ConnectionKey
 	Method Method
 }
 

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -53,8 +53,8 @@ func (tx *EbpfTx) Incomplete() bool {
 	return tx.Request_started == 0 || tx.Response_last_seen == 0 || tx.StatusCode() == 0 || tx.Path_size == 0 || tx.Method() == http.MethodUnknown
 }
 
-func (tx *EbpfTx) ConnTuple() types.ConnectionKey {
-	return types.ConnectionKey{
+func (tx *EbpfTx) ConnTuple() *types.ConnectionKey {
+	return &types.ConnectionKey{
 		SrcIPHigh: tx.Tup.Saddr_h,
 		SrcIPLow:  tx.Tup.Saddr_l,
 		DstIPHigh: tx.Tup.Daddr_h,

--- a/pkg/network/protocols/kafka/model_linux.go
+++ b/pkg/network/protocols/kafka/model_linux.go
@@ -9,8 +9,8 @@ package kafka
 
 import "github.com/DataDog/datadog-agent/pkg/network/types"
 
-func (tx *EbpfTx) ConnTuple() types.ConnectionKey {
-	return types.ConnectionKey{
+func (tx *EbpfTx) ConnTuple() *types.ConnectionKey {
+	return &types.ConnectionKey{
 		SrcIPHigh: tx.Tup.Saddr_h,
 		SrcIPLow:  tx.Tup.Saddr_l,
 		DstIPHigh: tx.Tup.Daddr_h,

--- a/pkg/network/protocols/kafka/stats.go
+++ b/pkg/network/protocols/kafka/stats.go
@@ -20,7 +20,7 @@ type Key struct {
 	RequestAPIKey  uint16
 	RequestVersion uint16
 	TopicName      string
-	types.ConnectionKey
+	*types.ConnectionKey
 }
 
 // NewKey generates a new Key

--- a/pkg/network/types/connection_key.go
+++ b/pkg/network/types/connection_key.go
@@ -21,10 +21,10 @@ type ConnectionKey struct {
 }
 
 // NewConnectionKey generates a new ConnectionKey
-func NewConnectionKey(saddr, daddr util.Address, sport, dport uint16) ConnectionKey {
+func NewConnectionKey(saddr, daddr util.Address, sport, dport uint16) *ConnectionKey {
 	saddrl, saddrh := util.ToLowHigh(saddr)
 	daddrl, daddrh := util.ToLowHigh(daddr)
-	return ConnectionKey{
+	return &ConnectionKey{
 		SrcIPHigh: saddrh,
 		SrcIPLow:  saddrl,
 		SrcPort:   sport,

--- a/pkg/network/usm_connection_keys.go
+++ b/pkg/network/usm_connection_keys.go
@@ -19,13 +19,13 @@ import (
 // Each ConnectionStats object contains both the source and destination addresses, as well as an IPTranslation object that stores the original addresses in the event that the connection is NAT'd.
 // This function generates all relevant combinations of connection keys: [(source, dest), (dest, source), (NAT'd source, NAT'd dest), (NAT'd dest, NAT'd source)].
 // This is necessary to handle all possible scenarios for connections originating from the USM module (i.e., whether they are NAT'd or not, and whether they use TLS).
-func ConnectionKeysFromConnectionStats(connectionStats ConnectionStats) []types.ConnectionKey {
+func ConnectionKeysFromConnectionStats(connectionStats ConnectionStats) []*types.ConnectionKey {
 	hasTranslation := connectionStats.IPTranslation != nil
 	connectionKeysCount := 2
 	if hasTranslation {
 		connectionKeysCount = 4
 	}
-	connectionKeys := make([]types.ConnectionKey, connectionKeysCount)
+	connectionKeys := make([]*types.ConnectionKey, connectionKeysCount)
 	// USM data is always indexed as (client, server), but we don't know which is the remote
 	// and which is the local address. To account for this, we'll construct 2 possible
 	// connection keys and check for both of them in the aggregations map.
@@ -51,7 +51,7 @@ func ConnectionKeysFromConnectionStats(connectionStats ConnectionStats) []types.
 // 4) (dst, src) NAT
 // In addition to that, we do a best-effort to call `f` in the order that most
 // likely to succeed early (see comment below)
-func WithKey(connectionStats ConnectionStats, f func(key types.ConnectionKey) (stop bool)) {
+func WithKey(connectionStats ConnectionStats, f func(key *types.ConnectionKey) (stop bool)) {
 	var (
 		clientIP, serverIP, clientIPNAT, serverIPNAT         util.Address
 		clientPort, serverPort, clientPortNAT, serverPortNAT uint16

--- a/pkg/network/usm_connection_keys_test.go
+++ b/pkg/network/usm_connection_keys_test.go
@@ -53,10 +53,10 @@ func TestWithKey(t *testing.T) {
 	})
 }
 
-func shouldGenerateKeys(t *testing.T, c ConnectionStats, expectedKeys ...types.ConnectionKey) {
-	var generatedKeys []types.ConnectionKey
+func shouldGenerateKeys(t *testing.T, c ConnectionStats, expectedKeys ...*types.ConnectionKey) {
+	var generatedKeys []*types.ConnectionKey
 
-	WithKey(c, func(key types.ConnectionKey) bool {
+	WithKey(c, func(key *types.ConnectionKey) bool {
 		generatedKeys = append(generatedKeys, key)
 		return false
 	})


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Improves GroupByConnection method, by using pointer to connection tuple rather than copying values.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Performance
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Benchmark results

Before:
```
BenchmarkGroupByConnection-16    	     312	   3815368 ns/op	 3879311 B/op	   20332 allocs/op
```

After
```
BenchmarkGroupByConnection-16    	     546	   2115388 ns/op	 1795733 B/op	   20221 allocs/op
```

Runtime - faster by ~44%
Bytes allocated - less by ~53%

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
