### PR TITLE
[USMON-523] Add agent-side quantization for HTTP paths

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -224,6 +224,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnv(join(smNS, "max_http_stats_buffered"))
 	cfg.BindEnvAndSetDefault(join(smNS, "max_kafka_stats_buffered"), 100000)
 	cfg.BindEnv(join(smNS, "max_concurrent_requests"))
+	cfg.BindEnvAndSetDefault(join(smNS, "enable_quantization"), false)
 
 	oldHTTPRules := join(netNS, "http_replace_rules")
 	newHTTPRules := join(smNS, "http_replace_rules")

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -224,7 +224,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnv(join(smNS, "max_http_stats_buffered"))
 	cfg.BindEnvAndSetDefault(join(smNS, "max_kafka_stats_buffered"), 100000)
 	cfg.BindEnv(join(smNS, "max_concurrent_requests"))
-	cfg.BindEnvAndSetDefault(join(smNS, "enable_quantization"), false)
+	cfg.BindEnv(join(smNS, "enable_quantization"))
 
 	oldHTTPRules := join(netNS, "http_replace_rules")
 	newHTTPRules := join(smNS, "http_replace_rules")

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -254,6 +254,9 @@ type Config struct {
 	// EnableHTTPStatsByStatusCode specifies if the HTTP stats should be aggregated by the actual status code
 	// instead of the status code family.
 	EnableHTTPStatsByStatusCode bool
+
+	// EnableUSMQuantization enables endpoint quantization for USM programs
+	EnableUSMQuantization bool
 }
 
 func join(pieces ...string) string {
@@ -347,6 +350,7 @@ func New() *Config {
 		JavaAgentBlockRegex:         cfg.GetString(join(smjtNS, "block_regex")),
 		EnableGoTLSSupport:          cfg.GetBool(join(smNS, "tls", "go", "enabled")),
 		EnableHTTPStatsByStatusCode: cfg.GetBool(join(smNS, "enable_http_stats_by_status_code")),
+		EnableUSMQuantization:       cfg.GetBool(join(smNS, "enable_quantization")),
 	}
 
 	httpRRKey := join(smNS, "http_replace_rules")

--- a/pkg/network/protocols/http/quantization.go
+++ b/pkg/network/protocols/http/quantization.go
@@ -1,0 +1,145 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package http contains the userspace portion of USM's HTTP monitoring code
+package http
+
+import (
+	"bytes"
+)
+
+// URLQuantizer is responsible for quantizing URLs
+type URLQuantizer struct {
+	tokenizer *tokenizer
+	buf       *bytes.Buffer
+}
+
+// NewURLQuantizer returns a new instance of a URLQuantizer
+func NewURLQuantizer() *URLQuantizer {
+	return &URLQuantizer{
+		tokenizer: new(tokenizer),
+		buf:       bytes.NewBuffer(nil),
+	}
+}
+
+// Quantize path (eg /segment1/segment2/segment3) by doing the following:
+// * If a segment contains only letters, we keep it as it is;
+// * If a segment contains one or more digits or special characters, we replace it by '*'
+// * If a segments represents an API version (eg. v123) we keep it as it is
+//
+// Note that the quantization happens *in-place* and the supplied argument byte
+// slice is modified, so the returned value will still point to the same
+// underlying byte array.
+func (q *URLQuantizer) Quantize(path []byte) []byte {
+	q.tokenizer.Reset(path)
+	q.buf.Reset()
+	replacements := 0
+
+	for q.tokenizer.Next() {
+		q.buf.WriteByte('/')
+		tokenType, tokenValue := q.tokenizer.Value()
+		if tokenType == tokenWildcard {
+			replacements++
+			q.buf.WriteByte('*')
+			continue
+		}
+
+		q.buf.Write(tokenValue)
+	}
+
+	if replacements == 0 {
+		return path
+	}
+
+	// Copy quantized path into original byte slice
+	n := copy(path[:], q.buf.Bytes())
+
+	return path[:n]
+}
+
+// tokenType represents a type of token handled by the `tokenizer`
+type tokenType string
+
+const (
+	// tokenUnknown represents a token of type unknown
+	tokenUnknown = "token:unknown"
+	// tokenWildcard represents a token that contains digits or special chars
+	tokenWildcard = "token:wildcard"
+	// tokenString represents a token that contains only letters
+	tokenString = "token:string"
+	// tokenAPIVersion represents an API version (eg. v123)
+	tokenAPIVersion = "token:api-version"
+)
+
+// tokenizer provides a stream of tokens for a given URL
+type tokenizer struct {
+	i, j int
+	path []byte
+
+	countAllowedChars int // a-Z, "-", "_"
+	countNumbers      int // 0-9
+	countSpecialChars int // anything else
+}
+
+// Reset underlying path being consumed
+func (t *tokenizer) Reset(path []byte) {
+	t.i = 0
+	t.j = 0
+	t.path = path
+}
+
+// Next attempts to parse the next token, and returns true if a token was read
+func (t *tokenizer) Next() bool {
+	t.countNumbers = 0
+	t.countAllowedChars = 0
+	t.countSpecialChars = 0
+	t.i = t.j + 1
+
+	if t.i >= len(t.path)-1 {
+		return false
+	}
+
+	for t.j = t.i; t.j < len(t.path); t.j++ {
+		c := t.path[t.j]
+
+		if c == '/' {
+			break
+		} else if c >= '0' && c <= '9' {
+			t.countNumbers++
+		} else if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '-' || c == '_' {
+			t.countAllowedChars++
+		} else {
+			t.countSpecialChars++
+		}
+	}
+
+	return true
+}
+
+// Value returns the current token along with it's byte value
+// Note that the byte value is only valid until the next call to `Reset()`
+func (t *tokenizer) Value() (tokenType, []byte) {
+	if t.i < 0 || t.j > len(t.path) || t.i >= t.j {
+		return tokenUnknown, nil
+	}
+
+	return t.getType(), t.path[t.i:t.j]
+}
+
+func (t *tokenizer) getType() tokenType {
+	if t.countAllowedChars == 1 && t.countNumbers > 0 && t.path[t.i] == 'v' {
+		return tokenAPIVersion
+	}
+
+	if t.countSpecialChars > 0 || t.countNumbers > 0 {
+		return tokenWildcard
+	}
+
+	if t.countAllowedChars > 0 && t.countSpecialChars == 0 && t.countNumbers == 0 {
+		return tokenString
+	}
+
+	return tokenUnknown
+}

--- a/pkg/network/protocols/http/quantization.go
+++ b/pkg/network/protocols/http/quantization.go
@@ -118,7 +118,7 @@ func (t *tokenizer) Next() bool {
 	return true
 }
 
-// Value returns the current token along with it's byte value
+// Value returns the current token along with its byte value
 // Note that the byte value is only valid until the next call to `Reset()`
 func (t *tokenizer) Value() (tokenType, []byte) {
 	if t.i < 0 || t.j > len(t.path) || t.i >= t.j {

--- a/pkg/network/protocols/http/quantization.go
+++ b/pkg/network/protocols/http/quantization.go
@@ -97,7 +97,7 @@ func (t *tokenizer) Next() bool {
 	t.countSpecialChars = 0
 	t.i = t.j + 1
 
-	if t.i >= len(t.path)-1 {
+	if t.i >= len(t.path) {
 		return false
 	}
 

--- a/pkg/network/protocols/http/quantization.go
+++ b/pkg/network/protocols/http/quantization.go
@@ -106,10 +106,6 @@ func (t *tokenizer) Next() bool {
 	t.countSpecialChars = 0
 	t.i = t.j + 1
 
-	if t.i >= len(t.path) {
-		return false
-	}
-
 	for t.j = t.i; t.j < len(t.path); t.j++ {
 		c := t.path[t.j]
 
@@ -124,7 +120,7 @@ func (t *tokenizer) Next() bool {
 		}
 	}
 
-	return true
+	return t.i < len(t.path)
 }
 
 // Value returns the current token along with its byte value

--- a/pkg/network/protocols/http/quantization_test.go
+++ b/pkg/network/protocols/http/quantization_test.go
@@ -1,0 +1,164 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package http
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTokenizer(t *testing.T) {
+	tokenizer := new(tokenizer)
+
+	type val struct {
+		tokenType tokenType
+		data      []byte
+	}
+
+	type testCase struct {
+		path     []byte
+		expected []val
+	}
+
+	testCases := []testCase{
+		{
+			path:     []byte("/"),
+			expected: nil,
+		},
+		{
+			path:     []byte("/abc/def"),
+			expected: []val{{tokenString, []byte("abc")}, {tokenString, []byte("def")}},
+		},
+		{
+			path:     []byte("/abc/123/def"),
+			expected: []val{{tokenString, []byte("abc")}, {tokenWildcard, []byte("123")}, {tokenString, []byte("def")}},
+		},
+		{
+			path:     []byte("/abc/def123"),
+			expected: []val{{tokenString, []byte("abc")}, {tokenWildcard, []byte("def123")}},
+		},
+		{
+			path:     []byte("/abc#def"),
+			expected: []val{{tokenWildcard, []byte("abc#def")}},
+		},
+		{
+			path:     []byte("/v5/abc"),
+			expected: []val{{tokenAPIVersion, []byte("v5")}, {tokenString, []byte("abc")}},
+		},
+	}
+
+	for _, tc := range testCases {
+		tokenizer.Reset(tc.path)
+		var got []val
+		for tokenizer.Next() {
+			tokenType, tokenValue := tokenizer.Value()
+
+			// copy the data since it only remains valid for a single test case
+			data := make([]byte, len(tokenValue))
+			copy(data, tokenValue)
+
+			got = append(got, val{tokenType, data})
+		}
+
+		assert.Equalf(t, tc.expected, got, "tokenization of %s should have returned %+v. got %+v", tc.path, tc.expected, got)
+	}
+}
+
+func TestURLQuantizer(t *testing.T) {
+	quantizer := NewURLQuantizer()
+
+	type testCase struct {
+		path     []byte
+		expected []byte
+	}
+
+	testCases := []testCase{
+		{
+			path:     []byte("/"),
+			expected: []byte("/"),
+		},
+		{
+			path:     []byte("/abc"),
+			expected: []byte("/abc"),
+		},
+		{
+			path:     []byte("/trailing/slash/"),
+			expected: []byte("/trailing/slash/"),
+		},
+		{
+			path:     []byte("/users/1/view"),
+			expected: []byte("/users/*/view"),
+		},
+		{
+			path:     []byte("/abc/def"),
+			expected: []byte("/abc/def"),
+		},
+		{
+			path:     []byte("/abc/123/def"),
+			expected: []byte("/abc/*/def"),
+		},
+		{
+			path:     []byte("/abc/def123"),
+			expected: []byte("/abc/*"),
+		},
+		{
+			path:     []byte("/abc#def"),
+			expected: []byte("/*"),
+		},
+		{
+			path:     []byte("/v5/abc"),
+			expected: []byte("/v5/abc"),
+		},
+		{
+			path:     []byte("/latest/meta-data"),
+			expected: []byte("/latest/meta-data"),
+		},
+		{
+			path:     []byte("/health_check"),
+			expected: []byte("/health_check"),
+		},
+		{
+			path:     []byte("/abc/F05065B2-7934-4480-8500-A2C40D76F59F"),
+			expected: []byte("/abc/*"),
+		},
+	}
+
+	for _, tc := range testCases {
+		result := quantizer.Quantize(tc.path)
+		assert.Equal(t, tc.expected, result)
+
+		// Test quantization a second time to ensure idempotency.
+		// We do this to validate that bringing the quantization code to
+		// the agent-side won't cause any issues for the backend, which uses a
+		// similar set of heuristics. In other words, an agent payload with
+		// pre-quantized endpoint arriving at the backend should be a no-op.
+		result = quantizer.Quantize(result)
+		assert.Equal(t, tc.expected, result)
+	}
+}
+
+// The purpose of this benchmark is to ensure that the whole quantization process doesn't allocate
+func BenchmarkQuantization(b *testing.B) {
+	quantizer := NewURLQuantizer()
+
+	// This should trigger the quantization since `/users/1/view` becomes
+	// `/users/*/view` post-quantization (see test case above)
+	path := []byte("/users/1/view")
+
+	// We keep the index for the number so we can revert it to the original value
+	numberIndex := bytes.IndexByte(path, '1')
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		quantizer.Quantize(path)
+
+		// Restore path to it's original value
+		path[numberIndex] = '1'
+	}
+}

--- a/pkg/network/protocols/http/quantization_test.go
+++ b/pkg/network/protocols/http/quantization_test.go
@@ -172,9 +172,28 @@ func BenchmarkQuantization(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		quantizer.Quantize(path)
+		path = quantizer.Quantize(path)
 
 		// Restore path to it's original value
 		path[numberIndex] = '1'
+	}
+}
+
+// This benchmark represents the case where a path does *not* trigger a quantization
+func BenchmarkQuantizationHappyPath(b *testing.B) {
+	quantizer := NewURLQuantizer()
+	path := []byte("/foo/bar")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		quantizer.Quantize(path)
+	}
+
+	b.StopTimer()
+	// Sanity check to ensure that no quantization was triggered and to make sure
+	// that the code above doesn't get optimized away
+	if !bytes.Equal([]byte("/foo/bar"), path) {
+		path = quantizer.Quantize(path)
+		panic("this path benchmark shouldn't trigger a quantization")
 	}
 }

--- a/pkg/network/protocols/http/quantization_test.go
+++ b/pkg/network/protocols/http/quantization_test.go
@@ -202,14 +202,13 @@ func BenchmarkQuantizationHappyPath(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		quantizer.Quantize(path)
+		path = quantizer.Quantize(path)
 	}
 
 	b.StopTimer()
 	// Sanity check to ensure that no quantization was triggered and to make sure
 	// that the code above doesn't get optimized away
 	if !bytes.Equal([]byte("/foo/bar"), path) {
-		path = quantizer.Quantize(path)
 		panic("this path benchmark shouldn't trigger a quantization")
 	}
 }

--- a/pkg/network/protocols/http/quantization_test.go
+++ b/pkg/network/protocols/http/quantization_test.go
@@ -142,6 +142,22 @@ func TestURLQuantizer(t *testing.T) {
 			path:     []byte("/abc/F05065B2-7934-4480-8500-A2C40D76F59F"),
 			expected: []byte("/abc/*"),
 		},
+		{
+			path:     []byte("/DataDog/datadog-agent/pull/19720"),
+			expected: []byte("/DataDog/datadog-agent/pull/*"),
+		},
+		{
+			path:     []byte("/DataDog/datadog-agent/blob/22ba7d3d9d7cba67886dc905970d7f2f68b37dc5/pkg/network/protocols/http/quantization_test.go"),
+			expected: []byte("/DataDog/datadog-agent/blob/*/pkg/network/protocols/http/*"),
+		},
+		{
+			path:     []byte("/uuid/v1/f475ca90-71ab-11ee-b962-0242ac120002"),
+			expected: []byte("/uuid/v1/*"),
+		},
+		{
+			path:     []byte("/uuid/v4/0253ee45-3098-4a7e-8569-73a99a9fc030"),
+			expected: []byte("/uuid/v4/*"),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/network/protocols/http/quantization_test.go
+++ b/pkg/network/protocols/http/quantization_test.go
@@ -31,6 +31,14 @@ func TestTokenizer(t *testing.T) {
 			expected: nil,
 		},
 		{
+			path:     []byte("/1"),
+			expected: []val{{tokenWildcard, []byte("1")}},
+		},
+		{
+			path:     []byte("/foo/1"),
+			expected: []val{{tokenString, []byte("foo")}, {tokenWildcard, []byte("1")}},
+		},
+		{
 			path:     []byte("/abc/def"),
 			expected: []val{{tokenString, []byte("abc")}, {tokenString, []byte("def")}},
 		},
@@ -65,7 +73,7 @@ func TestTokenizer(t *testing.T) {
 			got = append(got, val{tokenType, data})
 		}
 
-		assert.Equalf(t, tc.expected, got, "tokenization of %s should have returned %+v. got %+v", tc.path, tc.expected, got)
+		assert.Equalf(t, tc.expected, got, "tokenization of %s should have returned %s. got %s", tc.path, tc.expected, got)
 	}
 }
 
@@ -81,6 +89,14 @@ func TestURLQuantizer(t *testing.T) {
 		{
 			path:     []byte("/"),
 			expected: []byte("/"),
+		},
+		{
+			path:     []byte("/a"),
+			expected: []byte("/a"),
+		},
+		{
+			path:     []byte("/1"),
+			expected: []byte("/*"),
 		},
 		{
 			path:     []byte("/abc"),
@@ -130,7 +146,7 @@ func TestURLQuantizer(t *testing.T) {
 
 	for _, tc := range testCases {
 		result := quantizer.Quantize(tc.path)
-		assert.Equal(t, tc.expected, result)
+		assert.Equalf(t, tc.expected, result, "expected: %s, got: %s", tc.expected, result)
 
 		// Test quantization a second time to ensure idempotency.
 		// We do this to validate that bringing the quantization code to
@@ -138,7 +154,7 @@ func TestURLQuantizer(t *testing.T) {
 		// similar set of heuristics. In other words, an agent payload with
 		// pre-quantized endpoint arriving at the backend should be a no-op.
 		result = quantizer.Quantize(result)
-		assert.Equal(t, tc.expected, result)
+		assert.Equalf(t, tc.expected, result, "expected: %s, got: %s", tc.expected, result)
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Add agent-side path quantization for HTTP1 and HTTP2 endpoints.
This essentially translates something like `/orders/1/view` into `/orders/*/view`.

### Motivation

Reduce the cardinality of data emitted by the agent (which can result in both CPU and memory savings).
(Note this shouldn't have any user impact or result in loss of data resolution since it contains a subset of quantization rules we do in the backend anyways)

### Additional Notes

The reduction in the number of USM aggregations (eg. datapoints) is heavily dependent on the workload. The main factors are usually cardinality of the paths and cardinality of connections.

For example, in the context of client/server traffic _with no keep-alives_, pre-quantization data may look like the following:
1. `(Connection1, /orders/1/view, 1 hit)`
2. `(Connection2, /orders/2/view, 1 hit)`

In this contex path quantization will be innocuous for the most part, as it won't change the number of datapoints emitted by the agent since the "dominant" factor here is the cardinality of connections:

1. `(Connection1, /orders/*/view, 1 hit)`
2. `(Connection2, /orders/*/view, 1 hit)`

Conversely, if we had two different HTTP requests being issued _from the same TCP connection_, we would emit one datapoint instead of two. So basically:

1. `(Connection1, /orders/1/view, 1 hit)`
2. `(Connection1, /orders/2/view, 1 hit)`

would become:

1. `(Connection1, /orders/*/view, 2 hits)`

#### Overhead

Given that the quantization code is in the HTTP hot path, I tried to minimize its overhead.
The quantization code doesn't allocate, and I couldn't notice any change in CPU usage looking at system resource metrics (though profiles of a load test server show something like 1% being spent on this codepath).

Yellow represents the change

<img width="500" alt="overhead" src="https://github.com/DataDog/datadog-agent/assets/692520/6e062585-560a-4509-a448-ef395c9a5c52">


```
BenchmarkQuantization
BenchmarkQuantization-4            	25483719	        47.21 ns/op	       0 B/op	       0 allocs/op
BenchmarkQuantizationHappyPath
BenchmarkQuantizationHappyPath-4   	37649494	        31.55 ns/op	       0 B/op	       0 allocs/op
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Start system-probe with path quantization enabled:
```
service_monitoring_config:
  enable_quantization: true
```

Issue a HTTP request with the following command:

```
curl -X POST http://httpbin.org/anything/v1/12345/foobar/no.way
```

Verify that the output of

```
curl --unix /opt/datadog-agent/run/sysprobe.sock http://unix/network_tracer/debug/http_monitoring | jq
```

Includes the quantized version of the URL:

```
/anything/v1/*/foobar/*
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
