### PR TITLE
[oracle] Add database_instance and db_server tags (DBMON-2942)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -198,6 +198,7 @@ func GetLogPrompt(c InstanceConfig) string {
 	return fmt.Sprintf("%s>", GetConnectData(c))
 }
 
+// GetConnectData returns the connection configuration
 func GetConnectData(c InstanceConfig) string {
 	if c.TnsAlias != "" {
 		return c.TnsAlias

--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -82,32 +82,33 @@ type CustomQuery struct {
 
 // InstanceConfig is used to deserialize integration instance config.
 type InstanceConfig struct {
-	Server                   string               `yaml:"server"`
-	Port                     int                  `yaml:"port"`
-	ServiceName              string               `yaml:"service_name"`
-	Username                 string               `yaml:"username"`
-	Password                 string               `yaml:"password"`
-	TnsAlias                 string               `yaml:"tns_alias"`
-	TnsAdmin                 string               `yaml:"tns_admin"`
-	Protocol                 string               `yaml:"protocol"`
-	Wallet                   string               `yaml:"wallet"`
-	DBM                      bool                 `yaml:"dbm"`
-	Tags                     []string             `yaml:"tags"`
-	LogUnobfuscatedQueries   bool                 `yaml:"log_unobfuscated_queries"`
-	ObfuscatorOptions        obfuscate.SQLConfig  `yaml:"obfuscator_options"`
-	InstantClient            bool                 `yaml:"instant_client"`
-	ReportedHostname         string               `yaml:"reported_hostname"`
-	QuerySamples             QuerySamplesConfig   `yaml:"query_samples"`
-	QueryMetrics             QueryMetricsConfig   `yaml:"query_metrics"`
-	SysMetrics               SysMetricsConfig     `yaml:"sysmetrics"`
-	Tablespaces              TablespacesConfig    `yaml:"tablespaces"`
-	ProcessMemory            ProcessMemoryConfig  `yaml:"process_memory"`
-	SharedMemory             SharedMemoryConfig   `yaml:"shared_memory"`
-	ExecutionPlans           ExecutionPlansConfig `yaml:"execution_plans"`
-	AgentSQLTrace            AgentSQLTrace        `yaml:"agent_sql_trace"`
-	UseGlobalCustomQueries   string               `yaml:"use_global_custom_queries"`
-	CustomQueries            []CustomQuery        `yaml:"custom_queries"`
-	MetricCollectionInterval int64                `yaml:"metric_collection_interval"`
+	Server                             string               `yaml:"server"`
+	Port                               int                  `yaml:"port"`
+	ServiceName                        string               `yaml:"service_name"`
+	Username                           string               `yaml:"username"`
+	Password                           string               `yaml:"password"`
+	TnsAlias                           string               `yaml:"tns_alias"`
+	TnsAdmin                           string               `yaml:"tns_admin"`
+	Protocol                           string               `yaml:"protocol"`
+	Wallet                             string               `yaml:"wallet"`
+	DBM                                bool                 `yaml:"dbm"`
+	Tags                               []string             `yaml:"tags"`
+	LogUnobfuscatedQueries             bool                 `yaml:"log_unobfuscated_queries"`
+	ObfuscatorOptions                  obfuscate.SQLConfig  `yaml:"obfuscator_options"`
+	InstantClient                      bool                 `yaml:"instant_client"`
+	ReportedHostname                   string               `yaml:"reported_hostname"`
+	QuerySamples                       QuerySamplesConfig   `yaml:"query_samples"`
+	QueryMetrics                       QueryMetricsConfig   `yaml:"query_metrics"`
+	SysMetrics                         SysMetricsConfig     `yaml:"sysmetrics"`
+	Tablespaces                        TablespacesConfig    `yaml:"tablespaces"`
+	ProcessMemory                      ProcessMemoryConfig  `yaml:"process_memory"`
+	SharedMemory                       SharedMemoryConfig   `yaml:"shared_memory"`
+	ExecutionPlans                     ExecutionPlansConfig `yaml:"execution_plans"`
+	AgentSQLTrace                      AgentSQLTrace        `yaml:"agent_sql_trace"`
+	UseGlobalCustomQueries             string               `yaml:"use_global_custom_queries"`
+	CustomQueries                      []CustomQuery        `yaml:"custom_queries"`
+	MetricCollectionInterval           int64                `yaml:"metric_collection_interval"`
+	DatabaseInstanceCollectionInterval uint64               `yaml:"database_instance_collection_interval"`
 }
 
 // CheckConfig holds the config needed for an integration instance to run.
@@ -155,6 +156,8 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	instance.ExecutionPlans.Enabled = true
 
 	instance.UseGlobalCustomQueries = "true"
+
+	instance.DatabaseInstanceCollectionInterval = 1800
 	// Defaults end
 
 	if err := yaml.Unmarshal(rawInstance, &instance); err != nil {
@@ -192,6 +195,10 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 
 // GetLogPrompt returns a config based prompt
 func GetLogPrompt(c InstanceConfig) string {
+	return fmt.Sprintf("%s>", GetConnectData(c))
+}
+
+func GetConnectData(c InstanceConfig) string {
 	if c.TnsAlias != "" {
 		return c.TnsAlias
 	}
@@ -206,6 +213,5 @@ func GetLogPrompt(c InstanceConfig) string {
 	if c.ServiceName != "" {
 		p = fmt.Sprintf("%s/%s", p, c.ServiceName)
 	}
-	p = fmt.Sprintf("%s>", p)
 	return p
 }

--- a/pkg/collector/corechecks/oracle-dbm/init.go
+++ b/pkg/collector/corechecks/oracle-dbm/init.go
@@ -62,18 +62,16 @@ func (c *Check) init() error {
 
 	if c.config.ReportedHostname != "" {
 		c.dbHostname = c.config.ReportedHostname
-	} else {
-		if i.HostName.Valid {
-			c.dbHostname = i.HostName.String
-		} else {
-			// host_name is null on Oracle Autonomous Database
-			c.dbHostname = i.InstanceName
-		}
+	} else if i.HostName.Valid {
+		c.dbHostname = i.HostName.String
 	}
 	if i.HostName.Valid {
 		tags = append(tags, fmt.Sprintf("real_hostname:%s", i.HostName.String))
 	}
-	tags = append(tags, fmt.Sprintf("host:%s", c.dbHostname), fmt.Sprintf("oracle_version:%s", c.dbVersion))
+	if c.dbHostname != "" {
+		tags = append(tags, fmt.Sprintf("host:%s", c.dbHostname), fmt.Sprintf("db_server:%s", c.dbHostname))
+	}
+	tags = append(tags, fmt.Sprintf("db_instance:%s/%s", c.dbHostname, c.cdbName), fmt.Sprintf("oracle_version:%s", c.dbVersion))
 
 	c.logPrompt = fmt.Sprintf("%s@%s> ", c.cdbName, c.dbHostname)
 

--- a/pkg/collector/corechecks/oracle-dbm/init.go
+++ b/pkg/collector/corechecks/oracle-dbm/init.go
@@ -71,7 +71,7 @@ func (c *Check) init() error {
 	if c.dbHostname != "" {
 		tags = append(tags, fmt.Sprintf("host:%s", c.dbHostname), fmt.Sprintf("db_server:%s", c.dbHostname))
 	}
-	tags = append(tags, fmt.Sprintf("db_instance:%s/%s", c.dbHostname, c.cdbName), fmt.Sprintf("oracle_version:%s", c.dbVersion))
+	tags = append(tags, fmt.Sprintf("database_instance:%s/%s", c.dbHostname, c.cdbName), fmt.Sprintf("oracle_version:%s", c.dbVersion))
 
 	c.logPrompt = fmt.Sprintf("%s@%s> ", c.cdbName, c.dbHostname)
 

--- a/pkg/collector/corechecks/oracle-dbm/init.go
+++ b/pkg/collector/corechecks/oracle-dbm/init.go
@@ -71,7 +71,8 @@ func (c *Check) init() error {
 	if c.dbHostname != "" {
 		tags = append(tags, fmt.Sprintf("host:%s", c.dbHostname), fmt.Sprintf("db_server:%s", c.dbHostname))
 	}
-	tags = append(tags, fmt.Sprintf("database_instance:%s/%s", c.dbHostname, c.cdbName), fmt.Sprintf("oracle_version:%s", c.dbVersion))
+	tags = append(tags, fmt.Sprintf("oracle_version:%s", c.dbVersion))
+	tags = append(tags, fmt.Sprintf("dd.internal.resource:database_instance:%s/%s", c.dbHostname, c.cdbName))
 
 	c.logPrompt = fmt.Sprintf("%s@%s> ", c.cdbName, c.dbHostname)
 

--- a/pkg/collector/corechecks/oracle-dbm/metadata.go
+++ b/pkg/collector/corechecks/oracle-dbm/metadata.go
@@ -1,0 +1,71 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle
+
+package oracle
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/common"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+type dbInstanceMetadata struct {
+	Dbm            bool   `json:"dbm"`
+	ConnectionHost string `json:"connection_host"`
+}
+
+type dbInstanceEvent struct {
+	Host               string             `json:"host"`
+	AgentVersion       string             `json:"agent_version"`
+	Dbms               string             `json:"dbms"`
+	Kind               string             `json:"kind"`
+	CollectionInterval uint64             `json:"collection_interval"`
+	DbmsVersion        string             `json:"dbms_version"`
+	Tags               []string           `json:"tags"`
+	Timestamp          float64            `json:"timestamp"`
+	Metadata           dbInstanceMetadata `json:"metadata"`
+}
+
+func sendDbInstanceMetadata(c *Check) error {
+	configTags := make([]string, len(c.config.Tags))
+	copy(configTags, c.config.Tags)
+	m := dbInstanceMetadata{
+		Dbm:            true,
+		ConnectionHost: config.GetConnectData(c.config.InstanceConfig),
+	}
+	e := dbInstanceEvent{
+		Host:               c.dbHostname,
+		AgentVersion:       c.agentVersion,
+		Dbms:               common.IntegrationName,
+		Kind:               "database_instance",
+		CollectionInterval: c.config.InstanceConfig.DatabaseInstanceCollectionInterval,
+		DbmsVersion:        c.dbVersion,
+		Tags:               configTags,
+		Timestamp:          float64(time.Now().UnixMilli()),
+		Metadata:           m,
+	}
+
+	payloadBytes, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata payload: %w", err)
+	}
+
+	sender, err := c.GetSender()
+	if err != nil {
+		return fmt.Errorf("failed to get sender for metadata payload: %w", err)
+	}
+	sender.EventPlatformEvent(payloadBytes, "dbm-metadata")
+	log.Debugf("%s dbm-metadata payload %s", c.logPrompt, strings.ReplaceAll(string(payloadBytes), "@", "XX"))
+	sender.Commit()
+
+	return nil
+}

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -76,6 +76,7 @@ type Check struct {
 	driver                                  string
 	metricLastRun                           time.Time
 	statementsLastRun                       time.Time
+	dbInstanceLastRun                       time.Time
 	filePath                                string
 	sqlTraceRunsCount                       int
 	connectedToPdb                          bool
@@ -145,6 +146,15 @@ func (c *Check) Run() error {
 			return fmt.Errorf("%s failed to connect with go-ora %w", c.logPrompt, err)
 		}
 		c.connection = conn
+	}
+
+	dbInstanceIntervalExpired := checkIntervalExpired(&c.dbInstanceLastRun, 1800)
+
+	if dbInstanceIntervalExpired {
+		err := sendDbInstanceMetadata(c)
+		if err != nil {
+			return fmt.Errorf("%s failed to send db instance metadata %w", c.logPrompt, err)
+		}
 	}
 
 	metricIntervalExpired := checkIntervalExpired(&c.metricLastRun, c.config.MetricCollectionInterval)

--- a/releasenotes/notes/oracle-db_instance-tag-aabef83bcc9f10f4.yaml
+++ b/releasenotes/notes/oracle-db_instance-tag-aabef83bcc9f10f4.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    Emit `db_instance` tag with the value `host/cdb`. The goal is to show each database separately in the DBM entry page. Currently, the backend initializes `db_instance` to `host`.
-    Also, the Agent will emit the new `db_server` tag because we have to initialize the `host` tag to `host\cdb`.
+    Emit `database_instance` tag with the value `host/cdb`. The goal is to show each database separately in the DBM entry page. Currently, the backend initializes `database_instance` to `host`.
+    Also, the Agent will emit the new `db_server` tag because we have to initialize the `host` tag to `host/cdb`.

--- a/releasenotes/notes/oracle-db_instance-tag-aabef83bcc9f10f4.yaml
+++ b/releasenotes/notes/oracle-db_instance-tag-aabef83bcc9f10f4.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Emit `db_instance` tag with the value `host/cdb`. The goal is to show each database separately in the DBM entry page. Currently, the backend initializes `db_instance` to `host`.
+    Also, the Agent will emit the new `db_server` tag because we have to initialize the `host` tag to `host\cdb`.


### PR DESCRIPTION
### What does this PR do?

1. Add `database_instance` tag and populate it with `host/cdb`.

2. Add `db_server` tag and populate it with `host`.

### Motivation

1. Currently, the backend initializes `database_instance` to `host`. Consequently, the DBM entry page contains hosts instead of databases. 

2. The tag `host` is using for billing. Currently, it's populated with the database server name. Since we want to bill per database, we are appending `cdb` to host. Then, we need another tag which just stores the database server name.

### Additional Notes

1. A backend change is necessary to populate `database_instance` to `host/cdb` if `db_instance` isn't set, to support the older agent versions.

2. We'll need to replace `hosts` with `db_server` in the dashboard.

### Describe how to test/QA your changes

Check that the `db_server` and `db_instance` metrics are emitted.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
