### PR TITLE
[wlm] fix flaky test in kubeapiserver collector

### DIFF
--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/deployments_test.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/deployments_test.go
@@ -226,7 +226,7 @@ func Test_DeploymentsFakeKubernetesClient(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			testFakeHelper(t, tt.createResource, newDeploymentStore, tt.expected)
+			testCollectEvent(t, tt.createResource, newDeploymentStore, tt.expected)
 		})
 	}
 }

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/node_test.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/node_test.go
@@ -74,5 +74,5 @@ func Test_NodesFakeKubernetesClient(t *testing.T) {
 			},
 		},
 	}
-	testFakeHelper(t, createResource, newNodeStore, expected)
+	testCollectEvent(t, createResource, newNodeStore, expected)
 }

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/pod_test.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/pod_test.go
@@ -137,5 +137,5 @@ func Test_PodsFakeKubernetesClient(t *testing.T) {
 			},
 		},
 	}
-	testFakeHelper(t, createResource, newPodStore, expected)
+	testCollectEvent(t, createResource, newPodStore, expected)
 }

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
@@ -22,29 +22,27 @@ func testFakeHelper(t *testing.T, createResource func(*fake.Clientset) error, ne
 	// Create a fake client to mock API calls.
 	client := fake.NewSimpleClientset()
 
-	// Creating a fake deployment
-	err := createResource(client)
-	assert.NoError(t, err)
-
 	// Use the fake client in kubeapiserver context.
 	wlm := workloadmeta.NewMockStore()
-	ctx := context.TODO()
-	store, _ := newStore(ctx, wlm, client)
+	store, _ := newStore(context.TODO(), wlm, client)
 	stopStore := make(chan struct{})
 	go store.Run(stopStore)
 
 	ch := wlm.Subscribe(dummySubscriber, workloadmeta.NormalPriority, nil)
-
-	actual := []workloadmeta.EventBundle{}
 	// When Subscribe is called, the first Bundle contains events about the items currently in the store.
 	// In that case, the first bundle is empty.
 	<-ch
+
+	// Creating a fake resource
+	err := createResource(client)
+	assert.NoError(t, err)
+
 	bundle := <-ch
 	close(bundle.Ch)
 	// nil the bundle's Ch so we can
 	// deep-equal just the events later
 	bundle.Ch = nil
-	actual = append(actual, bundle)
+	actual := []workloadmeta.EventBundle{bundle}
 	close(stopStore)
 	wlm.Unsubscribe(ch)
 	assert.Equal(t, expected, actual)

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
@@ -18,7 +18,7 @@ import (
 
 const dummySubscriber = "dummy-subscriber"
 
-func testFakeHelper(t *testing.T, createResource func(*fake.Clientset) error, newStore storeGenerator, expected []workloadmeta.EventBundle) {
+func testCollectEvent(t *testing.T, createResource func(*fake.Clientset) error, newStore storeGenerator, expected []workloadmeta.EventBundle) {
 	// Create a fake client to mock API calls.
 	client := fake.NewSimpleClientset()
 
@@ -33,10 +33,11 @@ func testFakeHelper(t *testing.T, createResource func(*fake.Clientset) error, ne
 	// In that case, the first bundle is empty.
 	<-ch
 
-	// Creating a fake resource
+	// Creating a resource
 	err := createResource(client)
 	assert.NoError(t, err)
 
+	// Retrieving the resource in an event bundle
 	bundle := <-ch
 	close(bundle.Ch)
 	// nil the bundle's Ch so we can


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Fixes a flaky test. The resource is created after the first bundle is cleared.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
When `Subscribe()` is called, the first Bundle contains events about the items currently in the store. Apparently, it could contain the deployment because of a race issue.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
