### PR TITLE
[USMON-579] usm: tls classification: refactor test to spare 66% of runtime

### DIFF
--- a/pkg/network/protocols/tls/openssl/openssl.go
+++ b/pkg/network/protocols/tls/openssl/openssl.go
@@ -14,6 +14,7 @@ import (
 	protocolsUtils "github.com/DataDog/datadog-agent/pkg/network/protocols/testutil"
 )
 
+// RunServerOpenssl launches an openssl server.
 func RunServerOpenssl(t *testing.T, serverPort string, clientCount int, args ...string) error {
 	env := []string{
 		"OPENSSL_PORT=" + serverPort,
@@ -28,7 +29,8 @@ func RunServerOpenssl(t *testing.T, serverPort string, clientCount int, args ...
 	return protocolsUtils.RunDockerServer(t, "openssl-server", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile("ACCEPT"), protocolsUtils.DefaultTimeout)
 }
 
-func RunClientOpenssl(t *testing.T, addr string, port string, args string) bool {
+// RunClientOpenssl launches an openssl client.
+func RunClientOpenssl(t *testing.T, addr, port, args string) bool {
 	command := []string{
 		"docker", "run", "--network=host", "menci/archlinuxarm:base",
 		"openssl", "s_client", "-connect", addr + ":" + port, args,

--- a/pkg/network/protocols/tls/openssl/openssl.go
+++ b/pkg/network/protocols/tls/openssl/openssl.go
@@ -7,15 +7,17 @@ package openssl
 
 import (
 	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 	protocolsUtils "github.com/DataDog/datadog-agent/pkg/network/protocols/testutil"
 )
 
-func RunServerOpenssl(t *testing.T, serverPort string, args ...string) error {
+func RunServerOpenssl(t *testing.T, serverPort string, clientCount int, args ...string) error {
 	env := []string{
 		"OPENSSL_PORT=" + serverPort,
+		"CLIENTS=" + strconv.Itoa(clientCount),
 	}
 	if len(args) > 0 {
 		env = append(env, "OPENSSL_ARGS="+args[0])
@@ -23,7 +25,7 @@ func RunServerOpenssl(t *testing.T, serverPort string, args ...string) error {
 
 	t.Helper()
 	dir, _ := testutil.CurDir()
-	return protocolsUtils.RunDockerServer(t, "openssl-server", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile("exited with code"), protocolsUtils.DefaultTimeout)
+	return protocolsUtils.RunDockerServer(t, "openssl-server", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile("ACCEPT"), protocolsUtils.DefaultTimeout)
 }
 
 func RunClientOpenssl(t *testing.T, addr string, port string, args string) bool {

--- a/pkg/network/protocols/tls/openssl/testdata/docker-compose.yml
+++ b/pkg/network/protocols/tls/openssl/testdata/docker-compose.yml
@@ -3,6 +3,6 @@ version: '3'
 services:
   openssl-server:
     image: menci/archlinuxarm:base
-    entrypoint: bash -c "yes '' | openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 1 -nodes && openssl s_server -key key.pem -cert cert.pem -accept 0.0.0.0:${OPENSSL_PORT:-44330} -naccept 1 ${OPENSSL_ARGS}"
+    entrypoint: bash -c "yes '' | openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 1 -nodes && openssl s_server -key key.pem -cert cert.pem -accept 0.0.0.0:${OPENSSL_PORT:-44330} -naccept ${CLIENTS} ${OPENSSL_ARGS}"
     ports:
       - ${OPENSSL_PORT:-44330}:44330/tcp


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Running the server only once
Removing sleeps
server is launched with expected number of connections, which make teardown way faster.
Tests are now taking 20s instead of 90s.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
minimizing kitchen test time
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
