### PR TITLE
pkg/obfuscate: remove duplicate structs across packages

### DIFF
--- a/pkg/obfuscate/obfuscate.go
+++ b/pkg/obfuscate/obfuscate.go
@@ -149,35 +149,35 @@ type SQLMetadata struct {
 // HTTPConfig holds the configuration settings for HTTP obfuscation.
 type HTTPConfig struct {
 	// RemoveQueryStrings determines query strings to be removed from HTTP URLs.
-	RemoveQueryString bool
+	RemoveQueryString bool `mapstructure:"remove_query_string" json:"remove_query_string"`
 
 	// RemovePathDigits determines digits in path segments to be obfuscated.
-	RemovePathDigits bool
+	RemovePathDigits bool `mapstructure:"remove_paths_with_digits" json:"remove_path_digits"`
 }
 
 // RedisConfig holds the configuration settings for Redis obfuscation
 type RedisConfig struct {
 	// Enabled specifies whether this feature should be enabled.
-	Enabled bool
+	Enabled bool `mapstructure:"enabled"`
 
 	// RemoveAllArgs specifies whether all arguments to a given Redis
 	// command should be obfuscated.
-	RemoveAllArgs bool
+	RemoveAllArgs bool `mapstructure:"remove_all_args"`
 }
 
 // JSONConfig holds the obfuscation configuration for sensitive
 // data found in JSON objects.
 type JSONConfig struct {
 	// Enabled will specify whether obfuscation should be enabled.
-	Enabled bool
+	Enabled bool `mapstructure:"enabled"`
 
 	// KeepValues will specify a set of keys for which their values will
 	// not be obfuscated.
-	KeepValues []string
+	KeepValues []string `mapstructure:"keep_values"`
 
 	// ObfuscateSQLValues will specify a set of keys for which their values
 	// will be passed through SQL obfuscation
-	ObfuscateSQLValues []string
+	ObfuscateSQLValues []string `mapstructure:"obfuscate_sql_values"`
 }
 
 // NewObfuscator creates a new obfuscator

--- a/pkg/trace/agent/obfuscate_test.go
+++ b/pkg/trace/agent/obfuscate_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
@@ -141,7 +142,7 @@ func TestObfuscateConfig(t *testing.T) {
 		"redis.raw_command",
 		"SET key val",
 		"SET key ?",
-		&config.ObfuscationConfig{Redis: config.RedisObfuscationConfig{Enabled: true}},
+		&config.ObfuscationConfig{Redis: obfuscate.RedisConfig{Enabled: true}},
 	))
 
 	t.Run("redis/remove_all_args", testConfig(
@@ -149,7 +150,7 @@ func TestObfuscateConfig(t *testing.T) {
 		"redis.raw_command",
 		"SET key val",
 		"SET ?",
-		&config.ObfuscationConfig{Redis: config.RedisObfuscationConfig{
+		&config.ObfuscationConfig{Redis: obfuscate.RedisConfig{
 			Enabled:       true,
 			RemoveAllArgs: true,
 		}},
@@ -168,7 +169,7 @@ func TestObfuscateConfig(t *testing.T) {
 		"http.url",
 		"http://mysite.mydomain/1/2?q=asd",
 		"http://mysite.mydomain/?/??",
-		&config.ObfuscationConfig{HTTP: config.HTTPObfuscationConfig{
+		&config.ObfuscationConfig{HTTP: obfuscate.HTTPConfig{
 			RemovePathDigits:  true,
 			RemoveQueryString: true,
 		}},
@@ -187,7 +188,7 @@ func TestObfuscateConfig(t *testing.T) {
 		"http.url",
 		"http://mysite.mydomain/1/2?q=asd",
 		"http://mysite.mydomain/?/??",
-		&config.ObfuscationConfig{HTTP: config.HTTPObfuscationConfig{
+		&config.ObfuscationConfig{HTTP: obfuscate.HTTPConfig{
 			RemovePathDigits:  true,
 			RemoveQueryString: true,
 		}},
@@ -207,7 +208,7 @@ func TestObfuscateConfig(t *testing.T) {
 		`{"role": "database"}`,
 		`{"role":"?"}`,
 		&config.ObfuscationConfig{
-			ES: config.JSONObfuscationConfig{Enabled: true},
+			ES: obfuscate.JSONConfig{Enabled: true},
 		},
 	))
 

--- a/pkg/trace/api/info.go
+++ b/pkg/trace/api/info.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 )
 
 // makeInfoHandler returns a new handler for handling the discovery endpoint.
@@ -26,14 +26,14 @@ func (r *HTTPReceiver) makeInfoHandler() (hash string, handler http.HandlerFunc)
 		}
 	}
 	type reducedObfuscationConfig struct {
-		ElasticSearch        bool                          `json:"elastic_search"`
-		Mongo                bool                          `json:"mongo"`
-		SQLExecPlan          bool                          `json:"sql_exec_plan"`
-		SQLExecPlanNormalize bool                          `json:"sql_exec_plan_normalize"`
-		HTTP                 config.HTTPObfuscationConfig  `json:"http"`
-		RemoveStackTraces    bool                          `json:"remove_stack_traces"`
-		Redis                config.RedisObfuscationConfig `json:"redis"`
-		Memcached            bool                          `json:"memcached"`
+		ElasticSearch        bool                  `json:"elastic_search"`
+		Mongo                bool                  `json:"mongo"`
+		SQLExecPlan          bool                  `json:"sql_exec_plan"`
+		SQLExecPlanNormalize bool                  `json:"sql_exec_plan_normalize"`
+		HTTP                 obfuscate.HTTPConfig  `json:"http"`
+		RemoveStackTraces    bool                  `json:"remove_stack_traces"`
+		Redis                obfuscate.RedisConfig `json:"redis"`
+		Memcached            bool                  `json:"memcached"`
 	}
 	type reducedConfig struct {
 		DefaultEnv             string                        `json:"default_env"`

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 )
 
@@ -213,7 +214,7 @@ func TestInfoHandler(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	jsonObfCfg := config.JSONObfuscationConfig{
+	jsonObfCfg := obfuscate.JSONConfig{
 		Enabled:            true,
 		KeepValues:         []string{"a", "b", "c"},
 		ObfuscateSQLValues: []string{"x", "y"},
@@ -223,12 +224,12 @@ func TestInfoHandler(t *testing.T) {
 		Mongo:                jsonObfCfg,
 		SQLExecPlan:          jsonObfCfg,
 		SQLExecPlanNormalize: jsonObfCfg,
-		HTTP: config.HTTPObfuscationConfig{
+		HTTP: obfuscate.HTTPConfig{
 			RemoveQueryString: true,
 			RemovePathDigits:  true,
 		},
 		RemoveStackTraces: false,
-		Redis:             config.RedisObfuscationConfig{Enabled: true},
+		Redis:             obfuscate.RedisConfig{Enabled: true},
 		Memcached:         config.Enablable{Enabled: false},
 	}
 	conf := &config.AgentConfig{

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -81,20 +81,20 @@ type OTLP struct {
 // for various span types.
 type ObfuscationConfig struct {
 	// ES holds the obfuscation configuration for ElasticSearch bodies.
-	ES JSONObfuscationConfig `mapstructure:"elasticsearch"`
+	ES obfuscate.JSONConfig `mapstructure:"elasticsearch"`
 
 	// Mongo holds the obfuscation configuration for MongoDB queries.
-	Mongo JSONObfuscationConfig `mapstructure:"mongodb"`
+	Mongo obfuscate.JSONConfig `mapstructure:"mongodb"`
 
 	// SQLExecPlan holds the obfuscation configuration for SQL Exec Plans. This is strictly for safety related obfuscation,
 	// not normalization. Normalization of exec plans is configured in SQLExecPlanNormalize.
-	SQLExecPlan JSONObfuscationConfig `mapstructure:"sql_exec_plan"`
+	SQLExecPlan obfuscate.JSONConfig `mapstructure:"sql_exec_plan"`
 
 	// SQLExecPlanNormalize holds the normalization configuration for SQL Exec Plans.
-	SQLExecPlanNormalize JSONObfuscationConfig `mapstructure:"sql_exec_plan_normalize"`
+	SQLExecPlanNormalize obfuscate.JSONConfig `mapstructure:"sql_exec_plan_normalize"`
 
 	// HTTP holds the obfuscation settings for HTTP URLs.
-	HTTP HTTPObfuscationConfig `mapstructure:"http"`
+	HTTP obfuscate.HTTPConfig `mapstructure:"http"`
 
 	// RemoveStackTraces specifies whether stack traces should be removed.
 	// More specifically "error.stack" tag values will be cleared.
@@ -102,7 +102,7 @@ type ObfuscationConfig struct {
 
 	// Redis holds the configuration for obfuscating the "redis.raw_command" tag
 	// for spans of type "redis".
-	Redis RedisObfuscationConfig `mapstructure:"redis"`
+	Redis obfuscate.RedisConfig `mapstructure:"redis"`
 
 	// Memcached holds the configuration for obfuscating the "memcached.command" tag
 	// for spans of type "memcached".
@@ -122,35 +122,13 @@ func (o *ObfuscationConfig) Export(conf *AgentConfig) obfuscate.Config {
 			DollarQuotedFunc: conf.HasFeature("dollar_quoted_func"),
 			Cache:            conf.HasFeature("sql_cache"),
 		},
-		ES: obfuscate.JSONConfig{
-			Enabled:            o.ES.Enabled,
-			KeepValues:         o.ES.KeepValues,
-			ObfuscateSQLValues: o.ES.ObfuscateSQLValues,
-		},
-		Mongo: obfuscate.JSONConfig{
-			Enabled:            o.Mongo.Enabled,
-			KeepValues:         o.Mongo.KeepValues,
-			ObfuscateSQLValues: o.Mongo.ObfuscateSQLValues,
-		},
-		SQLExecPlan: obfuscate.JSONConfig{
-			Enabled:            o.SQLExecPlan.Enabled,
-			KeepValues:         o.SQLExecPlan.KeepValues,
-			ObfuscateSQLValues: o.SQLExecPlan.ObfuscateSQLValues,
-		},
-		SQLExecPlanNormalize: obfuscate.JSONConfig{
-			Enabled:            o.SQLExecPlanNormalize.Enabled,
-			KeepValues:         o.SQLExecPlanNormalize.KeepValues,
-			ObfuscateSQLValues: o.SQLExecPlanNormalize.ObfuscateSQLValues,
-		},
-		HTTP: obfuscate.HTTPConfig{
-			RemoveQueryString: o.HTTP.RemoveQueryString,
-			RemovePathDigits:  o.HTTP.RemovePathDigits,
-		},
-		Redis: obfuscate.RedisConfig{
-			Enabled:       o.Redis.Enabled,
-			RemoveAllArgs: o.Redis.RemoveAllArgs,
-		},
-		Logger: new(debugLogger),
+		ES:                   o.ES,
+		Mongo:                o.Mongo,
+		SQLExecPlan:          o.SQLExecPlan,
+		SQLExecPlanNormalize: o.SQLExecPlanNormalize,
+		HTTP:                 o.HTTP,
+		Redis:                o.Redis,
+		Logger:               new(debugLogger),
 	}
 }
 
@@ -172,49 +150,15 @@ type CreditCardsConfig struct {
 	Luhn bool `mapstructure:"luhn"`
 }
 
-// HTTPObfuscationConfig holds the configuration settings for HTTP obfuscation.
-type HTTPObfuscationConfig struct {
-	// RemoveQueryStrings determines query strings to be removed from HTTP URLs.
-	RemoveQueryString bool `mapstructure:"remove_query_string" json:"remove_query_string"`
-
-	// RemovePathDigits determines digits in path segments to be obfuscated.
-	RemovePathDigits bool `mapstructure:"remove_paths_with_digits" json:"remove_path_digits"`
-}
-
 // Enablable can represent any option that has an "enabled" boolean sub-field.
 type Enablable struct {
 	Enabled bool `mapstructure:"enabled"`
-}
-
-// RedisObfuscationConfig holds the configuration settings for Redis obfuscation
-type RedisObfuscationConfig struct {
-	// Enabled specifies whether this feature should be enabled.
-	Enabled bool `mapstructure:"enabled"`
-
-	// RemoveAllArgs specifies whether all arguments to a given Redis
-	// command should be obfuscated.
-	RemoveAllArgs bool `mapstructure:"remove_all_args"`
 }
 
 // TelemetryConfig holds Instrumentation telemetry Endpoints information
 type TelemetryConfig struct {
 	Enabled   bool `mapstructure:"enabled"`
 	Endpoints []*Endpoint
-}
-
-// JSONObfuscationConfig holds the obfuscation configuration for sensitive
-// data found in JSON objects.
-type JSONObfuscationConfig struct {
-	// Enabled will specify whether obfuscation should be enabled.
-	Enabled bool `mapstructure:"enabled"`
-
-	// KeepValues will specify a set of keys for which their values will
-	// not be obfuscated.
-	KeepValues []string `mapstructure:"keep_values"`
-
-	// ObfuscateSQLValues will specify a set of keys for which their values
-	// will be passed through SQL obfuscation
-	ObfuscateSQLValues []string `mapstructure:"obfuscate_sql_values"`
 }
 
 // ReplaceRule specifies a replace rule.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Refactors some of the code to remove duplicated structs between `pkg/trace/config` and `pkg/obfuscate`, making `pkg/obfuscate` the source of truth for configuration related to obfuscation.

This PR could be taken a lot farther, by trying to entirely eliminate the duplicated code between `pkg/obfuscate` and `pkg/trace/config`. That's out of scope for this PR though. For example, these two structs are basically the same: https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/config/config.go#L80-L113 and https://github.com/DataDog/datadog-agent/blob/main/pkg/obfuscate/obfuscate.go#L64-L94
Having those separately risks them going out of sync, which has already happened (i.e. Memcached is in the config for `pkg/trace/config` but not in `pkg/obfuscate`) 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The only difference between the structs was that one defined JSON strings, and the other did not. We can combine them and just use the same structs throughout to reduce tech debt.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

This change removes exported structs in `pkg/trace/config`, so if someone is relying on this library, their code will fail to build. However I've done some investigation and see `pkg/trace/config` is only used in a few places, and should be safe to change in this way. This package is imported within Datadog in:
- DataDog/datadog-agent (which all usages are changed in this PR)
- An internal, private repo that hasn't been touched since 2019. We can change the code there if we need to, and they would notice it's broken if they updated their agent version.
- An internal, archived repo for a security agent that won't be getting updates
- DataDog/opentelemetry-collector-contrib, which has no usages of the structs being removed. [[Redis]](https://github.com/search?q=repo%3ADataDog%2Fopentelemetry-collector-contrib+RedisObfuscationConfig&type=code) [[HTTP]](https://github.com/search?q=repo%3ADataDog%2Fopentelemetry-collector-contrib+HTTPObfuscationConfig&type=code) [[JSON]](https://github.com/search?q=repo%3ADataDog%2Fopentelemetry-collector-contrib+JSONObfuscationConfig&type=code)

No external libraries should have a reason to import `pkg/config/trace`.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Unit tests should cover this

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
