### PR TITLE
[CWS] Allow silent workloads snapshot to fail gracefully

### DIFF
--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -10,6 +10,7 @@ package dump
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -18,6 +19,7 @@ import (
 	"github.com/cilium/ebpf"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"go.uber.org/atomic"
+	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
 	manager "github.com/DataDog/ebpf-manager"
@@ -406,7 +408,7 @@ func (adm *ActivityDumpManager) insertActivityDump(newDump *ActivityDump) error 
 }
 
 // handleDefaultDumpRequest starts dumping a new workload with the provided load configuration and the default dump configuration
-func (adm *ActivityDumpManager) startDumpWithConfig(containerID string, cookie uint64, loadConfig model.ActivityDumpLoadConfig) {
+func (adm *ActivityDumpManager) startDumpWithConfig(containerID string, cookie uint64, loadConfig model.ActivityDumpLoadConfig) error {
 	newDump := NewActivityDump(adm, func(ad *ActivityDump) {
 		ad.Metadata.ContainerID = containerID
 		ad.SetLoadConfig(cookie, loadConfig)
@@ -436,8 +438,9 @@ func (adm *ActivityDumpManager) startDumpWithConfig(containerID string, cookie u
 	))
 
 	if err := adm.insertActivityDump(newDump); err != nil {
-		seclog.Errorf("couldn't start tracing [%s]: %v", newDump.GetSelectorStr(), err)
+		return fmt.Errorf("couldn't start tracing [%s]: %v", newDump.GetSelectorStr(), err)
 	}
+	return nil
 }
 
 // HandleCGroupTracingEvent handles a cgroup tracing event
@@ -450,7 +453,9 @@ func (adm *ActivityDumpManager) HandleCGroupTracingEvent(event *model.CgroupTrac
 		return
 	}
 
-	adm.startDumpWithConfig(event.ContainerContext.ID, event.ConfigCookie, event.Config)
+	if err := adm.startDumpWithConfig(event.ContainerContext.ID, event.ConfigCookie, event.Config); err != nil {
+		seclog.Errorf("%v", err)
+	}
 }
 
 // SetSecurityProfileManager sets the security profile manager
@@ -508,7 +513,14 @@ workloadLoop:
 		}
 
 		// if we're still here, we can start tracing this workload
-		adm.startDumpWithConfig(workloads[0].ID, utils.NewCookie(), *adm.loadController.getDefaultLoadConfig())
+		if err := adm.startDumpWithConfig(workloads[0].ID, utils.NewCookie(), *adm.loadController.getDefaultLoadConfig()); err != nil {
+			if !errors.Is(err, unix.E2BIG) {
+				seclog.Debugf("%v", err)
+				break
+			} else {
+				seclog.Errorf("%v", err)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR lowers the log level of an error which can be safely ignored when inserting in a map returns `unix.E2BIG`.

### Motivation

We snapshot silent workloads to allow the CWS Security Profile feature to monitor all workloads, including the ones that might not do much on a machine (i.e. pause containers for example). However, this process requires that the user space agent makes the decision of dumping a new workload. Since we cannot implement a lock between the userspace agent and our eBPF kernel programs, we have to gracefully accept that the kernel might have been faster, and as such, might have already filled the map we use to store the container IDs of workloads we're actively dumping.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Check out the deployment in staging and look for this error log pattern:

```
yyyy-MM-dd HH:mm:ss UTC | SYS-PROBE | ERROR | (pkg/security/security_profile/dump/manager.go:407 in startDumpWithConfig) | couldn't start tracing [container_id:*]: couldn't insert new dump: couldn't push activity dump container ID *: update: key too big for map: argument list too long
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
