### PR TITLE
Pin oscrypto to a git reference to get bugfix

### DIFF
--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -35,5 +35,11 @@ build do
     }
   end
 
-  command "#{pip} install .", :env => build_env
+  # We need a newer version of oscrypto than the one released to get a fix for a bug
+  # that gets triggered when having double digits on the OpenSSL version
+  # (https://github.com/wbond/oscrypto/issues/75).
+  # We can remove the oscrypto pinning once the fix becomes part of a new release
+  oscrypto_commit = "d5f3437ed24257895ae1edd9e503cfb352e635a8"
+
+  command "#{pip} install . 'oscrypto @ git+https://github.com/wbond/oscrypto.git@#{oscrypto_commit}'", :env => build_env
 end

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -41,5 +41,5 @@ build do
   # We can remove the oscrypto pinning once the fix becomes part of a new release
   oscrypto_commit = "d5f3437ed24257895ae1edd9e503cfb352e635a8"
 
-  command "#{pip} install . 'oscrypto @ git+https://github.com/wbond/oscrypto.git@#{oscrypto_commit}'", :env => build_env
+  command "#{pip} install . \"oscrypto @ git+https://github.com/wbond/oscrypto.git@#{oscrypto_commit}\"", :env => build_env
 end


### PR DESCRIPTION
### What does this PR do?

Pins `oscrypto`, a `snowflake-connector-python` dependency, to a version on github which is still unreleased.

### Motivation

Get fix for https://github.com/wbond/oscrypto/issues/75, which hasn't been released yet and which breaks the snowflake integration when shipped with OpenSSL version 3.0.11 (and any version with double digits on any version segment).

### Additional Notes

Testing this patch manually, `agent status` shows the integration to be working:

```
    snowflake (5.0.0)
    -----------------
      Instance ID: snowflake:404312cee7262141 [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/snowflake.d/snowflake.yaml
      Total Runs: 1
      Metric Samples: Last Run: 2, Total: 2
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 1
      Average Execution Time : 28.758s
      Last Execution Date : 2023-10-03 14:01:12 UTC (1696341672000)
      Last Successful Execution Date : 2023-10-03 14:01:12 UTC (1696341672000)
      metadata:
        version.major: 7
        version.minor: 34
        version.patch: 1
        version.raw: 7.34.1
        version.scheme: semver
```

### Possible Drawbacks / Trade-offs

We should keep an eye on future oscrypto releases to remove this pin.

### Describe how to test/QA your changes

Run the integration

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
