### PR TITLE
pkg/trace/api: fix flaky TestReceiverRequestBodyLength

### DIFF
--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -89,32 +89,35 @@ func TestReceiverRequestBodyLength(t *testing.T) {
 
 	// Before going further, make sure receiver is started
 	// since it's running in another goroutine
-	for i := 0; i < 10; i++ {
+	serverReady := false
+	for i := 0; i < 100; i++ {
 		var client http.Client
 
 		body := bytes.NewBufferString("[]")
 		req, err := http.NewRequest("POST", url, body)
-		assert.Nil(err)
+		assert.NoError(err)
 
 		resp, err := client.Do(req)
 		if err == nil {
 			resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
+				serverReady = true
 				break
 			}
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
 
+	assert.True(serverReady)
 	testBody := func(expectedStatus int, bodyData string) {
 		var client http.Client
 
 		body := bytes.NewBufferString(bodyData)
 		req, err := http.NewRequest("POST", url, body)
-		assert.Nil(err)
+		assert.NoError(err)
 
 		resp, err := client.Do(req)
-		assert.Nil(err)
+		assert.NoError(err)
 		assert.Equal(expectedStatus, resp.StatusCode)
 		resp.Body.Close()
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

- Fix flaky `TestReceiverRequestBodyLength` by waiting more on the server to be ready, 1s instead of 100ms.
- Fail fast if the server is not ready after 1s.
- Print meaningful error messages when the test fails by using `assert.NoError(err)` instead of `assert.Nil(err)`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Wasn't able to reproduce locally, example from the CI https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/331779462

```
=== Failed
=== FAIL: api TestReceiverRequestBodyLength (0.91s)
    api_test.go:117: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/pkg/trace/api/api_test.go:117
        	            				/go/src/github.com/DataDog/datadog-agent/pkg/trace/api/api_test.go:122
        	Error:      	Expected nil, but got: &url.Error{Op:"Post", URL:"http://localhost:8126/v0.4/traces", Err:(*net.OpError)(0xc000492c30)}
        	Test:       	TestReceiverRequestBodyLength
```

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
