### PR TITLE
Fix ebpfcheck hash map size calculations

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -354,17 +354,17 @@ func (k *EBPFProbe) getMapStats(stats *EBPFStats) error {
 	return nil
 }
 
-const sizeofBpfArray = 320
+const sizeofBpfArray = 320 // struct bpf_array
 
 func arrayMemoryUsage(info *ebpf.MapInfo, nrCPUS uint64) (max uint64, rss uint64) {
-	perCPU := info.Type == ebpf.PerCPUArray
+	perCPU := isPerCPU(info.Type)
 	numEntries := uint64(info.MaxEntries)
-	elemSize := uint64(info.ValueSize)
+	elemSize := uint64(roundUpPow2(info.ValueSize, 8))
 
 	usage := uint64(sizeofBpfArray)
 
 	if perCPU {
-		usage += numEntries * uint64(unsafe.Sizeof(uintptr(0)))
+		usage += numEntries * sizeOfPointer
 		usage += numEntries * elemSize * nrCPUS
 	} else {
 		if info.Flags&unix.BPF_F_MMAPABLE > 0 {
@@ -378,22 +378,42 @@ func arrayMemoryUsage(info *ebpf.MapInfo, nrCPUS uint64) (max uint64, rss uint64
 	return usage, usage
 }
 
-const sizeofHtabElem = 48
-const sizeOfBucket = 16
+const sizeofHtab = uint64(704)    // struct bpf_htab
+const sizeofHtabElem = uint64(48) // struct htab_elem
+const sizeOfBucket = uint64(16)   // struct bucket
 const hashtabMapLockCount = 8
+const sizeOfPointer = uint64(unsafe.Sizeof(uintptr(0)))
+const sizeOfInt = uint64(unsafe.Sizeof(1))
+
+func isPerCPU(typ ebpf.MapType) bool {
+	switch typ {
+	case ebpf.PerCPUHash, ebpf.PerCPUArray, ebpf.LRUCPUHash:
+		return true
+	}
+	return false
+}
+
+func isLRU(typ ebpf.MapType) bool {
+	switch typ {
+	case ebpf.LRUHash, ebpf.LRUCPUHash:
+		return true
+	}
+	return false
+}
 
 func hashMapMemoryUsage(info *ebpf.MapInfo, nrCPUS uint64) (max uint64, rss uint64) {
 	valueSize := uint64(roundUpPow2(info.ValueSize, 8))
-	perCPU := info.Type == ebpf.PerCPUHash || info.Type == ebpf.LRUCPUHash
-	lru := info.Type == ebpf.LRUHash || info.Type == ebpf.LRUCPUHash
+	keySize := uint64(roundUpPow2(info.KeySize, 8))
+	perCPU := isPerCPU(info.Type)
+	lru := isLRU(info.Type)
 	//prealloc := (info.Flags & unix.BPF_F_NO_PREALLOC) == 0
 	hasExtraElems := !perCPU && !lru
 
 	nBuckets := uint64(roundUpNearestPow2(info.MaxEntries))
-	usage := uint64(sizeofHtabElem)
+	usage := sizeofHtab
 	usage += sizeOfBucket * nBuckets
 	// could we get the size of the locks more directly with BTF?
-	usage += uint64(unsafe.Sizeof(1)) * nrCPUS * hashtabMapLockCount
+	usage += sizeOfInt * nrCPUS * hashtabMapLockCount
 
 	// TODO proper support of non-preallocated maps, will require coordination with eBPF to read size (if possible)
 	//if prealloc {
@@ -402,12 +422,19 @@ func hashMapMemoryUsage(info *ebpf.MapInfo, nrCPUS uint64) (max uint64, rss uint
 	if hasExtraElems {
 		numEntries += nrCPUS
 	}
-	usage += uint64(info.KeySize) * numEntries
+
+	elemSize := sizeofHtabElem + keySize
+	if perCPU {
+		elemSize += sizeOfPointer
+	} else {
+		elemSize += valueSize
+	}
+	usage += elemSize * numEntries
 
 	if perCPU {
 		usage += valueSize * nrCPUS * numEntries
 	} else if !lru {
-		usage += sizeofHtabElem * nrCPUS
+		usage += sizeOfPointer * nrCPUS
 	}
 
 	//

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
@@ -9,6 +9,7 @@ package ebpfcheck
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -18,7 +19,9 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/perf"
 	"github.com/cilium/ebpf/rlimit"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
@@ -97,6 +100,90 @@ func TestEBPFPerfBufferLength(t *testing.T) {
 	})
 }
 
+func TestMinMapSize(t *testing.T) {
+	ebpftest.RequireKernelVersion(t, minimumKernelVersion)
+	err := rlimit.RemoveMemlock()
+	require.NoError(t, err)
+
+	cpus, err := kernel.PossibleCPUs()
+	require.NoError(t, err)
+	nrcpus := uint64(cpus)
+
+	ebpftest.TestBuildMode(t, ebpftest.CORE, "", func(t *testing.T) {
+		cfg := testConfig()
+		const keySize, valueSize, maxEntries = 50, 150, 1000
+
+		probe, err := NewProbe(cfg)
+		require.NoError(t, err)
+		t.Cleanup(probe.Close)
+
+		mapTypes := []struct {
+			typ     ebpf.MapType
+			keySize uint32
+		}{
+			{typ: ebpf.Array, keySize: 4},
+			{typ: ebpf.PerCPUArray, keySize: 4},
+			{typ: ebpf.Hash, keySize: keySize},
+			{typ: ebpf.LRUHash, keySize: keySize},
+			{typ: ebpf.LRUCPUHash, keySize: keySize},
+			{typ: ebpf.PerCPUHash, keySize: keySize},
+		}
+
+		// create all the maps
+		ids := make(map[ebpf.MapType]ebpf.MapID)
+		for _, mt := range mapTypes {
+			testMapSpec := &ebpf.MapSpec{Name: fmt.Sprintf("et_%s", mt.typ), Type: mt.typ, KeySize: mt.keySize, ValueSize: valueSize, MaxEntries: maxEntries}
+			testMap, err := ebpf.NewMap(testMapSpec)
+			require.NoError(t, err, mt.typ)
+			t.Cleanup(func() { _ = testMap.Close() })
+			info, err := testMap.Info()
+			require.NoError(t, err, mt.typ)
+			ids[mt.typ], _ = info.ID()
+		}
+
+		// wait until we have stats about all maps
+		var result []model.EBPFMapStats
+		require.Eventually(t, func() bool {
+			stats := probe.GetAndFlush()
+			t.Logf("%+v", stats.Maps)
+			for _, id := range ids {
+				if !slices.ContainsFunc(stats.Maps, func(stats model.EBPFMapStats) bool {
+					return stats.ID == uint32(id)
+				}) {
+					return false
+				}
+			}
+			result = stats.Maps
+			return true
+		}, 5*time.Second, 500*time.Millisecond, "failed to find all maps")
+
+		// assert max size is at least the naive map size
+		for _, mt := range mapTypes {
+			idx := slices.IndexFunc(result, func(stats model.EBPFMapStats) bool {
+				return stats.ID == uint32(ids[mt.typ])
+			})
+			typStats := result[idx]
+
+			ks := uint64(keySize)
+			switch mt.typ {
+			case ebpf.Array, ebpf.PerCPUArray:
+				// array types don't use space for the indexes
+				ks = 1
+			}
+
+			minSize := uint64(0)
+			if isPerCPU(mt.typ) {
+				// hash of key -> ~per-cpu array
+				minSize = (ks * uint64(maxEntries)) + (uint64(valueSize) * uint64(maxEntries) * nrcpus)
+			} else {
+				minSize = (ks + valueSize) * maxEntries
+			}
+			t.Logf("typ: %s min: %d val: %d", mt.typ, minSize, typStats.MaxSize)
+			assert.GreaterOrEqual(t, typStats.MaxSize, minSize, "map type: %s", mt.typ.String())
+		}
+	})
+}
+
 func testConfig() *ddebpf.Config {
 	cfg := ddebpf.NewConfig()
 	return cfg
@@ -104,7 +191,7 @@ func testConfig() *ddebpf.Config {
 
 func BenchmarkMatchProcessRSS(b *testing.B) {
 	pid := os.Getpid()
-	addrs := []uintptr{}
+	var addrs []uintptr
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -118,7 +205,7 @@ func BenchmarkMatchRSS(b *testing.B) {
 	data, err := os.ReadFile("./testdata/smaps.out")
 	require.NoError(b, err)
 	rdr := bytes.NewReader(data)
-	addrs := []uintptr{}
+	var addrs []uintptr
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
@@ -76,7 +76,8 @@ func TestEBPFPerfBufferLength(t *testing.T) {
 		}, 5*time.Second, 500*time.Millisecond, "failed to find perf buffer map")
 
 		// 4 is value size, 1 extra page for metadata
-		expected := (onlineCPUs * uint64(pageSize) * uint64(numPages+1)) + nrcpus*4 + sizeofBpfArray
+		valueSize := uint64(roundUpPow2(4, 8))
+		expected := (onlineCPUs * uint64(pageSize) * uint64(numPages+1)) + nrcpus*valueSize + sizeofBpfArray
 		if result.MaxSize != expected {
 			t.Fatalf("expected perf buffer size %d got %d", expected, result.MaxSize)
 		}

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
@@ -113,7 +113,7 @@ func TestMinMapSize(t *testing.T) {
 		cfg := testConfig()
 		const keySize, valueSize, maxEntries = 50, 150, 1000
 
-		probe, err := NewProbe(cfg)
+		probe, err := NewEBPFProbe(cfg)
 		require.NoError(t, err)
 		t.Cleanup(probe.Close)
 
@@ -142,13 +142,13 @@ func TestMinMapSize(t *testing.T) {
 		}
 
 		// wait until we have stats about all maps
-		var result []model.EBPFMapStats
+		var result []EBPFMapStats
 		require.Eventually(t, func() bool {
 			stats := probe.GetAndFlush()
 			t.Logf("%+v", stats.Maps)
 			for _, id := range ids {
-				if !slices.ContainsFunc(stats.Maps, func(stats model.EBPFMapStats) bool {
-					return stats.ID == uint32(id)
+				if !slices.ContainsFunc(stats.Maps, func(stats EBPFMapStats) bool {
+					return stats.id == uint32(id)
 				}) {
 					return false
 				}
@@ -159,8 +159,8 @@ func TestMinMapSize(t *testing.T) {
 
 		// assert max size is at least the naive map size
 		for _, mt := range mapTypes {
-			idx := slices.IndexFunc(result, func(stats model.EBPFMapStats) bool {
-				return stats.ID == uint32(ids[mt.typ])
+			idx := slices.IndexFunc(result, func(stats EBPFMapStats) bool {
+				return stats.id == uint32(ids[mt.typ])
 			})
 			typStats := result[idx]
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixes the hash map size calculation in the eBPF check.

### Motivation

Incorrect hash map size (way too small)

### Additional Notes

Added a test that ensure our calculations are greater than the naive map size calculations.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
