### PR TITLE
Exclude ancostas and maascamp from OpenTelemetry QA

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -87,6 +87,7 @@ jira_statuses = [
 ]
 github_team = "opentelemetry"
 github_labels = ["team/opentelemetry"]
+exclude_members = ["ancostas", "Maascamp"]
 
 [teams."eBPF Platform"]
 jira_project = "EBPF"


### PR DESCRIPTION
### What does this PR do?

Exclude ancostas and maascamp from OpenTelemetry QA.

