### PR TITLE
Forcibly disables language detection to reduce jmx subcommand log spam

### DIFF
--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -226,6 +226,11 @@ func disableCmdPort() {
 // runJmxCommandConsole sets up the common utils necessary for JMX, and executes the command
 // with the Console reporter
 func runJmxCommandConsole(log log.Component, config config.Component, cliParams *cliParams) error {
+	// This prevents log-spam from "pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector.go"
+	// It appears that this collector creates some contention in AD.
+	// Disabling it is both more efficient and gets rid of this log spam
+	pkgconfig.Datadog.Set("language_detection.enabled", "false")
+
 	err := pkgconfig.SetupJMXLogger(cliParams.logFile, "", false, true, false)
 	if err != nil {
 		return fmt.Errorf("Unable to set up JMX logger: %v", err)


### PR DESCRIPTION
### What does this PR do?
Ensures that the `language_detection` feature is off for `agent jmx` subcommand executions.
It is not needed and should speed up agent subcommand execution.

### Motivation
When the `language_detection` feature is on, I observe log spam from the workload meta process_collector.

eg:
```
2023-09-20 15:45:34 UTC | CORE | WARN | (pkg/workloadmeta/collectors/internal/remote/generic.go:202 in Run) | error received from remote workloadmeta: rpc error: code = Unknown desc = the stream was closed because another client called StreamEntities
2023-09-20 15:45:34 UTC | CORE | DEBUG | (pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector.go:84 in StreamEntities) | starting a new stream
2023-09-20 15:45:34 UTC | CORE | INFO | (pkg/workloadmeta/collectors/internal/remote/generic.go:164 in func1) | workloadmeta stream established successfully
2023-09-20 15:45:34 UTC | CORE | DEBUG | (pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector.go:188 in HandleResync) | resync, handling [69] events
2023-09-20 15:45:34 UTC | CORE | WARN | (pkg/workloadmeta/collectors/internal/remote/generic.go:202 in Run) | error received from remote workloadmeta: rpc error: code = Unknown desc = the stream was closed because another client called StreamEntities
2023-09-20 15:45:34 UTC | CORE | DEBUG | (pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector.go:84 in StreamEntities) | starting a new stream
2023-09-20 15:45:34 UTC | CORE | INFO | (pkg/workloadmeta/collectors/internal/remote/generic.go:164 in func1) | workloadmeta stream established successfully
2023-09-20 15:45:34 UTC | CORE | DEBUG | (pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector.go:188 in HandleResync) | resync, handling [69] events
2023-09-20 15:45:34 UTC | CORE | WARN | (pkg/workloadmeta/collectors/internal/remote/generic.go:202 in Run) | error received from remote workloadmeta: rpc error: code = Unknown desc = the stream was closed because another client called StreamEntities
2023-09-20 15:45:34 UTC | CORE | DEBUG | (pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector.go:84 in StreamEntities) | starting a new stream
2023-09-20 15:45:34 UTC | CORE | INFO | (pkg/workloadmeta/collectors/internal/remote/generic.go:164 in func1) | workloadmeta stream established successfully
2023-09-20 15:45:34 UTC | CORE | DEBUG | (pkg/workloadmeta/collectors/internal/remote/process_collector/process_collector.go:188 in HandleResync) | resync, handling [69] events
```

### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
