### PR TITLE
remove initContainers from the Containers section in wlm

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -824,11 +824,14 @@ func (k *KSMCheck) sendTelemetry(s sender.Sender) {
 	// reset the cache for the next check run
 	defer k.telemetry.reset()
 
+	log.Infof("A instance tags %v %d %d", k.instance.Tags, len(k.instance.Tags), cap(k.instance.Tags))
 	s.Gauge(ksmMetricPrefix+"telemetry.metrics.count.total", float64(k.telemetry.getTotal()), "", k.instance.Tags)
 	s.Gauge(ksmMetricPrefix+"telemetry.unknown_metrics.count", float64(k.telemetry.getUnknown()), "", k.instance.Tags) // useful to track metrics that aren't mapped to DD metrics
+	log.Infof("B instance tags %v %d %d", k.instance.Tags, len(k.instance.Tags), cap(k.instance.Tags))
 	for resource, count := range k.telemetry.getResourcesCount() {
 		s.Gauge(ksmMetricPrefix+"telemetry.metrics.count", float64(count), "", append(k.instance.Tags, "resource_name:"+resource))
 	}
+	log.Infof("C instance tags %v %d %d", k.instance.Tags, len(k.instance.Tags), cap(k.instance.Tags))
 }
 
 // KubeStateMetricsFactory returns a new KSMCheck

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_telemetry_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_telemetry_test.go
@@ -8,8 +8,10 @@
 package ksm
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,4 +48,38 @@ func TestCountByResource(t *testing.T) {
 	assert.Equal(t, 2, tc.getResourcesCount()["foo"])
 	assert.Equal(t, 1, tc.getResourcesCount()["bar"])
 	assert.Len(t, tc.metricsCountByResource, 2)
+}
+
+// TestDoesNotUpdateInstanceTags exists to make sure that `sendTelemetry` does not update `instanceTags` by mistake in some edge cases
+// First, if the array has enough capacity to append an element, no allocation is made. So at the initial state we have
+// Tags: len(2), capacity(4), ["tag1:1", "tag1:1"]
+// Then KSM calls append(tags, "resource_name:foo") which induces
+// Tags: len(2), capacity(4), ["tag1:1", "tag1:1", "resource_name:foo"] /!\ the array is not updated
+// Then, KSM uses the raw sender that calls pkg/util/sort_uniq.go(SortUniqInPlace) making Tags become
+// Tags: len(2), capacity(4), ["tag1:1", "resource_name:foo", "tag1:1"]
+// and here resource_name is added by mistake
+func TestDoesNotUpdateInstanceTags(t *testing.T) {
+	k := &KSMCheck{
+		telemetry: newTelemetryCache(),
+		instance: &KSMConfig{
+			Tags: []string{
+				"tag1:value1", "tag2:value2", "cluster_name:ali-cluster", "kube_cluster_name:ali-cluster",
+			},
+			Telemetry: true,
+		},
+	}
+
+	// Apppend the same tag twice so one will be removed by SortUniqInPlace
+	k.instance.Tags = append(k.instance.Tags, "kube_cluster_name:ali-cluster")
+	// k.instance.Tags = append(k.instance.Tags, "tag1:1")
+
+	y := k.instance.Tags
+
+	y = util.SortUniqInPlace(y)
+
+	// append the tag and sort uniq in place
+	r := append(k.instance.Tags, "resource_name:foo")
+	r = util.SortUniqInPlace(r)
+	panic(fmt.Sprintf("%v %d %d", k.instance.Tags, len(k.instance.Tags), cap(k.instance.Tags)))
+	assert.ElementsMatch(t, k.instance.Tags, []string{"tag:1"})
 }

--- a/pkg/sbom/scanner/scanner.go
+++ b/pkg/sbom/scanner/scanner.go
@@ -115,7 +115,9 @@ func (s *Scanner) start(ctx context.Context) {
 
 				collector := request.collector
 				if err := s.enoughDiskSpace(request.opts); err != nil {
-					sendResult(sbom.ScanResult{Error: fmt.Errorf("failed to check current disk usage: %w", err)})
+					sendResult(sbom.ScanResult{
+						Error: fmt.Errorf("failed to check current disk usage: %w", err),
+					})
 					telemetry.SBOMFailures.Inc(request.Collector(), request.Type(), "disk_space")
 					continue
 				}

--- a/pkg/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/pkg/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -121,7 +121,6 @@ func (c *collector) parsePods(pods []*kubelet.Pod) []workloadmeta.CollectorEvent
 			pod.Status.Containers,
 			&podID,
 		)
-		podContainers = append(podContainers, podInitContainers...)
 
 		podOwners := pod.Owners()
 		owners := make([]workloadmeta.KubernetesPodOwner, 0, len(podOwners))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR removes initContainers from the Containers section in wlm
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
info is duplicated
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
