### PR TITLE
Better test coverage and clean-up in orchestrator redact package

### DIFF
--- a/pkg/orchestrator/redact/data_scrubber_test.go
+++ b/pkg/orchestrator/redact/data_scrubber_test.go
@@ -47,7 +47,7 @@ func benchmarkMatching(nbContainers int, b *testing.B) {
 	b.Run("simplified", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			for _, c := range containersBenchmarks {
-				ScrubContainer(&c, scrubber)
+				scrubContainer(&c, scrubber)
 			}
 		}
 	})
@@ -74,7 +74,7 @@ func benchmarkMatchingCustomRegex(nbContainers int, b *testing.B) {
 	b.Run("simplified", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			for _, c := range containersBenchmarks {
-				ScrubContainer(&c, scrubber)
+				scrubContainer(&c, scrubber)
 			}
 		}
 	})

--- a/pkg/orchestrator/redact/pod_test.go
+++ b/pkg/orchestrator/redact/pod_test.go
@@ -13,73 +13,259 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestRedactAnnotations(t *testing.T) {
-	lastAppliedConfiguration := `{
-  "apiVersion": "apps/v1",
-  "kind": "ReplicaSet",
-  "metadata": {
-    "annotations": {},
-    "name": "gitlab-password-all",
-    "namespace": "datadog-agent"
-  },
-  "spec": {
-    "replicas": 1,
-    "selector": {
-      "matchLabels": {
-        "tier": "frontend"
-      }
-    },
-    "template": {
-      "metadata": {
-        "labels": {
-          "tier": "frontend"
-        }
-      },
-      "spec": {
-        "containers": [
-          {
-            "env": [
-              {
-                "name": "GITLAB_TOKEN",
-                "value": "test"
-              },
-              {
-                "name": "TOKEN",
-                "value": "test"
-              },
-              {
-                "name": "password",
-                "value": "test"
-              },
-              {
-                "name": "secret",
-                "value": "test"
-              },
-              {
-                "name": "pwd",
-                "value": "test"
-              },
-              {
-                "name": "api_key",
-                "value": "test"
-              }
-            ],
-            "image": "gcr.io/google_samples/gb-frontend:v3",
-            "name": "php-redis"
-          }
-        ]
-      }
-    }
-  }
-}`
+func TestRemoveLastAppliedConfigurationAnnotation(t *testing.T) {
 	objectMeta := metav1.ObjectMeta{Annotations: map[string]string{
-		"kubectl.kubernetes.io/last-applied-configuration": lastAppliedConfiguration,
+		v1.LastAppliedConfigAnnotation: `{"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{},"name":"quota","namespace":"default"},"spec":{"containers":[{"args":["-c","while true; do echo hello; sleep 10;done"],"command":["/bin/sh"],"image":"ubuntu","name":"high-priority","resources":{"limits":{"cpu":"500m","memory":"10Gi"},"requests":{"cpu":"500m","memory":"10Gi"}}}],"priorityClassName":"high-priority"}}`,
 	}}
 	RemoveLastAppliedConfigurationAnnotation(objectMeta.Annotations)
-	actual := objectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
-	expected := replacedValue
-	assert.Equal(t, expected, actual)
+	actual := objectMeta.Annotations[v1.LastAppliedConfigAnnotation]
+	assert.Equal(t, redactedAnnotationValue, actual)
+}
 
+func TestRemoveLastAppliedConfigurationAnnotationNotPresent(t *testing.T) {
+	objectMeta := metav1.ObjectMeta{Annotations: map[string]string{
+		"not.last.applied.annotation": "value",
+	}}
+
+	RemoveLastAppliedConfigurationAnnotation(objectMeta.Annotations)
+	actual := objectMeta.Annotations[v1.LastAppliedConfigAnnotation]
+	assert.Equal(t, "", actual)
+}
+
+func TestRemoveLastAppliedConfigurationAnnotationEmpty(t *testing.T) {
+	objectMeta := metav1.ObjectMeta{Annotations: map[string]string{
+		v1.LastAppliedConfigAnnotation: "",
+	}}
+
+	RemoveLastAppliedConfigurationAnnotation(objectMeta.Annotations)
+	actual := objectMeta.Annotations[v1.LastAppliedConfigAnnotation]
+	assert.Equal(t, redactedAnnotationValue, actual)
+}
+
+func TestScrubPod(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"ad.datadoghq.com/postgres.logs":           `[{"source":"postgresql","service":"postgresql"}]`,
+				"cni.projectcalico.org/podIPs":             `10.1.91.209/32`,
+				"kubernetes.io/config.seen":                `2023-09-12T14:45:38.769079271Z`,
+				"kubernetes.io/config.source":              `api`,
+				"ad.datadoghq.com/http_check.instances":    `[{"url": "%%host%%", "username": "admin", "password": "test1234"}]`,
+				"ad.datadoghq.com/http_check.init_configs": `[{}]`,
+				"cni.projectcalico.org/containerID":        `3e1aac38cc95af5899db757c5fb7b7cddb96c6dfe979378b785a4e5e732954e8`,
+				"cni.projectcalico.org/podIP":              `10.1.91.209/32`,
+				"ad.datadoghq.com/postgres.check_names":    `["http_check"]`,
+			},
+		},
+		Spec: v1.PodSpec{
+			InitContainers: []v1.Container{
+				{
+					Name:    "init-1",
+					Image:   "bootstrap",
+					Command: []string{"bootstrap", "--crash-on-error", "start", "--password", "dKbgOrFmlhkyjGPkmuUtXwnOsxRXevnsef"},
+					Args:    []string{},
+					Env: []v1.EnvVar{
+						{Name: "LOG_LEVEL", Value: "DEBUG"},
+						{Name: "VAULT_ADDR", Value: "https://vault.domain.com"},
+						{Name: "VAULT_AUTH_PATH", Value: "/domain/cluster"},
+						{Name: "AVAILABILITY_ZONE", Value: "zone-1"},
+					},
+				},
+			},
+			Containers: []v1.Container{
+				{
+					Name:    "container-1",
+					Image:   "app",
+					Command: []string{"app", "--parameter", "value", "--password", "fOPeWWuFKUxwGLRTNnoM٪YwCExdwUcQBDZMogm"},
+					Args:    []string{"--token", "GgItUUMOmܪnwPwcJNKbhwfutPmUgGXKHGin", "--other-parameter", "other-value"},
+					Env: []v1.EnvVar{
+						{Name: "API_KEY", Value: "LkhqmrnfESPrvhyfpephDDokCKvVokxXg"},
+						{Name: "DD_SITE", Value: "datadoghq.com"},
+					},
+				},
+				{
+					Name:    "container-2",
+					Image:   "sidecard",
+					Command: []string{"sidecard", "--password", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", "--verbose"},
+					Args:    []string{"--timeout", "10m", "--credentials", "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"},
+					Env:     []v1.EnvVar{},
+				},
+			},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+		},
+	}
+
+	expectedPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"ad.datadoghq.com/postgres.logs":           `[{"source":"postgresql","service":"postgresql"}]`,
+				"cni.projectcalico.org/podIPs":             `10.1.91.209/32`,
+				"kubernetes.io/config.seen":                `2023-09-12T14:45:38.769079271Z`,
+				"kubernetes.io/config.source":              `api`,
+				"ad.datadoghq.com/http_check.instances":    `[{"url": "%%host%%", "username": "********", "password": "********"}]`,
+				"ad.datadoghq.com/http_check.init_configs": `[{}]`,
+				"cni.projectcalico.org/containerID":        `3e1aac38cc95af5899db757c5fb7b7cddb96c6dfe979378b785a4e5e732954e8`,
+				"cni.projectcalico.org/podIP":              `10.1.91.209/32`,
+				"ad.datadoghq.com/postgres.check_names":    `["http_check"]`,
+			},
+		},
+		Spec: v1.PodSpec{
+			InitContainers: []v1.Container{
+				{
+					Name:    "init-1",
+					Image:   "bootstrap",
+					Command: []string{"bootstrap", "--crash-on-error", "start", "--password", "********"},
+					Args:    []string{},
+					Env: []v1.EnvVar{
+						{Name: "LOG_LEVEL", Value: "DEBUG"},
+						{Name: "VAULT_ADDR", Value: "********"},
+						{Name: "VAULT_AUTH_PATH", Value: "********"},
+						{Name: "AVAILABILITY_ZONE", Value: "zone-1"},
+					},
+				},
+			},
+			Containers: []v1.Container{
+				{
+					Name:    "container-1",
+					Image:   "app",
+					Command: []string{"app", "--parameter", "value", "--password", "********"},
+					Args:    []string{"--token", "********", "--other-parameter", "other-value"},
+					Env: []v1.EnvVar{
+						{Name: "API_KEY", Value: "********"},
+						{Name: "DD_SITE", Value: "datadoghq.com"},
+					},
+				},
+				{
+					Name:    "container-2",
+					Image:   "sidecard",
+					Command: []string{"sidecard", "--password", "********", "--verbose"},
+					Args:    []string{"--timeout", "10m", "--credentials", "********"},
+					Env:     []v1.EnvVar{},
+				},
+			},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+		},
+	}
+
+	scrubber := NewDefaultDataScrubber()
+	scrubber.AddCustomSensitiveWords([]string{"token", "username", "vault"})
+	ScrubPod(pod, scrubber)
+
+	assert.EqualValues(t, expectedPod, pod)
+}
+
+func TestScrubPodTemplate(t *testing.T) {
+	template := &v1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"ad.datadoghq.com/postgres.logs":           `[{"source":"postgresql","service":"postgresql"}]`,
+				"cni.projectcalico.org/podIPs":             `10.1.91.209/32`,
+				"kubernetes.io/config.seen":                `2023-09-12T14:45:38.769079271Z`,
+				"kubernetes.io/config.source":              `api`,
+				"ad.datadoghq.com/http_check.instances":    `[{"url": "%%host%%", "username": "admin", "password": "test1234"}]`,
+				"ad.datadoghq.com/http_check.init_configs": `[{}]`,
+				"cni.projectcalico.org/containerID":        `3e1aac38cc95af5899db757c5fb7b7cddb96c6dfe979378b785a4e5e732954e8`,
+				"cni.projectcalico.org/podIP":              `10.1.91.209/32`,
+				"ad.datadoghq.com/postgres.check_names":    `["http_check"]`,
+			},
+		},
+		Spec: v1.PodSpec{
+			InitContainers: []v1.Container{
+				{
+					Name:    "init-1",
+					Image:   "bootstrap",
+					Command: []string{"bootstrap", "--crash-on-error", "start", "--password", "dKbgOrFmlhkyjGPkmuUtXwnOsxRXevnsef"},
+					Args:    []string{},
+					Env: []v1.EnvVar{
+						{Name: "LOG_LEVEL", Value: "DEBUG"},
+						{Name: "VAULT_ADDR", Value: "https://vault.domain.com"},
+						{Name: "VAULT_AUTH_PATH", Value: "/domain/cluster"},
+						{Name: "AVAILABILITY_ZONE", Value: "zone-1"},
+					},
+				},
+			},
+			Containers: []v1.Container{
+				{
+					Name:    "container-1",
+					Image:   "app",
+					Command: []string{"app", "--parameter", "value", "--password", "fOPeWWuFKUxwGLRTNnoM٪YwCExdwUcQBDZMogm"},
+					Args:    []string{"--token", "GgItUUMOmܪnwPwcJNKbhwfutPmUgGXKHGin", "--other-parameter", "other-value"},
+					Env: []v1.EnvVar{
+						{Name: "API_KEY", Value: "LkhqmrnfESPrvhyfpephDDokCKvVokxXg"},
+						{Name: "DD_SITE", Value: "datadoghq.com"},
+					},
+				},
+				{
+					Name:    "container-2",
+					Image:   "sidecard",
+					Command: []string{"sidecard", "--password", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", "--verbose"},
+					Args:    []string{"--timeout", "10m", "--credentials", "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"},
+					Env:     []v1.EnvVar{},
+				},
+			},
+		},
+	}
+
+	expectedTemplate := &v1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"ad.datadoghq.com/postgres.logs":           `[{"source":"postgresql","service":"postgresql"}]`,
+				"cni.projectcalico.org/podIPs":             `10.1.91.209/32`,
+				"kubernetes.io/config.seen":                `2023-09-12T14:45:38.769079271Z`,
+				"kubernetes.io/config.source":              `api`,
+				"ad.datadoghq.com/http_check.instances":    `[{"url": "%%host%%", "username": "********", "password": "********"}]`,
+				"ad.datadoghq.com/http_check.init_configs": `[{}]`,
+				"cni.projectcalico.org/containerID":        `3e1aac38cc95af5899db757c5fb7b7cddb96c6dfe979378b785a4e5e732954e8`,
+				"cni.projectcalico.org/podIP":              `10.1.91.209/32`,
+				"ad.datadoghq.com/postgres.check_names":    `["http_check"]`,
+			},
+		},
+		Spec: v1.PodSpec{
+			InitContainers: []v1.Container{
+				{
+					Name:    "init-1",
+					Image:   "bootstrap",
+					Command: []string{"bootstrap", "--crash-on-error", "start", "--password", "********"},
+					Args:    []string{},
+					Env: []v1.EnvVar{
+						{Name: "LOG_LEVEL", Value: "DEBUG"},
+						{Name: "VAULT_ADDR", Value: "********"},
+						{Name: "VAULT_AUTH_PATH", Value: "********"},
+						{Name: "AVAILABILITY_ZONE", Value: "zone-1"},
+					},
+				},
+			},
+			Containers: []v1.Container{
+				{
+					Name:    "container-1",
+					Image:   "app",
+					Command: []string{"app", "--parameter", "value", "--password", "********"},
+					Args:    []string{"--token", "********", "--other-parameter", "other-value"},
+					Env: []v1.EnvVar{
+						{Name: "API_KEY", Value: "********"},
+						{Name: "DD_SITE", Value: "datadoghq.com"},
+					},
+				},
+				{
+					Name:    "container-2",
+					Image:   "sidecard",
+					Command: []string{"sidecard", "--password", "********", "--verbose"},
+					Args:    []string{"--timeout", "10m", "--credentials", "********"},
+					Env:     []v1.EnvVar{},
+				},
+			},
+		},
+	}
+
+	scrubber := NewDefaultDataScrubber()
+	scrubber.AddCustomSensitiveWords([]string{"token", "username", "vault"})
+	ScrubPodTemplateSpec(template, scrubber)
+
+	assert.EqualValues(t, expectedTemplate, template)
 }
 
 func TestScrubAnnotations(t *testing.T) {
@@ -106,30 +292,8 @@ func TestScrubAnnotations(t *testing.T) {
 		"ad.datadoghq.com/postgres.check_names":  `["postgres"]`,
 	}
 	scrubber := NewDefaultDataScrubber()
-	ScrubAnnotations(annotations, scrubber)
+	scrubAnnotations(annotations, scrubber)
 	assert.Equal(t, expectedAnnotations, annotations)
-}
-
-func TestRedactAnnotationsValueDoesNotExist(t *testing.T) {
-	objectMeta := metav1.ObjectMeta{Annotations: map[string]string{
-		"something/else": "some pseudo yaml",
-	}}
-
-	RemoveLastAppliedConfigurationAnnotation(objectMeta.Annotations)
-	actual := objectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
-	expected := ""
-	assert.Equal(t, expected, actual)
-}
-
-func TestRedactAnnotationsValueIsEmpty(t *testing.T) {
-	objectMeta := metav1.ObjectMeta{Annotations: map[string]string{
-		"kubectl.kubernetes.io/last-applied-configuration": "",
-	}}
-
-	RemoveLastAppliedConfigurationAnnotation(objectMeta.Annotations)
-	actual := objectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
-	expected := replacedValue
-	assert.Equal(t, expected, actual)
 }
 
 func TestScrubContainer(t *testing.T) {
@@ -137,7 +301,7 @@ func TestScrubContainer(t *testing.T) {
 	tests := getScrubCases()
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ScrubContainer(&tc.input, scrubber)
+			scrubContainer(&tc.input, scrubber)
 			assert.Equal(t, tc.expected, tc.input)
 		})
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

The package was not testing public functions used to scrub the pod and pod template, only inner functions called by those. In addition, doing a small clean-up to not duplicate obfuscated values.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
