### PR TITLE
Temporary disable flaky windows secret unit test

### DIFF
--- a/pkg/secrets/info_windows_test.go
+++ b/pkg/secrets/info_windows_test.go
@@ -19,6 +19,10 @@ import (
 )
 
 func TestGetExecutablePermissionsError(t *testing.T) {
+	// This test plus unit tests for Linux file will be moving to integration tests
+	// (in soon to be added _windows_integration_tests() and _linux_integration_tests() functions)
+	t.Skip("skipping flaky Windows test (it hangs on execution of its PowerShell script in latest github environment)")
+
 	secretBackendCommand = "some_command"
 	t.Cleanup(resetPackageVars)
 
@@ -49,9 +53,8 @@ func setupSecretCommmand(t *testing.T) {
 }
 
 func TestGetExecutablePermissionsSuccess(t *testing.T) {
-	// This test as well as TestGetExecutablePermissionsError test (see above) plus unit tests
-	// for Linux file will be moving to integration tests (see soon to be added _windows_integration_tests()
-	// and  _linux_integration_tests packages() functions)
+	// This test plus unit tests for Linux file will be moving to integration tests
+	// (in soon to be added _windows_integration_tests() and _linux_integration_tests() functions)
 	t.Skip("skipping flaky Windows test (it hangs on execution of its PowerShell script in latest github environment)")
 
 	setupSecretCommmand(t)

--- a/pkg/secrets/info_windows_test.go
+++ b/pkg/secrets/info_windows_test.go
@@ -49,6 +49,11 @@ func setupSecretCommmand(t *testing.T) {
 }
 
 func TestGetExecutablePermissionsSuccess(t *testing.T) {
+	// This test as well as TestGetExecutablePermissionsError test (see above) plus unit tests
+	// for Linux file will be moving to integration tests (see soon to be added _windows_integration_tests()
+	// and  _linux_integration_tests packages() functions)
+	t.Skip("skipping flaky Windows test (it hangs on execution of its PowerShell script in latest github environment)")
+
 	setupSecretCommmand(t)
 
 	res, err := getExecutablePermissions()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
It appears that this test started failing with the recent github [new release](https://github.com/actions/runner-images/releases). Root cause is not clear. We do not believe there is a bug there. Powershell script execution simply hangs in the exec system call. We need a core dump to understand the reason (and it is not guaranteed to be obvious and may require a full system dump actually).

At the same time this is not a good unit test in a sense of involved machinery. We would like to move it soon to integration tests coming soon in a pending PR.

Accordingly, we temporarily disable this test and create a JIRA to restore it in one way or another.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
