### PR TITLE
CloudWatchEvent resources can potentially be empty

### DIFF
--- a/pkg/serverless/trigger/extractor.go
+++ b/pkg/serverless/trigger/extractor.go
@@ -50,6 +50,9 @@ func ExtractAlbEventARN(event events.ALBTargetGroupRequest) string {
 
 // ExtractCloudwatchEventARN returns an ARN from a CloudWatchEvent
 func ExtractCloudwatchEventARN(event events.CloudWatchEvent) string {
+	if len(event.Resources) == 0 {
+		return ""
+	}
 	return event.Resources[0]
 }
 

--- a/pkg/serverless/trigger/extractor_test.go
+++ b/pkg/serverless/trigger/extractor_test.go
@@ -83,6 +83,13 @@ func TestExtractCloudwatchEventARN(t *testing.T) {
 
 	arn := ExtractCloudwatchEventARN(event)
 	assert.Equal(t, "test-arn", arn)
+
+	eventEmptyResources := events.CloudWatchEvent{
+		Resources: []string{},
+	}
+
+	arnEmpty := ExtractCloudwatchEventARN(eventEmptyResources)
+	assert.Equal(t, "", arnEmpty)
 }
 
 func TestExtractCloudwatchLogsEventARN(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Handle the empty `CloudWatchEvent.Resources` case.

### Motivation

This PR is to fix an issue where customers reported cases that the `CloudWatchEvent.Resources` were empty.
[AWS doc ](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-events-structure.html#:~:text=A%20JSON%20array,include%20resource%20ARNs)also indicates that the resources can potentially be an empty list.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
