### PR TITLE
Sopell/debug origin detection

### DIFF
--- a/comp/dogstatsd/listeners/uds_common.go
+++ b/comp/dogstatsd/listeners/uds_common.go
@@ -196,6 +196,7 @@ func (l *UDSListener) Listen() {
 
 			// Extract container id from credentials
 			pid, container, taggingErr := processUDSOrigin(oobS[:oobn])
+			log.Errorf("UDS processed origin pid=%q container=%q taggingErr=%q", pid, container, taggingErr)
 
 			if capBuff != nil {
 				capBuff.Pb.Timestamp = time.Now().UnixNano()

--- a/comp/dogstatsd/listeners/uds_linux.go
+++ b/comp/dogstatsd/listeners/uds_linux.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -84,6 +85,7 @@ func processUDSOrigin(ancillary []byte) (int, string, error) {
 		return int(pid), packets.NoOrigin, err
 	}
 
+	log.Errorf("For pid %v, we found entity %q", pid, entity)
 	return int(pid), entity, nil
 }
 
@@ -103,12 +105,15 @@ func getEntityForPID(pid int32, capture bool) (string, error) {
 		if !capture {
 			cache.Cache.Set(key, entity, pidToEntityCacheDuration)
 		}
+		log.Errorf("Yes entity -- %q ", entity)
 		return entity, nil
 	case errNoContainerMatch:
+		log.Errorf("No entity -- ErrNoContainerMatch ")
 		// No runtime detected, cache the `packets.NoOrigin` result
 		cache.Cache.Set(key, packets.NoOrigin, pidToEntityCacheDuration)
 		return packets.NoOrigin, nil
 	default:
+		log.Errorf("No entity -- Other ")
 		// Other lookup error, retry next time
 		return packets.NoOrigin, err
 	}

--- a/pkg/metrics/metric_sample.go
+++ b/pkg/metrics/metric_sample.go
@@ -8,6 +8,7 @@ package metrics
 import (
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // MetricType is the representation of an aggregator metric type
@@ -116,6 +117,7 @@ func (m *MetricSample) GetHost() string {
 
 // GetTags returns the metric sample tags
 func (m *MetricSample) GetTags(taggerBuffer, metricBuffer tagset.TagsAccumulator) {
+	log.Errorf("name %q tags: %v, originFromUDS: %q originFromClient %q", m.Name, m.Tags, m.OriginFromUDS, m.OriginFromClient)
 	metricBuffer.Append(m.Tags...)
 	tagger.EnrichTags(taggerBuffer, m.OriginFromUDS, m.OriginFromClient, m.Cardinality)
 }

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -268,6 +268,7 @@ func EnrichTags(tb tagset.TagsAccumulator, udsOrigin string, clientOrigin string
 	cardinality := taggerCardinality(cardinalityName)
 
 	if udsOrigin != packets.NoOrigin {
+		log.Errorf("Origin is %q, new tags will be added", udsOrigin)
 		if err := AccumulateTagsFor(udsOrigin, cardinality, tb); err != nil {
 			log.Errorf(err.Error())
 		}

--- a/pkg/tagger/local/tagger.go
+++ b/pkg/tagger/local/tagger.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/tagset"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
 	tagger_api "github.com/DataDog/datadog-agent/pkg/tagger/api"
@@ -85,6 +86,7 @@ func (t *Tagger) getTags(entity string, cardinality collectors.TagCardinality) (
 // AccumulateTagsFor appends tags for a given entity from the tagger to the TagsAccumulator
 func (t *Tagger) AccumulateTagsFor(entity string, cardinality collectors.TagCardinality, tb tagset.TagsAccumulator) error {
 	tags, err := t.getTags(entity, cardinality)
+	log.Errorf("New tags being added to entity %q: %q", entity, tags)
 	tb.AppendHashed(tags)
 	return err
 }

--- a/pkg/util/containers/metrics/docker/collector.go
+++ b/pkg/util/containers/metrics/docker/collector.go
@@ -81,6 +81,7 @@ func (d *dockerCollector) GetContainerStats(containerNS, containerID string, cac
 
 	// Try to collect the container's PIDs via Docker API, if we can't spec() will fill in the entry PID
 	outStats.PID.PIDs, err = d.pids(containerID)
+	log.Errorf("Retrieved %d pids for container %q. Pids: %v", len(outStats.PID.PIDs), containerID, outStats.PID.PIDs)
 	if err != nil {
 		log.Warnf("Unable to collect container's PIDs via Docker API, PID list will be incomplete, cid: %s, err: %v", containerID, err)
 	}
@@ -183,8 +184,10 @@ func (d *dockerCollector) refreshPIDCache(currentTime time.Time, cacheValidity t
 
 	// Full refresh
 	containers := d.metadataStore.ListContainers()
+	log.Errorf("Did a full PID refresh, found %d containers: %v", len(containers), containers)
 
 	for _, container := range containers {
+		log.Errorf("For container ID %q I found pid %d. Runtime is %v", container.ID, container.PID, container.Runtime)
 		if container.Runtime == workloadmeta.ContainerRuntimeDocker && container.PID != 0 {
 			d.pidCache.Store(currentTime, strconv.Itoa(container.PID), container.ID, nil)
 		}

--- a/test/new-e2e/workshop/basic_agent_test.go
+++ b/test/new-e2e/workshop/basic_agent_test.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package workshop
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/params"
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2params"
+	"github.com/stretchr/testify/require"
+)
+
+type basicAgentSuite struct {
+	e2e.Suite[e2e.AgentEnv]
+}
+
+func TestBasicAgentSuite(t *testing.T) {
+	t.Logf("Starting e2e.Run at %q", time.Now().String())
+	e2e.Run[e2e.AgentEnv](t, &basicAgentSuite{}, e2e.AgentStackDef(
+		[]ec2params.Option{
+			ec2params.WithOS(ec2os.AmazonLinuxDockerOS),
+			ec2params.WithName("sopell-instance-woo"),
+		},
+		agentparams.WithAgentConfig("log_level: debug"),
+		agentparams.WithTelemetry(),
+	), params.WithDevMode(), params.WithStackName("cache-busteeeeer"))
+}
+
+func (v *basicAgentSuite) TestBasicVM() {
+	require.True(v.T(), v.Env().Agent.IsReady())
+	config := v.Env().Agent.Config()
+	require.Contains(v.T(), config, "log_level: debug")
+
+	v.UpdateEnv(e2e.AgentStackDef(nil, agentparams.WithAgentConfig("log_level: trace")))
+	require.Contains(v.T(), v.Env().Agent.Config(), "log_level: trace")
+}

--- a/test/new-e2e/workshop/basic_ubuntu_test.go
+++ b/test/new-e2e/workshop/basic_ubuntu_test.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package workshop
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/params"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2params"
+	"github.com/stretchr/testify/require"
+)
+
+type basicUbuntuSuite struct {
+	e2e.Suite[e2e.VMEnv]
+}
+
+func TestBasicUbuntuSuite(t *testing.T) {
+	e2e.Run(t, &basicUbuntuSuite{}, e2e.EC2VMStackDef(ec2params.WithOS(ec2os.UbuntuOS)), params.WithDevMode())
+}
+
+func (v *basicUbuntuSuite) TestBasicVM() {
+	res := v.Env().VM.Execute("cat /etc/os-release")
+	require.Contains(v.T(), res, "Ubuntu")
+}

--- a/test/new-e2e/workshop/hello_test.go
+++ b/test/new-e2e/workshop/hello_test.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package workshop
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/params"
+)
+
+type vmSuite struct {
+	e2e.Suite[e2e.VMEnv]
+}
+
+func TestVMSuite(t *testing.T) {
+	e2e.Run(t, &vmSuite{}, e2e.EC2VMStackDef(), params.WithDevMode())
+}
+
+func (v *vmSuite) TestBasicVM() {
+	v.Env().VM.Execute("ls")
+}

--- a/test/regression/cases/uds_dogstatsd_to_api/datadog-agent/datadog.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api/datadog-agent/datadog.yaml
@@ -12,3 +12,15 @@ confd_path: /etc/datadog-agent/conf.d
 cloud_provider_metadata: []
 
 dogstatsd_socket: '/tmp/dsd.socket'
+# Enable UDS-based origin detection and
+# add all available tags
+dogstatsd_origin_detection: true
+dogstatsd_tag_cardinality: "high"
+
+# Auditing if origin detection is working correctly
+log_payloads: true # requires log level debug
+log_level: debug
+# Sanity check
+dogstatsd_tags: ["scott:opell"]
+
+process_collection.enabled: false


### PR DESCRIPTION

### What does this PR do?
Debugging issue from https://github.com/DataDog/single-machine-performance/pull/1265

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
