### PR TITLE
ebpfcheck: move non-error logs to trace level

### DIFF
--- a/pkg/collector/corechecks/ebpf/ebpf.go
+++ b/pkg/collector/corechecks/ebpf/ebpf.go
@@ -118,7 +118,7 @@ func (m *EBPFCheck) Run() error {
 		moduleTotalMapMaxSize[mapStats.Module] += mapStats.MaxSize
 		moduleTotalMapRSS[mapStats.Module] += mapStats.RSS
 
-		log.Debugf("ebpf check: map=%s maxsize=%d type=%s", mapStats.Name, mapStats.MaxSize, mapStats.Type.String())
+		log.Tracef("ebpf check: map=%s maxsize=%d type=%s", mapStats.Name, mapStats.MaxSize, mapStats.Type.String())
 	}
 
 	for _, mapInfo := range stats.Maps {
@@ -170,7 +170,7 @@ func (m *EBPFCheck) Run() error {
 			tags = append(tags, "program_tag:"+progInfo.Tag)
 		}
 		var debuglogs []string
-		if log.ShouldLog(seelog.DebugLvl) {
+		if log.ShouldLog(seelog.TraceLvl) {
 			debuglogs = []string{"program=" + progInfo.Name, "type=" + progInfo.Type.String()}
 		}
 
@@ -184,7 +184,7 @@ func (m *EBPFCheck) Run() error {
 				continue
 			}
 			sender.Gauge("ebpf.programs."+k, v, "", tags)
-			if log.ShouldLog(seelog.DebugLvl) {
+			if log.ShouldLog(seelog.TraceLvl) {
 				debuglogs = append(debuglogs, fmt.Sprintf("%s=%.0f", k, v))
 			}
 		}
@@ -203,13 +203,13 @@ func (m *EBPFCheck) Run() error {
 				continue
 			}
 			sender.MonotonicCountWithFlushFirstValue("ebpf.programs."+k, v, "", tags, true)
-			if log.ShouldLog(seelog.DebugLvl) {
+			if log.ShouldLog(seelog.TraceLvl) {
 				debuglogs = append(debuglogs, fmt.Sprintf("%s=%.0f", k, v))
 			}
 		}
 
-		if log.ShouldLog(seelog.DebugLvl) {
-			log.Debugf("ebpf check: %s", strings.Join(debuglogs, " "))
+		if log.ShouldLog(seelog.TraceLvl) {
+			log.Tracef("ebpf check: %s", strings.Join(debuglogs, " "))
 		}
 	}
 	if totalProgRSS > 0 {

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -74,7 +74,6 @@ func NewProbe(cfg *ddebpf.Config) (*Probe, error) {
 	if cfg.BPFDebug {
 		filename = "ebpf-debug.o"
 	}
-	log.Debugf("loading %s", filename)
 	err = ddebpf.LoadCOREAsset(cfg, filename, func(buf bytecode.AssetReader, opts manager.Options) error {
 		var err error
 		probe, err = startEBPFCheck(buf, opts)
@@ -263,10 +262,10 @@ func (k *Probe) getProgramStats(stats *model.EBPFStats) error {
 		stats.Programs = append(stats.Programs, ps)
 	}
 
-	log.Debugf("found %d programs", len(stats.Programs))
+	log.Tracef("found %d programs", len(stats.Programs))
 	deduplicateProgramNames(stats)
 	for _, ps := range stats.Programs {
-		log.Debugf("name=%s prog_id=%d type=%s", ps.Name, ps.ID, ps.Type.String())
+		log.Tracef("name=%s prog_id=%d type=%s", ps.Name, ps.ID, ps.Type.String())
 	}
 
 	return nil
@@ -355,13 +354,13 @@ func (k *Probe) getMapStats(stats *model.EBPFStats) error {
 		stats.Maps = append(stats.Maps, baseMapStats)
 	}
 
-	log.Debugf("found %d maps", mapCount)
+	log.Tracef("found %d maps", mapCount)
 	deduplicateMapNames(stats)
 	for _, mp := range stats.Maps {
-		log.Debugf("name=%s map_id=%d max=%d rss=%d type=%s", mp.Name, mp.ID, mp.MaxSize, mp.RSS, mp.Type)
+		log.Tracef("name=%s map_id=%d max=%d rss=%d type=%s", mp.Name, mp.ID, mp.MaxSize, mp.RSS, mp.Type)
 	}
 	for _, mp := range stats.PerfBuffers {
-		log.Debugf("name=%s map_id=%d max=%d rss=%d type=%s", mp.Name, mp.ID, mp.MaxSize, mp.RSS, mp.Type)
+		log.Tracef("name=%s map_id=%d max=%d rss=%d type=%s", mp.Name, mp.ID, mp.MaxSize, mp.RSS, mp.Type)
 	}
 
 	return nil
@@ -486,7 +485,7 @@ func perfBufferMemoryUsage(mapStats *model.EBPFPerfBufferStats, info *ebpf.MapIn
 			}
 			return fmt.Errorf("error reading perf buffer fd map %s, mapid=%d cpu=%d: %s", info.Name, mapid, i, err)
 		}
-		log.Debugf("map_id=%d cpu=%d len=%d addr=%x", mapid, i, region.Len, region.Addr)
+		log.Tracef("map_id=%d cpu=%d len=%d addr=%x", mapid, i, region.Len, region.Addr)
 		mapStats.MaxSize += region.Len
 		mapStats.CPUBuffers = append(mapStats.CPUBuffers, model.EBPFCPUPerfBufferStats{
 			CPU: i,
@@ -497,7 +496,7 @@ func perfBufferMemoryUsage(mapStats *model.EBPFPerfBufferStats, info *ebpf.MapIn
 		})
 	}
 
-	log.Debugf("map_id=%d num_cpus=%d", mapid, len(mapStats.CPUBuffers))
+	log.Tracef("map_id=%d num_cpus=%d", mapid, len(mapStats.CPUBuffers))
 	addrs := make([]uintptr, 0, len(mapStats.CPUBuffers))
 	for _, b := range mapStats.CPUBuffers {
 		addrs = append(addrs, b.Addr)
@@ -517,7 +516,7 @@ func perfBufferMemoryUsage(mapStats *model.EBPFPerfBufferStats, info *ebpf.MapIn
 			if rss, ok := rssMap[cpub.Addr]; ok {
 				cpub.RSS = rss
 				mapStats.RSS += rss
-				log.Debugf("perf buffer map_id=%d cpu=%d rss=%d", mapid, cpub.CPU, cpub.RSS)
+				log.Tracef("perf buffer map_id=%d cpu=%d rss=%d", mapid, cpub.CPU, cpub.RSS)
 			} else {
 				log.Debugf("unable to find RSS data map_id=%d cpu=%d addr=%x", mapid, cpub.CPU, cpub.Addr)
 			}
@@ -550,7 +549,7 @@ func ringBufferMemoryUsage(mapStats *model.EBPFMapStats, info *ebpf.MapInfo, k *
 	if err := k.ringBufferMap.Lookup(unsafe.Pointer(&mapid), unsafe.Pointer(&ringInfo)); err != nil {
 		return fmt.Errorf("error reading ring buffer map %s, mapid=%d: %s", info.Name, mapid, err)
 	}
-	log.Debugf("map_id=%d data_len=%d data_addr=%x cons_len=%d cons_addr=%x", mapid, ringInfo.Data.Len, ringInfo.Data.Addr, ringInfo.Consumer.Len, ringInfo.Consumer.Addr)
+	log.Tracef("map_id=%d data_len=%d data_addr=%x cons_len=%d cons_addr=%x", mapid, ringInfo.Data.Len, ringInfo.Data.Addr, ringInfo.Consumer.Len, ringInfo.Consumer.Addr)
 	mapStats.MaxSize += ringInfo.Consumer.Len + ringInfo.Data.Len
 
 	addrs := []uintptr{uintptr(ringInfo.Consumer.Addr), uintptr(ringInfo.Data.Addr)}
@@ -561,7 +560,7 @@ func ringBufferMemoryUsage(mapStats *model.EBPFMapStats, info *ebpf.MapInfo, k *
 		mapStats.RSS = mapStats.MaxSize
 	} else {
 		for addr, size := range rss {
-			log.Debugf("ring buffer map_id=%d addr=%x rss=%d", mapid, addr, size)
+			log.Tracef("ring buffer map_id=%d addr=%x rss=%d", mapid, addr, size)
 			mapStats.RSS += size
 		}
 	}
@@ -574,7 +573,7 @@ func (k *Probe) getMmapRSS(mapid uint32, addrs []uintptr) (map[uintptr]uint64, e
 		return nil, fmt.Errorf("pid map lookup: %s", err)
 	}
 
-	log.Debugf("map pid=%d map_id=%d", pid, mapid)
+	log.Tracef("map pid=%d map_id=%d", pid, mapid)
 	return matchProcessRSS(int(pid), addrs)
 }
 


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Moves any non-error logs to trace level.

### Motivation

somewhat spammy logs when debug is enabled

### Additional Notes

https://datadoghq.atlassian.net/browse/EBPF-249

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
