### PR TITLE
Fix agent not starting with api key missing on Windows

### DIFF
--- a/cmd/agent/subcommands/run/command_windows.go
+++ b/cmd/agent/subcommands/run/command_windows.go
@@ -157,6 +157,9 @@ func run(log log.Component,
 func getPlatformModules() fx.Option {
 	return fx.Options(
 		agentcrashdetect.Module,
-		comptraceconfig.MainAgentModule,
+		comptraceconfig.Module,
+		fx.Replace(comptraceconfig.Params{
+			FailIfAPIKeyMissing: false,
+		}),
 	)
 }

--- a/cmd/agent/subcommands/run/command_windows.go
+++ b/cmd/agent/subcommands/run/command_windows.go
@@ -157,6 +157,6 @@ func run(log log.Component,
 func getPlatformModules() fx.Option {
 	return fx.Options(
 		agentcrashdetect.Module,
-		comptraceconfig.Module,
+		comptraceconfig.MainAgentModule,
 	)
 }

--- a/comp/trace/config/component.go
+++ b/comp/trace/config/component.go
@@ -50,11 +50,9 @@ type Mock interface {
 // Module defines the fx options for this component.
 var Module = fxutil.Component(
 	fx.Provide(newConfig),
-)
-
-// MainAgentModule defines the fx options for this component for the main Datadog Agent.
-var MainAgentModule = fxutil.Component(
-	fx.Provide(newConfigForMainAgent),
+	fx.Supply(Params{
+		FailIfAPIKeyMissing: true,
+	}),
 )
 
 // MockModule defines the fx options for the mock component.

--- a/comp/trace/config/component.go
+++ b/comp/trace/config/component.go
@@ -58,4 +58,7 @@ var Module = fxutil.Component(
 // MockModule defines the fx options for the mock component.
 var MockModule = fxutil.Component(
 	fx.Provide(newMock),
+	fx.Supply(Params{
+		FailIfAPIKeyMissing: true,
+	}),
 )

--- a/comp/trace/config/component.go
+++ b/comp/trace/config/component.go
@@ -52,6 +52,10 @@ var Module = fxutil.Component(
 	fx.Provide(newConfig),
 )
 
+var MainAgentModule = fxutil.Component(
+	fx.Provide(newConfigForMainAgent),
+)
+
 // MockModule defines the fx options for the mock component.
 var MockModule = fxutil.Component(
 	fx.Provide(newMock),

--- a/comp/trace/config/component.go
+++ b/comp/trace/config/component.go
@@ -52,6 +52,7 @@ var Module = fxutil.Component(
 	fx.Provide(newConfig),
 )
 
+// MainAgentModule defines the fx options for this component for the main Datadog Agent.
 var MainAgentModule = fxutil.Component(
 	fx.Provide(newConfigForMainAgent),
 )

--- a/comp/trace/config/config.go
+++ b/comp/trace/config/config.go
@@ -24,7 +24,7 @@ import (
 
 type dependencies struct {
 	fx.In
-
+	Params Params
 	Config coreconfig.Component
 }
 
@@ -41,12 +41,12 @@ type cfg struct {
 	warnings *pkgconfig.Warnings
 }
 
-func generateNewConfig(deps dependencies, failIfAPIKeyMissing bool) (Component, error) {
+func newConfig(deps dependencies) (Component, error) {
 	tracecfg, err := setupConfig(deps, "")
 
 	if err != nil {
 		// Allow main Agent to start with missing API key
-		if !(err == traceconfig.ErrMissingAPIKey && !failIfAPIKeyMissing) {
+		if !(err == traceconfig.ErrMissingAPIKey && !deps.Params.FailIfAPIKeyMissing) {
 			return nil, err
 		}
 	}
@@ -58,14 +58,6 @@ func generateNewConfig(deps dependencies, failIfAPIKeyMissing bool) (Component, 
 	c.SetMaxMemCPU(pkgconfig.IsContainerized())
 
 	return &c, nil
-}
-
-func newConfig(deps dependencies) (Component, error) {
-	return generateNewConfig(deps, true)
-}
-
-func newConfigForMainAgent(deps dependencies) (Component, error) {
-	return generateNewConfig(deps, false)
 }
 
 func (c *cfg) Warnings() *pkgconfig.Warnings {

--- a/comp/trace/config/config.go
+++ b/comp/trace/config/config.go
@@ -41,12 +41,12 @@ type cfg struct {
 	warnings *pkgconfig.Warnings
 }
 
-func generateNewConfig(deps dependencies, failIfApiKeyMissing bool) (Component, error) {
+func generateNewConfig(deps dependencies, failIfAPIKeyMissing bool) (Component, error) {
 	tracecfg, err := setupConfig(deps, "")
 
 	if err != nil {
 		// Allow main Agent to start with missing API key
-		if !(err == traceconfig.ErrMissingAPIKey && !failIfApiKeyMissing) {
+		if !(err == traceconfig.ErrMissingAPIKey && !failIfAPIKeyMissing) {
 			return nil, err
 		}
 	}

--- a/comp/trace/config/params.go
+++ b/comp/trace/config/params.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+// Params defines the parameters for the config component.
+type Params struct {
+	// FailIfAPIKeyMissing controls if the Agent should fail if the API key is missing from the config.
+	FailIfAPIKeyMissing bool
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR introduces an extra `Module` for the Trace Agent config component that doesn't need the API key to start.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The main Datadog Agent should be able to start without an API key, but the Trace Agent doesn't. Since the Datadog Agent now requires the ability to read the Trace Agent config (I believe for internal telemetry), we should make sure it doesn't require an API key to start.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Full CI pipeline here: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/20843825/

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
