### PR TITLE
[SBOM] Add metric `datadog.agent.sbom_images`

### DIFF
--- a/pkg/collector/corechecks/sbom/telemetry.go
+++ b/pkg/collector/corechecks/sbom/telemetry.go
@@ -1,0 +1,95 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+//go:build trivy
+
+// Package sbom contains the sbom check
+package sbom
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+)
+
+const (
+	imageMetric = "datadog.agent.sbom_images"
+)
+
+// imageTelemetry contains metrics that must always be sent
+type imageTelemetry struct {
+	sender                sender.Sender
+	imageWithoutSBOMCount float64
+	imageWithSBOMCount    float64
+	imageHasSBOM          map[string]bool
+}
+
+func newImageTelemetry(sender sender.Sender) *imageTelemetry {
+	return &imageTelemetry{sender: sender, imageHasSBOM: make(map[string]bool)}
+}
+
+func (t *imageTelemetry) observeNewImage(img *workloadmeta.ContainerImageMetadata) {
+	knownHasSBOM, ok := t.imageHasSBOM[img.ID]
+	newHasSBOM := img.SBOM != nil
+	if ok {
+		// If the image is already known
+		if newHasSBOM == knownHasSBOM {
+			// If there is no change, don't do anything
+			return
+		}
+		// If there is a change then update both counters accordingly
+		t.imageWithSBOMCount += and(newHasSBOM, !knownHasSBOM)    // +1 for transition NoSBOM=>SBOM else -1
+		t.imageWithoutSBOMCount += and(!newHasSBOM, knownHasSBOM) // +1 for transition => SBOM=>NoSBOM else -1
+		t.sendMetric(newHasSBOM)
+	} else {
+		// If the image is not known, add it to the map and update the right counter (with or without sbom)
+		t.imageHasSBOM[img.ID] = newHasSBOM
+		updateCountForNewImage(t, newHasSBOM)
+		t.sendMetric(newHasSBOM)
+	}
+}
+
+// and returns 1 if A and B otherwise -1
+func and(a, b bool) float64 {
+	if a && b {
+		return 1
+	}
+	return -1
+}
+
+// updateCountForNewImage updates the counts for unknown images
+func updateCountForNewImage(t *imageTelemetry, newHasSBOM bool) {
+	if newHasSBOM {
+		t.imageWithSBOMCount++
+		return
+	}
+	t.imageWithoutSBOMCount++
+}
+
+// sendMetric submits metrics
+func (t *imageTelemetry) sendMetric(sendImageWithSBOM bool) {
+	sbomTag := fmt.Sprintf("with_sbom:%v", sendImageWithSBOM)
+	value := t.imageWithSBOMCount
+	if !sendImageWithSBOM {
+		value = t.imageWithoutSBOMCount
+	}
+	t.sender.Gauge(imageMetric, value, "", []string{sbomTag})
+	t.sender.Commit()
+}
+
+func (t *imageTelemetry) unobserveImage(img *workloadmeta.ContainerImageMetadata) {
+	hasSBOM, ok := t.imageHasSBOM[img.ID]
+	if !ok {
+		return
+	}
+	if hasSBOM {
+		t.imageWithSBOMCount--
+	} else {
+		t.imageWithoutSBOMCount--
+	}
+	t.sendMetric(hasSBOM)
+	delete(t.imageHasSBOM, img.ID)
+}

--- a/pkg/collector/corechecks/sbom/telemetry.go
+++ b/pkg/collector/corechecks/sbom/telemetry.go
@@ -64,7 +64,6 @@ func and(a, b bool) float64 {
 func updateCountForNewImage(t *imageTelemetry, newHasSBOM bool) {
 	if newHasSBOM {
 		t.imageWithSBOMCount++
-		return
 	}
 	t.imageWithoutSBOMCount++
 }

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -148,6 +148,8 @@ func PrintConfig(w io.Writer, c integration.Config, checkName string) {
 		fmt.Fprintf(w, "%s:\n", color.BlueString("Log Config"))
 		printYaml(w, c.LogsConfig)
 	}
+	fmt.Fprintf(w, "%s:\n", color.BlueString("Filters"))
+
 	if c.IsTemplate() {
 		fmt.Fprintf(w, "%s:\n", color.BlueString("Auto-discovery IDs"))
 		for _, id := range c.ADIdentifiers {

--- a/releasenotes/notes/add-sbom-telemetry-counting-image-21d48dffc399eb53.yaml
+++ b/releasenotes/notes/add-sbom-telemetry-counting-image-21d48dffc399eb53.yaml
@@ -1,0 +1,5 @@
+
+enhancements:
+  - |
+    Added the metric `datadog.agent.sbom_images`, tagged as `with_sbom`, to measure the number of images processed by the SBOM check both with and without SBOM.
+    This metric is consistently sent to Datadog whenever the SBOM check is enabled.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR adds the metric `datadog.agent.sbom_images` tracking the number of images processed by the SBOM check but also the number of images that have a SBOM attached to them.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We want to easily know when some images are not scanned.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
We'll most likely also send the number of errors that occurred during the scan process but it requires a larger refactoring.
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Deploy the agent with the SBOM check enabled scanning container images. Observe the metric from the UI and make sure it is in sync with `agent workload-list -v`.
Don't hesitate to start/delete containers and pull/delete images.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
