### PR TITLE
Allow forcing clusterchecks rebalancing for scheduler workers utilisation rebalancing  algo

### DIFF
--- a/cmd/cluster-agent/api/v1/clusterchecks.go
+++ b/cmd/cluster-agent/api/v1/clusterchecks.go
@@ -31,7 +31,7 @@ func installClusterCheckEndpoints(r *mux.Router, sc clusteragent.ServerContext) 
 	r.HandleFunc("/clusterchecks", api.WithTelemetryWrapper("getState", getState(sc))).Methods("GET")
 }
 
-// Payload struct is for the JSON messages received from a client POST request
+// RebalancePostPayload struct is for the JSON messages received from a client POST request
 type RebalancePostPayload struct {
 	Force bool `json:"force"`
 }

--- a/pkg/cli/subcommands/clusterchecks/command.go
+++ b/pkg/cli/subcommands/clusterchecks/command.go
@@ -102,7 +102,7 @@ func run(log log.Component, config config.Component, cliParams *cliParams) error
 	return flare.GetEndpointsChecks(color.Output, cliParams.checkName)
 }
 
-func rebalance(log log.Component, config config.Component, cliParams *cliParams) error {
+func rebalance(_ log.Component, _ config.Component, cliParams *cliParams) error {
 
 	fmt.Println("Requesting a cluster check rebalance...")
 	c := util.GetClient(false) // FIX: get certificates right then make this true

--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -216,7 +216,7 @@ func (d *dispatcher) run(ctx context.Context) {
 			// Rebalance if needed
 			if d.advancedDispatching {
 				// Rebalance checks distribution
-				d.rebalance()
+				d.rebalance(false)
 			}
 		}
 	}

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance.go
@@ -171,9 +171,9 @@ func (d *dispatcher) moveCheck(src, dest, checkID string) error {
 	return nil
 }
 
-func (d *dispatcher) rebalance() []types.RebalanceResponse {
+func (d *dispatcher) rebalance(force bool) []types.RebalanceResponse {
 	if config.Datadog.GetBool("cluster_checks.rebalance_with_utilization") {
-		return d.rebalanceUsingUtilization()
+		return d.rebalanceUsingUtilization(force)
 	}
 
 	return d.rebalanceUsingBusyness()
@@ -298,7 +298,7 @@ func (d *dispatcher) rebalanceUsingBusyness() []types.RebalanceResponse {
 // checks are not very costly. They're ignored by this function.
 // - It can't predict the execution time of checks that are running for the
 // first time. This could become a problem for checks that take too long.
-func (d *dispatcher) rebalanceUsingUtilization() []types.RebalanceResponse {
+func (d *dispatcher) rebalanceUsingUtilization(force bool) []types.RebalanceResponse {
 	// Collect CLC runners stats and update cache before rebalancing
 	d.updateRunnersStats()
 
@@ -325,20 +325,28 @@ func (d *dispatcher) rebalanceUsingUtilization() []types.RebalanceResponse {
 	currentUtilizationStdDev := currentChecksDistribution.utilizationStdDev()
 	proposedUtilizationStdDev := proposedDistribution.utilizationStdDev()
 	minPercImprovement := config.Datadog.GetInt("cluster_checks.rebalance_min_percentage_improvement")
-	if !rebalanceIsWorthIt(currentChecksDistribution, proposedDistribution, minPercImprovement) {
-		log.Debugf("Didn't find a distribution better enough so that rescheduling checks is worth it (current utilization stddev: %.3f, found utilization stddev: %.3f)",
-			currentUtilizationStdDev, proposedUtilizationStdDev)
-		setPredictedUtilization(currentChecksDistribution)
-		return nil
+
+	if force || rebalanceIsWorthIt(currentChecksDistribution, proposedDistribution, minPercImprovement) {
+
+		jsonDistribution, _ := json.Marshal(proposedDistribution)
+
+		if force {
+			log.Infof("Forcing rebalance proposed distribution for the cluster checks. Utilization stdDev of proposed distribution: %.3f. StdDev of current distribution: %.3f. Proposed distribution: %s",
+				proposedUtilizationStdDev, currentUtilizationStdDev, jsonDistribution)
+		} else {
+			log.Infof("Found a better distribution for the cluster checks. Utilization stdDev of proposed distribution: %.3f. StdDev of current distribution: %.3f. Proposed distribution: %s",
+				proposedUtilizationStdDev, currentUtilizationStdDev, jsonDistribution)
+		}
+
+		setPredictedUtilization(proposedDistribution)
+
+		return d.applyDistribution(proposedDistribution, currentChecksDistribution)
 	}
 
-	jsonDistribution, _ := json.Marshal(proposedDistribution)
-	log.Infof("Found a better distribution for the cluster checks. Utilization stdDev of proposed distribution: %.3f. StdDev of current distribution: %.3f. Proposed distribution: %s",
-		proposedUtilizationStdDev, currentUtilizationStdDev, jsonDistribution)
-
-	setPredictedUtilization(proposedDistribution)
-
-	return d.applyDistribution(proposedDistribution, currentChecksDistribution)
+	log.Debugf("Didn't find a distribution better enough so that rescheduling checks is worth it (current utilization stddev: %.3f, found utilization stddev: %.3f)",
+		currentUtilizationStdDev, proposedUtilizationStdDev)
+	setPredictedUtilization(currentChecksDistribution)
+	return nil
 }
 
 func (d *dispatcher) currentDistribution() checksDistribution {

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -1560,7 +1560,7 @@ func TestRebalanceUsingUtilization(t *testing.T) {
 		"digest2": "node1",
 	}
 
-	checksMoved := testDispatcher.rebalanceUsingUtilization()
+	checksMoved := testDispatcher.rebalanceUsingUtilization(false)
 
 	requireNotLocked(t, testDispatcher.store)
 
@@ -1592,7 +1592,7 @@ func TestRebalanceUsingUtilization(t *testing.T) {
 
 	// The next rebalance should not move anything because there were not any
 	// changes in the checks stats.
-	checksMoved = testDispatcher.rebalanceUsingUtilization()
+	checksMoved = testDispatcher.rebalanceUsingUtilization(false)
 	assert.Empty(t, checksMoved)
 }
 

--- a/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_rebalance_test.go
@@ -1389,7 +1389,7 @@ func TestRebalance(t *testing.T) {
 			}
 
 			// rebalance checks
-			dispatcher.rebalance()
+			dispatcher.rebalance(false)
 
 			// assert runner stats repartition is updated correctly
 			for node, store := range tc.out {

--- a/pkg/clusteragent/clusterchecks/handler_api.go
+++ b/pkg/clusteragent/clusterchecks/handler_api.go
@@ -98,12 +98,12 @@ func (h *Handler) GetAllEndpointsCheckConfigs() (types.ConfigResponse, error) {
 }
 
 // RebalanceClusterChecks triggers an attempt to rebalance cluster checks
-func (h *Handler) RebalanceClusterChecks() ([]types.RebalanceResponse, error) {
+func (h *Handler) RebalanceClusterChecks(force bool) ([]types.RebalanceResponse, error) {
 	if !h.dispatcher.advancedDispatching {
 		return nil, fmt.Errorf("no checks to rebalance: advanced dispatching is not enabled")
 	}
 
-	rebalancingDecisions := h.dispatcher.rebalance()
+	rebalancingDecisions := h.dispatcher.rebalance(force)
 	response := []types.RebalanceResponse{}
 
 	for _, decision := range rebalancingDecisions {

--- a/releasenotes-dca/notes/allow-force-clusterchecks-rebalancing-46b8f58eb157ecde.yaml
+++ b/releasenotes-dca/notes/allow-force-clusterchecks-rebalancing-46b8f58eb157ecde.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    Allow forcing clusterchecks rebalancing with utilisation.
+    Added a new --force option to the `datadog-cluster-agent clusterchecks rebalance` command that allows you to force clustercheck rebalancing with utilization.

--- a/releasenotes-dca/notes/allow-force-clusterchecks-rebalancing-46b8f58eb157ecde.yaml
+++ b/releasenotes-dca/notes/allow-force-clusterchecks-rebalancing-46b8f58eb157ecde.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Allow forcing clusterchecks rebalancing with utilisation.


### PR DESCRIPTION
### What does this PR do?

Allow forcing clusterchecks rebalancing for scheduler workers utilisation rebalancing  algorithm

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

There’s a command to execute a cluster checks rebalance: `datadog-cluster-agent clusterchecks rebalance`

The code doesn’t always rebalance, it only does so if the new checks distribution that it found is better than the current one by a threshold defined. We do this to avoid re-scheduling too many checks for little benefit.

This PR introduces a new command `datadog-cluster-agent clusterchecks rebalance --force` that skips those checks. This could be used as a quick solution when we detect an issue. The current solution is to kill the leader DCA manually.


### Additional Notes
- Forcing a rebalance doesn't necessarily mean that cluster checks dispatching will be changed. This is because it is possible that the new proposed distribution is identical to the current one, and thus no clusterchecks are rescheduled.
- We have 2 possible algorithms to rebalance clusterchecks. One of them uses busyness to decide whether (and how) to rebalance the checks. The second one uses the scheduler workers utilisation. Forcing rebalancing is being enabled only for the latter.
- Using the `--force` option while not using rebalancing with utilisation will not result in forcing rebalancing.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- Deploy the agent and cluster agent enabling the clustercheck runners and the cluster agent. You should set the environment variables (see sample below) to allow advanced dispatching and rebalancing with utilisation. Set the replicas of the clusterchecks runners to 1. Here is a sample configuration using helm:
```
clusterChecksRunner:
  enabled: true
  replicas: 1
  image:
    repository: datadog/agent
    tag: 7.48.0-rc.9-jmx
    doNotCheckTag: true

clusterAgent:
  enabled: true

  env:
    - name: DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED
      value: true
    - name: DD_CLUSTER_CHECKS_REBALANCE_WITH_UTILIZATION
      value: true

  image:
    repository: clusteragent-image
    tag: latest
    doNotCheckTag: true
    pullPolicy: Always
```
- Install the helm chart on a 3 node minikube cluster locally (or on any kubernetes cluster)
- Make sure all agent, cluster agent, and clustercheck runners are running
- Create 2 services with autodiscovery. To use autodiscovery you can add annotations to the service as such:
```
annotations:
    ad.datadoghq.com/service.checks: |
      {
        "http_check": {
          "init_config": {},
          "instances": [
            {
              "url":"http://%%host%%",
              "name":"My Nginx",
              "timeout":2
            }
          ]
        }
      }
```
- You can then create pods matching the services' selectors and annotations. (For the annotation above, you can create a pod with `nginx` as an image, and give it a label that is identical to the `selector` set in the service)
- This should configure 2 cluster checks and dispatch them to the single replica of the clustercheck runners that exist on the cluster. (you can verify this by checking the logs on the cluster agent pod using `kubectl logs <pod-id>`, this should show messages regarding dispatching both cluster checks on the clusterchecks runner)
- Use `kubectl edit deployment` to increase the number of replicas of the cluster checks runners to 3.
- You can then try rebalancing the clusterchecks by running the following command on the cluster agent pod: `datadog-cluster-agent clusterchecks rebalance --force` 
- Executing the same command several times should force rebalancing most of the times. (NOTE: it is possible that sometimes no clusterchecks are not rebalanced, which is expected)
- You can then check the logs on the cluster agent and verify messages saying that rebalancing was being forced:  **Forcing rebalance proposed distribution for the cluster checks. Utilization stdDev of proposed distribution: 0.000. StdDev of current distribution: 0.000. Proposed distribution: ....**


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
