### PR TITLE
[CSPM] Remove the ResolveAndEvaluateRegoRule function

### DIFF
--- a/cmd/security-agent/subcommands/check/command.go
+++ b/cmd/security-agent/subcommands/check/command.go
@@ -11,7 +11,6 @@ package check
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -198,10 +197,8 @@ func RunCheck(log log.Component, config config.Component, checkArgs *CliParams) 
 				ruleEvents = compliance.EvaluateXCCDFRule(context.Background(), hname, statsdClient, benchmark, rule)
 			case rule.IsRego():
 				inputs, err := resolver.ResolveInputs(context.Background(), rule)
-				if errors.Is(err, compliance.ErrIncompatibleEnvironment) {
-					ruleEvents = append(ruleEvents, compliance.NewCheckSkipped(compliance.RegoEvaluator, err, "", "", rule, benchmark))
-				} else if err != nil {
-					ruleEvents = append(ruleEvents, compliance.NewCheckError(compliance.RegoEvaluator, err, "", "", rule, benchmark))
+				if err != nil {
+					ruleEvents = append(ruleEvents, compliance.CheckEventFromError(compliance.RegoEvaluator, rule, benchmark, err))
 				} else {
 					ruleEvents = compliance.EvaluateRegoRule(context.Background(), inputs, benchmark, rule)
 				}

--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -10,7 +10,6 @@ package compliance
 
 import (
 	"context"
-	"errors"
 	"expvar"
 	"fmt"
 	"hash/fnv"
@@ -255,10 +254,8 @@ func (a *Agent) runRegoBenchmarks(ctx context.Context) {
 			resolver := NewResolver(ctx, a.opts.ResolverOptions)
 			for _, rule := range benchmark.Rules {
 				inputs, err := resolver.ResolveInputs(ctx, rule)
-				if errors.Is(err, ErrIncompatibleEnvironment) {
-					a.reportEvents(ctx, benchmark, NewCheckSkipped(RegoEvaluator, err, "", "", rule, benchmark))
-				} else if err != nil {
-					a.reportEvents(ctx, benchmark, NewCheckError(RegoEvaluator, err, "", "", rule, benchmark))
+				if err != nil {
+					a.reportEvents(ctx, benchmark, CheckEventFromError(RegoEvaluator, rule, benchmark, err))
 				} else {
 					events := EvaluateRegoRule(ctx, inputs, benchmark, rule)
 					a.reportEvents(ctx, benchmark, events...)

--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -10,6 +10,7 @@ package compliance
 
 import (
 	"context"
+	"errors"
 	"expvar"
 	"fmt"
 	"hash/fnv"
@@ -250,10 +251,19 @@ func (a *Agent) runRegoBenchmarks(ctx context.Context) {
 			if sleepAborted(ctx, time.After(randomJitter(seed, a.opts.RunJitterMax))) {
 				return
 			}
+
 			resolver := NewResolver(ctx, a.opts.ResolverOptions)
 			for _, rule := range benchmark.Rules {
-				events := ResolveAndEvaluateRegoRule(ctx, resolver, benchmark, rule)
-				a.reportEvents(ctx, benchmark, events)
+				inputs, err := resolver.ResolveInputs(ctx, rule)
+				if errors.Is(err, ErrIncompatibleEnvironment) {
+					a.reportEvents(ctx, benchmark, NewCheckSkipped(RegoEvaluator, err, "", "", rule, benchmark))
+				} else if err != nil {
+					a.reportEvents(ctx, benchmark, NewCheckError(RegoEvaluator, err, "", "", rule, benchmark))
+				} else {
+					events := EvaluateRegoRule(ctx, inputs, benchmark, rule)
+					a.reportEvents(ctx, benchmark, events...)
+				}
+
 				if sleepAborted(ctx, throttler.C) {
 					resolver.Close()
 					return
@@ -298,7 +308,7 @@ func (a *Agent) runXCCDFBenchmarks(ctx context.Context) {
 			}
 			for _, rule := range benchmark.Rules {
 				events := EvaluateXCCDFRule(ctx, a.opts.Hostname, a.opts.StatsdClient, benchmark, rule)
-				a.reportEvents(ctx, benchmark, events)
+				a.reportEvents(ctx, benchmark, events...)
 				if sleepAborted(ctx, throttler.C) {
 					return
 				}
@@ -361,7 +371,7 @@ func (a *Agent) runAptConfigurationExport(ctx context.Context) {
 	}
 }
 
-func (a *Agent) reportEvents(ctx context.Context, benchmark *Benchmark, events []*CheckEvent) {
+func (a *Agent) reportEvents(ctx context.Context, benchmark *Benchmark, events ...*CheckEvent) {
 	store := workloadmeta.GetGlobalStore()
 	for _, event := range events {
 		a.updateEvent(event)

--- a/pkg/compliance/evaluator_rego.go
+++ b/pkg/compliance/evaluator_rego.go
@@ -8,7 +8,6 @@ package compliance
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -21,48 +20,28 @@ import (
 	regotypes "github.com/open-policy-agent/opa/types"
 )
 
-// ResolveAndEvaluateRegoRule both resolves the inputs of a given rego rule,
-// using passed resolver, and evaluates them against the rule's rego program.
-func ResolveAndEvaluateRegoRule(ctx context.Context, resolver Resolver, benchmark *Benchmark, rule *Rule) []*CheckEvent {
+// EvaluateRegoRule evaluates the given rule and resolved inputs map against
+// the rule's rego program.
+func EvaluateRegoRule(ctx context.Context, resolvedInputs ResolvedInputs, benchmark *Benchmark, rule *Rule) []*CheckEvent {
 	wrapErr := func(errReason error) []*CheckEvent {
 		return []*CheckEvent{NewCheckError(RegoEvaluator, errReason, "", "", rule, benchmark)}
 	}
-	wrapSkip := func(skipReason error) []*CheckEvent {
-		return []*CheckEvent{NewCheckSkipped(RegoEvaluator, skipReason, "", "", rule, benchmark)}
-	}
 
 	if !rule.IsRego() {
-		return wrapSkip(fmt.Errorf("given rule is not a rego rule %s", rule.ID))
-	}
-
-	resolvedInputs, err := resolver.ResolveInputs(ctx, rule)
-	if errors.Is(err, ErrIncompatibleEnvironment) {
-		return wrapSkip(fmt.Errorf("skipping input resolution for rule=%s: %s", rule.ID, err))
-	}
-	if err != nil {
-		return wrapErr(fmt.Errorf("input resolution error for rule=%s: %w", rule.ID, err))
+		log.Errorf("given rule is not an Rego rule %s", rule.ID)
+		return nil
 	}
 
 	log.Infof("running rego check for rule=%s", rule.ID)
-	events, err := EvaluateRegoRule(ctx, resolvedInputs, benchmark, rule)
-	if err != nil {
-		return wrapErr(fmt.Errorf("rego rule evaluation error for rule=%s: %w", rule.ID, err))
-	}
-	return events
-}
-
-// EvaluateRegoRule evaluates the given rule and resolved inputs map against
-// the rule's rego program.
-func EvaluateRegoRule(ctx context.Context, resolvedInputs ResolvedInputs, benchmark *Benchmark, rule *Rule) ([]*CheckEvent, error) {
 	log.Tracef("building rego modules for rule=%s", rule.ID)
 	modules, err := buildRegoModules(benchmark.dirname, rule)
 	if err != nil {
-		return nil, fmt.Errorf("could not build rego modules: %w", err)
+		return wrapErr(fmt.Errorf("could not build rego modules: %w", err))
 	}
 
 	input, err := regoast.InterfaceToValue(resolvedInputs)
 	if err != nil {
-		return nil, fmt.Errorf("could not create input value: %v", err)
+		return wrapErr(fmt.Errorf("could not create input value: %v", err))
 	}
 
 	var options []func(*rego.Rego)
@@ -84,15 +63,15 @@ func EvaluateRegoRule(ctx context.Context, resolvedInputs ResolvedInputs, benchm
 	r := rego.New(options...)
 	rSet, err := r.Eval(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("rego eval: %w", err)
+		return wrapErr(fmt.Errorf("rego eval: %w", err))
 	}
 	if len(rSet) == 0 || len(rSet[0].Expressions) == 0 {
-		return nil, fmt.Errorf("empty results set")
+		return wrapErr(fmt.Errorf("empty results set"))
 	}
 
 	results, ok := rSet[0].Expressions[0].Value.([]interface{})
 	if !ok {
-		return nil, fmt.Errorf("could not cast expression value")
+		return wrapErr(fmt.Errorf("could not cast expression value"))
 	}
 
 	log.TraceFunc(func() string {
@@ -113,7 +92,7 @@ func EvaluateRegoRule(ctx context.Context, resolvedInputs ResolvedInputs, benchm
 		}
 	}
 
-	return events, nil
+	return events
 }
 
 func newCheckEventFromRegoResult(data interface{}, rule *Rule, resolvedInputs ResolvedInputs, benchmark *Benchmark) *CheckEvent {

--- a/pkg/compliance/evaluator_rego.go
+++ b/pkg/compliance/evaluator_rego.go
@@ -24,7 +24,7 @@ import (
 // the rule's rego program.
 func EvaluateRegoRule(ctx context.Context, resolvedInputs ResolvedInputs, benchmark *Benchmark, rule *Rule) []*CheckEvent {
 	wrapErr := func(errReason error) []*CheckEvent {
-		return []*CheckEvent{NewCheckError(RegoEvaluator, errReason, "", "", rule, benchmark)}
+		return []*CheckEvent{CheckEventFromError(RegoEvaluator, rule, benchmark, errReason)}
 	}
 
 	if !rule.IsRego() {

--- a/pkg/compliance/resolver.go
+++ b/pkg/compliance/resolver.go
@@ -46,10 +46,6 @@ import (
 // Rule.
 const inputsResolveTimeout = 5 * time.Second
 
-// ErrIncompatibleEnvironment is returns by the resolver to signal that the
-// given rule's inputs are not resolvable in the current environment.
-var ErrIncompatibleEnvironment = errors.New("environment not compatible this type of input")
-
 // DockerProvider is a function returning a Docker client.
 type DockerProvider func(context.Context) (docker.CommonAPIClient, error)
 

--- a/pkg/compliance/tests/helpers.go
+++ b/pkg/compliance/tests/helpers.go
@@ -262,7 +262,13 @@ func (c *assertedRule) run(t *testing.T, options compliance.ResolverOptions) {
 	defer resolver.Close()
 	benchmark := benchmarks[0]
 	for _, rule := range benchmark.Rules {
-		events := compliance.ResolveAndEvaluateRegoRule(ctx, resolver, benchmark, rule)
+		inputs, err := resolver.ResolveInputs(ctx, rule)
+		var events []*compliance.CheckEvent
+		if err != nil {
+			events = append(events, compliance.CheckEventFromError(compliance.RegoEvaluator, rule, benchmark, err))
+		} else {
+			events = compliance.EvaluateRegoRule(ctx, inputs, benchmark, rule)
+		}
 		if c.noEvent {
 			if len(events) > 0 {
 				for _, event := range events {


### PR DESCRIPTION
### What does this PR do?

It removes the ResolveAndEvaluateRegoRule method that was doing both resolving of inputs and rego evaluation.

### Motivation

Simplify things down and untie "resolving of inputs" and "rego evaluation". My goal is to move everything rego related into its own submodule to import it independently from the rest of the compliance module. This change helps to move into this direction.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
