### PR TITLE
[e2e] cleanup task refresh

### DIFF
--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -171,9 +171,14 @@ def _clean_locks():
 
 
 def _clean_stacks(ctx: Context):
-    print("🧹 Clean up stacks")
+    print("🧹 Clean up stack")
     stacks = _get_existing_stacks(ctx)
 
+    for stack in stacks:
+        print(f"🗑️  Destroying stack {stack}")
+        _destroy_stack(ctx, stack)
+
+    stacks = _get_existing_stacks(ctx)
     for stack in stacks:
         print(f"🗑️ Cleaning up stack {stack}")
         _remove_stack(ctx, stack)
@@ -194,6 +199,13 @@ def _get_existing_stacks(ctx: Context) -> List[str]:
             print(f"Adding stack {stack_name}")
             e2e_stacks.append(stack_name)
         return e2e_stacks
+
+
+def _destroy_stack(ctx: Context, stack_name: str):
+    # running in temp dir as this is where datadog-agent test
+    # stacks are stored
+    with ctx.cd(tempfile.gettempdir()):
+        ctx.run(f"pulumi destroy --stack {stack_name} -r --yes --remove --skip-preview", pty=True)
 
 
 def _remove_stack(ctx: Context, stack_name: str):

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -150,6 +150,8 @@ def clean(ctx, locks=True, stacks=False):
 
     if locks:
         _clean_locks()
+        if not stacks:
+            print("If you still have issues, try running with -s option to clean up stacks")
 
     if stacks:
         _clean_stacks(ctx)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Destroy stacks on cleanup task with `-s` option.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

When forcing stack state removal we might break sync with remote, and this prevents running a test where a stack created instances on the cloud, as AWS does not allow creating instances with the same name

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
