### PR TITLE
ebpf platform: ebpf telemetry: Remove redundant allocations when accessing eBPF maps from user mode

### DIFF
--- a/pkg/network/telemetry/ebpf_telemetry.go
+++ b/pkg/network/telemetry/ebpf_telemetry.go
@@ -103,7 +103,7 @@ func (b *EBPFTelemetry) getMapsTelemetry(ch chan<- prometheus.Metric) map[string
 	t := make(map[string]interface{})
 
 	for m, k := range b.mapKeys {
-		err := b.MapErrMap.Lookup(&k, &val)
+		err := b.MapErrMap.Lookup(unsafe.Pointer(&k), unsafe.Pointer(&val))
 		if err != nil {
 			log.Debugf("failed to get telemetry for map:key %s:%d\n", m, k)
 			continue
@@ -136,7 +136,7 @@ func (b *EBPFTelemetry) getHelpersTelemetry(ch chan<- prometheus.Metric) map[str
 	helperTelemMap := make(map[string]interface{})
 
 	for probeName, k := range b.probeKeys {
-		err := b.HelperErrMap.Lookup(&k, &val)
+		err := b.HelperErrMap.Lookup(unsafe.Pointer(&k), unsafe.Pointer(&val))
 		if err != nil {
 			log.Debugf("failed to get telemetry for map:key %s:%d\n", probeName, k)
 			continue


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Removes redundant allocations coming from user-mode ebpf map calls (Lookup).
The cillium implementation has zero allocation if the key and the value is of type unsafe.Pointer, and the pointers represents the correct key and value format in the kernel.
In this case by casting the pointers into unsafe.Pointer we remove drastically allocations, bytes and runtime.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Read cillium's code and found this nice change.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Test:

```go
func BenchmarkTelemetry(b *testing.B) {
	tracer := setupTracer(b, testConfig())
	b.ReportAllocs()
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		tracer.bpfTelemetry.GetHelpersTelemetry()
		tracer.bpfTelemetry.GetMapsTelemetry()
	}
}
```

Results:
```
// main
BenchmarkTelemetry-16    	    4471	    242628 ns/op	  287058 B/op	     595 allocs/op

// chaging only getHelpersTelemetry
BenchmarkTelemetry-16    	   14092	     83803 ns/op	   44343 B/op	     414 allocs/op

// changing getHelpersTelemetry & getMapsTelemetry
BenchmarkTelemetry-16    	   19252	     61702 ns/op	   18150 B/op	     311 allocs/op
```

Runtime down by ~75%
Bytes down by ~94%
allocations by ~48%
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
