### PR TITLE
[SEC-10658][CWS] check container filesystem is mounted before generating its SBOM

### DIFF
--- a/pkg/security/resolvers/cgroup/model/model.go
+++ b/pkg/security/resolvers/cgroup/model/model.go
@@ -126,6 +126,17 @@ func (cgce *CacheEntry) SetTags(tags []string) {
 	}
 }
 
+// GetWorkloadSelector returns a copy of the workload selector of this cgroup
+func (cgce *CacheEntry) GetWorkloadSelectorCopy() *WorkloadSelector {
+	cgce.Lock()
+	defer cgce.Unlock()
+
+	return &WorkloadSelector{
+		Image: cgce.WorkloadSelector.Image,
+		Tag:   cgce.WorkloadSelector.Tag,
+	}
+}
+
 // NeedsTagsResolution returns true if this workload is missing its tags
 func (cgce *CacheEntry) NeedsTagsResolution() bool {
 	return len(cgce.ID) != 0 && !cgce.WorkloadSelector.IsReady()

--- a/pkg/security/resolvers/cgroup/model/model.go
+++ b/pkg/security/resolvers/cgroup/model/model.go
@@ -126,7 +126,7 @@ func (cgce *CacheEntry) SetTags(tags []string) {
 	}
 }
 
-// GetWorkloadSelector returns a copy of the workload selector of this cgroup
+// GetWorkloadSelectorCopy returns a copy of the workload selector of this cgroup
 func (cgce *CacheEntry) GetWorkloadSelectorCopy() *WorkloadSelector {
 	cgce.Lock()
 	defer cgce.Unlock()

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -54,18 +54,15 @@ type SBOM struct {
 	Source      string
 	Service     string
 	ContainerID string
+	workloadKey string
 
 	deleted        *atomic.Bool
 	scanSuccessful *atomic.Bool
 	cgroup         *cgroupModel.CacheEntry
 }
 
-// getWorkloadKey (thread unsafe) returns a key to indentify the workload
-func (s *SBOM) getWorkloadKey() string {
-	if s.cgroup == nil {
-		return ""
-	}
-	return s.cgroup.WorkloadSelector.Image + ":" + s.cgroup.WorkloadSelector.Tag
+func getWorkloadKey(selector *cgroupModel.WorkloadSelector) string {
+	return selector.Image + ":" + selector.Tag
 }
 
 // IsComputed returns true if SBOM was successfully generated
@@ -85,12 +82,13 @@ func (s *SBOM) reset() {
 }
 
 // NewSBOM returns a new empty instance of SBOM
-func NewSBOM(host string, source string, id string, cgroup *cgroupModel.CacheEntry) (*SBOM, error) {
+func NewSBOM(host string, source string, id string, cgroup *cgroupModel.CacheEntry, workloadKey string) (*SBOM, error) {
 	return &SBOM{
 		files:          make(map[uint64]*Package),
 		Host:           host,
 		Source:         source,
 		ContainerID:    id,
+		workloadKey:    workloadKey,
 		deleted:        atomic.NewBool(false),
 		scanSuccessful: atomic.NewBool(false),
 		cgroup:         cgroup,
@@ -255,9 +253,8 @@ func (r *Resolver) analyzeWorkload(sbom *SBOM) error {
 	}
 
 	// bail out if the workload has been analyzed while queued up
-	sbomKey := sbom.getWorkloadKey()
 	r.sbomsCacheLock.RLock()
-	if r.sbomsCache.Contains(sbomKey) {
+	if r.sbomsCache.Contains(sbom.workloadKey) {
 		r.sbomsCacheLock.RUnlock()
 		return nil
 	}
@@ -335,7 +332,7 @@ func (r *Resolver) analyzeWorkload(sbom *SBOM) error {
 
 	// add to cache
 	r.sbomsCacheLock.Lock()
-	r.sbomsCache.Add(sbomKey, sbom)
+	r.sbomsCache.Add(sbom.workloadKey, sbom)
 	r.sbomsCacheLock.Unlock()
 
 	seclog.Infof("new sbom generated for '%s': %d files added", sbom.ContainerID, len(sbom.files))
@@ -365,8 +362,8 @@ func (r *Resolver) ResolvePackage(containerID string, file *model.FileEvent) *Pa
 
 // newWorkloadEntry (thread unsafe) creates a new SBOM entry for the sbom designated by the provided process cache
 // entry
-func (r *Resolver) newWorkloadEntry(id string, cgroup *cgroupModel.CacheEntry) (*SBOM, error) {
-	sbom, err := NewSBOM(r.hostname, r.source, id, cgroup)
+func (r *Resolver) newWorkloadEntry(id string, cgroup *cgroupModel.CacheEntry, workloadKey string) (*SBOM, error) {
+	sbom, err := NewSBOM(r.hostname, r.source, id, cgroup, workloadKey)
 	if err != nil {
 		return nil, err
 	}
@@ -389,15 +386,13 @@ func (r *Resolver) queueWorkload(sbom *SBOM) {
 	r.sbomsCacheLock.Lock()
 	defer r.sbomsCacheLock.Unlock()
 
-	if workloadKey := sbom.getWorkloadKey(); workloadKey != "" {
-		cachedSBOM, ok := r.sbomsCache.Get(workloadKey)
-		if ok {
-			// copy report and file cache (keeping a reference is fine, we won't be modifying the content)
-			sbom.files = cachedSBOM.files
-			sbom.report = cachedSBOM.report
-			r.sbomsCacheHit.Inc()
-			return
-		}
+	cachedSBOM, ok := r.sbomsCache.Get(sbom.workloadKey)
+	if ok {
+		// copy report and file cache (keeping a reference is fine, we won't be modifying the content)
+		sbom.files = cachedSBOM.files
+		sbom.report = cachedSBOM.report
+		r.sbomsCacheHit.Inc()
+		return
 	}
 	r.sbomsCacheMiss.Inc()
 
@@ -409,15 +404,15 @@ func (r *Resolver) queueWorkload(sbom *SBOM) {
 }
 
 // OnWorkloadSelectorResolvedEvent is used to handle the creation of a new cgroup with its resolved tags
-func (r *Resolver) OnWorkloadSelectorResolvedEvent(sbom *cgroupModel.CacheEntry) {
-	r.Retain(sbom.ID, sbom)
-}
-
-// Retain increments the reference counter of the SBOM of a sbom
-func (r *Resolver) Retain(id string, cgroup *cgroupModel.CacheEntry) {
+func (r *Resolver) OnWorkloadSelectorResolvedEvent(cgroup *cgroupModel.CacheEntry) {
 	r.sbomsLock.Lock()
 	defer r.sbomsLock.Unlock()
 
+	if cgroup == nil {
+		return
+	}
+
+	id := cgroup.ID
 	// We don't scan hosts for now
 	if len(id) == 0 {
 		return
@@ -425,7 +420,8 @@ func (r *Resolver) Retain(id string, cgroup *cgroupModel.CacheEntry) {
 
 	_, ok := r.sboms[id]
 	if !ok {
-		sbom, err := r.newWorkloadEntry(id, cgroup)
+		workloadKey := getWorkloadKey(cgroup.GetWorkloadSelectorCopy())
+		sbom, err := r.newWorkloadEntry(id, cgroup, workloadKey)
 		if err != nil {
 			seclog.Errorf("couldn't create new SBOM entry for sbom '%s': %v", id, err)
 		}
@@ -443,11 +439,11 @@ func (r *Resolver) GetWorkload(id string) *SBOM {
 }
 
 // OnCGroupDeletedEvent is used to handle a CGroupDeleted event
-func (r *Resolver) OnCGroupDeletedEvent(sbom *cgroupModel.CacheEntry) {
-	r.Delete(sbom.ID)
+func (r *Resolver) OnCGroupDeletedEvent(cgroup *cgroupModel.CacheEntry) {
+	r.Delete(cgroup.ID)
 }
 
-// Delete removes the SBOM of the provided cgroup
+// Delete removes the SBOM of the provided cgroup id
 func (r *Resolver) Delete(id string) {
 	sbom := r.GetWorkload(id)
 	if sbom == nil {
@@ -475,8 +471,8 @@ func (r *Resolver) deleteSBOM(sbom *SBOM) {
 		return
 	}
 
-	// compute sbom key before reset
-	sbomKey := sbom.getWorkloadKey()
+	// save the sbom key before reset
+	sbomKey := sbom.workloadKey
 
 	// cleanup and insert SBOM in cache
 	sbom.reset()

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -287,7 +287,7 @@ func (r *Resolver) analyzeWorkload(sbom *SBOM) error {
 				return fmt.Errorf("stat failed for `%s`: couldn't stat container proc root path", containerProcRootPath)
 			}
 			if stat.Dev == r.hostRootDevice {
-				return fmt.Errorf("couldn't generate sbom: container '%s' not yet ready", sbom.ContainerID)
+				return fmt.Errorf("couldn't generate sbom: filesystem of container '%s' matches the host root filesystem", sbom.ContainerID)
 			}
 		}
 

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -203,7 +203,7 @@ func (r *Resolver) Start(ctx context.Context) {
 			case sbom := <-r.scannerChan:
 				if err := retry.Do(func() error {
 					return r.analyzeWorkload(sbom)
-				}, retry.Attempts(maxSBOMGenerationRetries), retry.Delay(20*time.Millisecond)); err != nil {
+				}, retry.Attempts(maxSBOMGenerationRetries), retry.Delay(200*time.Millisecond)); err != nil {
 					seclog.Errorf(err.Error())
 				}
 			}

--- a/pkg/security/tests/sbom_test.go
+++ b/pkg/security/tests/sbom_test.go
@@ -11,9 +11,7 @@ package tests
 import (
 	"fmt"
 	"os/exec"
-	"strconv"
 	"testing"
-	"time"
 
 	"github.com/avast/retry-go/v4"
 
@@ -44,15 +42,6 @@ func TestSBOM(t *testing.T) {
 
 	dockerWrapper.Run(t, "package-rule", func(t *testing.T, kind wrapperType, cmdFunc func(bin string, args, env []string) *exec.Cmd) {
 		test.WaitSignal(t, func() error {
-			retry.Do(func() error {
-				workload, found := test.probe.GetResolvers().CGroupResolver.GetWorkload(dockerWrapper.containerID)
-				if !found {
-					return fmt.Errorf("failed to find workload '%s'", dockerWrapper.containerID)
-				}
-				// fake tag resolution to trigger SBOM generation
-				workload.SetTags([]string{"image_name:ubuntu", "image_tag:" + strconv.Itoa(time.Now().Nanosecond())})
-				return nil
-			})
 			retry.Do(func() error {
 				sbom := test.probe.GetResolvers().SBOMResolver.GetWorkload(dockerWrapper.containerID)
 				if sbom == nil {


### PR DESCRIPTION
The `TestSBOM/package-rule` test was failing because the container's filesystem wasn't mounted at the time the SBOM was generated, which caused the SBOM to be generated against the host root filesystem instead of the container root filesystem.

This PR ensures that an error is returned when the host and container root share the same device number to prevent this from happening.
It also increases the delay between SBOM generation retries to wait longer for the container filesystem to be mounted.

Other WorkloadSelector-related changes avoid a race on the cgroup cache entry workload selector.  

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
