### PR TITLE
[CWS] make sure to get the mount id before setting the path id

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/mmap.h
+++ b/pkg/security/ebpf/c/include/hooks/mmap.h
@@ -81,8 +81,8 @@ int rethook_fget(ctx_t *ctx) {
 
     struct file *f = (struct file*) CTX_PARMRET(ctx, 1);
     syscall->mmap.dentry = get_file_dentry(f);
-    set_file_inode(syscall->mmap.dentry, &syscall->mmap.file, 0);
     syscall->mmap.file.path_key.mount_id = get_file_mount_id(f);
+    set_file_inode(syscall->mmap.dentry, &syscall->mmap.file, 0);
 
     syscall->resolver.key = syscall->mmap.file.path_key;
     syscall->resolver.dentry = syscall->mmap.dentry;

--- a/pkg/security/ebpf/c/include/hooks/module.h
+++ b/pkg/security/ebpf/c/include/hooks/module.h
@@ -42,8 +42,8 @@ int __attribute__((always_inline)) trace_kernel_file(ctx_t *ctx, struct file *f,
     }
 
     syscall->init_module.dentry = get_file_dentry(f);
-    set_file_inode(syscall->init_module.dentry, &syscall->init_module.file, 0);
     syscall->init_module.file.path_key.mount_id = get_file_mount_id(f);
+    set_file_inode(syscall->init_module.dentry, &syscall->init_module.file, 0);
 
     syscall->resolver.key = syscall->init_module.file.path_key;
     syscall->resolver.dentry = syscall->init_module.dentry;

--- a/pkg/security/ebpf/c/include/hooks/splice.h
+++ b/pkg/security/ebpf/c/include/hooks/splice.h
@@ -33,8 +33,8 @@ int hook_get_pipe_info(ctx_t *ctx) {
     if (!syscall->splice.file_found) {
         struct file *f = (struct file*) CTX_PARM1(ctx);
         syscall->splice.dentry = get_file_dentry(f);
-        set_file_inode(syscall->splice.dentry, &syscall->splice.file, 0);
         syscall->splice.file.path_key.mount_id = get_file_mount_id(f);
+        set_file_inode(syscall->splice.dentry, &syscall->splice.file, 0);
     }
 
     return 0;


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This potentially fixes incorrect path resolutions for `load_module`, `mmap` and `splice` event types, as path invalidation was not taken into account before that.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
