### PR TITLE
[CWS] one level dentry inode cache

### DIFF
--- a/pkg/security/resolvers/dentry/cache.go
+++ b/pkg/security/resolvers/dentry/cache.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build linux
+
 package dentry
 
 import (

--- a/pkg/security/resolvers/dentry/cache.go
+++ b/pkg/security/resolvers/dentry/cache.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package dentry
+
+import (
+	"sync"
+
+	"github.com/hashicorp/golang-lru/v2/simplelru"
+)
+
+type betterCache[K comparable, V any] struct {
+	lock sync.Mutex
+	lru  *simplelru.LRU[K, V]
+}
+
+func newBetterCache[K comparable, V any](size int) (*betterCache[K, V], error) {
+	inner, err := simplelru.NewLRU[K, V](size, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &betterCache[K, V]{
+		lru: inner,
+	}, nil
+}
+
+func (c *betterCache[K, V]) Get(key K) (V, bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.lru.Get(key)
+}
+
+func (c *betterCache[K, V]) Add(key K, value V) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.lru.Add(key, value)
+}
+
+func (c *betterCache[K, V]) FilterByKeys(shouldRemove func(K) bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	for _, key := range c.lru.Keys() {
+		if shouldRemove(key) {
+			c.lru.Remove(key)
+		}
+	}
+}

--- a/pkg/security/resolvers/dentry/resolver.go
+++ b/pkg/security/resolvers/dentry/resolver.go
@@ -177,7 +177,12 @@ func (dr *Resolver) sendERPCStats() error {
 
 // DelCacheEntries removes all the entries belonging to a mountID
 func (dr *Resolver) DelCacheEntries(mountID uint32) {
-	// delete(dr.cache, mountID)
+	// TODO(paulcacheux): this is really bad for now
+	for _, key := range dr.cache.Keys() {
+		if key.MountID == mountID {
+			dr.cache.Remove(key)
+		}
+	}
 }
 
 func (dr *Resolver) lookupInodeFromCache(pathKey model.PathKey) (*PathEntry, error) {


### PR DESCRIPTION
### What does this PR do?

This PR simplifies the dentry resolver by having only using a one level map cache. This means that all cached entries are in the same LRU (instead of one LRU per mount as before).

The end goal is to make the `cacheInode` and `lookupInodeFromCache` operations faster (we never allocate a new LRU in those paths, we only lookup one LRU instead of 2), sacrificing a bit the performance of `DelCacheEntries`.

One other goal of this is to ensure the upper bound limit of the cache. Since we are using one LRU we are bounded by its size contrary to now where the mountID keyed first level map is unbounded.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
