### PR TITLE
[clusterchecks/metrics] Add "check_name" to "configs_info"

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
@@ -158,7 +158,7 @@ func (d *dispatcher) expireNodes() {
 				// Requires https://github.com/prometheus/client_golang/pull/1013
 				for k, v := range d.store.idToDigest {
 					if v == digest {
-						configsInfo.Delete(name, string(k), le.JoinLeaderValue)
+						configsInfo.Delete(name, config.Name, string(k), le.JoinLeaderValue)
 					}
 				}
 			}

--- a/pkg/clusteragent/clusterchecks/metrics.go
+++ b/pkg/clusteragent/clusterchecks/metrics.go
@@ -44,7 +44,7 @@ var (
 		[]string{"node", le.JoinLeaderLabel}, "Busyness of a node per the number of metrics submitted and average duration of all checks run",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 	configsInfo = telemetry.NewGaugeWithOpts("cluster_checks", "configs_info",
-		[]string{"node", "check_id", le.JoinLeaderLabel}, "Information about the dispatched checks (node, check ID)",
+		[]string{"node", "check_name", "check_id", le.JoinLeaderLabel}, "Information about the dispatched checks (node, check name, check ID)",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 	predictedUtilization = telemetry.NewGaugeWithOpts("cluster_checks", "predicted_utilization",
 		[]string{"node", le.JoinLeaderLabel}, "Utilization predicted by the rebalance algorithm",

--- a/releasenotes-dca/notes/add-check-name-tag-cluster-checks-config-info-566ca6587e55acf4.yaml
+++ b/releasenotes-dca/notes/add-check-name-tag-cluster-checks-config-info-566ca6587e55acf4.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added the ``check_name`` tag to the ``cluster_checks.configs_info`` metric emitted by the Cluster Agent telemetry.


### PR DESCRIPTION

### What does this PR do?

Adds the `check_name` tag to the `cluster_checks.configs_info` metric emitted by the Cluster Agent telemetry.

We're already tagging the metric with `check_id`, but `check_name` is also convenient for some queries, for example, to know in which runners a particular check (not instance) is being run.


### Describe how to test/QA your changes

Enable the telemetry in the Cluster Agent (`DD_TELEMETRY_ENABLED=true`) with cluster check runners deployed. Deploy a cluster check and verify the telemetry (`http://localhost:5000/metrics`). `cluster_checks.config_info` should be tagged with `check_name`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
