### PR TITLE
fetch dummy conntrack entry from netlink before init of ebpf conntracker

### DIFF
--- a/pkg/network/netlink/consumer.go
+++ b/pkg/network/netlink/consumer.go
@@ -337,7 +337,9 @@ func (c *Consumer) dumpTable(family uint8, output chan Event, ns netns.NsHandle)
 	})
 }
 
-func FetchDummyEntry(ns netns.NsHandle) error {
+// LoadNfConntrackKernelModule requests a dummy connection tuple from netlink conntrack which is discarded but has
+// the side effect of loading the nf_conntrack_netlink module
+func LoadNfConntrackKernelModule(ns netns.NsHandle) error {
 	sock, err := NewSocket(ns)
 	if err != nil {
 		return fmt.Errorf("could not open netlink socket for net ns %d: %w", int(ns), err)

--- a/pkg/network/netlink/consumer.go
+++ b/pkg/network/netlink/consumer.go
@@ -361,7 +361,9 @@ func LoadNfConntrackKernelModule(ns netns.NsHandle) error {
 		Data: dummyTupleData,
 	}
 
-	_, err = conn.Send(req)
+	if _, err = conn.Send(req); err != nil {
+		log.Warnf("Error while sending netlink request: %v", err)
+	}
 	_, _, err = sock.ReceiveAndDiscard()
 	if err != nil {
 		log.Warnf("Error while trying to load dummy entry from netlink: %v", err)

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -244,9 +244,9 @@ func newConntracker(cfg *config.Config, bpfTelemetry *nettelemetry.EBPFTelemetry
 	var err error
 
 	consumer, err := netlink.NewConsumer(cfg)
-	defer consumer.Stop()
 
-	err = consumer.LoadConntrackModule()
+	err = consumer.FetchDummyEntry()
+	consumer.Stop()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -243,10 +243,8 @@ func newConntracker(cfg *config.Config, bpfTelemetry *nettelemetry.EBPFTelemetry
 	var c netlink.Conntracker
 	var err error
 
-	consumer, err := netlink.NewConsumer(cfg)
-
-	err = consumer.FetchDummyEntry()
-	consumer.Stop()
+	ns, err := cfg.GetRootNetNs()
+	err = netlink.FetchDummyEntry(ns)
 	c, err = NewEBPFConntracker(cfg, bpfTelemetry)
 
 	if err == nil {

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -247,9 +247,6 @@ func newConntracker(cfg *config.Config, bpfTelemetry *nettelemetry.EBPFTelemetry
 
 	err = consumer.FetchDummyEntry()
 	consumer.Stop()
-	if err != nil {
-		return nil, err
-	}
 	c, err = NewEBPFConntracker(cfg, bpfTelemetry)
 
 	if err == nil {

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -249,7 +249,7 @@ func newConntracker(cfg *config.Config, bpfTelemetry *nettelemetry.EBPFTelemetry
 	} else {
 		defer ns.Close()
 		if err = netlink.LoadNfConntrackKernelModule(ns); err != nil {
-			log.Warnf("failed to load conntrack kernel module, though it may already be loaded")
+			log.Warnf("failed to load conntrack kernel module, though it may already be loaded: %s", err)
 		}
 	}
 

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -245,8 +245,9 @@ func newConntracker(cfg *config.Config, bpfTelemetry *nettelemetry.EBPFTelemetry
 
 	ns, err := cfg.GetRootNetNs()
 	if err != nil {
-		log.Warnf("error fetching root net namespace %s", err)
+		log.Warnf("error fetching root net namespace, will not attempt to load nf_conntrack_netlink module: %s", err)
 	} else {
+		defer ns.Close()
 		if err = netlink.LoadNfConntrackKernelModule(ns); err != nil {
 			log.Warnf("failed to load conntrack kernel module, though it may already be loaded")
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fetches a "dummy" entry from conntrack table which has the side effect of loading the nf_conntrack_netlink module. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

https://datadoghq.atlassian.net/browse/NPM-339

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
