### PR TITLE
Fix e2e test flakiness by making value threshold less aggressive

### DIFF
--- a/test/e2e/argo-workflows/templates/cpu-stress.yaml
+++ b/test/e2e/argo-workflows/templates/cpu-stress.yaml
@@ -66,7 +66,7 @@ spec:
             var nb = db.series.find({
             metric: "cri.cpu.usage",
             tags: { $all: ["kube_deployment:cpu-stress", "kube_container_name:cpu-stress"] },
-            "points.0.1": { $gt: 980000000, $lt: 1010000000 } }).count();
+            "points.0.1": { $gt: 950000000, $lt: 1010000000 } }).count();
             print("find: " + nb)
             if (nb != 0) {
               print("cpu value in target range")


### PR DESCRIPTION
### What does this PR do?

The [`find-metrics-cpu-container-runtime` e2e test](https://github.com/DataDog/datadog-agent/blob/22a40c3987c5cffd2c328b1b0cd39aed15211f68/test/e2e/argo-workflows/templates/cpu-stress.yaml#L56-L76) checks the `cri.cpu.usage` metric of a container that is [expected to burn exactly 1 core](https://github.com/DataDog/datadog-agent/blob/22a40c3987c5cffd2c328b1b0cd39aed15211f68/test/e2e/argo-workflows/templates/cpu-stress.yaml#L32-L41).
But [it is sometimes failing to pass](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/331446743).
This seems to be because the container is competing with some other processes on the core and is hence consuming slightly less.

### Motivation

Make the find-metrics-cpu-container-runtime e2e test less flaky.

### Additional Notes

[Investigation notebook](https://dddev.datadoghq.com/notebook/6549469/l%C3%A9na%C3%AFc-sep-21-2023-11-55)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
