### PR TITLE
Handle differences between GNU and BSD stat command

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -90,7 +90,6 @@ function prepare_dmg_file() {
         file_size=$(stat -f %z "$dmg_file_to_prepare")
     fi
 
-    
     if [[ "$file_owner" -ne 0 ]] || [[ "$file_permission" -ne 600 ]] || [[ "$file_size" -ne 0 ]]; then
         echo -e "\033[31mFailed to prepare datadog-agent dmg file\033[0m\n"
         exit 1;
@@ -461,4 +460,3 @@ If you ever want to stop the Agent, please use the the launchctl command.
 The Agent will start automatically at system startup.
 \033[0m"
 fi
-

--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -80,9 +80,17 @@ function prepare_dmg_file() {
     $sudo_cmd touch "$dmg_file_to_prepare"
     $sudo_cmd chmod 600 "$dmg_file_to_prepare"
 
-    file_owner=$(stat -c %u "$dmg_file_to_prepare")
-    file_permission=$(stat -c %a "$dmg_file_to_prepare")
-    file_size=$(stat -c %s "$dmg_file_to_prepare")
+    if stat --help >/dev/null 2>&1; then # Handle differences between GNU and BSD stat command
+        file_owner=$(stat -c %u "$dmg_file_to_prepare")
+        file_permission=$(stat -c %a "$dmg_file_to_prepare")
+        file_size=$(stat -c %s "$dmg_file_to_prepare")
+    else
+        file_owner=$(stat -f %u "$dmg_file_to_prepare")
+        file_permission=$(stat -f %OLp "$dmg_file_to_prepare")
+        file_size=$(stat -f %z "$dmg_file_to_prepare")
+    fi
+
+    
     if [[ "$file_owner" -ne 0 ]] || [[ "$file_permission" -ne 600 ]] || [[ "$file_size" -ne 0 ]]; then
         echo -e "\033[31mFailed to prepare datadog-agent dmg file\033[0m\n"
         exit 1;
@@ -453,3 +461,4 @@ If you ever want to stop the Agent, please use the the launchctl command.
 The Agent will start automatically at system startup.
 \033[0m"
 fi
+


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Had a check to use the correct format for `stat` command.
This is needed to have the script working properly on MacOS using BSD stat command (all MacOS by default) and MacOS using a GNU version of the `stat` command (like our laptop)
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fix install script for MacOS
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
