### PR TITLE
Fix bug where `resource_name` can be attached to `kubernetes_state`

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -827,7 +827,10 @@ func (k *KSMCheck) sendTelemetry(s sender.Sender) {
 	s.Gauge(ksmMetricPrefix+"telemetry.metrics.count.total", float64(k.telemetry.getTotal()), "", k.instance.Tags)
 	s.Gauge(ksmMetricPrefix+"telemetry.unknown_metrics.count", float64(k.telemetry.getUnknown()), "", k.instance.Tags) // useful to track metrics that aren't mapped to DD metrics
 	for resource, count := range k.telemetry.getResourcesCount() {
-		s.Gauge(ksmMetricPrefix+"telemetry.metrics.count", float64(count), "", append(k.instance.Tags, "resource_name:"+resource))
+		t := make([]string, len(k.instance.Tags), len(k.instance.Tags)+1)
+		copy(t, k.instance.Tags)
+		s.Gauge(ksmMetricPrefix+"telemetry.metrics.count", float64(count), "", append(t, "resource_name:"+resource))
+		panic(fmt.Sprintf("%v", k.instance.Tags))
 	}
 }
 

--- a/releasenotes/notes/fix-resource_name-attached-to-kubernetes-state-core-metrics-730b53d0f5a9499c.yaml
+++ b/releasenotes/notes/fix-resource_name-attached-to-kubernetes-state-core-metrics-730b53d0f5a9499c.yaml
@@ -1,0 +1,5 @@
+
+fixes:
+  - |
+    Fix bug where `resource_name` could be attached to every `kubernetes_state_core` metrics when the check is configured with
+    `telemetry: true`.


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR fixes a bug where every KSM metric is tagged with `resource_name`.

Here is a reproduction of what happens.
```
// Here is what k.instance.Tags is storing after appending `tag1:1` twice:
// Tags: len(2), capacity(4), ["tag1:1", "tag1:1"]
// As you can see, it stores an array, a capacity and its len.
// If the array has enough capacity to append an element, no allocation is made. Thus, when KSM calls append(tags, "resource_name:foo"), tags becomes:
// Tags: len(2), capacity(4), ["tag1:1", "tag1:1", "resource_name:foo"] 
// /!\ the array is updated while the len and capacity are not.
// Then, KSM uses the raw sender that calls pkg/util/sort_uniq.go(SortUniqInPlace) making Tags become
// Tags: len(2), capacity(4), ["tag1:1", "resource_name:foo", "tag1:1"]
// In other words, here resource_name is added by mistake
func TestDoesNotUpdateInstanceTags(t *testing.T) {
	k := &KSMCheck{
		telemetry: newTelemetryCache(),
		instance: &KSMConfig{
			Tags:      make([]string, 0, 4),
			Telemetry: true,
		},
	}
	// Append the same tag twice so one will be removed by SortUniqInPlace
	k.instance.Tags = append(k.instance.Tags, "tag1:1")
	k.instance.Tags = append(k.instance.Tags, "tag1:1")

	// Append the resource_name tag and sort uniq in place
	r := append(k.instance.Tags, "resource_name:foo")
	r = util.SortUniqInPlace(r)
        // Here, k.instance.Tags has a resource_name tag
	assert.ElementsMatch(t, k.instance.Tags, []string{"tag:1"}	) // should fail because `resource_name` is here
}
```
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
We want KSM core check tagging to be correct.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
It is difficult to cover with a unit test because the `MockSender` does not call `util.SortUniqInPlace`.
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
It is costly to create a new string but it's not like we have the choice.
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
I think we can reproduce by simply including global tags and having twice the same tag. The `Tags` array should have a capacity large enough to avoid a reallocation.

The `Tags` array is in this function: https://github.com/DataDog/datadog-agent/blob/60387d27ceb18c3912b907fd35dfab16407e470f/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go#L777.

So simply deploy the DCA and the KSM core check with:
`-name: "DD_TAGS"
- value: "key1:value1 key1:value1"

In theory, if `kube_cluster_name` is set, you should have an array of len 3 and capacity 4, enough to reproduce the bug.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
