### PR TITLE
Check ID when fetching github workflow

### DIFF
--- a/tasks/libs/common/github_api.py
+++ b/tasks/libs/common/github_api.py
@@ -155,6 +155,15 @@ class GithubAPI:
         runs = workflow.get_runs(branch=ref)
         return max(runs, key=lambda run: run.created_at, default=None)
 
+    def workflow_run_for_ref_after_date(self, workflow_name, ref, oldest_date):
+        """
+        Gets all the workflow triggered after a given date
+        """
+        workflow = self._repository.get_workflow(workflow_name)
+        date_filter = f"%3E{oldest_date.strftime('%Y-%m-%dT%H:%M')}"
+        runs = workflow.get_run(create=date_filter, branch=ref)
+        return runs
+
     def _chose_auth(self):
         """
         Attempt to find a working authentication, in order:

--- a/tasks/libs/common/github_api.py
+++ b/tasks/libs/common/github_api.py
@@ -160,9 +160,10 @@ class GithubAPI:
         Gets all the workflow triggered after a given date
         """
         workflow = self._repository.get_workflow(workflow_name)
-        date_filter = f"%3E{oldest_date.strftime('%Y-%m-%dT%H:%M')}"
-        runs = workflow.get_runs(create=date_filter, branch=ref)
-        return runs
+        runs = workflow.get_runs(branch=ref)
+        recent_runs = [run for run in runs if run.created_at > oldest_date]
+
+        return sorted(recent_runs, key=lambda run: run.created_at, reverse=True)
 
     def _chose_auth(self):
         """

--- a/tasks/libs/common/github_api.py
+++ b/tasks/libs/common/github_api.py
@@ -161,7 +161,7 @@ class GithubAPI:
         """
         workflow = self._repository.get_workflow(workflow_name)
         date_filter = f"%3E{oldest_date.strftime('%Y-%m-%dT%H:%M')}"
-        runs = workflow.get_run(create=date_filter, branch=ref)
+        runs = workflow.get_runs(create=date_filter, branch=ref)
         return runs
 
     def _chose_auth(self):

--- a/tasks/libs/common/github_api.py
+++ b/tasks/libs/common/github_api.py
@@ -147,14 +147,6 @@ class GithubAPI:
 
         return self.download_from_url(headers["location"], destination_dir, run.id)
 
-    def latest_workflow_run_for_ref(self, workflow_name, ref):
-        """
-        Gets latest workflow run for a given reference
-        """
-        workflow = self._repository.get_workflow(workflow_name)
-        runs = workflow.get_runs(branch=ref)
-        return max(runs, key=lambda run: run.created_at, default=None)
-
     def workflow_run_for_ref_after_date(self, workflow_name, ref, oldest_date):
         """
         Gets all the workflow triggered after a given date

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -81,7 +81,7 @@ def trigger_macos_workflow(
         recent_runs = gh.workflow_run_for_ref_after_date(workflow_name, github_action_ref, now)
         for recent_run in recent_runs:
             jobs = recent_run.jobs()
-            if len(jobs) >= 2:
+            if jobs.totalCount() >= 2:
                 workflow_id_job = jobs[0]  # Workflow Provider ID job is the first job in the workflow
                 if len(workflow_id_job["steps"]) > 2:
                     id_steps = workflow_id_job["steps"][1]  # Step with the ID is the second one

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -79,8 +79,7 @@ def trigger_macos_workflow(
             if jobs.totalCount >= 2:
                 workflow_id_job = jobs[0]  # Workflow Provider ID job is the first job in the workflow
                 if len(workflow_id_job.steps) > 2:
-                    id_steps = workflow_id_job.steps[1]  # Step with the ID is the second one
-                    if id_steps.name == workflow_id:
+                    if any([step.name == workflow_id for step in workflow_id_job.steps]):
                         return recent_run
                 else:
                     print("waiting for steps to be executed...")

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -65,6 +65,7 @@ def trigger_macos_workflow(
     inputs["id"] = workflow_id
 
     gh = GithubAPI('DataDog/datadog-agent-macos-build')
+    print("Triggered workflow with id: ", workflow_id)
     gh.trigger_workflow(workflow_name, github_action_ref, inputs)
 
     # Thus the following hack: query the latest run for ref, wait until we get a non-completed run

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -75,15 +75,12 @@ def trigger_macos_workflow(
         print(f"Fetching triggered workflow (try {i + 1}/{MAX_RETRIES})")
         recent_runs = gh.workflow_run_for_ref_after_date(workflow_name, github_action_ref, now)
         for recent_run in recent_runs:
-            print("Recent run found: ", recent_run)
             jobs = recent_run.jobs()
-            print("Jobs found: ", jobs)
             if jobs.totalCount >= 2:
                 flattened_step_list = []
                 for job in jobs:
                     flattened_step_list += job.steps
 
-                print("Steps flattened: ", flattened_step_list)
                 if any([step.name == workflow_id for step in flattened_step_list]):
                     return recent_run
             else:

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -75,9 +75,12 @@ def trigger_macos_workflow(
         print(f"Fetching triggered workflow (try {i + 1}/{MAX_RETRIES})")
         recent_runs = gh.workflow_run_for_ref_after_date(workflow_name, github_action_ref, now)
         for recent_run in recent_runs:
+            print("Recent run found: ", recent_run)
             jobs = recent_run.jobs()
+            print("Jobs found: ", jobs)
             if jobs.totalCount >= 2:
                 workflow_id_job = jobs[0]  # Workflow Provider ID job is the first job in the workflow
+                print("Steps: ", workflow_id_job.steps)
                 if len(workflow_id_job.steps) > 2:
                     if any([step.name == workflow_id for step in workflow_id_job.steps]):
                         return recent_run

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -77,12 +77,9 @@ def trigger_macos_workflow(
         for recent_run in recent_runs:
             jobs = recent_run.jobs()
             if jobs.totalCount >= 2:
-                flattened_step_list = []
                 for job in jobs:
-                    flattened_step_list += job.steps
-
-                if any([step.name == workflow_id for step in flattened_step_list]):
-                    return recent_run
+                    if any([step.name == workflow_id for step in job.steps]):
+                        return recent_run
             else:
                 print("waiting for jobs to popup...")
                 sleep(3)

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -81,7 +81,7 @@ def trigger_macos_workflow(
         recent_runs = gh.workflow_run_for_ref_after_date(workflow_name, github_action_ref, now)
         for recent_run in recent_runs:
             jobs = recent_run.jobs()
-            if jobs.totalCount() >= 2:
+            if jobs.totalCount >= 2:
                 workflow_id_job = jobs[0]  # Workflow Provider ID job is the first job in the workflow
                 if len(workflow_id_job["steps"]) > 2:
                     id_steps = workflow_id_job["steps"][1]  # Step with the ID is the second one

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -85,7 +85,7 @@ def trigger_macos_workflow(
                 workflow_id_job = jobs[0]  # Workflow Provider ID job is the first job in the workflow
                 if len(workflow_id_job.steps) > 2:
                     id_steps = workflow_id_job.steps[1]  # Step with the ID is the second one
-                    if id_steps["name"] == workflow_id:
+                    if id_steps.name == workflow_id:
                         return recent_run
                 else:
                     print("waiting for steps to be executed...")

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -83,8 +83,8 @@ def trigger_macos_workflow(
             jobs = recent_run.jobs()
             if jobs.totalCount >= 2:
                 workflow_id_job = jobs[0]  # Workflow Provider ID job is the first job in the workflow
-                if len(workflow_id_job["steps"]) > 2:
-                    id_steps = workflow_id_job["steps"][1]  # Step with the ID is the second one
+                if len(workflow_id_job.steps) > 2:
+                    id_steps = workflow_id_job.steps[1]  # Step with the ID is the second one
                     if id_steps["name"] == workflow_id:
                         return recent_run
                 else:

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -67,10 +67,9 @@ def trigger_macos_workflow(
     gh = GithubAPI('DataDog/datadog-agent-macos-build')
     gh.trigger_workflow(workflow_name, github_action_ref, inputs)
 
-    # Thus the following hack: query the latest run for ref, wait until we get a non-completed run
-    # that started after we triggered the workflow.
-    # In practice, this should almost never be a problem, even if the Agent 6 and 7 jobs run at the
-    # same time, given that these two jobs will target different github_action_ref on RCs / releases.
+    # Thus the following hack: Send an id as input when creating a workflow on Github. The worklow will use the id and put it in the name of one of its jobs.
+    # We then fetch workflows and check if it contains the id in its job name.
+
     MAX_RETRIES = 10  # Retry up to 10 times
     for i in range(MAX_RETRIES):
         print(f"Fetching triggered workflow (try {i + 1}/{MAX_RETRIES})")

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -73,10 +73,6 @@ def trigger_macos_workflow(
     MAX_RETRIES = 10  # Retry up to 10 times
     for i in range(MAX_RETRIES):
         print(f"Fetching triggered workflow (try {i + 1}/{MAX_RETRIES})")
-        run = gh.latest_workflow_run_for_ref(workflow_name, github_action_ref)
-        if run is not None and run.created_at is not None and run.created_at >= now:
-            return run
-
         recent_runs = gh.workflow_run_for_ref_after_date(workflow_name, github_action_ref, now)
         for recent_run in recent_runs:
             jobs = recent_run.jobs()

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -51,6 +51,11 @@ def trigger_macos_workflow(
     if version_cache_file_content:
         inputs["version_cache"] = version_cache_file_content
 
+    # The workflow trigger endpoint doesn't return anything. You need to fetch the workflow run id
+    # by yourself.
+    workflow_id = str(uuid.uuid1())
+    inputs["id"] = workflow_id
+
     print(
         "Creating workflow on datadog-agent-macos-build on commit {} with args:\n{}".format(  # noqa: FS002
             github_action_ref, "\n".join([f"  - {k}: {inputs[k]}" for k in inputs])
@@ -59,13 +64,7 @@ def trigger_macos_workflow(
     # Hack: get current time to only fetch workflows that started after now.
     now = datetime.utcnow()
 
-    # The workflow trigger endpoint doesn't return anything. You need to fetch the workflow run id
-    # by yourself.
-    workflow_id = str(uuid.uuid1())
-    inputs["id"] = workflow_id
-
     gh = GithubAPI('DataDog/datadog-agent-macos-build')
-    print("Triggered workflow with id: ", workflow_id)
     gh.trigger_workflow(workflow_name, github_action_ref, inputs)
 
     # Thus the following hack: query the latest run for ref, wait until we get a non-completed run

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -79,14 +79,13 @@ def trigger_macos_workflow(
             jobs = recent_run.jobs()
             print("Jobs found: ", jobs)
             if jobs.totalCount >= 2:
-                workflow_id_job = jobs[0]  # Workflow Provider ID job is the first job in the workflow
-                print("Steps: ", workflow_id_job.steps)
-                if len(workflow_id_job.steps) > 2:
-                    if any([step.name == workflow_id for step in workflow_id_job.steps]):
-                        return recent_run
-                else:
-                    print("waiting for steps to be executed...")
-                    sleep(3)
+                flattened_step_list = []
+                for job in jobs:
+                    flattened_step_list += job.steps
+
+                print("Steps flattened: ", flattened_step_list)
+                if any([step.name == workflow_id for step in flattened_step_list]):
+                    return recent_run
             else:
                 print("waiting for jobs to popup...")
                 sleep(3)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Implement check to be sure Gitlab retrieve the correct workflow from Github.
Highly inspired from @julien-lebot PR https://github.com/DataDog/datadog-agent/pull/12678
Thanks!

Related PR on macos build repository has been merged long time ago here: https://github.com/DataDog/datadog-agent-macos-build/pull/99
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Prevent cases where Gitlab fetch the incorrect workflow and then output strange errors
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
