### PR TITLE
Fix flare e2e test

### DIFF
--- a/test/fakeintake/server/server.go
+++ b/test/fakeintake/server/server.go
@@ -246,14 +246,6 @@ func (fi *Server) handleDatadogRequest(w http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	// Datadog Agent sends a HEAD request to avoid redirect issue before sending the actual flare
-	if req.Method == http.MethodHead && req.URL.Path == "/support/flare" {
-		writeHTTPResponse(w, httpResponse{
-			statusCode: http.StatusOK,
-		})
-		return
-	}
-
 	// from now on accept only POST requests
 	if req.Method != http.MethodPost {
 		response := buildErrorResponse(fmt.Errorf("invalid request with route %s and method %s", req.URL.Path, req.Method))

--- a/test/new-e2e/agent-subcommands/flare/fixtures/datadog-agent.yaml
+++ b/test/new-e2e/agent-subcommands/flare/fixtures/datadog-agent.yaml
@@ -4,7 +4,3 @@ process_config.process_discovery.enabled: false # for process_discovery_check_ou
 
 telemetry.enabled: true # for telemetry.log
 logs_enabled: true # for registry.json
-
-# Should be moved to system-probe.yaml when #18770 is merged
-system_probe_config.bpf_dir: /tmp/dummy_system_probe_config_bpf_dir/
-system_probe_config.sysprobe_socket: /tmp/dummy_dir/dummy_system_probe_sysprobe_socket

--- a/test/new-e2e/agent-subcommands/flare/fixtures/system-probe.yaml
+++ b/test/new-e2e/agent-subcommands/flare/fixtures/system-probe.yaml
@@ -4,3 +4,5 @@
 # ./logs/system-probe.log
 # ./expvar/system-probe
 system_probe_config.enabled: true
+system_probe_config.bpf_dir: /tmp/dummy_system_probe_config_bpf_dir/
+system_probe_config.sysprobe_socket: /tmp/dummy_dir/dummy_system_probe_sysprobe_socket

--- a/test/new-e2e/agent-subcommands/flare/flare_files.go
+++ b/test/new-e2e/agent-subcommands/flare/flare_files.go
@@ -8,7 +8,6 @@ package flare
 // defaultFlareFiles contains all the files that are included in the flare archive by default (no need for a specific configuration option)
 var defaultFlareFiles = []string{
 	"config-check.log",
-	"connectivity.log",
 	"diagnose.log",
 	"docker_ps.log",
 	"envvars.log",

--- a/test/new-e2e/agent-subcommands/flare/flare_test.go
+++ b/test/new-e2e/agent-subcommands/flare/flare_test.go
@@ -77,8 +77,8 @@ func (v *commandFlareSuite) TestFlareWithAllConfiguration() {
 
 	withFiles := []agentparams.Option{
 		// TODO: use dedicated functions when https://github.com/DataDog/test-infra-definitions/pull/309 is merged
-		agentparams.WithFile("/etc/datadog-agent/system-probe.yaml", string(systemProbeConfiguration), useSudo),
-		agentparams.WithFile("/etc/datadog-agent/security-agent.yaml", string(securityAgentConfiguration), useSudo),
+		agentparams.WithSystemProbeConfig(string(systemProbeConfiguration)),
+		agentparams.WithSecurityAgentConfig(string(securityAgentConfiguration)),
 		agentparams.WithFile(confdPath+"test.yaml", "dummy content", useSudo),
 		agentparams.WithFile(confdPath+"test.yml", "dummy content", useSudo),
 		agentparams.WithFile(confdPath+"test.yml.test", "dummy content", useSudo),

--- a/test/new-e2e/agent-subcommands/flare/flare_test.go
+++ b/test/new-e2e/agent-subcommands/flare/flare_test.go
@@ -30,7 +30,7 @@ func TestFlareSuite(t *testing.T) {
 func requestAgentFlareAndFetchFromFakeIntake(v *commandFlareSuite, flareArgs ...client.AgentArgsOption) flare.Flare {
 	// Wait for the fakeintake to be ready to avoid 503 when sending the flare
 	// Definitely not the best way to do it, but the easiest at the moment
-	time.Sleep(30 * time.Second)
+	time.Sleep(60 * time.Second)
 	_ = v.Env().Agent.Flare(flareArgs...)
 
 	flare, err := v.Env().Fakeintake.Client.GetLatestFlare()

--- a/test/new-e2e/agent-subcommands/flare/flare_test.go
+++ b/test/new-e2e/agent-subcommands/flare/flare_test.go
@@ -10,6 +10,7 @@ import (
 	_ "embed"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/test/fakeintake/client/flare"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
@@ -27,6 +28,9 @@ func TestFlareSuite(t *testing.T) {
 }
 
 func requestAgentFlareAndFetchFromFakeIntake(v *commandFlareSuite, flareArgs ...client.AgentArgsOption) flare.Flare {
+	// Wait for the fakeintake to be ready to avoid 503 when sending the flare
+	// Definitely not the best way to do it, but the easiest at the moment
+	time.Sleep(30 * time.Second)
 	_ = v.Env().Agent.Flare(flareArgs...)
 
 	flare, err := v.Env().Fakeintake.Client.GetLatestFlare()


### PR DESCRIPTION

### What does this PR do?

Fix failing e2e tests in the CI

### Motivation

Failing tests are bad

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

Sleep is not the best solution. It will need a change when the framework will provide tool to verify fakeintake readiness

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
