### PR TITLE
[oracle] Bug fix for `ORA-06502: PL/SQL: numeric or value error: character string buffer too small`

### DIFF
--- a/releasenotes/notes/oracle-multibyte-charset-adf4626d730bc117.yaml
+++ b/releasenotes/notes/oracle-multibyte-charset-adf4626d730bc117.yaml
@@ -8,7 +8,7 @@
 ---
 fixes:
   - |
-    Bug fix for the error `ORA-06502: PL/SQL: numeric or value error: character string buffer too small` which was raised by the activity sampling.
+    Bug fix for `ORA-06502: PL/SQL: numeric or value error: character string buffer too small`. This error would occasionally appear during activity sampling.
 other:
   - |
     Add here every other information you want in the CHANGELOG that

--- a/releasenotes/notes/oracle-multibyte-charset-adf4626d730bc117.yaml
+++ b/releasenotes/notes/oracle-multibyte-charset-adf4626d730bc117.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Bug fix for the error `ORA-06502: PL/SQL: numeric or value error: character string buffer too small` which was raised by the activity sampling.
+other:
+  - |
+    Add here every other information you want in the CHANGELOG that
+    don't fit in any other section. This section should rarely be
+    used.

--- a/releasenotes/notes/oracle-multibyte-charset-adf4626d730bc117.yaml
+++ b/releasenotes/notes/oracle-multibyte-charset-adf4626d730bc117.yaml
@@ -9,8 +9,3 @@
 fixes:
   - |
     Bug fix for `ORA-06502: PL/SQL: numeric or value error: character string buffer too small`. This error would occasionally appear during activity sampling.
-other:
-  - |
-    Add here every other information you want in the CHANGELOG that
-    don't fit in any other section. This section should rarely be
-    used.


### PR DESCRIPTION
### What does this PR do?

Bug fix for the error `ORA-06502: PL/SQL: numeric or value error: character string buffer too small` which very rarely appears during activity sampling.

### Additional Notes

The activity sampling view returns the first 4000 *characters* of the SQL statement text into an VARCHAR2 variable. The VARCHAR2 data type is maximum size 4000 *bytes*. On databases with a multi-byte characterset configured, e.g. Unicode,  If some of the characters occupy mode than one bytes (some special characters), and the query text is very large, the text can overflow the maximum size of the VARCHAR2 data type, which is 4000 *bytes*.

For this reason, we are introducing a significant margin of safety and now returning only the first 3500 characters of the query, so that there won't be overflow even if there are many multibyte characters in the query. Multi byte characters are very rare - only some special characters occupy more than a single byte.

For a demo see https://datadoghq.atlassian.net/browse/DBMON-2840 .

### Possible Drawbacks / Trade-offs

If the query text is equal to the `substring` length value, the Agent assumes that the query was truncated, and issues another query to fetch the full text. The `substring` length value is reduced from 4000 to 3500, so we can expect some more executions to fetch the full text. This query, however, is optimized and efficient, so that's an acceptable trade off.

### Describe how to test/QA your changes

Primum non nocere: just check that the activity sampling is functioning.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
