### PR TITLE
[workloadmeta/containerd/image] Add missing labels

### DIFF
--- a/releasenotes/notes/fix-missing-labels-container-images-c2d6b05d564694b4.yaml
+++ b/releasenotes/notes/fix-missing-labels-container-images-c2d6b05d564694b4.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a problem that caused the Agent to miss some image labels when using
+    ``containerd`` as the container runtime.


### PR DESCRIPTION
### What does this PR do?

Fixes an issue in the containerd workloadmeta collector.

Not all the labels of a container image were reported.


### Describe how to test/QA your changes

Deploy the agent on an environment with containerd and with image metadata collection enabled (`DD_CONTAINER_IMAGE_ENABLED=true`). Run `agent workload-list --verbose` and verify that list of labels reported for the `container_image_metadata` entities is complete. It should show all the labels reported for the image with `docker image inspect` plus all the ones added when Running on Kubernetes (they start with `io.cri-containerd`).

For the agent image you should see labels such as `baseimage.name`, `baseimage.os`, `maintainer`, among others.

For completeness, this should be tried on Kubernetes+containerd and containerd without Kubernetes.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
