### PR TITLE
Optimize jsonObfuscator using sync.Pool and smart buffers allocation

### DIFF
--- a/pkg/obfuscate/json.go
+++ b/pkg/obfuscate/json.go
@@ -168,8 +168,8 @@ func (p *jsonObfuscator) obfuscate(data []byte) (string, error) {
 
 		case scanObjectKey:
 			// done scanning key
-			k := strings.Trim(string(keyBuf), `"`)
-			if !st.keeping && p.keepKeys[k] {
+			k := string(bytes.Trim(keyBuf, `"`))
+			if !st.hasFlag(keepingFlag) && p.keepKeys[k] {
 				// we should not obfuscate values of this key
 				st.keeping = true
 				st.keepDepth = depth + 1

--- a/pkg/obfuscate/json.go
+++ b/pkg/obfuscate/json.go
@@ -118,20 +118,17 @@ func (p *jsonObfuscator) obfuscate(data []byte) (string, error) {
 			st.closures = append(st.closures, true)
 			st.setKey()
 			st.transformingValue = false
-
 		case scanBeginArray:
 			// array begins: [
 			st.closures = append(st.closures, false)
 			st.setKey()
 			st.transformingValue = false
-
 		case scanEndArray, scanEndObject:
 			// array or object closing
 			if n := len(st.closures) - 1; n > 0 {
 				st.closures = st.closures[:n]
 			}
 			fallthrough
-
 		case scanObjectValue, scanArrayValue:
 			// done scanning value
 			st.setKey()
@@ -149,7 +146,6 @@ func (p *jsonObfuscator) obfuscate(data []byte) (string, error) {
 			} else if st.keeping && depth < st.keepDepth {
 				st.keeping = false
 			}
-
 		case scanBeginLiteral, scanContinue:
 			// starting or continuing a literal
 			if st.transformingValue {
@@ -166,7 +162,6 @@ func (p *jsonObfuscator) obfuscate(data []byte) (string, error) {
 				}
 				continue
 			}
-
 		case scanObjectKey:
 			// done scanning key
 			k := string(bytes.Trim(keyBuf, `"`))
@@ -180,13 +175,10 @@ func (p *jsonObfuscator) obfuscate(data []byte) (string, error) {
 				// proceeds as usual
 				st.transformingValue = true
 			}
-
 			keyBuf = keyBuf[:0]
 			st.key = false
-
 		case scanSkipSpace:
 			continue
-
 		case scanError:
 			// we've encountered an error, mark that there might be more JSON
 			// using the ellipsis and return whatever we've managed to obfuscate

--- a/pkg/obfuscate/json.go
+++ b/pkg/obfuscate/json.go
@@ -6,6 +6,7 @@
 package obfuscate
 
 import (
+	"bytes"
 	"strconv"
 	"strings"
 )

--- a/pkg/obfuscate/json.go
+++ b/pkg/obfuscate/json.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 // ObfuscateMongoDBString obfuscates the given MongoDB JSON query.
@@ -36,6 +37,8 @@ func obfuscateJSONString(cmd string, obfuscator *jsonObfuscator) string {
 }
 
 type jsonObfuscator struct {
+	buffPool      sync.Pool       // pool for fixed-length buffers (50 showed to be the optimal running benchmarks with different lenghts)
+	statePool     sync.Pool       // pool for jsonObfuscatorState values
 	keepKeys      map[string]bool // the values for these keys will not be obfuscated
 	transformKeys map[string]bool // the values for these keys pass through the transformer
 	transformer   func(string) string
@@ -61,6 +64,18 @@ func newJSONObfuscator(cfg *JSONConfig, o *Obfuscator) *jsonObfuscator {
 		keepKeys:      keepValue,
 		transformKeys: transformKeys,
 		transformer:   transformer,
+		buffPool: sync.Pool{
+			New: func() any {
+				return new(bytes.Buffer)
+			},
+		},
+		statePool: sync.Pool{
+			New: func() any {
+				return &jsonObfuscatorState{
+					closures: []bool{},
+				}
+			},
+		},
 	}
 }
 
@@ -78,13 +93,23 @@ func sqlObfuscationTransformer(o *Obfuscator) func(string) string {
 }
 
 type jsonObfuscatorState struct {
-	scan              *scanner // scanner
-	closures          []bool   // closure stack, true if object (e.g. {[{ => []bool{true, false, true})
-	keepDepth         int      // the depth at which we've stopped obfuscating
-	key               bool     // true if scanning a key
-	wiped             bool     // true if obfuscation string (`"?"`) was already written for current value
-	keeping           bool     // true if not obfuscating
-	transformingValue bool     // true if collecting the next literal for transformation
+	scan              scanner // scanner
+	closures          []bool  // closure stack, true if object (e.g. {[{ => []bool{true, false, true})
+	keepDepth         int     // the depth at which we've stopped obfuscating
+	key               bool    // true if scanning a key
+	wiped             bool    // true if obfuscation string (`"?"`) was already written for current value
+	keeping           bool    // true if not obfuscating
+	transformingValue bool    // true if collecting the next literal for transformation
+}
+
+func (st *jsonObfuscatorState) reset() {
+	st.scan.reset()
+	st.closures = st.closures[0:0]
+	st.keepDepth = 0
+	st.key = false
+	st.wiped = false
+	st.keeping = false
+	st.transformingValue = false
 }
 
 // setKey verifies if we are currently scanning a key based on the current state
@@ -97,20 +122,26 @@ func (st *jsonObfuscatorState) setKey() {
 }
 
 func (p *jsonObfuscator) obfuscate(data []byte) (string, error) {
-	var out strings.Builder
-	st := jsonObfuscatorState{
-		closures: []bool{},
-		scan:     &scanner{},
+	if len(data) == 0 {
+		return "", nil
 	}
 
-	keyBuf := make([]byte, 0, 10) // recording key token
-	valBuf := make([]byte, 0, 10) // recording value
+	var out strings.Builder
+	st := p.statePool.Get().(*jsonObfuscatorState)
+	st.reset()
+
+	buf := p.buffPool.Get().(*bytes.Buffer) // recording current token
+	buf.Reset()
+	defer func() {
+		p.statePool.Put(st)
+		p.buffPool.Put(buf)
+	}()
 
 	out.Grow(len(data))
-	st.scan.reset()
+	buf.Grow(len(data) / 10) // Benchmarks show that the optimal point is a tenth of the data length.
 	for _, c := range data {
 		st.scan.bytes++
-		op := st.scan.step(st.scan, c)
+		op := st.scan.step(&st.scan, c)
 		depth := len(st.closures)
 		switch op {
 		case scanBeginObject:
@@ -133,38 +164,38 @@ func (p *jsonObfuscator) obfuscate(data []byte) (string, error) {
 			// done scanning value
 			st.setKey()
 			if st.transformingValue && p.transformer != nil {
-				v, err := strconv.Unquote(string(valBuf))
+				v, err := strconv.Unquote(buf.String())
 				if err != nil {
-					v = string(valBuf)
+					v = buf.String()
 				}
 				result := p.transformer(v)
 				out.WriteByte('"')
 				out.WriteString(result)
 				out.WriteByte('"')
 				st.transformingValue = false
-				valBuf = valBuf[:0]
+				buf.Reset()
 			} else if st.keeping && depth < st.keepDepth {
 				st.keeping = false
 			}
 		case scanBeginLiteral, scanContinue:
 			// starting or continuing a literal
 			if st.transformingValue {
-				valBuf = append(valBuf, c)
+				buf.WriteByte(c)
 				continue
 			} else if st.key {
 				// it's a key
-				keyBuf = append(keyBuf, c)
+				buf.WriteByte(c)
 			} else if !st.keeping {
 				// it's a value we're not keeping
 				if !st.wiped {
-					out.Write([]byte(`"?"`))
+					out.WriteString(`"?"`)
 					st.wiped = true
 				}
 				continue
 			}
 		case scanObjectKey:
 			// done scanning key
-			k := string(bytes.Trim(keyBuf, `"`))
+			k := string(bytes.Trim(buf.Bytes(), `"`))
 			if !st.keeping && p.keepKeys[k] {
 				// we should not obfuscate values of this key
 				st.keeping = true
@@ -175,7 +206,7 @@ func (p *jsonObfuscator) obfuscate(data []byte) (string, error) {
 				// proceeds as usual
 				st.transformingValue = true
 			}
-			keyBuf = keyBuf[:0]
+			buf.Reset()
 			st.key = false
 		case scanSkipSpace:
 			continue
@@ -183,7 +214,7 @@ func (p *jsonObfuscator) obfuscate(data []byte) (string, error) {
 			// we've encountered an error, mark that there might be more JSON
 			// using the ellipsis and return whatever we've managed to obfuscate
 			// thus far.
-			out.Write([]byte("..."))
+			out.WriteString("...")
 			return out.String(), st.scan.err
 		}
 		out.WriteByte(c)

--- a/pkg/obfuscate/json.go
+++ b/pkg/obfuscate/json.go
@@ -105,6 +105,7 @@ func (p *jsonObfuscator) obfuscate(data []byte) (string, error) {
 	keyBuf := make([]byte, 0, 10) // recording key token
 	valBuf := make([]byte, 0, 10) // recording value
 
+	out.Grow(len(data))
 	st.scan.reset()
 	for _, c := range data {
 		st.scan.bytes++

--- a/pkg/obfuscate/json.go
+++ b/pkg/obfuscate/json.go
@@ -169,7 +169,7 @@ func (p *jsonObfuscator) obfuscate(data []byte) (string, error) {
 		case scanObjectKey:
 			// done scanning key
 			k := string(bytes.Trim(keyBuf, `"`))
-			if !st.hasFlag(keepingFlag) && p.keepKeys[k] {
+			if !st.keeping && p.keepKeys[k] {
 				// we should not obfuscate values of this key
 				st.keeping = true
 				st.keepDepth = depth + 1

--- a/pkg/obfuscate/json.go
+++ b/pkg/obfuscate/json.go
@@ -37,7 +37,7 @@ func obfuscateJSONString(cmd string, obfuscator *jsonObfuscator) string {
 }
 
 type jsonObfuscator struct {
-	buffPool      sync.Pool       // pool for fixed-length buffers (50 showed to be the optimal running benchmarks with different lenghts)
+	buffPool      sync.Pool       // pool for fixed-length buffers (50 showed to be the optimal running benchmarks with different length)
 	statePool     sync.Pool       // pool for jsonObfuscatorState values
 	keepKeys      map[string]bool // the values for these keys will not be obfuscated
 	transformKeys map[string]bool // the values for these keys pass through the transformer

--- a/pkg/obfuscate/json_test.go
+++ b/pkg/obfuscate/json_test.go
@@ -185,7 +185,6 @@ func TestObfuscateJSONConcurrently(t *testing.T) {
 		if v == expected {
 			continue
 		}
-
 		t.Fatalf("mangled payload after obfuscation: %q", v)
 	}
 }

--- a/releasenotes/notes/faster-obfuscation-744c6710d52ad6d9.yaml
+++ b/releasenotes/notes/faster-obfuscation-744c6710d52ad6d9.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Improved performance and memory consumption, both halved on average.
+fixes:
+  - |
+    Concurrency issue at high volumes fixed.

--- a/releasenotes/notes/faster-obfuscation-744c6710d52ad6d9.yaml
+++ b/releasenotes/notes/faster-obfuscation-744c6710d52ad6d9.yaml
@@ -1,7 +1,7 @@
 ---
 enhancements:
   - |
-    Improved performance and memory consumption, both halved on average.
+    APM: Improved performance and memory consumption in obfuscation, both halved on average.
 fixes:
   - |
-    Concurrency issue at high volumes fixed.
+    APM: Concurrency issue at high volumes fixed in obfuscation.


### PR DESCRIPTION
### What does this PR do?

Improves from #19643 fixed implementation. The fix caused an increment of allocations, up to 13 per op.

The optimizations reduces allocations to 2 per op, 3 per op in the worst case.

There is still some room for optimization, but the code would be hard to read and maintain.

### Motivation

I measured the impact of allocating the new internal state struct and I found that it was significant (in bytes and nanoseconds scale):

main:

```
BenchmarkObfuscateJSON/elasticsearch.body.1-10                                           1381185               855.3 ns/op           384 B/op          7 allocs/op
```

This PR:

```
BenchmarkObfuscateJSON/elasticsearch.body.1-10                                           1000000              1053 ns/op             576 B/op         13 allocs/op
BenchmarkObfuscateJSON/obfuscate.mongo.json.keep_values-10                               1979707               606.8 ns/op           400 B/op         11 allocs/op
```

I applied two optimizations ([`out.Grow()`](https://github.com/DataDog/datadog-agent/pull/19643/files#diff-7ce08f4ef3a4c33487f631696e3fe94835170c85781693113325c558be655abbR109) and [`bytes.Trim()` instead of `strings.Trim()`](https://github.com/DataDog/datadog-agent/pull/19643/files#diff-7ce08f4ef3a4c33487f631696e3fe94835170c85781693113325c558be655abbR172)) that improved performance, setting it closer to the original implementation:

```
BenchmarkObfuscateJSON/elasticsearch.body.1-10                                           1268534               943.5 ns/op           440 B/op          9 allocs/op
BenchmarkObfuscateJSON/obfuscate.mongo.json.keep_values-10                               2123896               549.2 ns/op           312 B/op          7 allocs/op
```

Introducing `sync.Pool` allocations are down to 1-3 allocs/op:

```
BenchmarkObfuscateJSON/elasticsearch.body.1-10                                    	 1505170	       798.2 ns/op	     224 B/op	       2 allocs/op
BenchmarkObfuscateJSON/obfuscate.mongo.json.keep_values-10                        	 2821915	       424.2 ns/op	     160 B/op	       2 allocs/op
```

PS: if we apply the optimizations to main, except `sync.Pool`, we see that the performance impact of the fix would be proportionally to the baseline, doubling allocation. At least it has been mitigated and set almost to the original implementation's performance.

```
BenchmarkObfuscateJSON/elasticsearch.body.1-10                                           1585716               754.8 ns/op           248 B/op          3 allocs/op
```

### Describe how to test/QA your changes

Unit tests are in place to test and benchmark the implementation.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
