### PR TITLE
[CSPM] Handle podsecuritypolicies deprecation

### DIFF
--- a/cmd/security-agent/subcommands/check/command.go
+++ b/cmd/security-agent/subcommands/check/command.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
@@ -263,14 +264,14 @@ func reportComplianceEvents(log log.Component, config config.Component, events [
 	return nil
 }
 
-func complianceKubernetesProvider(_ctx context.Context) (dynamic.Interface, error) {
+func complianceKubernetesProvider(_ctx context.Context) (dynamic.Interface, discovery.DiscoveryInterface, error) {
 	ctx, cancel := context.WithTimeout(_ctx, 2*time.Second)
 	defer cancel()
 	apiCl, err := apiserver.WaitForAPIClient(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return apiCl.DynamicCl, nil
+	return apiCl.DynamicCl, apiCl.DiscoveryCl, nil
 }
 
 type fakeResolver struct {

--- a/pkg/compliance/resolver.go
+++ b/pkg/compliance/resolver.go
@@ -758,7 +758,7 @@ func (r *defaultResolver) resolveKubeApiserver(ctx context.Context, spec InputSp
 
 func (r *defaultResolver) checkKubeServerResourceSupport(resourceSchema kubeschema.GroupVersionResource) (bool, error) {
 	if r.kubernetesDiscoCl == nil {
-		return false, ErrIncompatibleEnvironment
+		return true, nil
 	}
 
 	if r.kubeResourcesCache == nil {

--- a/pkg/compliance/tests/helpers.go
+++ b/pkg/compliance/tests/helpers.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 )
 
@@ -111,7 +112,9 @@ func (s *suite) Run() {
 				options.DockerProvider = func(ctx context.Context) (docker.CommonAPIClient, error) { return s.dockerClient, nil }
 			}
 			if s.kubeClient != nil {
-				options.KubernetesProvider = func(ctx context.Context) (dynamic.Interface, error) { return s.kubeClient, nil }
+				options.KubernetesProvider = func(ctx context.Context) (dynamic.Interface, discovery.DiscoveryInterface, error) {
+					return s.kubeClient, nil, nil
+				}
 			}
 			c.run(t, options)
 		})


### PR DESCRIPTION
### What does this PR do?

Handle the podsecuritypolicies deprecation as part of K8s v1.25.

### Motivation

Avoid querying deprecated endpoints of the apiserver.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

GKE: deploy a compliance agent and check if the dashboard warns against deprecated calls to apiserver/control plane.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
