### PR TITLE
test/integration/common: fix log_trace calls syntax

### DIFF
--- a/test/kitchen/test/integration/common/rspec_datadog/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec_datadog/spec_helper.rb
@@ -154,7 +154,7 @@ def stop(flavor)
   end
   wait_until_service_stopped(service)
   if result == nil || result == false
-      log_trace "datadog-agent" "stop"
+      log_trace "datadog-agent", "stop"
   end
   result
 end
@@ -175,7 +175,7 @@ def start(flavor)
   end
   wait_until_service_started(service)
   if result == nil || result == false
-      log_trace "datadog-agent" "start"
+      log_trace "datadog-agent", "start"
   end
   result
 end
@@ -211,7 +211,7 @@ def restart(flavor)
     end
   end
   if result == nil || result == false
-      log_trace "datadog-agent" "restart"
+      log_trace "datadog-agent", "restart"
   end
   result
 end


### PR DESCRIPTION
### What does this PR do?

Found during #19466's review of failed pipelines, we fix some `log_trace` calls in specs adding a missing comma.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
