### PR TITLE
cleanup sbom config and internal metrics

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1131,7 +1131,6 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("sbom.clear_cache_on_exit", false)
 	config.BindEnvAndSetDefault("sbom.cache.enabled", true)
 	config.BindEnvAndSetDefault("sbom.cache.max_disk_size", 1000*1000*100) // used by custom cache: max disk space used by cached objects. Not equal to max disk usage
-	config.BindEnvAndSetDefault("sbom.cache.max_cache_entries", 100000)    // used by custom cache keys stored in memory
 	config.BindEnvAndSetDefault("sbom.cache.clean_interval", "1h")         // used by custom cache.
 
 	// Container SBOM configuration

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -68,9 +68,8 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault("sbom.host.analyzers", []string{"os"})
 	cfg.BindEnvAndSetDefault("sbom.cache_directory", filepath.Join(defaultRunPath, "sbom-sysprobe"))
 	cfg.BindEnvAndSetDefault("sbom.clear_cache_on_exit", false)
-	cfg.BindEnvAndSetDefault("sbom.cache.enabled", false)
+	cfg.BindEnvAndSetDefault("sbom.cache.enabled", true)
 	cfg.BindEnvAndSetDefault("sbom.cache.max_disk_size", 1000*1000*100) // used by custom cache: max disk space used by cached objects. Not equal to max disk usage
-	cfg.BindEnvAndSetDefault("sbom.cache.max_cache_entries", 10000)     // used by custom cache keys stored in memory
 	cfg.BindEnvAndSetDefault("sbom.cache.clean_interval", "30m")        // used by custom cache.
 
 	// Auto exit configuration

--- a/pkg/sbom/telemetry/telemetry.go
+++ b/pkg/sbom/telemetry/telemetry.go
@@ -55,39 +55,12 @@ var (
 		commonOpts,
 	)
 
-	// SBOMCacheMemSize size in memory of the cache used for SBOM collection
-	SBOMCacheMemSize = telemetry.NewGaugeWithOpts(
-		subsystem,
-		"cache_mem_size",
-		[]string{},
-		"SBOM cache size in memory (in bytes)",
-		commonOpts,
-	)
-
 	// SBOMCacheDiskSize size in disk of the custom cache used for SBOM collection
 	SBOMCacheDiskSize = telemetry.NewGaugeWithOpts(
 		subsystem,
 		"cache_disk_size",
 		[]string{},
 		"SBOM size in disk of the custom cache (in bytes)",
-		commonOpts,
-	)
-
-	// SBOMCacheEntries number of cache keys stored in memory
-	SBOMCacheEntries = telemetry.NewGaugeWithOpts(
-		subsystem,
-		"cached_keys",
-		[]string{},
-		"Number of cache keys stored in memory",
-		commonOpts,
-	)
-
-	// SBOMCachedObjectSize total size of cached objects in disk (in bytes) used for SBOM collection
-	SBOMCachedObjectSize = telemetry.NewGaugeWithOpts(
-		subsystem,
-		"cached_objects_size",
-		[]string{},
-		"SBOM total size of cached objects in disk (in bytes)",
 		commonOpts,
 	)
 
@@ -104,15 +77,6 @@ var (
 	SBOMCacheMisses = telemetry.NewCounterWithOpts(
 		subsystem,
 		"cache_misses_total",
-		[]string{},
-		"SBOM total number of cache misses during SBOM collection",
-		commonOpts,
-	)
-
-	// SBOMCacheEvicts number of cache evicts during SBOM collection
-	SBOMCacheEvicts = telemetry.NewCounterWithOpts(
-		subsystem,
-		"cache_evicts_total",
 		[]string{},
 		"SBOM total number of cache misses during SBOM collection",
 		commonOpts,

--- a/pkg/util/trivy/cache.go
+++ b/pkg/util/trivy/cache.go
@@ -25,6 +25,9 @@ import (
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 )
 
+// cacheSize is the number of entries that can be stored in the LRU cache
+const cacheSize = 1600
+
 // telemetryTick is the frequency at which the cache usage metrics are collected.
 var telemetryTick = 1 * time.Minute
 
@@ -34,7 +37,7 @@ type CacheProvider func() (cache.Cache, CacheCleaner, error)
 
 // NewCustomBoltCache is a CacheProvider. It returns a custom implementation of a BoltDB cache using an LRU algorithm with a
 // maximum number of cache entries, maximum disk size and garbage collection of unused images with its custom cleaner.
-func NewCustomBoltCache(cacheDir string, maxCacheEntries int, maxDiskSize int) (cache.Cache, CacheCleaner, error) {
+func NewCustomBoltCache(cacheDir string, maxDiskSize int) (cache.Cache, CacheCleaner, error) {
 	if cacheDir == "" {
 		cacheDir = utils.DefaultCacheDir()
 	}
@@ -43,7 +46,6 @@ func NewCustomBoltCache(cacheDir string, maxCacheEntries int, maxDiskSize int) (
 		return nil, &StubCacheCleaner{}, err
 	}
 	cache, err := NewPersistentCache(
-		maxCacheEntries,
 		maxDiskSize,
 		db,
 	)
@@ -254,7 +256,6 @@ type PersistentCache struct {
 
 // NewPersistentCache creates a new instance of PersistentCache and returns a pointer to it.
 func NewPersistentCache(
-	maxCacheSize int,
 	maxCachedObjectSize int,
 	localDB PersistentDB,
 ) (*PersistentCache, error) {
@@ -265,7 +266,7 @@ func NewPersistentCache(
 		maximumCachedObjectSize:      maxCachedObjectSize,
 	}
 
-	lruCache, err := simplelru.NewLRU(maxCacheSize, func(key string, _ struct{}) {
+	lruCache, err := simplelru.NewLRU(cacheSize, func(key string, _ struct{}) {
 		persistentCache.lastEvicted = key
 	})
 	if err != nil {
@@ -338,7 +339,6 @@ func (c *PersistentCache) Clear() error {
 	}
 	c.lruCache.Purge()
 	c.currentCachedObjectTotalSize = 0
-	telemetry.SBOMCachedObjectSize.Set(0)
 	return nil
 }
 
@@ -413,7 +413,6 @@ func (c *PersistentCache) set(key string, value []byte) error {
 			c.addKeyInMemory(c.lastEvicted)
 			return err
 		}
-		telemetry.SBOMCacheEvicts.Inc()
 		c.subCurrentCachedObjectTotalSize(evictedSize)
 	}
 
@@ -476,30 +475,19 @@ func (c *PersistentCache) Remove(keys []string) error {
 
 // addKeyInMemory adds the provided key in the lrucache, returning if an entry was evicted.
 func (c *PersistentCache) addKeyInMemory(key string) bool {
-	ok := c.lruCache.Add(key, struct{}{})
-	if !ok {
-		telemetry.SBOMCacheEntries.Inc()
-	}
-	return ok
+	return c.lruCache.Add(key, struct{}{})
 }
 
 // removeKeyFromMemory removes the provided key from the lrucache, returning if the
 // key was contained.
 func (c *PersistentCache) removeKeyFromMemory(key string) bool {
-	ok := c.lruCache.Remove(key)
-	if ok {
-		telemetry.SBOMCacheEntries.Dec()
-	}
-	return ok
+	return c.lruCache.Remove(key)
 }
 
 // removeOldestKeyFromMemory removes the oldest key from the lrucache returning the key and
 // if a key was removed.
 func (c *PersistentCache) removeOldestKeyFromMemory() (string, bool) {
 	key, _, ok := c.lruCache.RemoveOldest()
-	if ok {
-		telemetry.SBOMCacheEntries.Dec()
-	}
 	return key, ok
 }
 
@@ -513,13 +501,11 @@ func (c *PersistentCache) GetCurrentCachedObjectTotalSize() int {
 // addCurrentCachedObjectTotalSize adds val to the current cached object total size.
 func (c *PersistentCache) addCurrentCachedObjectTotalSize(val int) {
 	c.currentCachedObjectTotalSize += val
-	telemetry.SBOMCachedObjectSize.Add(float64(val))
 }
 
 // subCurrentCachedObjectTotalSize subtract val to the current cached object total size.
 func (c *PersistentCache) subCurrentCachedObjectTotalSize(val int) {
 	c.currentCachedObjectTotalSize -= val
-	telemetry.SBOMCachedObjectSize.Sub(float64(val))
 }
 
 // collectTelemetry collects the database's size

--- a/pkg/util/trivy/cache_test.go
+++ b/pkg/util/trivy/cache_test.go
@@ -10,7 +10,7 @@ package trivy
 import (
 	"context"
 	"encoding/json"
-	"strings"
+	"fmt"
 	"testing"
 	"time"
 
@@ -20,12 +20,11 @@ import (
 )
 
 var (
-	defaultCacheSize = 100
-	defaultDiskSize  = 1000000
+	defaultDiskSize = 1000000
 )
 
 func TestCustomBoltCache_Artifacts(t *testing.T) {
-	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultCacheSize, defaultDiskSize)
+	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultDiskSize)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())
@@ -46,7 +45,7 @@ func TestCustomBoltCache_Artifacts(t *testing.T) {
 }
 
 func TestCustomBoltCache_Blobs(t *testing.T) {
-	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultCacheSize, defaultDiskSize)
+	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultDiskSize)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())
@@ -67,7 +66,7 @@ func TestCustomBoltCache_Blobs(t *testing.T) {
 }
 
 func TestCustomBoltCache_MissingBlobs(t *testing.T) {
-	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultCacheSize, defaultDiskSize)
+	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultDiskSize)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())
@@ -99,7 +98,7 @@ func TestCustomBoltCache_MissingBlobs(t *testing.T) {
 }
 
 func TestCustomBoltCache_Clear(t *testing.T) {
-	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultCacheSize, defaultDiskSize)
+	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultDiskSize)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())
@@ -118,7 +117,7 @@ func TestCustomBoltCache_Clear(t *testing.T) {
 }
 
 func TestCustomBoltCache_CurrentObjectSize(t *testing.T) {
-	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultCacheSize, defaultDiskSize)
+	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultDiskSize)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())
@@ -150,40 +149,37 @@ func TestCustomBoltCache_CurrentObjectSize(t *testing.T) {
 }
 
 func TestCustomBoltCache_Eviction(t *testing.T) {
-	// Set the maximum cache entries to 2
-	cache, _, err := NewCustomBoltCache(t.TempDir(), 2, defaultDiskSize)
+	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultDiskSize)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())
 	}()
 
 	// store 3 artifacts with different sizes
-	artifactIDs := []string{"key1", "key2", "key3"}
 	artifactSize := make(map[string]int)
-	for i, id := range artifactIDs {
-
+	totalSize := 0
+	for i := 0; i < cacheSize+1; i++ {
+		id := fmt.Sprintf("key%d", i)
 		artifact := newTestArtifactInfo()
-		artifact.Architecture = strings.Repeat("A", i*7)
-
+		artifact.Architecture = "A"
 		serializedArtifactInfo, err := json.Marshal(artifact)
 		require.NoError(t, err)
 		artifactSize[id] = len(serializedArtifactInfo)
-
+		totalSize += len(serializedArtifactInfo)
 		err = cache.PutArtifact(id, artifact)
 		require.NoError(t, err)
 	}
 
-	// Make sure only the artifact 2 and 3 are stored and currentCachedObjectTotalSize is correctly updated
+	// Make sure the first artifact is evicted while others are still there
 	persistentCache := cache.(*ScannerCache).Cache.(*PersistentCache)
-	require.Equal(t, artifactSize["key2"]+artifactSize["key3"], persistentCache.GetCurrentCachedObjectTotalSize())
+	require.Equal(t, totalSize-artifactSize["key0"], persistentCache.GetCurrentCachedObjectTotalSize())
 
-	_, err = cache.GetArtifact("key2")
-	require.NoError(t, err)
+	for i := 1; i < cacheSize+1; i++ {
+		_, err = cache.GetArtifact(fmt.Sprintf("key%d", i))
+		require.NoError(t, err)
+	}
 
-	_, err = cache.GetArtifact("key3")
-	require.NoError(t, err)
-
-	_, err = cache.GetArtifact("key1")
+	_, err = cache.GetArtifact("key0")
 	require.Error(t, err)
 }
 
@@ -194,7 +190,7 @@ func TestCustomBoltCache_DiskSizeLimit(t *testing.T) {
 	serializedArtifactInfo, err := json.Marshal(artifact)
 	require.NoError(t, err)
 
-	cache, _, err := NewCustomBoltCache(t.TempDir(), defaultCacheSize, len(serializedArtifactInfo))
+	cache, _, err := NewCustomBoltCache(t.TempDir(), len(serializedArtifactInfo))
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())
@@ -247,7 +243,7 @@ func TestCustomBoltCache_GarbageCollector(t *testing.T) {
 
 	globalStore.Reset([]workloadmeta.Entity{image1, image2, image3}, workloadmeta.SourceAll)
 
-	cache, cacheCleaner, err := NewCustomBoltCache(t.TempDir(), defaultCacheSize, defaultDiskSize)
+	cache, cacheCleaner, err := NewCustomBoltCache(t.TempDir(), defaultDiskSize)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, cache.Close())

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -5,7 +5,7 @@
 
 //go:build trivy
 
-// package trivy holds the the scan components
+// Package trivy holds the scan components
 package trivy
 
 import (

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -5,6 +5,7 @@
 
 //go:build trivy
 
+// package trivy holds the the scan components
 package trivy
 
 import (
@@ -114,7 +115,6 @@ func cacheProvider(cacheLocation string, useCustomCache bool) func() (cache.Cach
 		return func() (cache.Cache, CacheCleaner, error) {
 			return NewCustomBoltCache(
 				cacheLocation,
-				config.Datadog.GetInt("sbom.cache.max_cache_entries"),
 				config.Datadog.GetInt("sbom.cache.max_disk_size"),
 			)
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR enables the custom cache by default in system probe, as it is for the agent.

It also removes the config param `sbom.cache.max_cache_entries` which was used to control the maximum number of keys in the cache. We already have a metric based on the disk space.

It also removes the following internal metrics:
- `cache_mem_size` We never really used it.
- `cached_keys` The number of keys isn't so important compared to the size of the cache.
- `cached_objects_size` We have a metric for the cache disk space usage. It could be useful if we want to use protobuf to serialize artifacts but it's not currently the case.
- `cache_evicts_total` We never really used it
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Should we have a release note for this ?
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
