### PR TITLE
usm: grpc: Cut 30s from tests

### DIFF
--- a/pkg/network/protocols/grpc/monitor_test.go
+++ b/pkg/network/protocols/grpc/monitor_test.go
@@ -352,8 +352,10 @@ func (s *USMgRPCSuite) TestLargeBodiesGRPCScenarios() {
 	t.Cleanup(srv.Stop)
 	defaultCtx := context.Background()
 
-	longName1 := randStringRunes(30 * 1024 * 1024)
-	shortName := longName1[:5*1024*1024]
+	// Random string generation is an heavy operation, and it's proportional for the length (30MB)
+	// Instead of generating the same long string (long name) for every test, we're generating it only once.
+	longRandomString := randStringRunes(30 * 1024 * 1024)
+	shortRandomString := longRandomString[:5*1024*1024]
 
 	// c is a stream endpoint
 	// a + b are unary endpoints
@@ -367,10 +369,10 @@ func (s *USMgRPCSuite) TestLargeBodiesGRPCScenarios() {
 			runClients: func(t *testing.T, clientsCount int) {
 				clients := getClientsArray(t, clientsCount, grpc.Options{})
 
-				longName1[0] = '0' + rune(clientsCount)
+				longRandomString[0] = '0' + rune(clientsCount)
 				for i := 0; i < 5; i++ {
-					longName1[1] = 'a' + rune(i)
-					require.NoError(t, clients[getClientsIndex(i, clientsCount)].HandleUnary(defaultCtx, string(longName1)))
+					longRandomString[1] = 'a' + rune(i)
+					require.NoError(t, clients[getClientsIndex(i, clientsCount)].HandleUnary(defaultCtx, string(longRandomString)))
 				}
 			},
 			expectedEndpoints: map[http.Key]captureRange{
@@ -388,11 +390,11 @@ func (s *USMgRPCSuite) TestLargeBodiesGRPCScenarios() {
 			runClients: func(t *testing.T, clientsCount int) {
 				clients := getClientsArray(t, clientsCount, grpc.Options{})
 
-				longName1[3] = '0' + rune(clientsCount)
+				longRandomString[3] = '0' + rune(clientsCount)
 
-				require.NoError(t, clients[getClientsIndex(0, clientsCount)].HandleUnary(defaultCtx, string(shortName)))
+				require.NoError(t, clients[getClientsIndex(0, clientsCount)].HandleUnary(defaultCtx, string(shortRandomString)))
 				require.NoError(t, clients[getClientsIndex(1, clientsCount)].GetFeature(defaultCtx, -746143763, 407838351))
-				require.NoError(t, clients[getClientsIndex(2, clientsCount)].HandleUnary(defaultCtx, string(shortName)))
+				require.NoError(t, clients[getClientsIndex(2, clientsCount)].HandleUnary(defaultCtx, string(shortRandomString)))
 				require.NoError(t, clients[getClientsIndex(3, clientsCount)].GetFeature(defaultCtx, -743999179, 408122808))
 			},
 			expectedEndpoints: map[http.Key]captureRange{


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Generates a big string only once, and each sub-test just modifies 2 chracters to make it unique. Instead of 50MB, using 30MB payload.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Reducing test time
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
