### PR TITLE
Refactor kubeapiserver test to make sure the resource is eventually fetched

### DIFF
--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/deployments_test.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/deployments_test.go
@@ -149,7 +149,7 @@ func Test_DeploymentsFakeKubernetesClient(t *testing.T) {
 		name           string
 		createResource func(cl *fake.Clientset) error
 		deployment     *workloadmeta.KubernetesDeployment
-		expected       []workloadmeta.EventBundle
+		expected       workloadmeta.EventBundle
 	}{
 		{
 			name: "has env label",
@@ -165,20 +165,18 @@ func Test_DeploymentsFakeKubernetesClient(t *testing.T) {
 				)
 				return err
 			},
-			expected: []workloadmeta.EventBundle{
-				{
-					Events: []workloadmeta.Event{
-						{
-							Type: workloadmeta.EventTypeSet,
-							Entity: &workloadmeta.KubernetesDeployment{
-								EntityID: workloadmeta.EntityID{
-									ID:   "test-namespace/test-deployment",
-									Kind: workloadmeta.KindKubernetesDeployment,
-								},
-								Env:                    "env",
-								ContainerLanguages:     map[string][]languagemodels.Language{},
-								InitContainerLanguages: map[string][]languagemodels.Language{},
+			expected: workloadmeta.EventBundle{
+				Events: []workloadmeta.Event{
+					{
+						Type: workloadmeta.EventTypeSet,
+						Entity: &workloadmeta.KubernetesDeployment{
+							EntityID: workloadmeta.EntityID{
+								ID:   "test-namespace/test-deployment",
+								Kind: workloadmeta.KindKubernetesDeployment,
 							},
+							Env:                    "env",
+							ContainerLanguages:     map[string][]languagemodels.Language{},
+							InitContainerLanguages: map[string][]languagemodels.Language{},
 						},
 					},
 				},
@@ -201,22 +199,20 @@ func Test_DeploymentsFakeKubernetesClient(t *testing.T) {
 				)
 				return err
 			},
-			expected: []workloadmeta.EventBundle{
-				{
-					Events: []workloadmeta.Event{
-						{
-							Type: workloadmeta.EventTypeSet,
-							Entity: &workloadmeta.KubernetesDeployment{
-								EntityID: workloadmeta.EntityID{
-									ID:   "test-namespace/test-deployment",
-									Kind: workloadmeta.KindKubernetesDeployment,
-								},
-								ContainerLanguages: map[string][]languagemodels.Language{
-									"nginx": {{Name: languagemodels.Go}, {Name: languagemodels.Java}},
-								},
-								InitContainerLanguages: map[string][]languagemodels.Language{
-									"redis": {{Name: languagemodels.Go}, {Name: languagemodels.Python}},
-								},
+			expected: workloadmeta.EventBundle{
+				Events: []workloadmeta.Event{
+					{
+						Type: workloadmeta.EventTypeSet,
+						Entity: &workloadmeta.KubernetesDeployment{
+							EntityID: workloadmeta.EntityID{
+								ID:   "test-namespace/test-deployment",
+								Kind: workloadmeta.KindKubernetesDeployment,
+							},
+							ContainerLanguages: map[string][]languagemodels.Language{
+								"nginx": {{Name: languagemodels.Go}, {Name: languagemodels.Java}},
+							},
+							InitContainerLanguages: map[string][]languagemodels.Language{
+								"redis": {{Name: languagemodels.Go}, {Name: languagemodels.Python}},
 							},
 						},
 					},

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/node_test.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/node_test.go
@@ -55,20 +55,18 @@ func Test_NodesFakeKubernetesClient(t *testing.T) {
 		_, err := cl.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{ObjectMeta: objectMeta}, metav1.CreateOptions{})
 		return err
 	}
-	expected := []workloadmeta.EventBundle{
-		{
-			Events: []workloadmeta.Event{
-				{
-					Type: workloadmeta.EventTypeSet,
-					Entity: &workloadmeta.KubernetesNode{
-						EntityID: workloadmeta.EntityID{
-							ID:   objectMeta.Name,
-							Kind: workloadmeta.KindKubernetesNode,
-						},
-						EntityMeta: workloadmeta.EntityMeta{
-							Name:   objectMeta.Name,
-							Labels: objectMeta.Labels,
-						},
+	expected := workloadmeta.EventBundle{
+		Events: []workloadmeta.Event{
+			{
+				Type: workloadmeta.EventTypeSet,
+				Entity: &workloadmeta.KubernetesNode{
+					EntityID: workloadmeta.EntityID{
+						ID:   objectMeta.Name,
+						Kind: workloadmeta.KindKubernetesNode,
+					},
+					EntityMeta: workloadmeta.EntityMeta{
+						Name:   objectMeta.Name,
+						Labels: objectMeta.Labels,
 					},
 				},
 			},

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/pod_test.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/pod_test.go
@@ -117,22 +117,20 @@ func Test_PodsFakeKubernetesClient(t *testing.T) {
 		_, err := cl.CoreV1().Pods(metav1.NamespaceAll).Create(context.TODO(), &corev1.Pod{ObjectMeta: objectMeta}, metav1.CreateOptions{})
 		return err
 	}
-	expected := []workloadmeta.EventBundle{
-		{
-			Events: []workloadmeta.Event{
-				{
-					Type: workloadmeta.EventTypeSet,
-					Entity: &workloadmeta.KubernetesPod{
-						EntityID: workloadmeta.EntityID{
-							ID:   string(objectMeta.UID),
-							Kind: workloadmeta.KindKubernetesPod,
-						},
-						EntityMeta: workloadmeta.EntityMeta{
-							Name:   objectMeta.Name,
-							Labels: objectMeta.Labels,
-						},
-						Owners: []workloadmeta.KubernetesPodOwner{},
+	expected := workloadmeta.EventBundle{
+		Events: []workloadmeta.Event{
+			{
+				Type: workloadmeta.EventTypeSet,
+				Entity: &workloadmeta.KubernetesPod{
+					EntityID: workloadmeta.EntityID{
+						ID:   string(objectMeta.UID),
+						Kind: workloadmeta.KindKubernetesPod,
 					},
+					EntityMeta: workloadmeta.EntityMeta{
+						Name:   objectMeta.Name,
+						Labels: objectMeta.Labels,
+					},
+					Owners: []workloadmeta.KubernetesPodOwner{},
 				},
 			},
 		},

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/test_helpers.go
@@ -19,34 +19,46 @@ import (
 
 const dummySubscriber = "dummy-subscriber"
 
-func testCollectEvent(t *testing.T, createResource func(*fake.Clientset) error, newStore storeGenerator, expected []workloadmeta.EventBundle) {
+func testCollectEvent(t *testing.T, createResource func(*fake.Clientset) error, newStore storeGenerator, expected workloadmeta.EventBundle) {
 	// Create a fake client to mock API calls.
 	client := fake.NewSimpleClientset()
 
-	// Use the fake client in kubeapiserver context.
+	// Create a resource before starting the reflector store or workloadmeta so that if the reflector calls `List()` then
+	// this resource can't be skipped
+	err := createResource(client)
+	assert.NoError(t, err)
+
+	// Start the reflector
 	wlm := workloadmeta.NewMockStore()
 	store, _ := newStore(context.TODO(), wlm, client)
 	stopStore := make(chan struct{})
 	go store.Run(stopStore)
-	time.Sleep(5 * time.Second)
 
+	// Subscribe to the kubeapiserver events. Two cases are possible:
+	// - The reflector has already populated wlm with the resource, in that case the first call to <-ch will contain the event
+	// - The reflector is still initializing. In that case the second call to <-ch will contain the event
 	ch := wlm.Subscribe(dummySubscriber, workloadmeta.NormalPriority, nil)
-	// When Subscribe is called, the first Bundle contains events about the items currently in the store.
-	// In that case, the first bundle is empty.
-	<-ch
+	var bundle workloadmeta.EventBundle
+	assert.Eventually(t, func() bool {
+		select {
+		case bundle = <-ch:
+			close(bundle.Ch)
+			if len(bundle.Events) == 0 {
+				return false
+			}
+			// If bundle finally has an event, we can return from this
+			return true
 
-	// Creating a resource
-	err := createResource(client)
-	assert.NoError(t, err)
+		default:
+			return false
+		}
+	}, 30*time.Second, 500*time.Millisecond)
 
-	// Retrieving the resource in an event bundle
-	bundle := <-ch
-	close(bundle.Ch)
 	// nil the bundle's Ch so we can
 	// deep-equal just the events later
 	bundle.Ch = nil
-	actual := []workloadmeta.EventBundle{bundle}
+	actual := bundle
+	assert.Equal(t, expected, actual)
 	close(stopStore)
 	wlm.Unsubscribe(ch)
-	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
`testCollectEvents` is currently flaky. I think that it follows this sequence but I can't confirm it yet:
go store.Run(stopStore) is called
The Reflector calls list() and returns nothing https://github.com/kubernetes/client-go/blob/f2d91322bf55f2be90e300c4845d365470cd125a/tools/cache/reflector.go#L346
The ressource (pod, node...) is created.
The Reflector calls watch() https://github.com/kubernetes/client-go/blob/f2d91322bf55f2be90e300c4845d365470cd125a/tools/cache/reflector.go#L356, missing the event.

It looks like an issue in the reflector store but it's also an edge case that should be very rare with low impact. This PR refactors a test to make sure that the event is eventually caught by workloadmeta.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
CI should be green
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
It doesn't fix the bug but makes sure that the bug does not occur in the test.
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
None
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
CI should be green
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
