### PR TITLE
[CWS] build btfhub sync tool with `ebpf_bindata` tag

### DIFF
--- a/.github/workflows/cws-btfhub-sync.yml
+++ b/.github/workflows/cws-btfhub-sync.yml
@@ -16,8 +16,6 @@ jobs:
 
       - name: Checkout datadog-agent repository
         uses: actions/checkout@v4
-        with:
-          ref: main
 
       - name: Checkout btfhub-archive repository
         uses: actions/checkout@v4

--- a/pkg/security/ebpf/compile.go
+++ b/pkg/security/ebpf/compile.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux_bpf && !ebpf_bindata
+//go:build linux_bpf && !ebpf_bindata && !btfhubsync
 
 // Package ebpf holds ebpf related files
 package ebpf

--- a/pkg/security/ebpf/compile_unsupported.go
+++ b/pkg/security/ebpf/compile_unsupported.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build (linux && !linux_bpf) || ebpf_bindata
+//go:build (linux && !linux_bpf) || ebpf_bindata || btfhubsync
 
 // Package ebpf holds ebpf related files
 package ebpf

--- a/pkg/security/probe/constantfetch/btfhub/main.go
+++ b/pkg/security/probe/constantfetch/btfhub/main.go
@@ -60,7 +60,7 @@ func main() {
 		currentConstants, err := getCurrentConstants(constantOutputPath)
 		if err == nil && currentConstants.Commit != "" {
 			if currentConstants.Commit == archiveCommit {
-				fmt.Printf("already at most archive commit")
+				fmt.Printf("already at most recent archive commit")
 				return
 			}
 			preAllocHint = len(currentConstants.Kernels)

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -604,7 +604,7 @@ def generate_btfhub_constants(ctx, archive_path, force_refresh=False):
     output_path = "./pkg/security/probe/constantfetch/btfhub/constants.json"
     force_refresh_opt = "-force-refresh" if force_refresh else ""
     ctx.run(
-        f"go run -tags linux_bpf ./pkg/security/probe/constantfetch/btfhub/ -archive-root {archive_path} -output {output_path} {force_refresh_opt}",
+        f"go run -tags linux_bpf,ebpf_bindata ./pkg/security/probe/constantfetch/btfhub/ -archive-root {archive_path} -output {output_path} {force_refresh_opt}",
     )
 
 

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -604,7 +604,7 @@ def generate_btfhub_constants(ctx, archive_path, force_refresh=False):
     output_path = "./pkg/security/probe/constantfetch/btfhub/constants.json"
     force_refresh_opt = "-force-refresh" if force_refresh else ""
     ctx.run(
-        f"go run -tags linux_bpf,ebpf_bindata ./pkg/security/probe/constantfetch/btfhub/ -archive-root {archive_path} -output {output_path} {force_refresh_opt}",
+        f"go run -tags linux_bpf,btfhubsync ./pkg/security/probe/constantfetch/btfhub/ -archive-root {archive_path} -output {output_path} {force_refresh_opt}",
     )
 
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR fixes issue reported in https://github.com/DataDog/datadog-agent/actions/runs/6231171698

The goal of adding this tag is to prevent the need on auto generated files that are not present in the CI job: `pkg/ebpf/bytecode/runtime/runtime-security.go`

Success run https://github.com/DataDog/datadog-agent/actions/runs/6232450897/job/16915658090

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
