### PR TITLE
Add overlap detection to offset guessing

### DIFF
--- a/pkg/network/ebpf/c/prebuilt/offset-guess.c
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.c
@@ -10,36 +10,6 @@
 #include <uapi/linux/tcp.h>
 #include <uapi/linux/ip.h>
 
-#define sizeof_member(T, m) sizeof(((T*)0)->m)
-
-static const __u8 SIZEOF_SADDR = sizeof_member(tracer_status_t, saddr);
-static const __u8 SIZEOF_DADDR = sizeof_member(tracer_status_t, daddr);
-static const __u8 SIZEOF_FAMILY = sizeof_member(tracer_status_t, family);
-static const __u8 SIZEOF_SPORT = sizeof_member(tracer_status_t, sport);
-static const __u8 SIZEOF_DPORT = sizeof_member(tracer_status_t, dport);
-static const __u8 SIZEOF_NETNS = sizeof((void*)0); // possible_net_t*
-static const __u8 SIZEOF_NETNS_INO = sizeof_member(tracer_status_t, netns);
-static const __u8 SIZEOF_RTT = sizeof_member(tracer_status_t, rtt);
-static const __u8 SIZEOF_RTT_VAR = sizeof_member(tracer_status_t, rtt_var);
-static const __u8 SIZEOF_DADDR_IPV6 = sizeof_member(tracer_status_t, daddr_ipv6) / 4;
-static const __u8 SIZEOF_SADDR_FL4 = sizeof_member(tracer_status_t, saddr_fl4);
-static const __u8 SIZEOF_DADDR_FL4 = sizeof_member(tracer_status_t, daddr_fl4);
-static const __u8 SIZEOF_SPORT_FL4 = sizeof_member(tracer_status_t, sport_fl4);
-static const __u8 SIZEOF_DPORT_FL4 = sizeof_member(tracer_status_t, dport_fl4);
-static const __u8 SIZEOF_SADDR_FL6 = sizeof_member(tracer_status_t, saddr_fl6) / 4;
-static const __u8 SIZEOF_DADDR_FL6 = sizeof_member(tracer_status_t, daddr_fl6) / 4;
-static const __u8 SIZEOF_SPORT_FL6 = sizeof_member(tracer_status_t, sport_fl6);
-static const __u8 SIZEOF_DPORT_FL6 = sizeof_member(tracer_status_t, dport_fl6);
-static const __u8 SIZEOF_SOCKET_SK = sizeof((void*)0); // char*
-static const __u8 SIZEOF_SK_BUFF_SOCK = sizeof((void*)0); // char*
-static const __u8 SIZEOF_SK_BUFF_TRANSPORT_HEADER = sizeof_member(tracer_status_t, transport_header);
-static const __u8 SIZEOF_SK_BUFF_HEAD = sizeof((void*)0); // char*
-
-static const __u8 SIZEOF_CT_TUPLE_ORIGIN = sizeof_member(conntrack_status_t, saddr);
-static const __u8 SIZEOF_CT_TUPLE_REPLY = sizeof_member(conntrack_status_t, saddr);
-static const __u8 SIZEOF_CT_STATUS = sizeof_member(conntrack_status_t, status);
-static const __u8 SIZEOF_CT_NET = sizeof((void*)0); // possible_net_t*
-
 // aligned_offset returns an offset that when added to
 // p, would produce an address that is mod size (aligned).
 //

--- a/pkg/network/ebpf/c/prebuilt/offset-guess.h
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.h
@@ -123,5 +123,34 @@ typedef struct {
     __u32 netns;
 } conntrack_status_t;
 
+#define sizeof_member(T, m) sizeof(((T*)0)->m)
+
+static const __u8 SIZEOF_SADDR = sizeof_member(tracer_status_t, saddr);
+static const __u8 SIZEOF_DADDR = sizeof_member(tracer_status_t, daddr);
+static const __u8 SIZEOF_FAMILY = sizeof_member(tracer_status_t, family);
+static const __u8 SIZEOF_SPORT = sizeof_member(tracer_status_t, sport);
+static const __u8 SIZEOF_DPORT = sizeof_member(tracer_status_t, dport);
+static const __u8 SIZEOF_NETNS = sizeof((void*)0); // possible_net_t*
+static const __u8 SIZEOF_NETNS_INO = sizeof_member(tracer_status_t, netns);
+static const __u8 SIZEOF_RTT = sizeof_member(tracer_status_t, rtt);
+static const __u8 SIZEOF_RTT_VAR = sizeof_member(tracer_status_t, rtt_var);
+static const __u8 SIZEOF_DADDR_IPV6 = sizeof_member(tracer_status_t, daddr_ipv6) / 4;
+static const __u8 SIZEOF_SADDR_FL4 = sizeof_member(tracer_status_t, saddr_fl4);
+static const __u8 SIZEOF_DADDR_FL4 = sizeof_member(tracer_status_t, daddr_fl4);
+static const __u8 SIZEOF_SPORT_FL4 = sizeof_member(tracer_status_t, sport_fl4);
+static const __u8 SIZEOF_DPORT_FL4 = sizeof_member(tracer_status_t, dport_fl4);
+static const __u8 SIZEOF_SADDR_FL6 = sizeof_member(tracer_status_t, saddr_fl6) / 4;
+static const __u8 SIZEOF_DADDR_FL6 = sizeof_member(tracer_status_t, daddr_fl6) / 4;
+static const __u8 SIZEOF_SPORT_FL6 = sizeof_member(tracer_status_t, sport_fl6);
+static const __u8 SIZEOF_DPORT_FL6 = sizeof_member(tracer_status_t, dport_fl6);
+static const __u8 SIZEOF_SOCKET_SK = sizeof((void*)0); // char*
+static const __u8 SIZEOF_SK_BUFF_SOCK = sizeof((void*)0); // char*
+static const __u8 SIZEOF_SK_BUFF_TRANSPORT_HEADER = sizeof_member(tracer_status_t, transport_header);
+static const __u8 SIZEOF_SK_BUFF_HEAD = sizeof((void*)0); // char*
+
+static const __u8 SIZEOF_CT_TUPLE_ORIGIN = sizeof_member(conntrack_status_t, saddr);
+static const __u8 SIZEOF_CT_TUPLE_REPLY = sizeof_member(conntrack_status_t, saddr);
+static const __u8 SIZEOF_CT_STATUS = sizeof_member(conntrack_status_t, status);
+static const __u8 SIZEOF_CT_NET = sizeof((void*)0); // possible_net_t*
 
 #endif //__OFFSET_GUESS_H

--- a/pkg/network/tracer/offsetguess/offsetguess_types.go
+++ b/pkg/network/tracer/offsetguess/offsetguess_types.go
@@ -66,3 +66,9 @@ const (
 
 	GuessNotApplicable GuessWhat = 99999
 )
+
+const (
+	sizeofSKBuffSock            = C.SIZEOF_SK_BUFF_SOCK
+	sizeofSKBuffTransportHeader = C.SIZEOF_SK_BUFF_TRANSPORT_HEADER
+	sizeofSKBuffHead            = C.SIZEOF_SK_BUFF_HEAD
+)

--- a/pkg/network/tracer/offsetguess/offsetguess_types_linux.go
+++ b/pkg/network/tracer/offsetguess/offsetguess_types_linux.go
@@ -125,3 +125,9 @@ const (
 
 	GuessNotApplicable GuessWhat = 99999
 )
+
+const (
+	sizeofSKBuffSock            = 0x8
+	sizeofSKBuffTransportHeader = 0x2
+	sizeofSKBuffHead            = 0x8
+)

--- a/pkg/network/tracer/offsetguess/overlaps.go
+++ b/pkg/network/tracer/offsetguess/overlaps.go
@@ -13,13 +13,12 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-// offset, size tuple
 type offsetRange struct {
 	Offset uint64
 	Size   uint64
 }
 
-// ranges must be sorted by starting offset
+// skipOverlaps returns the next valid offset and a boolean indicating if there was any overlap detected.
 func skipOverlaps(offset uint64, ranges []offsetRange) (uint64, bool) {
 	overlapped := false
 StartOver:
@@ -29,6 +28,8 @@ StartOver:
 			if r.Offset <= offset && offset < next {
 				offset = next
 				overlapped = true
+				// completely redo the inner loop
+				// you must have no overlaps to return from the function
 				continue StartOver
 			}
 		}

--- a/pkg/network/tracer/offsetguess/overlaps.go
+++ b/pkg/network/tracer/offsetguess/overlaps.go
@@ -1,0 +1,129 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package offsetguess
+
+import (
+	"unsafe"
+
+	"golang.org/x/exp/slices"
+)
+
+// offset, size tuple
+type offsetRange struct {
+	Offset uint64
+	Size   uint64
+}
+
+// ranges must be sorted by starting offset
+func skipOverlaps(offset uint64, ranges []offsetRange) (uint64, bool) {
+	overlapped := false
+StartOver:
+	for {
+		for _, r := range ranges {
+			next := r.Offset + r.Size
+			if r.Offset <= offset && offset < next {
+				offset = next
+				overlapped = true
+				continue StartOver
+			}
+		}
+		break
+	}
+	return offset, overlapped
+}
+
+// the following range functions use the index of the current `GuessWhat` value,
+// to select only the ranges of fields guessed beforehand, offset against the same base subject.
+
+func (t *tracerOffsetGuesser) sockRanges() []offsetRange {
+	idx := slices.Index([]GuessWhat{
+		GuessSAddr,
+		GuessDAddr,
+		GuessDPort,
+		GuessFamily,
+		GuessSPort,
+		GuessNetNS,
+		GuessRTT,
+		GuessRTT, // stand in for rtt_var, will never be matched
+		GuessDAddrIPv6,
+	}, GuessWhat(t.status.What))
+
+	return []offsetRange{
+		{t.status.Offset_saddr, uint64(unsafe.Sizeof(t.status.Saddr))},
+		{t.status.Offset_daddr, uint64(unsafe.Sizeof(t.status.Daddr))},
+		{t.status.Offset_dport, uint64(unsafe.Sizeof(t.status.Dport))},
+		{t.status.Offset_family, uint64(unsafe.Sizeof(t.status.Family))},
+		{t.status.Offset_sport, uint64(unsafe.Sizeof(t.status.Sport))},
+		{t.status.Offset_netns, uint64(unsafe.Sizeof(t.status.Netns))},
+		{t.status.Offset_rtt, uint64(unsafe.Sizeof(t.status.Rtt))},
+		{t.status.Offset_rtt_var, uint64(unsafe.Sizeof(t.status.Rtt_var))},
+		{t.status.Offset_daddr_ipv6, uint64(unsafe.Sizeof(t.status.Daddr_ipv6))},
+	}[:idx]
+}
+
+func (t *tracerOffsetGuesser) flowI4Ranges() []offsetRange {
+	idx := slices.Index([]GuessWhat{
+		GuessSAddrFl4,
+		GuessDAddrFl4,
+		GuessSPortFl4,
+		GuessDPortFl4,
+	}, GuessWhat(t.status.What))
+
+	return []offsetRange{
+		{t.status.Offset_saddr_fl4, uint64(unsafe.Sizeof(t.status.Saddr_fl4))},
+		{t.status.Offset_daddr_fl4, uint64(unsafe.Sizeof(t.status.Daddr_fl4))},
+		{t.status.Offset_sport_fl4, uint64(unsafe.Sizeof(t.status.Sport_fl4))},
+		{t.status.Offset_dport_fl4, uint64(unsafe.Sizeof(t.status.Dport_fl4))},
+	}[:idx]
+}
+
+func (t *tracerOffsetGuesser) flowI6Ranges() []offsetRange {
+	idx := slices.Index([]GuessWhat{
+		GuessSAddrFl6,
+		GuessDAddrFl6,
+		GuessSPortFl6,
+		GuessDPortFl6,
+	}, GuessWhat(t.status.What))
+
+	return []offsetRange{
+		{t.status.Offset_saddr_fl6, uint64(unsafe.Sizeof(t.status.Saddr_fl6))},
+		{t.status.Offset_daddr_fl6, uint64(unsafe.Sizeof(t.status.Daddr_fl6))},
+		{t.status.Offset_sport_fl6, uint64(unsafe.Sizeof(t.status.Sport_fl6))},
+		{t.status.Offset_dport_fl6, uint64(unsafe.Sizeof(t.status.Dport_fl6))},
+	}[:idx]
+}
+
+func (t *tracerOffsetGuesser) skBuffRanges() []offsetRange {
+	idx := slices.Index([]GuessWhat{
+		GuessSKBuffSock,
+		GuessSKBuffTransportHeader,
+		GuessSKBuffHead,
+	}, GuessWhat(t.status.What))
+
+	return []offsetRange{
+		{t.status.Offset_sk_buff_sock, sizeofSKBuffSock},
+		{t.status.Offset_sk_buff_transport_header, sizeofSKBuffTransportHeader},
+		{t.status.Offset_sk_buff_head, sizeofSKBuffHead},
+	}[:idx]
+}
+
+func (c *conntrackOffsetGuesser) nfConnRanges() []offsetRange {
+	idx := slices.Index([]GuessWhat{
+		GuessCtTupleOrigin,
+		GuessCtTupleReply,
+		GuessCtStatus,
+		GuessCtNet,
+	}, GuessWhat(c.status.What))
+
+	return []offsetRange{
+		{c.status.Offset_origin, sizeofNfConntrackTuple},
+		{c.status.Offset_reply, sizeofNfConntrackTuple},
+		{c.status.Offset_status, uint64(unsafe.Sizeof(c.status.Status))},
+		{c.status.Offset_netns, uint64(unsafe.Sizeof(c.status.Netns))},
+	}[:idx]
+}

--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -263,6 +263,9 @@ func uint32ArrayFromIPv6(ip net.IP) (addr [4]uint32, err error) {
 	return
 }
 
+// IPv6LinkLocalPrefix is only exposed for testing purposes
+var IPv6LinkLocalPrefix = "fe80::"
+
 func GetIPv6LinkLocalAddress() ([]*net.UDPAddr, error) {
 	ints, err := net.Interfaces()
 	if err != nil {
@@ -279,7 +282,7 @@ func GetIPv6LinkLocalAddress() ([]*net.UDPAddr, error) {
 			continue
 		}
 		for _, a := range addrs {
-			if strings.HasPrefix(a.String(), "fe80::") && !strings.HasPrefix(i.Name, "dummy") {
+			if strings.HasPrefix(a.String(), IPv6LinkLocalPrefix) && !strings.HasPrefix(i.Name, "dummy") {
 				// this address *may* have CIDR notation
 				if ar, _, err := net.ParseCIDR(a.String()); err == nil {
 					udpAddrs = append(udpAddrs, &net.UDPAddr{IP: ar, Zone: i.Name})

--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -317,22 +317,42 @@ func (t *tracerOffsetGuesser) checkAndUpdateCurrentOffset(mp *ebpf.Map, expected
 		time.Sleep(10 * time.Millisecond)
 		return nil
 	}
+
+	var overlapped bool
 	switch GuessWhat(t.status.What) {
 	case GuessSAddr:
+		t.status.Offset_saddr, overlapped = skipOverlaps(t.status.Offset_saddr, t.sockRanges())
+		if overlapped {
+			// adjusted offset from eBPF overlapped with another field, we need to check new offset
+			break
+		}
+
 		if t.status.Saddr == expected.saddr {
 			t.logAndAdvance(t.status.Offset_saddr, GuessDAddr)
 			break
 		}
 		t.status.Offset_saddr++
-		t.status.Saddr = expected.saddr
+		t.status.Offset_saddr, _ = skipOverlaps(t.status.Offset_saddr, t.sockRanges())
 	case GuessDAddr:
+		t.status.Offset_daddr, overlapped = skipOverlaps(t.status.Offset_daddr, t.sockRanges())
+		if overlapped {
+			// adjusted offset from eBPF overlapped with another field, we need to check new offset
+			break
+		}
+
 		if t.status.Daddr == expected.daddr {
 			t.logAndAdvance(t.status.Offset_daddr, GuessDPort)
 			break
 		}
 		t.status.Offset_daddr++
-		t.status.Daddr = expected.daddr
+		t.status.Offset_daddr, _ = skipOverlaps(t.status.Offset_daddr, t.sockRanges())
 	case GuessDPort:
+		t.status.Offset_dport, overlapped = skipOverlaps(t.status.Offset_dport, t.sockRanges())
+		if overlapped {
+			// adjusted offset from eBPF overlapped with another field, we need to check new offset
+			break
+		}
+
 		if t.status.Dport == htons(expected.dport) {
 			t.logAndAdvance(t.status.Offset_dport, GuessFamily)
 			// we know the family ((struct __sk_common)->skc_family) is
@@ -341,7 +361,14 @@ func (t *tracerOffsetGuesser) checkAndUpdateCurrentOffset(mp *ebpf.Map, expected
 			break
 		}
 		t.status.Offset_dport++
+		t.status.Offset_dport, _ = skipOverlaps(t.status.Offset_dport, t.sockRanges())
 	case GuessFamily:
+		t.status.Offset_family, overlapped = skipOverlaps(t.status.Offset_family, t.sockRanges())
+		if overlapped {
+			// adjusted offset from eBPF overlapped with another field, we need to check new offset
+			break
+		}
+
 		if t.status.Family == expected.family {
 			t.logAndAdvance(t.status.Offset_family, GuessSPort)
 			// we know the sport ((struct inet_sock)->inet_sport) is
@@ -350,18 +377,33 @@ func (t *tracerOffsetGuesser) checkAndUpdateCurrentOffset(mp *ebpf.Map, expected
 			break
 		}
 		t.status.Offset_family++
+		t.status.Offset_family, _ = skipOverlaps(t.status.Offset_family, t.sockRanges())
 	case GuessSPort:
+		t.status.Offset_sport, overlapped = skipOverlaps(t.status.Offset_sport, t.sockRanges())
+		if overlapped {
+			// adjusted offset from eBPF overlapped with another field, we need to check new offset
+			break
+		}
+
 		if t.status.Sport == htons(expected.sport) {
 			t.logAndAdvance(t.status.Offset_sport, GuessSAddrFl4)
 			break
 		}
 		t.status.Offset_sport++
+		t.status.Offset_sport, _ = skipOverlaps(t.status.Offset_sport, t.sockRanges())
 	case GuessSAddrFl4:
+		t.status.Offset_saddr_fl4, overlapped = skipOverlaps(t.status.Offset_saddr_fl4, t.flowI4Ranges())
+		if overlapped {
+			// adjusted offset from eBPF overlapped with another field, we need to check new offset
+			break
+		}
+
 		if t.status.Saddr_fl4 == expected.saddrFl4 {
 			t.logAndAdvance(t.status.Offset_saddr_fl4, GuessDAddrFl4)
 			break
 		}
 		t.status.Offset_saddr_fl4++
+		t.status.Offset_saddr_fl4, _ = skipOverlaps(t.status.Offset_saddr_fl4, t.flowI4Ranges())
 		if t.status.Offset_saddr_fl4 >= threshold {
 			// Let's skip all other flowi4 fields
 			t.logAndAdvance(notApplicable, t.flowi6EntryState())
@@ -369,45 +411,73 @@ func (t *tracerOffsetGuesser) checkAndUpdateCurrentOffset(mp *ebpf.Map, expected
 			break
 		}
 	case GuessDAddrFl4:
+		t.status.Offset_daddr_fl4, overlapped = skipOverlaps(t.status.Offset_daddr_fl4, t.flowI4Ranges())
+		if overlapped {
+			// adjusted offset from eBPF overlapped with another field, we need to check new offset
+			break
+		}
+
 		if t.status.Daddr_fl4 == expected.daddrFl4 {
 			t.logAndAdvance(t.status.Offset_daddr_fl4, GuessSPortFl4)
 			break
 		}
 		t.status.Offset_daddr_fl4++
+		t.status.Offset_daddr_fl4, _ = skipOverlaps(t.status.Offset_daddr_fl4, t.flowI4Ranges())
 		if t.status.Offset_daddr_fl4 >= threshold {
 			t.logAndAdvance(notApplicable, t.flowi6EntryState())
 			t.status.Fl4_offsets = disabled
 			break
 		}
 	case GuessSPortFl4:
+		t.status.Offset_sport_fl4, overlapped = skipOverlaps(t.status.Offset_sport_fl4, t.flowI4Ranges())
+		if overlapped {
+			// adjusted offset from eBPF overlapped with another field, we need to check new offset
+			break
+		}
+
 		if t.status.Sport_fl4 == htons(expected.sportFl4) {
 			t.logAndAdvance(t.status.Offset_sport_fl4, GuessDPortFl4)
 			break
 		}
 		t.status.Offset_sport_fl4++
+		t.status.Offset_sport_fl4, _ = skipOverlaps(t.status.Offset_sport_fl4, t.flowI4Ranges())
 		if t.status.Offset_sport_fl4 >= threshold {
 			t.logAndAdvance(notApplicable, t.flowi6EntryState())
 			t.status.Fl4_offsets = disabled
 			break
 		}
 	case GuessDPortFl4:
+		t.status.Offset_dport_fl4, overlapped = skipOverlaps(t.status.Offset_dport_fl4, t.flowI4Ranges())
+		if overlapped {
+			// adjusted offset from eBPF overlapped with another field, we need to check new offset
+			break
+		}
+
 		if t.status.Dport_fl4 == htons(expected.dportFl4) {
 			t.logAndAdvance(t.status.Offset_dport_fl4, t.flowi6EntryState())
 			t.status.Fl4_offsets = enabled
 			break
 		}
 		t.status.Offset_dport_fl4++
+		t.status.Offset_dport_fl4, _ = skipOverlaps(t.status.Offset_dport_fl4, t.flowI4Ranges())
 		if t.status.Offset_dport_fl4 >= threshold {
 			t.logAndAdvance(notApplicable, t.flowi6EntryState())
 			t.status.Fl4_offsets = disabled
 			break
 		}
 	case GuessSAddrFl6:
+		t.status.Offset_saddr_fl6, overlapped = skipOverlaps(t.status.Offset_saddr_fl6, t.flowI6Ranges())
+		if overlapped {
+			// adjusted offset from eBPF overlapped with another field, we need to check new offset
+			break
+		}
+
 		if compareIPv6(t.status.Saddr_fl6, expected.saddrFl6) {
 			t.logAndAdvance(t.status.Offset_saddr_fl6, GuessDAddrFl6)
 			break
 		}
 		t.status.Offset_saddr_fl6++
+		t.status.Offset_saddr_fl6, _ = skipOverlaps(t.status.Offset_saddr_fl6, t.flowI6Ranges())
 		if t.status.Offset_saddr_fl6 >= threshold {
 			// Let's skip all other flowi6 fields
 			t.logAndAdvance(notApplicable, GuessNetNS)
@@ -415,40 +485,67 @@ func (t *tracerOffsetGuesser) checkAndUpdateCurrentOffset(mp *ebpf.Map, expected
 			break
 		}
 	case GuessDAddrFl6:
+		t.status.Offset_daddr_fl6, overlapped = skipOverlaps(t.status.Offset_daddr_fl6, t.flowI6Ranges())
+		if overlapped {
+			// adjusted offset from eBPF overlapped with another field, we need to check new offset
+			break
+		}
+
 		if compareIPv6(t.status.Daddr_fl6, expected.daddrFl6) {
 			t.logAndAdvance(t.status.Offset_daddr_fl6, GuessSPortFl6)
 			break
 		}
 		t.status.Offset_daddr_fl6++
+		t.status.Offset_daddr_fl6, _ = skipOverlaps(t.status.Offset_daddr_fl6, t.flowI6Ranges())
 		if t.status.Offset_daddr_fl6 >= threshold {
 			t.logAndAdvance(notApplicable, GuessNetNS)
 			t.status.Fl6_offsets = disabled
 			break
 		}
 	case GuessSPortFl6:
+		t.status.Offset_sport_fl6, overlapped = skipOverlaps(t.status.Offset_sport_fl6, t.flowI6Ranges())
+		if overlapped {
+			// adjusted offset from eBPF overlapped with another field, we need to check new offset
+			break
+		}
+
 		if t.status.Sport_fl6 == htons(expected.sportFl6) {
 			t.logAndAdvance(t.status.Offset_sport_fl6, GuessDPortFl6)
 			break
 		}
 		t.status.Offset_sport_fl6++
+		t.status.Offset_sport_fl6, _ = skipOverlaps(t.status.Offset_sport_fl6, t.flowI6Ranges())
 		if t.status.Offset_sport_fl6 >= threshold {
 			t.logAndAdvance(notApplicable, GuessNetNS)
 			t.status.Fl6_offsets = disabled
 			break
 		}
 	case GuessDPortFl6:
+		t.status.Offset_dport_fl6, overlapped = skipOverlaps(t.status.Offset_dport_fl6, t.flowI6Ranges())
+		if overlapped {
+			// adjusted offset from eBPF overlapped with another field, we need to check new offset
+			break
+		}
+
 		if t.status.Dport_fl6 == htons(expected.dportFl6) {
 			t.logAndAdvance(t.status.Offset_dport_fl6, GuessNetNS)
 			t.status.Fl6_offsets = enabled
 			break
 		}
 		t.status.Offset_dport_fl6++
+		t.status.Offset_dport_fl6, _ = skipOverlaps(t.status.Offset_dport_fl6, t.flowI6Ranges())
 		if t.status.Offset_dport_fl6 >= threshold {
 			t.logAndAdvance(notApplicable, GuessNetNS)
 			t.status.Fl6_offsets = disabled
 			break
 		}
 	case GuessNetNS:
+		t.status.Offset_netns, overlapped = skipOverlaps(t.status.Offset_netns, t.sockRanges())
+		if overlapped {
+			// adjusted offset from eBPF overlapped with another field, we need to check new offset
+			break
+		}
+
 		if t.status.Netns == expected.netns {
 			t.logAndAdvance(t.status.Offset_netns, GuessRTT)
 			log.Debugf("Successfully guessed %v with offset of %d bytes", "ino", t.status.Offset_ino)
@@ -459,8 +556,16 @@ func (t *tracerOffsetGuesser) checkAndUpdateCurrentOffset(mp *ebpf.Map, expected
 		if t.status.Err != 0 || t.status.Offset_ino >= threshold {
 			t.status.Offset_ino = 0
 			t.status.Offset_netns++
+			t.status.Offset_netns, _ = skipOverlaps(t.status.Offset_netns, t.sockRanges())
 		}
 	case GuessRTT:
+		t.status.Offset_rtt, overlapped = skipOverlaps(t.status.Offset_rtt, t.sockRanges())
+		if overlapped {
+			t.status.Offset_rtt_var = t.status.Offset_rtt + 4
+			// adjusted offset from eBPF overlapped with another field, we need to check new offset
+			break
+		}
+
 		// For more information on the bit shift operations see:
 		// https://elixir.bootlin.com/linux/v4.6/source/net/ipv4/tcp.c#L2686
 		if t.status.Rtt>>3 == expected.rtt && t.status.Rtt_var>>2 == expected.rttVar {
@@ -472,8 +577,8 @@ func (t *tracerOffsetGuesser) checkAndUpdateCurrentOffset(mp *ebpf.Map, expected
 		// rtt -> srtt_us
 		// rtt_var -> mdev_us
 		t.status.Offset_rtt++
+		t.status.Offset_rtt, _ = skipOverlaps(t.status.Offset_rtt, t.sockRanges())
 		t.status.Offset_rtt_var = t.status.Offset_rtt + 4
-
 	case GuessSocketSK:
 		if t.status.Sport_via_sk == htons(expected.sport) && t.status.Dport_via_sk == htons(expected.dport) {
 			// if we are on kernel version < 4.7, net_dev_queue tracepoint will not be activated, and thus we should skip
@@ -500,13 +605,27 @@ func (t *tracerOffsetGuesser) checkAndUpdateCurrentOffset(mp *ebpf.Map, expected
 			break
 		}
 		t.status.Offset_socket_sk++
+		// no overlaps because only field offset from `struct socket`
 	case GuessSKBuffSock:
+		t.status.Offset_sk_buff_sock, overlapped = skipOverlaps(t.status.Offset_sk_buff_sock, t.skBuffRanges())
+		if overlapped {
+			// adjusted offset from eBPF overlapped with another field, we need to check new offset
+			break
+		}
+
 		if t.status.Sport_via_sk_via_sk_buf == htons(expected.sportFl4) && t.status.Dport_via_sk_via_sk_buf == htons(expected.dportFl4) {
 			t.logAndAdvance(t.status.Offset_sk_buff_sock, GuessSKBuffTransportHeader)
 			break
 		}
 		t.status.Offset_sk_buff_sock++
+		t.status.Offset_sk_buff_sock, _ = skipOverlaps(t.status.Offset_sk_buff_sock, t.skBuffRanges())
 	case GuessSKBuffTransportHeader:
+		t.status.Offset_sk_buff_transport_header, overlapped = skipOverlaps(t.status.Offset_sk_buff_transport_header, t.skBuffRanges())
+		if overlapped {
+			// adjusted offset from eBPF overlapped with another field, we need to check new offset
+			break
+		}
+
 		networkDiffFromMac := t.status.Network_header - t.status.Mac_header
 		transportDiffFromNetwork := t.status.Transport_header - t.status.Network_header
 		if networkDiffFromMac == 14 && transportDiffFromNetwork == 20 {
@@ -514,7 +633,14 @@ func (t *tracerOffsetGuesser) checkAndUpdateCurrentOffset(mp *ebpf.Map, expected
 			break
 		}
 		t.status.Offset_sk_buff_transport_header++
+		t.status.Offset_sk_buff_transport_header, _ = skipOverlaps(t.status.Offset_sk_buff_transport_header, t.skBuffRanges())
 	case GuessSKBuffHead:
+		t.status.Offset_sk_buff_head, overlapped = skipOverlaps(t.status.Offset_sk_buff_head, t.skBuffRanges())
+		if overlapped {
+			// adjusted offset from eBPF overlapped with another field, we need to check new offset
+			break
+		}
+
 		if t.status.Sport_via_sk_via_sk_buf == htons(expected.sportFl4) && t.status.Dport_via_sk_via_sk_buf == htons(expected.dportFl4) {
 			if !t.guessTCPv6 && !t.guessUDPv6 {
 				t.logAndAdvance(t.status.Offset_sk_buff_head, GuessNotApplicable)
@@ -525,7 +651,14 @@ func (t *tracerOffsetGuesser) checkAndUpdateCurrentOffset(mp *ebpf.Map, expected
 			}
 		}
 		t.status.Offset_sk_buff_head++
+		t.status.Offset_sk_buff_head, _ = skipOverlaps(t.status.Offset_sk_buff_head, t.skBuffRanges())
 	case GuessDAddrIPv6:
+		t.status.Offset_daddr_ipv6, overlapped = skipOverlaps(t.status.Offset_daddr_ipv6, t.sockRanges())
+		if overlapped {
+			// adjusted offset from eBPF overlapped with another field, we need to check new offset
+			break
+		}
+
 		if compareIPv6(t.status.Daddr_ipv6, expected.daddrIPv6) {
 			t.logAndAdvance(t.status.Offset_daddr_ipv6, GuessNotApplicable)
 			// at this point, we've guessed all the offsets we need,
@@ -533,6 +666,7 @@ func (t *tracerOffsetGuesser) checkAndUpdateCurrentOffset(mp *ebpf.Map, expected
 			return t.setReadyState(mp)
 		}
 		t.status.Offset_daddr_ipv6++
+		t.status.Offset_daddr_ipv6, _ = skipOverlaps(t.status.Offset_daddr_ipv6, t.sockRanges())
 	default:
 		return fmt.Errorf("unexpected field to guess: %v", whatString[GuessWhat(t.status.What)])
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Adds overlap detection to offset guessing, so fields against the same base subject cannot have overlapping offset ranges.

### Motivation

Fixes an incorrect result when the IPv6 link-local address contained the UDP port number (53 or 0x35) as a byte.

### Additional Notes

Overlap detection needs to also happen before equality checks, because the eBPF side can adjust the offsets due to its enforcement of aligned reads. If the eBPF side adjusted the offset, we need to ensure it doesn't overlap before accepting it.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Added a failing test before fixing.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
