### PR TITLE
[USMON-518] Add dedicated config param for controlling eBPF map sizes

### DIFF
--- a/cmd/system-probe/config/adjust_usm.go
+++ b/cmd/system-probe/config/adjust_usm.go
@@ -40,6 +40,7 @@ func adjustUSM(cfg config.Config) {
 	applyDefault(cfg, smNS("http_notification_threshold"), 512)
 	deprecateInt64(cfg, netNS("http_max_request_fragment"), smNS("http_max_request_fragment"))
 	applyDefault(cfg, smNS("http_max_request_fragment"), 160)
+	applyDefault(cfg, smNS("max_concurrent_requests"), 65536)
 
 	if cfg.GetBool(dsmNS("enabled")) {
 		// DSM infers USM

--- a/cmd/system-probe/config/adjust_usm.go
+++ b/cmd/system-probe/config/adjust_usm.go
@@ -40,7 +40,7 @@ func adjustUSM(cfg config.Config) {
 	applyDefault(cfg, smNS("http_notification_threshold"), 512)
 	deprecateInt64(cfg, netNS("http_max_request_fragment"), smNS("http_max_request_fragment"))
 	applyDefault(cfg, smNS("http_max_request_fragment"), 160)
-	applyDefault(cfg, smNS("max_concurrent_requests"), 65536)
+	applyDefault(cfg, smNS("max_concurrent_requests"), cfg.GetInt(spNS("max_tracked_connections")))
 
 	if cfg.GetBool(dsmNS("enabled")) {
 		// DSM infers USM

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -224,7 +224,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnv(join(netNS, "max_http_stats_buffered"), "DD_SYSTEM_PROBE_NETWORK_MAX_HTTP_STATS_BUFFERED")
 	cfg.BindEnv(join(smNS, "max_http_stats_buffered"))
 	cfg.BindEnvAndSetDefault(join(smNS, "max_kafka_stats_buffered"), 100000)
-	cfg.BindEnvAndSetDefault(join(smNS, "max_concurrent_requests"), 65536)
+	cfg.BindEnv(join(smNS, "max_concurrent_requests"))
 
 	oldHTTPRules := join(netNS, "http_replace_rules")
 	newHTTPRules := join(smNS, "http_replace_rules")

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -224,7 +224,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnv(join(netNS, "max_http_stats_buffered"), "DD_SYSTEM_PROBE_NETWORK_MAX_HTTP_STATS_BUFFERED")
 	cfg.BindEnv(join(smNS, "max_http_stats_buffered"))
 	cfg.BindEnvAndSetDefault(join(smNS, "max_kafka_stats_buffered"), 100000)
-	cfg.BindEnvAndSetDefault(join(smNS, "max_concurrent_requests"), 30000)
+	cfg.BindEnvAndSetDefault(join(smNS, "max_concurrent_requests"), 65536)
 
 	oldHTTPRules := join(netNS, "http_replace_rules")
 	newHTTPRules := join(smNS, "http_replace_rules")

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -224,6 +224,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnv(join(netNS, "max_http_stats_buffered"), "DD_SYSTEM_PROBE_NETWORK_MAX_HTTP_STATS_BUFFERED")
 	cfg.BindEnv(join(smNS, "max_http_stats_buffered"))
 	cfg.BindEnvAndSetDefault(join(smNS, "max_kafka_stats_buffered"), 100000)
+	cfg.BindEnvAndSetDefault(join(smNS, "max_concurrent_requests"), 30000)
 
 	oldHTTPRules := join(netNS, "http_replace_rules")
 	newHTTPRules := join(smNS, "http_replace_rules")

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -157,7 +157,7 @@ type Config struct {
 	// get flushed on every client request (default 30s check interval)
 	MaxDNSStatsBuffered int
 
-	// MaxUSMConcurrentRequests represents the maximum number of concurrent requests (for a single protocol)
+	// MaxUSMConcurrentRequests represents the maximum number of requests (for a single protocol)
 	// that can happen concurrently at a given point in time. This parameter is used for sizing our eBPF maps.
 	MaxUSMConcurrentRequests uint32
 

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -157,6 +157,10 @@ type Config struct {
 	// get flushed on every client request (default 30s check interval)
 	MaxDNSStatsBuffered int
 
+	// MaxUSMConcurrentRequests represents the maximum number of concurrent requests (for a single protocol)
+	// that can happen concurrently at a given point in time. This parameter is used for sizing our eBPF maps.
+	MaxUSMConcurrentRequests uint32
+
 	// MaxHTTPStatsBuffered represents the maximum number of HTTP stats we'll buffer in memory. These stats
 	// get flushed on every client request (default 30s check interval)
 	MaxHTTPStatsBuffered int
@@ -303,6 +307,7 @@ func New() *Config {
 		EnableHTTP2Monitoring:     cfg.GetBool(join(smNS, "enable_http2_monitoring")),
 		EnableNativeTLSMonitoring: cfg.GetBool(join(smNS, "tls", "native", "enabled")),
 		EnableIstioMonitoring:     cfg.GetBool(join(smNS, "tls", "istio", "enabled")),
+		MaxUSMConcurrentRequests:  uint32(cfg.GetInt(join(smNS, "max_concurrent_requests"))),
 		MaxHTTPStatsBuffered:      cfg.GetInt(join(smNS, "max_http_stats_buffered")),
 		MaxKafkaStatsBuffered:     cfg.GetInt(join(smNS, "max_kafka_stats_buffered")),
 

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -1237,6 +1237,33 @@ service_monitoring_config:
 	})
 }
 
+func TestMaxUSMConcurrentRequests(t *testing.T) {
+	t.Run("default value", func(t *testing.T) {
+		aconfig.ResetSystemProbeConfig(t)
+		cfg := New()
+		// Assert that if not explicitly set this param defaults to `MaxTrackedConnections`
+		// Note this behavior should be deprecated on 7.50
+		assert.Equal(t, cfg.MaxTrackedConnections, cfg.MaxUSMConcurrentRequests)
+	})
+
+	t.Run("via yaml", func(t *testing.T) {
+		aconfig.ResetSystemProbeConfig(t)
+		cfg := configurationFromYAML(t, `
+service_monitoring_config:
+  max_concurrent_requests: 1000
+`)
+		assert.Equal(t, uint32(1000), cfg.MaxUSMConcurrentRequests)
+	})
+
+	t.Run("via ENV variable", func(t *testing.T) {
+		aconfig.ResetSystemProbeConfig(t)
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_MAX_CONCURRENT_REQUESTS", "3000")
+
+		cfg := New()
+		assert.Equal(t, uint32(3000), cfg.MaxUSMConcurrentRequests)
+	})
+}
+
 func TestUSMTLSNativeEnabled(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)

--- a/pkg/network/protocols/http/protocol.go
+++ b/pkg/network/protocols/http/protocol.go
@@ -106,7 +106,7 @@ func (p *protocol) Name() string {
 // We also configure the http event stream with the manager and its options.
 func (p *protocol) ConfigureOptions(mgr *manager.Manager, opts *manager.Options) {
 	opts.MapSpecEditors[inFlightMap] = manager.MapSpecEditor{
-		MaxEntries: p.cfg.MaxTrackedConnections,
+		MaxEntries: p.cfg.MaxUSMConcurrentRequests,
 		EditorFlag: manager.EditMaxEntries,
 	}
 	utils.EnableOption(opts, "http_monitoring_enabled")

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -125,7 +125,7 @@ const (
 // We also configure the http2 event stream with the manager and its options.
 func (p *protocol) ConfigureOptions(mgr *manager.Manager, opts *manager.Options) {
 	opts.MapSpecEditors[inFlightMap] = manager.MapSpecEditor{
-		MaxEntries: p.cfg.MaxTrackedConnections,
+		MaxEntries: p.cfg.MaxUSMConcurrentRequests,
 		EditorFlag: manager.EditMaxEntries,
 	}
 

--- a/pkg/network/usm/ebpf_javatls.go
+++ b/pkg/network/usm/ebpf_javatls.go
@@ -163,11 +163,11 @@ func (p *javaTLSProgram) Name() string {
 
 func (p *javaTLSProgram) ConfigureOptions(_ *manager.Manager, options *manager.Options) {
 	options.MapSpecEditors[javaTLSConnectionsMap] = manager.MapSpecEditor{
-		MaxEntries: p.cfg.MaxTrackedConnections,
+		MaxEntries: p.cfg.MaxUSMConcurrentRequests,
 		EditorFlag: manager.EditMaxEntries,
 	}
 	options.MapSpecEditors[javaDomainsToConnectionsMap] = manager.MapSpecEditor{
-		MaxEntries: p.cfg.MaxTrackedConnections,
+		MaxEntries: p.cfg.MaxUSMConcurrentRequests,
 		EditorFlag: manager.EditMaxEntries,
 	}
 	options.ActivatedProbes = append(options.ActivatedProbes,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Use dedicated configuration param for sizing a few of the USM eBPF maps.

### Motivation

Decouple USM map sizes from `MaxTrackedConnections` param and – to be done in a follow-up PR – reduce memory by choosing a better (lower) default.

### Additional Notes

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
                        