### PR TITLE
[clusterchecks/dispatcher_configs] Fix panic. Check if node exists before accessing node.name

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_configs.go
@@ -90,12 +90,7 @@ func (d *dispatcher) removeConfig(digest string) {
 
 	node, found := d.store.getNodeStore(d.store.digestToNode[digest])
 
-	checkName := ""
-	if found {
-		node.RLock()
-		checkName = node.digestToConfig[digest].Name
-		node.RUnlock()
-	}
+	checkName := d.store.digestToConfig[digest].Name
 
 	delete(d.store.digestToNode, digest)
 	delete(d.store.digestToConfig, digest)

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -400,6 +400,36 @@ func TestDanglingConfig(t *testing.T) {
 	assert.Equal(t, 0, len(dispatcher.store.danglingConfigs))
 }
 
+func TestUnscheduleDanglingConfig(t *testing.T) {
+	testDispatcher := newDispatcher()
+
+	testConfig := integration.Config{
+		Name:         "cluster-check-example",
+		ClusterCheck: true,
+		Instances: []integration.Data{
+			// Define 2 to test that all of them are deleted and not just 1.
+			integration.Data("tags: [\"t1:v1\"]"),
+			integration.Data("tags: [\"t2:v2\"]"),
+		},
+	}
+
+	// False because because no node is available
+	assert.False(t, testDispatcher.shouldDispatchDanling())
+
+	// No nodes created, so it will not get assigned
+	testDispatcher.Schedule([]integration.Config{testConfig})
+
+	testDispatcher.Unschedule([]integration.Config{testConfig})
+
+	configs, err := testDispatcher.getAllConfigs()
+	require.NoError(t, err)
+	assert.Empty(t, configs)
+
+	// Also check that internal structures not used by getAllConfigs() are cleaned up
+	assert.Empty(t, testDispatcher.store.danglingConfigs)
+	assert.Empty(t, testDispatcher.store.idToDigest)
+}
+
 func TestReset(t *testing.T) {
 	dispatcher := newDispatcher()
 	config := generateIntegration("cluster-check")

--- a/releasenotes-dca/notes/fix-panic-dca-remove-dangling-config-6978bb2869634784.yaml
+++ b/releasenotes-dca/notes/fix-panic-dca-remove-dangling-config-6978bb2869634784.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a panic in the Cluster Agent that happens when trying to unschedule a
+    check that has not been dispatched to any runner.


### PR DESCRIPTION
### What does this PR do?

Closes https://github.com/DataDog/datadog-agent/issues/17403

Fixes a panic in the Cluster Agent that happens when trying to unschedule a config that has not been assigned to any runner.

The second commit includes a small cleanup in the function where the panic occurs.

### Describe how to test/QA your changes

- Deploy the Agent on Kubernetes and with cluster check runners enabled. Set the number of replicas for the runners to 0 so cluster checks will not get assigned to any runner. You can use this config when deploying with the Helm chart:
```yaml
datadog:
  clusterChecks:
    enabled: true
clusterChecksRunner:
  enabled: true
  replicas: 0
```
- Create a cluster check. For example, create a service with an http check like describe here: https://docs.datadoghq.com/containers/cluster_agent/clusterchecks/?tab=helm#example-http-check-on-an-nginx-backed-service
- Run `agent clusterchecks` in the Cluster Agent and verify that the new check appears in the "unassigned" section.
- Delete the service with the cluster check and verify that the Cluster Agent does not crash.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
