### PR TITLE
[CWS] SECL policies memory size improvements

### DIFF
--- a/pkg/security/secl/compiler/eval/strings.go
+++ b/pkg/security/secl/compiler/eval/strings.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"golang.org/x/exp/slices"
 )
 
 // StringCmpOpts defines options to apply during string comparison
@@ -30,7 +32,7 @@ type StringValues struct {
 	stringMatchers []StringMatcher
 
 	// caches
-	scalarCache map[string]bool
+	scalarCache []string
 	fieldValues []FieldValue
 
 	exists map[interface{}]bool
@@ -43,10 +45,6 @@ func (s *StringValues) GetFieldValues() []FieldValue {
 
 // AppendFieldValue append a FieldValue
 func (s *StringValues) AppendFieldValue(value FieldValue) {
-	if s.scalarCache == nil {
-		s.scalarCache = make(map[string]bool)
-	}
-
 	if s.exists[value.Value] {
 		return
 	}
@@ -69,7 +67,7 @@ func (s *StringValues) Compile(opts StringCmpOpts) error {
 		if opts == DefaultStringCmpOpts && value.Type == ScalarValueType {
 			str := value.Value.(string)
 			s.scalars = append(s.scalars, str)
-			s.scalarCache[str] = true
+			s.scalarCache = append(s.scalarCache, str)
 		} else {
 			str, ok := value.Value.(string)
 			if !ok {
@@ -118,7 +116,7 @@ func (s *StringValues) AppendScalarValue(value string) {
 
 // Matches returns whether the value matches the string values
 func (s *StringValues) Matches(value string) bool {
-	if s.scalarCache != nil && s.scalarCache[value] {
+	if slices.Contains(s.scalarCache, value) {
 		return true
 	}
 	for _, pm := range s.stringMatchers {

--- a/pkg/security/secl/compiler/eval/strings.go
+++ b/pkg/security/secl/compiler/eval/strings.go
@@ -34,8 +34,6 @@ type StringValues struct {
 	// caches
 	scalarCache []string
 	fieldValues []FieldValue
-
-	exists map[interface{}]bool
 }
 
 // GetFieldValues return the list of FieldValue stored in the StringValues
@@ -45,13 +43,9 @@ func (s *StringValues) GetFieldValues() []FieldValue {
 
 // AppendFieldValue append a FieldValue
 func (s *StringValues) AppendFieldValue(value FieldValue) {
-	if s.exists[value.Value] {
+	if slices.Contains(s.fieldValues, value) {
 		return
 	}
-	if s.exists == nil {
-		s.exists = make(map[interface{}]bool)
-	}
-	s.exists[value.Value] = true
 
 	if value.Type == ScalarValueType {
 		s.scalars = append(s.scalars, value.Value.(string))
@@ -100,7 +94,6 @@ func (s *StringValues) SetFieldValues(values ...FieldValue) error {
 	// reset internal caches
 	s.stringMatchers = s.stringMatchers[:0]
 	s.scalarCache = nil
-	s.exists = nil
 
 	for _, value := range values {
 		s.AppendFieldValue(value)

--- a/pkg/security/secl/compiler/eval/strings_test.go
+++ b/pkg/security/secl/compiler/eval/strings_test.go
@@ -8,6 +8,8 @@ package eval
 
 import (
 	"testing"
+
+	"golang.org/x/exp/slices"
 )
 
 func TestStringValues(t *testing.T) {
@@ -19,7 +21,7 @@ func TestStringValues(t *testing.T) {
 			t.Error(err)
 		}
 
-		if !values.scalarCache["test123"] {
+		if !slices.Contains(values.scalarCache, "test123") {
 			t.Error("expected cache key not found")
 		}
 
@@ -36,7 +38,7 @@ func TestStringValues(t *testing.T) {
 			t.Error(err)
 		}
 
-		if values.scalarCache["test123"] {
+		if slices.Contains(values.scalarCache, "test123") {
 			t.Error("expected cache key found")
 		}
 


### PR DESCRIPTION
### What does this PR do?

This PR implements improvements to the memory size of SECL policies, around `StringValues`:
- removal of the `exists` map (the `fieldValues` plays this role perfectly already)
- convert `scalarCache` to a slice

This PR has no CPU performance impact. The rule evaluation is already nearly a non-concern from the system probe point of view, and even in the rule evaluation path most of the time is spent resolving paths (and then caching it)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
