### PR TITLE
[CWS] remove useless type hints

### DIFF
--- a/pkg/security/resolvers/hash/resolver_linux.go
+++ b/pkg/security/resolvers/hash/resolver_linux.go
@@ -170,7 +170,7 @@ func (resolver *Resolver) ComputeHashes(eventType model.EventType, process *mode
 	}
 
 	// check if the resolver is allowed to hash this event type
-	if !slices.Contains[model.EventType](resolver.opts.EventTypes, eventType) {
+	if !slices.Contains(resolver.opts.EventTypes, eventType) {
 		file.HashState = model.EventTypeNotConfigured
 		resolver.hashMiss[eventType][model.EventTypeNotConfigured].Inc()
 		return nil

--- a/pkg/security/security_profile/dump/activity_dump.go
+++ b/pkg/security/security_profile/dump/activity_dump.go
@@ -355,7 +355,7 @@ func (ad *ActivityDump) MatchesSelector(entry *model.ProcessCacheEntry) bool {
 
 // IsEventTypeValid returns true if the provided event type is traced by the activity dump
 func (ad *ActivityDump) IsEventTypeValid(event model.EventType) bool {
-	return slices.Contains[model.EventType](ad.LoadConfig.TracedEventTypes, event)
+	return slices.Contains(ad.LoadConfig.TracedEventTypes, event)
 }
 
 // NewProcessNodeCallback is a callback function used to propagate the fact that a new process node was added to the

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -128,7 +128,7 @@ func (p *SecurityProfile) MatchesSelector(entry *model.ProcessCacheEntry) bool {
 
 // IsEventTypeValid is used to control which event types should trigger anomaly detection alerts
 func (p *SecurityProfile) IsEventTypeValid(evtType model.EventType) bool {
-	return slices.Contains[model.EventType](p.anomalyDetectionEvents, evtType)
+	return slices.Contains(p.anomalyDetectionEvents, evtType)
 }
 
 // NewProcessNodeCallback is a callback function used to propagate the fact that a new process node was added to the activity tree


### PR DESCRIPTION
### What does this PR do?

This PR removes useless type hints in the CWS code, that can confuse the type checker especially with recent changes to `golang.org/x/exp/slices` (https://go-review.googlesource.com/c/exp/+/511895). This should basically be a no-op.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
