### PR TITLE
pkg/trace/api: remove spaces from hardcoded cloud resource type names

### DIFF
--- a/pkg/trace/api/telemetry.go
+++ b/pkg/trace/api/telemetry.go
@@ -29,11 +29,11 @@ type cloudResourceType string
 type cloudProvider string
 
 const (
-	awsLambda                     cloudResourceType = "AWS Lambda"
-	awsFargate                    cloudResourceType = "AWS Fargate"
-	cloudRun                      cloudResourceType = "GCP Cloud Run"
-	azureAppService               cloudResourceType = "Azure App Service"
-	azureContainerApp             cloudResourceType = "Azure Container App"
+	awsLambda                     cloudResourceType = "AWSLambda"
+	awsFargate                    cloudResourceType = "AWSFargate"
+	cloudRun                      cloudResourceType = "GCPCloudRun"
+	azureAppService               cloudResourceType = "AzureAppService"
+	azureContainerApp             cloudResourceType = "AzureContainerApp"
 	aws                           cloudProvider     = "AWS"
 	gcp                           cloudProvider     = "GCP"
 	azure                         cloudProvider     = "Azure"

--- a/pkg/trace/api/telemetry_test.go
+++ b/pkg/trace/api/telemetry_test.go
@@ -74,7 +74,7 @@ func TestTelemetryBasicProxyRequest(t *testing.T) {
 		assert.Equal("test_hostname", req.Header.Get("DD-Agent-Hostname"))
 		assert.Equal("test_env", req.Header.Get("DD-Agent-Env"))
 		assert.Equal("AWS", req.Header.Get("DD-Cloud-Provider"))
-		assert.Equal("AWS Lambda", req.Header.Get("DD-Cloud-Resource-Type"))
+		assert.Equal("AWSLambda", req.Header.Get("DD-Cloud-Resource-Type"))
 		assert.Equal("test_ARN", req.Header.Get("DD-Cloud-Resource-Identifier"))
 		assert.Equal("/path", req.URL.Path)
 		assert.Equal("", req.Header.Get("User-Agent"))
@@ -101,7 +101,7 @@ func TestGoogleCloudRun(t *testing.T) {
 
 	srv := assertingServer(t, func(req *http.Request, body []byte) error {
 		assert.Equal("GCP", req.Header.Get("DD-Cloud-Provider"))
-		assert.Equal("GCP Cloud Run", req.Header.Get("DD-Cloud-Resource-Type"))
+		assert.Equal("GCPCloudRun", req.Header.Get("DD-Cloud-Resource-Type"))
 		assert.Equal("test_service", req.Header.Get("DD-Cloud-Resource-Identifier"))
 
 		endpointCalled.Inc()
@@ -125,7 +125,7 @@ func TestAzureAppService(t *testing.T) {
 
 	srv := assertingServer(t, func(req *http.Request, body []byte) error {
 		assert.Equal("Azure", req.Header.Get("DD-Cloud-Provider"))
-		assert.Equal("Azure App Service", req.Header.Get("DD-Cloud-Resource-Type"))
+		assert.Equal("AzureAppService", req.Header.Get("DD-Cloud-Resource-Type"))
 		assert.Equal("test_app", req.Header.Get("DD-Cloud-Resource-Identifier"))
 		assert.Equal("/path", req.URL.Path)
 		assert.Equal("", req.Header.Get("User-Agent"))
@@ -152,7 +152,7 @@ func TestAzureContainerApp(t *testing.T) {
 
 	srv := assertingServer(t, func(req *http.Request, body []byte) error {
 		assert.Equal("Azure", req.Header.Get("DD-Cloud-Provider"))
-		assert.Equal("Azure Container App", req.Header.Get("DD-Cloud-Resource-Type"))
+		assert.Equal("AzureContainerApp", req.Header.Get("DD-Cloud-Resource-Type"))
 		assert.Equal("test_app", req.Header.Get("DD-Cloud-Resource-Identifier"))
 		assert.Equal("/path", req.URL.Path)
 		assert.Equal("", req.Header.Get("User-Agent"))
@@ -190,7 +190,7 @@ func TestAWSFargate(t *testing.T) {
 
 	srv := assertingServer(t, func(req *http.Request, body []byte) error {
 		assert.Equal("AWS", req.Header.Get("DD-Cloud-Provider"))
-		assert.Equal("AWS Fargate", req.Header.Get("DD-Cloud-Resource-Type"))
+		assert.Equal("AWSFargate", req.Header.Get("DD-Cloud-Resource-Type"))
 		assert.Equal("test_ARN", req.Header.Get("DD-Cloud-Resource-Identifier"))
 
 		endpointCalled.Inc()
@@ -222,7 +222,7 @@ func TestTelemetryProxyMultipleEndpoints(t *testing.T) {
 		assert.Equal("test_hostname", req.Header.Get("DD-Agent-Hostname"))
 		assert.Equal("test_env", req.Header.Get("DD-Agent-Env"))
 		assert.Equal("AWS", req.Header.Get("DD-Cloud-Provider"))
-		assert.Equal("AWS Lambda", req.Header.Get("DD-Cloud-Resource-Type"))
+		assert.Equal("AWSLambda", req.Header.Get("DD-Cloud-Resource-Type"))
 		assert.Equal("test_ARN", req.Header.Get("DD-Cloud-Resource-Identifier"))
 
 		endpointCalled.Add(2)
@@ -236,7 +236,7 @@ func TestTelemetryProxyMultipleEndpoints(t *testing.T) {
 		assert.Equal("test_hostname", req.Header.Get("DD-Agent-Hostname"))
 		assert.Equal("test_env", req.Header.Get("DD-Agent-Env"))
 		assert.Equal("AWS", req.Header.Get("DD-Cloud-Provider"))
-		assert.Equal("AWS Lambda", req.Header.Get("DD-Cloud-Resource-Type"))
+		assert.Equal("AWSLambda", req.Header.Get("DD-Cloud-Resource-Type"))
 		assert.Equal("test_ARN", req.Header.Get("DD-Cloud-Resource-Identifier"))
 
 		endpointCalled.Add(3)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This micro is a follow-on PR on the heels of https://github.com/DataDog/datadog-agent/pull/19507 . It removes spaces from the hardcoded strings that represent cloud resource types in telemetry messages:

- `AWS Lambda` becomes `AWSLambda`
- `AWS Fargate` becomes `AWSFargate`
- `GCP Cloud Run` becomes `GCPCloudRun`
- `Azure App Service` becomes `AzureAppService`
- `Azure Container App` becomes `AzureContainerApp`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

I figured this is a good idea while I was working on https://github.com/DataDog/instrumentation-telemetry-api-docs/pull/75 , the PR to document the new serverless headers. In theory, the HTTP spec allows spaces in header values and I've run end to end tests to make sure they are not a problem. But in practice, the code that sends these headers will need to be replicated in every language-specific APM tracer lib, and the spaces will be one more things those library developers will have to worry about handling correctly. So let's just rip them out, make the cloud resource types CamelCase, and save ourselves the extra trouble while there is still time left before the 7.49 freeze.

Jira: [Update the docs to specify serverless fields in agentless telemetry](https://datadoghq.atlassian.net/browse/AIT-8386)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Make sure the unit tests still pass.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
