### PR TITLE
[omnibus] Update session_reset_results patch in OpenSCAP

### DIFF
--- a/omnibus/config/patches/openscap/session_reset_results.patch
+++ b/omnibus/config/patches/openscap/session_reset_results.patch
@@ -1,15 +1,17 @@
 --- a/src/OVAL/oval_agent.c
 +++ b/src/OVAL/oval_agent.c
-@@ -259,6 +259,15 @@ void oval_agent_reset_syschar(oval_agent_session_t * ag_sess) {
+@@ -259,6 +259,17 @@ void oval_agent_reset_syschar(oval_agent_session_t * ag_sess) {
  	oval_syschar_model_reset(ag_sess->sys_model);
  }
  
 +void oval_agent_reset_results(oval_agent_session_t * ag_sess) {
 +#if defined(OVAL_PROBES_ENABLED)
-+	oval_results_model_free(ag_sess->res_model);
-+	ag_sess->res_model = oval_results_model_new_with_probe_session(
-+			ag_sess->def_model, ag_sess->sys_models, ag_sess->psess);
-+	oval_probe_session_reinit(ag_sess->psess, ag_sess->sys_model);
++	if (ag_sess != NULL) {
++		oval_results_model_free(ag_sess->res_model);
++		ag_sess->res_model = oval_results_model_new_with_probe_session(
++				ag_sess->def_model, ag_sess->sys_models, ag_sess->psess);
++		oval_probe_session_reinit(ag_sess->psess, ag_sess->sys_model);
++	}
 +#endif
 +}
 +
@@ -52,7 +54,7 @@
  	session->skip_rules = oscap_list_new();
  
  	_xccdf_session_reset_oval_agents_syschar(session);
-+	_xccdf_session_reset_oval_agents_results(session);
++	//_xccdf_session_reset_oval_agents_results(session);
  }
  
  const char *xccdf_session_get_filename(const struct xccdf_session *session)


### PR DESCRIPTION
### What does this PR do?

This change improves the `oval_agent_reset_results` function to handle a NULL session properly.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
