### PR TITLE
Remove buggy chmod directives in the `Dockerfile` of the cluster-agent

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -13,10 +13,10 @@ LABEL org.opencontainers.image.source "https://github.com/DataDog/datadog-agent"
 WORKDIR /output
 
 COPY datadog-cluster-agent.$TARGETARCH opt/datadog-agent/bin/datadog-cluster-agent
-COPY --chmod=744 ./conf.d etc/datadog-agent/conf.d
+COPY ./conf.d etc/datadog-agent/conf.d
 COPY ./datadog-cluster.yaml etc/datadog-agent/datadog-cluster.yaml
 COPY ./security-agent-policies/compliance/containers/ etc/datadog-agent/compliance.d
-COPY --chmod=744 ./install_info etc/datadog-agent/install_info
+COPY ./install_info etc/datadog-agent/install_info
 COPY entrypoint.sh .
 COPY readsecret.sh readsecret_multiple_providers.sh ./
 
@@ -52,12 +52,12 @@ ARG CIBUILD
 # indefinitely. Therefore we create a mirrorlist with the 2 mirrors that we know
 # should be reliable enough in combination and also well maintained.
 RUN if [ "$CIBUILD" = "true" ]; then \
-  echo "http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu" > /etc/apt/mirrorlist.main && \
-  echo "http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\tpriority:1\nhttp://ports.ubuntu.com/ubuntu-ports" > /etc/apt/mirrorlist.ports && \
-  sed -i -e 's#http://archive.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
-         -e 's#http://security.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
-         -e 's#http://ports.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' /etc/apt/sources.list; \
-  fi
+    echo "http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu" > /etc/apt/mirrorlist.main && \
+    echo "http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\tpriority:1\nhttp://ports.ubuntu.com/ubuntu-ports" > /etc/apt/mirrorlist.ports && \
+    sed -i -e 's#http://archive.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
+    -e 's#http://security.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.main#g' \
+    -e 's#http://ports.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist.ports#g' /etc/apt/sources.list; \
+    fi
 
 ENV PATH="/opt/datadog-agent/bin/:$PATH" \
     DOCKER_DD_AGENT="true" \
@@ -83,7 +83,8 @@ RUN adduser --system --no-create-home --disabled-password --ingroup root dd-agen
     && touch /var/log/datadog/.placeholder \
     && touch /tmp/.placeholder \
     && chown -R dd-agent:root /etc/datadog-agent/ /var/log/datadog/ /conf.d /tmp/ \
-    && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /var/log/datadog/ /conf.d /tmp/
+    && chmod g+r,g+w,g+X -R /var/log/datadog/ /conf.d /tmp/ \
+    && chmod g+r,g-w,g+X,o-w -R /etc/datadog-agent/
 
 # Ensure the glibc doesn't try to call syscalls that may not be supported
 COPY --from=nosys-seccomp /tmp/nosys.so /lib/x86_64-linux-gnu/nosys.so


### PR DESCRIPTION
### What does this PR do?

Remove buggy `chmod` directives in the `Dockerfile` of the cluster agent.

### Motivation

Current permissions of `/etc/datadog-agent/conf.d` and `etc/datadog-agent/install_info` are incorrect:

```shell
$ docker run -ti --rm --entrypoint /bin/bash gcr.io/datadoghq/cluster-agent:7.48.0-rc.6 -c "find /etc/datadog-agent/conf.d /etc/datadog-agent/install_info -ls"

  1802924      4 drwxrwsr-x   4 dd-agent root         4096 Sep 22 09:03 /etc/datadog-agent/conf.d
  1802925      4 drwxrwxr--   2 dd-agent root         4096 Sep 22 09:03 /etc/datadog-agent/conf.d/kubernetes_apiserver.d
  1800054      4 -rwxrwxr--   1 dd-agent root          992 Sep 20 10:59 /etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default
  1802926      4 drwxrwxr--   2 dd-agent root         4096 Sep 22 09:03 /etc/datadog-agent/conf.d/orchestrator.d
  1800055      4 -rwxrwxr--   1 dd-agent root           68 Sep 20 10:59 /etc/datadog-agent/conf.d/orchestrator.d/conf.yaml.default
  1800057      4 -rwxrwxr--   1 dd-agent root           86 Sep 20 10:59 /etc/datadog-agent/install_info
```

* `conf.yaml.default` files have the executable bit set although they are not executable,
* `install_info` has the executable bit set although it is not executable either,
* `conf.d` directory has the sgid bit set,
* `conf.d/kubernetes_apiserver.d` and `conf.d/orchestrator.d` directories are missing the search bit for other.

### Additional Notes

Reverts #16347, #18069 and DataDog/helm-charts#1096.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Check permissions on `/etc/datadog-agent/conf.d` and `etc/datadog-agent/install_info` with:

```shell
$ docker run -ti --rm --entrypoint /bin/bash gcr.io/datadoghq/cluster-agent:7.49.0-rc.1 -c "find /etc/datadog-agent/conf.d /etc/datadog-agent/install_info -ls"

  1933313      4 drwxr-xr-x   4 dd-agent root         4096 Sep 25 10:30 /etc/datadog-agent/conf.d
  1933314      4 drwxr-xr-x   2 dd-agent root         4096 Sep 25 10:30 /etc/datadog-agent/conf.d/kubernetes_apiserver.d
  1927827      4 -rw-r--r--   1 dd-agent root          992 Sep 22 14:32 /etc/datadog-agent/conf.d/kubernetes_apiserver.d/conf.yaml.default
  1933315      4 drwxr-xr-x   2 dd-agent root         4096 Sep 25 10:30 /etc/datadog-agent/conf.d/orchestrator.d
  1927828      4 -rw-r--r--   1 dd-agent root           68 Sep 22 14:32 /etc/datadog-agent/conf.d/orchestrator.d/conf.yaml.default
  1927830      4 -rw-r--r--   1 dd-agent root           86 Sep 22 14:32 /etc/datadog-agent/install_info
```

Validate that the cluster-agent is working fine (including the `kubernetes_apiserver` and the `orchestrator` checks) on both plain Kubernetes and OpenShift with the Helm chart DataDog/helm-charts#1180.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
