### PR TITLE
[RC] Fix hanging diagnose command

### DIFF
--- a/pkg/diagnose/check.go
+++ b/pkg/diagnose/check.go
@@ -20,6 +20,7 @@ import (
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func init() {
@@ -71,6 +72,10 @@ func diagnoseChecksInAgentProcess() []diagnosis.Diagnosis {
 
 	// get diagnoses from each
 	for _, ch := range checks {
+		if ch.Interval() == 0 {
+			pkglog.Infof("Ignoring long running check %s", ch.String())
+			continue
+		}
 		instanceDiagnoses := getInstanceDiagnoses(ch)
 		diagnoses = append(diagnoses, instanceDiagnoses...)
 	}
@@ -140,6 +145,10 @@ func diagnoseChecksInCLIProcess(diagCfg diagnosis.Config, senderManager sender.S
 		checkName := diagnoseConfig.Name
 		instances := collector.GetChecksByNameForConfigs(checkName, diagnoseConfigs)
 		for _, instance := range instances {
+			if instance.Interval() == 0 {
+				pkglog.Infof("Ignoring long running check %s", instance.String())
+				continue
+			}
 			instanceDiagnoses := getInstanceDiagnoses(instance)
 			diagnoses = append(diagnoses, instanceDiagnoses...)
 		}

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -296,16 +296,19 @@ func getProcessChecks(fb flaretypes.FlareBuilder, getAddressPort func() (url str
 	getCheck("process_discovery", "process_config.process_discovery.enabled")
 }
 
-func getDiagnoses(isLocal bool, senderManager sender.SenderManager) func() ([]byte, error) {
+func getDiagnoses(isFlareLocal bool, senderManager sender.SenderManager) func() ([]byte, error) {
+
 	fct := func(w io.Writer) error {
-		// Run agent diagnose command to be verbose and remote. If Agent is running small performance hit
-		// since this code will get diagnoses using Agent’s local port listener (instead of calling a
-		// function directly since the caller and callee are in the same process).However, the same code
-		// will continue to work well because agent diagnose command works locally as well (if it cannot
-		// connect to the running Agent).
+		// Run diagnose always "local" (in the host process that is)
 		diagCfg := diagnosis.Config{
 			Verbose:  true,
-			RunLocal: isLocal,
+			RunLocal: true,
+		}
+
+		// ... but when running within Agent some diagnose suites need to know
+		// that to run more optimally/differently by using existing in-memory objects
+		if !isFlareLocal {
+			diagCfg.RunningInAgentProcess = true
 		}
 
 		return diagnose.RunStdOut(w, diagCfg, senderManager)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Fix hanging diagnose command due to long-running checks not giving the lock back to the process agent.
* When run locally, diagnose was waiting infinitely until all checks ran and long running checks never exited
* When run remotely (in agent process), diagnose was was getting a lock on WrapperCheck object but on long running checks it never gave the (running) lock
Part of solution (which did not solve the root cause but make call flow simpler and more deterministic) was calling from running agent process (remote mode) diagnose remotely again (double remote).

Backported in 7.48 with #19656 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
1. Enable one long running check such as sbom or container_image (it may not be supported on Mac or Windows machines)
2. Run following commands which should not hang
- agent diagnose 
- agent diagnose --local
- agent flare
- agent flare --local

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
