### PR TITLE
[WIP] Add resync in kubeapiserver collector

### DIFF
--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/deployments.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/deployments.go
@@ -56,7 +56,7 @@ func newDeploymentStore(ctx context.Context, wlm workloadmeta.Store, client kube
 		deploymentListerWatcher,
 		&appsv1.Deployment{},
 		deploymentStore,
-		noResync,
+		resync,
 	)
 	return deploymentReflector, deploymentStore
 }

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/deployments.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/deployments.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"regexp"
 	"strings"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,7 +40,7 @@ func (f *deploymentFilter) filteredOut(entity workloadmeta.Entity) bool {
 		len(deployment.ContainerLanguages) == 0
 }
 
-func newDeploymentStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.Interface) (*cache.Reflector, *reflectorStore) {
+func newDeploymentStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.Interface, resync time.Duration) (*cache.Reflector, *reflectorStore) {
 	deploymentListerWatcher := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			return client.AppsV1().Deployments(metav1.NamespaceAll).List(ctx, options)

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go
@@ -74,7 +74,7 @@ func TestStoreGenerators(t *testing.T) {
 func collectResultStoreGenerator(funcs []storeGenerator) []*reflectorStore {
 	var stores []*reflectorStore
 	for _, f := range funcs {
-		_, s := f(nil, nil, nil)
+		_, s := f(nil, nil, nil, 0)
 		stores = append(stores, s)
 	}
 	return stores

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/node.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/node.go
@@ -9,6 +9,7 @@ package kubeapiserver
 
 import (
 	"context"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,7 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
-func newNodeStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.Interface) (*cache.Reflector, *reflectorStore) {
+func newNodeStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.Interface, resync time.Duration) (*cache.Reflector, *reflectorStore) {
 	nodeListerWatcher := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			return client.CoreV1().Nodes().List(ctx, options)
@@ -37,7 +38,7 @@ func newNodeStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes
 		nodeListerWatcher,
 		&corev1.Node{},
 		nodeStore,
-		noResync,
+		resync,
 	)
 	log.Debug("node reflector enabled")
 	return nodeReflector, nodeStore

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/pod.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/pod.go
@@ -10,6 +10,7 @@ package kubeapiserver
 import (
 	"context"
 	"regexp"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,7 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
-func newPodStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.Interface) (*cache.Reflector, *reflectorStore) {
+func newPodStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.Interface, resync time.Duration) (*cache.Reflector, *reflectorStore) {
 	podListerWatcher := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			return client.CoreV1().Pods(metav1.NamespaceAll).List(ctx, options)
@@ -39,7 +40,7 @@ func newPodStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.
 		podListerWatcher,
 		&corev1.Pod{},
 		podStore,
-		noResync,
+		resync,
 	)
 	log.Debug("pod reflector enabled")
 	return podReflector, podStore

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
@@ -10,6 +10,7 @@ package kubeapiserver
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	"github.com/stretchr/testify/assert"
@@ -24,7 +25,7 @@ func testCollectEvent(t *testing.T, createResource func(*fake.Clientset) error, 
 
 	// Use the fake client in kubeapiserver context.
 	wlm := workloadmeta.NewMockStore()
-	store, _ := newStore(context.TODO(), wlm, client)
+	store, _ := newStore(context.TODO(), wlm, client, 1*time.Second)
 	stopStore := make(chan struct{})
 	go store.Run(stopStore)
 

--- a/releasenotes/notes/fix-bug-kubeapiserver-informers-4d567e1e8e69787b.yaml
+++ b/releasenotes/notes/fix-bug-kubeapiserver-informers-4d567e1e8e69787b.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    Resolved an issue in ``workloadmeta`` where informers were not accurately capturing all nodes, pods, or deployments.
+


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Adds resync mechanism in kubeapiserver collector.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We could miss some pods/nodes/deployments if sync was lost for some seconds.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
Resync can be costly because it requires to List everything frequently.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
It's difficult to reproduce a case where we lose sync with the kube client. Perhaps start a cluster-agent on some node, create a network issue for a few seconds between the API Server and the Cluster-Agent. In the meantime, create a deployment. Verify that it gets stored in `agent workload-list -v`

Otherwise, it should also fix flaky tests.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
