### PR TITLE
Add check to dwarfutil type finding logic to include slices

### DIFF
--- a/pkg/network/go/dwarfutils/type_finder.go
+++ b/pkg/network/go/dwarfutils/type_finder.go
@@ -115,8 +115,21 @@ func (f *TypeFinder) FindStructFieldOffset(structName string, fieldName string) 
 
 	var fieldOffset uint64
 	foundField := false
+
 	if structType, ok := typ.(*godwarf.StructType); ok {
 		for _, field := range structType.Field {
+			if field.Name == fieldName {
+				fieldOffset = uint64(field.ByteOffset)
+				foundField = true
+				break
+			}
+		}
+	}
+
+	// slices are an implemented as structs internally within go
+	// and are reflected as such in dwarf
+	if sliceType, ok := typ.(*godwarf.SliceType); ok {
+		for _, field := range sliceType.Field {
 			if field.Name == fieldName {
 				fieldOffset = uint64(field.ByteOffset)
 				foundField = true


### PR DESCRIPTION

### What does this PR do?

Go implements certain types as structs internally. For example, slices. Slices have 3 fields, `array`, `len`, and `cap`. In the Go implementation of Go DI that we are building, we rely on DWARF for type definitions and on the dwarfutils library (and bininspect) for calculating offsets of various parameters. This all means that in order for us to properly calculate offsets we need this library to be aware of the multiple fields of the internal slice type and their fields.

This adds a check in `FindStructFieldOffset` to check if a given struct type name is actually the name of a slice type.

### Motivation

Required for Go DI to work.

### Additional Notes

Here's DWARF entries for the []uint16 type (found in any Go binary):

```
0x00016ba4:   DW_TAG_structure_type
                DW_AT_name      ("[]uint16")
                DW_AT_byte_size (24)
                DW_AT_GO_kind   (0x17)
                DW_AT_GO_runtime_type   (0x0000000000000000)
                DW_AT_GO_elem   (0x00000000000030a2)

0x00016bbc:     DW_TAG_member
                  DW_AT_name    ("array")
                  DW_AT_data_member_location    (0)
                  DW_AT_type    (0x000000000001c46e "uint16 *")
                  DW_AT_GO_embedded_field       (0x00)

0x00016bc9:     DW_TAG_member
                  DW_AT_name    ("len")
                  DW_AT_data_member_location    (8)
                  DW_AT_type    (0x0000000000003604 "int")
                  DW_AT_GO_embedded_field       (0x00)

0x00016bd4:     DW_TAG_member
                  DW_AT_name    ("cap")
                  DW_AT_data_member_location    (16)
                  DW_AT_type    (0x0000000000003604 "int")
                  DW_AT_GO_embedded_field       (0x00)
```

Similarly, here's what a normal struct looks like:

```
0x00018e1e:   DW_TAG_structure_type
                DW_AT_name      ("main.nStruct")
                DW_AT_byte_size (24)
                DW_AT_GO_kind   (0x19)
                DW_AT_GO_runtime_type   (0x0000000000000000)

0x00018e36:     DW_TAG_member
                  DW_AT_name    ("aBool")
                  DW_AT_data_member_location    (0)
                  DW_AT_type    (0x0000000000002ead "bool")
                  DW_AT_GO_embedded_field       (0x00)

0x00018e43:     DW_TAG_member
                  DW_AT_name    ("aInt")
                  DW_AT_data_member_location    (8)
                  DW_AT_type    (0x0000000000003604 "int")
                  DW_AT_GO_embedded_field       (0x00)

0x00018e4f:     DW_TAG_member
                  DW_AT_name    ("aInt16")
                  DW_AT_data_member_location    (16)
                  DW_AT_type    (0x00000000000079d8 "int16")
                  DW_AT_GO_embedded_field       (0x00)
```


### Possible Drawbacks / Trade-offs

Open to discussion.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
