### PR TITLE
Scrub sensitive content in pod annotations

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
@@ -148,6 +148,6 @@ func (h *PodHandlers) ScrubBeforeExtraction(ctx *processors.ProcessorContext, re
 func (h *PodHandlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
 	r := resource.(*corev1.Pod)
 	if ctx.Cfg.IsScrubbingEnabled {
-		redact.ScrubPodSpec(&r.Spec, ctx.Cfg.Scrubber)
+		redact.ScrubPod(r, ctx.Cfg.Scrubber)
 	}
 }

--- a/pkg/orchestrator/redact/data_scrubber.go
+++ b/pkg/orchestrator/redact/data_scrubber.go
@@ -7,11 +7,14 @@ package redact
 
 import (
 	"bytes"
+	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+const regexSensitiveParamInJSON = `(?P<before_value>"%s"\s*:\s*)(?P<value>("[^\"]+"))`
 
 var (
 	defaultSensitiveWords = []string{
@@ -28,8 +31,9 @@ type DataScrubber struct {
 	// RegexSensitivePatterns are custom regex patterns which are currently not exposed externally
 	RegexSensitivePatterns []*regexp.Regexp
 	// LiteralSensitivePatterns are custom words which use to match against
-	LiteralSensitivePatterns []string
-	scrubbedCmdLines         map[string][]string
+	LiteralSensitivePatterns         []string
+	regexSensitiveWordsInAnnotations []*regexp.Regexp
+	scrubbedCmdLines                 map[string][]string
 }
 
 // NewDefaultDataScrubber creates a DataScrubber with the default behavior: enabled
@@ -41,7 +45,16 @@ func NewDefaultDataScrubber() *DataScrubber {
 		scrubbedCmdLines:         make(map[string][]string),
 	}
 
+	newDataScrubber.setupAnnotationRegexps(defaultSensitiveWords)
+
 	return newDataScrubber
+}
+
+func (ds *DataScrubber) setupAnnotationRegexps(words []string) {
+	for _, word := range words {
+		r := regexp.MustCompile(fmt.Sprintf(regexSensitiveParamInJSON, regexp.QuoteMeta(word)))
+		ds.regexSensitiveWordsInAnnotations = append(ds.regexSensitiveWordsInAnnotations, r)
+	}
 }
 
 // ContainsSensitiveWord returns true if the given string contains
@@ -53,6 +66,17 @@ func (ds *DataScrubber) ContainsSensitiveWord(word string) bool {
 		}
 	}
 	return false
+}
+
+// ScrubAnnotationValue obfuscate sensitive information from an annotation
+// value.
+func (ds *DataScrubber) ScrubAnnotationValue(annotationValue string) string {
+	for _, r := range ds.regexSensitiveWordsInAnnotations {
+		if r.MatchString(annotationValue) {
+			return r.ReplaceAllString(annotationValue, `${before_value}"********"`)
+		}
+	}
+	return annotationValue
 }
 
 // ScrubSimpleCommand hides the argument value for any key which matches a "sensitive word" pattern.
@@ -142,6 +166,7 @@ func (ds *DataScrubber) ScrubSimpleCommand(cmdline []string) ([]string, bool) {
 // AddCustomSensitiveWords adds custom sensitive words on the DataScrubber object
 func (ds *DataScrubber) AddCustomSensitiveWords(words []string) {
 	ds.LiteralSensitivePatterns = append(ds.LiteralSensitivePatterns, words...)
+	ds.setupAnnotationRegexps(words)
 }
 
 // AddCustomSensitiveRegex adds custom sensitive regex on the DataScrubber object

--- a/pkg/orchestrator/redact/data_scrubber.go
+++ b/pkg/orchestrator/redact/data_scrubber.go
@@ -14,7 +14,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const regexSensitiveParamInJSON = `(?P<before_value>"%s"\s*:\s*)(?P<value>("[^\"]+"))`
+// regexSensitiveParamInJSON is using non greedy operators in the value capture
+// group to work around missing support for look behind assertions in Go.
+const regexSensitiveParamInJSON = `(?P<before_value>"%s"\s*:\s*)(?P<value>".*?[^\\]+?")`
 
 var (
 	defaultSensitiveWords = []string{

--- a/pkg/orchestrator/redact/data_scrubber_test.go
+++ b/pkg/orchestrator/redact/data_scrubber_test.go
@@ -312,3 +312,102 @@ func setupInsensitiveCmdLines() []testCase {
 		{[]string{"agent 1_pword:1234"}, []string{"agent 1_pword:1234"}},
 	}
 }
+
+func BenchmarkScrubSensitiveAnnotation(b *testing.B) {
+	annotationValue := `[{"host": "%%host%%", "port" : 5432, "username": "postgresadmin", "password": "eZH47hUGspGF.66QZnNZGaHaq@z6UBuu"}]`
+	scrubber := NewDefaultDataScrubber()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		scrubber.ScrubAnnotationValue(annotationValue)
+	}
+}
+
+func TestScrubAnnotationValue(t *testing.T) {
+	scrubber := NewDefaultDataScrubber()
+	testCases := setupSensitiveAnnotations()
+	for _, testCase := range testCases {
+		value := scrubber.ScrubAnnotationValue(testCase.annotationValue)
+		assert.Equal(t, testCase.expectedAnnotationValue, value)
+	}
+}
+
+func TestScrubAnnotationValueWithCustomWords(t *testing.T) {
+	scrubber := NewDefaultDataScrubber()
+	testCases := setupSensitiveAnnotationsWithCustomWords()
+	customWords := testCasesSensitiveWords(testCases)
+
+	scrubber.AddCustomSensitiveWords(customWords)
+
+	for _, testCase := range testCases {
+		value := scrubber.ScrubAnnotationValue(testCase.annotationValue)
+		assert.Equal(t, testCase.expectedAnnotationValue, value)
+	}
+}
+
+type annotationTestCase struct {
+	annotationValue         string
+	expectedAnnotationValue string
+}
+
+func setupSensitiveAnnotations() []annotationTestCase {
+	return []annotationTestCase{
+		// preserve indentation
+		{`{"access_token"  :   "test1234"}`, `{"access_token"  :   "********"}`},
+		{`{"access_token":"test1234"}`, `{"access_token":"********"}`},
+		{`{"access_token": "test1234"}`, `{"access_token": "********"}`},
+
+		// other words
+		{`{"access_token": "test1234"}`, `{"access_token": "********"}`},
+		{`{"api_key": "test1234"}`, `{"api_key": "********"}`},
+		{`{"auth_token": "test1234"}`, `{"auth_token": "********"}`},
+		{`{"credentials": "test1234"}`, `{"credentials": "********"}`},
+		{`{"mysql_pwd": "test1234"}`, `{"mysql_pwd": "********"}`},
+		{`{"passwd": "test1234"}`, `{"passwd": "********"}`},
+		{`{"password": "test1234"}`, `{"password": "********"}`},
+		{`{"secret": "test1234"}`, `{"secret": "********"}`},
+		{`{"stripetoken": "test1234"}`, `{"stripetoken": "********"}`},
+
+		// preserve the rest of the value
+		{`{"param1": 1, "password": "test1234", "param2": 2}`, `{"param1": 1, "password": "********", "param2": 2}`},
+
+		// no match
+		{`{"parameter": "test1234"}`, `{"parameter": "test1234"}`},
+	}
+}
+
+type annotationTestCaseCustomWord struct {
+	word                    string
+	annotationValue         string
+	expectedAnnotationValue string
+}
+
+func setupSensitiveAnnotationsWithCustomWords() []annotationTestCaseCustomWord {
+	return []annotationTestCaseCustomWord{
+		// exact match
+		{"hide_me", `{"hide_me": "test1234"}`, `{"hide_me": "********"}`},
+
+		// subset of another string
+		{"hide_me", `{"dont_hide_me": "value"}`, `{"dont_hide_me": "value"}`},
+
+		// special characters are escaped
+		{"a.+*?()|[]{}^$z", `{"a.+*?()|[]{}^$z": "test1234"}`, `{"a.+*?()|[]{}^$z": "********"}`},
+		{".*_hide_me", `{"dont_hide_me": "value"}`, `{"dont_hide_me": "value"}`},
+	}
+}
+
+func testCasesSensitiveWords(testCases []annotationTestCaseCustomWord) []string {
+	dedupedWords := make(map[string]struct{})
+	words := []string{}
+
+	for _, testCase := range testCases {
+		dedupedWords[testCase.word] = struct{}{}
+	}
+	for word := range dedupedWords {
+		words = append(words, word)
+	}
+
+	return words
+}

--- a/pkg/orchestrator/redact/data_scrubber_test.go
+++ b/pkg/orchestrator/redact/data_scrubber_test.go
@@ -392,6 +392,9 @@ func setupSensitiveAnnotationsWithCustomWords() []annotationTestCaseCustomWord {
 		// subset of another string
 		{"hide_me", `{"dont_hide_me": "value"}`, `{"dont_hide_me": "value"}`},
 
+		// double quotes in value
+		{"hide_me", `{"hide_me": "\"tes\\\\"t\"1\\"234\""}`, `{"hide_me": "********"}`},
+
 		// special characters are escaped
 		{"a.+*?()|[]{}^$z", `{"a.+*?()|[]{}^$z": "test1234"}`, `{"a.+*?()|[]{}^$z": "********"}`},
 		{".*_hide_me", `{"dont_hide_me": "value"}`, `{"dont_hide_me": "value"}`},

--- a/pkg/orchestrator/redact/pod.go
+++ b/pkg/orchestrator/redact/pod.go
@@ -18,9 +18,10 @@ const (
 	replacedValue = "-"
 )
 
-// ScrubPodTemplateSpec calls ScrubContainer for every container within a pod
-// template spec.
+// ScrubPodTemplateSpec scrubs a pod template.
 func ScrubPodTemplateSpec(template *v1.PodTemplateSpec, scrubber *DataScrubber) {
+	ScrubAnnotations(template.Annotations, scrubber)
+
 	for c := 0; c < len(template.Spec.InitContainers); c++ {
 		ScrubContainer(&template.Spec.InitContainers[c], scrubber)
 	}
@@ -29,13 +30,22 @@ func ScrubPodTemplateSpec(template *v1.PodTemplateSpec, scrubber *DataScrubber) 
 	}
 }
 
-// ScrubPodSpec calls ScrubContainer for every container within a pod spec.
-func ScrubPodSpec(spec *v1.PodSpec, scrubber *DataScrubber) {
-	for c := 0; c < len(spec.InitContainers); c++ {
-		ScrubContainer(&spec.InitContainers[c], scrubber)
+// ScrubPod scrubs a pod.
+func ScrubPod(p *v1.Pod, scrubber *DataScrubber) {
+	ScrubAnnotations(p.Annotations, scrubber)
+
+	for c := 0; c < len(p.Spec.InitContainers); c++ {
+		ScrubContainer(&p.Spec.InitContainers[c], scrubber)
 	}
-	for c := 0; c < len(spec.Containers); c++ {
-		ScrubContainer(&spec.Containers[c], scrubber)
+	for c := 0; c < len(p.Spec.Containers); c++ {
+		ScrubContainer(&p.Spec.InitContainers[c], scrubber)
+	}
+}
+
+// ScrubAnnotations scrubs sensitive information from pod annotations.
+func ScrubAnnotations(annotations map[string]string, scrubber *DataScrubber) {
+	for k, v := range annotations {
+		annotations[k] = scrubber.ScrubAnnotationValue(v)
 	}
 }
 

--- a/releasenotes-dca/notes/k8s-annotation-scrubbing-1877b03331b56234.yaml
+++ b/releasenotes-dca/notes/k8s-annotation-scrubbing-1877b03331b56234.yaml
@@ -1,0 +1,3 @@
+---
+enhancements:
+  - Sensitive information is now scrubbed from pod annotations.

--- a/releasenotes/notes/k8s-annotation-scrubbing-a5273de9ae1793be.yaml
+++ b/releasenotes/notes/k8s-annotation-scrubbing-a5273de9ae1793be.yaml
@@ -1,0 +1,3 @@
+---
+enhancements:
+  - Sensitive information is now scrubbed from pod annotations.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Improve the scrubber to remove sensitive content from pod annotations in addition to container environment variables and command lines. Annotations can contain configuration in json format like autodiscovery configuration so we need to also parse them in case clear text credentials are present by mistake.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
