### PR TITLE
Allow longer delays in integration test.

### DIFF
--- a/comp/netflow/server/integration_test.go
+++ b/comp/netflow/server/integration_test.go
@@ -68,7 +68,7 @@ func TestNetFlow_IntegrationTest_NetFlow5(t *testing.T) {
 	err = testutil.SendUDPPacket(port, packetData)
 	require.NoError(t, err, "error sending udp packet")
 
-	netflowEvents, err := flowaggregator.WaitForFlowsToBeFlushed(srv.FlowAgg, 5*time.Second, 2)
+	netflowEvents, err := flowaggregator.WaitForFlowsToBeFlushed(srv.FlowAgg, 30*time.Second, 2)
 	assert.Equal(t, uint64(2), netflowEvents)
 	assert.NoError(t, err)
 }
@@ -94,7 +94,7 @@ func TestNetFlow_IntegrationTest_NetFlow9(t *testing.T) {
 	err = testutil.SendUDPPacket(port, packetData)
 	require.NoError(t, err, "error sending udp packet")
 
-	netflowEvents, err := flowaggregator.WaitForFlowsToBeFlushed(srv.FlowAgg, 5*time.Second, 6)
+	netflowEvents, err := flowaggregator.WaitForFlowsToBeFlushed(srv.FlowAgg, 30*time.Second, 6)
 	assert.Equal(t, uint64(29), netflowEvents)
 	assert.NoError(t, err)
 }
@@ -121,7 +121,7 @@ func TestNetFlow_IntegrationTest_SFlow5(t *testing.T) {
 	err = testutil.SendUDPPacket(port, data)
 	require.NoError(t, err, "error sending udp packet")
 
-	netflowEvents, err := flowaggregator.WaitForFlowsToBeFlushed(srv.FlowAgg, 5*time.Second, 6)
+	netflowEvents, err := flowaggregator.WaitForFlowsToBeFlushed(srv.FlowAgg, 30*time.Second, 6)
 	assert.Equal(t, uint64(7), netflowEvents)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
### What does this PR do?

Raise the timeout on a flaky test to make it not flaky.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
