### PR TITLE
[usm] Remove `conn_tuple_t` from `http_transaction_t`

### DIFF
--- a/pkg/network/ebpf/c/protocols/http/http.h
+++ b/pkg/network/ebpf/c/protocols/http/http.h
@@ -35,6 +35,18 @@ static __always_inline void http_begin_response(http_transaction_t *http, const 
     log_debug("http_begin_response: htx=%llx status=%d\n", http, status_code);
 }
 
+static __always_inline void http_batch_enqueue_wrapper(conn_tuple_t *tuple, http_transaction_t *http) {
+    u32 zero = 0;
+    http_event_t *event = bpf_map_lookup_elem(&http_scratch_buffer, &zero);
+    if (!event) {
+        return;
+    }
+
+    bpf_memcpy(&event->tuple, tuple, sizeof(conn_tuple_t));
+    bpf_memcpy(&event->http, http, sizeof(http_transaction_t));
+    http_batch_enqueue(event);
+}
+
 static __always_inline void http_parse_data(char const *p, http_packet_t *packet_type, http_method_t *method) {
     if ((p[0] == 'H') && (p[1] == 'T') && (p[2] == 'T') && (p[3] == 'P')) {
         *packet_type = HTTP_RESPONSE;
@@ -99,16 +111,18 @@ static __always_inline bool http_seen_before(http_transaction_t *http, skb_info_
     return false;
 }
 
-static __always_inline http_transaction_t *http_fetch_state(http_transaction_t *http, http_packet_t packet_type) {
+static __always_inline http_transaction_t *http_fetch_state(conn_tuple_t *tuple, http_transaction_t *http, http_packet_t packet_type) {
     if (packet_type == HTTP_PACKET_UNKNOWN) {
-        return bpf_map_lookup_elem(&http_in_flight, &http->tup);
+        return bpf_map_lookup_elem(&http_in_flight, tuple);
     }
 
     // We detected either a request or a response
     // In this case we initialize (or fetch) state associated to this tuple
-    bpf_map_update_with_telemetry(http_in_flight, &http->tup, http, BPF_NOEXIST);
-    return bpf_map_lookup_elem(&http_in_flight, &http->tup);
+    bpf_map_update_with_telemetry(http_in_flight, tuple, http, BPF_NOEXIST);
+    return bpf_map_lookup_elem(&http_in_flight, tuple);
 }
+
+
 
 // Returns true if the given http transaction should be flushed to the user mode.
 // We flush a transaction if:
@@ -123,20 +137,22 @@ static __always_inline bool http_should_flush_previous_state(http_transaction_t 
 
 // http_process is responsible for parsing traffic and emitting events
 // representing HTTP transactions.
-static __always_inline void http_process(http_transaction_t *http_stack, skb_info_t *skb_info, __u64 tags) {
-    char *buffer = (char *)http_stack->request_fragment;
+static __always_inline void http_process(http_event_t *event, skb_info_t *skb_info, __u64 tags) {
+    conn_tuple_t *tuple = &event->tuple;
+    http_transaction_t *http = &event->http;
+    char *buffer = (char *)http->request_fragment;
     http_packet_t packet_type = HTTP_PACKET_UNKNOWN;
     http_method_t method = HTTP_METHOD_UNKNOWN;
     http_parse_data(buffer, &packet_type, &method);
 
-    http_transaction_t *http = http_fetch_state(http_stack, packet_type);
+    http = http_fetch_state(tuple, http, packet_type);
     if (!http || http_seen_before(http, skb_info, packet_type)) {
         return;
     }
 
     if (http_should_flush_previous_state(http, packet_type)) {
-        http_batch_enqueue(http);
-        bpf_memcpy(http, http_stack, sizeof(http_transaction_t));
+        http_batch_enqueue_wrapper(tuple, http);
+        bpf_memcpy(http, &event->http, sizeof(http_transaction_t));
     }
 
     log_debug("http_process: type=%d method=%d\n", packet_type, method);
@@ -155,8 +171,8 @@ static __always_inline void http_process(http_transaction_t *http_stack, skb_inf
     }
 
     if (http_closed(skb_info)) {
-        http_batch_enqueue(http);
-        bpf_map_delete_elem(&http_in_flight, &http_stack->tup);
+        http_batch_enqueue_wrapper(tuple, http);
+        bpf_map_delete_elem(&http_in_flight, tuple);
     }
 
     return;
@@ -165,14 +181,14 @@ static __always_inline void http_process(http_transaction_t *http_stack, skb_inf
 // this function is called by the socket-filter program to decide whether or not we should inspect
 // the contents of a certain packet, in order to avoid the cost of processing packets that are not
 // of interest such as empty ACKs, UDP data or encrypted traffic.
-static __always_inline bool http_allow_packet(http_transaction_t *http, struct __sk_buff* skb, skb_info_t *skb_info) {
+static __always_inline bool http_allow_packet(conn_tuple_t *tuple, struct __sk_buff* skb, skb_info_t *skb_info) {
     // we're only interested in TCP traffic
-    if (!(http->tup.metadata&CONN_TYPE_TCP)) {
+    if (!(tuple->metadata&CONN_TYPE_TCP)) {
         return false;
     }
 
     bool empty_payload = skb_info->data_off == skb->len;
-    if (empty_payload || http->tup.sport == HTTPS_PORT || http->tup.dport == HTTPS_PORT) {
+    if (empty_payload || tuple->sport == HTTPS_PORT || tuple->dport == HTTPS_PORT) {
         // if the payload data is empty or encrypted packet, we only
         // process it if the packet represents a TCP termination
         return skb_info->tcp_flags&(TCPHDR_FIN|TCPHDR_RST);
@@ -184,21 +200,21 @@ static __always_inline bool http_allow_packet(http_transaction_t *http, struct _
 SEC("socket/http_filter")
 int socket__http_filter(struct __sk_buff* skb) {
     skb_info_t skb_info;
-    http_transaction_t http;
-    bpf_memset(&http, 0, sizeof(http));
+    http_event_t event;
+    bpf_memset(&event, 0, sizeof(http_event_t));
 
-    if (!fetch_dispatching_arguments(&http.tup, &skb_info)) {
+    if (!fetch_dispatching_arguments(&event.tuple, &skb_info)) {
         log_debug("http_filter failed to fetch arguments for tail call\n");
         return 0;
     }
 
-    if (!http_allow_packet(&http, skb, &skb_info)) {
+    if (!http_allow_packet(&event.tuple, skb, &skb_info)) {
         return 0;
     }
-    normalize_tuple(&http.tup);
+    normalize_tuple(&event.tuple);
 
-    read_into_buffer_skb((char *)http.request_fragment, skb, skb_info.data_off);
-    http_process(&http, &skb_info, NO_TAGS);
+    read_into_buffer_skb((char *)event.http.request_fragment, skb, skb_info.data_off);
+    http_process(&event, &skb_info, NO_TAGS);
     return 0;
 }
 
@@ -210,11 +226,11 @@ int uprobe__http_process(struct pt_regs *ctx) {
         return 0;
     }
 
-    http_transaction_t http;
-    bpf_memset(&http, 0, sizeof(http));
-    bpf_memcpy(&http.tup, &args->tup, sizeof(conn_tuple_t));
-    read_into_user_buffer_http(http.request_fragment, args->buffer_ptr);
-    http_process(&http, NULL, args->tags);
+    http_event_t event;
+    bpf_memset(&event, 0, sizeof(http_event_t));
+    bpf_memcpy(&event.tuple, &args->tup, sizeof(conn_tuple_t));
+    read_into_user_buffer_http(event.http.request_fragment, args->buffer_ptr);
+    http_process(&event, NULL, args->tags);
     http_batch_flush(ctx);
 
     return 0;
@@ -228,12 +244,12 @@ int uprobe__http_termination(struct pt_regs *ctx) {
         return 0;
     }
 
-    http_transaction_t http;
-    bpf_memset(&http, 0, sizeof(http));
-    bpf_memcpy(&http.tup, &args->tup, sizeof(conn_tuple_t));
+    http_event_t event;
+    bpf_memset(&event, 0, sizeof(http_event_t));
+    bpf_memcpy(&event.tuple, &args->tup, sizeof(conn_tuple_t));
     skb_info_t skb_info = {0};
     skb_info.tcp_flags |= TCPHDR_FIN;
-    http_process(&http, &skb_info, NO_TAGS);
+    http_process(&event, &skb_info, NO_TAGS);
     http_batch_flush(ctx);
 
     return 0;

--- a/pkg/network/ebpf/c/protocols/http/maps.h
+++ b/pkg/network/ebpf/c/protocols/http/maps.h
@@ -9,4 +9,9 @@
 /* This map is used to keep track of in-flight HTTP transactions for each TCP connection */
 BPF_HASH_MAP(http_in_flight, conn_tuple_t, http_transaction_t, 0)
 
+
+/* This map acts as a scratch buffer for "preparing" http_event_t objects before they're
+   enqueued. The primary motivation here is to save eBPF stack memory. */
+BPF_PERCPU_ARRAY_MAP(http_scratch_buffer, u32, http_event_t, 1)
+
 #endif

--- a/pkg/network/ebpf/c/protocols/http/types.h
+++ b/pkg/network/ebpf/c/protocols/http/types.h
@@ -39,9 +39,8 @@ typedef enum
     HTTP_PATCH
 } http_method_t;
 
-// HTTP transaction information associated to a certain socket (tuple_t)
+// HTTP transaction information associated to a certain socket (conn_tuple_t)
 typedef struct {
-    conn_tuple_t tup;
     __u64 request_started;
     __u64 response_last_seen;
     __u64 tags;
@@ -52,6 +51,11 @@ typedef struct {
     __u8  request_method;
     char request_fragment[HTTP_BUFFER_SIZE] __attribute__ ((aligned (8)));
 } http_transaction_t;
+
+typedef struct {
+    conn_tuple_t tuple;
+    http_transaction_t http;
+} http_event_t;
 
 // OpenSSL types
 typedef struct {

--- a/pkg/network/ebpf/c/protocols/http/usm-events.h
+++ b/pkg/network/ebpf/c/protocols/http/usm-events.h
@@ -4,6 +4,6 @@
 #include "protocols/events.h"
 #include "protocols/http/types.h"
 
-USM_EVENTS_INIT(http, http_transaction_t, HTTP_BATCH_SIZE);
+USM_EVENTS_INIT(http, http_event_t, HTTP_BATCH_SIZE);
 
 #endif

--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -32,7 +32,7 @@
 
 #define HTTPS_PORT 443
 
-static __always_inline void http_process(http_transaction_t *http_stack, skb_info_t *skb_info, __u64 tags);
+static __always_inline void http_process(http_event_t *event, skb_info_t *skb_info, __u64 tags);
 
 /* this function is called by all TLS hookpoints (OpenSSL, GnuTLS and GoTLS, JavaTLS) and */
 /* it's used for classify the subset of protocols that is supported by `classify_protocol_for_dispatcher` */

--- a/pkg/network/protocols/http/incomplete_stats.go
+++ b/pkg/network/protocols/http/incomplete_stats.go
@@ -93,13 +93,13 @@ func (b *incompleteBuffer) Add(tx Transaction) {
 
 	// copy underlying httpTX value. this is now needed because these objects are
 	// now coming directly from pooled perf records
-	ebpfTX, ok := tx.(*EbpfTx)
+	ebpfTX, ok := tx.(*EbpfEvent)
 	if !ok {
 		// should never happen
 		return
 	}
 
-	ebpfTxCopy := new(EbpfTx)
+	ebpfTxCopy := new(EbpfEvent)
 	*ebpfTxCopy = *ebpfTX
 	tx = ebpfTxCopy
 

--- a/pkg/network/protocols/http/incomplete_stats_test.go
+++ b/pkg/network/protocols/http/incomplete_stats_test.go
@@ -22,22 +22,26 @@ func TestOrphanEntries(t *testing.T) {
 		now := time.Now()
 		tel := NewTelemetry("http")
 		buffer := newIncompleteBuffer(config.New(), tel)
-		request := &EbpfTx{
-			Request_fragment: requestFragment([]byte("GET /foo/bar")),
-			Request_started:  uint64(now.UnixNano()),
+		request := &EbpfEvent{
+			Http: EbpfTx{
+				Request_fragment: requestFragment([]byte("GET /foo/bar")),
+				Request_started:  uint64(now.UnixNano()),
+			},
 		}
-		request.Tup.Sport = 60000
+		request.Tuple.Sport = 60000
 
 		buffer.Add(request)
 		now = now.Add(5 * time.Second)
 		complete := buffer.Flush(now)
 		assert.Len(t, complete, 0)
 
-		response := &EbpfTx{
-			Response_status_code: 200,
-			Response_last_seen:   uint64(now.UnixNano()),
+		response := &EbpfEvent{
+			Http: EbpfTx{
+				Response_status_code: 200,
+				Response_last_seen:   uint64(now.UnixNano()),
+			},
 		}
-		response.Tup.Sport = 60000
+		response.Tuple.Sport = 60000
 		buffer.Add(response)
 		complete = buffer.Flush(now)
 		require.Len(t, complete, 1)
@@ -53,9 +57,11 @@ func TestOrphanEntries(t *testing.T) {
 		buffer := newIncompleteBuffer(config.New(), tel)
 		now := time.Now()
 		buffer.minAgeNano = (30 * time.Second).Nanoseconds()
-		request := &EbpfTx{
-			Request_fragment: requestFragment([]byte("GET /foo/bar")),
-			Request_started:  uint64(now.UnixNano()),
+		request := &EbpfEvent{
+			Http: EbpfTx{
+				Request_fragment: requestFragment([]byte("GET /foo/bar")),
+				Request_started:  uint64(now.UnixNano()),
+			},
 		}
 		buffer.Add(request)
 		_ = buffer.Flush(now)

--- a/pkg/network/protocols/http/model_linux.go
+++ b/pkg/network/protocols/http/model_linux.go
@@ -62,6 +62,7 @@ func (e *EbpfEvent) Incomplete() bool {
 	return e.Http.Request_started == 0 || e.Http.Response_status_code == 0
 }
 
+// ConnTuple returns a `types.ConnectionKey` for the transaction
 func (e *EbpfEvent) ConnTuple() types.ConnectionKey {
 	return types.ConnectionKey{
 		SrcIPHigh: e.Tuple.Saddr_h,
@@ -73,30 +74,37 @@ func (e *EbpfEvent) ConnTuple() types.ConnectionKey {
 	}
 }
 
+// Method returns the HTTP method of the HTTP transaction
 func (e *EbpfEvent) Method() Method {
 	return Method(e.Http.Request_method)
 }
 
+// StatusCode returns the status code of the HTTP transaction
 func (e *EbpfEvent) StatusCode() uint16 {
 	return e.Http.Response_status_code
 }
 
+// SetStatusCode of the underlying HTTP transaction
 func (e *EbpfEvent) SetStatusCode(code uint16) {
 	e.Http.Response_status_code = code
 }
 
+// ResponseLastSeen returns the timestamp of the last captured segment of the HTTP transaction
 func (e *EbpfEvent) ResponseLastSeen() uint64 {
 	return e.Http.Response_last_seen
 }
 
+// SetResponseLastSeen of the HTTP transaction
 func (e *EbpfEvent) SetResponseLastSeen(lastSeen uint64) {
 	e.Http.Response_last_seen = lastSeen
-
 }
+
+// RequestStarted returns the timestamp of the first segment of the HTTP transaction
 func (e *EbpfEvent) RequestStarted() uint64 {
 	return e.Http.Request_started
 }
 
+// SetRequestMethod of the underlying HTTP transaction
 func (e *EbpfEvent) SetRequestMethod(m Method) {
 	e.Http.Request_method = uint8(m)
 }
@@ -107,10 +115,12 @@ func (e *EbpfEvent) StaticTags() uint64 {
 	return e.Http.Tags
 }
 
+// DynamicTags returns the dynamic tags associated to the HTTP trasnaction
 func (e *EbpfEvent) DynamicTags() []string {
 	return nil
 }
 
+// String returns a string representation of the underlying event
 func (e *EbpfEvent) String() string {
 	var output strings.Builder
 	output.WriteString("ebpfTx{")

--- a/pkg/network/protocols/http/model_linux.go
+++ b/pkg/network/protocols/http/model_linux.go
@@ -10,9 +10,10 @@ package http
 import (
 	"bytes"
 	"encoding/hex"
-	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	"strconv"
 	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 
 	"github.com/DataDog/datadog-agent/pkg/network/types"
 )
@@ -21,13 +22,13 @@ import (
 // GET variables excluded.
 // Example:
 // For a request fragment "GET /foo?var=bar HTTP/1.1", this method will return "/foo"
-func (tx *EbpfTx) Path(buffer []byte) ([]byte, bool) {
-	bLen := bytes.IndexByte(tx.Request_fragment[:], 0)
+func (e *EbpfEvent) Path(buffer []byte) ([]byte, bool) {
+	bLen := bytes.IndexByte(e.Http.Request_fragment[:], 0)
 	if bLen == -1 {
-		bLen = len(tx.Request_fragment)
+		bLen = len(e.Http.Request_fragment)
 	}
 	// trim null byte + after
-	b := tx.Request_fragment[:bLen]
+	b := e.Http.Request_fragment[:bLen]
 	// find first space after request method
 	i := bytes.IndexByte(b, ' ')
 	i++
@@ -48,74 +49,74 @@ func (tx *EbpfTx) Path(buffer []byte) ([]byte, bool) {
 }
 
 // RequestLatency returns the latency of the request in nanoseconds
-func (tx *EbpfTx) RequestLatency() float64 {
-	if uint64(tx.Request_started) == 0 || uint64(tx.Response_last_seen) == 0 {
+func (e *EbpfEvent) RequestLatency() float64 {
+	if uint64(e.Http.Request_started) == 0 || uint64(e.Http.Response_last_seen) == 0 {
 		return 0
 	}
-	return protocols.NSTimestampToFloat(tx.Response_last_seen - tx.Request_started)
+	return protocols.NSTimestampToFloat(e.Http.Response_last_seen - e.Http.Request_started)
 }
 
 // Incomplete returns true if the transaction contains only the request or response information
 // This happens in the context of localhost with NAT, in which case we join the two parts in userspace
-func (tx *EbpfTx) Incomplete() bool {
-	return tx.Request_started == 0 || tx.Response_status_code == 0
+func (e *EbpfEvent) Incomplete() bool {
+	return e.Http.Request_started == 0 || e.Http.Response_status_code == 0
 }
 
-func (tx *EbpfTx) ConnTuple() types.ConnectionKey {
+func (e *EbpfEvent) ConnTuple() types.ConnectionKey {
 	return types.ConnectionKey{
-		SrcIPHigh: tx.Tup.Saddr_h,
-		SrcIPLow:  tx.Tup.Saddr_l,
-		DstIPHigh: tx.Tup.Daddr_h,
-		DstIPLow:  tx.Tup.Daddr_l,
-		SrcPort:   tx.Tup.Sport,
-		DstPort:   tx.Tup.Dport,
+		SrcIPHigh: e.Tuple.Saddr_h,
+		SrcIPLow:  e.Tuple.Saddr_l,
+		DstIPHigh: e.Tuple.Daddr_h,
+		DstIPLow:  e.Tuple.Daddr_l,
+		SrcPort:   e.Tuple.Sport,
+		DstPort:   e.Tuple.Dport,
 	}
 }
 
-func (tx *EbpfTx) Method() Method {
-	return Method(tx.Request_method)
+func (e *EbpfEvent) Method() Method {
+	return Method(e.Http.Request_method)
 }
 
-func (tx *EbpfTx) StatusCode() uint16 {
-	return tx.Response_status_code
+func (e *EbpfEvent) StatusCode() uint16 {
+	return e.Http.Response_status_code
 }
 
-func (tx *EbpfTx) SetStatusCode(code uint16) {
-	tx.Response_status_code = code
+func (e *EbpfEvent) SetStatusCode(code uint16) {
+	e.Http.Response_status_code = code
 }
 
-func (tx *EbpfTx) ResponseLastSeen() uint64 {
-	return tx.Response_last_seen
+func (e *EbpfEvent) ResponseLastSeen() uint64 {
+	return e.Http.Response_last_seen
 }
 
-func (tx *EbpfTx) SetResponseLastSeen(lastSeen uint64) {
-	tx.Response_last_seen = lastSeen
+func (e *EbpfEvent) SetResponseLastSeen(lastSeen uint64) {
+	e.Http.Response_last_seen = lastSeen
 
 }
-func (tx *EbpfTx) RequestStarted() uint64 {
-	return tx.Request_started
+func (e *EbpfEvent) RequestStarted() uint64 {
+	return e.Http.Request_started
 }
 
-func (tx *EbpfTx) SetRequestMethod(m Method) {
-	tx.Request_method = uint8(m)
+func (e *EbpfEvent) SetRequestMethod(m Method) {
+	e.Http.Request_method = uint8(m)
 }
 
 // StaticTags returns an uint64 representing the tags bitfields
 // Tags are defined here : pkg/network/ebpf/kprobe_types.go
-func (tx *EbpfTx) StaticTags() uint64 {
-	return tx.Tags
+func (e *EbpfEvent) StaticTags() uint64 {
+	return e.Http.Tags
 }
 
-func (tx *EbpfTx) DynamicTags() []string {
+func (e *EbpfEvent) DynamicTags() []string {
 	return nil
 }
 
-func (tx *EbpfTx) String() string {
+func (e *EbpfEvent) String() string {
 	var output strings.Builder
 	output.WriteString("ebpfTx{")
-	output.WriteString("Method: '" + Method(tx.Request_method).String() + "', ")
-	output.WriteString("Tags: '0x" + strconv.FormatUint(tx.Tags, 16) + "', ")
-	output.WriteString("Fragment: '" + hex.EncodeToString(tx.Request_fragment[:]) + "', ")
+	output.WriteString("Method: '" + Method(e.Http.Request_method).String() + "', ")
+	output.WriteString("Tags: '0x" + strconv.FormatUint(e.Http.Tags, 16) + "', ")
+	output.WriteString("Fragment: '" + hex.EncodeToString(e.Http.Request_fragment[:]) + "', ")
 	output.WriteString("}")
 	return output.String()
 }

--- a/pkg/network/protocols/http/protocol.go
+++ b/pkg/network/protocols/http/protocol.go
@@ -163,7 +163,7 @@ func (p *protocol) DumpMaps(output *strings.Builder, mapName string, currentMap 
 }
 
 func (p *protocol) processHTTP(data []byte) {
-	tx := (*EbpfTx)(unsafe.Pointer(&data[0]))
+	tx := (*EbpfEvent)(unsafe.Pointer(&data[0]))
 	p.telemetry.Count(tx)
 	p.statkeeper.Process(tx)
 }
@@ -187,11 +187,11 @@ func (p *protocol) setupMapCleaner(mgr *manager.Manager) {
 			return false
 		}
 
-		if updated := int64(httpTxn.ResponseLastSeen()); updated > 0 {
+		if updated := int64(httpTxn.Response_last_seen); updated > 0 {
 			return (now - updated) > ttl
 		}
 
-		started := int64(httpTxn.RequestStarted())
+		started := int64(httpTxn.Request_started)
 		return started > 0 && (now-started) > ttl
 	})
 

--- a/pkg/network/protocols/http/statkeeper_test_linux.go
+++ b/pkg/network/protocols/http/statkeeper_test_linux.go
@@ -16,20 +16,20 @@ import (
 )
 
 func generateIPv4HTTPTransaction(source util.Address, dest util.Address, sourcePort int, destPort int, path string, code int, latency time.Duration) Transaction {
-	var tx EbpfTx
+	var event EbpfEvent
 
 	reqFragment := fmt.Sprintf("GET %s HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0", path)
 	latencyNS := uint64(uint64(latency))
-	tx.Request_started = 1
-	tx.Request_method = 1
-	tx.Response_last_seen = tx.Request_started + latencyNS
-	tx.Response_status_code = uint16(code)
-	tx.Request_fragment = requestFragment([]byte(reqFragment))
-	tx.Tup.Saddr_l = uint64(binary.LittleEndian.Uint32(source.Bytes()))
-	tx.Tup.Sport = uint16(sourcePort)
-	tx.Tup.Daddr_l = uint64(binary.LittleEndian.Uint32(dest.Bytes()))
-	tx.Tup.Dport = uint16(destPort)
-	tx.Tup.Metadata = 1
+	event.Http.Request_started = 1
+	event.Http.Request_method = 1
+	event.Http.Response_last_seen = event.Http.Request_started + latencyNS
+	event.Http.Response_status_code = uint16(code)
+	event.Http.Request_fragment = requestFragment([]byte(reqFragment))
+	event.Tuple.Saddr_l = uint64(binary.LittleEndian.Uint32(source.Bytes()))
+	event.Tuple.Sport = uint16(sourcePort)
+	event.Tuple.Daddr_l = uint64(binary.LittleEndian.Uint32(dest.Bytes()))
+	event.Tuple.Dport = uint16(destPort)
+	event.Tuple.Metadata = 1
 
-	return &tx
+	return &event
 }

--- a/pkg/network/protocols/http/types.go
+++ b/pkg/network/protocols/http/types.go
@@ -18,6 +18,7 @@ type ConnTuple = C.conn_tuple_t
 type SslSock C.ssl_sock_t
 type SslReadArgs C.ssl_read_args_t
 
+type EbpfEvent C.http_event_t
 type EbpfTx C.http_transaction_t
 
 const (

--- a/pkg/network/protocols/http/types_linux.go
+++ b/pkg/network/protocols/http/types_linux.go
@@ -24,8 +24,11 @@ type SslReadArgs struct {
 	Buf *byte
 }
 
+type EbpfEvent struct {
+	Tuple ConnTuple
+	Http  EbpfTx
+}
 type EbpfTx struct {
-	Tup                  ConnTuple
 	Request_started      uint64
 	Response_last_seen   uint64
 	Tags                 uint64


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Remove `conn_tuple_t` field from `http_transaction_t`. The map `http_in_flight` is keyed by `conn_tuple_t` and therefore there is no need for a tuple to be embedded in the map value.

### Motivation

Reduce kernel memory (which reflects in the working set memory metric in the context of eBPF maps).

### Additional Notes

For a `http_in_flight` map size of 65536 (default `MaxTrackedConns`)

Before
18.87Mb

After
15.72Mb

Yellow represents the change. The gains are quite modest but we decided to rollout the change because we believe the aggregate effect will be worth it once we have the same change for HTTP2.
<img width="574" alt="working_set" src="https://github.com/DataDog/datadog-agent/assets/692520/5b1343ad-066f-456d-98d3-668a35363e12">

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
