### PR TITLE
[oracle] Improve cache handling

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/cache_wrapper.go
+++ b/pkg/collector/corechecks/oracle-dbm/cache_wrapper.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle
+
+package oracle
+
+import (
+	"time"
+
+	cache "github.com/patrickmn/go-cache"
+)
+
+func newCache(retention int) *cache.Cache {
+	return cache.New(time.Duration(retention)*time.Minute, 10*time.Minute)
+}
+
+func getFqtEmittedCache() *cache.Cache {
+	return newCache(60)
+}
+
+func getPlanEmittedCache(c *Check) *cache.Cache {
+	var planCacheRetention = c.config.ExecutionPlans.PlanCacheRetention
+	if planCacheRetention == 0 {
+		planCacheRetention = 1
+	}
+
+	return newCache(planCacheRetention)
+}

--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -33,7 +33,6 @@ type QueryMetricsConfig struct {
 	Enabled            bool  `yaml:"enabled"`
 	CollectionInterval int64 `yaml:"collection_interval"`
 	DBRowsLimit        int   `yaml:"db_rows_limit"`
-	PlanCacheRetention int   `yaml:"plan_cache_retention"`
 	DisableLastActive  bool  `yaml:"disable_last_active"`
 	Lookback           int64 `yaml:"lookback"`
 }
@@ -56,6 +55,7 @@ type SharedMemoryConfig struct {
 
 type ExecutionPlansConfig struct {
 	Enabled              bool `yaml:"enabled"`
+	PlanCacheRetention   int  `yaml:"plan_cache_retention"`
 	LogUnobfuscatedPlans bool `yaml:"log_unobfuscated_plans"`
 }
 
@@ -142,7 +142,8 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	instance.QueryMetrics.Enabled = true
 	instance.QueryMetrics.CollectionInterval = defaultMetricCollectionInterval
 	instance.QueryMetrics.DBRowsLimit = 10000
-	instance.QueryMetrics.PlanCacheRetention = 15
+
+	instance.ExecutionPlans.PlanCacheRetention = 15
 
 	instance.SysMetrics.Enabled = true
 	instance.Tablespaces.Enabled = true

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -252,12 +252,10 @@ func assertBool(val bool) bool {
 
 // Teardown cleans up resources used throughout the check.
 func (c *Check) Teardown() {
+	log.Infof("%s Teardown", c.logPrompt)
 	closeDatabase(c, c.db)
 	closeDatabase(c, c.dbCustomQueries)
 	closeGoOraConnection(c)
-
-	c.fqtEmitted = nil
-	c.planEmitted = nil
 }
 
 // Configure configures the Oracle check.
@@ -303,13 +301,8 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 
 	c.tagsString = strings.Join(c.tags, ",")
 
-	c.fqtEmitted = cache.New(60*time.Minute, 10*time.Minute)
-
-	var planCacheRetention = c.config.QueryMetrics.PlanCacheRetention
-	if planCacheRetention == 0 {
-		planCacheRetention = 1
-	}
-	c.planEmitted = cache.New(time.Duration(planCacheRetention)*time.Minute, 10*time.Minute)
+	c.fqtEmitted = getFqtEmittedCache()
+	c.planEmitted = getPlanEmittedCache(c)
 
 	return nil
 }

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -707,39 +707,42 @@ func (c *Check) StatementMetrics() (int, error) {
 
 			oracleRows = append(oracleRows, oracleRow)
 
-			if c.fqtEmitted != nil {
-				if _, found := c.fqtEmitted.Get(queryRow.QuerySignature); !found {
-					FQTDBMetadata := FQTDBMetadata{Tables: queryRow.Tables, Commands: queryRow.Commands}
-					FQTDB := FQTDB{Instance: c.cdbName, QuerySignature: queryRow.QuerySignature, Statement: SQLStatement, FQTDBMetadata: FQTDBMetadata}
-					FQTDBOracle := FQTDBOracle{
-						CDBName: c.cdbName,
-					}
-					FQTPayload := FQTPayload{
-						Timestamp:    float64(time.Now().UnixMilli()),
-						Host:         c.dbHostname,
-						AgentVersion: c.agentVersion,
-						Source:       common.IntegrationName,
-						Tags:         c.tagsString,
-						DBMType:      "fqt",
-						FQTDB:        FQTDB,
-						FQTDBOracle:  FQTDBOracle,
-					}
-					FQTPayloadBytes, err := json.Marshal(FQTPayload)
-					if err != nil {
-						log.Errorf("%s Error marshalling fqt payload: %s", c.logPrompt, err)
-					}
-					log.Debugf("%s Query metrics fqt payload %s", c.logPrompt, string(FQTPayloadBytes))
-					sender.EventPlatformEvent(FQTPayloadBytes, "dbm-samples")
-					c.fqtEmitted.Set(queryRow.QuerySignature, "1", cache.DefaultExpiration)
+			if c.fqtEmitted == nil {
+				c.fqtEmitted = getFqtEmittedCache()
+			}
+
+			if _, found := c.fqtEmitted.Get(queryRow.QuerySignature); !found {
+				FQTDBMetadata := FQTDBMetadata{Tables: queryRow.Tables, Commands: queryRow.Commands}
+				FQTDB := FQTDB{Instance: c.cdbName, QuerySignature: queryRow.QuerySignature, Statement: SQLStatement, FQTDBMetadata: FQTDBMetadata}
+				FQTDBOracle := FQTDBOracle{
+					CDBName: c.cdbName,
 				}
-			} else {
-				log.Errorf("%s Internal error: fqtEmitted = nil. The check might have been restarted. Ignore if it doesn't appear anymore.", c.logPrompt)
+				FQTPayload := FQTPayload{
+					Timestamp:    float64(time.Now().UnixMilli()),
+					Host:         c.dbHostname,
+					AgentVersion: c.agentVersion,
+					Source:       common.IntegrationName,
+					Tags:         c.tagsString,
+					DBMType:      "fqt",
+					FQTDB:        FQTDB,
+					FQTDBOracle:  FQTDBOracle,
+				}
+				FQTPayloadBytes, err := json.Marshal(FQTPayload)
+				if err != nil {
+					log.Errorf("%s Error marshalling fqt payload: %s", c.logPrompt, err)
+				}
+				log.Debugf("%s Query metrics fqt payload %s", c.logPrompt, string(FQTPayloadBytes))
+				sender.EventPlatformEvent(FQTPayloadBytes, "dbm-samples")
+				c.fqtEmitted.Set(queryRow.QuerySignature, "1", cache.DefaultExpiration)
 			}
 
 			if c.config.ExecutionPlans.Enabled {
 				planCacheKey := strconv.FormatUint(statementMetricRow.PlanHashValue, 10)
+				if c.planEmitted == nil {
+					c.planEmitted = getPlanEmittedCache(c)
+				}
 				_, found := c.planEmitted.Get(planCacheKey)
-				if c.config.QueryMetrics.PlanCacheRetention == 0 || !found {
+				if c.config.ExecutionPlans.PlanCacheRetention == 0 || !found {
 					var planStepsPayload []PlanDefinition
 					var planStepsDB []PlanRows
 					var oraclePlan OraclePlan

--- a/releasenotes/notes/oracle-fix-panic-in-statment-metrics-8bb4e15457fe6062.yaml
+++ b/releasenotes/notes/oracle-fix-panic-in-statment-metrics-8bb4e15457fe6062.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix `panic: runtime error: invalid memory address or nil pointer dereference` in `StatementMetrics` by improving cache handling.


### PR DESCRIPTION
### What does this PR do?

Improves cache handling.

### Motivation

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1025635f6]

goroutine 527 [running]:
github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm.(*Check).StatementMetrics(0xc000c56900)
  /Users/nenad.noveljic/go/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/statements.go:741 +0x2e96
github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm.(*Check).Run(0xc000c56900)
  /Users/nenad.noveljic/go/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/oracle.go:218 +0x5d4
github.com/DataDog/datadog-agent/pkg/collector/internal/middleware.(*CheckWrapper).Run(0xc000194960?)
  /Users/nenad.noveljic/go/src/github.com/DataDog/datadog-agent/pkg/collector/internal/middleware/check_wrapper.go:48 +0xc5
github.com/DataDog/datadog-agent/pkg/collector/worker.(*Worker).Run(0xc000b65400)
  /Users/nenad.noveljic/go/src/github.com/DataDog/datadog-agent/pkg/collector/worker/worker.go:152 +0x36a
github.com/DataDog/datadog-agent/pkg/collector/runner.(*Runner).newWorker.func1()
  /Users/nenad.noveljic/go/src/github.com/DataDog/datadog-agent/pkg/collector/runner/runner.go:133 +0x6d
created by github.com/DataDog/datadog-agent/pkg/collector/runner.(*Runner).newWorker
  /Users/nenad.noveljic/go/src/github.com/DataDog/datadog-agent/pkg/collector/runner/runner.go:130 +0x1da
```

### Describe how to test/QA your changes

Set collection interval of query metrics to 1 and check that you don't get repetitive FQT and plan events. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
