### PR TITLE
[USMON-578] usm: gotls: tests: Cut test runtime by 50%, by removing sleep and introducing a method to check if USM hooked a go process

### DIFF
--- a/pkg/network/protocols/tls/gotls/testutil/client_builder.go
+++ b/pkg/network/protocols/tls/gotls/testutil/client_builder.go
@@ -18,7 +18,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func NewGoTLSClient(t *testing.T, serverAddr string, numRequests int) func() {
+// NewGoTLSClient triggers an external go tls client that runs `numRequests` HTTPs requests to `serverAddr`.
+// Returns the command executed and a callback to start sending requests.
+func NewGoTLSClient(t *testing.T, serverAddr string, numRequests int) (*exec.Cmd, func()) {
 	clientBin := buildGoTLSClientBin(t)
 	clientCmd := fmt.Sprintf("%s %s %d", clientBin, serverAddr, numRequests)
 
@@ -26,7 +28,7 @@ func NewGoTLSClient(t *testing.T, serverAddr string, numRequests int) func() {
 	c, clientInput, err := nettestutil.StartCommandCtx(timedCtx, clientCmd)
 
 	require.NoError(t, err)
-	return func() {
+	return c, func() {
 		defer cancel()
 		_, err = clientInput.Write([]byte{1})
 		require.NoError(t, err)

--- a/pkg/network/protocols/tls/gotls/testutil/gotls_client/gotls_client.go
+++ b/pkg/network/protocols/tls/gotls/testutil/gotls_client/gotls_client.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-	"time"
 )
 
 func main() {
@@ -42,9 +41,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not read from stdin: %s", err)
 	}
-
-	// Needed to give time to the tracer to hook GoTLS functions
-	time.Sleep(5 * time.Second)
 
 	for i := 0; i < reqCount; i++ {
 		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://%s/%d/request-%d", serverAddr, http.StatusOK, i), nil)

--- a/pkg/network/usm/utils/debugger_testutils.go
+++ b/pkg/network/usm/utils/debugger_testutils.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && test
+
+package utils
+
+// GetTracedPrograms returns a list of traced programs by the specific program type
+func GetTracedPrograms(programType string) []TracedProgram {
+	res := debugger.GetTracedPrograms()
+	i := 0 // output index
+	for _, x := range res {
+		if x.ProgramType == programType {
+			// copy and increment index
+			res[i] = x
+			i++
+		}
+	}
+	return res[:i]
+}


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Cuts go tls runtime by 50%, by removing time.Sleep(time.Second*5) from the code, and replaced it
with a sophisticated check to know if USM hooked the process.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Improving test time and reducing flakiness

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
