### PR TITLE
[CWS] remove ring buffer very high size for high core count nodes

### DIFF
--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -45,11 +45,9 @@ func computeDefaultEventsRingBufferSize() uint32 {
 
 	if numCPU <= 16 {
 		return uint32(8 * 256 * os.Getpagesize())
-	} else if numCPU <= 64 {
-		return uint32(16 * 256 * os.Getpagesize())
 	}
 
-	return uint32(32 * 256 * os.Getpagesize())
+	return uint32(16 * 256 * os.Getpagesize())
 }
 
 // AllProbes returns the list of all the probes of the runtime security module


### PR DESCRIPTION
### What does this PR do?

This PR removes the biggest size bucket for ring buffer dimensioning, used when the host has more than 64 cores. This was resulting in oversized ringbuffer that was using more memory while at the same time not really protecting us from lost events. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

This change should display no external facing impact. The goal in QA-ing this is to ensure that nodes with >64 cores are not showing anormal amount of lost events.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
