### PR TITLE
Create ndm components

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -202,6 +202,7 @@
 /comp/forwarder @DataDog/agent-shared-components
 /comp/logs @DataDog/agent-metrics-logs
 /comp/metadata @DataDog/agent-shared-components
+/comp/ndmtmp @DataDog/network-device-monitoring
 /comp/otelcol @DataDog/opentelemetry
 /comp/process @DataDog/processes
 /comp/remote-config @DataDog/remote-config

--- a/comp/README.md
+++ b/comp/README.md
@@ -98,6 +98,26 @@ Package runner implements a component to generate the 'resources' metadata paylo
 
 Package runner implements a component to generate metadata payload at the right interval.
 
+## [comp/ndmtmp](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/ndmtmp) (Component Bundle)
+
+*Datadog Team*: network-device-monitoring
+
+Package ndmtmp implements the "ndmtmp" bundle, which exposes the default
+sender.Sender and the event platform forwarder. This is a temporary module
+intended for ndm internal use until these pieces are properly componentized.
+
+### [comp/ndmtmp/aggregator](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/ndmtmp/aggregator)
+
+Package aggregator exposes the AgentDemultiplexer as a DemultiplexerWithAggregator
+
+### [comp/ndmtmp/forwarder](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/ndmtmp/forwarder)
+
+Package forwarder exposes the event platform forwarder for netflow.
+
+### [comp/ndmtmp/sender](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/ndmtmp/sender)
+
+Package sender exposes a Sender for netflow.
+
 ## [comp/otelcol](https://pkg.go.dev/github.com/DataDog/dd-agent-comp-experiments/comp/otelcol) (Component Bundle)
 
 *Datadog Team*: opentelemetry

--- a/comp/ndmtmp/aggregator/aggregator.go
+++ b/comp/ndmtmp/aggregator/aggregator.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package aggregator exposes the AgentDemultiplexer as a DemultiplexerWithAggregator
+package aggregator
+
+import (
+	"context"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"go.uber.org/fx"
+)
+
+func getAggregator(agg *aggregator.AgentDemultiplexer) Component {
+	return agg
+}
+
+func newMock(logger log.Component, lc fx.Lifecycle) Component {
+	agg := aggregator.InitTestAgentDemultiplexerWithFlushInterval(logger, 10*time.Millisecond)
+	lc.Append(fx.Hook{OnStop: func(context.Context) error {
+		agg.Stop(false)
+		return nil
+	}})
+	return agg
+}

--- a/comp/ndmtmp/aggregator/component.go
+++ b/comp/ndmtmp/aggregator/component.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package aggregator exposes the AgentDemultiplexer as a DemultiplexerWithAggregator
+package aggregator
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: network-device-monitoring
+
+// Component is the component type.
+type Component interface {
+	aggregator.DemultiplexerWithAggregator
+}
+
+// Mock implements mock-specific methods.
+type Mock interface {
+	Component
+}
+
+// Module defines the fx options for this component.
+var Module = fxutil.Component(
+	fx.Provide(getAggregator),
+)
+
+// MockModule defines the fx options for the mock component.
+var MockModule = fxutil.Component(
+	fx.Provide(newMock),
+)

--- a/comp/ndmtmp/bundle.go
+++ b/comp/ndmtmp/bundle.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package ndmtmp implements the "ndmtmp" bundle, which exposes the default
+// sender.Sender and the event platform forwarder. This is a temporary module
+// intended for ndm internal use until these pieces are properly componentized.
+package ndmtmp
+
+import (
+	"github.com/DataDog/datadog-agent/comp/ndmtmp/aggregator"
+	"github.com/DataDog/datadog-agent/comp/ndmtmp/forwarder"
+	"github.com/DataDog/datadog-agent/comp/ndmtmp/sender"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: network-device-monitoring
+
+// TODO: (components) Delete this module when the sender and event platform forwarder are fully componentized.
+
+// Bundle defines the fx options for this bundle.
+var Bundle = fxutil.Bundle(
+	sender.Module,
+	forwarder.Module,
+	aggregator.Module,
+)
+
+// MockBundle defines the fx options for mock versions of everything in this bundle.
+var MockBundle = fxutil.Bundle(
+	sender.Module,
+	forwarder.MockModule,
+	aggregator.MockModule,
+)

--- a/comp/ndmtmp/bundle_test.go
+++ b/comp/ndmtmp/bundle_test.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package ndmtmp
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/ndmtmp/aggregator"
+	"github.com/DataDog/datadog-agent/comp/ndmtmp/forwarder"
+	"github.com/DataDog/datadog-agent/comp/ndmtmp/sender"
+	ddagg "github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+)
+
+func TestBundleDependencies(t *testing.T) {
+	require.NoError(t, fx.ValidateApp(
+		// instantiate all of the ndmtmp components, since this is not done
+		// automatically.
+		fx.Invoke(func(forwarder.Component) {}),
+		fx.Invoke(func(sender.Component) {}),
+		fx.Invoke(func(aggregator.Component) {}),
+		Bundle,
+		fx.Provide(func() *ddagg.AgentDemultiplexer {
+			return &ddagg.AgentDemultiplexer{}
+		}),
+	))
+}
+
+func TestMockBundleDependencies(t *testing.T) {
+	require.NoError(t, fx.ValidateApp(
+		log.MockModule,
+		fx.Supply(fx.Annotate(t, fx.As(new(testing.TB)))),
+		fx.Invoke(func(forwarder.Component) {}),
+		fx.Invoke(func(sender.Component) {}),
+		fx.Invoke(func(aggregator.Component) {}),
+		MockBundle,
+	))
+}

--- a/comp/ndmtmp/forwarder/component.go
+++ b/comp/ndmtmp/forwarder/component.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package forwarder exposes the event platform forwarder for netflow.
+package forwarder
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/pkg/epforwarder"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: network-device-monitoring
+
+// Component is the component type.
+type Component interface {
+	epforwarder.EventPlatformForwarder
+}
+
+// Module defines the fx options for this component.
+var Module = fxutil.Component(
+	fx.Provide(getForwarder),
+)
+
+// MockComponent is the type for mock components.
+// It is a gomock-generated mock of EventPlatformForwarder.
+type MockComponent interface {
+	Component
+	EXPECT() *epforwarder.MockEventPlatformForwarderMockRecorder
+}
+
+// MockModule defines a component with a mock forwarder
+var MockModule = fxutil.Component(
+	fx.Provide(
+		getMockForwarder,
+		// Provide the mock as the primary component as well
+		func(c MockComponent) Component { return c },
+	),
+)

--- a/comp/ndmtmp/forwarder/forwarder.go
+++ b/comp/ndmtmp/forwarder/forwarder.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package forwarder exposes the event platform forwarder for netflow.
+package forwarder
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/ndmtmp/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/epforwarder"
+	"github.com/golang/mock/gomock"
+)
+
+func getForwarder(agg aggregator.Component) (Component, error) {
+	return agg.GetEventPlatformForwarder()
+}
+
+func getMockForwarder(t testing.TB) MockComponent {
+	ctrl := gomock.NewController(t)
+	return epforwarder.NewMockEventPlatformForwarder(ctrl)
+}

--- a/comp/ndmtmp/sender/component.go
+++ b/comp/ndmtmp/sender/component.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package sender exposes a Sender for netflow.
+package sender
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: network-device-monitoring
+
+// Component is the component type.
+type Component interface {
+	sender.Sender
+}
+
+// Module defines the fx options for this component.
+var Module = fxutil.Component(
+	fx.Provide(getDefaultSender),
+)

--- a/comp/ndmtmp/sender/sender.go
+++ b/comp/ndmtmp/sender/sender.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package sender exposes a Sender for netflow.
+package sender
+
+import "github.com/DataDog/datadog-agent/comp/ndmtmp/aggregator"
+
+func getDefaultSender(agg aggregator.Component) (Component, error) {
+	return agg.GetDefaultSender()
+}


### PR DESCRIPTION
### What does this PR do?
This PR provides an `ndmtmp` bundle for several things that we expect will eventually be componentized, but which we need right now for the netflow and snmp traps components. It exposes the passed-in `*aggregator.AgentDemultiplexer` as an `aggregator.DemultiplexerWithAggregator`, and exposes the events platform forwarder and default sender as components as well.

### Motivation
We need this for the netflow and snmp traps components - we want to inject these as components so that we can override them with mocks in our tests.

### Additional Notes
This is based on #19140, which will be rebased on top this once this is merged in.

### Possible Drawbacks / Trade-offs
There should be no user-facing effects.

### Describe how to test/QA your changes
There should be no user-facing effects.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
