### PR TITLE
Fix panic in SBOM collection when an image can't be scanned because of insufficient disk space

### DIFF
--- a/pkg/sbom/collectors/containerd/containerd.go
+++ b/pkg/sbom/collectors/containerd/containerd.go
@@ -36,6 +36,11 @@ type ScanRequest struct {
 	FromFilesystem   bool
 }
 
+// GetImgMetadata returns the image metadata
+func (r *ScanRequest) GetImgMetadata() *workloadmeta.ContainerImageMetadata {
+	return r.ImageMeta
+}
+
 // Collector returns the collector name
 func (r *ScanRequest) Collector() string {
 	return collectorName

--- a/pkg/sbom/collectors/docker/docker.go
+++ b/pkg/sbom/collectors/docker/docker.go
@@ -32,6 +32,11 @@ type ScanRequest struct {
 	DockerClient client.ImageAPIClient
 }
 
+// GetImgMetadata returns the image metadata
+func (r *ScanRequest) GetImgMetadata() *workloadmeta.ContainerImageMetadata {
+	return r.ImageMeta
+}
+
 // Collector returns the collector name
 func (r *ScanRequest) Collector() string {
 	return collectorName

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -60,7 +60,7 @@ type ScanRequest interface {
 	ID() string
 }
 
-// ImageScanRequests defines methods exclusive to image scan requests
+// ImageScanRequest defines methods exclusive to image scan requests
 type ImageScanRequest interface {
 	// GetImgMetadata() returns the image metadata.
 	GetImgMetadata() *workloadmeta.ContainerImageMetadata

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -60,6 +60,12 @@ type ScanRequest interface {
 	ID() string
 }
 
+// ImageScanRequests defines methods exclusive to image scan requests
+type ImageScanRequest interface {
+	// GetImgMetadata() returns the image metadata.
+	GetImgMetadata() *workloadmeta.ContainerImageMetadata
+}
+
 // ScanResult defines the scan result
 type ScanResult struct {
 	Error     error

--- a/pkg/sbom/scanner/scanner.go
+++ b/pkg/sbom/scanner/scanner.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/sbom/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
 const (
@@ -77,6 +78,14 @@ func (s *Scanner) enoughDiskSpace(opts sbom.ScanOptions) error {
 	return nil
 }
 
+func sendResult(request *scanRequest, result *sbom.ScanResult) {
+	select {
+	case request.ch <- *result:
+	default:
+		log.Errorf("Failed to push scanner result for '%s' into channel", request.ID())
+	}
+}
+
 func (s *Scanner) start(ctx context.Context) {
 	if s.running {
 		return
@@ -104,18 +113,18 @@ func (s *Scanner) start(ctx context.Context) {
 				}
 				telemetry.SBOMAttempts.Inc(request.Collector(), request.Type())
 
-				sendResult := func(scanResult sbom.ScanResult) {
-					select {
-					case request.ch <- scanResult:
-					default:
-						log.Errorf("Failed to push scanner result for '%s' into channel", request.ID())
-					}
-
-				}
-
 				collector := request.collector
 				if err := s.enoughDiskSpace(request.opts); err != nil {
-					sendResult(sbom.ScanResult{Error: fmt.Errorf("failed to check current disk usage: %w", err)})
+					var imgMeta *workloadmeta.ContainerImageMetadata
+					// It should always be true
+					if imageRequest, ok := request.ScanRequest.(sbom.ImageScanRequest); ok {
+						imgMeta = imageRequest.GetImgMetadata()
+					}
+					result := sbom.ScanResult{
+						ImgMeta: imgMeta,
+						Error:   fmt.Errorf("failed to check current disk usage: %w", err),
+					}
+					sendResult(&request, &result)
 					telemetry.SBOMFailures.Inc(request.Collector(), request.Type(), "disk_space")
 					continue
 				}
@@ -137,7 +146,7 @@ func (s *Scanner) start(ctx context.Context) {
 					telemetry.SBOMGenerationDuration.Observe(generationDuration.Seconds(), request.Collector(), request.Type())
 				}
 				cancel()
-				sendResult(scanResult)
+				sendResult(&request, &scanResult)
 				if request.opts.WaitAfter != 0 {
 					t := time.NewTimer(request.opts.WaitAfter)
 					select {

--- a/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -76,6 +76,11 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 
 	go func() {
 		for result := range resultChan {
+			if result.ImgMeta == nil {
+				log.Errorf("Scan result does not hold the image identifier. Error: %s", result.Error)
+				continue
+			}
+
 			status := workloadmeta.Success
 			reportedError := ""
 			var report *cyclonedx.BOM

--- a/pkg/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
@@ -82,6 +82,10 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 
 	go func() {
 		for result := range resultChan {
+			if result.ImgMeta == nil {
+				log.Errorf("Scan result does not hold the image identifier. Error: %s", result.Error)
+				continue
+			}
 			status := workloadmeta.Success
 			reportedError := ""
 			var report *cyclonedx.BOM


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR fixes a panic in SBOM collection that occurs when not enough disk space is available.

In that case, an error is returned without imgMeta: https://github.com/DataDog/datadog-agent/blob/bb30f44dc8c2bd28c1b8680c0e479c14e6efa937/pkg/sbom/scanner/scanner.go#L118

Then it panics when we try to access `imgMeta`: https://github.com/DataDog/datadog-agent/blob/bb30f44dc8c2bd28c1b8680c0e479c14e6efa937/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go#L107

```
goroutine 567 [running]:
github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/containerd.(*collector).startSBOMCollection.func2()
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go:107 +0x32f
created by github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/containerd.(*collector).startSBOMCollection
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go:77 +0x37c
```


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The agent should not panic on edge cases.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
None
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Deploy the agent with:
```
    - name: DD_SBOM_CACHE_ENABLED
      value: "true"
    - name: DD_SBOM_CONTAINER_IMAGE_ENABLED
      value: "true"
    - name: DD_SBOM_CONTAINER_IMAGE_CHECK_DISK_USAGE
      value: "true"
    - name: DD_SBOM_CONTAINER_IMAGE_MIN_AVAILABLE_DISK
      value: "1000Gb"
```
Make sure the agent does not panic and errors are shown in the output of `agent workload-list -v` as follows:
```
----------- SBOM -----------
Status: Failed
Error: failed to check current disk usage: not enough disk space to safely collect sbom, 192108482560 available, 1073741824000 required
```
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
