### PR TITLE
usm: openssl: Fixed potential UT crash

### DIFF
--- a/pkg/network/protocols/testutil/serverutils.go
+++ b/pkg/network/protocols/testutil/serverutils.go
@@ -75,8 +75,8 @@ func RunHostServer(t *testing.T, command []string, env []string, serverStartRege
 		t.Fatalf("command not set %v host server", command)
 	}
 	t.Helper()
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
 
 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 	serverName := cmd.String()
@@ -88,7 +88,6 @@ func RunHostServer(t *testing.T, command []string, env []string, serverStartRege
 	err := cmd.Start()
 	require.NoErrorf(t, err, "could not start %s on host", serverName)
 	t.Cleanup(func() {
-		cancel()
 		_ = cmd.Wait()
 	})
 
@@ -104,11 +103,6 @@ func RunHostServer(t *testing.T, command []string, env []string, serverStartRege
 			t.Logf("%s host server pid %d is ready", serverName, cmd.Process.Pid)
 			patternScanner.PrintLogs(t)
 			return true
-		case <-time.After(time.Second * 60):
-			patternScanner.PrintLogs(t)
-			// please don't use t.Fatalf() here as we could test if it failed later
-			t.Errorf("failed to start %s host server pid %d", serverName, cmd.Process.Pid)
-			return false
 		}
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Fixes a possible panic in the openssl client tests.
Wrong usage of Context object
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Tests stability 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Stack trace
```
[4.18.0-372.9.1.el8.x86_64] panic: Fail in goroutine after TestUSMSuite/prebuilt has completed
       [4.18.0-372.9.1.el8.x86_64] 
       [4.18.0-372.9.1.el8.x86_64] goroutine 11937 [running]:
       [4.18.0-372.9.1.el8.x86_64] testing.(*common).Fail(0xc002339a00)
       [4.18.0-372.9.1.el8.x86_64] /usr/local/go/src/testing/testing.go:933 +0xe5
       [4.18.0-372.9.1.el8.x86_64] testing.(*common).Fail(0xc000394d00)
       [4.18.0-372.9.1.el8.x86_64] /usr/local/go/src/testing/testing.go:927 +0x47
       [4.18.0-372.9.1.el8.x86_64] testing.(*common).Fail(0xc0023381a0)
       [4.18.0-372.9.1.el8.x86_64] /usr/local/go/src/testing/testing.go:927 +0x47
       [4.18.0-372.9.1.el8.x86_64] testing.(*common).Errorf(0xc0023381a0, {0x25ee30e?, 0xc0023381a0?}, {0xc000e0ce68?, 0x25c4794?, 0x1?})
       [4.18.0-372.9.1.el8.x86_64] /usr/local/go/src/testing/testing.go:1050 +0x65
       [4.18.0-372.9.1.el8.x86_64] github.com/DataDog/datadog-agent/pkg/network/protocols/testutil.RunHostServer(0xc0023381a0, {0xc00148d3b0?, 0x9, 0x9}, {0xc000e0cf38, 0x0, 0xc0023c4ea0?}, 0xc0008e55e0)
       [4.18.0-372.9.1.el8.x86_64] /go/src/github.com/DataDog/datadog-agent/pkg/network/protocols/testutil/serverutils.go:110 +0x768
```
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
