### PR TITLE
omnibus: configure: use existing `configure` command

### DIFF
--- a/omnibus/config/software/cyrus-sasl.rb
+++ b/omnibus/config/software/cyrus-sasl.rb
@@ -17,11 +17,7 @@ build do
   license "Carnegie Mellon University license"
   license_file "https://raw.githubusercontent.com/cyrusimap/cyrus-sasl/master/COPYING"
 
-  env = {
-    "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
-    "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-    "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
-  }
+  env = with_standard_compiler_flags(with_embedded_path)
 
   configure_opts = ["--with-dblib=lmdb"]
 

--- a/omnibus/config/software/cyrus-sasl.rb
+++ b/omnibus/config/software/cyrus-sasl.rb
@@ -23,16 +23,14 @@ build do
     "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
   }
 
-  configure_command = ["./configure",
-                        "--prefix=#{install_dir}/embedded",
-                        "--with-dblib=lmdb"]
+  configure_opts = ["--with-dblib=lmdb"]
 
   if osx?
     # https://github.com/Homebrew/homebrew-core/blob/e2071268473bcddaf72f8e3f7aa4153a18d1ccfa/Formula/cyrus-sasl.rb
-    configure_command = configure_command.append("--disable-macos-framework")
+    configure_opts = configure_opts.append("--disable-macos-framework")
   end
 
-  command configure_command.join(" "), env: env
+  configure(*configure_opts, env: env)
   command "make", :env => env
   command "make install", :env => env
 

--- a/omnibus/config/software/freetds.rb
+++ b/omnibus/config/software/freetds.rb
@@ -23,9 +23,7 @@ build do
     "--disable-static",
   ]
 
-  configure_command = configure_args.unshift("./configure").join(" ")
-
-  command configure_command, env: env, in_msys_bash: true
+  configure(*configure_args, env: env)
   command "make -j #{workers}", env: env
 
   # Only `libtdsodbc.so/libtdsodbc.so.0.0.0` are needed for SQLServer integration.

--- a/omnibus/config/software/libacl.rb
+++ b/omnibus/config/software/libacl.rb
@@ -33,13 +33,11 @@ relative_path "acl-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  configure_command = [
-    "./configure",
-    "--prefix=#{install_dir}/embedded",
+  configure_options = [
     "--disable-static",
   ]
 
-  command configure_command.join(" "), env: env
+  configure(*configure_options, env: env)
 
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env

--- a/omnibus/config/software/libcom_err.rb
+++ b/omnibus/config/software/libcom_err.rb
@@ -18,10 +18,13 @@ build do
     "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
   }
 
-  # For libcom_err, we need to build e2fsprogs (since libcom_err is a subpackage of it), 
+  # For libcom_err, we need to build e2fsprogs (since libcom_err is a subpackage of it),
   # and manually move the contents of libcom_err into the Agent
   # Build e2fsprogs in a temp directory
-  command "./configure --prefix=#{install_dir}/embedded/temp_dir --enable-elf-shlibs", :env => env
+  configure_options = [
+    "--enable-elf-shlibs"
+  ]
+  configure(*configure_options, prefix: "#{install_dir}/embedded/temp_dir", :env => env)
   command "make", :env => env
 
   # Move libcom_err files directly
@@ -33,7 +36,7 @@ build do
   copy "lib/et/com_err.pc", "#{install_dir}/embedded/lib/"
 
   copy "lib/et/com_err.h", "#{install_dir}/embedded/include/"
-  
+
   copy "lib/et/compile_et", "#{install_dir}/embedded/bin/"
 
   # Remove the temp_dir

--- a/omnibus/config/software/libcom_err.rb
+++ b/omnibus/config/software/libcom_err.rb
@@ -12,11 +12,7 @@ build do
   license = "MIT"
   license_file = "https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/tree/lib/et/com_err.c"
 
-  env = {
-    "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-    "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-    "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
-  }
+  env = with_standard_compiler_flags(with_embedded_path)
 
   # For libcom_err, we need to build e2fsprogs (since libcom_err is a subpackage of it),
   # and manually move the contents of libcom_err into the Agent

--- a/omnibus/config/software/libelf.rb
+++ b/omnibus/config/software/libelf.rb
@@ -32,10 +32,7 @@ build do
        if (!checks_passed)
 EOF
 )
-  env = {
-    "CFLAGS" => "-I#{install_dir}/embedded/include -O2 -pipe",
-    "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
-  }
+  env = with_standard_compiler_flags(with_embedded_path)
   configure_options = [
     " --disable-static",
     " --disable-debuginfod",

--- a/omnibus/config/software/libelf.rb
+++ b/omnibus/config/software/libelf.rb
@@ -36,11 +36,12 @@ EOF
     "CFLAGS" => "-I#{install_dir}/embedded/include -O2 -pipe",
     "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
   }
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded" \
-          " --disable-static",
-          " --disable-debuginfod" \
-          " --disable-dependency-tracking", :env => env
+  configure_options = [
+    " --disable-static",
+    " --disable-debuginfod",
+    " --disable-dependency-tracking",
+  ]
+  configure(*configure_options, env: env)
   make "-j #{workers}", :env => env
   make 'install', :env => env
   delete "#{install_dir}/embedded/bin/eu-*"

--- a/omnibus/config/software/libkrb5.rb
+++ b/omnibus/config/software/libkrb5.rb
@@ -21,18 +21,17 @@ build do
   license "BSD-style"
   license_file "https://raw.githubusercontent.com/krb5/krb5/master/NOTICE"
 
-  cmd = ["./configure",
-         "--without-keyutils", # this would require additional deps/system deps, disable it
+  configure_options = ["--without-keyutils", # this would require additional deps/system deps, disable it
          "--without-system-verto", # do not prefer libverto from the system, if installed
          "--without-libedit", # we don't want to link with libraries outside of the install dir
-         "--disable-static",
-         "--prefix=#{install_dir}/embedded"].join(" ")
+         "--disable-static"
+  ]
   env = {
     "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
     "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
     "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
   }
-  command cmd, :env => env
+  configure(*configure_options, :env => env)
   command "make -j #{workers}", :env => { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }
   command "make install", :env => { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }
 

--- a/omnibus/config/software/libkrb5.rb
+++ b/omnibus/config/software/libkrb5.rb
@@ -26,11 +26,7 @@ build do
          "--without-libedit", # we don't want to link with libraries outside of the install dir
          "--disable-static"
   ]
-  env = {
-    "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-    "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-    "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
-  }
+  env = with_standard_compiler_flags(with_embedded_path)
   configure(*configure_options, :env => env)
   command "make -j #{workers}", :env => { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }
   command "make install", :env => { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }

--- a/omnibus/config/software/librdkafka.rb
+++ b/omnibus/config/software/librdkafka.rb
@@ -23,8 +23,10 @@ build do
     "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
     "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
   }
-
-  command "./configure --enable-sasl --prefix=#{install_dir}/embedded", :env => env
+  configure_options = [
+    "--enable-sasl",
+  ]
+  configure(*configure_options, :env => env)
   command "make -j #{workers}", :env => env
   command "make install", :env => env
 

--- a/omnibus/config/software/librdkafka.rb
+++ b/omnibus/config/software/librdkafka.rb
@@ -18,11 +18,7 @@ build do
   license "BSD-style"
   license_file "https://raw.githubusercontent.com/confluentinc/librdkafka/master/LICENSE"
 
-  env = {
-    "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-    "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-    "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
-  }
+  env = with_standard_compiler_flags(with_embedded_path)
   configure_options = [
     "--enable-sasl",
   ]

--- a/omnibus/config/software/libxcrypt.rb
+++ b/omnibus/config/software/libxcrypt.rb
@@ -34,9 +34,10 @@ build do
     # This builds libcrypt.so.2
     # To build libcrypt.so.1, the --disable-obsolete-api option
     # needs to be removed.
-    command ["./configure",
-        "--prefix=#{install_dir}/embedded",
-        "--disable-obsolete-api"].join(" "), env: env
+    configure_options = [
+        "--disable-obsolete-api",
+    ]
+    configure(*configure_options, env: env)
     command "make -j #{workers}", env: env
     command "make -j #{workers} install"
 end

--- a/omnibus/config/software/m4.rb
+++ b/omnibus/config/software/m4.rb
@@ -32,7 +32,7 @@ relative_path "m4-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  command "./configure --prefix=#{install_dir}/embedded", env: env
+  configure(env: env)
 
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env

--- a/omnibus/config/software/pcre2.rb
+++ b/omnibus/config/software/pcre2.rb
@@ -30,12 +30,10 @@ relative_path "pcre2-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  configure_command = [
-    "./configure",
-    "--prefix=#{install_dir}/embedded",
+  configure_options = [
   ]
 
-  command configure_command.join(" "), env: env
+  configure(*configure_options, env: env)
 
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env

--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -34,12 +34,8 @@ if ohai["platform"] != "windows"
 
   relative_path "Python-#{version}"
 
-  env = {
-    "CFLAGS" => "-I#{install_dir}/embedded/include -O2 -g -pipe -fPIC",
-    "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
-    "PKG_CONFIG" => "#{install_dir}/embedded/bin/pkg-config",
-    "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig"
-  }
+  env = with_standard_compiler_flags(with_embedded_path)
+  env['CFLAGS'] << ' -fPIC'
 
   python_configure_options = ["--with-ensurepip=no"] # pip is installed separately by its own software def
 

--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -41,19 +41,17 @@ if ohai["platform"] != "windows"
     "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig"
   }
 
-  python_configure = ["./configure",
-                      "--prefix=#{install_dir}/embedded",
-                      "--with-ensurepip=no"] # pip is installed separately by its own software def
+  python_configure_options = ["--with-ensurepip=no"] # pip is installed separately by its own software def
 
   if mac_os_x?
-    python_configure.push("--enable-ipv6",
+    python_configure_options.push("--enable-ipv6",
                           "--with-universal-archs=intel",
                           "--enable-shared",
                           "--disable-static",
                           "--without-gcc",
                           "CC=clang")
   elsif linux?
-    python_configure.push("--enable-unicode=ucs4",
+    python_configure_options.push("--enable-unicode=ucs4",
                           "--enable-shared",
                           "--disable-static")
   end
@@ -70,7 +68,7 @@ if ohai["platform"] != "windows"
     patch :source => "python2.7_2.7.18-cve-2020-8492.diff" unless windows?
     patch :source => "python2.7_2.7.18-cve-2021-3177.diff" unless windows?
 
-    command python_configure.join(" "), :env => env
+    configure(*python_configure_options, :env => env)
     command "make -j #{workers}", :env => env
     command "make install", :env => env
     delete "#{install_dir}/embedded/lib/python2.7/test"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -19,25 +19,25 @@ if ohai["platform"] != "windows"
 
   relative_path "Python-#{version}"
 
-  python_configure = ["./configure",
-                      "--prefix=#{install_dir}/embedded",
-                      "--with-ssl=#{install_dir}/embedded",
-                      "--with-ensurepip=yes"] # We upgrade pip later, in the pip3 software definition
+  python_configure_options = [
+    "--with-ssl=#{install_dir}/embedded",
+    "--with-ensurepip=yes" # We upgrade pip later, in the pip3 software definition
+  ]
 
   if mac_os_x?
-    python_configure.push("--enable-ipv6",
+    python_configure_options.push("--enable-ipv6",
                           "--with-universal-archs=intel",
                           "--enable-shared",
                           "--disable-static")
   elsif linux?
-    python_configure.push("--enable-shared",
+    python_configure_options.push("--enable-shared",
                           "--disable-static",
                           "--enable-ipv6")
   elsif aix?
     # something here...
   end
 
-  python_configure.push("--with-dbmliborder=")
+  python_configure_options.push("--with-dbmliborder=")
 
   build do
     # 2.0 is the license version here, not the python version
@@ -54,7 +54,7 @@ if ohai["platform"] != "windows"
               "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig"
             }
           end
-    command python_configure.join(" "), :env => env
+    configure(*python_configure_options, :env => env)
     command "make -j #{workers}", :env => env
     command "make install", :env => env
     delete "#{install_dir}/embedded/lib/python3.9/test"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -43,17 +43,7 @@ if ohai["platform"] != "windows"
     # 2.0 is the license version here, not the python version
     license "Python-2.0"
 
-    env = case ohai["platform"]
-          when "aix"
-            aix_env
-          else
-            {
-              "CFLAGS" => "-I#{install_dir}/embedded/include -O2 -g -pipe",
-              "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
-              "PKG_CONFIG" => "#{install_dir}/embedded/bin/pkg-config",
-              "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig"
-            }
-          end
+    env = with_standard_compiler_flags(with_embedded_path)
     configure(*python_configure_options, :env => env)
     command "make -j #{workers}", :env => env
     command "make install", :env => env

--- a/omnibus/config/software/rpm.rb
+++ b/omnibus/config/software/rpm.rb
@@ -44,8 +44,6 @@ relative_path "rpm-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  env["CC"] = "/usr/bin/gcc"
-  env["CXX"] = "/usr/bin/g++"
   env["CFLAGS"] << " -fPIC"
 
   patch source: "0001-Include-fcntl.patch", env: env # fix build
@@ -56,7 +54,7 @@ build do
   patch source: "0418-Move-variable-to-nearest-available-scope.patch", env: env
 
   update_config_guess
-  
+
   env["SQLITE_CFLAGS"] ="-I#{install_dir}/embedded/include"
   env["SQLITE_LIBS"] ="-L#{install_dir}/embedded/lib -lsqlite3"
   env["LUA_CFLAGS"] ="-I#{install_dir}/embedded/include"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR aims at using a uniformed way of invoking `configure` scripts. It uses the omnibus provided `configure` command instead of a manual invocation through `command`
It also ensures we use `with_standard_compiler_flags` when fetching the environment.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This allows us to have a central place to modify if we need to change our invocation of configure scripts, and reduces the environment related boilerplate in all software recipes.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

This PR is most likely easier to review commit by commit

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
