### PR TITLE
[CSPM] Add low priority scheduling of benchmarks

### DIFF
--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -510,7 +510,7 @@ func sleepRandomJitter(ctx context.Context, runInterval time.Duration, runCount 
 		jitterMax = defaultJitterMax
 	}
 
-	var runCountBuf [4]byte
+	var runCountBuf [8]byte
 	binary.LittleEndian.PutUint64(runCountBuf[:], runCount)
 
 	h := fnv.New64a()

--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -10,10 +10,12 @@ package compliance
 
 import (
 	"context"
+	"encoding/binary"
 	"expvar"
 	"fmt"
 	"hash/fnv"
 	"math/rand"
+	"strconv"
 	"sync"
 	"time"
 
@@ -33,6 +35,22 @@ const containersCountMetricName = "datadog.security_agent.compliance.containers_
 
 var status = expvar.NewMap("compliance")
 
+const (
+	// defaultEvalThrottling is the time that space out rule evaluation to avoid CPU
+	// spikes.
+	defaultEvalThrottling = 2 * time.Second
+
+	// defaultCheckInterval defines the default value used as interval for
+	// executing benchmarks.
+	defaultCheckInterval = 20 * time.Minute
+
+	// defaultCheckInterval defines the default value used as interval for
+	// executing benchmarks with a low priority: usually because of the
+	// compute overhead of executing such benchmarks, or the nature of
+	// configurations which tend to be constant.
+	defaultCheckIntervalLowPriority = 3 * time.Hour
+)
+
 // AgentOptions holds the different options to configure the compliance agent.
 type AgentOptions struct {
 	// ResolverOptions is the options passed to the constructed resolvers
@@ -51,19 +69,14 @@ type AgentOptions struct {
 	// applied on all loaded benchmarks.
 	RuleFilter RuleFilter
 
-	// CheckInterval is the period at which benchmarks are being run. It should
-	// also be roughly (see RunJitterMax) the interval at which rule checks
-	// are being run. By default: 20 minutes.
+	// CheckInterval is the period at which benchmarks are being run. It
+	// should also be roughly the interval at which rule checks are being run.
+	// By default: 20 minutes.
 	CheckInterval time.Duration
 
-	// RunJitterMax is the maximum duration of the jitter that randomizes the
-	// benchmarks evaluations. If less than 0, the jitter is null. By default
-	// is is one tenth of the specified CheckInterval.
-	RunJitterMax time.Duration
-
-	// EvalThrottling is the time that space out rule evaluation to avoid CPU
-	// spikes.
-	EvalThrottling time.Duration
+	// CheckIntervalLowPriority is like CheckInterval but for low-priority
+	// benchmarks.
+	CheckIntervalLowPriority time.Duration
 }
 
 // Agent is the compliance agent that is responsible for running compliance
@@ -128,16 +141,11 @@ func NewAgent(senderManager sender.SenderManager, opts AgentOptions) *Agent {
 	if opts.Reporter.Endpoints() == nil {
 		panic("compliance: missing agent endpoints")
 	}
-	if opts.CheckInterval == 0 {
-		opts.CheckInterval = 20 * time.Minute
+	if opts.CheckInterval <= 0 {
+		opts.CheckInterval = defaultCheckInterval
 	}
-	if opts.RunJitterMax == 0 {
-		opts.RunJitterMax = opts.CheckInterval / 10
-	} else if opts.RunJitterMax < 0 {
-		opts.RunJitterMax = 0
-	}
-	if opts.EvalThrottling == 0 {
-		opts.EvalThrottling = 2 * time.Second
+	if opts.CheckIntervalLowPriority <= 0 {
+		opts.CheckIntervalLowPriority = defaultCheckIntervalLowPriority
 	}
 	if ruleFilter := opts.RuleFilter; ruleFilter != nil {
 		opts.RuleFilter = func(r *Rule) bool { return DefaultRuleFilter(r) && ruleFilter(r) }
@@ -238,16 +246,16 @@ func (a *Agent) runRegoBenchmarks(ctx context.Context) {
 	}
 	a.addBenchmarks(benchmarks...)
 
-	runTicker := time.NewTicker(a.opts.CheckInterval)
-	throttler := time.NewTicker(a.opts.EvalThrottling)
+	checkInterval := a.opts.CheckInterval
+	runTicker := time.NewTicker(checkInterval)
+	throttler := time.NewTicker(defaultEvalThrottling)
 	defer runTicker.Stop()
 	defer throttler.Stop()
 
-	log.Debugf("will be executing %d rego benchmarks every %s", len(benchmarks), a.opts.CheckInterval)
-	for {
-		for i, benchmark := range benchmarks {
-			seed := fmt.Sprintf("%s%s%d", a.opts.Hostname, benchmark.FrameworkID, i)
-			if sleepAborted(ctx, time.After(randomJitter(seed, a.opts.RunJitterMax))) {
+	log.Debugf("will be executing %d rego benchmarks every %s", len(benchmarks), checkInterval)
+	for runCount := uint64(0); ; runCount++ {
+		for _, benchmark := range benchmarks {
+			if sleepRandomJitter(ctx, checkInterval, runCount, a.opts.Hostname, benchmark.FrameworkID) {
 				return
 			}
 
@@ -291,16 +299,16 @@ func (a *Agent) runXCCDFBenchmarks(ctx context.Context) {
 	}
 	a.addBenchmarks(benchmarks...)
 
-	runTicker := time.NewTicker(a.opts.CheckInterval)
-	throttler := time.NewTicker(a.opts.EvalThrottling)
+	checkInterval := a.opts.CheckIntervalLowPriority
+	runTicker := time.NewTicker(checkInterval)
+	throttler := time.NewTicker(defaultEvalThrottling)
 	defer runTicker.Stop()
 	defer throttler.Stop()
 
-	log.Debugf("will be executing %d XCCDF benchmarks every %s", len(benchmarks), a.opts.CheckInterval)
-	for {
-		for i, benchmark := range benchmarks {
-			seed := fmt.Sprintf("%s%s%d", a.opts.Hostname, benchmark.FrameworkID, i)
-			if sleepAborted(ctx, time.After(randomJitter(seed, a.opts.RunJitterMax))) {
+	log.Debugf("will be executing %d XCCDF benchmarks every %s", len(benchmarks), checkInterval)
+	for runCount := uint64(0); ; runCount++ {
+		for _, benchmark := range benchmarks {
+			if sleepRandomJitter(ctx, checkInterval, runCount, a.opts.Hostname, benchmark.FrameworkID) {
 				FinishXCCDFBenchmark(ctx, benchmark)
 				return
 			}
@@ -325,13 +333,12 @@ func (a *Agent) runKubernetesConfigurationsExport(ctx context.Context) {
 		return
 	}
 
-	runTicker := time.NewTicker(a.opts.CheckInterval)
+	checkInterval := a.opts.CheckIntervalLowPriority
+	runTicker := time.NewTicker(checkInterval)
 	defer runTicker.Stop()
 
-	for i := 0; ; i++ {
-		seed := fmt.Sprintf("%s%s%d", a.opts.Hostname, "kubernetes-configuration", i)
-		jitter := randomJitter(seed, a.opts.RunJitterMax)
-		if sleepAborted(ctx, time.After(jitter)) {
+	for runCount := uint64(0); ; runCount++ {
+		if sleepRandomJitter(ctx, checkInterval, runCount, a.opts.Hostname, "kubernetes-configuration") {
 			return
 		}
 		k8sResourceType, k8sResourceData := k8sconfig.LoadConfiguration(ctx, a.opts.HostRoot)
@@ -353,13 +360,12 @@ func (a *Agent) runAptConfigurationExport(ctx context.Context) {
 		return
 	}
 
-	runTicker := time.NewTicker(a.opts.CheckInterval)
+	checkInterval := a.opts.CheckIntervalLowPriority
+	runTicker := time.NewTicker(checkInterval)
 	defer runTicker.Stop()
 
-	for i := 0; ; i++ {
-		seed := fmt.Sprintf("%s%s%d", a.opts.Hostname, "apt-configuration", i)
-		jitter := randomJitter(seed, a.opts.RunJitterMax)
-		if sleepAborted(ctx, time.After(jitter)) {
+	for runCount := uint64(0); ; runCount++ {
+		if sleepRandomJitter(ctx, checkInterval, runCount, a.opts.Hostname, "apt-configuration") {
 			return
 		}
 		aptResourceType, aptResourceData := aptconfig.LoadConfiguration(ctx, a.opts.HostRoot)
@@ -475,13 +481,42 @@ func sleepAborted(ctx context.Context, ch <-chan time.Time) bool {
 	}
 }
 
-func randomJitter(seed string, maxDuration time.Duration) time.Duration {
-	if maxDuration == 0 {
-		return 0
+// sleepRandomJitter returns a jitter duration adapted to space out randomly
+// our benchmark runs given the current run count and the run interval. The
+// random timing is generated with a seeded RNG using the list of optional
+// seeding strings and the runCount value.
+func sleepRandomJitter(ctx context.Context, runInterval time.Duration, runCount uint64, seeds ...string) bool {
+	// guardrail in case runInterval is set to a negative or null value.
+	if runInterval <= 0 {
+		select {
+		case <-ctx.Done():
+			return true
+		default:
+			return false
+		}
 	}
+
+	// If we are jittering the first run, we hardcode a reasonably small
+	// amount of time to make sure we init the checks quickly for short-lived
+	// hosts. Otherwise we use the tenth of the run interval.
+	const defaultJitterMax = 20 * time.Minute
+
+	jitterMax := runInterval / 10
+	if runCount == 0 && jitterMax > defaultJitterMax {
+		jitterMax = defaultJitterMax
+	}
+
+	var runCountBuf [4]byte
+	binary.LittleEndian.PutUint64(runCountBuf[:], runCount)
+
 	h := fnv.New64a()
-	h.Write([]byte(seed))
+	h.Write(runCountBuf[:])
+	for _, seed := range seeds {
+		h.Write([]byte(seed))
+	}
+
 	r := rand.New(rand.NewSource(int64(h.Sum64())))
-	d := r.Int63n(maxDuration.Milliseconds())
-	return time.Duration(d) * time.Millisecond
+	d := r.Int63n(jitterMax.Milliseconds())
+	sleep := time.Duration(d) * time.Millisecond
+	return sleepAborted(ctx, time.After(sleep))
 }

--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -375,7 +375,8 @@ func (a *Agent) runAptConfigurationExport(ctx context.Context) {
 }
 
 func (a *Agent) reportResourceLog(resourceTTL time.Duration, resourceLog *ResourceLog) {
-	resourceLog.ExpireAt = time.Now().Add(2 * resourceTTL).Truncate(1 * time.Second)
+	expireAt := time.Now().Add(2 * resourceTTL).Truncate(1 * time.Second)
+	resourceLog.ExpireAt = &expireAt
 	a.opts.Reporter.ReportEvent(resourceLog)
 }
 
@@ -383,7 +384,7 @@ func (a *Agent) reportCheckEvents(eventsTTL time.Duration, events ...*CheckEvent
 	store := workloadmeta.GetGlobalStore()
 	eventsExpireAt := time.Now().Add(2 * eventsTTL).Truncate(1 * time.Second)
 	for _, event := range events {
-		event.ExpireAt = eventsExpireAt
+		event.ExpireAt = &eventsExpireAt
 		a.updateEvent(event)
 		if event.Result == CheckSkipped {
 			continue

--- a/pkg/compliance/data.go
+++ b/pkg/compliance/data.go
@@ -76,7 +76,7 @@ type CheckEvent struct {
 	RuleVersion  int                    `json:"agent_rule_version,omitempty"`
 	FrameworkID  string                 `json:"agent_framework_id,omitempty"`
 	Evaluator    Evaluator              `json:"evaluator,omitempty"`
-	ExpireAt     time.Time              `json:"expire_at,omitempty"`
+	ExpireAt     *time.Time             `json:"expire_at,omitempty"`
 	Result       CheckResult            `json:"result,omitempty"`
 	ResourceType string                 `json:"resource_type,omitempty"`
 	ResourceID   string                 `json:"resource_id,omitempty"`
@@ -90,7 +90,7 @@ type CheckEvent struct {
 // ResourceLog is the data structure holding a resource configuration data.
 type ResourceLog struct {
 	AgentVersion string      `json:"agent_version,omitempty"`
-	ExpireAt     time.Time   `json:"expire_at,omitempty"`
+	ExpireAt     *time.Time  `json:"expire_at,omitempty"`
 	ResourceType string      `json:"resource_type,omitempty"`
 	ResourceID   string      `json:"resource_id,omitempty"`
 	ResourceData interface{} `json:"resource_data,omitempty"`

--- a/pkg/compliance/data.go
+++ b/pkg/compliance/data.go
@@ -120,14 +120,12 @@ func NewCheckError(
 	rule *Rule,
 	benchmark *Benchmark,
 ) *CheckEvent {
-	expireAt := time.Now().Add(1 * time.Hour).UTC().Truncate(1 * time.Second)
 	return &CheckEvent{
 		AgentVersion: version.AgentVersion,
 		RuleID:       rule.ID,
 		FrameworkID:  benchmark.FrameworkID,
 		ResourceID:   resourceID,
 		ResourceType: resourceType,
-		ExpireAt:     expireAt,
 		Evaluator:    evaluator,
 		Result:       CheckError,
 		Data:         map[string]interface{}{"error": errReason.Error()},
@@ -146,14 +144,12 @@ func NewCheckEvent(
 	rule *Rule,
 	benchmark *Benchmark,
 ) *CheckEvent {
-	expireAt := time.Now().Add(1 * time.Hour).UTC().Truncate(1 * time.Second)
 	return &CheckEvent{
 		AgentVersion: version.AgentVersion,
 		RuleID:       rule.ID,
 		FrameworkID:  benchmark.FrameworkID,
 		ResourceID:   resourceID,
 		ResourceType: resourceType,
-		ExpireAt:     expireAt,
 		Evaluator:    evaluator,
 		Result:       result,
 		Data:         data,
@@ -169,12 +165,10 @@ func NewCheckSkipped(
 	rule *Rule,
 	benchmark *Benchmark,
 ) *CheckEvent {
-	expireAt := time.Now().Add(1 * time.Hour).UTC().Truncate(1 * time.Second)
 	return &CheckEvent{
 		AgentVersion: version.AgentVersion,
 		RuleID:       rule.ID,
 		FrameworkID:  benchmark.FrameworkID,
-		ExpireAt:     expireAt,
 		Evaluator:    evaluator,
 		Result:       CheckSkipped,
 		Data:         map[string]interface{}{"error": skipReason.Error()},
@@ -183,10 +177,8 @@ func NewCheckSkipped(
 
 // NewResourceLog returns a ResourceLog.
 func NewResourceLog(resourceID, resourceType string, resource interface{}) *ResourceLog {
-	expireAt := time.Now().Add(1 * time.Hour).UTC().Truncate(1 * time.Second)
 	return &ResourceLog{
 		AgentVersion: version.AgentVersion,
-		ExpireAt:     expireAt,
 		ResourceType: resourceType,
 		ResourceID:   resourceID,
 		ResourceData: resource,


### PR DESCRIPTION
### What does this PR do?

Adding a new scheduling interval for benchmarks that has a bigger default value and shall be used to schedule benchmarks for which we want to lower the impact on the resource usage of the machine.

By introducing this new timings, I had to rework the jittering that space out randomly the benchmarks runs. Specifically to handle the first run of our benchmark which is always required to run in a relatively short time to handle short-lived hosts.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Review host benchmarks events and make sure they respect the low-priority scheduling. Also check for their `expire_at` fields.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
