### PR TITLE
Fix kitchen eventlog query

### DIFF
--- a/test/kitchen/test/integration/common/rspec_datadog/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec_datadog/spec_helper.rb
@@ -219,12 +219,8 @@ end
 def log_trace(flavor, action)
   service = get_service_name(flavor)
   if os == :windows
-    if action == "stop" || action == "restart"
-      system "wevtutil qe System /q:\"*[System[(EventID=7040) and (EventData[Data[@Name='param1']='#{service}'])]\""
-    end
-    if action == "start" || action == "restart"
-      system "wevtutil qe System /q:\"*[System[(EventID=7036) and (EventData[Data[@Name='param1']='#{service}'])]\""
-    end
+    system "powershell.exe -Command \"Get-EventLog -LogName Application -Newest 10 -Source #{service} | fl\""
+    system "powershell.exe -Command \"Get-EventLog -LogName System -Newest 10 -Source \\\"Service Control Manager\\\" | fl\""
   else
     if has_systemctl
       system "sudo journalctl -u #{service} -xe --no-pager"

--- a/test/kitchen/test/integration/common/rspec_datadog/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec_datadog/spec_helper.rb
@@ -219,7 +219,9 @@ end
 def log_trace(flavor, action)
   service = get_service_name(flavor)
   if os == :windows
-    system "powershell.exe -Command \"Get-EventLog -LogName Application -Newest 10 -Source #{service} | fl\""
+    # Collect events from DatadogAgent and this service, since this service may depend on datadogagent it may be
+    # that the actual error is coming from datadogagent failing to start.
+    system "powershell.exe -Command \"Get-EventLog -LogName Application -Newest 10 -Source datadogagent,#{service} | fl\""
     system "powershell.exe -Command \"Get-EventLog -LogName System -Newest 10 -Source \\\"Service Control Manager\\\" | fl\""
   else
     if has_systemctl


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Collect more information from the event log by collecting a broader set of event IDs. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The original XPATH query had a syntax error and also didn't seem to be collecting the most helpful events, for example event 7036 says that a service starts or stopped, but event 7038 contains the actual error.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
The output should be easier to read, too, since it will be formatted rather than the raw XML.

xref https://github.com/DataDog/datadog-agent/pull/19873

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
Currently limited to the last 10 events in the log for the agent service and the service control manager, which should be enough to see the error since the event log is collected right when the service fails to start/stop. 

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
