### PR TITLE
[NPM-2998] clean up sources of potential flakiness

### DIFF
--- a/pkg/network/netlink/conntrack_integration_test.go
+++ b/pkg/network/netlink/conntrack_integration_test.go
@@ -12,7 +12,6 @@ import (
 	"net"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
@@ -163,9 +162,6 @@ func BenchmarkConntrackExists(b *testing.B) {
 
 func TestConntrackExists6(t *testing.T) {
 	ns := testutil.SetupCrossNsDNAT6(t)
-
-	// wait a small amount of time to ensure IPv6 setup is functional
-	time.Sleep(100 * time.Millisecond)
 
 	tcpCloser := nettestutil.StartServerTCPNs(t, net.ParseIP("fd00::2"), 8080, ns)
 	defer tcpCloser.Close()

--- a/pkg/network/testutil/ping.go
+++ b/pkg/network/testutil/ping.go
@@ -8,7 +8,6 @@ package testutil
 import (
 	"fmt"
 	"net"
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -16,7 +15,7 @@ import (
 
 // PingTCP connects to the provided IP address over TCP/TCPv6, sends the string "ping",
 // reads from the connection, and returns the open connection for further use/inspection.
-func PingTCP(tb testing.TB, ip net.IP, port int) net.Conn {
+func PingTCP(tb require.TestingT, ip net.IP, port int) net.Conn {
 	addr := fmt.Sprintf("%s:%d", ip, port)
 	network := "tcp"
 	if isIpv6(ip) {
@@ -26,7 +25,6 @@ func PingTCP(tb testing.TB, ip net.IP, port int) net.Conn {
 
 	conn, err := net.DialTimeout(network, addr, time.Second)
 	require.NoError(tb, err)
-	tb.Cleanup(func() { conn.Close() })
 
 	_, err = conn.Write([]byte("ping"))
 	require.NoError(tb, err)
@@ -39,7 +37,7 @@ func PingTCP(tb testing.TB, ip net.IP, port int) net.Conn {
 
 // PingUDP connects to the provided IP address over UDP/UDPv6, sends the string "ping",
 // and returns the open connection for further use/inspection.
-func PingUDP(tb testing.TB, ip net.IP, port int) net.Conn {
+func PingUDP(tb require.TestingT, ip net.IP, port int) net.Conn {
 	network := "udp"
 	if isIpv6(ip) {
 		network = "udp6"
@@ -50,7 +48,6 @@ func PingUDP(tb testing.TB, ip net.IP, port int) net.Conn {
 	}
 	conn, err := net.DialUDP(network, nil, addr)
 	require.NoError(tb, err)
-	tb.Cleanup(func() { conn.Close() })
 
 	_, err = conn.Write([]byte("ping"))
 	require.NoError(tb, err)

--- a/pkg/network/testutil/ping.go
+++ b/pkg/network/testutil/ping.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,13 +25,21 @@ func PingTCP(tb require.TestingT, ip net.IP, port int) net.Conn {
 	}
 
 	conn, err := net.DialTimeout(network, addr, time.Second)
-	require.NoError(tb, err)
+	if !assert.NoError(tb, err) {
+		return nil
+	}
 
 	_, err = conn.Write([]byte("ping"))
-	require.NoError(tb, err)
+	if !assert.NoError(tb, err) {
+		return nil
+	}
+
 	bs := make([]byte, 10)
 	_, err = conn.Read(bs)
-	require.NoError(tb, err)
+
+	if !assert.NoError(tb, err) {
+		return nil
+	}
 
 	return conn
 }
@@ -47,10 +56,14 @@ func PingUDP(tb require.TestingT, ip net.IP, port int) net.Conn {
 		Port: port,
 	}
 	conn, err := net.DialUDP(network, nil, addr)
-	require.NoError(tb, err)
+	if !assert.NoError(tb, err) {
+		return nil
+	}
 
 	_, err = conn.Write([]byte("ping"))
-	require.NoError(tb, err)
+	if !assert.NoError(tb, err) {
+		return nil
+	}
 
 	return conn
 }

--- a/pkg/network/testutil/server.go
+++ b/pkg/network/testutil/server.go
@@ -69,10 +69,12 @@ func StartServerTCP(t testing.TB, ip net.IP, port int) io.Closer {
 	}()
 	<-ch
 
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		conn := PingTCP(t, ip, port)
-		conn.Close()
-	}, 3*time.Second, 10*time.Millisecond, "timed out waiting for TCP server to come up")
+	require.EventuallyWithT(t, func(tb *assert.CollectT) {
+		conn := PingTCP(tb, ip, l.Addr().(*net.TCPAddr).Port)
+		if conn != nil {
+			conn.Close()
+		}
+	}, 3*time.Second, 100*time.Millisecond, "timed out waiting for TCP server to come up")
 
 	return l
 }
@@ -125,7 +127,9 @@ func StartServerUDP(t *testing.T, ip net.IP, port int) io.Closer {
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		conn := PingUDP(t, ip, port)
-		conn.Close()
+		if conn != nil {
+			conn.Close()
+		}
 	}, 3*time.Second, 10*time.Millisecond, "timed out waiting for UDP server to come up")
 
 	return l

--- a/pkg/network/testutil/server.go
+++ b/pkg/network/testutil/server.go
@@ -69,11 +69,9 @@ func StartServerTCP(t testing.TB, ip net.IP, port int) io.Closer {
 	}()
 	<-ch
 
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		conn := PingTCP(t, ip, port)
-		if conn != nil {
-			conn.Close()
-		}
+		conn.Close()
 	}, 3*time.Second, 10*time.Millisecond, "timed out waiting for TCP server to come up")
 
 	return l
@@ -125,7 +123,7 @@ func StartServerUDP(t *testing.T, ip net.IP, port int) io.Closer {
 	}()
 	<-ch
 
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		conn := PingUDP(t, ip, port)
 		conn.Close()
 	}, 3*time.Second, 10*time.Millisecond, "timed out waiting for UDP server to come up")

--- a/pkg/network/testutil/server.go
+++ b/pkg/network/testutil/server.go
@@ -10,12 +10,13 @@ package testutil
 import (
 	"errors"
 	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netns"
 	"io"
 	"net"
 	"testing"
-
-	"github.com/stretchr/testify/require"
-	"github.com/vishvananda/netns"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
@@ -27,10 +28,13 @@ func StartServerTCPNs(t testing.TB, ip net.IP, port int, ns string) io.Closer {
 	require.NoError(t, err)
 
 	var closer io.Closer
-	_ = kernel.WithNS(h, func() error {
+	err = kernel.WithNS(h, func() error {
 		closer = StartServerTCP(t, ip, port)
 		return nil
 	})
+	require.NoError(t, err)
+
+	// TODO: open a connection and make sure it can be hit?
 
 	return closer
 }
@@ -67,6 +71,13 @@ func StartServerTCP(t testing.TB, ip net.IP, port int) io.Closer {
 	}()
 	<-ch
 
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		conn := PingTCP(t, ip, port)
+		if conn != nil {
+			conn.Close()
+		}
+	}, 10*time.Second, time.Millisecond*10, "timed out waiting for TCP server to come up")
+
 	return l
 }
 
@@ -77,10 +88,11 @@ func StartServerUDPNs(t *testing.T, ip net.IP, port int, ns string) io.Closer {
 	require.NoError(t, err)
 
 	var closer io.Closer
-	_ = kernel.WithNS(h, func() error {
+	err = kernel.WithNS(h, func() error {
 		closer = StartServerUDP(t, ip, port)
 		return nil
 	})
+	require.NoError(t, err)
 
 	return closer
 }
@@ -114,6 +126,13 @@ func StartServerUDP(t *testing.T, ip net.IP, port int) io.Closer {
 		}
 	}()
 	<-ch
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		conn := PingUDP(t, ip, port)
+		if conn != nil {
+			conn.Close()
+		}
+	}, 10*time.Second, 10*time.Millisecond, "timed out waiting for UDP server to come up")
 
 	return l
 }

--- a/pkg/network/testutil/server.go
+++ b/pkg/network/testutil/server.go
@@ -127,9 +127,7 @@ func StartServerUDP(t *testing.T, ip net.IP, port int) io.Closer {
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		conn := PingUDP(t, ip, port)
-		if conn != nil {
-			conn.Close()
-		}
+		conn.Close()
 	}, 3*time.Second, 10*time.Millisecond, "timed out waiting for UDP server to come up")
 
 	return l

--- a/pkg/network/testutil/server.go
+++ b/pkg/network/testutil/server.go
@@ -74,7 +74,7 @@ func StartServerTCP(t testing.TB, ip net.IP, port int) io.Closer {
 		if conn != nil {
 			conn.Close()
 		}
-	}, 10*time.Second, time.Millisecond*10, "timed out waiting for TCP server to come up")
+	}, 3*time.Second, 10*time.Millisecond, "timed out waiting for TCP server to come up")
 
 	return l
 }
@@ -130,7 +130,7 @@ func StartServerUDP(t *testing.T, ip net.IP, port int) io.Closer {
 		if conn != nil {
 			conn.Close()
 		}
-	}, 10*time.Second, 10*time.Millisecond, "timed out waiting for UDP server to come up")
+	}, 3*time.Second, 10*time.Millisecond, "timed out waiting for UDP server to come up")
 
 	return l
 }

--- a/pkg/network/testutil/server.go
+++ b/pkg/network/testutil/server.go
@@ -34,8 +34,6 @@ func StartServerTCPNs(t testing.TB, ip net.IP, port int, ns string) io.Closer {
 	})
 	require.NoError(t, err)
 
-	// TODO: open a connection and make sure it can be hit?
-
 	return closer
 }
 


### PR DESCRIPTION
### What does this PR do?

We recently saw TestConntrackExists6 flake with the following stack trace

```
       [4.19.0-25-arm64] /go/src/github.com/DataDog/datadog-agent/pkg/network/netlink/conntrack_integration_test.go:176
       [4.19.0-25-arm64] Error:      	Received unexpected error:
       [4.19.0-25-arm64] dial tcp6 [fd00::2]:80: i/o timeout
       [4.19.0-25-arm64] Test:       	TestConntrackExists6
```

The likely explanation for this is that the TCP server started by this test didn't come up by the time PingTCP was called.

This change updates the StartTCPServer and STartUDPServer test helpers to wait until the test servers can accept a ping before returning. This should make all tests relying on StartTCPServer/StartUDPServer less flaky.


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
