### PR TITLE
[Backport][7.48.x] Do not create boltdb cache at collector initialization

### DIFF
--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -226,12 +226,6 @@ func disableCmdPort() {
 // runJmxCommandConsole sets up the common utils necessary for JMX, and executes the command
 // with the Console reporter
 func runJmxCommandConsole(log log.Component, config config.Component, cliParams *cliParams) error {
-	// Always disable SBOM collection in `jmx` command to avoid BoltDB flock issue
-	// and consuming CPU & Memory for asynchronous scans that would not be shown in `agent jmx` output.
-	pkgconfig.Datadog.Set("sbom.host.enabled", "false")
-	pkgconfig.Datadog.Set("sbom.container_image.enabled", "false")
-	pkgconfig.Datadog.Set("runtime_security_config.sbom.enabled", "false")
-
 	err := pkgconfig.SetupJMXLogger(cliParams.logFile, "", false, true, false)
 	if err != nil {
 		return fmt.Errorf("Unable to set up JMX logger: %v", err)

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -181,12 +181,6 @@ func run(log log.Component, config config.Component, sysprobeconfig sysprobeconf
 		return nil
 	}
 
-	// Always disable SBOM collection in `check` command to avoid BoltDB flock issue
-	// and consuming CPU & Memory for asynchronous scans that would not be shown in `agent check` output.
-	pkgconfig.Datadog.Set("sbom.host.enabled", "false")
-	pkgconfig.Datadog.Set("sbom.container_image.enabled", "false")
-	pkgconfig.Datadog.Set("runtime_security_config.sbom.enabled", "false")
-
 	hostnameDetected, err := hostname.Get(context.TODO())
 	if err != nil {
 		fmt.Printf("Cannot get hostname, exiting: %v\n", err)

--- a/pkg/diagnose/check.go
+++ b/pkg/diagnose/check.go
@@ -82,10 +82,6 @@ func diagnoseChecksInCLIProcess(diagCfg diagnosis.Config) []diagnosis.Diagnosis 
 	// 	run() github.com\DataDog\datadog-agent\pkg\cli\subcommands\check\command.go
 	//  runCheck() github.com\DataDog\datadog-agent\cmd\agent\gui\checks.go
 
-	// Always disable SBOM collection in `check` command to avoid BoltDB flock issue
-	// and consuming CPU & Memory for asynchronous scans that would not be shown in `agent check` output.
-	pkgconfig.Datadog.Set("container_image_collection.sbom.enabled", "false")
-
 	hostnameDetected, err := hostname.Get(context.TODO())
 	if err != nil {
 		return []diagnosis.Diagnosis{

--- a/pkg/sbom/collectors/containerd/containerd.go
+++ b/pkg/sbom/collectors/containerd/containerd.go
@@ -54,8 +54,9 @@ type ContainerdCollector struct {
 	trivyCollector *trivy.Collector
 }
 
+// CleanCache cleans the cache
 func (c *ContainerdCollector) CleanCache() error {
-	return c.trivyCollector.GetCacheCleaner().Clean()
+	return c.trivyCollector.CleanCache()
 }
 
 func (c *ContainerdCollector) Init(cfg config.Config) error {

--- a/pkg/sbom/collectors/docker/docker.go
+++ b/pkg/sbom/collectors/docker/docker.go
@@ -47,10 +47,12 @@ type Collector struct {
 	trivyCollector *trivy.Collector
 }
 
+// CleanCache cleans the cache
 func (c *Collector) CleanCache() error {
-	return c.trivyCollector.GetCacheCleaner().Clean()
+	return c.trivyCollector.CleanCache()
 }
 
+// Init initializes the collector
 func (c *Collector) Init(cfg config.Config) error {
 	trivyCollector, err := trivy.GetGlobalCollector(cfg)
 	if err != nil {

--- a/pkg/sbom/collectors/host/host.go
+++ b/pkg/sbom/collectors/host/host.go
@@ -43,8 +43,9 @@ type HostCollector struct {
 	trivyCollector *trivy.Collector
 }
 
+// CleanCache cleans the cache
 func (c *HostCollector) CleanCache() error {
-	return c.trivyCollector.GetCacheCleaner().Clean()
+	return c.trivyCollector.CleanCache()
 }
 
 func (c *HostCollector) Init(cfg config.Config) error {


### PR DESCRIPTION
* Do not create boltdb cache at collector initialization

* Do not rely on explicitely disabling SBOM collection in CLI

(cherry picked from commit 23514b1a6366e599a0f97b0a065cbc77d15f7390)

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR moves the BoltDB cache for Trivy later in the agent lifecycle to avoid
having the CLI deadlocking on the flock syscall.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

When the agent starts with SBOM collection enabled, it creates a BoltDB cache
and get a lock on it. Invoking the agent CLI - such as agent flare - also tried to
lock the cache, causing a deadlock of the CLI.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
