### PR TITLE
[pkg/trace] Stop OTLPReceiver before stopping Receiver

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -186,6 +186,10 @@ func (a *Agent) work() {
 func (a *Agent) loop() {
 	<-a.ctx.Done()
 	log.Info("Exiting...")
+
+	// Stop OTLPReceiver before Receiver to avoid sending to closed channel
+	a.OTLPReceiver.Stop()
+
 	if err := a.Receiver.Stop(); err != nil {
 		log.Error(err)
 	}
@@ -199,7 +203,6 @@ func (a *Agent) loop() {
 		a.NoPrioritySampler,
 		a.RareSampler,
 		a.EventProcessor,
-		a.OTLPReceiver,
 		a.obfuscator,
 		a.obfuscator,
 		a.cardObfuscator,

--- a/releasenotes/notes/avoid-data-race-otlp-90e19c52940c4eaa.yaml
+++ b/releasenotes/notes/avoid-data-race-otlp-90e19c52940c4eaa.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a panic that may happen if the Trace Agent received an OTLP payload during shutdown

--- a/releasenotes/notes/avoid-data-race-otlp-90e19c52940c4eaa.yaml
+++ b/releasenotes/notes/avoid-data-race-otlp-90e19c52940c4eaa.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fixes a panic that may happen if the Trace Agent received an OTLP payload during shutdown
+    Fixes a panic that occurs when the Trace Agent receives an OTLP payload during shutdown


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Stop the trace agent's OTLPReceiver before stopping the Receiver.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The current code can run into a race where the Receiver closes its out
channel but the OTLPReceiver still attempts to send to it.
Changing the shutdown order fixes this.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

This seems hard to reproduce but one can try sending an OTLP payload during shutdown

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
