### PR TITLE
[USMON-547] faster protocol classification tests

### DIFF
--- a/pkg/network/protocols/mysql/testdata/docker-compose.yml
+++ b/pkg/network/protocols/mysql/testdata/docker-compose.yml
@@ -8,3 +8,6 @@ services:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASS:-root}
     ports:
       - ${MYSQL_ADDR:-127.0.0.1}:${MYSQL_PORT:-3306}:3306
+    tmpfs:
+      - /var/lib/mysql
+

--- a/pkg/network/protocols/testutil/serverutils.go
+++ b/pkg/network/protocols/testutil/serverutils.go
@@ -27,6 +27,11 @@ const (
 // - serverStartRegex is a regex to be matched on the server logs to ensure it started correctly.
 func RunDockerServer(t testing.TB, serverName, dockerPath string, env []string, serverStartRegex *regexp.Regexp, timeout time.Duration) error {
 	t.Helper()
+	// Ensuring no previous instances exists.
+	c := exec.Command("docker-compose", "-f", dockerPath, "down", "--remove-orphans")
+	c.Env = append(c.Env, env...)
+	_ = c.Run()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -44,7 +49,8 @@ func RunDockerServer(t testing.TB, serverName, dockerPath string, env []string, 
 
 		c := exec.Command("docker-compose", "-f", dockerPath, "down", "--remove-orphans")
 		c.Env = append(c.Env, env...)
-		_ = c.Run()
+		// Not waiting for its finish.
+		_ = c.Start()
 	})
 
 	for {

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -1782,7 +1782,7 @@ func waitForConnectionsWithProtocol(t *testing.T, tr *Tracer, targetAddr, server
 			t.Log(conns)
 		}
 		return !failed
-	}, 5*time.Second, 500*time.Millisecond, "could not find incoming or outgoing connections")
+	}, 5*time.Second, 100*time.Millisecond, "could not find incoming or outgoing connections")
 	if failed {
 		t.Logf("incoming=%+v outgoing=%+v", incoming, outgoing)
 	}

--- a/pkg/network/tracer/tracer_windows.go
+++ b/pkg/network/tracer/tracer_windows.go
@@ -204,6 +204,10 @@ func (t *Tracer) RegisterClient(clientID string) error {
 	return nil
 }
 
+func (t *Tracer) removeClient(clientID string) {
+	t.state.RemoveClient(clientID)
+}
+
 func (t *Tracer) getConnTelemetry() map[network.ConnTelemetryType]int64 {
 	return map[network.ConnTelemetryType]int64{
 		network.MonotonicDNSPacketsDropped: driver.HandleTelemetry.ReadPacketsSkipped.Load(),


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

* Merges kafka's produce and fetch sub-tests, cutting 50% of kafka tests
* Modifies the docker teardown to be non-blocking (90s improvement)
* Default interval for the validator is 100ms instead of 500ms - reduces 140s from tests
* Uses in-memory mysql, by that cuts 30s.

Totally - cuts ~4.5m (out of 8.5m local)
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Faster kitchen tests.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
