### PR TITLE
[CSPM] Terminate oscap-io processes after benchmark run

### DIFF
--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -301,15 +301,18 @@ func (a *Agent) runXCCDFBenchmarks(ctx context.Context) {
 		for i, benchmark := range benchmarks {
 			seed := fmt.Sprintf("%s%s%d", a.opts.Hostname, benchmark.FrameworkID, i)
 			if sleepAborted(ctx, time.After(randomJitter(seed, a.opts.RunJitterMax))) {
+				FinishXCCDFBenchmark(ctx, benchmark)
 				return
 			}
 			for _, rule := range benchmark.Rules {
 				events := EvaluateXCCDFRule(ctx, a.opts.Hostname, a.opts.StatsdClient, benchmark, rule)
 				a.reportEvents(ctx, benchmark, events...)
 				if sleepAborted(ctx, throttler.C) {
+					FinishXCCDFBenchmark(ctx, benchmark)
 					return
 				}
 			}
+			FinishXCCDFBenchmark(ctx, benchmark)
 		}
 		if sleepAborted(ctx, runTicker.C) {
 			return

--- a/pkg/compliance/evaluator_xccdf.go
+++ b/pkg/compliance/evaluator_xccdf.go
@@ -233,7 +233,7 @@ func (p *oscapIO) Run(ctx context.Context) error {
 	}()
 
 	if err := cmd.Wait(); err != nil {
-		log.Warnf("process exited: %v", err)
+		log.Debugf("process exited: %v", err)
 		return err
 	}
 
@@ -243,7 +243,7 @@ func (p *oscapIO) Run(ctx context.Context) error {
 func (p *oscapIO) Stop() {
 	oscapIOsMu.Lock()
 	defer oscapIOsMu.Unlock()
-	oscapIOs[p.File] = nil
+	delete(oscapIOs, p.File)
 	close(p.DoneCh)
 }
 
@@ -273,7 +273,7 @@ func evaluateXCCDFRule(ctx context.Context, hostname string, statsdClient *stats
 		go func() {
 			err := p.Run(ctx)
 			if err != nil {
-				log.Warnf("Run: %v", err)
+				log.Debugf("Run: %v", err)
 			}
 		}()
 	}
@@ -314,7 +314,7 @@ func evaluateXCCDFRule(ctx context.Context, hostname string, statsdClient *stats
 			log.Warnf("timed out waiting for expected results for rule %s", reqs[i].Rule)
 			// If no result has been received, it's likely for the oscap-io process to be stuck, so we kill it.
 			oscapIOsMu.Lock()
-			oscapIOs[p.File] = nil
+			delete(oscapIOs, p.File)
 			oscapIOsMu.Unlock()
 			err := p.Kill()
 			if err != nil {
@@ -363,4 +363,38 @@ func evaluateXCCDFRule(ctx context.Context, hostname string, statsdClient *stats
 	}
 
 	return events
+}
+
+// FinishXCCDFBenchmark finishes an XCCDF benchmark by terminating the oscap-io processes.
+func FinishXCCDFBenchmark(ctx context.Context, benchmark *Benchmark) {
+	oscapIOsMu.Lock()
+	defer oscapIOsMu.Unlock()
+
+	if len(oscapIOs) == 0 {
+		// No oscap-io process is running.
+		return
+	}
+
+	for _, rule := range benchmark.Rules {
+		if !rule.IsXCCDF() {
+			continue
+		}
+		if len(benchmark.Rules[0].InputSpecs) == 0 {
+			continue
+		}
+		file := filepath.Join(benchmark.dirname, rule.InputSpecs[0].XCCDF.Name)
+		p := oscapIOs[file]
+		if p == nil {
+			continue
+		}
+		delete(oscapIOs, file)
+		err := p.Kill()
+		if err != nil {
+			log.Warnf("failed to kill process: %v", err)
+		}
+		if len(oscapIOs) == 0 {
+			// If no oscap-io process is running, we don't have to loop through every rules.
+			return
+		}
+	}
 }


### PR DESCRIPTION
### What does this PR do?

This change adds a new function `FinishXCCDFBenchmark`, called after all the rules from an XCCDF benchmark has been run.

The `FinishXCCDFBenchmark` function terminates the `oscap-io` processes, so they won't stay in memory when not necessary.

New `oscap-io` processes will be started during the next run of an XCCDF benchmark.

This change also decreases the verbosity of log message related to the end of processes, since it's normal behavior now.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
