### PR TITLE
[linter] Fix some issues in container-integrations files

### DIFF
--- a/pkg/clusteragent/clusterchecks/checks_distribution.go
+++ b/pkg/clusteragent/clusterchecks/checks_distribution.go
@@ -100,7 +100,7 @@ func (distribution *checksDistribution) addCheck(checkID string, workersNeeded f
 	runnerInfo, runnerExists := distribution.Runners[runner]
 	if runnerExists {
 		runnerInfo.WorkersUsed += workersNeeded
-		runnerInfo.NumChecks += 1
+		runnerInfo.NumChecks++
 	} else {
 		distribution.Runners[runner] = &RunnerStatus{
 			WorkersUsed: workersNeeded,
@@ -175,7 +175,7 @@ func (distribution *checksDistribution) numEmptyRunners() int {
 
 	for _, runnerStatus := range distribution.Runners {
 		if runnerStatus.NumChecks == 0 {
-			empty += 1
+			empty++
 		}
 	}
 
@@ -187,7 +187,7 @@ func (distribution *checksDistribution) numRunnersWithHighUtilization() int {
 
 	for _, runnerStatus := range distribution.Runners {
 		if runnerStatus.utilization() > 0.8 {
-			withHighUtilization += 1
+			withHighUtilization++
 		}
 	}
 

--- a/pkg/clusteragent/clusterchecks/helpers.go
+++ b/pkg/clusteragent/clusterchecks/helpers.go
@@ -16,10 +16,10 @@ import (
 )
 
 var (
-	checkExecutionTimeWeight   float64 = 0
+	checkExecutionTimeWeight           = 0.0
 	checkMetricSamplesWeight   float64 = 1
 	checkHistogramBucketWeight float64 = 1
-	checkEventsWeight          float64 = 0.2
+	checkEventsWeight                  = 0.2
 )
 
 // makeConfigArray flattens a map of configs into a slice. Creating a new slice

--- a/pkg/collector/corechecks/containerimage/processor.go
+++ b/pkg/collector/corechecks/containerimage/processor.go
@@ -72,10 +72,10 @@ func (p *processor) processImage(img *workloadmeta.ContainerImageMetadata) {
 		log.Errorf("Could not retrieve tags for container image %s: %v", img.ID, err)
 	}
 
-	var lastCreated *timestamppb.Timestamp = nil
+	var lastCreated *timestamppb.Timestamp
 	layers := make([]*model.ContainerImage_ContainerImageLayer, 0, len(img.Layers))
 	for _, layer := range img.Layers {
-		var created *timestamppb.Timestamp = nil
+		var created *timestamppb.Timestamp
 		if layer.History.Created != nil {
 			created = timestamppb.New(*layer.History.Created)
 			lastCreated = created

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
@@ -183,7 +183,7 @@ func (r *runningAggregator) recordContainer(p *Provider, pod *kubelet.Pod, cStat
 		return
 	}
 	hashTags := generateTagHash(tags)
-	r.runningContainersCounter[hashTags] += 1
+	r.runningContainersCounter[hashTags]++
 	if _, ok := r.runningContainersTags[hashTags]; !ok {
 		r.runningContainersTags[hashTags] = utils.ConcatenateTags(tags, p.config.Tags)
 	}
@@ -203,7 +203,7 @@ func (r *runningAggregator) recordPod(p *Provider, pod *kubelet.Pod) {
 		return
 	}
 	hashTags := generateTagHash(tags)
-	r.runningPodsCounter[hashTags] += 1
+	r.runningPodsCounter[hashTags]++
 	if _, ok := r.runningPodsTags[hashTags]; !ok {
 		r.runningPodsTags[hashTags] = utils.ConcatenateTags(tags, p.config.Tags)
 	}

--- a/pkg/collector/corechecks/sbom/convert.go
+++ b/pkg/collector/corechecks/sbom/convert.go
@@ -599,7 +599,7 @@ func convertMetadata(in *cyclonedx.Metadata) *cyclonedx_v1_4.Metadata {
 		return nil
 	}
 
-	var licenses *cyclonedx_v1_4.LicenseChoice = nil
+	var licenses *cyclonedx_v1_4.LicenseChoice
 	if in.Licenses != nil && len(*in.Licenses) > 0 {
 		licenses = convertLicenseChoice(&(*in.Licenses)[0])
 	}
@@ -827,7 +827,7 @@ func convertSwid(in *cyclonedx.SWID) *cyclonedx_v1_4.Swid {
 		return nil
 	}
 
-	var tagVersion *int32 = nil
+	var tagVersion *int32
 	if in.TagVersion != nil {
 		tagVersion = pointer.Ptr(int32(*in.TagVersion))
 	}

--- a/pkg/util/kubernetes/autoscalers/processor_test.go
+++ b/pkg/util/kubernetes/autoscalers/processor_test.go
@@ -719,5 +719,5 @@ func (m *mockGauge) Delete(tagsValue ...string) {
 	delete(m.values, strings.Join(tagsValue, ","))
 }
 
-func (g *mockGauge) WithValues(tagsValue ...string) telemetryComponent.SimpleGauge  { return nil }
-func (g *mockGauge) WithTags(tags map[string]string) telemetryComponent.SimpleGauge { return nil }
+func (*mockGauge) WithValues(tagsValue ...string) telemetryComponent.SimpleGauge  { return nil }
+func (*mockGauge) WithTags(tags map[string]string) telemetryComponent.SimpleGauge { return nil }

--- a/pkg/workloadmeta/collectors/core-agent/collectors.go
+++ b/pkg/workloadmeta/collectors/core-agent/collectors.go
@@ -8,5 +8,5 @@
 package collectors
 
 import (
-	_ "github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote/process_collector"
+	_ "github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/remote/process_collector" // Load the collectors
 )

--- a/pkg/workloadmeta/collectors/internal/containerd/image.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image.go
@@ -379,7 +379,7 @@ func getLayersWithHistory(ctx context.Context, store content.Store, manifest oci
 			}
 
 			manifestLayer := manifest.Layers[manifestLayersIdx]
-			manifestLayersIdx += 1
+			manifestLayersIdx++
 
 			layer.MediaType = manifestLayer.MediaType
 			layer.Digest = manifestLayer.Digest.String()

--- a/pkg/workloadmeta/collectors/internal/ecs/ecs_test.go
+++ b/pkg/workloadmeta/collectors/internal/ecs/ecs_test.go
@@ -11,9 +11,10 @@ package ecs
 import (
 	"context"
 	"errors"
+	"testing"
+
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	v1 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v1"
 	"github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3or4"
@@ -52,7 +53,7 @@ type fakev3or4EcsClient struct {
 	mockGetTaskWithTags func(context.Context) (*v3or4.Task, error)
 }
 
-func (store *fakev3or4EcsClient) GetTask(ctx context.Context) (*v3or4.Task, error) {
+func (*fakev3or4EcsClient) GetTask(ctx context.Context) (*v3or4.Task, error) {
 	return nil, errors.New("unimplemented")
 }
 
@@ -60,7 +61,7 @@ func (c *fakev3or4EcsClient) GetTaskWithTags(ctx context.Context) (*v3or4.Task, 
 	return c.mockGetTaskWithTags(ctx)
 }
 
-func (store *fakev3or4EcsClient) GetContainer(ctx context.Context) (*v3or4.Container, error) {
+func (*fakev3or4EcsClient) GetContainer(ctx context.Context) (*v3or4.Container, error) {
 	return nil, errors.New("unimplemented")
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes some types of linter issues detected with `inv -e show-linters-issues --filter-team "@Datadog/container-integrations" --filter-linters "revive"` :
- "increment-decrement"
- "receiver-naming"
- "blank-imports"
- "var-declaration"

I'll fix other types in separate PRs.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
