### PR TITLE
[oracle] Removing unused code

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/activity.go
+++ b/pkg/collector/corechecks/oracle-dbm/activity.go
@@ -288,7 +288,6 @@ func (c *Check) getSQLRow(SQLID sql.NullString, forceMatchingSignature *string, 
 	SQLRow := OracleSQLRow{}
 	if SQLID.Valid {
 		SQLRow.SQLID = SQLID.String
-		c.statementsFilter.SQLIDs[SQLID.String] = 1
 	} else {
 		SQLRow.SQLID = ""
 		return SQLRow, nil
@@ -299,7 +298,6 @@ func (c *Check) getSQLRow(SQLID sql.NullString, forceMatchingSignature *string, 
 			return SQLRow, fmt.Errorf("failed converting force_matching_signature to uint64 %w", err)
 		}
 		SQLRow.ForceMatchingSignature = forceMatchingSignatureUint64
-		c.statementsFilter.ForceMatchingSignatures[*forceMatchingSignature] = 1
 	} else {
 		SQLRow.ForceMatchingSignature = 0
 	}
@@ -314,19 +312,6 @@ func (c *Check) getSQLRow(SQLID sql.NullString, forceMatchingSignature *string, 
 
 func (c *Check) SampleSession() error {
 	start := time.Now()
-
-	if c.statementsFilter.SQLIDs == nil {
-		c.statementsFilter.SQLIDs = make(map[string]int)
-	}
-	if c.statementsFilter.ForceMatchingSignatures == nil {
-		c.statementsFilter.ForceMatchingSignatures = make(map[string]int)
-	}
-	if c.statementsCache.SQLIDs == nil {
-		c.statementsCache.SQLIDs = make(map[string]StatementsCacheData)
-	}
-	if c.statementsCache.forceMatchingSignatures == nil {
-		c.statementsCache.forceMatchingSignatures = make(map[string]StatementsCacheData)
-	}
 
 	var sessionRows []OracleActivityRow
 	sessionSamples := []OracleActivityRowDB{}

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -56,23 +56,6 @@ type hostingType struct {
 	valid bool
 }
 
-// The structure is filled by activity sampling and serves as a filter for query metrics
-type StatementsFilter struct {
-	SQLIDs                  map[string]int
-	ForceMatchingSignatures map[string]int
-}
-
-type StatementsCacheData struct {
-	statement      string
-	querySignature string
-	tables         []string
-	commands       []string
-}
-type StatementsCache struct {
-	SQLIDs                  map[string]StatementsCacheData
-	forceMatchingSignatures map[string]StatementsCacheData
-}
-
 type pgaOverAllocationCount struct {
 	value float64
 	valid bool
@@ -90,10 +73,6 @@ type Check struct {
 	tags                                    []string
 	tagsString                              string
 	cdbName                                 string
-	statementsFilter                        StatementsFilter
-	statementsCache                         StatementsCache
-	DDstatementsCache                       StatementsCache
-	DDPrevStatementsCache                   StatementsCache
 	statementMetricsMonotonicCountsPrevious map[StatementMetricsKeyDB]StatementMetricsMonotonicCountDB
 	dbHostname                              string
 	dbVersion                               string

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -965,11 +965,6 @@ func (c *Check) StatementMetrics() (int, error) {
 	}
 	sender.Commit()
 
-	c.statementsFilter.SQLIDs = nil
-	c.statementsFilter.ForceMatchingSignatures = nil
-	c.statementsCache.SQLIDs = nil
-	c.statementsCache.forceMatchingSignatures = nil
-
 	if planErrors > 0 {
 		return SQLCount, fmt.Errorf("SQL statements processed: %d, plan errors: %d", SQLCount, planErrors)
 	}

--- a/pkg/collector/corechecks/oracle-dbm/statements_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements_test.go
@@ -59,7 +59,6 @@ func TestUInt64Binding(t *testing.T) {
 
 		m := make(map[string]int)
 		m["2267897546238586672"] = 1
-		chk.statementsFilter = StatementsFilter{ForceMatchingSignatures: m}
 
 		err = chk.db.Get(&r, "select force_matching_signature, sql_text from v$sqlstats where sql_text like '%t111%'") // force_matching_signature=17202440635181618732
 		assert.NoError(t, err, "running statement with large force_matching_signature with %s driver", driver)


### PR DESCRIPTION
### What does this PR do?

Removing unused code that was a part of the old query metrics algorithm.

### Motivation

The unused code was causing linter errors when I tried to generate a new custom build:

```
pkg/collector/corechecks/oracle-dbm/oracle.go:65:2: field `statement` is unused (unused)
	statement      string
	^
pkg/collector/corechecks/oracle-dbm/oracle.go:66:2: field `querySignature` is unused (unused)
	querySignature string
	^
pkg/collector/corechecks/oracle-dbm/oracle.go:67:2: field `tables` is unused (unused)
	tables         []string
	^
pkg/collector/corechecks/oracle-dbm/oracle.go:68:2: field `commands` is unused (unused)
	commands       []string
	^
```

Interestingly, no linter errors were generated in the recent PRs.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Describe how to test/QA your changes

n/a

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
