### PR TITLE
Improve the obfuscation error diagnostics

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -354,6 +354,22 @@ func (c *Check) copyToPreviousMap(newMap map[StatementMetricsKeyDB]StatementMetr
 	}
 }
 
+func handlePredicate(predicateType string, dbValue sql.NullString, payloadValue *string, statement StatementMetricsDB, c *Check, o *obfuscate.Obfuscator) {
+	if dbValue.Valid {
+		obfuscated, err := o.ObfuscateSQLString(dbValue.String)
+		if err == nil {
+			*payloadValue = obfuscated.Query
+		} else {
+			*payloadValue = fmt.Sprintf("%s obfuscation error", predicateType)
+			logEntry := fmt.Sprintf("%s %s for sql_id: %s, plan_hash_value: %d", c.logPrompt, *payloadValue, statement.SQLID, statement.PlanHashValue)
+			if c.config.ExecutionPlans.LogUnobfuscatedPlans {
+				logEntry = fmt.Sprintf("%s obfuscated filter: %s, unobfuscated filter: %s", logEntry, dbValue.String, payloadValue)
+			}
+			log.Error(logEntry)
+		}
+	}
+}
+
 func (c *Check) StatementMetrics() (int, error) {
 	if !checkIntervalExpired(&c.statementsLastRun, c.config.QueryMetrics.CollectionInterval) {
 		return 0, nil
@@ -673,30 +689,8 @@ func (c *Check) StatementMetrics() (int, error) {
 								if stepRow.TempSpace.Valid {
 									stepPayload.TempSpace = stepRow.TempSpace.Float64
 								}
-								if stepRow.AccessPredicates.Valid {
-									obfuscated, err := o.ObfuscateSQLString(stepRow.AccessPredicates.String)
-									if err == nil {
-										stepPayload.AccessPredicates = obfuscated.Query
-									} else {
-										stepPayload.AccessPredicates = "Access obfuscation error"
-										if c.config.ExecutionPlans.LogUnobfuscatedPlans {
-											stepPayload.AccessPredicates = fmt.Sprintf("%s, unobfuscated filter: %s", stepPayload.AccessPredicates, stepRow.AccessPredicates.String)
-										}
-										log.Errorf("%s %s", c.logPrompt, stepPayload.AccessPredicates)
-									}
-								}
-								if stepRow.FilterPredicates.Valid {
-									obfuscated, err := o.ObfuscateSQLString(stepRow.FilterPredicates.String)
-									if err == nil {
-										stepPayload.FilterPredicates = obfuscated.Query
-									} else {
-										stepPayload.FilterPredicates = "Filter obfuscation error"
-										if c.config.ExecutionPlans.LogUnobfuscatedPlans {
-											stepPayload.FilterPredicates = fmt.Sprintf("%s, unobfuscated filter: %s", stepPayload.FilterPredicates, stepRow.FilterPredicates.String)
-										}
-										log.Errorf("%s %s", c.logPrompt, stepPayload.FilterPredicates)
-									}
-								}
+								handlePredicate("access", stepRow.AccessPredicates, &stepPayload.AccessPredicates, statementMetricRow, c, o)
+								handlePredicate("filter", stepRow.FilterPredicates, &stepPayload.FilterPredicates, statementMetricRow, c, o)
 								if stepRow.Projection.Valid {
 									stepPayload.Projection = stepRow.Projection.String
 								}

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -363,7 +363,7 @@ func handlePredicate(predicateType string, dbValue sql.NullString, payloadValue 
 			*payloadValue = fmt.Sprintf("%s obfuscation error", predicateType)
 			logEntry := fmt.Sprintf("%s %s for sql_id: %s, plan_hash_value: %d", c.logPrompt, *payloadValue, statement.SQLID, statement.PlanHashValue)
 			if c.config.ExecutionPlans.LogUnobfuscatedPlans {
-				logEntry = fmt.Sprintf("%s obfuscated filter: %s, unobfuscated filter: %s", logEntry, dbValue.String, payloadValue)
+				logEntry = fmt.Sprintf("%s unobfuscated filter: %s", logEntry, dbValue.String)
 			}
 			log.Error(logEntry)
 		}

--- a/releasenotes/notes/oracle-obfuscation-diagnostic-f30f284976064640.yaml
+++ b/releasenotes/notes/oracle-obfuscation-diagnostic-f30f284976064640.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add `sql_id` and `plan_hash_value` to obfuscation error message.


### PR DESCRIPTION
### What does this PR do?

Adding `sql_id` and `plan_hash_value` to the plan obfuscation error message. 

A sample log entry with `log_unobfuscated_plan=true`:

```
2023-09-27 13:41:33 CEST | CORE | ERROR | (pkg/collector/corechecks/oracle-dbm/statements.go:368 in handlePredicate) | fejr1pod@nenad-oad-1>  filter obfuscation error for sql_id: cw7d9tb30tz6u, plan_hash_value: 3098447909 unobfuscated filter: ((INTERNAL_FUNCTION("M"."STATUS") AND CEIL(DECODE(MOD("U"."ASTATUS",16),1,"U"."EXPTIME",2,"U"."EXPTIME",5,"U"."EXPTIME",6,"U"."EXPTIME",9,"U"."EXPTIME",10,"U"."EXPTIME",DECODE("U"."PASSWORD",'GLOBAL',TO_DATE(NULL),'EXTERNAL',TO_DATE(NULL),DECODE(INTERNAL_FUNCTION("U"."PTIME"),'',TO_DATE(NULL),DECODE("PR"."LIMIT#",2147483647,TO_DATE(NULL),DECODE("PR"."LIMIT#",0,DECODE("DP"."LIMIT#",2147483647,TO_DATE(NULL),INTERNAL_FUNCTION("U"."PTIME")+"DP"."LIMIT#"/86400),INTERNAL_FUNCTION("U"."PTIME")+"PR"."LIMIT#"/86400)))))-SYSDATE@!)=0) OR ("M"."STATUS"='EXPIRED(GRACE)' AND CEIL(DECODE(MOD("U"."ASTATUS",16),1,"U"."EXPTIME",2,"U"."EXPTIME",5,"U"."EXPTIME",6,"U"."EXPTIME",9,"U"."EXPTIME",10,"U"."EXPTIME",DECODE("U"."PASSWORD",'GLOBAL',TO_DATE(NULL),'EXTERNAL',TO_DATE(NULL),DECODE(INTERNAL_FUNCTION("U"."PTIME"),'',TO_DATE(NULL),DECODE("PR"."LIMIT#",2147483647,TO_DATE(NULL),DECODE("PR"."LIMIT#",0,DECODE("DP"."LIMIT#",2147483647,TO_DATE(NULL),INTERNAL_FUNCTION("U"."PTIME")+"DP"."LIMIT#"/86400),INTERNAL_FUNCTION("U"."PTIME")+"PR"."LIMIT#"/86400)))))-SYSDATE@!)=:1))
```

### Motivation

These information is useful for retrieving the original predicates from the database when we have to troubleshooting obfuscation errors.

### Describe how to test/QA your changes

First do no harm: check that the filter and access predicates in execution plan samples are properly obfuscated.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
