### PR TITLE
Fix linux loader error due to windows check.

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -44,7 +44,6 @@ BIN_PATH = os.path.join(".", "bin", "agent")
 AGENT_TAG = "datadog/agent:master"
 
 AGENT_CORECHECKS = [
-    "agentcrashdetect",
     "container",
     "containerd",
     "container_image",
@@ -67,10 +66,14 @@ AGENT_CORECHECKS = [
     "systemd",
     "tcp_queue_length",
     "uptime",
-    "winkmem",
-    "wincrashdetect",
     "winproc",
     "jetson",
+]
+
+WINDOWS_CORECHECKS = [
+    "agentcrashdetect",
+    "winkmem",
+    "wincrashdetect",
 ]
 
 IOT_AGENT_CORECHECKS = [
@@ -237,6 +240,14 @@ def refresh_assets(_, build_tags, development=True, flavor=AgentFlavor.base.name
     for check in AGENT_CORECHECKS if not flavor.is_iot() else IOT_AGENT_CORECHECKS:
         check_dir = os.path.join(dist_folder, f"conf.d/{check}.d/")
         copy_tree(f"./cmd/agent/dist/conf.d/{check}.d/", check_dir)
+
+    ## add additional windows-only corechecks, only on windows. Otherwise the check loader
+    ## on linux will throw an error because the module is not found, but the config is.
+    if sys.platform == 'win32':
+        for check in WINDOWS_CORECHECKS:
+            check_dir = os.path.join(dist_folder, f"conf.d/{check}.d/")
+            copy_tree(f"./cmd/agent/dist/conf.d/{check}.d/", check_dir)
+
     if "apm" in build_tags:
         shutil.copy("./cmd/agent/dist/conf.d/apm.yaml.default", os.path.join(dist_folder, "conf.d/apm.yaml.default"))
     if "process" in build_tags:


### PR DESCRIPTION
Linux check loader is throwing an error because certain windows-only checks are (correctly) not present.  However, the config yaml is being placed, so the loader tries to load them.

Don't place the config yamls for checks that don't exist on a given platform



### Describe how to test/QA your changes

On linux, ensure this message does not appear in agent status
`=========
Collector
=========

  Running Checks
  ==============
    No checks have run yet

  Loading Errors
  ==============
    agentcrashdetect
    ----------------
      Core Check Loader:
        Check agentcrashdetect not found in Catalog

      JMX Check Loader:
        check is not a jmx check, or unable to determine if it's so

      Python Check Loader:
        unable to import module 'agentcrashdetect': No module named 'agentcrashdetect'`

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
