### PR TITLE
[CWS] Fix: link process nodes to their parents when loading a profile

### DIFF
--- a/pkg/security/security_profile/activity_tree/activity_tree_proto_dec_v1.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_proto_dec_v1.go
@@ -19,17 +19,18 @@ import (
 // ProtoDecodeActivityTree decodes an ActivityTree structure
 func ProtoDecodeActivityTree(dest *ActivityTree, nodes []*adproto.ProcessActivityNode) {
 	for _, node := range nodes {
-		dest.ProcessNodes = append(dest.ProcessNodes, protoDecodeProcessActivityNode(node))
+		dest.ProcessNodes = append(dest.ProcessNodes, protoDecodeProcessActivityNode(dest, node))
 	}
 }
 
-func protoDecodeProcessActivityNode(pan *adproto.ProcessActivityNode) *ProcessNode {
+func protoDecodeProcessActivityNode(parent ProcessNodeParent, pan *adproto.ProcessActivityNode) *ProcessNode {
 	if pan == nil {
 		return nil
 	}
 
 	ppan := &ProcessNode{
 		Process:        protoDecodeProcessNode(pan.Process),
+		Parent:         parent,
 		GenerationType: NodeGenerationType(pan.GenerationType),
 		MatchedRules:   make([]*model.MatchedRule, 0, len(pan.MatchedRules)),
 		Children:       make([]*ProcessNode, 0, len(pan.Children)),
@@ -44,7 +45,7 @@ func protoDecodeProcessActivityNode(pan *adproto.ProcessActivityNode) *ProcessNo
 	}
 
 	for _, child := range pan.Children {
-		ppan.Children = append(ppan.Children, protoDecodeProcessActivityNode(child))
+		ppan.Children = append(ppan.Children, protoDecodeProcessActivityNode(ppan, child))
 	}
 
 	for _, fan := range pan.Files {


### PR DESCRIPTION
### What does this PR do?

This [PR ](https://github.com/DataDog/datadog-agent/pull/19342) introduced a link between process nodes and their parent, but the link wasn't done when loading a profile, which could lead to bad merge/rebase algo later on.


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
