### PR TITLE
[CWS] Event consumers use new accessors

### DIFF
--- a/pkg/network/events/monitor.go
+++ b/pkg/network/events/monitor.go
@@ -114,7 +114,11 @@ func (h *eventHandlerWrapper) Copy(ev *model.Event) any {
 			Pid:         ev.GetProcessPid(),
 			ContainerID: intern.GetByString(ev.GetContainerId()),
 			StartTime:   processStartTime.UnixNano(),
-			Envs:        ev.GetProcessEnvp(),
+			Envs: ev.GetProcessEnvp(map[string]bool{
+				"DD_SERVICE": true,
+				"DD_VERSION": true,
+				"DD_ENV":     true,
+			}),
 		}
 	}
 

--- a/pkg/network/events/monitor.go
+++ b/pkg/network/events/monitor.go
@@ -10,6 +10,7 @@ package events
 import (
 	"strings"
 	"sync"
+	"time"
 
 	"go.uber.org/atomic"
 	"go4.org/intern"
@@ -100,19 +101,20 @@ func (h *eventHandlerWrapper) HandleEvent(ev any) {
 func (h *eventHandlerWrapper) Copy(ev *model.Event) any {
 	m := theMonitor.Load()
 	if m != nil {
-		ev.ResolveFields()
-
-		var envCopy []string
-		if envsEntry := ev.ProcessContext.EnvsEntry; envsEntry != nil {
-			envCopy = make([]string, len(envsEntry.Values))
-			copy(envCopy, envsEntry.Values)
+		// If this consumer subscribes to more event types, this block will have to account for those additional event types
+		var processStartTime time.Time
+		if ev.GetEventType() == model.ExecEventType {
+			processStartTime = ev.GetProcessExecTime()
+		}
+		if ev.GetEventType() == model.ForkEventType {
+			processStartTime = ev.GetProcessForkTime()
 		}
 
 		return &Process{
-			Pid:         ev.ProcessContext.Pid,
-			ContainerID: intern.GetByString(ev.ProcessContext.ContainerID),
-			StartTime:   ev.ProcessContext.ExecTime.UnixNano(),
-			Envs:        envCopy,
+			Pid:         ev.GetProcessPid(),
+			ContainerID: intern.GetByString(ev.GetContainerId()),
+			StartTime:   processStartTime.UnixNano(),
+			Envs:        ev.GetProcessEnvp(),
 		}
 	}
 

--- a/pkg/process/events/consumer/events_consumer_unix.go
+++ b/pkg/process/events/consumer/events_consumer_unix.go
@@ -14,33 +14,24 @@ import (
 
 // Copy copies the necessary fields from the event received from the event monitor
 func (p *ProcessConsumer) Copy(event *smodel.Event) any {
-	// Force resolution of all event fields before exposing it through the API server
-	event.ResolveFields()
-	event.ResolveEventTime()
-
-	entry := event.ProcessContext
-
-	var cmdline []string
-	if entry.ArgsEntry != nil {
-		// ignore if the args have been truncated
-		cmdline = entry.ArgsEntry.Values
-	}
+	cmdline := []string{event.GetProcessArgv0()}
+	cmdline = append(cmdline, event.GetProcessArgv()...)
 
 	return &model.ProcessEvent{
 		EventType:      model.NewEventType(event.GetEventType().String()),
-		CollectionTime: event.Timestamp,
-		Pid:            entry.Pid,
-		ContainerID:    entry.ContainerID,
-		Ppid:           entry.PPid,
-		UID:            entry.UID,
-		GID:            entry.GID,
-		Username:       entry.User,
-		Group:          entry.Group,
-		Exe:            entry.FileEvent.PathnameStr, // FileEvent is not a pointer, so it can be directly accessed
+		CollectionTime: event.GetTimestamp(),
+		Pid:            event.GetProcessPid(),
+		ContainerID:    event.GetContainerId(),
+		Ppid:           event.GetProcessPpid(),
+		UID:            event.GetProcessUid(),
+		GID:            event.GetProcessGid(),
+		Username:       event.GetProcessUser(),
+		Group:          event.GetProcessGroup(),
+		Exe:            event.GetExecFilePath(),
 		Cmdline:        cmdline,
-		ForkTime:       entry.ForkTime,
-		ExecTime:       entry.ExecTime,
-		ExitTime:       entry.ExitTime,
-		ExitCode:       event.Exit.Code,
+		ForkTime:       event.GetProcessForkTime(),
+		ExecTime:       event.GetProcessExecTime(),
+		ExitTime:       event.GetProcessExitTime(),
+		ExitCode:       event.GetExitCode(),
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR follows https://github.com/DataDog/datadog-agent/pull/19144 and https://github.com/DataDog/datadog-agent/pull/18701 to only resolve fields that a consumer needs, rather than resolving the whole event struct. The getters also provide utilities like returning only filtered environment variables and scrubbed args, and return copies of fields that are passed by reference instead of value.

There does not appear to be any significant performance impacts (or improvements) due to this PR.

<img width="1745" alt="image" src="https://github.com/DataDog/datadog-agent/assets/24510443/c307711f-1b30-45df-820e-27f1acdc1f8f">


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
