### PR TITLE
[clusterchecks/dispatcher_configs] Fix dangling configs gauge

### DIFF
--- a/pkg/clusteragent/clusterchecks/dispatcher_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_configs.go
@@ -106,16 +106,19 @@ func (d *dispatcher) removeConfig(digest string) {
 		}
 	}
 
-	// Remove from node configs if assigned
-	if found {
-		node.Lock()
-		nodeName := node.name
-		node.removeConfig(digest)
-		node.Unlock()
+	if !found { // Dangling config. Not assigned to any node.
+		danglingConfigs.Dec(le.JoinLeaderValue)
+		return
+	}
 
-		for _, checkID := range checkIDsToRemove {
-			configsInfo.Delete(nodeName, checkName, string(checkID), le.JoinLeaderValue)
-		}
+	// Remove from node configs if assigned
+	node.Lock()
+	nodeName := node.name
+	node.removeConfig(digest)
+	node.Unlock()
+
+	for _, checkID := range checkIDsToRemove {
+		configsInfo.Delete(nodeName, checkName, string(checkID), le.JoinLeaderValue)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes the `cluster_checks_configs_dangling` metric emitted by the Cluster Agent. It's not decreased when a dangling config is deleted.

This is related with a panic that was fixed recently (https://github.com/DataDog/datadog-agent/pull/19809). The panic was hiding that the related metric was not updated.


### Describe how to test/QA your changes

Same as https://github.com/DataDog/datadog-agent/pull/19809 but check that the `cluster_checks_configs_dangling` shows the right number when there are some dangling configs and 0 when there are none.
You can check the metrics in the Cluster Agent (`http://localhost:5000/metrics`).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
