### PR TITLE
[CWS] option to enable TTY fallback

### DIFF
--- a/pkg/security/module/cws_linux.go
+++ b/pkg/security/module/cws_linux.go
@@ -17,6 +17,7 @@ func getFamilyAddress(config *config.RuntimeSecurityConfig) (string, string) {
 // UpdateEventMonitorOpts adapt the event monitor options
 func UpdateEventMonitorOpts(opts *eventmonitor.Opts) {
 	opts.ProbeOpts.PathResolutionEnabled = true
+	opts.ProbeOpts.TTYFallbackEnabled = true
 }
 
 // DisableRuntimeSecurity disables all the runtime security features

--- a/pkg/security/probe/opts_linux.go
+++ b/pkg/security/probe/opts_linux.go
@@ -25,6 +25,8 @@ type Opts struct {
 	TagsResolver tags.Resolver
 	// SyscallsMapMonitorEnabled enable syscalls map monitor
 	SyscallsMapMonitorEnabled bool
+	// TTYFallbackEnabled enable the tty procfs fallback
+	TTYFallbackEnabled bool
 }
 
 func (o *Opts) normalize() {

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -1611,6 +1611,7 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 		PathResolutionEnabled: opts.PathResolutionEnabled,
 		TagsResolver:          opts.TagsResolver,
 		UseRingBuffer:         useRingBuffers,
+		TTYFallbackEnabled:    opts.TTYFallbackEnabled,
 	}
 	p.resolvers, err = resolvers.NewResolvers(config, p.Manager, p.StatsdClient, p.scrubber, p.Erpc, resolversOpts)
 	if err != nil {

--- a/pkg/security/resolvers/process/resolver_linux.go
+++ b/pkg/security/resolvers/process/resolver_linux.go
@@ -58,7 +58,8 @@ const (
 
 // ResolverOpts options of resolver
 type ResolverOpts struct {
-	envsWithValue map[string]bool
+	ttyFallbackEnabled bool
+	envsWithValue      map[string]bool
 }
 
 // Resolver resolved process context
@@ -1016,7 +1017,7 @@ func (p *Resolver) GetProcessEnvp(pr *model.Process) ([]string, bool) {
 
 // SetProcessTTY resolves TTY and cache the result
 func (p *Resolver) SetProcessTTY(pce *model.ProcessCacheEntry) string {
-	if pce.TTYName == "" {
+	if pce.TTYName == "" && p.opts.ttyFallbackEnabled {
 		tty := utils.PidTTY(pce.Pid)
 		pce.TTYName = tty
 	}
@@ -1371,6 +1372,12 @@ func (o *ResolverOpts) WithEnvsValue(envsWithValue []string) *ResolverOpts {
 	for _, envVar := range envsWithValue {
 		o.envsWithValue[envVar] = true
 	}
+	return o
+}
+
+// WithTTYFallbackEnabled enables the TTY fallback
+func (o *ResolverOpts) WithTTYFallbackEnabled() *ResolverOpts {
+	o.ttyFallbackEnabled = true
 	return o
 }
 

--- a/pkg/security/resolvers/resolvers_linux.go
+++ b/pkg/security/resolvers/resolvers_linux.go
@@ -45,6 +45,7 @@ type Opts struct {
 	PathResolutionEnabled bool
 	TagsResolver          tags.Resolver
 	UseRingBuffer         bool
+	TTYFallbackEnabled    bool
 }
 
 // Resolvers holds the list of the event attribute resolvers
@@ -131,6 +132,9 @@ func NewResolvers(config *config.Config, manager *manager.Manager, statsdClient 
 
 	processOpts := process.NewResolverOpts()
 	processOpts.WithEnvsValue(config.Probe.EnvsWithValue)
+	if opts.TTYFallbackEnabled {
+		processOpts.WithTTYFallbackEnabled()
+	}
 
 	processResolver, err := process.NewResolver(manager, config.Probe, statsdClient,
 		scrubber, containerResolver, mountResolver, cgroupsResolver, userGroupResolver, timeResolver, pathResolver, processOpts)

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -942,6 +942,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 			DontDiscardRuntime:        true,
 			PathResolutionEnabled:     true,
 			SyscallsMapMonitorEnabled: true,
+			TTYFallbackEnabled:        true,
 		},
 	}
 	if opts.tagsResolver != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Add an option to disable the TTY Fallback for non CWS event monitor consumers. This should improve the CPU impact.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
