### PR TITLE
Fix Agent version in installer

### DIFF
--- a/tools/windows/DatadogAgentInstaller/WixSetup.Tests/AgentVersionTests.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup.Tests/AgentVersionTests.cs
@@ -6,7 +6,7 @@ namespace WixSetup.Tests
     public class AgentVersionTests
     {
         [Fact]
-        public void Should_Version_Be_7_99_0_1_By_Default()
+        public void Should_Version_Be_7_99_0_0_By_Default()
         {
             // Explicit null to avoid env var influence.
             var version = new Datadog.AgentVersion(null);
@@ -14,7 +14,7 @@ namespace WixSetup.Tests
             version.Version.Major.Should().Be(7);
             version.Version.Minor.Should().Be(99);
             version.Version.Build.Should().Be(0);
-            version.Version.Revision.Should().Be(1);
+            version.Version.Revision.Should().Be(0);
         }
 
         [Fact]
@@ -26,7 +26,7 @@ namespace WixSetup.Tests
             version.Version.Major.Should().Be(6);
             version.Version.Minor.Should().Be(35);
             version.Version.Build.Should().Be(0);
-            version.Version.Revision.Should().Be(1);
+            version.Version.Revision.Should().Be(0);
         }
 
         [Fact]

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -123,6 +123,9 @@ namespace WixSetup.Datadog
                     Win64 = true
                 }
             );
+            // Always generate a new GUID otherwise WixSharp will generate one based on
+            // the version
+            project.ProductId = Guid.NewGuid();
             project
                 .SetCustomActions(_agentCustomActions)
                 .SetProjectInfo(

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentVersion.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentVersion.cs
@@ -19,7 +19,7 @@ namespace WixSetup.Datadog
         public AgentVersion(string packageVersion)
         {
             PackageVersion = packageVersion;
-            Version = new Version(7, 99, 0, 1);
+            Version = new Version(7, 99, 0, 0);
             if (PackageVersion != null)
             {
                 var versionRegex = new Regex(@"(?<major>\d+)[.](?<minor>\d+)[.](?<build>\d+)([-~]rc.(?<rc>\d+))?");
@@ -39,7 +39,7 @@ namespace WixSetup.Datadog
                         major: versionMatch.Groups["major"].Value.ToInt(),
                         minor: versionMatch.Groups["minor"].Value.ToInt(),
                         build: versionMatch.Groups["build"].Value.ToInt(),
-                        revision: 1
+                        revision: 0
                     );
                 }
             }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR fixes the version numbering of the Windows installer, now the patch version starts at 0.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Previously the patch version started at 1, meaning that RC.1 and stable released version shared the same version number (e.g. `7.47.0` and `7.47.0.1` were equal).
Since WixSharp uses the version number to generate the product code, this can cause conflict between supposedly differing installer version that end up sharing the same product code.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
