### PR TITLE
[comp/netflow] Fix flaky TestNetFlow_IntegrationTest_*

### DIFF
--- a/comp/netflow/server/integration_test.go
+++ b/comp/netflow/server/integration_test.go
@@ -61,6 +61,8 @@ func TestNetFlow_IntegrationTest_NetFlow5(t *testing.T) {
 	testutil.ExpectNetflow5Payloads(t, epForwarder)
 	epForwarder.EXPECT().SendEventPlatformEventBlocking(gomock.Any(), "network-devices-metadata").Return(nil).Times(1)
 
+	time.Sleep(100 * time.Millisecond) // wait to make sure goflow listener is started before sending
+
 	// Send netflowV5Data twice to test aggregator
 	// Flows will have 2x bytes/packets after aggregation
 	packetData, err := testutil.GetNetFlow5Packet()
@@ -68,7 +70,7 @@ func TestNetFlow_IntegrationTest_NetFlow5(t *testing.T) {
 	err = testutil.SendUDPPacket(port, packetData)
 	require.NoError(t, err, "error sending udp packet")
 
-	netflowEvents, err := flowaggregator.WaitForFlowsToBeFlushed(srv.FlowAgg, 30*time.Second, 2)
+	netflowEvents, err := flowaggregator.WaitForFlowsToBeFlushed(srv.FlowAgg, 15*time.Second, 2)
 	assert.Equal(t, uint64(2), netflowEvents)
 	assert.NoError(t, err)
 }
@@ -89,12 +91,14 @@ func TestNetFlow_IntegrationTest_NetFlow9(t *testing.T) {
 	epForwarder.EXPECT().SendEventPlatformEventBlocking(gomock.Any(), epforwarder.EventTypeNetworkDevicesNetFlow).Return(nil).Times(29)
 	epForwarder.EXPECT().SendEventPlatformEventBlocking(gomock.Any(), "network-devices-metadata").Return(nil).Times(1)
 
+	time.Sleep(100 * time.Millisecond) // wait to make sure goflow listener is started before sending
+
 	packetData, err := testutil.GetNetFlow9Packet()
 	require.NoError(t, err, "error getting packet")
 	err = testutil.SendUDPPacket(port, packetData)
 	require.NoError(t, err, "error sending udp packet")
 
-	netflowEvents, err := flowaggregator.WaitForFlowsToBeFlushed(srv.FlowAgg, 30*time.Second, 6)
+	netflowEvents, err := flowaggregator.WaitForFlowsToBeFlushed(srv.FlowAgg, 15*time.Second, 6)
 	assert.Equal(t, uint64(29), netflowEvents)
 	assert.NoError(t, err)
 }
@@ -115,13 +119,15 @@ func TestNetFlow_IntegrationTest_SFlow5(t *testing.T) {
 	epForwarder.EXPECT().SendEventPlatformEventBlocking(gomock.Any(), epforwarder.EventTypeNetworkDevicesNetFlow).Return(nil).Times(7)
 	epForwarder.EXPECT().SendEventPlatformEventBlocking(gomock.Any(), "network-devices-metadata").Return(nil).Times(1)
 
+	time.Sleep(100 * time.Millisecond) // wait to make sure goflow listener is started before sending
+
 	data, err := testutil.GetSFlow5Packet()
 	require.NoError(t, err, "error getting sflow data")
 
 	err = testutil.SendUDPPacket(port, data)
 	require.NoError(t, err, "error sending udp packet")
 
-	netflowEvents, err := flowaggregator.WaitForFlowsToBeFlushed(srv.FlowAgg, 30*time.Second, 6)
+	netflowEvents, err := flowaggregator.WaitForFlowsToBeFlushed(srv.FlowAgg, 15*time.Second, 6)
 	assert.Equal(t, uint64(7), netflowEvents)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

[comp/netflow] Fix flaky test

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This `time.Sleep(100 * time.Millisecond)` was present before the Componetization (https://github.com/DataDog/datadog-agent/pull/19140) to help make test more reliable:

```
time.Sleep(100 * time.Millisecond) // wait to make sure goflow listener is started before sending
```

This PR is adding it back to prevent test being flaky.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
