### PR TITLE
[clusterchecks/dispatcher_configs] Simplify shouldDispatchDangling func and fix typo in name

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_configs.go
@@ -119,9 +119,9 @@ func (d *dispatcher) removeConfig(digest string) {
 	}
 }
 
-// shouldDispatchDanling returns true if there are dangling configs
+// shouldDispatchDangling returns true if there are dangling configs
 // and node registered, available for dispatching.
-func (d *dispatcher) shouldDispatchDanling() bool {
+func (d *dispatcher) shouldDispatchDangling() bool {
 	d.store.RLock()
 	defer d.store.RUnlock()
 

--- a/pkg/clusteragent/clusterchecks/dispatcher_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_configs.go
@@ -125,13 +125,7 @@ func (d *dispatcher) shouldDispatchDanling() bool {
 	d.store.RLock()
 	defer d.store.RUnlock()
 
-	if len(d.store.danglingConfigs) == 0 {
-		return false
-	}
-	if len(d.store.nodes) == 0 {
-		return false
-	}
-	return true
+	return len(d.store.danglingConfigs) > 0 && len(d.store.nodes) > 0
 }
 
 // retrieveAndClearDangling extracts dangling configs from the store

--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -199,7 +199,7 @@ func (d *dispatcher) run(ctx context.Context) {
 			d.expireNodes()
 
 			// Re-dispatch dangling configs
-			if d.shouldDispatchDanling() {
+			if d.shouldDispatchDangling() {
 				danglingConfs := d.retrieveAndClearDangling()
 				d.reschedule(danglingConfs)
 			}

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -321,7 +321,7 @@ func TestRescheduleDanglingFromExpiredNodes(t *testing.T) {
 	dispatcher.processNodeStatus("nodeB", "10.0.0.2", types.NodeStatus{})
 
 	// Ensure we have 1 dangling to schedule, as new available node is registered
-	assert.True(t, dispatcher.shouldDispatchDanling())
+	assert.True(t, dispatcher.shouldDispatchDangling())
 	configs := dispatcher.retrieveAndClearDangling()
 	// Assert the check is scheduled
 	dispatcher.reschedule(configs)
@@ -380,19 +380,19 @@ func TestDanglingConfig(t *testing.T) {
 		ClusterCheck: true,
 	}
 
-	assert.False(t, dispatcher.shouldDispatchDanling())
+	assert.False(t, dispatcher.shouldDispatchDangling())
 
 	// No node is available, config will be dispatched to the dummy "" node
 	dispatcher.Schedule([]integration.Config{config})
 	assert.Equal(t, 0, len(dispatcher.store.digestToNode))
 	assert.Equal(t, 1, len(dispatcher.store.danglingConfigs))
 
-	// shouldDispatchDanling is still false because no node is available
-	assert.False(t, dispatcher.shouldDispatchDanling())
+	// shouldDispatchDangling is still false because no node is available
+	assert.False(t, dispatcher.shouldDispatchDangling())
 
-	// register a node, shouldDispatchDanling will become true
+	// register a node, shouldDispatchDangling will become true
 	dispatcher.processNodeStatus("nodeA", "10.0.0.1", types.NodeStatus{})
-	assert.True(t, dispatcher.shouldDispatchDanling())
+	assert.True(t, dispatcher.shouldDispatchDangling())
 
 	// get the danglings and make sure they are removed from the store
 	configs := dispatcher.retrieveAndClearDangling()
@@ -414,7 +414,7 @@ func TestUnscheduleDanglingConfig(t *testing.T) {
 	}
 
 	// False because because no node is available
-	assert.False(t, testDispatcher.shouldDispatchDanling())
+	assert.False(t, testDispatcher.shouldDispatchDangling())
 
 	// No nodes created, so it will not get assigned
 	testDispatcher.Schedule([]integration.Config{testConfig})


### PR DESCRIPTION

### What does this PR do?

Small cleanup opportunity that I saw while working on related code.


### Describe how to test/QA your changes

Skip

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
