### PR TITLE
Fix `use_podman_logs` config conflict with `docker_path_override`

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1512,7 +1512,7 @@ func useHostEtc(config Config) {
 
 func checkConflictingOptions(config Config) error {
 	// Verify that either use_podman_logs OR docker_path_override are set since they conflict
-	if config.GetBool("logs_config.use_podman_logs") && config.IsSet("logs_config.docker_path_override") {
+	if config.GetBool("logs_config.use_podman_logs") && len(config.GetString("logs_config.docker_path_override")) > 0 {
 		log.Warnf("'use_podman_logs' is set to true and 'docker_path_override' is set, please use one or the other")
 		return errors.New("'use_podman_logs' is set to true and 'docker_path_override' is set, please use one or the other")
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -664,6 +664,19 @@ logs_config:
 	assert.NotNil(t, err)
 }
 
+func TestUsePodmanLogs(t *testing.T) {
+	// If use_podman_logs is true and docker_path_override is not set, the config should not return an error
+	datadogYaml := `
+logs_config:
+  use_podman_logs: true
+`
+
+	config := SetupConfFromYAML(datadogYaml)
+	err := checkConflictingOptions(config)
+
+	assert.Nil(t, err)
+}
+
 func TestSetupFipsEndpoints(t *testing.T) {
 	datadogYaml := `
 dd_url: https://somehost:1234

--- a/releasenotes/notes/fix-podman-logs-ac177eac8b78d783.yaml
+++ b/releasenotes/notes/fix-podman-logs-ac177eac8b78d783.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix config conflict preventing ``logs_config.use_podman_logs`` from working


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

The agent failed to start with `DD_LOGS_CONFIG_USE_PODMAN_LOGS=true` because the `config.IsSet("logs_config.docker_path_override")` always returns true since the default is set to `""`. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Bug Fix
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Start an agent with `DD_LOGS_CONFIG_USE_PODMAN_LOGS=true` (agent should start without error)
- Start an agent with `DD_LOGS_CONFIG_USE_PODMAN_LOGS=true` and `logs_config.docker_path_override` set to a non-empty string (agent should fail to start with an error)

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
