### PR TITLE
[SEC-10775][CWS][event monitor] add a config option to enable syscalls monitoring

### DIFF
--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -16,6 +16,7 @@ import (
 	procconsumer "github.com/DataDog/datadog-agent/pkg/process/events/consumer"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
 	secmodule "github.com/DataDog/datadog-agent/pkg/security/module"
+	"github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -32,7 +33,11 @@ var EventMonitor = module.Factory{
 			return nil, module.ErrNotEnabled
 		}
 
-		opts := eventmonitor.Opts{}
+		opts := eventmonitor.Opts{
+			ProbeOpts: probe.Opts{
+				SyscallsMonitorEnabled: secconfig.Probe.SyscallsMonitorEnabled,
+			},
+		}
 		secmoduleOpts := secmodule.Opts{}
 
 		// adapt options

--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -16,7 +16,6 @@ import (
 	procconsumer "github.com/DataDog/datadog-agent/pkg/process/events/consumer"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
 	secmodule "github.com/DataDog/datadog-agent/pkg/security/module"
-	"github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -33,16 +32,12 @@ var EventMonitor = module.Factory{
 			return nil, module.ErrNotEnabled
 		}
 
-		opts := eventmonitor.Opts{
-			ProbeOpts: probe.Opts{
-				SyscallsMonitorEnabled: secconfig.Probe.SyscallsMonitorEnabled,
-			},
-		}
+		opts := eventmonitor.Opts{}
 		secmoduleOpts := secmodule.Opts{}
 
 		// adapt options
 		if secconfig.RuntimeSecurity.IsRuntimeEnabled() {
-			secmodule.UpdateEventMonitorOpts(&opts)
+			secmodule.UpdateEventMonitorOpts(&opts, secconfig)
 		} else {
 			secmodule.DisableRuntimeSecurity(secconfig)
 		}

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -312,6 +312,7 @@ func InitSystemProbeConfig(cfg Config) {
 	eventMonitorBindEnv(cfg, join(evNS, "runtime_compilation.compiled_constants_enabled"))
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.enabled"), true)
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "events_stats.polling_interval"), 20)
+	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "syscalls_monitor.enabled"), false)
 	cfg.BindEnvAndSetDefault(join(evNS, "socket"), "/opt/datadog-agent/run/event-monitor.sock")
 	cfg.BindEnvAndSetDefault(join(evNS, "event_server.burst"), 40)
 

--- a/pkg/security/module/cws_linux.go
+++ b/pkg/security/module/cws_linux.go
@@ -15,9 +15,10 @@ func getFamilyAddress(config *config.RuntimeSecurityConfig) (string, string) {
 }
 
 // UpdateEventMonitorOpts adapt the event monitor options
-func UpdateEventMonitorOpts(opts *eventmonitor.Opts) {
+func UpdateEventMonitorOpts(opts *eventmonitor.Opts, config *config.Config) {
 	opts.ProbeOpts.PathResolutionEnabled = true
 	opts.ProbeOpts.TTYFallbackEnabled = true
+	opts.ProbeOpts.SyscallsMonitorEnabled = config.Probe.SyscallsMonitorEnabled
 }
 
 // DisableRuntimeSecurity disables all the runtime security features

--- a/pkg/security/module/cws_others.go
+++ b/pkg/security/module/cws_others.go
@@ -17,7 +17,7 @@ func getFamilyAddress(config *config.RuntimeSecurityConfig) (string, string) {
 }
 
 // UpdateEventMonitorOpts adapt the event monitor options
-func UpdateEventMonitorOpts(opts *eventmonitor.Opts) {}
+func UpdateEventMonitorOpts(opts *eventmonitor.Opts, config *config.Config) {}
 
 // DisableRuntimeSecurity disables all the runtime security features
 func DisableRuntimeSecurity(config *config.Config) {}

--- a/pkg/security/probe/config/config.go
+++ b/pkg/security/probe/config/config.go
@@ -128,6 +128,9 @@ type Config struct {
 
 	// StatsPollingInterval determines how often metrics should be polled
 	StatsPollingInterval time.Duration
+
+	// SyscallsMonitorEnabled defines if syscalls monitoring metrics should be collected
+	SyscallsMonitorEnabled bool
 }
 
 // NewConfig returns a new Config object
@@ -159,6 +162,7 @@ func NewConfig() (*Config, error) {
 		EnvsWithValue:                getStringSlice("envs_with_value"),
 		NetworkEnabled:               getBool("network.enabled"),
 		StatsPollingInterval:         time.Duration(getInt("events_stats.polling_interval")) * time.Second,
+		SyscallsMonitorEnabled:       getBool("syscalls_monitor.enabled"),
 
 		// event server
 		SocketPath:       coreconfig.SystemProbe.GetString(join(evNS, "socket")),

--- a/pkg/security/probe/opts_linux.go
+++ b/pkg/security/probe/opts_linux.go
@@ -23,8 +23,8 @@ type Opts struct {
 	PathResolutionEnabled bool
 	// TagsResolver will override the default one. Mainly here for tests.
 	TagsResolver tags.Resolver
-	// SyscallsMapMonitorEnabled enable syscalls map monitor
-	SyscallsMapMonitorEnabled bool
+	// SyscallsMonitorEnabled enable syscalls map monitor
+	SyscallsMonitorEnabled bool
 	// TTYFallbackEnabled enable the tty procfs fallback
 	TTYFallbackEnabled bool
 }

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -1537,7 +1537,7 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 		},
 		manager.ConstantEditor{
 			Name:  "monitor_syscalls_map_enabled",
-			Value: utils.BoolTouint64(opts.SyscallsMapMonitorEnabled),
+			Value: utils.BoolTouint64(opts.SyscallsMonitorEnabled),
 		},
 	)
 

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -66,9 +66,12 @@ func (m *Monitor) Init() error {
 	if err != nil {
 		return fmt.Errorf("couldn't create the approver monitor: %w", err)
 	}
-	m.syscallsMonitor, err = syscalls.NewSyscallsMonitor(p.Manager, p.StatsdClient)
-	if err != nil {
-		return fmt.Errorf("couldn't create the approver monitor: %w", err)
+
+	if p.Opts.SyscallsMonitorEnabled {
+		m.syscallsMonitor, err = syscalls.NewSyscallsMonitor(p.Manager, p.StatsdClient)
+		if err != nil {
+			return fmt.Errorf("couldn't create the approver monitor: %w", err)
+		}
 	}
 
 	m.cgroupsMonitor = cgroups.NewCgroupsMonitor(p.StatsdClient, p.resolvers.CGroupResolver)
@@ -137,8 +140,10 @@ func (m *Monitor) SendStats() error {
 		return fmt.Errorf("failed to send evaluation set stats: %w", err)
 	}
 
-	if err := m.syscallsMonitor.SendStats(); err != nil {
-		return fmt.Errorf("failed to send evaluation set stats: %w", err)
+	if m.probe.Opts.SyscallsMonitorEnabled {
+		if err := m.syscallsMonitor.SendStats(); err != nil {
+			return fmt.Errorf("failed to send evaluation set stats: %w", err)
+		}
 	}
 
 	return nil

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -938,11 +938,11 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 	emopts := eventmonitor.Opts{
 		StatsdClient: statsdClient,
 		ProbeOpts: probe.Opts{
-			StatsdClient:              statsdClient,
-			DontDiscardRuntime:        true,
-			PathResolutionEnabled:     true,
-			SyscallsMapMonitorEnabled: true,
-			TTYFallbackEnabled:        true,
+			StatsdClient:           statsdClient,
+			DontDiscardRuntime:     true,
+			PathResolutionEnabled:  true,
+			SyscallsMonitorEnabled: true,
+			TTYFallbackEnabled:     true,
 		},
 	}
 	if opts.tagsResolver != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR adds an event monitoring config option to enable syscalls monitoring.
This is used to collect metrics about inflight/missed syscall events.
This option is only used if runtime security is also enabled for now.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
