### PR TITLE
usm: gotls: Remove redundant allocations by using unsafe pointer

### DIFF
--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"syscall"
 	"time"
+	"unsafe"
 
 	"github.com/cihub/seelog"
 	"github.com/cilium/ebpf"
@@ -519,7 +520,7 @@ func (p *GoTLSProgram) addInspectionResultToMap(binID binaryID, result *bininspe
 		return fmt.Errorf("error while parsing inspection result: %w", err)
 	}
 
-	err = p.offsetsDataMap.Put(binID, offsetsData)
+	err = p.offsetsDataMap.Put(unsafe.Pointer(&binID), unsafe.Pointer(&offsetsData))
 	if err != nil {
 		return fmt.Errorf("could not write binary inspection result to map for binID %v: %w", binID, err)
 	}
@@ -528,7 +529,7 @@ func (p *GoTLSProgram) addInspectionResultToMap(binID binaryID, result *bininspe
 }
 
 func (p *GoTLSProgram) removeInspectionResultFromMap(binID binaryID) {
-	err := p.offsetsDataMap.Delete(binID)
+	err := p.offsetsDataMap.Delete(unsafe.Pointer(&binID))
 	if err != nil {
 		log.Errorf("could not remove inspection result from map for ino %v: %s", binID, err)
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Removes redundant allocations coming from user-mode ebpf map calls (Put and Delete).
The cillium implementation has zero allocation if the key and the value is of type unsafe.Pointer, and the pointers represents the correct key and value format in the kernel.
In goTLS this is the case, and by casting the pointers into unsafe.Pointer we remove completely the allocations.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Read cillium's code and found this nice change.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Before:
```
BenchmarkGoTLSProgram_Insepction-16    	  447474	      3212 ns/op	     859 B/op	       7 allocs/op
```

After:
```
BenchmarkGoTLSProgram_Insepction-16    	 1000000	      1022 ns/op	      20 B/op	       1 allocs/op
```

runtime down by ~68%
Bytes down by ~98%
Allocations down by ~86%
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
