### PR TITLE
[Windows] Update overlapped reader

### DIFF
--- a/pkg/windowsdriver/include/procmonapi.h
+++ b/pkg/windowsdriver/include/procmonapi.h
@@ -16,7 +16,7 @@ typedef __int64 LONG64;
 typedef unsigned char       uint8_t;
 
 // define a version signature so that the driver won't load out of date structures, etc.
-#define DD_PROCMONDRIVER_VERSION       0x01
+#define DD_PROCMONDRIVER_VERSION       0x02
 #define DD_PROCMONDRIVER_SIGNATURE     ((uint64_t)0xDD01 << 32 | DD_PROCMONDRIVER_VERSION)
 #define DD_PROCMONDRIVER_DEVICE_TYPE   FILE_DEVICE_UNKNOWN
 // for more information on defining control codes, see
@@ -26,14 +26,19 @@ typedef unsigned char       uint8_t;
 
 
 
-#define DDPROCMONDRIVER_IOCTL_GET_NEWPROCS  CTL_CODE(DD_PROCMONDRIVER_DEVICE_TYPE, \
+#define DDPROCMONDRIVER_IOCTL_START  CTL_CODE(DD_PROCMONDRIVER_DEVICE_TYPE, \
                                               0x801, \
-                                              METHOD_BUFFERED,\
+                                              METHOD_OUT_DIRECT,\
                                               FILE_ANY_ACCESS)
 
-#define DDPROCMONDRIVER_IOCTL_GET_DEADPROCS  CTL_CODE(DD_PROCMONDRIVER_DEVICE_TYPE, \
+#define DDPROCMONDRIVER_IOCTL_STOP  CTL_CODE(DD_PROCMONDRIVER_DEVICE_TYPE, \
                                               0x802, \
-                                              METHOD_BUFFERED,\
+                                              METHOD_OUT_DIRECT,\
+                                              FILE_ANY_ACCESS)
+
+#define DDPROCMONDRIVER_IOCTL_GETSTATS  CTL_CODE(DD_PROCMONDRIVER_DEVICE_TYPE, \
+                                              0x803, \
+                                              METHOD_OUT_DIRECT,\
                                               FILE_ANY_ACCESS)
 
 typedef enum _dd_notify_type {
@@ -41,6 +46,15 @@ typedef enum _dd_notify_type {
     DD_NOTIFY_START = 1,
 } DD_NOTIFY_TYPE;
 
+typedef struct _dd_procmon_stats {
+    uint64_t            processStartCount;
+    uint64_t            processStopCount;
+
+    uint64_t            missedNotifications;
+    uint64_t            allocationFailures;
+    uint64_t            workItemFailures;
+
+} DD_PROCMON_STATS;
 
 typedef struct _dd_process_notification {
     uint64_t            size;  // total size of structure.

--- a/pkg/windowsdriver/olreader/olreader.go
+++ b/pkg/windowsdriver/olreader/olreader.go
@@ -141,6 +141,7 @@ func (olr *OverlappedReader) Stop() {
 	olr.cleanBuffers()
 }
 
+// Ioctl passes an ioctl() through to the underlying handle
 func (olr *OverlappedReader) Ioctl(ioControlCode uint32, inBuffer *byte, inBufferSize uint32, outBuffer *byte, outBufferSize uint32, bytesReturned *uint32, overlapped *windows.Overlapped) (err error) {
 	return windows.DeviceIoControl(olr.h, ioControlCode, inBuffer, inBufferSize, outBuffer, outBufferSize, bytesReturned, overlapped)
 }

--- a/pkg/windowsdriver/olreader/olreader.go
+++ b/pkg/windowsdriver/olreader/olreader.go
@@ -140,6 +140,10 @@ func (olr *OverlappedReader) Stop() {
 	olr.wg.Wait()
 	olr.cleanBuffers()
 }
+
+func (olr *OverlappedReader) Ioctl(ioControlCode uint32, inBuffer *byte, inBufferSize uint32, outBuffer *byte, outBufferSize uint32, bytesReturned *uint32, overlapped *windows.Overlapped) (err error) {
+	return windows.DeviceIoControl(olr.h, ioControlCode, inBuffer, inBufferSize, outBuffer, outBufferSize, bytesReturned, overlapped)
+}
 func (olr *OverlappedReader) initiateReads() error {
 	for _, buf := range olr.buffers {
 		err := windows.ReadFile(olr.h, buf.data[:], nil, &(buf.ol))

--- a/pkg/windowsdriver/procmon/procmon.go
+++ b/pkg/windowsdriver/procmon/procmon.go
@@ -80,7 +80,10 @@ func (wp *WinProcmon) OnError(err error) {
 
 }
 func (wp *WinProcmon) Stop() {
-	wp.reader.Ioctl(ProcmonStopIOCTL,
+	// since we're stopping, if for some reason this ioctl fails, there's nothing we can
+	// do, we're on our way out.  Closing the handle will ultimately cause the same cleanup
+	// to happen.
+	_ = wp.reader.Ioctl(ProcmonStopIOCTL,
 		nil, // inBuffer
 		0,
 		nil,

--- a/pkg/windowsdriver/procmon/procmon.go
+++ b/pkg/windowsdriver/procmon/procmon.go
@@ -80,10 +80,33 @@ func (wp *WinProcmon) OnError(err error) {
 
 }
 func (wp *WinProcmon) Stop() {
+	wp.reader.Ioctl(ProcmonStopIOCTL,
+		nil, // inBuffer
+		0,
+		nil,
+		0,
+		nil,
+		nil)
 	wp.reader.Stop()
 }
 func (wp *WinProcmon) Start() error {
-	return wp.reader.Read()
+	err := wp.reader.Read()
+	if err != nil {
+		return err
+	}
+	// this will initiate the driver actually sending things up
+	// start grabbing notifications
+	err = wp.reader.Ioctl(ProcmonStartIOCTL,
+		nil, // inBuffer
+		0,
+		nil,
+		0,
+		nil,
+		nil)
+	if err != nil {
+		wp.reader.Stop()
+	}
+	return err
 }
 
 func decodeStruct(data []uint8, sz uint32) (t DDProcessNotifyType, pid uint64, imagefile, cmdline string, consumed uint32) {

--- a/pkg/windowsdriver/procmon/types.go
+++ b/pkg/windowsdriver/procmon/types.go
@@ -21,9 +21,19 @@ import "C"
 const Signature = C.DD_PROCMONDRIVER_SIGNATURE
 
 const (
+	ProcmonStartIOCTL = C.DDPROCMONDRIVER_IOCTL_START
+	ProcmonStopIOCTL  = C.DDPROCMONDRIVER_IOCTL_STOP
+	ProcmonStatsIOCTL = C.DDPROCMONDRIVER_IOCTL_GETSTATS
+
+	ProcmonSignature = C.DD_PROCMONDRIVER_SIGNATURE
+)
+
+const (
 	ProcmonNotifyStop  = C.DD_NOTIFY_STOP
 	ProcmonNotifyStart = C.DD_NOTIFY_START
 )
+
+type DDProcmonStats C.struct__dd_procmon_stats
 
 type DDProcessNotifyType C.enum__dd_notify_type
 type DDProcessNotification C.struct__dd_process_notification

--- a/pkg/windowsdriver/procmon/types_windows.go
+++ b/pkg/windowsdriver/procmon/types_windows.go
@@ -3,12 +3,28 @@
 
 package procmon
 
-const Signature = 0xdd0100000001
+const Signature = 0xdd0100000002
+
+const (
+	ProcmonStartIOCTL = 0x222006
+	ProcmonStopIOCTL  = 0x22200a
+	ProcmonStatsIOCTL = 0x22200e
+
+	ProcmonSignature = 0xdd0100000002
+)
 
 const (
 	ProcmonNotifyStop  = 0x0
 	ProcmonNotifyStart = 0x1
 )
+
+type DDProcmonStats struct {
+	ProcessStartCount   uint64
+	ProcessStopCount    uint64
+	MissedNotifications uint64
+	AllocationFailures  uint64
+	WorkItemFailures    uint64
+}
 
 type DDProcessNotifyType uint32
 type DDProcessNotification struct {


### PR DESCRIPTION
Adds capability to send an ioctl via the same filehandle. Expands use for process monitor


### Motivation


### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes


### Reviewer's Checklist
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
