### PR TITLE
[CSPM] Paths of K8s certificate resource configuration was prefixed by /host/root

### DIFF
--- a/pkg/compliance/k8sconfig/loader.go
+++ b/pkg/compliance/k8sconfig/loader.go
@@ -296,7 +296,7 @@ func (l *loader) loadKeyFileMeta(name string) *K8sKeyFileMeta {
 
 // https://github.com/kubernetes/kubernetes/blob/ad18954259eae3db51bac2274ed4ca7304b923c4/cmd/kubeadm/test/kubeconfig/util.go#L77-L87
 func (l *loader) loadCertFileMeta(name string) *K8sCertFileMeta {
-	name, info, certData, ok := l.loadMeta(name, true)
+	fullpath, info, certData, ok := l.loadMeta(name, true)
 	if !ok {
 		return nil
 	}
@@ -308,7 +308,7 @@ func (l *loader) loadCertFileMeta(name string) *K8sCertFileMeta {
 	meta.User = utils.GetFileUser(info)
 	meta.Group = utils.GetFileGroup(info)
 	meta.Mode = uint32(info.Mode())
-	dir := filepath.Dir(name)
+	dir := filepath.Dir(fullpath)
 	if dirInfo, err := os.Stat(dir); err == nil {
 		meta.DirMode = uint32(dirInfo.Mode())
 		meta.DirUser = utils.GetFileUser(dirInfo)


### PR DESCRIPTION
### What does this PR do?

Fix the path of resolved configuration path for certificate data.

### Motivation

Not compliance rules apply on these fields, but their content is misleading since it is prefixed by `/host/root`

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

The path of certificates configuration values should not be prefixed by /host/root anymore.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
