### PR TITLE
feat(serverless/appsec/httpsec): support additional body types

### DIFF
--- a/pkg/serverless/appsec/httpsec/http.go
+++ b/pkg/serverless/appsec/httpsec/http.go
@@ -82,7 +82,7 @@ func parseBody(headers map[string][]string, rawBody *string) (body interface{}) 
 
 	result, err := tryParseBodyBytes(mimeHeaders, raw)
 	if err != nil {
-		log.Warnf("unable to parse request body: %w", err)
+		log.Warnf("unable to parse request body: %v", err)
 		return rawStr
 	} else if result == nil {
 		return rawStr

--- a/pkg/serverless/appsec/httpsec/http_test.go
+++ b/pkg/serverless/appsec/httpsec/http_test.go
@@ -1,0 +1,75 @@
+package httpsec
+
+import (
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+)
+
+func TestParseBodyJson(t *testing.T) {
+	rawBody := "{ \"foo\": 1337 }"
+	payload := parseBody(
+		map[string][]string{
+			"content-type": []string{"application/json;charset=utf-8"},
+		},
+		&rawBody,
+	)
+
+	require.Equal(t, map[string]any{
+		"foo": 1337., // JSON numbers are float64 in go
+	}, payload)
+}
+
+func TestParseBodyUrlEncoded(t *testing.T) {
+	rawBody := "foo=1337&bar=b%20a%20z"
+	payload := parseBody(
+		map[string][]string{
+			"content-type": []string{"application/x-www-form-urlencoded"},
+		},
+		&rawBody,
+	)
+
+	require.Equal(t, map[string][]string{"foo": {"1337"}, "bar": {"b a z"}}, payload)
+}
+
+func TestParseBodyMultipartFormData(t *testing.T) {
+	rawBody := strings.Join(
+		[]string{
+			"--B0UND4RY",
+			"Content-Disposition: form-data; name=\"foo\"",
+			"",
+			"1337",
+			"--B0UND4RY",
+			"Content-Disposition: form-data; name=\"file1\"; filename=\"a.txt\"",
+			"Content-Type: text/plain",
+			"",
+			"Content of a.txt.",
+			"",
+			"--B0UND4RY",
+			"Content-Disposition: form-data; name=\"file2\"; filename=\"a.json\"",
+			"Content-Type: application/json",
+			"",
+			"{ \"foo\": 1337, \"bar\": \"baz\" }",
+			"--B0UND4RY--",
+			"",
+		}, "\r\n",
+	)
+	payload := parseBody(
+		map[string][]string{
+			"content-type": []string{"multipart/form-data; boundary=B0UND4RY"},
+		},
+		&rawBody,
+	)
+
+	require.Equal(t, map[string]any{
+		"foo":   map[string]any{"data": "1337"},
+		"file1": map[string]any{"filename": "a.txt", "data": "Content of a.txt.\r\n"},
+		"file2": map[string]any{
+			"filename": "a.json",
+			"data": map[string]any{
+				"foo": 1337.,
+				"bar": "baz",
+			},
+		},
+	}, payload)
+}

--- a/pkg/serverless/appsec/httpsec/http_test.go
+++ b/pkg/serverless/appsec/httpsec/http_test.go
@@ -10,7 +10,7 @@ func TestParseBodyJson(t *testing.T) {
 	rawBody := "{ \"foo\": 1337 }"
 	payload := parseBody(
 		map[string][]string{
-			"content-type": []string{"application/json;charset=utf-8"},
+			"content-type": {"application/json;charset=utf-8"},
 		},
 		&rawBody,
 	)
@@ -24,7 +24,7 @@ func TestParseBodyUrlEncoded(t *testing.T) {
 	rawBody := "foo=1337&bar=b%20a%20z"
 	payload := parseBody(
 		map[string][]string{
-			"content-type": []string{"application/x-www-form-urlencoded"},
+			"content-type": {"application/x-www-form-urlencoded"},
 		},
 		&rawBody,
 	)
@@ -56,7 +56,7 @@ func TestParseBodyMultipartFormData(t *testing.T) {
 	)
 	payload := parseBody(
 		map[string][]string{
-			"content-type": []string{"multipart/form-data; boundary=B0UND4RY"},
+			"content-type": {"multipart/form-data; boundary=B0UND4RY"},
 		},
 		&rawBody,
 	)

--- a/pkg/serverless/appsec/httpsec/http_test.go
+++ b/pkg/serverless/appsec/httpsec/http_test.go
@@ -50,6 +50,11 @@ func TestParseBodyMultipartFormData(t *testing.T) {
 			"Content-Type: application/json",
 			"",
 			"{ \"foo\": 1337, \"bar\": \"baz\" }",
+			"--B0UND4RY",
+			"Content-Disposition: form-data; name=\"broken\"; filename=\"bad.json\"",
+			"Content-Type: application/vnd.api+json",
+			"",
+			"{ invalid: true }", // Intentionally not valid JSON
 			"--B0UND4RY--",
 			"",
 		}, "\r\n",
@@ -62,7 +67,7 @@ func TestParseBodyMultipartFormData(t *testing.T) {
 	)
 
 	require.Equal(t, map[string]any{
-		"foo":   map[string]any{"data": "1337"},
+		"foo":   map[string]any{"data": nil},
 		"file1": map[string]any{"filename": "a.txt", "data": "Content of a.txt.\r\n"},
 		"file2": map[string]any{
 			"filename": "a.json",
@@ -71,5 +76,6 @@ func TestParseBodyMultipartFormData(t *testing.T) {
 				"bar": "baz",
 			},
 		},
+		"broken": map[string]any{"filename": "bad.json", "data": nil},
 	}, payload)
 }

--- a/pkg/serverless/appsec/httpsec/http_test.go
+++ b/pkg/serverless/appsec/httpsec/http_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 package httpsec
 
 import (


### PR DESCRIPTION
### What does this PR do?

Add support for `application/x-www-form-urlencoded` and `multipart/form-data` body Content-Types, and basic tests around the body parsing function.

### Motivation

This provides additional insight to the WAF.

### Possible Drawbacks / Trade-offs

This is dropping/ignoring additional part-level headers in the `multipart/form-data` case, and there could be other ways to present the decoded multipart form data.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
