### PR TITLE
[oracle] Adjust links to documentation for non-CDB architecture

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/init.go
+++ b/pkg/collector/corechecks/oracle-dbm/init.go
@@ -43,6 +43,7 @@ func (c *Check) init() error {
 	if d.Cdb == "NO" {
 		isMultitenant = false
 	}
+	c.multitenant = isMultitenant
 
 	var i vInstance
 	// host_name is null on Oracle Autonomous Database

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -84,6 +84,7 @@ type Check struct {
 	hostingType                             hostingCode
 	logPrompt                               string
 	initialized                             bool
+	multitenant                             bool
 }
 
 func handleServiceCheck(c *Check, err error) {

--- a/pkg/collector/corechecks/oracle-dbm/sql_wrappers.go
+++ b/pkg/collector/corechecks/oracle-dbm/sql_wrappers.go
@@ -52,12 +52,20 @@ func handlePrivilegeError(c *Check, err error) (bool, error) {
 		return isPrivilegeError, err
 	}
 
-	links := map[hostingCode]string{
-		selfManaged: "https://docs.datadoghq.com/database_monitoring/setup_oracle/selfhosted/#grant-permissions",
-		rds:         "https://docs.datadoghq.com/database_monitoring/setup_oracle/rds/#grant-permissions",
-		oci:         "https://docs.datadoghq.com/database_monitoring/setup_oracle/autonomous_database/#grant-permissions",
+	var link string
+	switch c.hostingType {
+	case selfManaged:
+		if c.multitenant {
+			link = "https://docs.datadoghq.com/database_monitoring/setup_oracle/selfhosted/?tab=multitenant#grant-permissions"
+		} else {
+			link = "https://docs.datadoghq.com/database_monitoring/setup_oracle/selfhosted/?tab=noncdb#grant-permissions"
+		}
+	case rds:
+		link = "https://docs.datadoghq.com/database_monitoring/setup_oracle/rds/#grant-permissions"
+	case oci:
+		link = "https://docs.datadoghq.com/database_monitoring/setup_oracle/autonomous_database/#grant-permissions"
 	}
-	link := links[c.hostingType]
+
 	isPrivilegeError = true
 	return isPrivilegeError, fmt.Errorf("Some privileges are missing. Execute the `grant` commands from %s . Error: %w", link, err)
 }

--- a/releasenotes/notes/oracle-non-cdb-doc-link-b94117088cdc302a.yaml
+++ b/releasenotes/notes/oracle-non-cdb-doc-link-b94117088cdc302a.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Adjust doc links to grant privilege commands for multitenant and non-cdb architecture.
+    Adjust doc links to grant privilege commands for multitenant and non-CDB architecture.

--- a/releasenotes/notes/oracle-non-cdb-doc-link-b94117088cdc302a.yaml
+++ b/releasenotes/notes/oracle-non-cdb-doc-link-b94117088cdc302a.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Adjust doc links to grant privilege commands for multitenant and non-cdb architecture.


### PR DESCRIPTION
### What does this PR do?

When query execution by the Agent is failing due to missing privileges, we enrich the error message with the link to commands for granting the necessary object privileges. The support for the Oracle non-CDB legacy architecture was added recently. With this PR, we are adding the link to the `grant` commands for non-CDB infrastructure.

### Describe how to test/QA your changes

Revoke the privilege and check if the link to the documentation is correct.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
