### PR TITLE
[CWS] insert snapshot entry in the right order for Windows

### DIFF
--- a/pkg/security/resolvers/process/resolver_windows.go
+++ b/pkg/security/resolvers/process/resolver_windows.go
@@ -10,7 +10,8 @@ package process
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -82,6 +83,8 @@ func (p *Resolver) insertEntry(entry *model.ProcessCacheEntry) {
 	parent := p.processes[entry.PPid]
 	if parent != nil {
 		entry.SetAncestor(parent)
+	} else {
+		log.Tracef("unable to find parent of %v\n", entry)
 	}
 }
 
@@ -112,7 +115,7 @@ func (p *Resolver) AddNewEntry(pid uint32, ppid uint32, file string, commandLine
 
 	e.Process.Args = commandLine
 	e.Process.FileEvent.PathnameStr = file
-	e.Process.FileEvent.BasenameStr = path.Base(e.Process.FileEvent.PathnameStr)
+	e.Process.FileEvent.BasenameStr = filepath.Base(e.Process.FileEvent.PathnameStr)
 	e.ExecTime = time.Now()
 
 	p.insertEntry(e)
@@ -179,6 +182,7 @@ func (p *Resolver) Snapshot() {
 	if err != nil {
 		return
 	}
+
 	// the list returned is a map of pid to procutil.Process.
 	// The processes can be iterated with the following caveats
 	// Pid should be valid
@@ -187,6 +191,8 @@ func (p *Resolver) Snapshot() {
 	// the `Cmdline` is an array of strings, parsed on ` ` boundaries
 	// the `stats` field is mostly not filled in because of the `false` argument to `ProcessesByPID()`
 	//     however, the create time will be filled in
+	entries := make([]*model.ProcessCacheEntry, 0, len(pmap))
+
 	for pid, proc := range pmap {
 		e := p.processCacheEntryPool.Get()
 		e.PIDContext.Pid = Pid(pid)
@@ -194,21 +200,40 @@ func (p *Resolver) Snapshot() {
 
 		e.Process.Args = strings.Join(proc.GetCmdline(), " ")
 		e.Process.FileEvent.PathnameStr = proc.Exe
-		e.Process.FileEvent.BasenameStr = path.Base(e.Process.FileEvent.PathnameStr)
-		e.ExecTime = time.Now()
+		e.Process.FileEvent.BasenameStr = filepath.Base(e.Process.FileEvent.PathnameStr)
+		e.ExecTime = time.Unix(0, proc.Stats.CreateTime)
 
-		p.insertEntry(e)
+		entries = append(entries, e)
 
 		log.Tracef("PID %d  %d PPID %d\n", pid, proc.Pid, proc.Ppid)
 		log.Tracef("  executable %s\n", proc.Exe)
 		log.Tracef("  executable %v\n", proc.GetCmdline())
 		log.Tracef("  createtime %v\n", proc.Stats.CreateTime)
-	}
-	// another note on PPids.  Windows reuses process IDS.  So consider the following
+		log.Tracef("  exectime %s\n", e.ExecTime)
 
-	// process 1 starts
-	// process 1 starts process 2 (so 1 is the parent of 2)
-	// process 1 ends/dies
-	// another process starts and is given the pid (1)
-	// process 2's PPid will still be 2, but the current Pid(1) was not the one that created pid 2.
+		// TODO:
+		// another note on PPids.  Windows reuses process IDS.  So consider the following
+
+		// process 1 starts
+		// process 1 starts process 2 (so 1 is the parent of 2)
+		// process 1 ends/dies
+		// another process starts and is given the pid (1)
+		// process 2's PPid will still be 2, but the current Pid(1) was not the one that created pid 2.
+	}
+
+	// make sure to insert them in the creation time order
+	sort.Slice(entries, func(i, j int) bool {
+		entryA := entries[i]
+		entryB := entries[j]
+
+		if entryA.ExecTime.Equal(entryB.ExecTime) {
+			return entries[i].Pid < entries[j].Pid
+		}
+
+		return entryA.ExecTime.Before(entryB.ExecTime)
+	})
+
+	for _, e := range entries {
+		p.insertEntry(e)
+	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Insert the snapshot entry in the right order to ensure finding the parent. It also fixes the BasenameStr.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
