### PR TITLE
Create manual deploy for docker images on failure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -626,7 +626,7 @@ workflow:
   - <<: *if_not_deploy
     when: never
   - <<: *if_rc_tag_on_beta_repo_branch
-    when: on_success
+    when: manual
     variables:
       AGENT_REPOSITORY: ci/datadog-agent/agent-release
       CLUSTER_AGENT_REPOSITORY: ci/datadog-agent/cluster-agent-release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -505,7 +505,7 @@ workflow:
       DSD_REPOSITORY: dogstatsd
       IMG_REGISTRIES: public
   
-  .on_deploy_a7_rc_manual:
+.on_deploy_a7_rc_manual:
   - <<: *if_not_version_7
     when: never
   - <<: *if_not_deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -387,6 +387,12 @@ workflow:
   - <<: *if_deploy
     when: on_failure
 
+.on_deploy_rc_failure:
+  - <<: *if_not_deploy
+    when: never
+  - <<: *if_rc_tag_on_beta_repo_branch
+    when: on_failure
+
 .on_deploy_a6:
   - <<: *if_not_version_6
     when: never
@@ -399,6 +405,18 @@ workflow:
     when: never
   - <<: *if_rc_tag_on_beta_repo_branch
     when: on_success
+    variables:
+      AGENT_REPOSITORY: agent
+      DSD_REPOSITORY: dogstatsd
+      IMG_REGISTRIES: public
+
+.on_deploy_a6_rc_manual:
+  - <<: *if_not_version_6
+    when: never
+  - <<: *if_not_deploy
+    when: never
+  - <<: *if_rc_tag_on_beta_repo_branch
+    when: manual
     variables:
       AGENT_REPOSITORY: agent
       DSD_REPOSITORY: dogstatsd
@@ -482,6 +500,18 @@ workflow:
     when: never
   - <<: *if_rc_tag_on_beta_repo_branch
     when: on_success
+    variables:
+      AGENT_REPOSITORY: agent
+      DSD_REPOSITORY: dogstatsd
+      IMG_REGISTRIES: public
+  
+  .on_deploy_a7_rc_manual:
+  - <<: *if_not_version_7
+    when: never
+  - <<: *if_not_deploy
+    when: never
+  - <<: *if_rc_tag_on_beta_repo_branch
+    when: manual
     variables:
       AGENT_REPOSITORY: agent
       DSD_REPOSITORY: dogstatsd
@@ -578,6 +608,19 @@ workflow:
 # agent 7 versions should be published internally using these
 # configurations.
 .on_deploy_a7_internal_rc:
+  - <<: *if_not_version_7
+    when: never
+  - <<: *if_not_deploy
+    when: never
+  - <<: *if_rc_tag_on_beta_repo_branch
+    when: on_success
+    variables:
+      AGENT_REPOSITORY: ci/datadog-agent/agent-release
+      CLUSTER_AGENT_REPOSITORY: ci/datadog-agent/cluster-agent-release
+      DSD_REPOSITORY: ci/datadog-agent/dogstatsd-release
+      IMG_REGISTRIES: internal-aws-ddbuild
+
+.on_deploy_a7_internal_rc_manual:
   - <<: *if_not_version_7
     when: never
   - <<: *if_not_deploy

--- a/.gitlab/deploy_containers.yml
+++ b/.gitlab/deploy_containers.yml
@@ -207,6 +207,7 @@ deploy_containers-a7-rc_on_failure:
     !reference [.on_deploy_a7_rc_manual]
   variables:
     VERSION: 7-rc
+  needs: ["check_failure_for_manual"]
 
 deploy_containers-a7_on_failure:
   extends: .deploy_containers-a7_external

--- a/.gitlab/deploy_containers.yml
+++ b/.gitlab/deploy_containers.yml
@@ -186,6 +186,7 @@ deploy_containers_latest-dogstatsd:
 check_failure_for_manual:
   stage: deploy_containers
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
   rules:
     !reference [.on_deploy_rc_failure]
   script:

--- a/.gitlab/deploy_containers.yml
+++ b/.gitlab/deploy_containers.yml
@@ -180,3 +180,66 @@ deploy_containers_latest-dogstatsd:
   variables:
     IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     IMG_DESTINATIONS: ${DSD_REPOSITORY}:7,${DSD_REPOSITORY}:latest
+
+# On failure manual publish jobs
+
+check_failure_for_manual:
+  stage: deploy_containers
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  rules:
+    !reference [.on_deploy_rc_failure]
+  script:
+    - echo "Job in previous stage failed, enabling manual deploy of images"
+
+deploy_containers-a7_internal-rc_on_failure:
+  extends: .deploy_containers-a7-base
+  rules:
+    !reference [.on_deploy_a7_internal_rc_manual]
+  variables:
+    VERSION: 7-rc
+  needs: ["check_failure_for_manual"]
+
+
+deploy_containers-a7-rc_on_failure:
+  extends: .deploy_containers-a7_external
+  rules:
+    !reference [.on_deploy_a7_rc_manual]
+  variables:
+    VERSION: 7-rc
+
+deploy_containers-a7_on_failure:
+  extends: .deploy_containers-a7_external
+  rules:
+    !reference [.on_deploy_a7_rc_manual]
+  needs: ["check_failure_for_manual"]
+
+
+deploy_containers-dogstatsd_on_failure:
+  extends: .docker_publish_job_definition
+  stage: deploy_containers
+  rules:
+    !reference [.on_deploy_a7_rc_manual]
+  dependencies: []
+  before_script:
+    - source /root/.bashrc
+    - export VERSION="$(inv agent.version --major-version 7 --url-safe)"
+    - export IMG_SOURCES="${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64"
+    - export IMG_DESTINATIONS="${DSD_REPOSITORY}:${VERSION}"
+  needs: ["check_failure_for_manual"]
+
+
+deploy_containers-a6_on_failure:
+  extends: .deploy_containers-a6-base
+  rules:
+    !reference [.on_deploy_a6_rc_manual]
+  needs: ["check_failure_for_manual"]
+
+
+deploy_containers-a6-rc_on_failure:
+  extends: .deploy_containers-a6-base
+  rules:
+    !reference [.on_deploy_a6_rc_manual]
+  variables:
+    VERSION: 6-rc
+  needs: ["check_failure_for_manual"]
+


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Modify the CI to be able to manually run the docker image deploy job on failure of a job in the previous stages of the pipeline.

Here is an example of a pipeline with this thing activated, with fake job to show what happens when we have a failure.
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/20841976
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

To not have to painfully create pipeline on `public-images` to deploy docker images when one job that should not prevent from releasing the image fail

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

The solution I propose is kinda hacky, I did not find a way to allow the existing job to be manually triggered when a previous job failed. As a workaround I created new manual jobs that depends on a job that will run only `on_failure`. If the pipeline succeed we should not be able to run manually the deployment of docker images
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
