### PR TITLE
Remove `--no-binary :all:` when building cryptography

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -216,7 +216,6 @@ build do
         specific_build_env["cryptography"] = nix_build_env.merge(
             {
                 "RUSTFLAGS" => "-C link-arg=-Wl,-rpath,#{install_dir}/embedded/lib",
-                "PIP_NO_BINARY" => ":all:",
                 "OPENSSL_DIR" => "#{install_dir}/embedded/",
                 # We have a manually installed dependency (snowflake connector) that already installed cryptography (but without the flags)
                 # We force reinstall it from source to be sure we use the flag


### PR DESCRIPTION

### What does this PR do?

Removes `--no-binary :all:` when building cryptography.

### Motivation

Build broken due to a combination of setuptools-scm and --no-binary :all: (https://github.com/pypa/setuptools_scm/issues/918).

### Additional Notes

This flag was introduced in #18757, along with others, while trying to fix build problems for cryptography on centos 6. From looking at the commits on that PR, I think that it was just one attempt out of many and it wasn't unclear whether it helped fix the build problem, but we never attempted to remove it once we hit a combination that actually ended up in a successful build. All this to say that it's probably fine to remove it since it was added for avoiding build errors, not runtime errors.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
