### PR TITLE
[pkg/networkdevice/profile] Harmonize MetricTagConfig OID/Symbol(name) to Symbol object v2

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -678,7 +678,7 @@ func (c *CheckConfig) parseScalarOids(metrics []profiledefinition.MetricsConfig,
 		oids = append(oids, metric.Symbol.OID)
 	}
 	for _, metricTag := range metricTags {
-		oids = append(oids, metricTag.OID)
+		oids = append(oids, metricTag.Symbol.OID)
 	}
 	if c.CollectDeviceMetadata {
 		for resource, metadataConfig := range metadataConfigs {

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -219,11 +219,10 @@ bulk_max_repetitions: 20
 	expectedMetrics = append(expectedMetrics, fixtureProfileDefinitionMap()["f5-big-ip"].Definition.Metrics...)
 
 	expectedMetricTags := []profiledefinition.MetricTagConfig{
-		{Tag: "my_symbol", OID: "1.2.3", Name: "mySymbol"},
-		{Tag: "my_symbol_mapped", OID: "1.2.3", Name: "mySymbol", Mapping: map[string]string{"1": "one", "2": "two"}},
+		{Tag: "my_symbol", Symbol: profiledefinition.SymbolConfigCompat{OID: "1.2.3", Name: "mySymbol"}},
+		{Tag: "my_symbol_mapped", Symbol: profiledefinition.SymbolConfigCompat{OID: "1.2.3", Name: "mySymbol"}, Mapping: map[string]string{"1": "one", "2": "two"}},
 		{
-			OID:     "1.2.3",
-			Name:    "mySymbol",
+			Symbol:  profiledefinition.SymbolConfigCompat{OID: "1.2.3", Name: "mySymbol"},
 			Match:   "(\\w)(\\w+)",
 			Pattern: regexp.MustCompile(`(\w)(\w+)`),
 			Tags: map[string]string{
@@ -232,8 +231,7 @@ bulk_max_repetitions: 20
 			},
 		},
 		{
-			OID:     "1.3.6.1.2.1.1.5.0",
-			Name:    "sysName",
+			Symbol:  profiledefinition.SymbolConfigCompat{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
 			Match:   "(\\w)(\\w+)",
 			Pattern: regexp.MustCompile(`(\w)(\w+)`),
 			Tags: map[string]string{
@@ -242,7 +240,7 @@ bulk_max_repetitions: 20
 				"suffix":   "\\2",
 			},
 		},
-		{Tag: "snmp_host", OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
+		{Tag: "snmp_host", Symbol: profiledefinition.SymbolConfigCompat{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"}},
 	}
 
 	assert.Equal(t, expectedMetrics, config.Metrics)
@@ -364,7 +362,7 @@ profiles:
 	}
 
 	metricsTags := []profiledefinition.MetricTagConfig{
-		{Tag: "snmp_host", OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
+		{Tag: "snmp_host", Symbol: profiledefinition.SymbolConfigCompat{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"}},
 	}
 
 	assert.Equal(t, "123", config.CommunityString)
@@ -1125,7 +1123,7 @@ func Test_snmpConfig_setProfile(t *testing.T) {
 		Device:  profiledefinition.DeviceMeta{Vendor: "b-vendor"},
 		Metrics: []profiledefinition.MetricsConfig{{Symbol: profiledefinition.SymbolConfig{OID: "2.3.4.5.6.1", Name: "b-metric"}}},
 		MetricTags: []profiledefinition.MetricTagConfig{
-			{Tag: "btag", OID: "2.3.4.5.6.2", Name: "b-tag-name"},
+			{Tag: "btag", Symbol: profiledefinition.SymbolConfigCompat{OID: "2.3.4.5.6.2", Name: "b-tag-name"}},
 		},
 		Metadata: profiledefinition.MetadataConfig{
 			"device": {
@@ -1251,7 +1249,7 @@ func Test_snmpConfig_setProfile(t *testing.T) {
 	c.RequestedMetrics = append(c.RequestedMetrics,
 		profiledefinition.MetricsConfig{Symbol: profiledefinition.SymbolConfig{OID: "3.1", Name: "global-metric"}})
 	c.RequestedMetricTags = append(c.RequestedMetricTags,
-		profiledefinition.MetricTagConfig{Tag: "global-tag", OID: "3.2", Name: "globalSymbol"})
+		profiledefinition.MetricTagConfig{Tag: "global-tag", Symbol: profiledefinition.SymbolConfigCompat{OID: "3.2", Name: "globalSymbol"}})
 	err = c.SetProfile("profile1")
 	assert.NoError(t, err)
 	assert.Equal(t, OidConfig{
@@ -1640,9 +1638,9 @@ func TestSetAutodetectPreservesRequests(t *testing.T) {
 	met1 := metric("1.1", "metricOne")
 	met2 := metric("1.2", "metricTwo")
 	met3 := metric("1.3", "metricThree")
-	tag1 := profiledefinition.MetricTagConfig{Tag: "tag_one", OID: "2.1", Name: "tagOne"}
-	tag2 := profiledefinition.MetricTagConfig{Tag: "tag_two", OID: "2.2", Name: "tagTwo"}
-	tag3 := profiledefinition.MetricTagConfig{Tag: "tag_three", OID: "2.3", Name: "tagThree"}
+	tag1 := profiledefinition.MetricTagConfig{Tag: "tag_one", Symbol: profiledefinition.SymbolConfigCompat{OID: "2.1", Name: "tagOne"}}
+	tag2 := profiledefinition.MetricTagConfig{Tag: "tag_two", Symbol: profiledefinition.SymbolConfigCompat{OID: "2.2", Name: "tagTwo"}}
+	tag3 := profiledefinition.MetricTagConfig{Tag: "tag_three", Symbol: profiledefinition.SymbolConfigCompat{OID: "2.3", Name: "tagThree"}}
 
 	config := &CheckConfig{
 		CollectTopology:     false,
@@ -2170,7 +2168,7 @@ func TestCheckConfig_Copy(t *testing.T) {
 			},
 		},
 		RequestedMetricTags: []profiledefinition.MetricTagConfig{
-			{Tag: "my_symbol", OID: "1.2.3", Name: "mySymbol"},
+			{Tag: "my_symbol", Symbol: profiledefinition.SymbolConfigCompat{OID: "1.2.3", Name: "mySymbol"}},
 		},
 		Metrics: []profiledefinition.MetricsConfig{
 			{
@@ -2181,7 +2179,7 @@ func TestCheckConfig_Copy(t *testing.T) {
 			},
 		},
 		MetricTags: []profiledefinition.MetricTagConfig{
-			{Tag: "my_symbol", OID: "1.2.3", Name: "mySymbol"},
+			{Tag: "my_symbol", Symbol: profiledefinition.SymbolConfigCompat{OID: "1.2.3", Name: "mySymbol"}},
 		},
 		OidBatchSize:       10,
 		BulkMaxRepetitions: 10,

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich.go
@@ -190,7 +190,11 @@ func validateEnrichMetricTag(metricTag *profiledefinition.MetricTagConfig) []str
 		metricTag.Symbol.OID = metricTag.OID
 		metricTag.OID = ""
 	}
-
+	if metricTag.Symbol.OID != "" || metricTag.Symbol.Name != "" {
+		symbol := profiledefinition.SymbolConfig(metricTag.Symbol)
+		errors = append(errors, validateEnrichSymbol(&symbol, MetricTagSymbol)...)
+		metricTag.Symbol = profiledefinition.SymbolConfigCompat(symbol)
+	}
 	if metricTag.Match != "" {
 		pattern, err := regexp.Compile(metricTag.Match)
 		if err != nil {

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich.go
@@ -175,6 +175,22 @@ func validateEnrichMetricTag(metricTag *profiledefinition.MetricTagConfig) []str
 	if metricTag.Column.OID != "" || metricTag.Column.Name != "" {
 		errors = append(errors, validateEnrichSymbol(&metricTag.Column, MetricTagSymbol)...)
 	}
+
+	// OID/Name to Symbol harmonization:
+	// When users declare metric tag like:
+	//   metric_tags:
+	//     - OID: 1.2.3
+	//       name: aSymbol
+	// this will lead to OID stored as MetricTagConfig.OID  and name stored as MetricTagConfig.Symbol.Name
+	// When this happens, we harmonize by moving MetricTagConfig.OID to MetricTagConfig.Symbol.OID.
+	if metricTag.OID != "" && metricTag.Symbol.OID != "" {
+		errors = append(errors, fmt.Sprintf("metric tag OID and symbol.OID cannot be both declared: OID=%s, symbol.OID=%s", metricTag.OID, metricTag.Symbol.OID))
+	}
+	if metricTag.OID != "" && metricTag.Symbol.OID == "" {
+		metricTag.Symbol.OID = metricTag.OID
+		metricTag.OID = ""
+	}
+
 	if metricTag.Match != "" {
 		pattern, err := regexp.Compile(metricTag.Match)
 		if err != nil {

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich.go
@@ -180,7 +180,7 @@ func validateEnrichMetricTag(metricTag *profiledefinition.MetricTagConfig) []str
 	// When users declare metric tag like:
 	//   metric_tags:
 	//     - OID: 1.2.3
-	//       name: aSymbol
+	//       symbol: aSymbol
 	// this will lead to OID stored as MetricTagConfig.OID  and name stored as MetricTagConfig.Symbol.Name
 	// When this happens, we harmonize by moving MetricTagConfig.OID to MetricTagConfig.Symbol.OID.
 	if metricTag.OID != "" && metricTag.Symbol.OID != "" {

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_validate_enrich_test.go
@@ -657,6 +657,19 @@ func Test_ValidateEnrichMetricTags(t *testing.T) {
 				"metric tag OID and symbol.OID cannot be both declared",
 			},
 		},
+		{
+			name: "Missing OID",
+			metrics: []profiledefinition.MetricTagConfig{
+				{
+					Symbol: profiledefinition.SymbolConfigCompat{
+						Name: "mySymbol",
+					},
+				},
+			},
+			expectedErrors: []string{
+				"symbol oid missing",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/profile.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/profile.go
@@ -120,6 +120,13 @@ func loadProfiles(pConfig profileConfigMap) (profileConfigMap, error) {
 			}
 			profConfig.Definition = *profDefinition
 		}
+		profiledefinition.NormalizeMetrics(profConfig.Definition.Metrics)
+		errors := validateEnrichMetadata(profConfig.Definition.Metadata)
+		errors = append(errors, ValidateEnrichMetrics(profConfig.Definition.Metrics)...)
+		errors = append(errors, ValidateEnrichMetricTags(profConfig.Definition.MetricTags)...)
+		if len(errors) > 0 {
+			return nil, fmt.Errorf("validation errors: %s", strings.Join(errors, "\n"))
+		}
 		profiles[name] = profConfig
 	}
 	return profiles, nil
@@ -136,13 +143,6 @@ func readProfileDefinition(definitionFile string) (*profiledefinition.ProfileDef
 	err = yaml.Unmarshal(buf, profileDefinition)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshall %q: %v", filePath, err)
-	}
-	profiledefinition.NormalizeMetrics(profileDefinition.Metrics)
-	errors := validateEnrichMetadata(profileDefinition.Metadata)
-	errors = append(errors, ValidateEnrichMetrics(profileDefinition.Metrics)...)
-	errors = append(errors, ValidateEnrichMetricTags(profileDefinition.MetricTags)...)
-	if len(errors) > 0 {
-		return nil, fmt.Errorf("validation errors: %s", strings.Join(errors, "\n"))
 	}
 	return profileDefinition, nil
 }

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/profile_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/profile_test.go
@@ -66,8 +66,7 @@ func fixtureProfileDefinitionMap() profileConfigMap {
 				StaticTags:   []string{"static_tag:from_profile_root", "static_tag:from_base_profile"},
 				MetricTags: []profiledefinition.MetricTagConfig{
 					{
-						OID:     "1.3.6.1.2.1.1.5.0",
-						Name:    "sysName",
+						Symbol:  profiledefinition.SymbolConfigCompat{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
 						Match:   "(\\w)(\\w+)",
 						Pattern: regexp.MustCompile(`(\w)(\w+)`),
 						Tags: map[string]string{
@@ -76,7 +75,7 @@ func fixtureProfileDefinitionMap() profileConfigMap {
 							"suffix":   "\\2",
 						},
 					},
-					{Tag: "snmp_host", Index: 0x0, Column: profiledefinition.SymbolConfig{OID: "", Name: ""}, OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
+					{Tag: "snmp_host", Index: 0x0, Column: profiledefinition.SymbolConfig{OID: "", Name: ""}, Symbol: profiledefinition.SymbolConfigCompat{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"}},
 				},
 				Metadata: profiledefinition.MetadataConfig{
 					"device": {
@@ -182,7 +181,7 @@ func fixtureProfileDefinitionMap() profileConfigMap {
 				},
 				MetricTags: []profiledefinition.MetricTagConfig{
 					{Tag: "snmp_host2", Column: profiledefinition.SymbolConfig{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"}},
-					{Tag: "unknown_symbol", OID: "1.3.6.1.2.1.1.999.0", Name: "unknownSymbol"},
+					{Tag: "unknown_symbol", Symbol: profiledefinition.SymbolConfigCompat{OID: "1.3.6.1.2.1.1.999.0", Name: "unknownSymbol"}},
 				},
 				Metadata: profiledefinition.MetadataConfig{},
 			},
@@ -314,10 +313,10 @@ func Test_loadProfiles(t *testing.T) {
 					DefinitionFile: validationErrorProfile,
 				},
 			},
-			expectedProfileDefMap: profileConfigMap{},
-			expectedLogs: []logCount{
-				{"cannot compile `match` (`global_metric_tags[\\w)(\\w+)`)", 1},
-				{"cannot compile `match` (`table_match[\\w)`)", 1},
+			expectedProfileDefMap: nil,
+			expectedIncludeErrors: []string{
+				"cannot compile `match` (`global_metric_tags[\\w)(\\w+)`)",
+				"cannot compile `match` (`table_match[\\w)`)",
 			},
 		},
 	}
@@ -558,9 +557,8 @@ func Test_mergeProfileDefinition(t *testing.T) {
 		},
 		MetricTags: []profiledefinition.MetricTagConfig{
 			{
-				Tag:  "tag1",
-				OID:  "2.1",
-				Name: "tagName1",
+				Tag:    "tag1",
+				Symbol: profiledefinition.SymbolConfigCompat{OID: "2.1", Name: "tagName1"},
 			},
 		},
 		Metadata: profiledefinition.MetadataConfig{
@@ -606,9 +604,8 @@ func Test_mergeProfileDefinition(t *testing.T) {
 		},
 		MetricTags: []profiledefinition.MetricTagConfig{
 			{
-				Tag:  "tag2",
-				OID:  "2.2",
-				Name: "tagName2",
+				Tag:    "tag2",
+				Symbol: profiledefinition.SymbolConfigCompat{OID: "2.2", Name: "tagName2"},
 			},
 		},
 		Metadata: profiledefinition.MetadataConfig{
@@ -660,14 +657,12 @@ func Test_mergeProfileDefinition(t *testing.T) {
 				},
 				MetricTags: []profiledefinition.MetricTagConfig{
 					{
-						Tag:  "tag2",
-						OID:  "2.2",
-						Name: "tagName2",
+						Tag:    "tag2",
+						Symbol: profiledefinition.SymbolConfigCompat{OID: "2.2", Name: "tagName2"},
 					},
 					{
-						Tag:  "tag1",
-						OID:  "2.1",
-						Name: "tagName1",
+						Tag:    "tag1",
+						Symbol: profiledefinition.SymbolConfigCompat{OID: "2.1", Name: "tagName1"},
 					},
 				},
 				Metadata: profiledefinition.MetadataConfig{
@@ -736,9 +731,8 @@ func Test_mergeProfileDefinition(t *testing.T) {
 				},
 				MetricTags: []profiledefinition.MetricTagConfig{
 					{
-						Tag:  "tag2",
-						OID:  "2.2",
-						Name: "tagName2",
+						Tag:    "tag2",
+						Symbol: profiledefinition.SymbolConfigCompat{OID: "2.2", Name: "tagName2"},
 					},
 				},
 				Metadata: profiledefinition.MetadataConfig{
@@ -784,9 +778,8 @@ func Test_mergeProfileDefinition(t *testing.T) {
 				},
 				MetricTags: []profiledefinition.MetricTagConfig{
 					{
-						Tag:  "tag1",
-						OID:  "2.1",
-						Name: "tagName1",
+						Tag:    "tag1",
+						Symbol: profiledefinition.SymbolConfigCompat{OID: "2.1", Name: "tagName1"},
 					},
 				},
 				Metadata: profiledefinition.MetadataConfig{

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -302,7 +302,7 @@ func (d *DeviceCheck) detectAvailableMetrics() ([]profiledefinition.MetricsConfi
 			}
 		}
 		for _, metricTag := range profileConfig.Definition.MetricTags {
-			if root.LeafExist(metricTag.OID) || root.LeafExist(metricTag.Column.OID) {
+			if root.LeafExist(metricTag.Symbol.OID) || root.LeafExist(metricTag.Column.OID) {
 				if metricTag.Tag != "" {
 					if alreadyGlobalTags[metricTag.Tag] {
 						continue

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -342,16 +342,15 @@ collect_topology: false
 	expectedMetricTags := []profiledefinition.MetricTagConfig{
 		{Tag: "snmp_host2", Column: profiledefinition.SymbolConfig{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"}},
 		{
-			OID:   "1.3.6.1.2.1.1.5.0",
-			Name:  "sysName",
-			Match: "(\\w)(\\w+)",
+			Symbol: profiledefinition.SymbolConfigCompat{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
+			Match:  "(\\w)(\\w+)",
 			Tags: map[string]string{
 				"prefix":   "\\1",
 				"suffix":   "\\2",
 				"some_tag": "some_tag_value",
 			},
 		},
-		{Tag: "snmp_host", OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
+		{Tag: "snmp_host", Symbol: profiledefinition.SymbolConfigCompat{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"}},
 	}
 	checkconfig.ValidateEnrichMetrics(expectedMetrics)
 	checkconfig.ValidateEnrichMetricTags(expectedMetricTags)
@@ -939,16 +938,15 @@ community_string: public
 
 	expectedMetricsTagConfigs := []profiledefinition.MetricTagConfig{
 		{
-			OID:   "1.3.6.1.2.1.1.5.0",
-			Name:  "sysName",
-			Match: "(\\w)(\\w+)",
+			Symbol: profiledefinition.SymbolConfigCompat{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
+			Match:  "(\\w)(\\w+)",
 			Tags: map[string]string{
 				"some_tag": "some_tag_value",
 				"prefix":   "\\1",
 				"suffix":   "\\2",
 			},
 		},
-		{Tag: "snmp_host", OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
+		{Tag: "snmp_host", Symbol: profiledefinition.SymbolConfigCompat{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"}},
 		{Tag: "snmp_host2", Column: profiledefinition.SymbolConfig{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"}},
 	}
 

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
@@ -85,7 +85,7 @@ func (ms *MetricSender) GetCheckInstanceMetricTags(metricTags []profiledefinitio
 
 	for _, metricTag := range metricTags {
 		// TODO: Support extract value see II-635
-		value, err := values.GetScalarValue(metricTag.OID)
+		value, err := values.GetScalarValue(metricTag.Symbol.OID)
 		if err != nil {
 			continue
 		}

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
@@ -471,8 +471,8 @@ func Test_metricSender_getCheckInstanceMetricTags(t *testing.T) {
 		{
 			name: "no scalar oids found",
 			metricsTags: []profiledefinition.MetricTagConfig{
-				{Tag: "my_symbol", OID: "1.2.3", Name: "mySymbol"},
-				{Tag: "snmp_host", OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
+				{Tag: "my_symbol", Symbol: profiledefinition.SymbolConfigCompat{OID: "1.2.3", Name: "mySymbol"}},
+				{Tag: "snmp_host", Symbol: profiledefinition.SymbolConfigCompat{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"}},
 			},
 			values:       &valuestore.ResultValueStore{},
 			expectedTags: []string{},
@@ -481,7 +481,7 @@ func Test_metricSender_getCheckInstanceMetricTags(t *testing.T) {
 		{
 			name: "report scalar tags with regex",
 			metricsTags: []profiledefinition.MetricTagConfig{
-				{OID: "1.2.3", Name: "mySymbol", Match: "^([a-zA-Z]+)([0-9]+)$", Tags: map[string]string{
+				{Symbol: profiledefinition.SymbolConfigCompat{OID: "1.2.3", Name: "mySymbol"}, Match: "^([a-zA-Z]+)([0-9]+)$", Tags: map[string]string{
 					"word":   "\\1",
 					"number": "\\2",
 				}},
@@ -499,7 +499,7 @@ func Test_metricSender_getCheckInstanceMetricTags(t *testing.T) {
 		{
 			name: "error converting tag value",
 			metricsTags: []profiledefinition.MetricTagConfig{
-				{Tag: "my_symbol", OID: "1.2.3", Name: "mySymbol"},
+				{Tag: "my_symbol", Symbol: profiledefinition.SymbolConfigCompat{OID: "1.2.3", Name: "mySymbol"}},
 			},
 			values: &valuestore.ResultValueStore{
 				ScalarValues: valuestore.ScalarResultValuesType{
@@ -515,7 +515,7 @@ func Test_metricSender_getCheckInstanceMetricTags(t *testing.T) {
 		{
 			name: "tag value mapping",
 			metricsTags: []profiledefinition.MetricTagConfig{
-				{Tag: "my_symbol", OID: "1.2.3", Name: "mySymbol", Mapping: map[string]string{"1": "one", "2": "two"}},
+				{Tag: "my_symbol", Symbol: profiledefinition.SymbolConfigCompat{OID: "1.2.3", Name: "mySymbol"}, Mapping: map[string]string{"1": "one", "2": "two"}},
 			},
 			values: &valuestore.ResultValueStore{
 				ScalarValues: valuestore.ScalarResultValuesType{
@@ -530,7 +530,7 @@ func Test_metricSender_getCheckInstanceMetricTags(t *testing.T) {
 		{
 			name: "invalid tag value mapping",
 			metricsTags: []profiledefinition.MetricTagConfig{
-				{Tag: "my_symbol", OID: "1.2.3", Name: "mySymbol", Mapping: map[string]string{"1": "one", "2": "two"}},
+				{Tag: "my_symbol", Symbol: profiledefinition.SymbolConfigCompat{OID: "1.2.3", Name: "mySymbol"}, Mapping: map[string]string{"1": "one", "2": "two"}},
 			},
 			values: &valuestore.ResultValueStore{
 				ScalarValues: valuestore.ScalarResultValuesType{
@@ -545,7 +545,7 @@ func Test_metricSender_getCheckInstanceMetricTags(t *testing.T) {
 		{
 			name: "empty tag value mapping",
 			metricsTags: []profiledefinition.MetricTagConfig{
-				{Tag: "my_symbol", OID: "1.2.3", Name: "mySymbol", Mapping: map[string]string{}},
+				{Tag: "my_symbol", Symbol: profiledefinition.SymbolConfigCompat{OID: "1.2.3", Name: "mySymbol"}, Mapping: map[string]string{}},
 			},
 			values: &valuestore.ResultValueStore{
 				ScalarValues: valuestore.ScalarResultValuesType{

--- a/pkg/collector/corechecks/snmp/internal/test/conf.d/snmp.d/default_profiles/.keep
+++ b/pkg/collector/corechecks/snmp/internal/test/conf.d/snmp.d/default_profiles/.keep
@@ -1,0 +1,1 @@
+keep default_profiles folder for tests

--- a/pkg/collector/corechecks/snmp/internal/test/conf.d/snmp.d/default_profiles/.keep
+++ b/pkg/collector/corechecks/snmp/internal/test/conf.d/snmp.d/default_profiles/.keep
@@ -1,1 +1,0 @@
-keep default_profiles folder for tests

--- a/pkg/collector/corechecks/snmp/internal/test/test_profiles/validation_error.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/test_profiles/validation_error.yaml
@@ -1,7 +1,5 @@
 # Profile for F5 BIG-IP devices
 #
-extends:
-  - does_not_exist.yaml
 
 device:
   vendor: "f5"

--- a/pkg/networkdevice/profile/profiledefinition/metrics.go
+++ b/pkg/networkdevice/profile/profiledefinition/metrics.go
@@ -39,6 +39,18 @@ const (
 	ProfileMetricTypePercent ProfileMetricType = "percent"
 )
 
+// SymbolConfigCompat is used to deserialize string field or SymbolConfig.
+// For OID/Name to Symbol harmonization:
+// When users declare metric tag like:
+//
+//	metric_tags:
+//	  - OID: 1.2.3
+//	    name: aSymbol
+//
+// this will lead to OID stored as MetricTagConfig.OID  and name stored as MetricTagConfig.Symbol.Name
+// When this happens, in ValidateEnrichMetricTags we harmonize by moving MetricTagConfig.OID to MetricTagConfig.Symbol.OID.
+type SymbolConfigCompat SymbolConfig
+
 // SymbolConfig holds info for a single symbol/oid
 type SymbolConfig struct {
 	OID  string `yaml:"OID,omitempty" json:"OID,omitempty"`
@@ -74,8 +86,9 @@ type MetricTagConfig struct {
 	Column SymbolConfig `yaml:"column,omitempty" json:"column,omitempty"`
 
 	// Symbol config
-	OID  string `yaml:"OID,omitempty" json:"OID,omitempty"`
-	Name string `yaml:"symbol,omitempty" json:"symbol,omitempty"`
+	OID string `yaml:"OID,omitempty" json:"-"  jsonschema:"-"` // DEPRECATED replaced by Symbol field
+	// Using Symbol field below as string is deprecated
+	Symbol SymbolConfigCompat `yaml:"symbol,omitempty" json:"symbol,omitempty"`
 
 	IndexTransform []MetricIndexTransform `yaml:"index_transform,omitempty" json:"index_transform,omitempty"`
 

--- a/pkg/networkdevice/profile/profiledefinition/metrics.go
+++ b/pkg/networkdevice/profile/profiledefinition/metrics.go
@@ -45,7 +45,7 @@ const (
 //
 //	metric_tags:
 //	  - OID: 1.2.3
-//	    name: aSymbol
+//	    symbol: aSymbol
 //
 // this will lead to OID stored as MetricTagConfig.OID  and name stored as MetricTagConfig.Symbol.Name
 // When this happens, in ValidateEnrichMetricTags we harmonize by moving MetricTagConfig.OID to MetricTagConfig.Symbol.OID.

--- a/pkg/networkdevice/profile/profiledefinition/schema/profile_rc_schema.json
+++ b/pkg/networkdevice/profile/profiledefinition/schema/profile_rc_schema.json
@@ -70,11 +70,8 @@
         "column": {
           "$ref": "#/$defs/SymbolConfig"
         },
-        "OID": {
-          "type": "string"
-        },
         "symbol": {
-          "type": "string"
+          "$ref": "#/$defs/SymbolConfigCompat"
         },
         "index_transform": {
           "items": {
@@ -177,6 +174,33 @@
       "type": "array"
     },
     "SymbolConfig": {
+      "properties": {
+        "OID": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "extract_value": {
+          "type": "string"
+        },
+        "scale_factor": {
+          "type": "number"
+        },
+        "format": {
+          "type": "string"
+        },
+        "constant_value_one": {
+          "type": "boolean"
+        },
+        "metric_type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "SymbolConfigCompat": {
       "properties": {
         "OID": {
           "type": "string"

--- a/pkg/networkdevice/profile/profiledefinition/schema/testcases/valid_profile_apc_ups.json
+++ b/pkg/networkdevice/profile/profiledefinition/schema/testcases/valid_profile_apc_ups.json
@@ -214,23 +214,31 @@
     "metric_tags": [
       {
         "tag": "model",
-        "OID": "1.3.6.1.4.1.318.1.1.1.1.1.1.0",
-        "symbol": "upsBasicIdentModel"
+        "symbol": {
+          "OID": "1.3.6.1.4.1.318.1.1.1.1.1.1.0",
+          "name": "upsBasicIdentModel"
+        }
       },
       {
         "tag": "serial_num",
-        "OID": "1.3.6.1.4.1.318.1.1.1.1.2.3.0",
-        "symbol": "upsAdvIdentSerialNumber"
+        "symbol": {
+          "OID": "1.3.6.1.4.1.318.1.1.1.1.2.3.0",
+          "name": "upsAdvIdentSerialNumber"
+        }
       },
       {
         "tag": "firmware_version",
-        "OID": "1.3.6.1.4.1.318.1.1.1.1.2.1.0",
-        "symbol": "upsAdvIdentFirmwareRevision"
+        "symbol": {
+          "OID": "1.3.6.1.4.1.318.1.1.1.1.2.1.0",
+          "name": "upsAdvIdentFirmwareRevision"
+        }
       },
       {
-        "OID": "1.3.6.1.4.1.318.1.1.1.1.1.2.0",
-        "symbol": "upsBasicIdentName",
-        "tag": "ups_name"
+        "tag": "ups_name",
+        "symbol": {
+          "OID": "1.3.6.1.4.1.318.1.1.1.1.1.2.0",
+          "name": "upsBasicIdentName"
+        }
       }
     ]
   }

--- a/pkg/networkdevice/profile/profiledefinition/yaml_utils.go
+++ b/pkg/networkdevice/profile/profiledefinition/yaml_utils.go
@@ -27,6 +27,23 @@ func (a *StringArray) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// UnmarshalYAML unmarshalls SymbolConfig
+func (a *SymbolConfigCompat) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var symbol SymbolConfig
+	err := unmarshal(&symbol)
+	if err != nil {
+		var str string
+		err := unmarshal(&str)
+		if err != nil {
+			return err
+		}
+		*a = SymbolConfigCompat(SymbolConfig{Name: str})
+	} else {
+		*a = SymbolConfigCompat(symbol)
+	}
+	return nil
+}
+
 // UnmarshalYAML unmarshalls MetricTagConfigList
 func (mtcl *MetricTagConfigList) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var multi []MetricTagConfig

--- a/pkg/networkdevice/profile/profiledefinition/yaml_utils_test.go
+++ b/pkg/networkdevice/profile/profiledefinition/yaml_utils_test.go
@@ -17,6 +17,10 @@ type MyStringArray struct {
 	SomeIds StringArray `yaml:"my_field"`
 }
 
+type MySymbolStruct struct {
+	SymbolField SymbolConfigCompat `yaml:"my_symbol_field"`
+}
+
 func Test_metricTagConfig_UnmarshalYAML(t *testing.T) {
 	myStruct := MetricsConfig{}
 	expected := MetricsConfig{MetricTags: []MetricTagConfig{{Index: 3}}}
@@ -60,6 +64,30 @@ func TestStringArray_UnmarshalYAML_string(t *testing.T) {
 
 	yaml.Unmarshal([]byte(`
 my_field: aaa
+`), &myStruct)
+
+	assert.Equal(t, expected, myStruct)
+}
+
+func TestSymbolConfig_UnmarshalYAML_symbolObject(t *testing.T) {
+	myStruct := MySymbolStruct{}
+	expected := MySymbolStruct{SymbolField: SymbolConfigCompat{OID: "1.2.3", Name: "aSymbol"}}
+
+	yaml.Unmarshal([]byte(`
+my_symbol_field:
+  name: aSymbol
+  OID: 1.2.3
+`), &myStruct)
+
+	assert.Equal(t, expected, myStruct)
+}
+
+func TestSymbolConfig_UnmarshalYAML_symbolString(t *testing.T) {
+	myStruct := MySymbolStruct{}
+	expected := MySymbolStruct{SymbolField: SymbolConfigCompat{Name: "aSymbol"}}
+
+	yaml.Unmarshal([]byte(`
+my_symbol_field: aSymbol
 `), &myStruct)
 
 	assert.Equal(t, expected, myStruct)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

[pkg/networkdevice/profile] Harmonize MetricTagConfig OID/Symbol(name) to Symbol object

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

1/ Better consistency.

2/ Using `SymbolConfig` in MetricTagConfig will help benefits from the feature related to SymbolConfig (format, extract_value, etc)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
