### PR TITLE
[workloadmeta/kubelet] Delete "docker-pullable://" prefix from image IDs

### DIFF
--- a/pkg/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/pkg/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -10,6 +10,7 @@ package kubelet
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/internal/third_party/golang/expansion"
@@ -24,9 +25,10 @@ import (
 )
 
 const (
-	collectorID   = "kubelet"
-	componentName = "workloadmeta-kubelet"
-	expireFreq    = 15 * time.Second
+	collectorID         = "kubelet"
+	componentName       = "workloadmeta-kubelet"
+	expireFreq          = 15 * time.Second
+	dockerImageIDPrefix = "docker-pullable://"
 )
 
 type collector struct {
@@ -186,17 +188,22 @@ func (c *collector) parsePodContainers(
 		var env map[string]string
 		var ports []workloadmeta.ContainerPort
 
-		image, err := workloadmeta.NewContainerImage(container.ImageID, container.Image)
+		// When running on docker, the image ID contains a prefix that's not
+		// included in other runtimes. Remove it for consistency.
+		// See https://github.com/kubernetes/kubernetes/issues/95968
+		imageID := strings.TrimPrefix(container.ImageID, dockerImageIDPrefix)
+
+		image, err := workloadmeta.NewContainerImage(imageID, container.Image)
 		if err != nil {
 			if err == containers.ErrImageIsSha256 {
 				// try the resolved image ID if the image name in the container
 				// status is a SHA256. this seems to happen sometimes when
 				// pinning the image to a SHA256
-				image, err = workloadmeta.NewContainerImage(container.ImageID, container.ImageID)
+				image, err = workloadmeta.NewContainerImage(imageID, imageID)
 			}
 
 			if err != nil {
-				log.Debugf("cannot split image name %q nor %q: %s", container.Image, container.ImageID, err)
+				log.Debugf("cannot split image name %q nor %q: %s", container.Image, imageID, err)
 			}
 		}
 
@@ -210,12 +217,12 @@ func (c *collector) parsePodContainers(
 		if containerSpec != nil {
 			env = extractEnvFromSpec(containerSpec.Env)
 
-			podContainer.Image, err = workloadmeta.NewContainerImage(container.ImageID, containerSpec.Image)
+			podContainer.Image, err = workloadmeta.NewContainerImage(imageID, containerSpec.Image)
 			if err != nil {
 				log.Debugf("cannot split image name %q: %s", containerSpec.Image, err)
 			}
 
-			podContainer.Image.ID = container.ImageID
+			podContainer.Image.ID = imageID
 			containerSecurityContext = extractContainerSecurityContext(containerSpec)
 			ports = make([]workloadmeta.ContainerPort, 0, len(containerSpec.Ports))
 			for _, port := range containerSpec.Ports {

--- a/releasenotes/notes/kubelet-wlm-remove-docker-image-prefix-0af81bc83f368386.yaml
+++ b/releasenotes/notes/kubelet-wlm-remove-docker-image-prefix-0af81bc83f368386.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The image_id tag no longer includes the ``docker-pullable://`` prefix when using Kubernetes with Docker as runtime.
+fixes:
+  - |
+    Fixed an issue in the SBOM check when using Kubernetes with Docker as runtime. Some images used by containers were incorrectly marked as unused.


### PR DESCRIPTION
### What does this PR do?

Changes the Kubelet workloadmeta collector so that it doesn't include the `docker-pullable://` prefix in image IDs.

When running on docker, the image ID contains a prefix that's not included in other runtimes. Remove it for consistency.
Reference: See https://github.com/kubernetes/kubernetes/issues/95968

This PR fixes two things:
- The "image_id" tag no longer includes the `docker-pullable://` prefix.
- The SBOM check wrongly reported some used images as unused when running on Kubernetes with Docker. The reason is that the prefix was added in the Kubelet collector, but not in the Docker collector which is the one that reports image metadata. Because of this mismatch, the SBOM check wrongly assumed that the image was not used.

### Describe how to test/QA your changes

Run the Agent on Kubernetes using Docker as the runtime. Enable the SBOM and the image metadata checks and verify:
- The "image_id" tag doesn't include the `docker-pullable://` prefix. You can verify this with `agent tagger-list` or checking any metric that includes the tag.
- Check that the SBOM check correctly reports the used images as being used. You can run `agent stream-event-platform` and verify the `inUse` field of the entities reported.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
