### PR TITLE
relax gRPC service requirements for pprof labels

### DIFF
--- a/cmd/system-probe/api/module/loader.go
+++ b/cmd/system-probe/api/module/loader.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unicode"
 
 	"github.com/gorilla/mux"
 	"google.golang.org/grpc"
@@ -250,29 +249,16 @@ func (s *systemProbeGRPCServer) RegisterService(desc *grpc.ServiceDesc, impl int
 }
 
 // NameFromGRPCServiceName extracts a system-probe module name from the gRPC service name.
-// It expects a prefix of `datadog.agent.systemprobe.` and then the pascal cased version of the module name.
+// It expects a form of `datadog.agent.systemprobe.<module_name>.ServiceName`.
 func NameFromGRPCServiceName(service string) string {
 	prefix := "datadog.agent.systemprobe."
 	if !strings.HasPrefix(service, prefix) {
 		return ""
 	}
 	s := strings.TrimPrefix(service, prefix)
-	// we are expecting a pascal case service name, so convert it to snake case to match system-probe module names
-	return toSnakeCase(s)
-}
-
-func toSnakeCase(s string) string {
-	var sb strings.Builder
-	sb.Grow(len(s))
-	for i, r := range s {
-		if unicode.IsUpper(r) {
-			if i > 0 {
-				sb.WriteRune('_')
-			}
-			sb.WriteRune(unicode.ToLower(r))
-		} else {
-			sb.WriteRune(r)
-		}
+	mod, _, ok := strings.Cut(s, ".")
+	if !ok {
+		return ""
 	}
-	return sb.String()
+	return mod
 }

--- a/cmd/system-probe/api/module/loader_test.go
+++ b/cmd/system-probe/api/module/loader_test.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package module
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNameFromGRPCServiceName(t *testing.T) {
+	assert.Equal(t, "", NameFromGRPCServiceName("a.b.c"))
+	assert.Equal(t, "", NameFromGRPCServiceName("datadog.agent.systemprobe.asdf"))
+	assert.Equal(t, "network_tracer", NameFromGRPCServiceName("datadog.agent.systemprobe.network_tracer.Usm"))
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Relaxes the gRPC service naming requirements to fetch the module name from the namespace, rather than the service name itself. 

### Motivation

This allows multiple gRPC services per-module.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
