### PR TITLE
pkg/trace: Refactoring

### DIFF
--- a/cmd/trace-agent/test/testsuite/span_sampling_test.go
+++ b/cmd/trace-agent/test/testsuite/span_sampling_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 package testsuite
 
 import (

--- a/cmd/trace-agent/test/testsuite/span_sampling_test.go
+++ b/cmd/trace-agent/test/testsuite/span_sampling_test.go
@@ -1,0 +1,54 @@
+package testsuite
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/cmd/trace-agent/test"
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	"github.com/DataDog/datadog-agent/pkg/trace/testutil"
+)
+
+func TestSpanSampling(t *testing.T) {
+	var r test.Runner
+	if err := r.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := r.Shutdown(time.Second); err != nil {
+			t.Log("shutdown: ", err)
+		}
+	}()
+
+	t.Run("one-sampled", func(t *testing.T) {
+		if err := r.RunAgent(nil); err != nil {
+			t.Fatal(err)
+		}
+		defer r.KillAgent()
+
+		p := testutil.GeneratePayload(1, &testutil.TraceConfig{
+			MinSpans: 3,
+			Keep:     true,
+		}, nil)
+		singleSpan := p[0][1]
+		singleSpan.Metrics["_dd.span_sampling.mechanism"] = 8
+		for _, s := range p[0] {
+			s.Metrics["_sampling_priority_v1"] = -1
+		}
+
+		if err := r.Post(p); err != nil {
+			t.Fatal(err)
+		}
+		waitForTrace(t, &r, func(v *pb.AgentPayload) {
+			require.Len(t, v.TracerPayloads, 1)
+			require.Len(t, v.TracerPayloads[0].Chunks, 1)
+			assert.False(t, v.TracerPayloads[0].Chunks[0].DroppedTrace)
+			assert.Equal(t, int32(2), v.TracerPayloads[0].Chunks[0].Priority)
+			require.Len(t, v.TracerPayloads[0].Chunks[0].Spans, 1)
+			assert.Equal(t, 8.0, v.TracerPayloads[0].Chunks[0].Spans[0].Metrics["_dd.span_sampling.mechanism"])
+		})
+	})
+}

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -477,7 +477,10 @@ func isManualUserDrop(priority sampler.SamplingPriority, pt *traceutil.Processed
 
 // sample performs all sampling on the processedTrace modifying it as needed and returning if the trace should be kept and the number of events in the trace
 func (a *Agent) sample(now time.Time, ts *info.TagStats, pt *traceutil.ProcessedTrace) (keep bool, numEvents int) {
-	keep, skipAnalyticsEvents := a.traceSampling(now, ts, pt) //TODO: why do we have `keep` when the trace itself has a traceDropped field
+	// We have a `keep` that is different from pt's `DroppedTrace` field as `DroppedTrace` will be sent to intake.
+	// For example: We want to maintain the overall trace level sampling decision for a trace with Analytics Events
+	// where a trace might be marked as DroppedTrace true, but we still sent analytics events in that ProcessedTrace.
+	keep, skipAnalyticsEvents := a.traceSampling(now, ts, pt)
 
 	var events []*pb.Span
 	if !skipAnalyticsEvents {

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -490,15 +490,14 @@ func (a *Agent) sample(now time.Time, ts *info.TagStats, pt *traceutil.Processed
 		events = a.getAnalyzedEvents(pt, ts)
 	}
 	if !keep {
-		// single span sampling
-		hadSSS := sampler.SingleSpanSampling(pt)
-		if !hadSSS {
-			// If there were no single span sampled spans let's use the analytics events
+		modified := sampler.SingleSpanSampling(pt)
+		if !modified {
+			// If there were no sampled spans, and we're not keeping the trace, let's use the analytics events
 			// This is OK because SSS is a replacement for analytics events so both should not be configured
 			// And when analytics events are fully gone we can get rid of all this
 			pt.TraceChunk.Spans = events
 		} else if len(events) > 0 {
-			log.Warnf("Detected both analytics events AND single span sampling in the same trace, single span sampling wins.")
+			log.Warnf("Detected both analytics events AND single span sampling in the same trace. Single span sampling wins because App Analytics is deprecated.")
 		}
 	}
 

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -1111,13 +1111,13 @@ func TestSample(t *testing.T) {
 		}
 		t.Run(name, func(t *testing.T) {
 			before := tt.trace.TraceChunk.ShallowCopy()
-			_, keep, sampled := a.sample(now, info.NewReceiverStats().GetTagStats(info.Tags{}), &tt.trace)
+			_, keep, sampled := a.traceSampling(now, info.NewReceiverStats().GetTagStats(info.Tags{}), &tt.trace)
 			assert.Equal(t, tt.keep, keep)
 			assert.Equal(t, tt.dropped, sampled.TraceChunk.DroppedTrace)
 			assert.Equal(t, before, tt.trace.TraceChunk) // make sure tt.trace.TraceChunk didn't change
 			cfg.Features["error_rare_sample_tracer_drop"] = struct{}{}
 			defer delete(cfg.Features, "error_rare_sample_tracer_drop")
-			_, keep, sampled = a.sample(now, info.NewReceiverStats().GetTagStats(info.Tags{}), &tt.trace)
+			_, keep, sampled = a.traceSampling(now, info.NewReceiverStats().GetTagStats(info.Tags{}), &tt.trace)
 			assert.Equal(t, tt.keepWithFeature, keep)
 			assert.Equal(t, before, tt.trace.TraceChunk) // make sure tt.trace.TraceChunk didn't change
 			assert.Equal(t, tt.dropped, sampled.TraceChunk.DroppedTrace)
@@ -1749,7 +1749,7 @@ func TestSampleWithPriorityNone(t *testing.T) {
 	}
 	// before := traceutil.CopyTraceChunk(pt.TraceChunk)
 	before := pt.TraceChunk.ShallowCopy()
-	numEvents, keep, sampled := agnt.sample(time.Now(), info.NewReceiverStats().GetTagStats(info.Tags{}), &pt)
+	numEvents, keep, sampled := agnt.traceSampling(time.Now(), info.NewReceiverStats().GetTagStats(info.Tags{}), &pt)
 	assert.True(t, keep) // Score Sampler should keep the trace.
 	assert.False(t, sampled.TraceChunk.DroppedTrace)
 	assert.Equal(t, before, pt.TraceChunk)

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -1110,17 +1110,17 @@ func TestSample(t *testing.T) {
 			conf:              cfg,
 		}
 		t.Run(name, func(t *testing.T) {
-			before := tt.trace.TraceChunk.ShallowCopy()
-			_, keep, sampled := a.traceSampling(now, info.NewReceiverStats().GetTagStats(info.Tags{}), &tt.trace)
+			// before := tt.trace.TraceChunk.ShallowCopy()
+			keep := a.traceSampling(now, info.NewReceiverStats().GetTagStats(info.Tags{}), &tt.trace)
 			assert.Equal(t, tt.keep, keep)
-			assert.Equal(t, tt.dropped, sampled.TraceChunk.DroppedTrace)
-			assert.Equal(t, before, tt.trace.TraceChunk) // make sure tt.trace.TraceChunk didn't change
+			assert.Equal(t, tt.dropped, tt.trace.TraceChunk.DroppedTrace)
+			// assert.Equal(t, before, tt.trace.TraceChunk) // make sure tt.trace.TraceChunk didn't change
 			cfg.Features["error_rare_sample_tracer_drop"] = struct{}{}
 			defer delete(cfg.Features, "error_rare_sample_tracer_drop")
-			_, keep, sampled = a.traceSampling(now, info.NewReceiverStats().GetTagStats(info.Tags{}), &tt.trace)
+			keep = a.traceSampling(now, info.NewReceiverStats().GetTagStats(info.Tags{}), &tt.trace)
 			assert.Equal(t, tt.keepWithFeature, keep)
-			assert.Equal(t, before, tt.trace.TraceChunk) // make sure tt.trace.TraceChunk didn't change
-			assert.Equal(t, tt.dropped, sampled.TraceChunk.DroppedTrace)
+			// assert.Equal(t, before, tt.trace.TraceChunk) // make sure tt.trace.TraceChunk didn't change
+			assert.Equal(t, tt.dropped, tt.trace.TraceChunk.DroppedTrace)
 		})
 	}
 }
@@ -1749,9 +1749,9 @@ func TestSampleWithPriorityNone(t *testing.T) {
 	}
 	// before := traceutil.CopyTraceChunk(pt.TraceChunk)
 	before := pt.TraceChunk.ShallowCopy()
-	numEvents, keep, sampled := agnt.traceSampling(time.Now(), info.NewReceiverStats().GetTagStats(info.Tags{}), &pt)
+	keep, numEvents := agnt.sample(time.Now(), info.NewReceiverStats().GetTagStats(info.Tags{}), &pt)
 	assert.True(t, keep) // Score Sampler should keep the trace.
-	assert.False(t, sampled.TraceChunk.DroppedTrace)
+	assert.False(t, pt.TraceChunk.DroppedTrace)
 	assert.Equal(t, before, pt.TraceChunk)
 	assert.EqualValues(t, numEvents, 0)
 }

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -1343,7 +1343,7 @@ Loop:
 			TraceChunk: chunk,
 			Root:       root,
 		}
-		numEvents, _ := processor.Process(pt)
+		_, numEvents, _ := processor.Process(pt)
 		totalSampled += int(numEvents)
 
 		<-eventTicker.C

--- a/pkg/trace/agent/normalizer.go
+++ b/pkg/trace/agent/normalizer.go
@@ -161,10 +161,10 @@ func (a *Agent) normalize(ts *info.TagStats, s *pb.Span) error {
 	return nil
 }
 
-// normalizeChunk takes a trace chunk and
+// setChunkAttributesFromRoot takes a trace chunk and from the root span
 // * populates Origin field if it wasn't populated
 // * populates Priority field if it wasn't populated
-func normalizeChunk(chunk *pb.TraceChunk, root *pb.Span) {
+func setChunkAttributesFromRoot(chunk *pb.TraceChunk, root *pb.Span) {
 	// check if priority is already populated
 	if chunk.Priority == int32(sampler.PriorityNone) {
 		// Older tracers set sampling priority in the root span.

--- a/pkg/trace/agent/normalizer_test.go
+++ b/pkg/trace/agent/normalizer_test.go
@@ -499,7 +499,7 @@ func TestNormalizeChunkPopulatingOrigin(t *testing.T) {
 	traceutil.SetMeta(root, "_dd.origin", "rum")
 	chunk := testutil.TraceChunkWithSpan(root)
 	chunk.Origin = ""
-	normalizeChunk(chunk, root)
+	setChunkAttributesFromRoot(chunk, root)
 	assert.Equal("rum", chunk.Origin)
 }
 
@@ -509,7 +509,7 @@ func TestNormalizeChunkNotPopulatingOrigin(t *testing.T) {
 	traceutil.SetMeta(root, "_dd.origin", "rum")
 	chunk := testutil.TraceChunkWithSpan(root)
 	chunk.Origin = "lambda"
-	normalizeChunk(chunk, root)
+	setChunkAttributesFromRoot(chunk, root)
 	assert.Equal("lambda", chunk.Origin)
 }
 
@@ -519,7 +519,7 @@ func TestNormalizeChunkPopulatingSamplingPriority(t *testing.T) {
 	traceutil.SetMetric(root, "_sampling_priority_v1", float64(sampler.PriorityAutoKeep))
 	chunk := testutil.TraceChunkWithSpan(root)
 	chunk.Priority = int32(sampler.PriorityNone)
-	normalizeChunk(chunk, root)
+	setChunkAttributesFromRoot(chunk, root)
 	assert.EqualValues(sampler.PriorityAutoKeep, chunk.Priority)
 }
 
@@ -529,7 +529,7 @@ func TestNormalizeChunkNotPopulatingSamplingPriority(t *testing.T) {
 	traceutil.SetMetric(root, "_sampling_priority_v1", float64(sampler.PriorityAutoKeep))
 	chunk := testutil.TraceChunkWithSpan(root)
 	chunk.Priority = int32(sampler.PriorityAutoDrop)
-	normalizeChunk(chunk, root)
+	setChunkAttributesFromRoot(chunk, root)
 	assert.EqualValues(sampler.PriorityAutoDrop, chunk.Priority)
 }
 
@@ -542,7 +542,7 @@ func TestNormalizePopulatePriorityFromAnySpan(t *testing.T) {
 	chunk.Spans[0].Metrics = nil
 	chunk.Spans[2].Metrics = nil
 	traceutil.SetMetric(chunk.Spans[1], "_sampling_priority_v1", float64(sampler.PriorityAutoKeep))
-	normalizeChunk(chunk, root)
+	setChunkAttributesFromRoot(chunk, root)
 	assert.EqualValues(sampler.PriorityAutoKeep, chunk.Priority)
 }
 

--- a/pkg/trace/event/processor.go
+++ b/pkg/trace/event/processor.go
@@ -50,8 +50,11 @@ func (p *Processor) Stop() {
 }
 
 // Process takes a processed trace, extracts events from it and samples them, returning a collection of
-// sampled events along with the total count of extracted events.
-func (p *Processor) Process(pt *traceutil.ProcessedTrace) (numExtracted int64, events []*pb.Span) {
+// sampled events along with the total count of events.
+// numEvents is the number of sampled events found in the trace
+// numExtracted is the number of events found in the trace
+// events is the slice of sampled analytics events to keep (only has values if pt will be dropped)
+func (p *Processor) Process(pt *traceutil.ProcessedTrace) (numEvents, numExtracted int64, events []*pb.Span) {
 	clientSampleRate := sampler.GetClientRate(pt.Root)
 	preSampleRate := sampler.GetPreSampleRate(pt.Root)
 	priority := sampler.SamplingPriority(pt.TraceChunk.Priority)
@@ -80,8 +83,9 @@ func (p *Processor) Process(pt *traceutil.ProcessedTrace) (numExtracted int64, e
 		if pt.TraceChunk.DroppedTrace {
 			events = append(events, span)
 		}
+		numEvents++
 	}
-	return numExtracted, events
+	return numEvents, numExtracted, events
 }
 
 func (p *Processor) extract(span *pb.Span, priority sampler.SamplingPriority) (float64, bool) {

--- a/pkg/trace/event/processor.go
+++ b/pkg/trace/event/processor.go
@@ -83,6 +83,8 @@ func (p *Processor) Process(pt *traceutil.ProcessedTrace) (numEvents, numExtract
 		}
 		numEvents++
 	}
+	//TODO: we can NOT modify `pt` and then we don't need to clone it i think (BIG WIN)
+	//TODO: Add an integration test for sampling + analytics events to verify no change in behavior
 	if pt.TraceChunk.DroppedTrace {
 		// we are not keeping anything out of this trace, except the events
 		pt.TraceChunk.Spans = events

--- a/pkg/trace/sampler/sampler.go
+++ b/pkg/trace/sampler/sampler.go
@@ -204,15 +204,21 @@ func setMetric(s *pb.Span, key string, val float64) {
 	s.Metrics[key] = val
 }
 
-// GetSingleSpanSampledSpans searches chunk for spans that have a span sampling tag set.
-// If it finds such spans, then it replaces chunk's spans with only those spans,
-// and sets the chunk's sampling priority to "user keep." Tracers that wish to
-// keep certain spans even when the trace is dropped will set the appropriate
-// tags on the spans to be kept.
-// GetSingleSpanSampledSpans returns whether any changes were actually made.
-// Do not call GetSingleSpanSampledSpans on a chunk that the other samplers have
-// decided to keep. Doing so might wrongfully remove spans from a kept trace. TODO: edit comment
-func GetSingleSpanSampledSpans(pt *traceutil.ProcessedTrace) []*pb.Span {
+// SingleSpanSampling does single span sampling on the trace, returning true if the trace was modified
+func SingleSpanSampling(pt *traceutil.ProcessedTrace) bool {
+	ssSpans := getSingleSpanSampledSpans(pt)
+	if len(ssSpans) > 0 {
+		// Span sampling has kept some spans -> update the chunk
+		pt.TraceChunk.Spans = ssSpans
+		pt.TraceChunk.Priority = int32(PriorityUserKeep)
+		pt.TraceChunk.DroppedTrace = false
+		return true
+	}
+	return false
+}
+
+// GetSingleSpanSampledSpans searches chunk for spans that have a span sampling tag set and returns them.
+func getSingleSpanSampledSpans(pt *traceutil.ProcessedTrace) []*pb.Span {
 	var sampledSpans []*pb.Span
 	for _, span := range pt.TraceChunk.Spans {
 		if _, ok := traceutil.GetMetric(span, KeySpanSamplingMechanism); ok {

--- a/pkg/trace/sampler/sampler.go
+++ b/pkg/trace/sampler/sampler.go
@@ -204,16 +204,15 @@ func setMetric(s *pb.Span, key string, val float64) {
 	s.Metrics[key] = val
 }
 
-// ApplySpanSampling searches chunk for spans that have a span sampling tag set.
+// GetSingleSpanSampledSpans searches chunk for spans that have a span sampling tag set.
 // If it finds such spans, then it replaces chunk's spans with only those spans,
 // and sets the chunk's sampling priority to "user keep." Tracers that wish to
 // keep certain spans even when the trace is dropped will set the appropriate
 // tags on the spans to be kept.
-// ApplySpanSampling returns whether any changes were actually made.
-// Do not call ApplySpanSampling on a chunk that the other samplers have
-// decided to keep. Doing so might wrongfully remove spans from a kept trace.
-func ApplySpanSampling(pt *traceutil.ProcessedTrace) (bool, *traceutil.ProcessedTrace) {
-	pt = pt.Clone()
+// GetSingleSpanSampledSpans returns whether any changes were actually made.
+// Do not call GetSingleSpanSampledSpans on a chunk that the other samplers have
+// decided to keep. Doing so might wrongfully remove spans from a kept trace. TODO: edit comment
+func GetSingleSpanSampledSpans(pt *traceutil.ProcessedTrace) []*pb.Span {
 	var sampledSpans []*pb.Span
 	for _, span := range pt.TraceChunk.Spans {
 		if _, ok := traceutil.GetMetric(span, KeySpanSamplingMechanism); ok {
@@ -223,11 +222,7 @@ func ApplySpanSampling(pt *traceutil.ProcessedTrace) (bool, *traceutil.Processed
 	}
 	if sampledSpans == nil {
 		// No span sampling tags → no span sampling.
-		return false, pt
+		return nil
 	}
-
-	pt.TraceChunk.Spans = sampledSpans
-	pt.TraceChunk.Priority = int32(PriorityUserKeep)
-	pt.TraceChunk.DroppedTrace = false
-	return true, pt
+	return sampledSpans
 }

--- a/pkg/trace/sampler/spansampler_test.go
+++ b/pkg/trace/sampler/spansampler_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 // TestNoTagNoTouch verifies that if none of the spans passed to
-// ApplySpanSampling have the span sampling tag, then ApplySpanSampling does not
+// GetSingleSpanSampledSpans have the span sampling tag, then GetSingleSpanSampledSpans does not
 // modify its argument at all.
 func TestNoTagNoTouch(t *testing.T) {
 	original := &pb.TraceChunk{
@@ -43,14 +43,14 @@ func TestNoTagNoTouch(t *testing.T) {
 	}
 
 	pt := &traceutil.ProcessedTrace{TraceChunk: original}
-	applied, sampled := ApplySpanSampling(pt)
+	applied, sampled := GetSingleSpanSampledSpans(pt)
 	assert.False(t, applied)
 	assert.True(t, proto.Equal(sampled.TraceChunk, original))
 }
 
 // TestTagCausesInPlaceFilterAndKeep verifies that the presence of a span
-// sampling tag in any of the spans passed to ApplySpanSampling causes the
-// argument of ApplySpanSampling to be modified in the following ways:
+// sampling tag in any of the spans passed to GetSingleSpanSampledSpans causes the
+// argument of GetSingleSpanSampledSpans to be modified in the following ways:
 //   - The chunk is filtered to contain only those spans that have the span
 //     sampling tag.
 //   - The chunk's sampling priority is PriorityUserKeep.
@@ -112,7 +112,7 @@ func TestTagCausesInPlaceFilterAndKeep(t *testing.T) {
 	}
 
 	pt := &traceutil.ProcessedTrace{TraceChunk: original}
-	applied, sampled := ApplySpanSampling(pt)
+	applied, sampled := GetSingleSpanSampledSpans(pt)
 	assert.True(t, applied)
 	assert.False(t, sampled.TraceChunk.DroppedTrace)
 	assert.Equal(t, int32(PriorityUserKeep), sampled.TraceChunk.Priority)

--- a/pkg/trace/sampler/spansampler_test.go
+++ b/pkg/trace/sampler/spansampler_test.go
@@ -9,44 +9,12 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/protobuf/proto"
-
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 )
-
-// TestNoTagNoTouch verifies that if none of the spans passed to
-// GetSingleSpanSampledSpans have the span sampling tag, then GetSingleSpanSampledSpans does not
-// modify its argument at all.
-func TestNoTagNoTouch(t *testing.T) {
-	original := &pb.TraceChunk{
-		Spans: []*pb.Span{
-			{
-				Service:  "testsvc",
-				Name:     "parent",
-				TraceID:  1,
-				SpanID:   1,
-				Start:    time.Now().Add(-time.Second).UnixNano(),
-				Duration: time.Millisecond.Nanoseconds(),
-			},
-			{
-				Service:  "testsvc",
-				Name:     "child",
-				TraceID:  1,
-				SpanID:   2,
-				Start:    time.Now().Add(-time.Second).UnixNano(),
-				Duration: time.Millisecond.Nanoseconds(),
-			},
-		},
-	}
-
-	pt := &traceutil.ProcessedTrace{TraceChunk: original}
-	applied, sampled := GetSingleSpanSampledSpans(pt)
-	assert.False(t, applied)
-	assert.True(t, proto.Equal(sampled.TraceChunk, original))
-}
 
 // TestTagCausesInPlaceFilterAndKeep verifies that the presence of a span
 // sampling tag in any of the spans passed to GetSingleSpanSampledSpans causes the
@@ -111,14 +79,15 @@ func TestTagCausesInPlaceFilterAndKeep(t *testing.T) {
 		},
 	}
 
-	pt := &traceutil.ProcessedTrace{TraceChunk: original}
-	applied, sampled := GetSingleSpanSampledSpans(pt)
-	assert.True(t, applied)
-	assert.False(t, sampled.TraceChunk.DroppedTrace)
-	assert.Equal(t, int32(PriorityUserKeep), sampled.TraceChunk.Priority)
-	assert.Len(t, sampled.TraceChunk.Spans, 2)
+	ptChunk := proto.Clone(original).(*pb.TraceChunk)
+	pt := &traceutil.ProcessedTrace{TraceChunk: ptChunk}
+	modified := SingleSpanSampling(pt)
+	assert.True(t, modified)
+	assert.False(t, pt.TraceChunk.DroppedTrace)
+	assert.Equal(t, int32(PriorityUserKeep), pt.TraceChunk.Priority)
+	assert.Len(t, pt.TraceChunk.Spans, 2)
 	// child
-	assert.Equal(t, original.Spans[1], sampled.TraceChunk.Spans[0])
+	assert.Equal(t, original.Spans[1], pt.TraceChunk.Spans[0])
 	// great-grandchild
-	assert.Equal(t, original.Spans[3], sampled.TraceChunk.Spans[1])
+	assert.Equal(t, original.Spans[3], pt.TraceChunk.Spans[1])
 }

--- a/pkg/trace/testutil/generate.go
+++ b/pkg/trace/testutil/generate.go
@@ -32,6 +32,7 @@ type TraceConfig struct {
 }
 
 // GeneratePayload generates a new payload.
+// The last span of a generated trace is the "root" of that trace
 func GeneratePayload(n int, tc *TraceConfig, sc *SpanConfig) pb.Traces {
 	if n == 0 {
 		return pb.Traces{}

--- a/pkg/trace/traceutil/azure.go
+++ b/pkg/trace/traceutil/azure.go
@@ -37,7 +37,7 @@ const (
 	appService = "app"
 )
 
-var appServicesTags map[string]string
+var appServicesTags map[string]string //TODO: make this actually cache?
 
 func GetAppServicesTags() map[string]string {
 	if appServicesTags != nil {

--- a/pkg/trace/traceutil/azure.go
+++ b/pkg/trace/traceutil/azure.go
@@ -37,13 +37,8 @@ const (
 	appService = "app"
 )
 
-var appServicesTags map[string]string //TODO: make this actually cache?
-
 func GetAppServicesTags() map[string]string {
-	if appServicesTags != nil {
-		return appServicesTags
-	}
-	return getAppServicesTags(os.Getenv)
+	return getAppServicesTags(os.Getenv) //TODO: make this function cache these values
 }
 
 func getAppServicesTags(getenv func(string) string) map[string]string {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
A few things:
* Adds a new test to the integration tests to better ensure that normalization and obfuscation occurs
* Renames a few fields and functions in the `Process` function to better align with what they are
* Refactor the sampling done in the `Process` function to better consolidate it
  * This helped reveal some unnecessary `Clone` operations we were doing which should result in slightly better real world performance. However initial benchmarking has been too noisy to identify a consistent performance improvement.
  * Analytics events and single span sampling have been altered so instead of modifying the trace chunk directly they instead return which spans they would like to sample, and the higher level `sample` will decide to use those spans or not.
* Remove `TestNoTagNoTouch` since it doesn't _actually_ copy or verify that the tags aren't modified by the function. And the new function signature makes it clear the underlying `GetSingleSpanSampledSpans` doesn't modify the incoming parameters. In place of this I improved the `TestTagCausesInPlaceFilterAndKeep` test to REALLY copy the original payload and ensure that internal spans are not modified.
 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Tech debt.

In more detail: The Process function is long, difficult to reason about, and just generally "a bit of a mess" having had many features grafted on over the years. Specifically modifying sampling code has been extremely difficult as trace chunks were mutated internally and sampling logic was spread both inside and outside the Process function with mutation occurring in unexpected places. 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
I _believe_ that this makes the code clearer and may show some minor performance benefits from the removal of all the `clone` calls, however by allowing the structure to mutate with calls it's possible that future changes make this difficult to maintain long-term.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
This _should_ be a true refactor, however as mentioned in the motivation a lot of this code is confusing and bug-prone. I've taken great care to verify unit tests and integration tests as I go ensuring that changes that I make are well-covered before making them. However given the importance of this area of the trace-agent I think it's valuable to do a few short QA tests: (Note I have done these tests locally against the PR here but given the changes here I think it's worth doing them again as part of the QA process, I'm happy to help with any setup questions)

- [ ] Smoke test with default sampling rules and rates, Send much greater than 10TPS and ensure that sampling occurs and we see APPROXIMATELY 10TPS
- [ ] Test with analytics events (turns out these are used a bunch even though they're deprecated 😭). Enable analytics events with `DD_APM_ANALYZED_SPANS=service_name|operation_name=0.5` replacing service_name and operation_name with the span details you want.
- [ ] Test with sampled spans, use span sampling rules in the tracer to mark individual spans in a trace to be kept (and mark the whole traces as user manual drop). Ensure that only the span sampled spans appear in the UI.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
