### PR TITLE
Attempt #2 to fix flaky secrets tests on windows

### DIFF
--- a/.github/workflows/windows-unittests.yml
+++ b/.github/workflows/windows-unittests.yml
@@ -54,7 +54,7 @@ jobs:
           powershell.exe -Command ./tasks/winbuildscripts/pre-go-build.ps1
           # FIXME: skipping rtloader tests because they fail with a DLL-not-found error
           # inv -e rtloader.test
-          inv -e test --skip-linters --rerun-fails=2 --python-runtimes 3 --coverage --profile --python-home-3=$pythonLocation
+          inv -e test --skip-linters --rerun-fails=2 --python-runtimes 3 --coverage --profile --python-home-3=$pythonLocation --test_run_name=pkg/secrets/... --timeout=600
 
       - name: Upload Codecov results
         uses: codecov/codecov-action@v3

--- a/.github/workflows/windows-unittests.yml
+++ b/.github/workflows/windows-unittests.yml
@@ -54,7 +54,7 @@ jobs:
           powershell.exe -Command ./tasks/winbuildscripts/pre-go-build.ps1
           # FIXME: skipping rtloader tests because they fail with a DLL-not-found error
           # inv -e rtloader.test
-          inv -e test --skip-linters --rerun-fails=2 --python-runtimes 3 --coverage --profile --python-home-3=$pythonLocation --test-run-name=pkg/secrets/... --timeout=600
+          inv -e test --skip-linters --rerun-fails=2 --python-runtimes 3 --coverage --profile --python-home-3=$pythonLocation --timeout=600
 
       - name: Upload Codecov results
         uses: codecov/codecov-action@v3

--- a/.github/workflows/windows-unittests.yml
+++ b/.github/workflows/windows-unittests.yml
@@ -54,7 +54,7 @@ jobs:
           powershell.exe -Command ./tasks/winbuildscripts/pre-go-build.ps1
           # FIXME: skipping rtloader tests because they fail with a DLL-not-found error
           # inv -e rtloader.test
-          inv -e test --skip-linters --rerun-fails=2 --python-runtimes 3 --coverage --profile --python-home-3=$pythonLocation --test_run_name=pkg/secrets/... --timeout=600
+          inv -e test --skip-linters --rerun-fails=2 --python-runtimes 3 --coverage --profile --python-home-3=$pythonLocation --test-run-name=pkg/secrets/... --timeout=600
 
       - name: Upload Codecov results
         uses: codecov/codecov-action@v3

--- a/pkg/secrets/info_windows_test.go
+++ b/pkg/secrets/info_windows_test.go
@@ -19,10 +19,6 @@ import (
 )
 
 func TestGetExecutablePermissionsError(t *testing.T) {
-	// This test plus unit tests for Linux file will be moving to integration tests
-	// (in soon to be added _windows_integration_tests() and _linux_integration_tests() functions)
-	t.Skip("skipping flaky Windows test (it hangs on execution of its PowerShell script in latest github environment)")
-
 	secretBackendCommand = "some_command"
 	t.Cleanup(resetPackageVars)
 
@@ -53,10 +49,6 @@ func setupSecretCommmand(t *testing.T) {
 }
 
 func TestGetExecutablePermissionsSuccess(t *testing.T) {
-	// This test plus unit tests for Linux file will be moving to integration tests
-	// (in soon to be added _windows_integration_tests() and _linux_integration_tests() functions)
-	t.Skip("skipping flaky Windows test (it hangs on execution of its PowerShell script in latest github environment)")
-
 	setupSecretCommmand(t)
 
 	res, err := getExecutablePermissions()

--- a/pkg/secrets/test/setAcl.ps1
+++ b/pkg/secrets/test/setAcl.ps1
@@ -43,7 +43,7 @@ if ($removeLocalSystem -eq $True) {
 
 # adding ACL for current user
 if ($addDDUser -eq $True) {
-    $ddCurrentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    $ddCurrentUser = $Env:ComputerName + "\" + $Env:UserName
     $ddAcl = New-Object  system.security.accesscontrol.filesystemaccessrule($ddCurrentUser, "FullControl","Allow")
     $acl.SetAccessRule($ddAcl)
 }

--- a/pkg/secrets/test/setAcl.ps1
+++ b/pkg/secrets/test/setAcl.ps1
@@ -43,7 +43,7 @@ if ($removeLocalSystem -eq $True) {
 
 # adding ACL for current user
 if ($addDDUser -eq $True) {
-    $ddCurrentUser = $Env:ComputerName + "\" + $Env:UserName
+    $ddCurrentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
     $ddAcl = New-Object  system.security.accesscontrol.filesystemaccessrule($ddCurrentUser, "FullControl","Allow")
     $acl.SetAccessRule($ddAcl)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
-->
### What does this PR do?
* Rolled back previous PR which disabled 2 unit tests.
* Increased default timeout to 10 minutes (from 3).

Unit tests started failing immediately when new github runner 20230918 had been used (instead of previous 20230910).  On previous github runner pkg/secrets test took 10-20 seconds but on all 20230918 which had started being used first time on Sep 20 (and which usage quickly ramped up in few days to be used all the time) the same test runs now 2m 45s to 3m (and timeout immediately after that).

There was a [very similar issue reported today](https://github.com/actions/runner-images/issues/8380) where Powershell script execution time changed from 1 second to 25 on Sep 21 and on the same runner version. Github support claims Windows Update is not disabled for some reason and perhaps contributes to that.

**Update**: Github [addressed](https://github.com/actions/runner-images/issues/8380#issuecomment-1737214302) the issue in the next runner 20230924, but this PR still needs to be merged:
* It restores previous disabled two unit tests
* Timeout increase from 3min to 10min appears to be useful to guard from "legit" outliers.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.

