### PR TITLE
Use context managers to monitor durations

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -4,7 +4,6 @@ Agent namespaced tasks
 
 
 import ast
-import datetime
 import glob
 import os
 import platform
@@ -36,6 +35,7 @@ from .utils import (
     get_version,
     has_both_python,
     load_release_versions,
+    stop_watch,
 )
 from .windows_resources import build_messagetable, build_rc, versioninfo_vars
 
@@ -629,14 +629,9 @@ def omnibus_build(
     Build the Agent packages with Omnibus Installer.
     """
     flavor = AgentFlavor[flavor]
-    deps_elapsed = None
-    bundle_elapsed = None
-    omnibus_elapsed = None
     if not skip_deps:
-        deps_start = datetime.datetime.now()
-        deps(ctx)
-        deps_end = datetime.datetime.now()
-        deps_elapsed = deps_end - deps_start
+        with stop_watch() as deps_elapsed:
+            deps(ctx)
 
     # base dir (can be overridden through env vars, command line takes precedence)
     base_dir = base_dir or os.environ.get("OMNIBUS_BASE_DIR")
@@ -675,32 +670,28 @@ def omnibus_build(
     with open(pip_config_file, 'w') as f:
         f.write(pip_index_url)
 
-    bundle_start = datetime.datetime.now()
-    bundle_install_omnibus(ctx, gem_path, env)
-    bundle_done = datetime.datetime.now()
-    bundle_elapsed = bundle_done - bundle_start
+    with stop_watch() as bundle_elapsed:
+        bundle_install_omnibus(ctx, gem_path, env)
 
-    omnibus_start = datetime.datetime.now()
-    omnibus_run_task(
-        ctx=ctx,
-        task="build",
-        target_project=target_project,
-        base_dir=base_dir,
-        env=env,
-        omnibus_s3_cache=omnibus_s3_cache,
-        log_level=log_level,
-    )
-    omnibus_done = datetime.datetime.now()
-    omnibus_elapsed = omnibus_done - omnibus_start
+    with stop_watch() as omnibus_elapsed:
+        omnibus_run_task(
+            ctx=ctx,
+            task="build",
+            target_project=target_project,
+            base_dir=base_dir,
+            env=env,
+            omnibus_s3_cache=omnibus_s3_cache,
+            log_level=log_level,
+        )
 
     # Delete the temporary pip.conf file once the build is done
     os.remove(pip_config_file)
 
     print("Build component timing:")
     if not skip_deps:
-        print(f"Deps:    {deps_elapsed}")
-    print(f"Bundle:  {bundle_elapsed}")
-    print(f"Omnibus: {omnibus_elapsed}")
+        print(f"Deps:    {deps_elapsed.duration}")
+    print(f"Bundle:  {bundle_elapsed.duration}")
+    print(f"Omnibus: {omnibus_elapsed.duration}")
 
 
 @task

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -35,7 +35,7 @@ from .utils import (
     get_version,
     has_both_python,
     load_release_versions,
-    stop_watch,
+    timed,
 )
 from .windows_resources import build_messagetable, build_rc, versioninfo_vars
 
@@ -630,7 +630,7 @@ def omnibus_build(
     """
     flavor = AgentFlavor[flavor]
     if not skip_deps:
-        with stop_watch() as deps_elapsed:
+        with timed(quiet=True) as deps_elapsed:
             deps(ctx)
 
     # base dir (can be overridden through env vars, command line takes precedence)
@@ -670,10 +670,10 @@ def omnibus_build(
     with open(pip_config_file, 'w') as f:
         f.write(pip_index_url)
 
-    with stop_watch() as bundle_elapsed:
+    with timed(quiet=True) as bundle_elapsed:
         bundle_install_omnibus(ctx, gem_path, env)
 
-    with stop_watch() as omnibus_elapsed:
+    with timed(quiet=True) as omnibus_elapsed:
         omnibus_run_task(
             ctx=ctx,
             task="build",

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -2,7 +2,6 @@
 Golang related tasks go here
 """
 
-import datetime
 import glob
 import os
 import shutil
@@ -15,7 +14,7 @@ from invoke.exceptions import Exit
 from .build_tags import ALL_TAGS, UNIT_TEST_TAGS, get_default_build_tags
 from .licenses import get_licenses_list
 from .modules import DEFAULT_MODULES, generate_dummy_package
-from .utils import get_build_flags
+from .utils import get_build_flags, timed
 
 GOOS_MAPPING = {
     "win32": "windows",
@@ -95,13 +94,11 @@ def deps(ctx, verbose=False):
     """
 
     print("downloading dependencies")
-    start = datetime.datetime.now()
-    verbosity = ' -x' if verbose else ''
-    for mod in DEFAULT_MODULES.values():
-        with ctx.cd(mod.full_path()):
-            ctx.run(f"go mod download{verbosity}")
-    dep_done = datetime.datetime.now()
-    print(f"go mod download, elapsed: {dep_done - start}")
+    with timed("go mod download"):
+        verbosity = ' -x' if verbose else ''
+        for mod in DEFAULT_MODULES.values():
+            with ctx.cd(mod.full_path()):
+                ctx.run(f"go mod download{verbosity}")
 
 
 @task
@@ -111,26 +108,23 @@ def deps_vendored(ctx, verbose=False):
     """
 
     print("vendoring dependencies")
-    start = datetime.datetime.now()
-    verbosity = ' -v' if verbose else ''
+    with timed("go mod vendor"):
+        verbosity = ' -v' if verbose else ''
 
-    ctx.run(f"go mod vendor{verbosity}")
-    ctx.run(f"go mod tidy{verbosity} -compat=1.17")
+        ctx.run(f"go mod vendor{verbosity}")
+        ctx.run(f"go mod tidy{verbosity} -compat=1.17")
 
-    # "go mod vendor" doesn't copy files that aren't in a package: https://github.com/golang/go/issues/26366
-    # This breaks when deps include other files that are needed (eg: .java files from gomobile): https://github.com/golang/go/issues/43736
-    # For this reason, we need to use a 3rd party tool to copy these files.
-    # We won't need this if/when we change to non-vendored modules
-    ctx.run(f'modvendor -copy="**/*.c **/*.h **/*.proto **/*.java"{verbosity}')
+        # "go mod vendor" doesn't copy files that aren't in a package: https://github.com/golang/go/issues/26366
+        # This breaks when deps include other files that are needed (eg: .java files from gomobile): https://github.com/golang/go/issues/43736
+        # For this reason, we need to use a 3rd party tool to copy these files.
+        # We won't need this if/when we change to non-vendored modules
+        ctx.run(f'modvendor -copy="**/*.c **/*.h **/*.proto **/*.java"{verbosity}')
 
-    # If github.com/DataDog/datadog-agent gets vendored too - nuke it
-    # This may happen because of the introduction of nested modules
-    if os.path.exists('vendor/github.com/DataDog/datadog-agent'):
-        print("Removing vendored github.com/DataDog/datadog-agent")
-        shutil.rmtree('vendor/github.com/DataDog/datadog-agent')
-
-    dep_done = datetime.datetime.now()
-    print(f"go mod vendor, elapsed: {dep_done - start}")
+        # If github.com/DataDog/datadog-agent gets vendored too - nuke it
+        # This may happen because of the introduction of nested modules
+        if os.path.exists('vendor/github.com/DataDog/datadog-agent'):
+            print("Removing vendored github.com/DataDog/datadog-agent")
+            shutil.rmtree('vendor/github.com/DataDog/datadog-agent')
 
 
 @task

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -552,3 +552,14 @@ def timed(name=""):
     finally:
         end = time.time()
         print(f"{name} completed in {end-start:.2f}s")
+
+
+class stop_watch:
+    """Context manager that stores the duration of an operation"""
+
+    def __enter__(self):
+        self._begin = time.time()
+        return self
+
+    def __exit__(self, *_):
+        self.duration = time.time() - self._begin

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -10,6 +10,7 @@ import re
 import sys
 import time
 from subprocess import check_output
+from types import SimpleNamespace
 
 from invoke import task
 from invoke.exceptions import Exit
@@ -543,23 +544,14 @@ def check_local_branch(ctx, branch):
 
 
 @contextlib.contextmanager
-def timed(name=""):
+def timed(name="", quiet=False):
     """Context manager that prints how long it took"""
     start = time.time()
+    res = SimpleNamespace()
     print(f"{name}")
     try:
-        yield
+        yield res
     finally:
-        end = time.time()
-        print(f"{name} completed in {end-start:.2f}s")
-
-
-class stop_watch:
-    """Context manager that stores the duration of an operation"""
-
-    def __enter__(self):
-        self._begin = time.time()
-        return self
-
-    def __exit__(self, *_):
-        self.duration = time.time() - self._begin
+        res.duration = time.time() - start
+        if not quiet:
+            print(f"{name} completed in {res.duration:.2f}s")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR adds a context manager helper to measure the duration of some operations, and uses the existing one when applicable

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Reduce duplication and boilerplate

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

This is currently returning a result in seconds, while some of the updated call sites where displaying the results as a `timedelta`.
We could also use `timedelta` for existing call sites

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
