### PR TITLE
[omnibus] Update oscap-io tool in OpenSCAP

### DIFF
--- a/omnibus/config/patches/openscap/oscap-io.patch
+++ b/omnibus/config/patches/openscap/oscap-io.patch
@@ -1,14 +1,14 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -327,6 +327,7 @@ cmake_dependent_option(ENABLE_OSCAP_UTIL_SSH "enables the oscap-ssh utility, thi
+@@ -338,6 +338,7 @@ cmake_dependent_option(ENABLE_OSCAP_UTIL_SSH "enables the oscap-ssh utility, thi
  cmake_dependent_option(ENABLE_OSCAP_UTIL_VM "enables the oscap-vm utility, this lets you scan VMs and VM storage images" ON "NOT WIN32" OFF)
  cmake_dependent_option(ENABLE_OSCAP_UTIL_PODMAN "enables the oscap-podman utility, this lets you scan Podman containers and container images" ON "NOT WIN32" OFF)
  cmake_dependent_option(ENABLE_OSCAP_UTIL_CHROOT "enables the oscap-chroot utility, this lets you scan entire chroots using offline scanning" ON "NOT WIN32" OFF)
 +cmake_dependent_option(ENABLE_OSCAP_UTIL_IO "enables the oscap-io utility" ON "NOT WIN32" OFF)
  option(ENABLE_OSCAP_UTIL_AUTOTAILOR "enables the autotailor utility that is able to perform command-line tailoring" TRUE)
- option(ENABLE_OSCAP_REMEDIATE_SERVICE "enables the oscap-remediate service" TRUE)
+ option(ENABLE_OSCAP_REMEDIATE_SERVICE "enables the oscap-remediate service" FALSE)
  
-@@ -460,6 +461,7 @@ message(STATUS "oscap-ssh: ${ENABLE_OSCAP_UTIL_SSH}")
+@@ -473,6 +474,7 @@ message(STATUS "oscap-ssh: ${ENABLE_OSCAP_UTIL_SSH}")
  message(STATUS "oscap-vm: ${ENABLE_OSCAP_UTIL_VM}")
  message(STATUS "oscap-podman: ${ENABLE_OSCAP_UTIL_PODMAN}")
  message(STATUS "oscap-chroot: ${ENABLE_OSCAP_UTIL_CHROOT}")
@@ -40,7 +40,7 @@
 +endif()
 --- /dev/null
 +++ b/utils/oscap-io/oscap-io.c
-@@ -0,0 +1,222 @@
+@@ -0,0 +1,227 @@
 +#include <stdio.h>
 +#include <stdlib.h>
 +#include <string.h>
@@ -60,11 +60,14 @@
 +session_new(char *file)
 +{
 +	struct xccdf_session *session;
++	char *err;
 +	int n;
 +
 +	session = xccdf_session_new(file);
 +	if (session == NULL) {
-+		fprintf(stderr, "error: xccdf_session_new: %s\n", oscap_err_get_full_error());
++		err = oscap_err_get_full_error();
++		fprintf(stderr, "error: xccdf_session_new: %s\n", err);
++		free(err);
 +		return NULL;
 +	}
 +
@@ -73,7 +76,7 @@
 +
 +	n = xccdf_session_load(session);
 +	if (n != 0) {
-+		char *err = oscap_err_get_full_error();
++		err = oscap_err_get_full_error();
 +		fprintf(stderr, "error: xccdf_session_load: %s\n", err);
 +		free(err);
 +		xccdf_session_free(session);
@@ -111,7 +114,7 @@
 +	struct xccdf_rule_result_iterator *resIt;
 +	struct xccdf_rule_result *res;
 +	int n, resultCode;
-+	char *result;
++	char *result, *err;
 +	const char *ruleRef;
 +
 +	if (rule != NULL) {
@@ -119,7 +122,9 @@
 +	}
 +
 +	if (xccdf_session_evaluate(session) != 0) {
-+		fprintf(stderr, "error: xccdf_session_evaluate: %s\n", oscap_err_get_full_error());
++		err = oscap_err_get_full_error();
++		fprintf(stderr, "error: xccdf_session_evaluate: %s\n", err);
++		free(err);
 +		xccdf_session_result_reset(session);
 +		return 1;
 +	}


### PR DESCRIPTION
### What does this PR do?

This change fixes memory leaks after `xccdf_session_new` and `xccdf_session_evaluate` failures.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
