### PR TITLE
[windows] Conditionally add apm tracing to agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ system-probe.yaml
 security-agent.yaml
 dogstatsd.yaml
 cloudfoundry.yaml
+apm-inject.yaml
 Dockerfiles/cluster-agent/datadog-cluster.yaml
 Dockerfiles/cluster-agent/dist
 Dockerfiles/cluster-agent/security-agent-policies

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -30,6 +30,8 @@ build do
             end
             if ENV['WINDOWS_DDPROCMON_DRIVER'] and not ENV['WINDOWS_DDPROCMON_DRIVER'].empty? and not windows_arch_i386?
               move "#{install_dir}/etc/datadog-agent/security-agent.yaml.example", conf_dir_root, :force=>true
+            if ENV['WINDOWS_APMINJECT_MODULE'] and not ENV['WINDOWS_APMINJECT_MODULE'].empty?
+              move "#{install_dir}/etc/datadog-agent/apm-inject.yaml.example", conf_dir_root, :force=>true
             end
             move "#{install_dir}/etc/datadog-agent/conf.d/*", conf_dir, :force=>true
             delete "#{install_dir}/bin/agent/agent.exe"

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -30,6 +30,7 @@ build do
             end
             if ENV['WINDOWS_DDPROCMON_DRIVER'] and not ENV['WINDOWS_DDPROCMON_DRIVER'].empty? and not windows_arch_i386?
               move "#{install_dir}/etc/datadog-agent/security-agent.yaml.example", conf_dir_root, :force=>true
+            end
             if ENV['WINDOWS_APMINJECT_MODULE'] and not ENV['WINDOWS_APMINJECT_MODULE'].empty?
               move "#{install_dir}/etc/datadog-agent/apm-inject.yaml.example", conf_dir_root, :force=>true
             end

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -167,6 +167,14 @@ build do
     end
   end
 
+  # APM Injection agent
+  if windows?
+    if ENV['WINDOWS_APMINJECT_MODULE'] and not ENV['WINDOWS_APMINJECT_MODULE'].empty?
+      command "inv generate-config --build-type apm-injection --output-file ./bin/agent/dist/apm-inject.yaml", :env => env
+     #move 'bin/agent/dist/system-probe.yaml', "#{conf_dir}/system-probe.yaml.example"
+      move 'bin/agent/dist/apm-inject.yaml', "#{conf_dir}/apm-inject.yaml.example"
+    end
+  end
   if linux?
     if debian?
       erb source: "upstart_debian.conf.erb",

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -406,6 +406,17 @@
       </Component>
       <?endif ?>
 
+      <?if $(var.IncludeAPMInject) = true ?>
+      <Component Id="apm_inject.yaml.example"
+                Guid="9D1D8978-49B4-4483-A931-B138233015E1"
+                NeverOverwrite="yes"
+                Permanent="yes">
+        <File Id="apm_inject.yaml.example"
+          Name="apm-inject.yaml"
+          KeyPath="yes"
+          Source="$(var.EtcFiles)\apm-inject.yaml.example"/>
+      </Component>
+      <?endif ?>
 
       <Directory Id="checks.d" Name="checks.d">
         <Component Id="checks.d"
@@ -512,6 +523,8 @@
         <ComponentRef Id="system_probe.yaml.example" />        
         <MergeRef Id="ddnpminstall"/>
         <?if $(var.IncludeAPMInject) = true ?>
+          <ComponentRef Id="apm_inject.yaml.example" />
+      
           <MergeRef Id="ddapminstall"/>
         <?endif ?>
         

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3980,7 +3980,6 @@ api_key:
     ## Valid values are basic, normal, detailed.
     #
     # verbosity: normal
-{{end -}}
 {{- if (eq .OS "windows")}}
 #####################################################
 ## Datadog Agent Manager System Tray Configuration ##
@@ -3996,3 +3995,72 @@ api_key:
   #
   # log_file: <TRAY_LOG_FILE_PATH>
 {{end -}}
+{{end -}}
+
+
+{{- if .APMInjection -}}
+##############################################
+## Datadog APM Auto-injection Configuration ##
+##############################################
+
+## @param injection_controller_config - custom object
+## This section configures the Datadog APM Auto Injection controller.
+## Uncomment this parameter and the one below to enable them.
+#
+# injection_controller_config:
+
+  ## @param enabled - boolean - optional - default: false
+  ## Set to true to enable the APM Auto-injection.
+  ## Please note that enabling this service will result in a kernel driver being loaded.
+  #
+  # enabled: false
+
+  ## @param log_file - string - optional - default: c:\programdata\datadog\logs\apm-inject.log
+  ## The full path to the file where injection controller logs are written.
+  #
+  # log_file: c:\programdata\datadog\logs\apm-inject.log
+
+  ## @param log_level - string - optional - default: info
+  ## Minimum log level of the injection controller.
+  ## Valid log levels are: debug, info, warn, and error.
+  #
+  # log_level: 'info'
+
+  ## @param log_to_console - boolean - optional - default: true
+  ## Set to 'false' to disable injection controller logging to stdout.
+  #
+  # log_to_console: true
+
+  ## @param socket_port - integer - optional - default: 3030
+  ## The port used for the injection controller communications API (served on localhost).
+  #
+  # socket_port: 3030
+
+  # internal_profiling:
+  #
+    ## @param enabled - boolean - optional - default: false
+    ## Enable internal profiling for the injection controller process.
+    #
+    # enabled: false
+
+## @param service_configs - list of custom objects
+## This section configures the services which will be automatically injected with APM
+## configurations, as well as the APM configurations which will be injected.
+#
+# service_configs:
+
+  ## @param service configuration - custom object
+  ## In order to configure APM auto-injection for a service or set of services, an injection condition
+  ## and APM configuration must be provided.
+  ##
+  ## Example:
+  ## - conditions:
+  ##     service_name: exampleService
+  ##   configuration:
+  ##     version: 1
+  ##     service_language: dotnet
+  ##
+  ## To learn about all the available service matching conditions & configuration options, visit
+  ## https://docs.datadoghq.com/tracing/trace_collection/library_injection_local
+
+{{end}}

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -55,6 +55,7 @@ type context struct {
 	DataStreamsModule                bool // Sub-module of System Probe
 	PrometheusScrape                 bool
 	OTLP                             bool
+	APMInjection                     bool
 }
 
 func mkContext(buildType string) context {
@@ -149,6 +150,11 @@ func mkContext(buildType string) context {
 		return context{
 			OS:            runtime.GOOS,
 			SecurityAgent: true,
+		}
+	case "apm-injection":
+		return context{
+			OS:           runtime.GOOS,
+			APMInjection: true,
 		}
 	}
 

--- a/release.json
+++ b/release.json
@@ -21,8 +21,8 @@
         "WINDOWS_DDPROCMON_SHASUM": "bc78923f7aaceeeddf9e7337bdddb7788b6a28da847a17852391ff58e1c1800a",
         "WINDOWS_APMINJECT_COMMENT": "The WINDOWS_APMINJECT entries below should NOT be added to the release targets",
         "WINDOWS_APMINJECT_MODULE": "release-signed",
-        "WINDOWS_APMINJECT_VERSION": "1.1.0",
-        "WINDOWS_APMINJECT_SHASUM": "0c71498a7761b8463faa9088b938ef3de1d846cd19c1614bc5691572452aac9a"
+        "WINDOWS_APMINJECT_VERSION": "1.1.1",
+        "WINDOWS_APMINJECT_SHASUM": "c5c228f6030ce2e19b8bfb28bd054dc246c7f1c799431e73018e6cb46ee59d2f"
     },
     "nightly-a7": {
         "INTEGRATIONS_CORE_VERSION": "master",
@@ -41,8 +41,8 @@
         "WINDOWS_DDPROCMON_SHASUM": "bc78923f7aaceeeddf9e7337bdddb7788b6a28da847a17852391ff58e1c1800a",
         "WINDOWS_APMINJECT_COMMENT": "The WINDOWS_APMINJECT entries below should NOT be added to the release targets",
         "WINDOWS_APMINJECT_MODULE": "release-signed",
-        "WINDOWS_APMINJECT_VERSION": "1.1.0",
-        "WINDOWS_APMINJECT_SHASUM": "0c71498a7761b8463faa9088b938ef3de1d846cd19c1614bc5691572452aac9a"
+        "WINDOWS_APMINJECT_VERSION": "1.1.1",
+        "WINDOWS_APMINJECT_SHASUM": "c5c228f6030ce2e19b8bfb28bd054dc246c7f1c799431e73018e6cb46ee59d2f"
     },
     "release-a6": {
         "INTEGRATIONS_CORE_VERSION": "7.48.0-rc.2",

--- a/release.json
+++ b/release.json
@@ -15,10 +15,14 @@
         "WINDOWS_DDNPM_VERSION": "2.5.2",
         "WINDOWS_DDNPM_SHASUM": "57a53c23e0b40da1e75094058498f9982dc80f6aa7feb5a1c8aece6e08292840",
         "SECURITY_AGENT_POLICIES_VERSION": "master",
-        "WINDOWS_APMINJECT_COMMENT": "The WINDOWS_DDPROCMON entries below should NOT be added to the release targets",
+        "WINDOWS_PROCMON_COMMENT": "The WINDOWS_DDPROCMON entries below should NOT be added to the release targets",
         "WINDOWS_DDPROCMON_DRIVER": "release-signed",
         "WINDOWS_DDPROCMON_VERSION": "0.9.1",
-        "WINDOWS_DDPROCMON_SHASUM": "bc78923f7aaceeeddf9e7337bdddb7788b6a28da847a17852391ff58e1c1800a"
+        "WINDOWS_DDPROCMON_SHASUM": "bc78923f7aaceeeddf9e7337bdddb7788b6a28da847a17852391ff58e1c1800a",
+        "WINDOWS_APMINJECT_COMMENT": "The WINDOWS_APMINJECT entries below should NOT be added to the release targets",
+        "WINDOWS_APMINJECT_MODULE": "release-signed",
+        "WINDOWS_APMINJECT_VERSION": "1.1.0",
+        "WINDOWS_APMINJECT_SHASUM": "0c71498a7761b8463faa9088b938ef3de1d846cd19c1614bc5691572452aac9a"
     },
     "nightly-a7": {
         "INTEGRATIONS_CORE_VERSION": "master",
@@ -31,10 +35,14 @@
         "WINDOWS_DDNPM_VERSION": "2.5.2",
         "WINDOWS_DDNPM_SHASUM": "57a53c23e0b40da1e75094058498f9982dc80f6aa7feb5a1c8aece6e08292840",
         "SECURITY_AGENT_POLICIES_VERSION": "master",
-        "WINDOWS_APMINJECT_COMMENT": "The WINDOWS_DDPROCMON entries below should NOT be added to the release targets",
+        "WINDOWS_DDPROCMON_COMMENT": "The WINDOWS_DDPROCMON entries below should NOT be added to the release targets",
         "WINDOWS_DDPROCMON_DRIVER": "release-signed",
         "WINDOWS_DDPROCMON_VERSION": "0.9.1",
-        "WINDOWS_DDPROCMON_SHASUM": "bc78923f7aaceeeddf9e7337bdddb7788b6a28da847a17852391ff58e1c1800a"
+        "WINDOWS_DDPROCMON_SHASUM": "bc78923f7aaceeeddf9e7337bdddb7788b6a28da847a17852391ff58e1c1800a",
+        "WINDOWS_APMINJECT_COMMENT": "The WINDOWS_APMINJECT entries below should NOT be added to the release targets",
+        "WINDOWS_APMINJECT_MODULE": "release-signed",
+        "WINDOWS_APMINJECT_VERSION": "1.1.0",
+        "WINDOWS_APMINJECT_SHASUM": "0c71498a7761b8463faa9088b938ef3de1d846cd19c1614bc5691572452aac9a"
     },
     "release-a6": {
         "INTEGRATIONS_CORE_VERSION": "7.48.0-rc.2",

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ConfigCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ConfigCustomActions.cs
@@ -344,12 +344,8 @@ namespace Datadog.CustomActions
             var configFolder = session.Property("APPLICATIONDATADIRECTORY");
             var datadogYaml = Path.Combine(configFolder, "datadog.yaml");
             var systemProbeYaml = Path.Combine(configFolder, "system-probe.yaml");
-<<<<<<< HEAD
             var securityAgentYaml = Path.Combine(configFolder, "security-agent.yaml");
-
-=======
             var injectionControllerYaml = Path.Combine(configFolder, "apm-inject.yaml");
->>>>>>> 1d306a7453 ([windows] Conditionally add apm tracing to agent)
             try
             {
                 if (!File.Exists(systemProbeYaml))

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ConfigCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ConfigCustomActions.cs
@@ -344,8 +344,12 @@ namespace Datadog.CustomActions
             var configFolder = session.Property("APPLICATIONDATADIRECTORY");
             var datadogYaml = Path.Combine(configFolder, "datadog.yaml");
             var systemProbeYaml = Path.Combine(configFolder, "system-probe.yaml");
+<<<<<<< HEAD
             var securityAgentYaml = Path.Combine(configFolder, "security-agent.yaml");
 
+=======
+            var injectionControllerYaml = Path.Combine(configFolder, "apm-inject.yaml");
+>>>>>>> 1d306a7453 ([windows] Conditionally add apm tracing to agent)
             try
             {
                 if (!File.Exists(systemProbeYaml))
@@ -381,6 +385,15 @@ namespace Datadog.CustomActions
                     }
                 }
 
+                // Conditionally include the APM injection MSM while it is in active development to make it easier
+                // to build/ship without it.
+                if (File.Exists(injectionControllerYaml + ".example"))
+                {
+                    if (!File.Exists(injectionControllerYaml))
+                    {
+                        File.Copy(injectionControllerYaml + ".example", injectionControllerYaml);
+                    }
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Conditionally adds apm tracing to the main agent installer. Whether component is configured is determined by the entry in `release.json`.

When configured, adds the apm injection component via merge module, and sets up beginning configuration.


### Motivation

Have the new feature available for testing on nightly builds.

### Additional Notes

Note:  This extends previous work to allow component to be conditionally added.  As noted in the "comment" entry in release.json, it is not intended to be included in release versions, and no artifacts _will_ be included in release versions as long as the `release.json` entries are not included.


### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
