### PR TITLE
Fix ebpfcheck test after renames

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
@@ -115,7 +115,7 @@ func TestMinMapSize(t *testing.T) {
 		cfg := testConfig()
 		const keySize, valueSize, maxEntries = 50, 150, 1000
 
-		probe, err := NewEBPFProbe(cfg)
+		probe, err := NewProbe(cfg)
 		require.NoError(t, err)
 		t.Cleanup(probe.Close)
 
@@ -144,13 +144,13 @@ func TestMinMapSize(t *testing.T) {
 		}
 
 		// wait until we have stats about all maps
-		var result []EBPFMapStats
+		var result []model.EBPFMapStats
 		require.Eventually(t, func() bool {
 			stats := probe.GetAndFlush()
 			t.Logf("%+v", stats.Maps)
 			for _, id := range ids {
-				if !slices.ContainsFunc(stats.Maps, func(stats EBPFMapStats) bool {
-					return stats.id == uint32(id)
+				if !slices.ContainsFunc(stats.Maps, func(stats model.EBPFMapStats) bool {
+					return stats.ID == uint32(id)
 				}) {
 					return false
 				}
@@ -161,8 +161,8 @@ func TestMinMapSize(t *testing.T) {
 
 		// assert max size is at least the naive map size
 		for _, mt := range mapTypes {
-			idx := slices.IndexFunc(result, func(stats EBPFMapStats) bool {
-				return stats.id == uint32(ids[mt.typ])
+			idx := slices.IndexFunc(result, func(stats model.EBPFMapStats) bool {
+				return stats.ID == uint32(ids[mt.typ])
 			})
 			typStats := result[idx]
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixes some test compilation errors after two conflicting PRs (#19561 and #19599) got merged.

### Motivation

Fix `main`

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
