### PR TITLE
USM: tests: eliminate sleeps

### DIFF
--- a/pkg/network/protocols/http/testutil/pythonserver.go
+++ b/pkg/network/protocols/http/testutil/pythonserver.go
@@ -53,11 +53,10 @@ finally:
 `
 )
 
-func HTTPPythonServer(t *testing.T, addr string, options Options) (func(), error) {
+// HTTPPythonServer launches a HTTP python server.
+func HTTPPythonServer(t *testing.T, addr string, options Options) *exec.Cmd {
 	host, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, err)
 
 	curDir, _ := CurDir()
 	crtPath := filepath.Join(curDir, "testdata/cert.pem.0")
@@ -74,14 +73,15 @@ func HTTPPythonServer(t *testing.T, addr string, options Options) (func(), error
 	rawConnect(portCtx, t, host, port)
 	cancelPortCtx()
 
-	return func() {
+	t.Cleanup(func() {
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
 		}
-	}, nil
+	})
+	return cmd
 }
 
-func writeTempFile(pattern string, content string) (*os.File, error) {
+func writeTempFile(pattern, content string) (*os.File, error) {
 	f, err := os.CreateTemp("", pattern)
 	if err != nil {
 		return nil, err
@@ -99,13 +99,13 @@ func writeTempFile(pattern string, content string) (*os.File, error) {
 	return f, nil
 }
 
-func rawConnect(ctx context.Context, t *testing.T, host string, port string) {
+func rawConnect(ctx context.Context, t *testing.T, host, port string) {
 	for {
 		select {
 		case <-ctx.Done():
 			t.Fatalf("failed connecting to %s:%s", host, port)
 		default:
-			conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), time.Second)
+			conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), time.Millisecond*100)
 			if err != nil {
 				continue
 			}
@@ -115,5 +115,4 @@ func rawConnect(ctx context.Context, t *testing.T, host string, port string) {
 			}
 		}
 	}
-
 }

--- a/pkg/network/protocols/http/testutil/pythonserver.go
+++ b/pkg/network/protocols/http/testutil/pythonserver.go
@@ -53,7 +53,7 @@ finally:
 `
 )
 
-// HTTPPythonServer launches a HTTP python server.
+// HTTPPythonServer launches an HTTP python server.
 func HTTPPythonServer(t *testing.T, addr string, options Options) *exec.Cmd {
 	host, port, err := net.SplitHostPort(addr)
 	require.NoError(t, err)

--- a/pkg/network/protocols/tls/java/jattach_test.go
+++ b/pkg/network/protocols/tls/java/jattach_test.go
@@ -64,12 +64,9 @@ func testInject(t *testing.T, prefix string) {
 //	o in the container, _simulated_ by running java in his own PID namespace
 func TestInject(t *testing.T) {
 	currKernelVersion, err := kernel.HostVersion()
-	if err != nil {
-		t.Skip("Can't detect kernel version on this platform")
-	}
-	pre410Kernel := currKernelVersion < kernel.VersionCode(4, 1, 0)
-	if pre410Kernel {
-		t.Skip("Kernel < 4.1.0 are not supported as /proc/pid/status doesn't report NSpid")
+	require.NoError(t, err)
+	if currKernelVersion < kernel.VersionCode(4, 14, 0) {
+		t.Skip("Java TLS injection tests can run only on USM supported machines.")
 	}
 
 	javaVersion, err := testutil.RunCommand("java -version")

--- a/pkg/network/protocols/tls/java/jattach_test.go
+++ b/pkg/network/protocols/tls/java/jattach_test.go
@@ -28,35 +28,34 @@ func testInject(t *testing.T, prefix string) {
 		}
 		t.Log(o)
 	}()
-	time.Sleep(time.Second) // give a chance to spawn java
 
-	pids, err := javatestutil.FindProcessByCommandLine("java", "JustWait")
+	var pids []int
+	var err error
+	require.Eventually(t, func() bool {
+		pids, err = javatestutil.FindProcessByCommandLine("java", "JustWait")
+		return len(pids) == 1
+	}, time.Second*5, time.Millisecond*100)
 	require.NoError(t, err)
-	require.Lenf(t, pids, 1, "expected to find 1 match, but found %v instead", len(pids))
 
-	defer func() {
-		process, _ := os.FindProcess(pids[0])
-		process.Signal(syscall.SIGKILL)
-		time.Sleep(200 * time.Millisecond) // give a chance to the process to give his report/output
-	}()
+	t.Cleanup(func() {
+		process, err := os.FindProcess(pids[0])
+		if err != nil {
+			return
+		}
+		_ = process.Signal(syscall.SIGKILL)
+		_, _ = process.Wait()
+	})
 
 	tfile, err := os.CreateTemp("", "TestAgentLoaded.agentmain.*")
 	require.NoError(t, err)
-	tfile.Close()
-	os.Remove(tfile.Name())
-	defer os.Remove(tfile.Name())
-
+	require.NoError(t, tfile.Close())
+	require.NoError(t, os.Remove(tfile.Name()))
 	// equivalent to jattach <pid> load instrument false testdata/TestAgentLoaded.jar=<tempfile>
-	err = InjectAgent(pids[0], "testdata/TestAgentLoaded.jar", "testfile="+tfile.Name())
-	require.NoError(t, err)
-
-	time.Sleep((MINIMUM_JAVA_AGE_TO_ATTACH_MS + 200) * time.Millisecond) // wait java process to be old enough to be injected
-
-	// check if agent was loaded
-	_, err = os.Stat(tfile.Name())
-	require.NoError(t, err)
-
-	t.Log("=== Test Success ===")
+	require.NoError(t, InjectAgent(pids[0], "testdata/TestAgentLoaded.jar", "testfile="+tfile.Name()))
+	require.Eventually(t, func() bool {
+		_, err = os.Stat(tfile.Name())
+		return err == nil
+	}, time.Second*15, time.Millisecond*100)
 }
 
 // We test injection on a java hotspot running
@@ -74,28 +73,22 @@ func TestInject(t *testing.T) {
 	}
 
 	javaVersion, err := testutil.RunCommand("java -version")
-	if err != nil {
-		t.Fatal("java is not installed", javaVersion, err)
-	}
-	t.Log(javaVersion)
+	require.NoErrorf(t, err, "java is not installed")
+	t.Logf("java version %v", javaVersion)
 
 	t.Run("host", func(t *testing.T) {
 		testInject(t, "")
 	})
-	if t.Failed() {
-		t.Fatal("host failed")
-	}
 
-	t.Run("PIDnamespace", func(t *testing.T) {
+	t.Run("PID namespace", func(t *testing.T) {
 		p := "unshare -p --fork "
 		_, err = testutil.RunCommand(p + "id")
 		if err != nil {
 			t.Skipf("unshare not supported on this platform %s", err)
 		}
 
-		// running the tagert process in a new PID namespace
-		// and testing if the test/plaform give enough permission to do that
+		// running the target process in a new PID namespace
+		// and testing if the test/platform give enough permission to do that
 		testInject(t, p)
 	})
-
 }

--- a/pkg/network/tracer/testutil/prefetch_file/prefetch_file.go
+++ b/pkg/network/tracer/testutil/prefetch_file/prefetch_file.go
@@ -8,24 +8,34 @@ package main
 import (
 	"fmt"
 	"os"
-	"time"
+	"os/signal"
+	"syscall"
 )
 
 func main() {
-	if len(os.Args) != 3 {
-		fmt.Println("usage: prefetch_file <filename> <wait_time>")
+	if len(os.Args) < 2 {
+		fmt.Println("usage: prefetch_file <filename>....")
 		os.Exit(1)
 	}
-	waitTime, err := time.ParseDuration(os.Args[2])
-	if err != nil {
-		fmt.Printf("%s is not a valid format of duration\n", os.Args[2])
-		os.Exit(1)
+
+	closers := make([]func() error, 0, len(os.Args)-1)
+	defer func() {
+		for _, closer := range closers {
+			_ = closer()
+		}
+	}()
+	for _, arg := range os.Args[1:] {
+		f, err := os.Open(arg)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		closers = append(closers, f.Close)
 	}
-	f, err := os.Open(os.Args[1])
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-	defer f.Close()
-	time.Sleep(waitTime)
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	fmt.Println("awaiting signal")
+	<-sigs
+	fmt.Println("exiting")
 }

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -117,7 +117,6 @@ const (
 	amqpPort     = "5672"
 	httpPort     = "8080"
 	httpsPort    = "8443"
-	tcpPort      = "9999"
 	http2Port    = "9090"
 	grpcPort     = "9091"
 	kafkaPort    = "9092"
@@ -1612,8 +1611,6 @@ func testEdgeCasesProtocolClassification(t *testing.T, tr *Tracer, clientHost, t
 		server, ok := ctx.extras["server"].(*TCPServer)
 		if ok {
 			server.Shutdown()
-			// Giving time for the port to be free again.
-			time.Sleep(time.Second)
 		}
 	}
 
@@ -1621,9 +1618,9 @@ func testEdgeCasesProtocolClassification(t *testing.T, tr *Tracer, clientHost, t
 		{
 			name: "tcp client without sending data",
 			context: testContext{
-				serverPort:    tcpPort,
-				serverAddress: net.JoinHostPort(serverHost, tcpPort),
-				targetAddress: net.JoinHostPort(targetHost, tcpPort),
+				serverPort:    "10001",
+				serverAddress: net.JoinHostPort(serverHost, "10001"),
+				targetAddress: net.JoinHostPort(targetHost, "10001"),
 				extras:        map[string]interface{}{},
 			},
 			preTracerSetup: func(t *testing.T, ctx testContext) {
@@ -1646,9 +1643,9 @@ func testEdgeCasesProtocolClassification(t *testing.T, tr *Tracer, clientHost, t
 		{
 			name: "tcp client with sending random data",
 			context: testContext{
-				serverPort:    tcpPort,
-				serverAddress: net.JoinHostPort(serverHost, tcpPort),
-				targetAddress: net.JoinHostPort(targetHost, tcpPort),
+				serverPort:    "10002",
+				serverAddress: net.JoinHostPort(serverHost, "10002"),
+				targetAddress: net.JoinHostPort(targetHost, "10002"),
 				extras:        map[string]interface{}{},
 			},
 			preTracerSetup: func(t *testing.T, ctx testContext) {
@@ -1680,9 +1677,9 @@ func testEdgeCasesProtocolClassification(t *testing.T, tr *Tracer, clientHost, t
 			// with the first protocol we've found.
 			name: "mixed protocols",
 			context: testContext{
-				serverPort:    tcpPort,
-				serverAddress: net.JoinHostPort(serverHost, tcpPort),
-				targetAddress: net.JoinHostPort(targetHost, tcpPort),
+				serverPort:    "10003",
+				serverAddress: net.JoinHostPort(serverHost, "10003"),
+				targetAddress: net.JoinHostPort(targetHost, "10003"),
 				extras:        map[string]interface{}{},
 			},
 			preTracerSetup: func(t *testing.T, ctx testContext) {

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -114,11 +114,6 @@ func testHTTPStats(t *testing.T, aggregateByStatusCode bool) {
 		return
 	}
 
-	cfg := testConfig()
-	cfg.EnableHTTPMonitoring = true
-	cfg.EnableHTTPStatsByStatusCode = aggregateByStatusCode
-	tr := setupTracer(t, cfg)
-
 	// Start an HTTP server on localhost:8080
 	serverAddr := "127.0.0.1:8080"
 	srv := &nethttp.Server{
@@ -134,10 +129,11 @@ func testHTTPStats(t *testing.T, aggregateByStatusCode bool) {
 	go func() { _ = srv.ListenAndServe() }()
 	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
 
-	// Allow the HTTP server time to get set up
-	time.Sleep(time.Millisecond * 500)
+	cfg := testConfig()
+	cfg.EnableHTTPMonitoring = true
+	cfg.EnableHTTPStatsByStatusCode = aggregateByStatusCode
+	tr := setupTracer(t, cfg)
 
-	// Send a series of HTTP requests to the test server
 	resp, err := nethttp.Get("http://" + serverAddr + "/test")
 	require.NoError(t, err)
 	_ = resp.Body.Close()

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -407,14 +407,20 @@ func (s *USMSuite) TestOpenSSLVersions() {
 	tr := setupTracer(t, cfg)
 
 	addressOfHTTPPythonServer := "127.0.0.1:8001"
-	closer, err := testutil.HTTPPythonServer(t, addressOfHTTPPythonServer, testutil.Options{
+	cmd := testutil.HTTPPythonServer(t, addressOfHTTPPythonServer, testutil.Options{
 		EnableTLS: true,
 	})
-	require.NoError(t, err)
-	defer closer()
 
-	// Giving the tracer time to install the hooks
-	time.Sleep(time.Second)
+	require.Eventuallyf(t, func() bool {
+		traced := utils.GetTracedPrograms("shared_libraries")
+		for _, prog := range traced {
+			if slices.Contains[[]uint32](prog.PIDs, uint32(cmd.Process.Pid)) {
+				return true
+			}
+		}
+		return false
+	}, time.Second*5, time.Millisecond*100, "process %v is not traced by shared libraries", cmd.Process.Pid)
+
 	client, requestFn := simpleGetRequestsGenerator(t, addressOfHTTPPythonServer)
 	var requests []*nethttp.Request
 	for i := 0; i < numberOfRequests; i++ {
@@ -467,11 +473,9 @@ func (s *USMSuite) TestOpenSSLVersionsSlowStart() {
 	cfg.EnableHTTPMonitoring = true
 
 	addressOfHTTPPythonServer := "127.0.0.1:8001"
-	closer, err := testutil.HTTPPythonServer(t, addressOfHTTPPythonServer, testutil.Options{
+	cmd := testutil.HTTPPythonServer(t, addressOfHTTPPythonServer, testutil.Options{
 		EnableTLS: true,
 	})
-	require.NoError(t, err)
-	t.Cleanup(closer)
 
 	client, requestFn := simpleGetRequestsGenerator(t, addressOfHTTPPythonServer)
 	// Send a couple of requests we won't capture.
@@ -483,7 +487,15 @@ func (s *USMSuite) TestOpenSSLVersionsSlowStart() {
 	tr := setupTracer(t, cfg)
 
 	// Giving the tracer time to install the hooks
-	time.Sleep(time.Second)
+	require.Eventuallyf(t, func() bool {
+		traced := utils.GetTracedPrograms("shared_libraries")
+		for _, prog := range traced {
+			if slices.Contains[[]uint32](prog.PIDs, uint32(cmd.Process.Pid)) {
+				return true
+			}
+		}
+		return false
+	}, time.Second*5, time.Millisecond*100, "process %v is not traced by shared libraries", cmd.Process.Pid)
 
 	// Send a warmup batch of requests to trigger the fallback behavior
 	for i := 0; i < numberOfRequests; i++ {
@@ -1190,14 +1202,24 @@ func testHTTPSClassification(t *testing.T, tr *Tracer, clientHost, targetHost, s
 				extras:        make(map[string]interface{}),
 			},
 			preTracerSetup: func(t *testing.T, ctx testContext) {
-				closer, err := testutil.HTTPPythonServer(t, ctx.serverAddress, testutil.Options{
+				cmd := testutil.HTTPPythonServer(t, ctx.serverAddress, testutil.Options{
 					EnableKeepAlive: false,
 					EnableTLS:       true,
 				})
-				require.NoError(t, err)
-				t.Cleanup(closer)
+				ctx.extras["cmd"] = cmd
 			},
 			validation: func(t *testing.T, ctx testContext, tr *Tracer) {
+				cmd := ctx.extras["cmd"].(*exec.Cmd)
+				require.Eventuallyf(t, func() bool {
+					traced := utils.GetTracedPrograms("shared_libraries")
+					for _, prog := range traced {
+						if slices.Contains[[]uint32](prog.PIDs, uint32(cmd.Process.Pid)) {
+							return true
+						}
+					}
+					return false
+				}, time.Second*5, time.Millisecond*100, "process %v is not traced by shared libraries", cmd.Process.Pid)
+
 				client := nethttp.Client{
 					Transport: &nethttp.Transport{
 						TLSClientConfig: &tls.Config{InsecureSkipVerify: true},

--- a/pkg/network/usm/sharedlibraries/testutil/testutil.go
+++ b/pkg/network/usm/sharedlibraries/testutil/testutil.go
@@ -8,20 +8,25 @@
 package testutil
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
+	protocolstestutil "github.com/DataDog/datadog-agent/pkg/network/protocols/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 // mutex protecting build process
 var mux sync.Mutex
 
-func OpenFromAnotherProcess(t *testing.T, paths ...string) *exec.Cmd {
+// OpenFromAnotherProcess launches an external file that holds active handler to the given paths.
+func OpenFromAnotherProcess(t *testing.T, paths ...string) (*exec.Cmd, error) {
 	programExecutable := getPrebuiltExecutable(t)
 
 	if programExecutable == "" {
@@ -30,6 +35,10 @@ func OpenFromAnotherProcess(t *testing.T, paths ...string) *exec.Cmd {
 	}
 
 	cmd := exec.Command(programExecutable, paths...)
+	patternScanner := protocolstestutil.NewScanner(regexp.MustCompile("awaiting signal"), make(chan struct{}, 1))
+	cmd.Stdout = patternScanner
+	cmd.Stderr = patternScanner
+
 	require.NoError(t, cmd.Start())
 
 	t.Cleanup(func() {
@@ -39,7 +48,16 @@ func OpenFromAnotherProcess(t *testing.T, paths ...string) *exec.Cmd {
 		_ = cmd.Process.Kill()
 	})
 
-	return cmd
+	for {
+		select {
+		case <-patternScanner.DoneChan:
+			return cmd, nil
+		case <-time.After(time.Second * 5):
+			patternScanner.PrintLogs(t)
+			// please don't use t.Fatalf() here as we could test if it failed later
+			return nil, fmt.Errorf("couldn't luanch process in time")
+		}
+	}
 }
 
 // getPrebuiltExecutable returns the path of the prebuilt fmapper program when applicable.

--- a/pkg/network/usm/sharedlibraries/watcher_test.go
+++ b/pkg/network/usm/sharedlibraries/watcher_test.go
@@ -77,7 +77,8 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetection() {
 	launchProcessMonitor(t)
 
 	// create files
-	command1 := fileopener.OpenFromAnotherProcess(t, fooPath1)
+	command1, err := fileopener.OpenFromAnotherProcess(t, fooPath1)
+	require.NoError(t, err)
 
 	require.Eventuallyf(t, func() bool {
 		return registerRecorder.CallsForPathID(fooPathID1) == 1
@@ -184,7 +185,8 @@ func (s *SharedLibrarySuite) TestSameInodeRegression() {
 	t.Cleanup(watcher.Stop)
 	launchProcessMonitor(t)
 
-	command1 := fileopener.OpenFromAnotherProcess(t, fooPath1, fooPath2)
+	command1, err := fileopener.OpenFromAnotherProcess(t, fooPath1, fooPath2)
+	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
 		return registerRecorder.CallsForPathID(fooPathID1) == 1 &&
@@ -231,7 +233,8 @@ func (s *SharedLibrarySuite) TestSoWatcherLeaks() {
 	t.Cleanup(watcher.Stop)
 	launchProcessMonitor(t)
 
-	command1 := fileopener.OpenFromAnotherProcess(t, fooPath1, fooPath2)
+	command1, err := fileopener.OpenFromAnotherProcess(t, fooPath1, fooPath2)
+	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
 		// Checking register callback was executed once for each library
@@ -241,7 +244,8 @@ func (s *SharedLibrarySuite) TestSoWatcherLeaks() {
 			hasPID(watcher, command1)
 	}, time.Second*10, 100*time.Millisecond)
 
-	command2 := fileopener.OpenFromAnotherProcess(t, fooPath1)
+	command2, err := fileopener.OpenFromAnotherProcess(t, fooPath1)
+	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
 		// Check that no more callbacks were executed, but we're tracking two PIDs now
@@ -294,9 +298,11 @@ func (s *SharedLibrarySuite) TestSoWatcherProcessAlreadyHoldingReferences() {
 	)
 	require.NoError(t, err)
 
-	command1 := fileopener.OpenFromAnotherProcess(t, fooPath1, fooPath2)
-	command2 := fileopener.OpenFromAnotherProcess(t, fooPath1)
-	time.Sleep(time.Second)
+	command1, err := fileopener.OpenFromAnotherProcess(t, fooPath1, fooPath2)
+	require.NoError(t, err)
+	command2, err := fileopener.OpenFromAnotherProcess(t, fooPath1)
+	require.NoError(t, err)
+
 	watcher.Start()
 	t.Cleanup(watcher.Stop)
 	launchProcessMonitor(t)

--- a/pkg/network/usm/utils/file_registry_test.go
+++ b/pkg/network/usm/utils/file_registry_test.go
@@ -25,7 +25,8 @@ func TestRegister(t *testing.T) {
 	registerRecorder := new(CallbackRecorder)
 
 	path, pathID := createTempTestFile(t, "foobar")
-	cmd := testutil.OpenFromAnotherProcess(t, path)
+	cmd, err := testutil.OpenFromAnotherProcess(t, path)
+	require.NoError(t, err)
 	pid := uint32(cmd.Process.Pid)
 
 	r := newFileRegistry()
@@ -46,8 +47,10 @@ func TestMultiplePIDsSharingSameFile(t *testing.T) {
 	r := newFileRegistry()
 	path, pathID := createTempTestFile(t, "foobar")
 
-	cmd1 := testutil.OpenFromAnotherProcess(t, path)
-	cmd2 := testutil.OpenFromAnotherProcess(t, path)
+	cmd1, err := testutil.OpenFromAnotherProcess(t, path)
+	require.NoError(t, err)
+	cmd2, err := testutil.OpenFromAnotherProcess(t, path)
+	require.NoError(t, err)
 
 	pid1 := uint32(cmd1.Process.Pid)
 	pid2 := uint32(cmd2.Process.Pid)
@@ -92,7 +95,8 @@ func TestRepeatedRegistrationsFromSamePID(t *testing.T) {
 
 	r := newFileRegistry()
 	path, pathID := createTempTestFile(t, "foobar")
-	cmd := testutil.OpenFromAnotherProcess(t, path)
+	cmd, err := testutil.OpenFromAnotherProcess(t, path)
+	require.NoError(t, err)
 	pid := uint32(cmd.Process.Pid)
 
 	r.Register(path, pid, registerCallback, unregisterCallback)
@@ -114,7 +118,8 @@ func TestFailedRegistration(t *testing.T) {
 
 	r := newFileRegistry()
 	path, pathID := createTempTestFile(t, "foobar")
-	cmd := testutil.OpenFromAnotherProcess(t, path)
+	cmd, err := testutil.OpenFromAnotherProcess(t, path)
+	require.NoError(t, err)
 	pid := uint32(cmd.Process.Pid)
 
 	r.Register(path, pid, registerCallback, IgnoreCB)
@@ -140,7 +145,8 @@ func TestFilePathInCallbackArgument(t *testing.T) {
 	}
 
 	path, _ := createTempTestFile(t, "foobar")
-	cmd := testutil.OpenFromAnotherProcess(t, path)
+	cmd, err := testutil.OpenFromAnotherProcess(t, path)
+	require.NoError(t, err)
 	pid := cmd.Process.Pid
 
 	r := newFileRegistry()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

The PR contains multiple changes in USM UTs, to eliminate tests and cut the total runtime.
Each changed is scoped within its own commit.

Total saving time ~1m

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Cut kitchen tests time
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
