### PR TITLE
usm: kafka: Fixed failed test

### DIFF
--- a/pkg/network/usm/kafka_monitor_test.go
+++ b/pkg/network/usm/kafka_monitor_test.go
@@ -141,8 +141,8 @@ func testKafkaProtocolParsing(t *testing.T) {
 						kgo.ConsumeTopics(topicName),
 					},
 				})
-				ctx.extras["client"] = client
 				require.NoError(t, err)
+				ctx.extras["client"] = client
 				require.NoError(t, client.CreateTopic(topicName))
 
 				record := &kgo.Record{Topic: topicName, Value: []byte("Hello Kafka!")}
@@ -191,8 +191,8 @@ func testKafkaProtocolParsing(t *testing.T) {
 						kgo.ClientID(""),
 					},
 				})
-				ctx.extras["client"] = client
 				require.NoError(t, err)
+				ctx.extras["client"] = client
 				require.NoError(t, client.CreateTopic(topicName))
 
 				record := &kgo.Record{Topic: topicName, Value: []byte("Hello Kafka!")}
@@ -233,8 +233,8 @@ func testKafkaProtocolParsing(t *testing.T) {
 						kgo.ClientID(""),
 					},
 				})
-				ctx.extras["client"] = client
 				require.NoError(t, err)
+				ctx.extras["client"] = client
 				require.NoError(t, client.CreateTopic(topicName))
 
 				numberOfIterations := 1000
@@ -277,8 +277,8 @@ func testKafkaProtocolParsing(t *testing.T) {
 						kgo.ClientID(""),
 					},
 				})
-				ctx.extras["client"] = client
 				require.NoError(t, err)
+				ctx.extras["client"] = client
 				require.NoError(t, client.CreateTopic(topicName))
 
 				record := &kgo.Record{Topic: topicName, Value: []byte("Hello Kafka!")}
@@ -372,8 +372,8 @@ func testKafkaProtocolParsing(t *testing.T) {
 						kgo.ClientID(""),
 					},
 				})
-				ctx.extras["client"] = client
 				require.NoError(t, err)
+				ctx.extras["client"] = client
 				require.NoError(t, client.CreateTopic(topicName))
 
 				record := &kgo.Record{Topic: topicName, Value: []byte("Hello Kafka!")}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Fixes a possible panic in the kafka parsing tests.
We saved the client before checking the creation was successful, and in case of an error, we would try to dereference a nil pointer.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Tests stability 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Stack trace
```
[6.1.25-37.47.amzn2023.aarch64] === FAIL: pkg/network/usm TestKafkaProtocolParsing/runtime_compiled/Sanity_-_produce_and_fetch (701.18s)
       [6.1.25-37.47.amzn2023.aarch64] kafka_monitor_test.go:145:
       [6.1.25-37.47.amzn2023.aarch64] Error Trace:	/go/src/github.com/DataDog/datadog-agent/pkg/network/usm/kafka_monitor_test.go:145
       [6.1.25-37.47.amzn2023.aarch64] /go/src/github.com/DataDog/datadog-agent/pkg/network/usm/kafka_monitor_test.go:479
       [6.1.25-37.47.amzn2023.aarch64] /go/src/github.com/DataDog/datadog-agent/pkg/network/usm/kafka_monitor_test.go:397
       [6.1.25-37.47.amzn2023.aarch64] Error:      	Received unexpected error:
       [6.1.25-37.47.amzn2023.aarch64] unable to dial: dial tcp :0->127.0.0.1:9092: i/o timeout
       [6.1.25-37.47.amzn2023.aarch64] Test:       	TestKafkaProtocolParsing/runtime_compiled/Sanity_-_produce_and_fetch
       [6.1.25-37.47.amzn2023.aarch64] --- FAIL: TestKafkaProtocolParsing/runtime_compiled/Sanity_-_produce_and_fetch (10.41s)
       [6.1.25-37.47.amzn2023.aarch64] panic: runtime error: invalid memory address or nil pointer dereference [recovered]
       [6.1.25-37.47.amzn2023.aarch64] panic: runtime error: invalid memory address or nil pointer dereference
       [6.1.25-37.47.amzn2023.aarch64] [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x144e450]
       [6.1.25-37.47.amzn2023.aarch64] 
       [6.1.25-37.47.amzn2023.aarch64] goroutine 74 [running]:
       [6.1.25-37.47.amzn2023.aarch64] testing.tRunner.func1.2({0x17b27a0, 0x28f9f00})
       [6.1.25-37.47.amzn2023.aarch64] /usr/local/go/src/testing/testing.go:1526 +0x1c8
       [6.1.25-37.47.amzn2023.aarch64] testing.tRunner.func1()
       [6.1.25-37.47.amzn2023.aarch64] /usr/local/go/src/testing/testing.go:1529 +0x364
       [6.1.25-37.47.amzn2023.aarch64] panic({0x17b27a0, 0x28f9f00})
       [6.1.25-37.47.amzn2023.aarch64] /usr/local/go/src/runtime/panic.go:884 +0x1f4
       [6.1.25-37.47.amzn2023.aarch64] github.com/DataDog/datadog-agent/pkg/network/usm.testKafkaProtocolParsing.func2(0x40002d5a08?, {{0x4000660bd0, 0xe}, {0x1a51a64, 0x4}, {0x4000660be0, 0xe}, 0x4000517f80})
       [6.1.25-37.47.amzn2023.aarch64] /go/src/github.com/DataDog/datadog-agent/pkg/network/usm/kafka_monitor_test.go:104 +0xa0
       [6.1.25-37.47.amzn2023.aarch64] github.com/DataDog/datadog-agent/pkg/network/usm.testProtocolParsingInner.func1()
       [6.1.25-37.47.amzn2023.aarch64] /go/src/github.com/DataDog/datadog-agent/pkg/network/usm/kafka_monitor_test.go:475 +0x48
```
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
