### PR TITLE
[windows] fix startup with empty api key

### DIFF
--- a/comp/trace/config/config.go
+++ b/comp/trace/config/config.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"html"
 	"net/http"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -44,7 +45,13 @@ type cfg struct {
 func newConfig(deps dependencies) (Component, error) {
 	tracecfg, err := setupConfig(deps, "")
 	if err != nil {
-		return nil, err
+		// The windows agent has a requirement that it can successfully start
+		// with an invalid config.  The `tracecfg` object is initialized with
+		// various defaults, that allow it to be "good enough".  On Windows,
+		// allow us to return the minimal config rather than failing startup
+		if runtime.GOOS != "windows" || tracecfg == nil {
+			return nil, err
+		}
 	}
 
 	c := cfg{

--- a/test/kitchen/test/integration/common/rspec_datadog/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec_datadog/spec_helper.rb
@@ -153,9 +153,6 @@ def stop(flavor)
     end
   end
   wait_until_service_stopped(service)
-  if result == nil || result == false
-      log_trace "datadog-agent", "stop"
-  end
   result
 end
 
@@ -174,9 +171,6 @@ def start(flavor)
     end
   end
   wait_until_service_started(service)
-  if result == nil || result == false
-      log_trace "datadog-agent", "start"
-  end
   result
 end
 
@@ -210,30 +204,7 @@ def restart(flavor)
       wait_until_service_started(service, 5)
     end
   end
-  if result == nil || result == false
-      log_trace "datadog-agent", "restart"
-  end
   result
-end
-
-def log_trace(flavor, action)
-  service = get_service_name(flavor)
-  if os == :windows
-    if action == "stop" || action == "restart"
-      system "wevtutil qe System /q:\"*[System[(EventID=7040) and (EventData[Data[@Name='param1']='#{service}'])]\""
-    end
-    if action == "start" || action == "restart"
-      system "wevtutil qe System /q:\"*[System[(EventID=7036) and (EventData[Data[@Name='param1']='#{service}'])]\""
-    end
-  else
-    if has_systemctl
-      system "sudo journalctl -u #{service} -xe --no-pager"
-    elsif has_upstart
-      system "sudo grep #{service} /var/log/upstart"
-    else
-      system "sudo grep #{service} /var/log/message"
-    end
-  end
 end
 
 def has_systemctl


### PR DESCRIPTION
Previous PR introduced a dependency on the trace agent config component.  The Windows agent expects to be able to start (with errors in the log etc.) to be able to start even without a valid api key.

With the new dependency on the trace config, make the trace component, on windows, able to initialize so that the Windows agent can start accordingly


### Motivation

Allow the windows agent to successfully start in certain bad-configuration scenarios

### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

Install the agent on Windows
set the config to be 
`api_key:`

ensure the agent does not error out on startup.

### Reviewer's Checklist
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
