### PR TITLE
[CWS] fallback to kprobes when fentry are not available

### DIFF
--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -303,6 +303,7 @@ func (k *Version) HaveLegacyPipeInodeInfoStruct() bool {
 	return k.Code != 0 && k.Code < Kernel5_5
 }
 
+// HaveFentrySupport returns whether the kernel supports fentry probes
 func (k *Version) HaveFentrySupport() bool {
 	if features.HaveProgramType(ebpf.Tracing) != nil {
 		return false

--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -17,7 +17,9 @@ import (
 
 	"github.com/acobaugh/osrelease"
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/features"
+	"github.com/cilium/ebpf/link"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
@@ -299,4 +301,37 @@ func (k *Version) HavePIDLinkStruct() bool {
 // HaveLegacyPipeInodeInfoStruct returns whether the kernel uses the legacy pipe_inode_info struct
 func (k *Version) HaveLegacyPipeInodeInfoStruct() bool {
 	return k.Code != 0 && k.Code < Kernel5_5
+}
+
+func (k *Version) HaveFentrySupport() bool {
+	if features.HaveProgramType(ebpf.Tracing) != nil {
+		return false
+	}
+
+	spec := &ebpf.ProgramSpec{
+		Type:       ebpf.Tracing,
+		AttachType: ebpf.AttachTraceFEntry,
+		AttachTo:   "bpf_init",
+		Instructions: asm.Instructions{
+			asm.LoadImm(asm.R0, 0, asm.DWord),
+			asm.Return(),
+		},
+	}
+	prog, err := ebpf.NewProgramWithOptions(spec, ebpf.ProgramOptions{
+		LogDisabled: true,
+	})
+	if err != nil {
+		return false
+	}
+	defer prog.Close()
+
+	link, err := link.AttachTracing(link.TracingOptions{
+		Program: prog,
+	})
+	if err != nil {
+		return false
+	}
+	defer link.Close()
+
+	return true
 }

--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -312,7 +312,7 @@ func (k *Version) HaveFentrySupport() bool {
 	spec := &ebpf.ProgramSpec{
 		Type:       ebpf.Tracing,
 		AttachType: ebpf.AttachTraceFEntry,
-		AttachTo:   "bpf_init",
+		AttachTo:   "vfs_open",
 		Instructions: asm.Instructions{
 			asm.LoadImm(asm.R0, 0, asm.DWord),
 			asm.Return(),

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -1424,7 +1424,6 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 			Erpc:               nerpc,
 			erpcRequest:        &erpc.Request{},
 			isRuntimeDiscarded: !opts.DontDiscardRuntime,
-			useFentry:          config.Probe.EventStreamUseFentry,
 		},
 	}
 
@@ -1445,8 +1444,8 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 		seclog.Warnf("the current environment may be misconfigured: %v", err)
 	}
 
+	p.useFentry = config.Probe.EventStreamUseFentry && p.kernelVersion.HaveFentrySupport()
 	useRingBuffers := p.UseRingBuffers()
-	p.UseFentry()
 	useMmapableMaps := p.kernelVersion.HaveMmapableMaps()
 
 	p.Manager = ebpf.NewRuntimeSecurityManager(useRingBuffers, p.useFentry)

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -19,8 +19,6 @@ import (
 	"sync"
 	"time"
 
-	cebpf "github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/features"
 	"github.com/hashicorp/go-multierror"
 	"github.com/mailru/easyjson"
 	"github.com/moby/sys/mountinfo"
@@ -140,7 +138,7 @@ func (p *Probe) UseRingBuffers() bool {
 }
 
 func (p *Probe) UseFentry() {
-	fmt.Printf("fentry supported: %v\n", features.HaveProgramType(cebpf.Tracing))
+	fmt.Printf("fentry supported: %v\n", p.kernelVersion.HaveFentrySupport())
 }
 
 func (p *Probe) sanityChecks() error {

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 	"time"
 
+	cebpf "github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/features"
 	"github.com/hashicorp/go-multierror"
 	"github.com/mailru/easyjson"
 	"github.com/moby/sys/mountinfo"
@@ -135,6 +137,10 @@ func (p *Probe) GetKernelVersion() (*kernel.Version, error) {
 // UseRingBuffers returns true if eBPF ring buffers are supported and used
 func (p *Probe) UseRingBuffers() bool {
 	return p.kernelVersion.HaveRingBuffers() && p.Config.Probe.EventStreamUseRingBuffer
+}
+
+func (p *Probe) UseFentry() {
+	fmt.Printf("fentry supported: %v\n", features.HaveProgramType(cebpf.Tracing))
 }
 
 func (p *Probe) sanityChecks() error {
@@ -1442,6 +1448,7 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 	}
 
 	useRingBuffers := p.UseRingBuffers()
+	p.UseFentry()
 	useMmapableMaps := p.kernelVersion.HaveMmapableMaps()
 
 	p.Manager = ebpf.NewRuntimeSecurityManager(useRingBuffers, p.useFentry)

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -145,7 +145,7 @@ func (p *Probe) selectFentryMode() {
 
 	supported := p.kernelVersion.HaveFentrySupport()
 	if !supported {
-		seclog.Warnf("fentry enabled but not supported, falling back to kprobe mode")
+		seclog.Errorf("fentry enabled but not supported, falling back to kprobe mode")
 	}
 	p.useFentry = supported
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds some feature detection to check if fentry probes are supported, and fallback on kprobe if they are not.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
