### PR TITLE
[oracle] Adding real_hostname tag

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/init.go
+++ b/pkg/collector/corechecks/oracle-dbm/init.go
@@ -54,7 +54,6 @@ func (c *Check) init() error {
 	c.dbVersion = i.VersionFull
 	if c.config.ReportedHostname != "" {
 		c.dbHostname = c.config.ReportedHostname
-		tags = append(tags, fmt.Sprintf("reported_hostname:%s", c.config.ReportedHostname))
 	} else {
 		if i.HostName.Valid {
 			c.dbHostname = i.HostName.String

--- a/pkg/collector/corechecks/oracle-dbm/init.go
+++ b/pkg/collector/corechecks/oracle-dbm/init.go
@@ -8,6 +8,7 @@
 package oracle
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
 
@@ -20,8 +21,9 @@ type vDatabase struct {
 }
 
 type vInstance struct {
-	HostName    string `db:"HOST_NAME"`
-	VersionFull string `db:"VERSION_FULL"`
+	HostName     sql.NullString `db:"HOST_NAME"`
+	InstanceName string         `db:"INSTANCE_NAME"`
+	VersionFull  string         `db:"VERSION_FULL"`
 }
 
 func (c *Check) init() error {
@@ -45,16 +47,24 @@ func (c *Check) init() error {
 	}
 
 	var i vInstance
-	// host_name is null on Oracle Autonomous Database
-	err = getWrapper(c, &i, "SELECT /* DD */ nvl(host_name, instance_name) host_name, version_full FROM v$instance")
+	err = getWrapper(c, &i, "SELECT /* DD */ host_name, instance_name, version_full FROM v$instance")
 	if err != nil {
 		return fmt.Errorf("%s failed to query v$instance: %w", c.logPrompt, err)
 	}
 	c.dbVersion = i.VersionFull
 	if c.config.ReportedHostname != "" {
 		c.dbHostname = c.config.ReportedHostname
+		tags = append(tags, fmt.Sprintf("reported_hostname:%s", c.config.ReportedHostname))
 	} else {
-		c.dbHostname = i.HostName
+		if i.HostName.Valid {
+			c.dbHostname = i.HostName.String
+		} else {
+			// host_name is null on Oracle Autonomous Database
+			c.dbHostname = i.InstanceName
+		}
+	}
+	if i.HostName.Valid {
+		tags = append(tags, fmt.Sprintf("real_hostname:%s", i.HostName.String))
 	}
 	tags = append(tags, fmt.Sprintf("host:%s", c.dbHostname), fmt.Sprintf("oracle_version:%s", c.dbVersion))
 

--- a/releasenotes/notes/oracle-new-hostname-tags-403695108b8bdb49.yaml
+++ b/releasenotes/notes/oracle-new-hostname-tags-403695108b8bdb49.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Adding `reported_hostname` and `real_hostname` tags.

--- a/releasenotes/notes/oracle-new-hostname-tags-403695108b8bdb49.yaml
+++ b/releasenotes/notes/oracle-new-hostname-tags-403695108b8bdb49.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Adding `reported_hostname` and `real_hostname` tags.
+    Adding `real_hostname` tag.


### PR DESCRIPTION
### What does this PR do?

Adding the `real_hostname` tag.

### Motivation

With the config parameter `reported_hostname`, a customer can override the real database hostname. The customers running databases on cloud sometimes use this parameter for convenience, as the host names on a cloud are cryptic. A disadvantage of overriding the real host name is that we're losing the information about the host name and, consequently, can't correlate database performance with host performance metrics. With the new tag `real_hostname` the Agent preserves this information.

### Describe how to test/QA your changes

Check the tags.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
