### PR TITLE
[release] Update release.json and Go modules for 6/7.48.0-rc.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,15 +44,15 @@ require (
 	github.com/CycloneDX/cyclonedx-go v0.7.1
 	github.com/DataDog/agent-payload/v5 v5.0.93
 	github.com/DataDog/appsec-internal-go v1.0.1-0.20230723140106-7cb513f54ce1
-	github.com/DataDog/datadog-agent/pkg/gohai v0.48.0-rc.9
-	github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0-rc.9
-	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.0-rc.9
-	github.com/DataDog/datadog-agent/pkg/security/secl v0.48.0-rc.9
-	github.com/DataDog/datadog-agent/pkg/trace v0.48.0-rc.9
-	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.48.0-rc.9
-	github.com/DataDog/datadog-agent/pkg/util/log v0.48.0-rc.9
-	github.com/DataDog/datadog-agent/pkg/util/pointer v0.48.0-rc.9
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.48.0-rc.9
+	github.com/DataDog/datadog-agent/pkg/gohai v0.48.0-rc.10
+	github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0-rc.10
+	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.0-rc.10
+	github.com/DataDog/datadog-agent/pkg/security/secl v0.48.0-rc.10
+	github.com/DataDog/datadog-agent/pkg/trace v0.48.0-rc.10
+	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.48.0-rc.10
+	github.com/DataDog/datadog-agent/pkg/util/log v0.48.0-rc.10
+	github.com/DataDog/datadog-agent/pkg/util/pointer v0.48.0-rc.10
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.48.0-rc.10
 	github.com/DataDog/datadog-go/v5 v5.3.0
 	github.com/DataDog/datadog-operator v1.1.0
 	github.com/DataDog/ebpf-manager v0.2.15
@@ -560,7 +560,7 @@ require (
 require github.com/lorenzosaino/go-sysctl v0.3.1
 
 require (
-	github.com/DataDog/datadog-agent/pkg/proto v0.48.0-rc.9
+	github.com/DataDog/datadog-agent/pkg/proto v0.48.0-rc.10
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.7.0
 	github.com/aquasecurity/trivy v0.0.0-00010101000000-000000000000
 	github.com/cloudfoundry-community/go-cfclient/v2 v2.0.1-0.20230503155151-3d15366c5820

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -10,13 +10,13 @@ go 1.20
 replace github.com/docker/distribution => github.com/docker/distribution v2.8.1+incompatible
 
 require (
-	github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0-rc.9
-	github.com/DataDog/datadog-agent/pkg/proto v0.48.0-rc.9
-	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.0-rc.9
-	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.48.0-rc.9
-	github.com/DataDog/datadog-agent/pkg/util/log v0.48.0-rc.9
-	github.com/DataDog/datadog-agent/pkg/util/pointer v0.48.0-rc.9
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.48.0-rc.9
+	github.com/DataDog/datadog-agent/pkg/obfuscate v0.48.0-rc.10
+	github.com/DataDog/datadog-agent/pkg/proto v0.48.0-rc.10
+	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.48.0-rc.10
+	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.48.0-rc.10
+	github.com/DataDog/datadog-agent/pkg/util/log v0.48.0-rc.10
+	github.com/DataDog/datadog-agent/pkg/util/pointer v0.48.0-rc.10
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.48.0-rc.10
 	github.com/DataDog/datadog-go/v5 v5.1.1
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.7.0
 	github.com/DataDog/sketches-go v1.4.2

--- a/pkg/util/cgroups/go.mod
+++ b/pkg/util/cgroups/go.mod
@@ -9,8 +9,8 @@ replace (
 )
 
 require (
-	github.com/DataDog/datadog-agent/pkg/util/log v0.48.0-rc.9
-	github.com/DataDog/datadog-agent/pkg/util/pointer v0.48.0-rc.9
+	github.com/DataDog/datadog-agent/pkg/util/log v0.48.0-rc.10
+	github.com/DataDog/datadog-agent/pkg/util/pointer v0.48.0-rc.10
 	github.com/containerd/cgroups v1.0.4
 	github.com/google/go-cmp v0.5.8
 	github.com/karrick/godirwalk v1.17.0
@@ -18,7 +18,7 @@ require (
 )
 
 require (
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.48.0-rc.9 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.48.0-rc.10 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/pkg/util/log/go.mod
+++ b/pkg/util/log/go.mod
@@ -5,7 +5,7 @@ go 1.20
 replace github.com/DataDog/datadog-agent/pkg/util/scrubber => ../scrubber
 
 require (
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.48.0-rc.9
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.48.0-rc.10
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/zap v1.22.0

--- a/release.json
+++ b/release.json
@@ -29,7 +29,7 @@
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {
-        "INTEGRATIONS_CORE_VERSION": "7.48.0-rc.6",
+        "INTEGRATIONS_CORE_VERSION": "7.48.0",
         "OMNIBUS_SOFTWARE_VERSION": "7.48.0-rc.8",
         "OMNIBUS_RUBY_VERSION": "7.48.0-rc.9",
         "JMXFETCH_VERSION": "0.47.10",
@@ -41,7 +41,7 @@
         "WINDOWS_DDNPM_SHASUM": "f12af44306eac3ea15828fd12c24d44ae519692a94a0f1f5d4fa868c3e596b07"
     },
     "release-a7": {
-        "INTEGRATIONS_CORE_VERSION": "7.48.0-rc.6",
+        "INTEGRATIONS_CORE_VERSION": "7.48.0",
         "OMNIBUS_SOFTWARE_VERSION": "7.48.0-rc.8",
         "OMNIBUS_RUBY_VERSION": "7.48.0-rc.9",
         "JMXFETCH_VERSION": "0.47.10",

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -9,7 +9,7 @@ go 1.20
 replace github.com/DataDog/datadog-agent/test/fakeintake => ../fakeintake
 
 require (
-	github.com/DataDog/datadog-agent/test/fakeintake v0.48.0-rc.9
+	github.com/DataDog/datadog-agent/test/fakeintake v0.48.0-rc.10
 	// Are you bumping github.com/DataDog/test-infra-definitions ?
 	// You should bump `TEST_INFRA_DEFINITIONS_BUILDIMAGES` in `.gitlab-ci.yml`
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version


### PR DESCRIPTION
integrations-core tag is already set to 7.48.0 as we did not expect any more changes in 7.48.0 scope