### PR TITLE
serverless/appsec/httpsec: support base64 encoded request body

### DIFF
--- a/pkg/serverless/appsec/httpsec/http.go
+++ b/pkg/serverless/appsec/httpsec/http.go
@@ -75,7 +75,7 @@ func parseBody(headers map[string][]string, rawBody *string, isBodyBase64 bool) 
 	if isBodyBase64 {
 		rawBodyDecoded, err := base64.StdEncoding.DecodeString(bodyDecoded)
 		if err != nil {
-			log.Warnf("cannot encode '%s' as base64: %v", bodyDecoded, err)
+			log.Errorf("cannot decode '%s' from base64: %v", bodyDecoded, err)
 			return nil
 		}
 

--- a/pkg/serverless/appsec/httpsec/http.go
+++ b/pkg/serverless/appsec/httpsec/http.go
@@ -75,7 +75,8 @@ func parseBody(headers map[string][]string, rawBody *string, isBodyBase64 bool) 
 	if isBodyBase64 {
 		rawBodyDecoded, err := base64.StdEncoding.DecodeString(bodyDecoded)
 		if err != nil {
-			panic(err)
+			log.Warnf("cannot encode '%s' as base64: %v", bodyDecoded, err)
+			return nil
 		}
 
 		bodyDecoded = string(rawBodyDecoded)

--- a/pkg/serverless/appsec/httpsec/http_test.go
+++ b/pkg/serverless/appsec/httpsec/http_test.go
@@ -121,6 +121,7 @@ func TestParseBodyXml(t *testing.T) {
 		payload := parseBody(
 			map[string][]string{"content-type": {ct}},
 			&rawBody,
+			false,
 		)
 
 		require.Equal(t,

--- a/pkg/serverless/appsec/httpsec/http_test.go
+++ b/pkg/serverless/appsec/httpsec/http_test.go
@@ -19,6 +19,7 @@ func TestParseBodyJson(t *testing.T) {
 			"content-type": {"application/json;charset=utf-8"},
 		},
 		&rawBody,
+		false,
 	)
 
 	require.Equal(t, map[string]any{
@@ -33,9 +34,25 @@ func TestParseBodyUrlEncoded(t *testing.T) {
 			"content-type": {"application/x-www-form-urlencoded"},
 		},
 		&rawBody,
+		false,
 	)
 
 	require.Equal(t, map[string][]string{"foo": {"1337"}, "bar": {"b a z"}}, payload)
+}
+
+func TestParseBodyBase64Json(t *testing.T) {
+	rawBody := "eyAiZm9vIjogMTMzNyB9"
+	payload := parseBody(
+		map[string][]string{
+			"content-type": {"application/json"},
+		},
+		&rawBody,
+		true,
+	)
+
+	require.Equal(t, map[string]any{
+		"foo": 1337., // JSON numbers are float64 in go
+	}, payload)
 }
 
 func TestParseBodyMultipartFormData(t *testing.T) {
@@ -70,6 +87,7 @@ func TestParseBodyMultipartFormData(t *testing.T) {
 			"content-type": {"multipart/form-data; boundary=B0UND4RY"},
 		},
 		&rawBody,
+		false,
 	)
 
 	require.Equal(t, map[string]any{

--- a/pkg/serverless/appsec/httpsec/proxy.go
+++ b/pkg/serverless/appsec/httpsec/proxy.go
@@ -169,6 +169,7 @@ func (lp *ProxyLifecycleProcessor) spanModifier(lastReqId string, chunk *pb.Trac
 			nil,
 			"", // Not provided by API Gateway
 			nil,
+			false,
 		)
 
 	case *events.APIGatewayCustomAuthorizerRequestTypeRequest:
@@ -180,6 +181,7 @@ func (lp *ProxyLifecycleProcessor) spanModifier(lastReqId string, chunk *pb.Trac
 			event.PathParameters,
 			event.RequestContext.Identity.SourceIP,
 			nil,
+			false,
 		)
 
 	case *events.ALBTargetGroupRequest:

--- a/pkg/serverless/appsec/httpsec/proxy.go
+++ b/pkg/serverless/appsec/httpsec/proxy.go
@@ -132,6 +132,7 @@ func (lp *ProxyLifecycleProcessor) spanModifier(lastReqId string, chunk *pb.Trac
 			event.PathParameters,
 			event.RequestContext.Identity.SourceIP,
 			&event.Body,
+			event.IsBase64Encoded,
 		)
 
 	case *events.APIGatewayV2HTTPRequest:
@@ -143,6 +144,7 @@ func (lp *ProxyLifecycleProcessor) spanModifier(lastReqId string, chunk *pb.Trac
 			event.PathParameters,
 			event.RequestContext.HTTP.SourceIP,
 			&event.Body,
+			event.IsBase64Encoded,
 		)
 
 	case *events.APIGatewayWebsocketProxyRequest:
@@ -154,6 +156,7 @@ func (lp *ProxyLifecycleProcessor) spanModifier(lastReqId string, chunk *pb.Trac
 			event.PathParameters,
 			event.RequestContext.Identity.SourceIP,
 			&event.Body,
+			event.IsBase64Encoded,
 		)
 
 	case *events.APIGatewayCustomAuthorizerRequest:
@@ -188,6 +191,7 @@ func (lp *ProxyLifecycleProcessor) spanModifier(lastReqId string, chunk *pb.Trac
 			nil,
 			"",
 			&event.Body,
+			event.IsBase64Encoded,
 		)
 
 	case *events.LambdaFunctionURLRequest:
@@ -199,6 +203,7 @@ func (lp *ProxyLifecycleProcessor) spanModifier(lastReqId string, chunk *pb.Trac
 			nil,
 			event.RequestContext.HTTP.SourceIP,
 			&event.Body,
+			event.IsBase64Encoded,
 		)
 	}
 
@@ -218,8 +223,9 @@ func (lp *ProxyLifecycleProcessor) spanModifier(lastReqId string, chunk *pb.Trac
 		log.Debug("appsec: missing span tag http.status_code")
 	}
 
-	if events := lp.appsec.Monitor(ctx.toAddresses()); len(events) > 0 {
-		setSecurityEventsTags(span, events, reqHeaders, nil)
+	if secEvents := lp.appsec.Monitor(ctx.toAddresses()); len(secEvents) > 0 {
+		log.Debug("appsec: ", len(secEvents), " attack attempt(s) detected")
+		setSecurityEventsTags(span, secEvents, reqHeaders, nil)
 		chunk.Priority = int32(sampler.PriorityUserKeep)
 	}
 }

--- a/pkg/serverless/appsec/httpsec/proxy.go
+++ b/pkg/serverless/appsec/httpsec/proxy.go
@@ -223,9 +223,8 @@ func (lp *ProxyLifecycleProcessor) spanModifier(lastReqId string, chunk *pb.Trac
 		log.Debug("appsec: missing span tag http.status_code")
 	}
 
-	if secEvents := lp.appsec.Monitor(ctx.toAddresses()); len(secEvents) > 0 {
-		log.Debug("appsec: ", len(secEvents), " attack attempt(s) detected")
-		setSecurityEventsTags(span, secEvents, reqHeaders, nil)
+	if events := lp.appsec.Monitor(ctx.toAddresses()); len(events) > 0 {
+		setSecurityEventsTags(span, events, reqHeaders, nil)
 		chunk.Priority = int32(sampler.PriorityUserKeep)
 	}
 }

--- a/pkg/serverless/trace/testdata/event_samples/api-gateway-appsec.json
+++ b/pkg/serverless/trace/testdata/event_samples/api-gateway-appsec.json
@@ -3,7 +3,7 @@
     "resource": "/{proxy+}",
     "path": "/path/to/resource/../../../../../database.yml.sqlite3",
     "httpMethod": "POST",
-    "isBase64Encoded": true,
+    "isBase64Encoded": false,
     "queryStringParameters": {
         "stage": "appscan_fingerprint"
     },


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

* Add support for base64 encoded bodies as input to the runtime api proxy.

### Motivation

Extend support of appsec in the serverless datadog extension.

### Additional Notes

Had to fix the test `api-gateway-appsec.json` because it was incorrectly telling that the body was in base64.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

They were already tests about this be we never bothered to understand that the body was in base64.
Also added a unit test.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
