### PR TITLE
Set empty string for leader_election_default_resource

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -717,7 +717,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("leader_lease_duration", "60")
 	config.BindEnvAndSetDefault("leader_election", false)
 	config.BindEnvAndSetDefault("leader_lease_name", "datadog-leader-election")
-	config.BindEnvAndSetDefault("leader_election_default_resource", "configmap")
+	config.BindEnvAndSetDefault("leader_election_default_resource", "")
 	config.BindEnvAndSetDefault("kube_resources_namespace", "")
 	config.BindEnvAndSetDefault("kube_cache_sync_timeout_seconds", 5)
 


### PR DESCRIPTION
### What does this PR do?
Set empty string for leader_election_default_resource

### Motivation
The cluster agent can detect it automatically.

### Additional Notes

