### PR TITLE
[CWS] remove wrong json tag on `EventSerializer` on windows

### DIFF
--- a/pkg/security/resolvers/process/resolver_windows.go
+++ b/pkg/security/resolvers/process/resolver_windows.go
@@ -113,7 +113,7 @@ func (p *Resolver) AddNewEntry(pid uint32, ppid uint32, file string, commandLine
 	e.PIDContext.Pid = pid
 	e.PPid = ppid
 
-	e.Process.Args = commandLine
+	e.Process.CmdLine = commandLine
 	e.Process.FileEvent.PathnameStr = file
 	e.Process.FileEvent.BasenameStr = filepath.Base(e.Process.FileEvent.PathnameStr)
 	e.ExecTime = time.Now()
@@ -198,10 +198,10 @@ func (p *Resolver) Snapshot() {
 		e.PIDContext.Pid = Pid(pid)
 		e.PPid = Pid(proc.Ppid)
 
-		e.Process.Args = strings.Join(proc.GetCmdline(), " ")
+		e.Process.CmdLine = strings.Join(proc.GetCmdline(), " ")
 		e.Process.FileEvent.PathnameStr = proc.Exe
 		e.Process.FileEvent.BasenameStr = filepath.Base(e.Process.FileEvent.PathnameStr)
-		e.ExecTime = time.Unix(0, proc.Stats.CreateTime)
+		e.ExecTime = time.Unix(0, proc.Stats.CreateTime*int64(time.Millisecond))
 
 		entries = append(entries, e)
 

--- a/pkg/security/secl/model/model_windows.go
+++ b/pkg/security/secl/model/model_windows.go
@@ -60,9 +60,9 @@ type Process struct {
 	ArgsEntry *ArgsEntry `field:"-" json:"-"`
 	EnvsEntry *EnvsEntry `field:"-" json:"-"`
 
-	Args string   `field:"args"`                                // SECLDoc[args] Definition:`Arguments of the process (as a string, excluding argv0)` Example:`exec.args == "-sV -p 22,53,110,143,4564 198.116.0-255.1-127"` Description:`Matches any process with these exact arguments.` Example:`exec.args =~ "* -F * http*"` Description:`Matches any process that has the "-F" argument anywhere before an argument starting with "http".`
-	Envs []string `field:"envs,handler:ResolveProcessEnvs:100"` // SECLDoc[envs] Definition:`Environment variable names of the process`
-	Envp []string `field:"envp,handler:ResolveProcessEnvp:100"` // SECLDoc[envp] Definition:`Environment variables of the process`                                                                                                                         // SECLDoc[envp] Definition:`Environment variables of the process`
+	CmdLine string   `field:"cmdline"`                             // SECLDoc[cmdline] Definition:`Command line of the process (as a string, excluding argv0)` Example:`exec.args == "-sV -p 22,53,110,143,4564 198.116.0-255.1-127"` Description:`Matches any process with these exact arguments.` Example:`exec.args =~ "* -F * http*"` Description:`Matches any process that has the "-F" argument anywhere before an argument starting with "http".`
+	Envs    []string `field:"envs,handler:ResolveProcessEnvs:100"` // SECLDoc[envs] Definition:`Environment variable names of the process`
+	Envp    []string `field:"envp,handler:ResolveProcessEnvp:100"` // SECLDoc[envp] Definition:`Environment variables of the process`                                                                                                                         // SECLDoc[envp] Definition:`Environment variables of the process`
 
 	// cache version
 	Variables eval.Variables `field:"-" json:"-"`

--- a/pkg/security/serializers/serializers_base_windows_easyjson.go
+++ b/pkg/security/serializers/serializers_base_windows_easyjson.go
@@ -138,8 +138,8 @@ func easyjson6b24c4ebDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers(in
 				}
 				(*out.Container).UnmarshalEasyJSON(in)
 			}
-		case "args":
-			out.Args = string(in.String())
+		case "cmdline":
+			out.CmdLine = string(in.String())
 		default:
 			in.SkipRecursive()
 		}
@@ -243,15 +243,15 @@ func easyjson6b24c4ebEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers(ou
 		}
 		(*in.Container).MarshalEasyJSON(out)
 	}
-	if in.Args != "" {
-		const prefix string = ",\"args\":"
+	if in.CmdLine != "" {
+		const prefix string = ",\"cmdline\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
 		} else {
 			out.RawString(prefix)
 		}
-		out.String(string(in.Args))
+		out.String(string(in.CmdLine))
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/serializers/serializers_windows.go
+++ b/pkg/security/serializers/serializers_windows.go
@@ -40,7 +40,7 @@ type ProcessSerializer struct {
 	// Container context
 	Container *ContainerContextSerializer `json:"container,omitempty"`
 	// Command line arguments
-	Args string `json:"args,omitempty"`
+	CmdLine string `json:"cmdline,omitempty"`
 }
 
 // FileEventSerializer serializes a file event to JSON
@@ -74,7 +74,7 @@ func newProcessSerializer(ps *model.Process, e *model.Event, resolvers *resolver
 		Pid:        ps.Pid,
 		PPid:       getUint32Pointer(&ps.PPid),
 		Executable: newFileSerializer(&ps.FileEvent, e),
-		Args:       ps.Args,
+		CmdLine:    ps.CmdLine,
 	}
 
 	if len(ps.ContainerID) != 0 {

--- a/pkg/security/serializers/serializers_windows.go
+++ b/pkg/security/serializers/serializers_windows.go
@@ -56,7 +56,7 @@ type NetworkDeviceSerializer struct{}
 // EventSerializer serializes an event to JSON
 // easyjson:json
 type EventSerializer struct {
-	*BaseEventSerializer `json:"evt,omitempty"`
+	*BaseEventSerializer
 }
 
 func newFileSerializer(fe *model.FileEvent, e *model.Event, forceInode ...uint64) *FileSerializer {

--- a/pkg/security/serializers/serializers_windows_easyjson.go
+++ b/pkg/security/serializers/serializers_windows_easyjson.go
@@ -94,10 +94,10 @@ func easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers(in
 				if out.Container == nil {
 					out.Container = new(ContainerContextSerializer)
 				}
-				easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers1(in, out.Container)
+				(*out.Container).UnmarshalEasyJSON(in)
 			}
-		case "args":
-			out.Args = string(in.String())
+		case "cmdline":
+			out.CmdLine = string(in.String())
 		default:
 			in.SkipRecursive()
 		}
@@ -166,17 +166,17 @@ func easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers(ou
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers1(out, *in.Container)
+		(*in.Container).MarshalEasyJSON(out)
 	}
-	if in.Args != "" {
-		const prefix string = ",\"args\":"
+	if in.CmdLine != "" {
+		const prefix string = ",\"cmdline\":"
 		if first {
 			first = false
 			out.RawString(prefix[1:])
 		} else {
 			out.RawString(prefix)
 		}
-		out.String(string(in.Args))
+		out.String(string(in.CmdLine))
 	}
 	out.RawByte('}')
 }
@@ -190,72 +190,7 @@ func (v ProcessSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 func (v *ProcessSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers(l, v)
 }
-func easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers1(in *jlexer.Lexer, out *ContainerContextSerializer) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		if in.IsNull() {
-			in.Skip()
-			in.WantComma()
-			continue
-		}
-		switch key {
-		case "id":
-			out.ID = string(in.String())
-		case "created_at":
-			if in.IsNull() {
-				in.Skip()
-				out.CreatedAt = nil
-			} else {
-				if out.CreatedAt == nil {
-					out.CreatedAt = new(utils.EasyjsonTime)
-				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.CreatedAt).UnmarshalJSON(data))
-				}
-			}
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers1(out *jwriter.Writer, in ContainerContextSerializer) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	if in.ID != "" {
-		const prefix string = ",\"id\":"
-		first = false
-		out.RawString(prefix[1:])
-		out.String(string(in.ID))
-	}
-	if in.CreatedAt != nil {
-		const prefix string = ",\"created_at\":"
-		if first {
-			first = false
-			out.RawString(prefix[1:])
-		} else {
-			out.RawString(prefix)
-		}
-		(*in.CreatedAt).MarshalEasyJSON(out)
-	}
-	out.RawByte('}')
-}
-func easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers2(in *jlexer.Lexer, out *NetworkDeviceSerializer) {
+func easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers1(in *jlexer.Lexer, out *NetworkDeviceSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -284,7 +219,7 @@ func easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers2(i
 		in.Consumed()
 	}
 }
-func easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers2(out *jwriter.Writer, in NetworkDeviceSerializer) {
+func easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers1(out *jwriter.Writer, in NetworkDeviceSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -293,14 +228,14 @@ func easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers2(o
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v NetworkDeviceSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers2(w, v)
+	easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers1(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *NetworkDeviceSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers2(l, v)
+	easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers1(l, v)
 }
-func easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers3(in *jlexer.Lexer, out *FileSerializer) {
+func easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers2(in *jlexer.Lexer, out *FileSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -333,7 +268,7 @@ func easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers3(i
 		in.Consumed()
 	}
 }
-func easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers3(out *jwriter.Writer, in FileSerializer) {
+func easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers2(out *jwriter.Writer, in FileSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -358,14 +293,14 @@ func easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers3(o
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v FileSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers3(w, v)
+	easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers2(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *FileSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers3(l, v)
+	easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers2(l, v)
 }
-func easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers4(in *jlexer.Lexer, out *FileEventSerializer) {
+func easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers3(in *jlexer.Lexer, out *FileEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -398,7 +333,7 @@ func easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers4(i
 		in.Consumed()
 	}
 }
-func easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers4(out *jwriter.Writer, in FileEventSerializer) {
+func easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers3(out *jwriter.Writer, in FileEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -423,14 +358,14 @@ func easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers4(o
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v FileEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers4(w, v)
+	easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers3(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *FileEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers4(l, v)
+	easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers3(l, v)
 }
-func easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers5(in *jlexer.Lexer, out *EventSerializer) {
+func easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers4(in *jlexer.Lexer, out *EventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -451,14 +386,90 @@ func easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers5(i
 		}
 		switch key {
 		case "evt":
+			(out.EventContextSerializer).UnmarshalEasyJSON(in)
+		case "date":
+			if data := in.Raw(); in.Ok() {
+				in.AddError((out.Date).UnmarshalJSON(data))
+			}
+		case "file":
 			if in.IsNull() {
 				in.Skip()
-				out.BaseEventSerializer = nil
+				out.FileEventSerializer = nil
 			} else {
-				if out.BaseEventSerializer == nil {
-					out.BaseEventSerializer = new(BaseEventSerializer)
+				if out.FileEventSerializer == nil {
+					out.FileEventSerializer = new(FileEventSerializer)
 				}
-				(*out.BaseEventSerializer).UnmarshalEasyJSON(in)
+				(*out.FileEventSerializer).UnmarshalEasyJSON(in)
+			}
+		case "dns":
+			if in.IsNull() {
+				in.Skip()
+				out.DNSEventSerializer = nil
+			} else {
+				if out.DNSEventSerializer == nil {
+					out.DNSEventSerializer = new(DNSEventSerializer)
+				}
+				(*out.DNSEventSerializer).UnmarshalEasyJSON(in)
+			}
+		case "network":
+			if in.IsNull() {
+				in.Skip()
+				out.NetworkContextSerializer = nil
+			} else {
+				if out.NetworkContextSerializer == nil {
+					out.NetworkContextSerializer = new(NetworkContextSerializer)
+				}
+				(*out.NetworkContextSerializer).UnmarshalEasyJSON(in)
+			}
+		case "exit":
+			if in.IsNull() {
+				in.Skip()
+				out.ExitEventSerializer = nil
+			} else {
+				if out.ExitEventSerializer == nil {
+					out.ExitEventSerializer = new(ExitEventSerializer)
+				}
+				(*out.ExitEventSerializer).UnmarshalEasyJSON(in)
+			}
+		case "process":
+			if in.IsNull() {
+				in.Skip()
+				out.ProcessContextSerializer = nil
+			} else {
+				if out.ProcessContextSerializer == nil {
+					out.ProcessContextSerializer = new(ProcessContextSerializer)
+				}
+				(*out.ProcessContextSerializer).UnmarshalEasyJSON(in)
+			}
+		case "dd":
+			if in.IsNull() {
+				in.Skip()
+				out.DDContextSerializer = nil
+			} else {
+				if out.DDContextSerializer == nil {
+					out.DDContextSerializer = new(DDContextSerializer)
+				}
+				(*out.DDContextSerializer).UnmarshalEasyJSON(in)
+			}
+		case "container":
+			if in.IsNull() {
+				in.Skip()
+				out.ContainerContextSerializer = nil
+			} else {
+				if out.ContainerContextSerializer == nil {
+					out.ContainerContextSerializer = new(ContainerContextSerializer)
+				}
+				(*out.ContainerContextSerializer).UnmarshalEasyJSON(in)
+			}
+		case "security_profile":
+			if in.IsNull() {
+				in.Skip()
+				out.SecurityProfileContextSerializer = nil
+			} else {
+				if out.SecurityProfileContextSerializer == nil {
+					out.SecurityProfileContextSerializer = new(SecurityProfileContextSerializer)
+				}
+				easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers5(in, out.SecurityProfileContextSerializer)
 			}
 		default:
 			in.SkipRecursive()
@@ -470,25 +481,210 @@ func easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers5(i
 		in.Consumed()
 	}
 }
-func easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers5(out *jwriter.Writer, in EventSerializer) {
+func easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers4(out *jwriter.Writer, in EventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
-	if in.BaseEventSerializer != nil {
+	if true {
 		const prefix string = ",\"evt\":"
 		first = false
 		out.RawString(prefix[1:])
-		(*in.BaseEventSerializer).MarshalEasyJSON(out)
+		(in.EventContextSerializer).MarshalEasyJSON(out)
+	}
+	if true {
+		const prefix string = ",\"date\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(in.Date).MarshalEasyJSON(out)
+	}
+	if in.FileEventSerializer != nil {
+		const prefix string = ",\"file\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.FileEventSerializer).MarshalEasyJSON(out)
+	}
+	if in.DNSEventSerializer != nil {
+		const prefix string = ",\"dns\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.DNSEventSerializer).MarshalEasyJSON(out)
+	}
+	if in.NetworkContextSerializer != nil {
+		const prefix string = ",\"network\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.NetworkContextSerializer).MarshalEasyJSON(out)
+	}
+	if in.ExitEventSerializer != nil {
+		const prefix string = ",\"exit\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.ExitEventSerializer).MarshalEasyJSON(out)
+	}
+	if in.ProcessContextSerializer != nil {
+		const prefix string = ",\"process\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.ProcessContextSerializer).MarshalEasyJSON(out)
+	}
+	if in.DDContextSerializer != nil {
+		const prefix string = ",\"dd\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.DDContextSerializer).MarshalEasyJSON(out)
+	}
+	if in.ContainerContextSerializer != nil {
+		const prefix string = ",\"container\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.ContainerContextSerializer).MarshalEasyJSON(out)
+	}
+	if in.SecurityProfileContextSerializer != nil {
+		const prefix string = ",\"security_profile\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers5(out, *in.SecurityProfileContextSerializer)
 	}
 	out.RawByte('}')
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v EventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers5(w, v)
+	easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers4(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *EventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers5(l, v)
+	easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers4(l, v)
+}
+func easyjson15047febDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers5(in *jlexer.Lexer, out *SecurityProfileContextSerializer) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "name":
+			out.Name = string(in.String())
+		case "status":
+			out.Status = string(in.String())
+		case "version":
+			out.Version = string(in.String())
+		case "tags":
+			if in.IsNull() {
+				in.Skip()
+				out.Tags = nil
+			} else {
+				in.Delim('[')
+				if out.Tags == nil {
+					if !in.IsDelim(']') {
+						out.Tags = make([]string, 0, 4)
+					} else {
+						out.Tags = []string{}
+					}
+				} else {
+					out.Tags = (out.Tags)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v1 string
+					v1 = string(in.String())
+					out.Tags = append(out.Tags, v1)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson15047febEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers5(out *jwriter.Writer, in SecurityProfileContextSerializer) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"name\":"
+		out.RawString(prefix[1:])
+		out.String(string(in.Name))
+	}
+	{
+		const prefix string = ",\"status\":"
+		out.RawString(prefix)
+		out.String(string(in.Status))
+	}
+	{
+		const prefix string = ",\"version\":"
+		out.RawString(prefix)
+		out.String(string(in.Version))
+	}
+	{
+		const prefix string = ",\"tags\":"
+		out.RawString(prefix)
+		if in.Tags == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v2, v3 := range in.Tags {
+				if v2 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v3))
+			}
+			out.RawByte(']')
+		}
+	}
+	out.RawByte('}')
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This tag should not be here (and is not on linux) because it create a new json layer `evt` instead of embedding its fields.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
