### PR TITLE
Componentize Hostname

### DIFF
--- a/comp/README.md
+++ b/comp/README.md
@@ -30,6 +30,10 @@ component temporarily wraps pkg/config.
 
 Package flare implements a component to generate flares from the agent.
 
+### [comp/core/hostname](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/core/hostname)
+
+Package hostname exposes hostname.Get() as a component.
+
 ### [comp/core/log](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/core/log)
 
 Package log implements a component to handle logging internal to the agent.

--- a/comp/core/bundle.go
+++ b/comp/core/bundle.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
@@ -34,4 +35,5 @@ var Bundle = fxutil.Bundle(
 	fx.Provide(func(params BundleParams) sysprobeconfig.Params { return params.SysprobeConfigParams }),
 	sysprobeconfig.Module,
 	telemetry.Module,
+	hostname.Module,
 )

--- a/comp/core/bundle_mock.go
+++ b/comp/core/bundle_mock.go
@@ -17,6 +17,7 @@ package core
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
@@ -35,4 +36,5 @@ var MockBundle = fxutil.Bundle(
 	fx.Provide(func(params BundleParams) sysprobeconfig.Params { return params.SysprobeConfigParams }),
 	sysprobeconfig.MockModule,
 	telemetry.Module,
+	hostname.MockModule,
 )

--- a/comp/core/bundle_test.go
+++ b/comp/core/bundle_test.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 )
 
@@ -21,6 +22,7 @@ func TestBundleDependencies(t *testing.T) {
 		// automatically.
 		fx.Invoke(func(config.Component) {}),
 		fx.Invoke(func(log.Component) {}),
+		fx.Invoke(func(hostname.Component) {}),
 
 		fx.Supply(BundleParams{}),
 		Bundle))
@@ -34,6 +36,7 @@ func TestMockBundleDependencies(t *testing.T) {
 		// automatically.
 		fx.Invoke(func(config.Component) {}),
 		fx.Invoke(func(log.Component) {}),
+		fx.Invoke(func(hostname.Component) {}),
 
 		fx.Supply(BundleParams{}),
 		MockBundle))

--- a/comp/core/hostname/component.go
+++ b/comp/core/hostname/component.go
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package hostname exposes hostname.Get() as a component.
+package hostname
+
+import (
+	"context"
+
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+)
+
+// team: agent-shared-components
+
+// Component is the component type.
+type Component interface {
+	// Get returns the host name for the agent.
+	Get(context.Context) (string, error)
+	// GetWithProvider returns the hostname for the Agent and the provider that was use to retrieve it.
+	GetWithProvider(ctx context.Context) (hostname.Data, error)
+	// GetSafe is Get(), but it returns 'unknown host' if anything goes wrong.
+	GetSafe(context.Context) string
+}
+
+// Mock implements mock-specific methods.
+type Mock interface {
+	Component
+	Set(string)
+}
+
+// Module defines the fx options for this component.
+var Module = fxutil.Component(
+	fx.Provide(newHostnameService),
+)
+
+// MockModule defines the fx options for the mock component.
+// Injecting MockModule will provide the hostname 'my-hostname';
+// override this with fx.Replace(hostname.MockHostname("whatever")).
+var MockModule = fxutil.Component(
+	fx.Provide(
+		newMock,
+		func(m Mock) Component { return m },
+	),
+	fx.Supply(MockHostname("my-hostname")),
+)

--- a/comp/core/hostname/component.go
+++ b/comp/core/hostname/component.go
@@ -27,12 +27,6 @@ type Component interface {
 	GetSafe(context.Context) string
 }
 
-// Mock implements mock-specific methods.
-type Mock interface {
-	Component
-	Set(string)
-}
-
 // Module defines the fx options for this component.
 var Module = fxutil.Component(
 	fx.Provide(newHostnameService),
@@ -44,7 +38,6 @@ var Module = fxutil.Component(
 var MockModule = fxutil.Component(
 	fx.Provide(
 		newMock,
-		func(m Mock) Component { return m },
 	),
 	fx.Supply(MockHostname("my-hostname")),
 )

--- a/comp/core/hostname/mock.go
+++ b/comp/core/hostname/mock.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package hostname
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+)
+
+type mockService struct {
+	name string
+}
+
+var _ Mock = (*mockService)(nil)
+
+func (m *mockService) Get(ctx context.Context) (string, error) {
+	return m.name, nil
+}
+
+func (m *mockService) GetSafe(ctx context.Context) string {
+	return m.name
+}
+
+func (m *mockService) Set(name string) {
+	m.name = name
+}
+
+// GetWithProvider returns the hostname for the Agent and the provider that was use to retrieve it.
+func (m *mockService) GetWithProvider(ctx context.Context) (hostname.Data, error) {
+	return hostname.Data{
+		Hostname: m.name,
+		Provider: "mockService",
+	}, nil
+}
+
+// MockHostname is an alias for injecting a mock hostname.
+// Usage: fx.Replace(hostname.MockHostname("whatever"))
+type MockHostname string
+
+func newMock(name MockHostname) Mock {
+	return &mockService{string(name)}
+}

--- a/comp/core/hostname/mock.go
+++ b/comp/core/hostname/mock.go
@@ -15,7 +15,7 @@ type mockService struct {
 	name string
 }
 
-var _ Mock = (*mockService)(nil)
+var _ Component = (*mockService)(nil)
 
 func (m *mockService) Get(ctx context.Context) (string, error) {
 	return m.name, nil
@@ -41,6 +41,6 @@ func (m *mockService) GetWithProvider(ctx context.Context) (hostname.Data, error
 // Usage: fx.Replace(hostname.MockHostname("whatever"))
 type MockHostname string
 
-func newMock(name MockHostname) Mock {
+func newMock(name MockHostname) Component {
 	return &mockService{string(name)}
 }

--- a/comp/core/hostname/mock_test.go
+++ b/comp/core/hostname/mock_test.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package hostname
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+)
+
+func TestMockGet(t *testing.T) {
+	s := fxutil.Test[Component](t, MockModule)
+	name, err := s.Get(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "my-hostname", name)
+}
+
+func TestMockGetWithProvider(t *testing.T) {
+	s := fxutil.Test[Component](t, MockModule)
+	data, err := s.GetWithProvider(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "my-hostname", data.Hostname)
+	assert.Equal(t, "mockService", data.Provider)
+}
+
+func TestMockProvide(t *testing.T) {
+	s := fxutil.Test[Component](t,
+		MockModule,
+		fx.Replace(MockHostname("foo")),
+	)
+	assert.Equal(t, "foo", s.GetSafe(context.Background()))
+}
+
+func TestMockSet(t *testing.T) {
+	s := fxutil.Test[Mock](t,
+		MockModule,
+	)
+	s.Set("bar")
+	assert.Equal(t, "bar", s.GetSafe(context.Background()))
+}

--- a/comp/core/hostname/mock_test.go
+++ b/comp/core/hostname/mock_test.go
@@ -37,11 +37,3 @@ func TestMockProvide(t *testing.T) {
 	)
 	assert.Equal(t, "foo", s.GetSafe(context.Background()))
 }
-
-func TestMockSet(t *testing.T) {
-	s := fxutil.Test[Mock](t,
-		MockModule,
-	)
-	s.Set("bar")
-	assert.Equal(t, "bar", s.GetSafe(context.Background()))
-}

--- a/comp/core/hostname/service.go
+++ b/comp/core/hostname/service.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package hostname
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+)
+
+type service struct{}
+
+var _ Component = (*service)(nil)
+
+// Get returns the hostname.
+func (hs *service) Get(ctx context.Context) (string, error) {
+	return hostname.Get(ctx)
+}
+
+// GetSafe returns the hostname, or 'unknown host' if anything goes wrong.
+func (hs *service) GetSafe(ctx context.Context) string {
+	name, err := hs.Get(ctx)
+	if err != nil {
+		return "unknown host"
+	}
+	return name
+}
+
+// GetWithProvider returns the hostname for the Agent and the provider that was use to retrieve it.
+func (hs *service) GetWithProvider(ctx context.Context) (hostname.Data, error) {
+	return hostname.GetWithProvider(ctx)
+}
+
+// newHostnameService fetches the hostname and returns a service wrapping it
+func newHostnameService() Component {
+	return &service{}
+}

--- a/comp/core/hostname/service_test.go
+++ b/comp/core/hostname/service_test.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package hostname
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGet(t *testing.T) {
+	t.Cleanup(func() {
+		// erase cache
+		cache.Cache.Delete(cache.BuildAgentKey("hostname"))
+		config.Datadog.Set("hostname", "")
+	})
+	config.Datadog.Set("hostname", "test-hostname")
+	s := fxutil.Test[Component](t, Module)
+	name, err := s.Get(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "test-hostname", name)
+}
+
+func TestGetWithProvider(t *testing.T) {
+	t.Cleanup(func() {
+		// erase cache)
+		cache.Cache.Delete(cache.BuildAgentKey("hostname"))
+		config.Datadog.Set("hostname", "")
+	})
+	config.Datadog.Set("hostname", "test-hostname2")
+	s := fxutil.Test[Component](t, Module)
+	data, err := s.GetWithProvider(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "test-hostname2", data.Hostname)
+	assert.Equal(t, "configuration", data.Provider)
+	assert.True(t, data.FromConfiguration())
+}


### PR DESCRIPTION
### What does this PR do?
This PR provides a hostname component that exposes `pkg/util/hostname.Get` and `.GetWithProvider` to the components system.

### Motivation
We need this for the netflow and snmp traps components.

### Additional Notes
This is based on #19140, which will be rebased on top this once this is merged in.

### Possible Drawbacks / Trade-offs
There should be no user-facing effects.

### Describe how to test/QA your changes
There should be no user-facing effects.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
