### PR TITLE
Add more Windows service info to flare

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -295,6 +295,9 @@
 /pkg/dynamicinstrumentation/            @DataDog/debugger
 /pkg/epforwarder/                       @DataDog/agent-shared-components @DataDog/agent-metrics-logs
 /pkg/flare/                             @DataDog/agent-shared-components
+/pkg/flare/*_win.go                     @Datadog/windows-agent
+/pkg/flare/*_windows.go                 @Datadog/windows-agent
+/pkg/flare/*_windows_test.go            @Datadog/windows-agent
 /pkg/otlp/                              @DataDog/opentelemetry
 /pkg/otlp/*_serverless*.go              @DataDog/serverless
 /pkg/otlp/*_not_serverless*.go          @DataDog/opentelemetry

--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -206,7 +206,7 @@ func getServiceStatus(fb flaretypes.FlareBuilder) error {
 				return nil, err
 			}
 
-			dd_services := []ServiceInfo{}
+			ddServices := []ServiceInfo{}
 
 			for _, i := range list {
 				if strings.HasPrefix(i, "datadog") {
@@ -219,30 +219,30 @@ func getServiceStatus(fb flaretypes.FlareBuilder) error {
 						if err != nil {
 							log.Warnf("Error getting info for %v: %v", i, err)
 						}
-						dd_services = append(dd_services, conf2)
+						ddServices = append(ddServices, conf2)
 					}
 				}
 			}
 
 			//ddnpm, npm_err := manager.OpenService("ddnpm")
-			ddnpm, npm_err := winutil.OpenService(manager, "ddnpm", windows.GENERIC_READ)
-			if npm_err != nil {
-				log.Warnf("Error Opening Service ddnpm %v", npm_err)
+			ddnpm, npmErr := winutil.OpenService(manager, "ddnpm", windows.GENERIC_READ)
+			if npmErr != nil {
+				log.Warnf("Error Opening Service ddnpm %v", npmErr)
 			} else {
-				ddnpm_conf, err := GetServiceInfo(ddnpm)
+				ddnpmConf, err := GetServiceInfo(ddnpm)
 				if err != nil {
-					log.Warnf("Error getting info for ddnpm:", err)
+					log.Warnf("Error getting info for ddnpm: %v", err)
 				}
-				dd_services = append(dd_services, ddnpm_conf)
+				ddServices = append(ddServices, ddnpmConf)
 			}
 
-			dd_json, err3 := json.MarshalIndent(dd_services, "", "  ")
+			ddJson, err3 := json.MarshalIndent(ddServices, "", "  ")
 			if err3 != nil {
 				log.Warnf("Error Marshaling to JSON %v", err3)
 				return nil, err3
 			}
 
-			return dd_json, err
+			return ddJson, err
 		},
 	)
 	/*return fb.AddFileFromFunc(

--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -191,7 +191,7 @@ func getServiceStatus(fb flaretypes.FlareBuilder) error {
 			}
 			defer manager.Disconnect()
 
-			//Returns a string slice with all running services. Does not return Kernel services only SERVICE_WIN32
+			// Returns a string slice with all running services. Does not return Kernel services only SERVICE_WIN32
 			list, err := manager.ListServices()
 			if err != nil {
 				log.Warnf("Error getting list of running services %v", err)
@@ -215,7 +215,7 @@ func getServiceStatus(fb flaretypes.FlareBuilder) error {
 				}
 			}
 
-			//Getting ddnpm service info separately
+			// Getting ddnpm service info separately
 			ddnpm, err := winutil.OpenService(manager, "ddnpm", windows.GENERIC_READ)
 			if err != nil {
 				log.Warnf("Error Opening Service ddnpm %v", err)

--- a/pkg/flare/service_windows.go
+++ b/pkg/flare/service_windows.go
@@ -68,27 +68,27 @@ func GetFailureActions(s *mgr.Service) (ServiceFailureActions, error) {
 		err = fmt.Errorf("%v, ResetPeriod: %v", err, err1)
 	}
 
-	sfa.RebootMessage, err = s.RebootMessage()
+	sfa.RebootMessage, err1 = s.RebootMessage()
 	if err1 != nil {
 		err = fmt.Errorf("%v, RebootMessage: %v", err, err1)
 	}
 
-	sfa.RecoveryCommand, err = s.RecoveryCommand()
+	sfa.RecoveryCommand, err1 = s.RecoveryCommand()
 	if err1 != nil {
 		err = fmt.Errorf("%v, RecoveryCommand: %v", err, err1)
 	}
 
-	sfa.FailureActionsOnNonCrashFailures, err = s.RecoveryActionsOnNonCrashFailures()
+	sfa.FailureActionsOnNonCrashFailures, err1 = s.RecoveryActionsOnNonCrashFailures()
 	if err1 != nil {
 		err = fmt.Errorf("%v, FailureActionsOnNonCrashFailure: %v", err, err1)
 	}
 
-	recovery_action_slice, err1 := s.RecoveryActions()
+	recoveryActionSlice, err1 := s.RecoveryActions()
 	if err1 != nil {
 		err = fmt.Errorf("%v, RecoveryActions: %v", err, err1)
 	}
 
-	for _, act := range recovery_action_slice {
+	for _, act := range recoveryActionSlice {
 		rau := RecoveryActionsUpdated{
 			Type:  ActionTypeToString(act.Type),
 			Delay: act.Delay / time.Millisecond,
@@ -133,7 +133,7 @@ func StartTypeToString(startType uint32) string {
 	case windows.SERVICE_SYSTEM_START:
 		return "System"
 	default:
-		return "Unkown"
+		return "Unknown"
 	}
 }
 
@@ -215,11 +215,12 @@ func GetServiceInfo(s *mgr.Service) (ServiceInfo, error) {
 		err = fmt.Errorf("%v, GetFailureActions: %v", err, err1)
 	}
 
-	srvc_status, err1 := s.Query()
+	srvcStatus, err1 := s.Query()
 	if err1 != nil {
 		err = fmt.Errorf("%v, Query: %v", err, err1)
 	}
-	srvinfo.ServiceState = ServiceStatusToString(srvc_status.State)
+	srvinfo.ServiceState = ServiceStatusToString(srvcStatus.State)
+	srvinfo.ProcessId = srvcStatus.ProcessId
 
 	srvinfo.DependentServices, err1 = s.ListDependentServices(svc.AnyActivity)
 	if err1 != nil {

--- a/pkg/flare/service_windows.go
+++ b/pkg/flare/service_windows.go
@@ -1,0 +1,281 @@
+//go:build windows
+
+package flare
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+type ServiceInfo struct {
+	ServiceName string
+	ServiceState 	 string
+	ProcessId        uint32
+	Config QueryServiceConfig
+	DependentServices []string
+	TriggersCount    uint32
+	ServiceFailureActions ServiceFailureActions
+}
+
+type QueryServiceConfig struct {
+	ServiceType      string
+	StartType        string
+	ErrorControl     string
+	BinaryPathName   string // fully qualified path to the service binary file, can also include arguments for an auto-start service
+	LoadOrderGroup   string
+	TagId            uint32
+	Dependencies     []string
+	ServiceStartName string // name of the account under which the service should run
+	DisplayName      string
+	Password         string
+	Description      string
+	SidType          uint32 // one of SERVICE_SID_TYPE, the type of sid to use for the service
+	DelayedAutoStart bool   // the service is started after other auto-start services are started plus a short delay
+}
+
+type RecoveryActionsUpdated struct{
+	Type string
+	Delay time.Duration
+}
+
+type ServiceFailureActions struct{
+	ResetPeriod uint32
+	RebootMessage string
+	RecoveryCommand string
+	FailureActionsOnNonCrashFailures bool
+	RecoveryActions []RecoveryActionsUpdated
+}
+
+func GetFailureActions(s *mgr.Service) (ServiceFailureActions, error) {
+	sfa := ServiceFailureActions{}
+
+	var err error
+	var err1 error
+
+	sfa.ResetPeriod, err1 = s.ResetPeriod()
+	if err1 != nil{
+		err = fmt.Errorf("%v, ResetPeriod: %v", err, err1)
+	}
+
+	sfa.RebootMessage, err = s.RebootMessage()
+	if err1 != nil{
+		err = fmt.Errorf("%v, RebootMessage: %v", err, err1)
+	}
+
+	sfa.RecoveryCommand, err = s.RecoveryCommand()
+	if err1 != nil{
+		err = fmt.Errorf("%v, RecoveryCommand: %v", err, err1)
+	}
+
+	sfa.FailureActionsOnNonCrashFailures, err = s.RecoveryActionsOnNonCrashFailures()
+	if err1 != nil{
+		err = fmt.Errorf("%v, FailureActionsOnNonCrashFailure: %v", err, err1)
+	}
+ 
+	recovery_action_slice, err1 := s.RecoveryActions()
+	if err1 != nil{
+		err = fmt.Errorf("%v, RecoveryActions: %v", err, err1)
+	}
+	
+	for _, act := range recovery_action_slice{
+		rau := RecoveryActionsUpdated{
+			Type: ActionTypeToString(act.Type),
+			Delay: act.Delay / time.Millisecond,
+		}
+		sfa.RecoveryActions = append(sfa.RecoveryActions, rau)
+	}
+
+	return sfa, err
+}
+
+func ServiceTypeToString(serviceType uint32) string {
+	switch serviceType {
+	case windows.SERVICE_KERNEL_DRIVER:
+		return "KernelDriver"
+	case windows.SERVICE_FILE_SYSTEM_DRIVER:
+		return "FileSystemDriver"
+	case windows.SERVICE_ADAPTER:
+		return "Adapter"
+	case windows.SERVICE_RECOGNIZER_DRIVER:
+		return "RecognizerDriver"
+	case windows.SERVICE_WIN32_OWN_PROCESS:
+		return "Win32OwnProcess"
+	case windows.SERVICE_WIN32_SHARE_PROCESS:
+		return "Win32ShareProcess"
+	case windows.SERVICE_INTERACTIVE_PROCESS:
+		return "InteractiveProcess"
+	default:
+		return "Unknown"
+	}
+}
+
+func StartTypeToString(startType uint32) string {
+	switch startType {
+	case windows.SERVICE_AUTO_START:
+		return "Automatic"
+	case windows.SERVICE_BOOT_START:
+		return "Boot"
+	case windows.SERVICE_DISABLED:
+		return "Disabled"
+	case windows.SERVICE_DEMAND_START:
+		return "Manual"
+	case windows.SERVICE_SYSTEM_START:
+		return "System"
+	default:
+		return "Unkown"
+	}
+}
+
+func ErrorControlToString(errorCode uint32) string {
+	switch errorCode {
+	case windows.SERVICE_ERROR_IGNORE:
+		return "Error Ignore"
+	case windows.SERVICE_ERROR_NORMAL:
+		return "Error Normal"
+	case windows.SERVICE_ERROR_SEVERE:
+		return "Error Severe"
+	case windows.SERVICE_ERROR_CRITICAL:
+		return "Error Critical"
+	default:
+		return "Unknown"
+	}
+}
+
+func  ServiceStatusToString(svc_state svc.State) string {
+	switch svc_state {
+	case svc.Stopped:
+		return "Stopped"
+	case svc.StartPending:
+		return "Start Pending"
+	case svc.StopPending:
+		return "Stop Pending"
+	case svc.Running:
+		return "Running"
+	case svc.ContinuePending:
+		return "Continue Pending"
+	case svc.PausePending:
+		return "Pause Pending"
+	case svc.Paused:
+		return "Pause"
+	default: 
+		return "Unknown"
+	}
+}
+
+func ConvertConfigToQueryServiceConfig (config mgr.Config) QueryServiceConfig {
+	return QueryServiceConfig{
+		ServiceType:      ServiceTypeToString(config.ServiceType),
+		StartType:        StartTypeToString(config.StartType),
+		ErrorControl:     ErrorControlToString(config.ErrorControl),
+		BinaryPathName:   config.BinaryPathName,
+		LoadOrderGroup:   config.LoadOrderGroup,
+		TagId:            config.TagId,
+		Dependencies:     config.Dependencies,
+		ServiceStartName: config.ServiceStartName,
+		DisplayName:      config.DisplayName,
+		Password:         config.Password,
+		Description:      config.Description,
+		SidType:          config.SidType,
+		DelayedAutoStart: config.DelayedAutoStart,
+	}
+}
+
+
+func GetServiceInfo(s *mgr.Service) (ServiceInfo, error) {
+	
+	srvinfo := ServiceInfo{}
+	srvinfo.ServiceName = s.Name
+
+	var err error
+	var err1 error
+
+	conf, err1 := s.Config()
+	if err1 != nil{
+		err = fmt.Errorf("%v, Config: %v", err, err1)
+	}
+	srvinfo.Config = ConvertConfigToQueryServiceConfig(conf)
+
+	srvinfo.TriggersCount , err1 = ServiceTriggerCount(s)
+	if err1 != nil{
+		err = fmt.Errorf("%v, ServiceTriggerCount: %v", err, err1)
+	}
+
+	srvinfo.ServiceFailureActions, err1 = GetFailureActions(s)
+	if err1 != nil{
+		err = fmt.Errorf("%v, GetFailureActions: %v", err, err1)
+	}
+
+	srvc_status, err1 := s.Query()
+	if err1 != nil{
+		err = fmt.Errorf("%v, Query: %v", err, err1)
+	}
+	srvinfo.ServiceState = ServiceStatusToString(srvc_status.State)
+
+	srvinfo.DependentServices, err1 = s.ListDependentServices(svc.AnyActivity)
+	if err1 != nil{
+		err = fmt.Errorf("%v, ListDependentServices: %v", err, err1)
+	}
+
+	return srvinfo, err
+}
+
+func ActionTypeToString(i int) string {
+	switch i {
+	case windows.SC_ACTION_NONE:
+		return "No Action."
+	case windows.SC_ACTION_REBOOT:
+		return "Reboot the computer."
+	case windows.SC_ACTION_RESTART:
+		return "Restart the service."
+	case windows.SC_ACTION_RUN_COMMAND:
+		return "Run a command."
+	default:
+		return "Unknown"
+	}
+}
+
+func queryServiceConfig2Local(s *mgr.Service, infoLevel uint32) ([]byte, error) {
+	n := uint32(1024)
+	for {
+		b := make([]byte, n)
+		err := windows.QueryServiceConfig2(s.Handle, infoLevel, &b[0], n, &n)
+		if err == nil {
+			return b, nil
+		}
+		if err.(syscall.Errno) != syscall.ERROR_INSUFFICIENT_BUFFER {
+			return nil, err
+		}
+		if n <= uint32(len(b)) {
+			return nil, err
+		}
+	}
+}
+
+//Based off of https://cs.opensource.google/go/x/sys/+/refs/tags/v0.12.0:windows/service.go;l=213-228
+type ServiceTriggerInfo struct{
+	TriggersCount uint32
+	Triggers uintptr
+	Reserved *uint8
+}
+
+func ServiceTriggerCount(s *mgr.Service) (uint32, error) {
+	b, err := queryServiceConfig2Local(s, windows.SERVICE_CONFIG_TRIGGER_INFO)
+	if err != nil {
+		return 0, err
+	}
+	p := (*ServiceTriggerInfo)(unsafe.Pointer(&b[0]))
+	/*if p.TriggersCount == nil {
+		return nil, err
+	}*/
+
+	return p.TriggersCount, nil
+}

--- a/pkg/flare/service_windows.go
+++ b/pkg/flare/service_windows.go
@@ -324,5 +324,5 @@ func getDDServices(manager *mgr.Mgr) ([]serviceInfo, error) {
 		ddServices = append(ddServices, ddnpmConf)
 	}
 
-	return ddServices, err
+	return ddServices, nil
 }

--- a/pkg/flare/service_windows.go
+++ b/pkg/flare/service_windows.go
@@ -280,7 +280,6 @@ func serviceTriggerCount(s *mgr.Service) (uint32, error) {
 	if err != nil {
 		return 0, err
 	}
-	//p := (*ServiceTriggerInfo)(unsafe.Pointer(&b[0]))
 	p := (*serviceTriggerInfo)(unsafe.Pointer(unsafe.SliceData(b)))
 
 	return p.TriggersCount, nil

--- a/pkg/flare/service_windows_test.go
+++ b/pkg/flare/service_windows_test.go
@@ -19,8 +19,8 @@ import (
 
 func TestWindowsService(t *testing.T) {
 	manager, err := winutil.OpenSCManager(scManagerAccess)
-	if err != nil {
-		assert.Fail(t, "Error connecting to SC Manager: %v", err)
+	if !assert.NoError(t, err) {
+		assert.FailNow(t, "Error connecting to SC Manager: %v", err)
 	}
 	defer manager.Disconnect()
 

--- a/pkg/flare/service_windows_test.go
+++ b/pkg/flare/service_windows_test.go
@@ -38,7 +38,7 @@ func TestWindowsService(t *testing.T) {
 	assert.Contains(t, evtlogConf.Config.ServiceType, "Win32ShareProcess", "Expected EventLog to have service type Win32ShareProcess")
 
 	var zero uint32
-	assert.Equal(t, evtlogConf.TriggersCount, zero, "Expected EventLog to have trigger count 0")
+	assert.Equal(t, *evtlogConf.TriggersCount, zero, "Expected EventLog to have trigger count 0")
 
 	assert.NotNil(t, evtlogConf.ServiceFailureActions.RecoveryActions, "Expected EventLog to have Recovery Actions")
 	assert.NotContains(t, evtlogConf.ServiceState, "Unknown", "Expected EventLog to have a valid State")

--- a/pkg/flare/service_windows_test.go
+++ b/pkg/flare/service_windows_test.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+package flare
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
+)
+
+func TestWindowsService(t *testing.T) {
+	manager, err := winutil.OpenSCManager(SC_MANAGER_ACCESS)
+	if err != nil {
+		log.Warnf("Error connecting to service control manager %v", err)
+		manager.Disconnect()
+		return
+	}
+	defer manager.Disconnect()
+
+	evtlog, npm_err := winutil.OpenService(manager, "EventLog", windows.GENERIC_READ)
+	if npm_err != nil {
+		return
+	}
+	evtlogConf, err := GetServiceInfo(evtlog)
+	if err != nil {
+		return
+	}
+
+	assert.Contains(t, evtlogConf.ServiceName, "EventLog")
+
+	assert.Contains(t, evtlogConf.Config.ServiceType, "Win32ShareProcess")
+
+	var zero uint32 = 0
+	assert.Equal(t, evtlogConf.TriggersCount, zero)
+
+	assert.NotNil(t, evtlogConf.ServiceFailureActions.RecoveryActions)
+	assert.NotContains(t, evtlogConf.ServiceState, "Unknown")
+
+	if evtlogConf.ServiceState == "Running" {
+		assert.NotEqual(t, evtlogConf.ProcessId, 0)
+	}
+
+}

--- a/pkg/flare/service_windows_test.go
+++ b/pkg/flare/service_windows_test.go
@@ -25,12 +25,12 @@ func TestWindowsService(t *testing.T) {
 	defer manager.Disconnect()
 
 	evtlog, err := winutil.OpenService(manager, "EventLog", windows.GENERIC_READ)
-	if err != nil {
-		assert.Fail(t, "Error opening service EventLog: %v", err)
+	if !assert.NoError(t, err) {
+		assert.FailNow(t, "Error opening service EventLog: %v", err)
 	}
 	evtlogConf, err := getServiceInfo(evtlog)
-	if err != nil {
-		assert.Fail(t, "Error getting Service Info: %v", err)
+	if !assert.NoError(t, err) {
+		assert.FailNow(t, "Error getting Service Info: %v", err)
 	}
 
 	assert.Contains(t, evtlogConf.ServiceName, "EventLog", "Expected service name EventLog")

--- a/pkg/flare/service_windows_test.go
+++ b/pkg/flare/service_windows_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 //go:build windows
 
 package flare
@@ -9,40 +14,37 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 )
 
 func TestWindowsService(t *testing.T) {
-	manager, err := winutil.OpenSCManager(SC_MANAGER_ACCESS)
+	manager, err := winutil.OpenSCManager(scManagerAccess)
 	if err != nil {
-		log.Warnf("Error connecting to service control manager %v", err)
-		manager.Disconnect()
-		return
+		assert.Fail(t, "Error connecting to SC Manager: %v", err)
 	}
 	defer manager.Disconnect()
 
-	evtlog, npm_err := winutil.OpenService(manager, "EventLog", windows.GENERIC_READ)
-	if npm_err != nil {
-		return
-	}
-	evtlogConf, err := GetServiceInfo(evtlog)
+	evtlog, err := winutil.OpenService(manager, "EventLog", windows.GENERIC_READ)
 	if err != nil {
-		return
+		assert.Fail(t, "Error opening service EventLog: %v", err)
+	}
+	evtlogConf, err := getServiceInfo(evtlog)
+	if err != nil {
+		assert.Fail(t, "Error getting Service Info: %v", err)
 	}
 
-	assert.Contains(t, evtlogConf.ServiceName, "EventLog")
+	assert.Contains(t, evtlogConf.ServiceName, "EventLog", "Expected service name EventLog")
 
-	assert.Contains(t, evtlogConf.Config.ServiceType, "Win32ShareProcess")
+	assert.Contains(t, evtlogConf.Config.ServiceType, "Win32ShareProcess", "Expected EventLog to have service type Win32ShareProcess")
 
-	var zero uint32 = 0
-	assert.Equal(t, evtlogConf.TriggersCount, zero)
+	var zero uint32
+	assert.Equal(t, evtlogConf.TriggersCount, zero, "Expected EventLog to have trigger count 0")
 
-	assert.NotNil(t, evtlogConf.ServiceFailureActions.RecoveryActions)
-	assert.NotContains(t, evtlogConf.ServiceState, "Unknown")
+	assert.NotNil(t, evtlogConf.ServiceFailureActions.RecoveryActions, "Expected EventLog to have Recovery Actions")
+	assert.NotContains(t, evtlogConf.ServiceState, "Unknown", "Expected EventLog to have a valid State")
 
 	if evtlogConf.ServiceState == "Running" {
-		assert.NotEqual(t, evtlogConf.ProcessId, 0)
+		assert.NotEqual(t, evtlogConf.ProcessID, zero, "Expected Running EventLog to have a non-zero ProcessID")
 	}
 
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR changes the function `getServiceStatus` in `/pkg/flare/` to create a file named `servicestatus.json`  that includes details about the Datadog Agent services running in the host. 

The function now gets more details about the Agent services such as the PID, Trigger count ([MSDN](https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_trigger_info)), Service Failure Actions ([MSDN](https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_failure_actionsa)) and Config ([MSDN](https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-query_service_configa)). 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Jira: https://datadoghq.atlassian.net/browse/WINA-81 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Install the Agent and create a flare. Check the flare .zip file for `servicestatus.json`
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
