### PR TITLE
[CI] Pin `setuptools-scm` to `7.1.0` for RPM

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -283,6 +283,11 @@ build do
     # Adding pympler for memory debug purposes
     requirements.push("pympler==0.7")
 
+    # Pinning setuptools-scm to 7.1.0 while we're fixing the CI (see https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/332672478)
+    if redhat?
+      requirements.push("setuptools-scm==7.1.0")
+    end
+
     # Render the filtered requirements file
     erb source: "static_requirements.txt.erb",
         dest: "#{static_reqs_out_file}",

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -222,6 +222,7 @@ build do
                 # We force reinstall it from source to be sure we use the flag
                 "PIP_NO_CACHE_DIR" => "off",
                 "PIP_FORCE_REINSTALL" => "1",
+                "PIP_NO_BUILD_ISOLATION" => "off"
             }
         )
     end

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -283,10 +283,6 @@ build do
     # Adding pympler for memory debug purposes
     requirements.push("pympler==0.7")
 
-    # Pinning setuptools-scm to 7.1.0 while we're fixing the CI (see https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/332672478)
-    if redhat? && !arm?
-      requirements.push("setuptools-scm==7.1.0")
-    end
 
     # Render the filtered requirements file
     erb source: "static_requirements.txt.erb",
@@ -345,6 +341,10 @@ build do
       # Then we install the rest (already installed libraries will be ignored) with the main flags
       command "#{python} -m pip install --no-deps --require-hashes -r #{windows_safe_path(install_dir)}\\#{agent_requirements_file}", :env => win_build_env
     else
+      # Pinning setuptools-scm to 7.1.0 while we're fixing the CI (see https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/332672478)
+      if redhat? && !arm?
+        command "#{python} -m pip install setuptools-scm==7.1.0", :env => nix_build_env
+      end
       # First we install the dependencies that need specific flags
       specific_build_env.each do |lib, env|
         command "#{python} -m pip install --no-deps --require-hashes -r #{install_dir}/agent_#{lib}_requirements-py3.txt", :env => env

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -284,7 +284,7 @@ build do
     requirements.push("pympler==0.7")
 
     # Pinning setuptools-scm to 7.1.0 while we're fixing the CI (see https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/332672478)
-    if redhat?
+    if redhat? && !arm?
       requirements.push("setuptools-scm==7.1.0")
     end
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR pins `setuptools-scm` to `7.1.0` for RPM build.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This is a temporary fix to have the CI back up to avoid introducing bugs while the RPM build is broken.

We need to fix `agent_rpm-x64-a6` and `agent_rpm-x64-a7` without this hack.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
