### PR TITLE
Add eventlog config to the flare

### DIFF
--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -294,7 +294,8 @@ func getEventLogConfig(fb flaretypes.FlareBuilder) error {
 	defer cancelfunc()
 
 	var out bytes.Buffer
-	f := &bytes.Buffer{}
+	// creating a buffer to append all cmd outputs
+	fullOutput := &bytes.Buffer{}
 	channels := [3]string{"Application", "System", "Security"}
 
 	for _, channel := range channels {
@@ -304,11 +305,13 @@ func getEventLogConfig(fb flaretypes.FlareBuilder) error {
 		if err != nil {
 			log.Warnf("Error getting config for %s: %s", channel, err)
 		}
-		_, err = f.Write(out.Bytes())
+		_, err = fullOutput.Write(out.Bytes())
 		if err != nil {
 			log.Warnf("Error writing file %v", err)
 		}
-		_, err = f.Write([]byte("\n"))
+
+		// adding a newline character to make the file easier to read
+		_, err = fullOutput.Write([]byte("\n"))
 		if err != nil {
 			log.Warnf("Error writing file %v", err)
 		}
@@ -316,7 +319,7 @@ func getEventLogConfig(fb flaretypes.FlareBuilder) error {
 		out.Reset()
 	}
 
-	return fb.AddFile("eventlogconfig.txt", f.Bytes())
+	return fb.AddFile("eventlogconfig.txt", fullOutput.Bytes())
 
 }
 

--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -303,17 +303,20 @@ func getEventLogConfig(fb flaretypes.FlareBuilder) error {
 		cmd.Stdout = &out
 		err := cmd.Run()
 		if err != nil {
-			log.Warnf("Error getting config for %s: %s", channel, err)
+			log.Warnf("Error getting config for %s: %v", channel, err)
+			return err
 		}
 		_, err = fullOutput.Write(out.Bytes())
 		if err != nil {
 			log.Warnf("Error writing file %v", err)
+			return err
 		}
 
 		// adding a newline character to make the file easier to read
 		_, err = fullOutput.Write([]byte("\n"))
 		if err != nil {
 			log.Warnf("Error writing file %v", err)
+			return err
 		}
 
 		out.Reset()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Added a function `getEventLogConfig` that gets the event log configuration for the Application, System, and Security channels. This creates a file called `eventlogconfig.txt` in the flare.

This function runs the command `wevtutil gl <CHANNEL>` ([MSDN](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/wevtutil)) and collects its output.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Jira: https://datadoghq.atlassian.net/browse/WINA-84
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Install the Agent and create a flare. Check the flare .zip file for `eventlogconfig.txt`
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
