### PR TITLE
[CSPM] Avoid recomputing rule evaluation when inputs are unchanged

### DIFF
--- a/cmd/security-agent/subcommands/check/command.go
+++ b/cmd/security-agent/subcommands/check/command.go
@@ -282,7 +282,7 @@ func newFakeResolver(regoInputPath string) compliance.Resolver {
 	return &fakeResolver{regoInputPath}
 }
 
-func (r *fakeResolver) ResolveInputs(ctx context.Context, rule *compliance.Rule) (compliance.ResolvedInputs, error) {
+func (r *fakeResolver) ResolveInputs(ctx context.Context, rule *compliance.Rule) (*compliance.ResolvedInputs, error) {
 	var fixtures map[string]map[string]interface{}
 	data, err := os.ReadFile(r.regoInputPath)
 	if err != nil {
@@ -300,7 +300,14 @@ func (r *fakeResolver) ResolveInputs(ctx context.Context, rule *compliance.Rule)
 		return nil, err
 	}
 	delete(fixture, "context")
-	return compliance.NewResolvedInputs(resolvingContext, fixture)
+	resolved := compliance.NewResolvedInputs()
+	resolved.SetResolvingContext(resolvingContext)
+	for k, v := range fixture {
+		if err := resolved.Put(k, v); err != nil {
+			return nil, err
+		}
+	}
+	return resolved, nil
 }
 
 func jsonRountrip(i interface{}, v interface{}) error {

--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -9,6 +9,7 @@
 package compliance
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"expvar"
@@ -257,17 +258,10 @@ func (a *Agent) runRegoBenchmarks(ctx context.Context) {
 			if sleepRandomJitter(ctx, checkInterval, runCount, a.opts.Hostname, benchmark.FrameworkID) {
 				return
 			}
-
 			resolver := NewResolver(ctx, a.opts.ResolverOptions)
 			for _, rule := range benchmark.Rules {
-				inputs, err := resolver.ResolveInputs(ctx, rule)
-				if err != nil {
-					a.reportCheckEvents(checkInterval, CheckEventFromError(RegoEvaluator, rule, benchmark, err))
-				} else {
-					events := EvaluateRegoRule(ctx, inputs, benchmark, rule)
-					a.reportCheckEvents(checkInterval, events...)
-				}
-
+				events, sum := a.resolveAndEvaluateRegoRule(ctx, resolver, rule, benchmark)
+				a.reportCheckEvents(rule.ID, sum, checkInterval, events...)
 				if sleepAborted(ctx, throttler.C) {
 					resolver.Close()
 					return
@@ -279,6 +273,23 @@ func (a *Agent) runRegoBenchmarks(ctx context.Context) {
 			return
 		}
 	}
+}
+
+func (a *Agent) resolveAndEvaluateRegoRule(ctx context.Context, resolver Resolver, rule *Rule, benchmark *Benchmark) ([]*CheckEvent, CheckInputsSum) {
+	resolved, err := resolver.ResolveInputs(ctx, rule)
+	if err != nil {
+		return []*CheckEvent{
+			CheckEventFromError(RegoEvaluator, rule, benchmark, err),
+		}, nil
+	}
+	sum, ok := resolved.HashSum()
+	if ok {
+		lastEvents, lastSum, ok := a.getCheckLastEvents(rule.ID)
+		if ok && bytes.Equal(sum, lastSum) {
+			return lastEvents, lastSum
+		}
+	}
+	return EvaluateRegoRule(ctx, resolved, benchmark, rule), sum
 }
 
 func (a *Agent) runXCCDFBenchmarks(ctx context.Context) {
@@ -313,7 +324,7 @@ func (a *Agent) runXCCDFBenchmarks(ctx context.Context) {
 			}
 			for _, rule := range benchmark.Rules {
 				events := EvaluateXCCDFRule(ctx, a.opts.Hostname, a.opts.StatsdClient, benchmark, rule)
-				a.reportCheckEvents(checkInterval, events...)
+				a.reportCheckEvents(rule.ID, nil, checkInterval, events...)
 				if sleepAborted(ctx, throttler.C) {
 					FinishXCCDFBenchmark(ctx, benchmark)
 					return
@@ -380,12 +391,12 @@ func (a *Agent) reportResourceLog(resourceTTL time.Duration, resourceLog *Resour
 	a.opts.Reporter.ReportEvent(resourceLog)
 }
 
-func (a *Agent) reportCheckEvents(eventsTTL time.Duration, events ...*CheckEvent) {
+func (a *Agent) reportCheckEvents(ruleID string, sum CheckInputsSum, eventsTTL time.Duration, events ...*CheckEvent) {
 	store := workloadmeta.GetGlobalStore()
 	eventsExpireAt := time.Now().Add(2 * eventsTTL).Truncate(1 * time.Second)
+	a.updateEvents(ruleID, sum, events)
 	for _, event := range events {
 		event.ExpireAt = &eventsExpireAt
-		a.updateEvent(event)
 		if event.Result == CheckSkipped {
 			continue
 		}
@@ -434,6 +445,15 @@ func (a *Agent) getChecksStatus() interface{} {
 	return statuses
 }
 
+func (a *Agent) getCheckLastEvents(ruleID string) (events []*CheckEvent, sum CheckInputsSum, ok bool) {
+	a.statusesMu.RLock()
+	defer a.statusesMu.RUnlock()
+	if status, ok := a.statuses[ruleID]; ok {
+		return status.LastEvents, status.LastSum, true
+	}
+	return
+}
+
 func (a *Agent) addBenchmarks(benchmarks ...*Benchmark) {
 	a.statusesMu.Lock()
 	defer a.statusesMu.Unlock()
@@ -455,25 +475,28 @@ func (a *Agent) addBenchmarks(benchmarks ...*Benchmark) {
 	}
 }
 
-func (a *Agent) updateEvent(event *CheckEvent) {
+func (a *Agent) updateEvents(ruleID string, sum CheckInputsSum, events []*CheckEvent) {
 	if client := a.opts.StatsdClient; client != nil {
-		tags := []string{
-			"rule_id:" + event.RuleID,
-			"rule_result:" + string(event.Result),
-			"agent_version:" + event.AgentVersion,
-		}
-		if err := client.Gauge(metrics.MetricChecksStatuses, 1, tags, 1.0); err != nil {
-			log.Errorf("failed to send checks metric: %v", err)
+		for _, event := range events {
+			tags := []string{
+				"rule_id:" + ruleID,
+				"rule_result:" + string(event.Result),
+				"agent_version:" + event.AgentVersion,
+			}
+			if err := client.Gauge(metrics.MetricChecksStatuses, 1, tags, 1.0); err != nil {
+				log.Errorf("failed to send checks metric: %v", err)
+			}
 		}
 	}
 
 	a.statusesMu.Lock()
 	defer a.statusesMu.Unlock()
-	status, ok := a.statuses[event.RuleID]
+	status, ok := a.statuses[ruleID]
 	if !ok || status == nil {
-		log.Errorf("check for rule=%s was not registered in checks monitor statuses", event.RuleID)
+		log.Errorf("check for rule=%s was not registered in checks monitor statuses", ruleID)
 	} else {
-		status.LastEvent = event
+		status.LastSum = sum
+		status.LastEvents = events
 	}
 }
 

--- a/pkg/compliance/data.go
+++ b/pkg/compliance/data.go
@@ -6,9 +6,12 @@
 package compliance
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash"
 	"os"
 	"path/filepath"
 	"sort"
@@ -32,6 +35,9 @@ const (
 
 // CheckResult lists the different states of a check result.
 type CheckResult string
+
+// CheckInputsSum holds the checksum of the inputs data used for the check.
+type CheckInputsSum []byte
 
 const (
 	// CheckPassed is used to report successful result of a rule check
@@ -57,7 +63,8 @@ type CheckStatus struct {
 	Framework   string
 	Source      string
 	InitError   error
-	LastEvent   *CheckEvent
+	LastSum     CheckInputsSum
+	LastEvents  []*CheckEvent
 }
 
 // CheckContainerMeta holds metadata related to the container that has been checked.
@@ -330,27 +337,91 @@ type ResolvingContext struct {
 //		Context  *ResolvingContext      `json:"context"`
 //		Resolved map[string]interface{} `json:",inline"`
 //	}
-type ResolvedInputs map[string]interface{}
+type ResolvedInputs struct {
+	m map[string]interface{}
 
-// GetContext returns the ResolvingContext associated with this resolved
+	h        hash.Hash
+	hinvalid bool
+}
+
+// NewResolvedInputs builds a ResolvedInputs map.
+func NewResolvedInputs() *ResolvedInputs {
+	return &ResolvedInputs{
+		m: make(map[string]interface{}),
+		h: sha256.New(),
+	}
+}
+
+// Data returns the inner content map holding the actual data.
+func (r *ResolvedInputs) Data() map[string]interface{} {
+	return r.m
+}
+
+// Context returns the ResolvingContext associated with this resolved
 // inputs.
-func (r ResolvedInputs) GetContext() *ResolvingContext {
-	c := r["context"].(ResolvingContext)
+func (r *ResolvedInputs) Context() *ResolvingContext {
+	c := r.m["context"].(ResolvingContext)
 	return &c
 }
 
-// NewResolvedInputs builds a ResolvedInputs map from the given resolving
-// context and generic resolved data.
-func NewResolvedInputs(resolvingContext ResolvingContext, resolved map[string]interface{}) (ResolvedInputs, error) {
-	ri := make(ResolvedInputs, len(resolved)+1)
-	for k, v := range resolved {
-		if k == "context" {
-			return nil, fmt.Errorf("NewResolvedInputs: \"context\" is a reserved keyword")
-		}
-		ri[k] = v
+// HashSum returns a checksum of the constructed resolved inputs map. Check
+// the second return value for checksum validity.
+func (r *ResolvedInputs) HashSum() (CheckInputsSum, bool) {
+	if r.hinvalid {
+		return nil, false
 	}
-	ri["context"] = resolvingContext
-	return ri, nil
+	return r.h.Sum(nil), true
+}
+
+// Put adds a new property to the resolved inputs map. "context" key is
+// reserved and should not be used (see SetResolvingContext).
+func (r *ResolvedInputs) Put(tagName string, value interface{}) error {
+	if tagName == "context" {
+		return fmt.Errorf("input with tag 'context' is reserved")
+	}
+	if _, ok := r.m[tagName]; ok {
+		return fmt.Errorf("input with tag %q already set", tagName)
+	}
+	r.m[tagName] = value
+	return nil
+}
+
+// SetResolvingContext updates the "context" key with given resolving context.
+func (r *ResolvedInputs) SetResolvingContext(resolvingContext ResolvingContext) {
+	r.m["context"] = resolvingContext
+}
+
+func (r *ResolvedInputs) markHashInvalid() {
+	r.hinvalid = true
+}
+
+func (r *ResolvedInputs) hashBytes(slice []byte) []byte {
+	r.h.Write(slice)
+	return slice
+}
+
+func (r *ResolvedInputs) hashStrings(slice []string) []string {
+	for _, s := range slice {
+		r.hashString(s)
+	}
+	return slice
+}
+
+func (r *ResolvedInputs) hashString(s string) string {
+	r.h.Write([]byte(s))
+	return s
+}
+
+func (r *ResolvedInputs) hashInt(i int) int {
+	r.hashUint64(uint64(i))
+	return i
+}
+
+func (r *ResolvedInputs) hashUint64(i uint64) uint64 {
+	var b [8]byte
+	binary.LittleEndian.PutUint64(b[:], i)
+	r.h.Write(b[:])
+	return i
 }
 
 // Benchmark represents a set of rules that have a common identity, typically

--- a/pkg/compliance/resolver.go
+++ b/pkg/compliance/resolver.go
@@ -100,7 +100,7 @@ type ResolverOptions struct {
 // associated with a given rule. The Close() method should be called whenever
 // the resolver is stopped being used to cleanup underlying resources.
 type Resolver interface {
-	ResolveInputs(ctx context.Context, rule *Rule) (ResolvedInputs, error)
+	ResolveInputs(ctx context.Context, rule *Rule) (*ResolvedInputs, error)
 	Close()
 }
 
@@ -167,7 +167,7 @@ func (r *defaultResolver) Close() {
 	r.kubeResourcesCache = nil
 }
 
-func (r *defaultResolver) ResolveInputs(ctx context.Context, rule *Rule) (ResolvedInputs, error) {
+func (r *defaultResolver) ResolveInputs(ctx context.Context, rule *Rule) (*ResolvedInputs, error) {
 	resolvingContext := ResolvingContext{
 		RuleID:     rule.ID,
 		Hostname:   r.opts.Hostname,
@@ -205,7 +205,7 @@ func (r *defaultResolver) ResolveInputs(ctx context.Context, rule *Rule) (Resolv
 		}
 	}
 
-	resolved := make(map[string]interface{})
+	resolved := NewResolvedInputs()
 	for _, spec := range rule.InputSpecs {
 		start := time.Now()
 
@@ -217,29 +217,31 @@ func (r *defaultResolver) ResolveInputs(ctx context.Context, rule *Rule) (Resolv
 		switch {
 		case spec.File != nil:
 			resultType = "file"
-			result, err = r.resolveFile(ctx, rootPath, *spec.File)
+			result, err = r.resolveFile(ctx, resolved, rootPath, *spec.File)
 		case spec.Process != nil:
 			resultType = "process"
-			result, err = r.resolveProcess(ctx, *spec.Process)
+			result, err = r.resolveProcess(ctx, resolved, *spec.Process)
 		case spec.Group != nil:
 			resultType = "group"
-			result, err = r.resolveGroup(ctx, *spec.Group)
+			result, err = r.resolveGroup(ctx, resolved, *spec.Group)
 		case spec.Audit != nil:
 			resultType = "audit"
-			result, err = r.resolveAudit(ctx, *spec.Audit)
+			result, err = r.resolveAudit(ctx, resolved, *spec.Audit)
 		case spec.Docker != nil:
+			resolved.markHashInvalid()
 			resultType = "docker"
 			result, err = r.resolveDocker(ctx, *spec.Docker)
 		case spec.KubeApiserver != nil:
+			resolved.markHashInvalid()
 			resultType = "kubernetes"
 			result, err = r.resolveKubeApiserver(ctx, *spec.KubeApiserver)
 			kubernetesCluster = r.resolveKubeClusterID(ctx)
 		case spec.Package != nil:
 			resultType = "package"
-			result, err = r.resolvePackage(ctx, *spec.Package)
+			result, err = r.resolvePackage(ctx, resolved, *spec.Package)
 		case spec.Constants != nil:
 			resultType = "constants"
-			result = *spec.Constants
+			result = *spec.Constants // not hashed - they are immutable
 		default:
 			return nil, fmt.Errorf("bad input spec")
 		}
@@ -251,24 +253,18 @@ func (r *defaultResolver) ResolveInputs(ctx context.Context, rule *Rule) (Resolv
 		if err != nil {
 			return nil, fmt.Errorf("could not resolve input spec %s(tagged=%q): %w", resultType, tagName, err)
 		}
-
-		if _, ok := resolved[tagName]; ok {
-			return nil, fmt.Errorf("input with tag %q already set", tagName)
+		if r, ok := result.([]interface{}); ok && reflect.ValueOf(r).IsNil() {
+			result = nil
 		}
-		if _, ok := resolvingContext.InputSpecs[tagName]; ok {
-			return nil, fmt.Errorf("input with tag %q already set", tagName)
+
+		err = resolved.Put(tagName, result)
+		if err != nil {
+			return nil, err
 		}
 
 		resolvingContext.InputSpecs[tagName] = spec
 		if kubernetesCluster != "" {
 			resolvingContext.KubernetesCluster = kubernetesCluster
-		}
-
-		if r, ok := result.([]interface{}); ok && reflect.ValueOf(r).IsNil() {
-			result = nil
-		}
-		if result != nil {
-			resolved[tagName] = result
 		}
 
 		if statsdClient := r.opts.StatsdClient; statsdClient != nil && resultType != "constants" {
@@ -286,7 +282,8 @@ func (r *defaultResolver) ResolveInputs(ctx context.Context, rule *Rule) (Resolv
 		}
 	}
 
-	return NewResolvedInputs(resolvingContext, resolved)
+	resolved.SetResolvingContext(resolvingContext)
+	return resolved, nil
 }
 
 func (r *defaultResolver) pathNormalize(rootPath, path string) string {
@@ -346,17 +343,17 @@ func (r *defaultResolver) getFileMeta(path string) (*fileMeta, error) {
 
 var processFlagBuiltinReg = regexp.MustCompile(`process\.flag\("(\S+)",\s*"(\S+)"\)`)
 
-func (r *defaultResolver) resolveFile(ctx context.Context, rootPath string, spec InputSpecFile) (result interface{}, err error) {
+func (r *defaultResolver) resolveFile(ctx context.Context, h *ResolvedInputs, rootPath string, spec InputSpecFile) (result interface{}, err error) {
 	path := strings.TrimSpace(spec.Path)
 	if matches := processFlagBuiltinReg.FindStringSubmatch(path); len(matches) == 3 {
 		processName, processFlag := matches[1], matches[2]
-		result, err = r.resolveFileFromProcessFlag(ctx, rootPath, processName, processFlag, spec.Parser)
+		result, err = r.resolveFileFromProcessFlag(ctx, h, rootPath, processName, processFlag, spec.Parser)
 	} else if spec.Glob != "" && path == "" {
-		result, err = r.resolveFileGlob(ctx, rootPath, spec.Glob, spec.Parser)
+		result, err = r.resolveFileGlob(ctx, h, rootPath, spec.Glob, spec.Parser)
 	} else if strings.Contains(path, "*") {
-		result, err = r.resolveFileGlob(ctx, rootPath, path, spec.Parser)
+		result, err = r.resolveFileGlob(ctx, h, rootPath, path, spec.Parser)
 	} else {
-		result, err = r.resolveFilePath(ctx, rootPath, path, spec.Parser)
+		result, err = r.resolveFilePath(ctx, h, rootPath, path, spec.Parser)
 	}
 	if errors.Is(err, os.ErrPermission) ||
 		errors.Is(err, os.ErrNotExist) ||
@@ -366,7 +363,7 @@ func (r *defaultResolver) resolveFile(ctx context.Context, rootPath string, spec
 	return
 }
 
-func (r *defaultResolver) resolveFilePath(ctx context.Context, rootPath, path, parser string) (interface{}, error) {
+func (r *defaultResolver) resolveFilePath(ctx context.Context, h *ResolvedInputs, rootPath, path, parser string) (interface{}, error) {
 	path = r.pathNormalize(rootPath, path)
 	file, err := r.getFileMeta(path)
 	if err != nil {
@@ -394,17 +391,19 @@ func (r *defaultResolver) resolveFilePath(ctx context.Context, rootPath, path, p
 			return nil, err
 		}
 	}
+
+	h.hashBytes(file.data)
 	return map[string]interface{}{
-		"path":        r.pathRelative(rootPath, path),
-		"glob":        "",
-		"permissions": file.perms,
-		"user":        file.user,
-		"group":       file.group,
-		"content":     content,
+		"path":        h.hashString(r.pathRelative(rootPath, path)),
+		"glob":        h.hashString(""),
+		"permissions": h.hashUint64(file.perms),
+		"user":        h.hashString(file.user),
+		"group":       h.hashString(file.group),
+		"content":     content, // hashed by file.data
 	}, nil
 }
 
-func (r *defaultResolver) resolveFileFromProcessFlag(ctx context.Context, rootPath, name, flag, parser string) (interface{}, error) {
+func (r *defaultResolver) resolveFileFromProcessFlag(ctx context.Context, h *ResolvedInputs, rootPath, name, flag, parser string) (interface{}, error) {
 	procs, err := r.getProcs(ctx)
 	if err != nil {
 		return nil, err
@@ -431,27 +430,27 @@ func (r *defaultResolver) resolveFileFromProcessFlag(ctx context.Context, rootPa
 	if !ok {
 		return nil, nil
 	}
-	return r.resolveFilePath(ctx, rootPath, path, parser)
+	return r.resolveFilePath(ctx, h, rootPath, path, parser)
 }
 
-func (r *defaultResolver) resolveFileGlob(ctx context.Context, rootPath, glob, parser string) (interface{}, error) {
+func (r *defaultResolver) resolveFileGlob(ctx context.Context, h *ResolvedInputs, rootPath, glob, parser string) (interface{}, error) {
 	paths, _ := filepath.Glob(r.pathNormalize(rootPath, glob)) // We ignore errors from Glob which are never I/O errors
 	var resolved []interface{}
 	for _, path := range paths {
 		path = r.pathRelative(rootPath, path)
-		file, err := r.resolveFilePath(ctx, rootPath, path, parser)
+		file, err := r.resolveFilePath(ctx, h, rootPath, path, parser)
 		if err != nil {
 			continue
 		}
 		if f, ok := file.(map[string]interface{}); ok {
-			f["glob"] = glob
+			f["glob"] = h.hashString(glob)
 		}
 		resolved = append(resolved, file)
 	}
 	return resolved, nil
 }
 
-func (r *defaultResolver) resolveProcess(ctx context.Context, spec InputSpecProcess) (interface{}, error) {
+func (r *defaultResolver) resolveProcess(ctx context.Context, h *ResolvedInputs, spec InputSpecProcess) (interface{}, error) {
 	procs, err := r.getProcs(ctx)
 	if err != nil {
 		return nil, err
@@ -475,13 +474,14 @@ func (r *defaultResolver) resolveProcess(ctx context.Context, spec InputSpecProc
 			}
 		}
 		exe, _ := p.Exe()
+
 		resolved = append(resolved, map[string]interface{}{
-			"name":    spec.Name,
-			"pid":     p.Pid,
-			"exe":     exe,
-			"cmdLine": cmdLine,
+			"name":    h.hashString(spec.Name),
+			"pid":     h.hashInt(int(p.Pid)),
+			"exe":     h.hashString(exe),
+			"cmdLine": h.hashStrings(cmdLine),
 			"flags":   parseCmdlineFlags(cmdLine),
-			"envs":    parseEnvironMap(envs, spec.Envs),
+			"envs":    parseEnvironMap(h.hashStrings(envs), spec.Envs),
 		})
 	}
 	return resolved, nil
@@ -498,7 +498,7 @@ func (r *defaultResolver) getProcs(ctx context.Context) ([]*process.Process, err
 	return r.procsCache, nil
 }
 
-func (r *defaultResolver) resolveGroup(ctx context.Context, spec InputSpecGroup) (interface{}, error) {
+func (r *defaultResolver) resolveGroup(ctx context.Context, h *ResolvedInputs, spec InputSpecGroup) (interface{}, error) {
 	f, err := os.Open(r.pathNormalizeToHostRoot("/etc/group"))
 	if err != nil {
 		return nil, err
@@ -523,16 +523,17 @@ func (r *defaultResolver) resolveGroup(ctx context.Context, spec InputSpecGroup)
 			return nil, fmt.Errorf("failed to parse group ID for %s: %w", spec.Name, err)
 		}
 		users := strings.Split(parts[3], ",")
+
 		return map[string]interface{}{
-			"name":  spec.Name,
-			"users": users,
-			"id":    gid,
+			"name":  h.hashString(spec.Name),
+			"users": h.hashStrings(users),
+			"id":    h.hashInt(gid),
 		}, nil
 	}
 	return nil, nil
 }
 
-func (r *defaultResolver) resolveAudit(ctx context.Context, spec InputSpecAudit) (interface{}, error) {
+func (r *defaultResolver) resolveAudit(ctx context.Context, h *ResolvedInputs, spec InputSpecAudit) (interface{}, error) {
 	cl := r.linuxAuditCl
 	if cl == nil {
 		return nil, ErrIncompatibleEnvironment
@@ -561,10 +562,11 @@ func (r *defaultResolver) resolveAudit(ctx context.Context, spec InputSpecAudit)
 					permissions += "a"
 				}
 			}
+
 			resolved = append(resolved, map[string]interface{}{
-				"path":        spec.Path,
+				"path":        h.hashString(spec.Path),
 				"enabled":     true,
-				"permissions": permissions,
+				"permissions": h.hashString(permissions),
 			})
 		}
 	}
@@ -797,45 +799,54 @@ var rpmDbs = []string{
 	"/var/lib/rpm/Packages",
 }
 
-func (r *defaultResolver) resolvePackage(ctx context.Context, spec InputSpecPackage) (pkg *packageInfo, err error) {
+func (r *defaultResolver) resolvePackage(ctx context.Context, h *ResolvedInputs, spec InputSpecPackage) (result map[string]interface{}, err error) {
 	if len(spec.Names) == 0 {
 		return nil, nil
 	}
 
+	var pkg *packageInfo
+	defer func() {
+		if pkg == nil {
+			return
+		}
+		if r.pkgsCache == nil {
+			r.pkgsCache = make(map[string]*packageInfo)
+		}
+		r.pkgsCache[pkg.Name] = pkg
+
+		result = map[string]interface{}{
+			"name":    h.hashString(pkg.Name),
+			"version": h.hashString(pkg.Version),
+			"arch":    h.hashString(pkg.Arch),
+		}
+	}()
+
 	if r.pkgsCache != nil {
 		for _, name := range spec.Names {
-			if p, ok := r.pkgsCache[name]; ok {
-				return p, nil
+			pkg = r.pkgsCache[name]
+			if pkg != nil {
+				return
 			}
 		}
 	}
 
-	defer func() {
-		if pkg != nil {
-			if r.pkgsCache == nil {
-				r.pkgsCache = make(map[string]*packageInfo)
-			}
-			r.pkgsCache[pkg.Name] = pkg
-		}
-	}()
-
 	// apk
 	apkPath := r.pathNormalizeToHostRoot(apkDb)
-	if pkg := findApkPackage(apkPath, spec.Names); pkg != nil {
-		return pkg, nil
+	if pkg = findApkPackage(apkPath, spec.Names); pkg != nil {
+		return
 	}
 
 	// dpkg
 	dpkgPath := r.pathNormalizeToHostRoot(dpkgDb)
-	if pkg := findDpkgPackage(dpkgPath, spec.Names); pkg != nil {
-		return pkg, nil
+	if pkg = findDpkgPackage(dpkgPath, spec.Names); pkg != nil {
+		return
 	}
 	dpkgDirPath := r.pathNormalizeToHostRoot(dpkgDbDir)
 	if files, _ := os.ReadDir(dpkgDirPath); len(files) > 0 {
 		for _, entry := range files {
 			dpkgPath := filepath.Join(dpkgDirPath, entry.Name())
-			if pkg := findDpkgPackage(dpkgPath, spec.Names); pkg != nil {
-				return pkg, nil
+			if pkg = findDpkgPackage(dpkgPath, spec.Names); pkg != nil {
+				return
 			}
 		}
 	}
@@ -843,12 +854,12 @@ func (r *defaultResolver) resolvePackage(ctx context.Context, spec InputSpecPack
 	// rpm
 	for _, path := range rpmDbs {
 		rpmPath := r.pathNormalizeToHostRoot(path)
-		if pkg := findRpmPackage(rpmPath, spec.Names); pkg != nil {
-			return pkg, nil
+		if pkg = findRpmPackage(rpmPath, spec.Names); pkg != nil {
+			return
 		}
 	}
 
-	return nil, nil
+	return
 }
 
 func parseCmdlineFlags(cmdline []string) map[string]string {


### PR DESCRIPTION
This PR introduces some hashing of our resolver outputs to being able to avoid doing unnecessary Rego evaluation if the inputs is unchanged.

The main motivation is to avoid the heavy lifting of compiling Rego policies for nothing. This step is the one that shows up the most in our profiles, while our inputs are most of the time constants.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
