### PR TITLE
Fix NPM kitchen test agent version selection

### DIFF
--- a/test/kitchen/test-definitions/windows-npm-test.md
+++ b/test/kitchen/test-definitions/windows-npm-test.md
@@ -2,32 +2,30 @@
 
 ## Test matrix
 
-The tests in this test file attempt to test all of the install/upgrade scenarios for installing the Windows agent with various install options.  Starting in 7.45, the installation option changed from a Windows feature (NPM) to a more general "allow closed source".  
+The tests in this test file attempt to test all of the install/upgrade scenarios for installing the Windows agent with various install options.  Starting in 7.45, the installation option changed from a Windows feature (NPM) to a more general "allow closed source".
 
-For these tests, then, installing/upgrading from an "old" version means <= 7.43.  
+For these tests, then, installing/upgrading from an "old" version means <= 7.43.
 Installing/upgrading from a "previous" version means > 7.43, but less than current version. (this is different for testing reacting
 to the way the new state is recorded).
 The "current" version is the version in test.
 
 
 Install scenarios expected
-1. Install old version with no NPM flag, install new version with closed source flag
+1. Install old version with no NPM flag, install new version
     - expect driver installed, system probe to enable & start
-2. Install old version with no NPM flag, install new version with no flags
+2. Install old version with no NPM flag, install new version
     - expect driver installed, disabled
-3. Install old version with NPM flag, install new version with no flags
+3. Install old version with NPM flag, install new version
     - expect install to detect NPM previously installed, results in system probe enabling/starting driver
-4. Install new version with no closed source flag
+4. Install new version with NPM disabled
     - expect driver installed, disabled
-5. Install new version with closed source flag
+5. Install new version with NPM enabled
     - expect driver installed, system probe to enable & start
-6. Install previous version with closed source flag, install new version with no flag
-    - expect previous setting to be maintained (driver installed, system probe starts it)
-7. Install version with no flag, reinstall same version with CS flag
+7. Install version with no flag, reinstall same version with ADDLOCAL=ALL
     - expect previous setting to be maintained (driver installed, system probe starts it)
 8.  Install version with ADDLOCAL=ALL
     - (driver installed, system probe starts it)
-9  Install version with ADDLOCAL=NPM
+9.  Install version with ADDLOCAL=NPM
 
 ## win-npm-upgrade-to-npm
 Scenario 1
@@ -43,7 +41,6 @@ Scenario 4
 
 ## win-npm-with-cs-option
 Scenario 5
- - currently failing
 
 ## Scenario 6 not currently enabled
 

--- a/test/kitchen/test-definitions/windows-npm-test.yml
+++ b/test/kitchen/test-definitions/windows-npm-test.yml
@@ -10,7 +10,7 @@ suites:
   attributes:
     datadog:
       agent_major_version: 7
-      agent_version: <%= ENV['LAST_STABLE_VERSION'] %>
+      agent_version: 7.42.0
       api_key: <%= api_key %>
       <% if ENV['AGENT_FLAVOR'] == 'datadog-iot-agent' %>
       agent_flavor: 'datadog-iot-agent'
@@ -56,7 +56,7 @@ suites:
   attributes:
     datadog:
       agent_major_version: 7
-      agent_version: <%= ENV['LAST_STABLE_VERSION'] %>
+      agent_version: 7.42.0
       api_key: <%= api_key %>
       <% if ENV['AGENT_FLAVOR'] == 'datadog-iot-agent' %>
       agent_flavor: 'datadog-iot-agent'
@@ -97,7 +97,7 @@ suites:
   attributes:
     datadog:
       agent_major_version: 7
-      agent_version: <%= ENV['LAST_STABLE_VERSION'] %>
+      agent_version: 7.42.0
       api_key: <%= api_key %>
       <% if ENV['AGENT_FLAVOR'] == 'datadog-iot-agent' %>
       agent_flavor: 'datadog-iot-agent'

--- a/test/kitchen/test-definitions/windows-npm-test.yml
+++ b/test/kitchen/test-definitions/windows-npm-test.yml
@@ -1,8 +1,8 @@
 suites:
 
 # Scenario 1
-# Install old version with no NPM flag, install new version with closed source flag
-#    - expect driver installed, system probe to enable & start
+# Install old version with no NPM flag, install new version
+#    - expect driver installed, enable NPM, expect system probe to enable & start
 - name: win-npm-upgrade-to-npm
   run_list:
     - "recipe[dd-agent-install]"
@@ -33,8 +33,6 @@ suites:
       <% if ENV['WINDOWS_AGENT_FILE'] %>
       windows_agent_filename: "<%= ENV['WINDOWS_AGENT_FILE'] %>"
       <% end %>
-      agent_install_options: >
-        ALLOWCLOSEDSOURCE=1
     dd-agent-import-conf:
       api_key: <%= api_key %>
     dd-agent-upgrade-rspec:
@@ -46,9 +44,9 @@ suites:
 
 
 
-# installs the current shipping latest build
-# then upgrades, and ensures that NPM not installed (due to lack of installation option)
-# scenario 2
+# Scenario 2
+# Install old version with no NPM flag, install new version
+#    - expect driver installed, does not enable NPM, expect NPM installed but not running
 - name: win-npm-upgrade-no-npm
   run_list:
     - "recipe[dd-agent-install]"
@@ -88,8 +86,8 @@ suites:
 
 
 # Scenario 3
-# Install old version with  NPM flag, install new version with no closed source flag
-#    - expect driver installed, system probe to enable & start
+# Install old version with NPM flag, install new version
+#    - expect driver installed, enable NPM, expect system probe to enable & start
 - name: win-npm-upgrade-to-npm-no-csflag
   run_list:
     - "recipe[dd-agent-install]"
@@ -132,6 +130,8 @@ suites:
 
 
 # Scenario 4
+# Install latest
+#    - expect driver installed, does not enable NPM, expect NPM installed but not running
 - name: win-npm-no-npm-option
   run_list:
     - "recipe[dd-agent-install]"
@@ -156,7 +156,9 @@ suites:
       agent_flavor: <%= ENV['AGENT_FLAVOR'] || "datadog-agent" %>
       skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>
 
-#Scenario 5
+# Scenario 5
+# Install latest
+#    - expect driver installed, enable NPM, expect system probe to enable & start
 - name: win-npm-with-cs-option
   run_list:
     - "recipe[dd-agent-install]"
@@ -176,14 +178,14 @@ suites:
       <% if ENV['WINDOWS_AGENT_FILE'] %>
       windows_agent_filename: "<%= ENV['WINDOWS_AGENT_FILE'] %>"
       <% end %>
-      agent_install_options: >
-        ALLOWCLOSEDSOURCE=1
       enable_testsigning: <%= ENV['WINDOWS_DDNPM_DRIVER'] == "testsigned" %>
     dd-agent-rspec:
       agent_flavor: <%= ENV['AGENT_FLAVOR'] || "datadog-agent" %>
       skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>
 
-# scenario 7
+# Scenario 7
+# Install latest, reinstall latest with ADDLOCAL=ALL to test old option compat
+#    - expect driver installed, enable NPM, expect system probe to enable & start
 - name: win-npm-reinstall-option
   run_list:
     - "recipe[dd-agent-install]"
@@ -219,7 +221,9 @@ suites:
       agent_flavor: <%= ENV['AGENT_FLAVOR'] || "datadog-agent" %>
       skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>
 
-#Scenario 8
+# Scenario 8
+# Install latest with ADDLOCAL=ALL to test old option compat
+#    - expect driver installed, enable NPM, expect system probe to enable & start
 - name: win-npm-with-addlocal-all
   run_list:
     - "recipe[dd-agent-install]"
@@ -247,7 +251,9 @@ suites:
       skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>
 
 
-#Scenario 9
+# Scenario 9
+# Install latest with ADDLOCAL=NPM to test old option compat
+#    - expect driver installed, enable NPM, expect system probe to enable & start
 - name: win-npm-with-addlocal-npm
   run_list:
     - "recipe[dd-agent-install]"
@@ -274,6 +280,9 @@ suites:
       agent_flavor: <%= ENV['AGENT_FLAVOR'] || "datadog-agent" %>
       skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>
 
+# Scenario 10
+# Install original NPM beta version, upgrade to latest
+#    - expect driver installed, enable NPM, expect system probe to enable & start
 - name: win-npm-beta-upgrade
   run_list:
     - "recipe[dd-agent-install]"

--- a/test/kitchen/test/integration/win-npm-beta-upgrade/rspec_datadog/win-npm-beta-upgrade_spec.rb
+++ b/test/kitchen/test/integration/win-npm-beta-upgrade/rspec_datadog/win-npm-beta-upgrade_spec.rb
@@ -5,5 +5,6 @@ describe 'the agent upgraded from npm beta' do
   it_behaves_like 'an installed Agent'
   it_behaves_like 'a running Agent with no errors'
   it_behaves_like 'a Windows Agent with NPM driver installed'
+  it_behaves_like 'a Windows Agent with NPM running'
   it_behaves_like 'an upgraded Agent with the expected version'
 end


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Pin the correct agent version in the NPM kitchen tests.

Update the test README since the ALLOWCLOSEDSOURCE option didn't make it into the final design.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The NPM install kitchen test is supposed to upgrade from v7.42.0 (or some other version before 7.45's NPM install changes) but set the wrong chef option so it was installing `LAST_STABLE_VERSION` instead.

https://datadoghq.atlassian.net/browse/WA-478

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
successful [pipeline](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/20171655) on 7.47

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
