### PR TITLE
Add support for LPM_TRIE maps to ebpf check

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -560,8 +560,8 @@ func ringBufferMemoryUsage(mapStats *model.EBPFMapStats, info *ebpf.MapInfo, k *
 		// default RSS to MaxSize in case of error
 		mapStats.RSS = mapStats.MaxSize
 	} else {
-		for i, size := range rss {
-			log.Debugf("ring buffer map_id=%d idx=%d rss=%d", mapid, i, size)
+		for addr, size := range rss {
+			log.Debugf("ring buffer map_id=%d addr=%x rss=%d", mapid, addr, size)
 			mapStats.RSS += size
 		}
 	}

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -222,12 +222,12 @@ func (k *Probe) getProgramStats(stats *model.EBPFStats) error {
 	for progid, err = ebpf.ProgramGetNextID(progid); err == nil; progid, err = ebpf.ProgramGetNextID(progid) {
 		pr, err := ebpf.NewProgramFromID(progid)
 		if err != nil {
-			log.Debugf("unable to get program %d: %s", progid, err)
+			log.Debugf("unable to get program prog_id=%d: %s", progid, err)
 			continue
 		}
 		var info ProgInfo
 		if err := ProgObjInfo(uint32(pr.FD()), &info); err != nil {
-			log.Debugf("error getting program info %d: %s", progid, err)
+			log.Debugf("error getting program info prog_id=%d: %s", progid, err)
 			continue
 		}
 
@@ -266,7 +266,7 @@ func (k *Probe) getProgramStats(stats *model.EBPFStats) error {
 	log.Debugf("found %d programs", len(stats.Programs))
 	deduplicateProgramNames(stats)
 	for _, ps := range stats.Programs {
-		log.Debugf("%s(%d) => %s", ps.Name, ps.ID, ps.Type.String())
+		log.Debugf("name=%s prog_id=%d type=%s", ps.Name, ps.ID, ps.Type.String())
 	}
 
 	return nil
@@ -282,7 +282,7 @@ func (k *Probe) getMapStats(stats *model.EBPFStats) error {
 	for mapid, err = ebpf.MapGetNextID(mapid); err == nil; mapid, err = ebpf.MapGetNextID(mapid) {
 		mp, err := ebpf.NewMapFromID(mapid)
 		if err != nil {
-			log.Debugf("unable to get map %d: %s", mapid, err)
+			log.Debugf("unable to get map map_id=%d: %s", mapid, err)
 			continue
 		}
 		mapCount++
@@ -291,7 +291,7 @@ func (k *Probe) getMapStats(stats *model.EBPFStats) error {
 		// we could maybe avoid the duplicate call by doing the id->fd->info chain ourselves
 		info, err := mp.Info()
 		if err != nil {
-			log.Debugf("error getting map info %d: %s", mapid, err)
+			log.Debugf("error getting map info map_id=%d: %s", mapid, err)
 			continue
 		}
 		name := info.Name
@@ -358,10 +358,10 @@ func (k *Probe) getMapStats(stats *model.EBPFStats) error {
 	log.Debugf("found %d maps", mapCount)
 	deduplicateMapNames(stats)
 	for _, mp := range stats.Maps {
-		log.Debugf("%s(%d) => max=%d rss=%d", mp.Name, mp.ID, mp.MaxSize, mp.RSS)
+		log.Debugf("name=%s map_id=%d max=%d rss=%d type=%s", mp.Name, mp.ID, mp.MaxSize, mp.RSS, mp.Type)
 	}
 	for _, mp := range stats.PerfBuffers {
-		log.Debugf("%s(%d) => max=%d rss=%d", mp.Name, mp.ID, mp.MaxSize, mp.RSS)
+		log.Debugf("name=%s map_id=%d max=%d rss=%d type=%s", mp.Name, mp.ID, mp.MaxSize, mp.RSS, mp.Type)
 	}
 
 	return nil
@@ -497,13 +497,14 @@ func perfBufferMemoryUsage(mapStats *model.EBPFPerfBufferStats, info *ebpf.MapIn
 		})
 	}
 
+	log.Debugf("map_id=%d num_cpus=%d", mapid, len(mapStats.CPUBuffers))
 	addrs := make([]uintptr, 0, len(mapStats.CPUBuffers))
 	for _, b := range mapStats.CPUBuffers {
 		addrs = append(addrs, b.Addr)
 	}
 	rssMap, err := k.getMmapRSS(uint32(mapid), addrs)
 	if err != nil {
-		log.Debugf("error getting mmap data id=%d: %s", mapid, err)
+		log.Debugf("error getting mmap data map_id=%d: %s", mapid, err)
 		// default RSS to MaxSize in case of error
 		mapStats.RSS = mapStats.MaxSize
 		for i := range mapStats.CPUBuffers {
@@ -516,9 +517,9 @@ func perfBufferMemoryUsage(mapStats *model.EBPFPerfBufferStats, info *ebpf.MapIn
 			if rss, ok := rssMap[cpub.Addr]; ok {
 				cpub.RSS = rss
 				mapStats.RSS += rss
-				log.Debugf("perf buffer id=%d cpu=%d rss=%d", mapid, cpub.CPU, cpub.RSS)
+				log.Debugf("perf buffer map_id=%d cpu=%d rss=%d", mapid, cpub.CPU, cpub.RSS)
 			} else {
-				log.Debugf("unable to find RSS data id=%d cpu=%d addr=%x", mapid, cpub.CPU, cpub.Addr)
+				log.Debugf("unable to find RSS data map_id=%d cpu=%d addr=%x", mapid, cpub.CPU, cpub.Addr)
 			}
 		}
 	}
@@ -555,11 +556,12 @@ func ringBufferMemoryUsage(mapStats *model.EBPFMapStats, info *ebpf.MapInfo, k *
 	addrs := []uintptr{uintptr(ringInfo.Consumer.Addr), uintptr(ringInfo.Data.Addr)}
 	rss, err := k.getMmapRSS(uint32(mapid), addrs)
 	if err != nil {
-		log.Debugf("error getting mmap data id=%d: %s", mapid, err)
+		log.Debugf("error getting mmap data map_id=%d: %s", mapid, err)
 		// default RSS to MaxSize in case of error
 		mapStats.RSS = mapStats.MaxSize
 	} else {
-		for _, size := range rss {
+		for i, size := range rss {
+			log.Debugf("ring buffer map_id=%d idx=%d rss=%d", mapid, i, size)
 			mapStats.RSS += size
 		}
 	}
@@ -572,7 +574,7 @@ func (k *Probe) getMmapRSS(mapid uint32, addrs []uintptr) (map[uintptr]uint64, e
 		return nil, fmt.Errorf("pid map lookup: %s", err)
 	}
 
-	log.Debugf("map pid=%d id=%d", pid, mapid)
+	log.Debugf("map pid=%d map_id=%d", pid, mapid)
 	return matchProcessRSS(int(pid), addrs)
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Add support for LPM_TRIE maps to ebpf check

### Motivation

cilium uses these map types in our environment

### Additional Notes

- Adds/fixes some logging.
- Fixes xlated instruction to be *length* (bytes) not count, and add a permodule total.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
