### PR TITLE
[netflow] Use Eventually in tests to avoid time.Sleep

### DIFF
--- a/comp/netflow/flowaggregator/aggregator.go
+++ b/comp/netflow/flowaggregator/aggregator.go
@@ -101,10 +101,6 @@ func NewFlowAggregator(sender sender.Sender, epForwarder epforwarder.EventPlatfo
 	}
 }
 
-func (agg *FlowAggregator) FlushedFlowCount() uint64 {
-	return agg.flushedFlowCount.Load()
-}
-
 // Start will start the FlowAggregator worker
 func (agg *FlowAggregator) Start() {
 	agg.logger.Info("Flow Aggregator started")

--- a/comp/netflow/flowaggregator/aggregator.go
+++ b/comp/netflow/flowaggregator/aggregator.go
@@ -101,6 +101,10 @@ func NewFlowAggregator(sender sender.Sender, epForwarder epforwarder.EventPlatfo
 	}
 }
 
+func (agg *FlowAggregator) FlushedFlowCount() uint64 {
+	return agg.flushedFlowCount.Load()
+}
+
 // Start will start the FlowAggregator worker
 func (agg *FlowAggregator) Start() {
 	agg.logger.Info("Flow Aggregator started")

--- a/comp/netflow/flowaggregator/aggregator_test.go
+++ b/comp/netflow/flowaggregator/aggregator_test.go
@@ -214,7 +214,8 @@ stopLoop:
 }
 
 func TestAggregator_withMockPayload(t *testing.T) {
-	port := testutil.GetFreePort()
+	port, err := testutil.GetFreePort()
+	require.NoError(t, err)
 	flushTime, _ := time.Parse(time.RFC3339, "2019-02-18T16:00:06Z")
 
 	sender := mocksender.NewMockSender("")
@@ -257,7 +258,7 @@ func TestAggregator_withMockPayload(t *testing.T) {
 }
 `)
 	compactMetadataEvent := new(bytes.Buffer)
-	err := json.Compact(compactMetadataEvent, metadataEvent)
+	err = json.Compact(compactMetadataEvent, metadataEvent)
 	require.NoError(t, err)
 
 	epForwarder.EXPECT().SendEventPlatformEventBlocking(&message.Message{Content: compactMetadataEvent.Bytes()}, "network-devices-metadata").Return(nil).Times(1)

--- a/comp/netflow/flowaggregator/testutil.go
+++ b/comp/netflow/flowaggregator/testutil.go
@@ -14,7 +14,7 @@ import (
 // flows to be flushed by the aggregator. It is intended for testing.
 func WaitForFlowsToBeFlushed(aggregator *FlowAggregator, timeoutDuration time.Duration, minEvents uint64) (uint64, error) {
 	timeout := time.After(timeoutDuration)
-	ticker := time.NewTicker(500 * time.Millisecond)
+	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 	// Keep trying until we're timed out or got a result or got an error
 	for {

--- a/comp/netflow/flowaggregator/testutil.go
+++ b/comp/netflow/flowaggregator/testutil.go
@@ -14,7 +14,7 @@ import (
 // flows to be flushed by the aggregator. It is intended for testing.
 func WaitForFlowsToBeFlushed(aggregator *FlowAggregator, timeoutDuration time.Duration, minEvents uint64) (uint64, error) {
 	timeout := time.After(timeoutDuration)
-	ticker := time.NewTicker(50 * time.Millisecond)
+	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
 	// Keep trying until we're timed out or got a result or got an error
 	for {

--- a/comp/netflow/server/integration_test.go
+++ b/comp/netflow/server/integration_test.go
@@ -8,7 +8,6 @@
 package server
 
 import (
-	"github.com/DataDog/datadog-agent/comp/netflow/flowaggregator"
 	"testing"
 	"time"
 
@@ -20,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/ndmtmp/forwarder"
 	"github.com/DataDog/datadog-agent/comp/netflow/common"
 	nfconfig "github.com/DataDog/datadog-agent/comp/netflow/config"
+	"github.com/DataDog/datadog-agent/comp/netflow/flowaggregator"
 	"github.com/DataDog/datadog-agent/comp/netflow/testutil"
 	"github.com/DataDog/datadog-agent/pkg/epforwarder"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"

--- a/comp/netflow/server/integration_test.go
+++ b/comp/netflow/server/integration_test.go
@@ -57,7 +57,8 @@ func assertFlowEventsCount(t *testing.T, port uint16, srv *Server, packetData []
 }
 
 func TestNetFlow_IntegrationTest_NetFlow5(t *testing.T) {
-	port := testutil.GetFreePort()
+	port, err := testutil.GetFreePort()
+	require.NoError(t, err)
 	var epForwarder forwarder.MockComponent
 	srv := fxutil.Test[Component](t, fx.Options(
 		testOptions,
@@ -81,7 +82,8 @@ func TestNetFlow_IntegrationTest_NetFlow5(t *testing.T) {
 }
 
 func TestNetFlow_IntegrationTest_NetFlow9(t *testing.T) {
-	port := testutil.GetFreePort()
+	port, err := testutil.GetFreePort()
+	require.NoError(t, err)
 	var epForwarder forwarder.MockComponent
 	srv := fxutil.Test[Component](t, fx.Options(
 		testOptions,
@@ -103,7 +105,8 @@ func TestNetFlow_IntegrationTest_NetFlow9(t *testing.T) {
 }
 
 func TestNetFlow_IntegrationTest_SFlow5(t *testing.T) {
-	port := testutil.GetFreePort()
+	port, err := testutil.GetFreePort()
+	require.NoError(t, err)
 	var epForwarder forwarder.MockComponent
 	srv := fxutil.Test[Component](t, fx.Options(
 		testOptions,

--- a/comp/netflow/server/integration_test.go
+++ b/comp/netflow/server/integration_test.go
@@ -63,16 +63,18 @@ func TestNetFlow_IntegrationTest_NetFlow5(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond) // wait to make sure goflow listener is started before sending
 
-	// Send netflowV5Data twice to test aggregator
-	// Flows will have 2x bytes/packets after aggregation
-	packetData, err := testutil.GetNetFlow5Packet()
-	require.NoError(t, err, "error getting packet")
-	err = testutil.SendUDPPacket(port, packetData)
-	require.NoError(t, err, "error sending udp packet")
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		// Send netflowV5Data twice to test aggregator
+		// Flows will have 2x bytes/packets after aggregation
+		packetData, err := testutil.GetNetFlow5Packet()
+		require.NoError(c, err, "error getting packet")
+		err = testutil.SendUDPPacket(port, packetData)
+		require.NoError(c, err, "error sending udp packet")
 
-	netflowEvents, err := flowaggregator.WaitForFlowsToBeFlushed(srv.FlowAgg, 15*time.Second, 2)
-	assert.Equal(t, uint64(2), netflowEvents)
-	assert.NoError(t, err)
+		netflowEvents, err := flowaggregator.WaitForFlowsToBeFlushed(srv.FlowAgg, 3*time.Second, 2)
+		assert.Equal(c, uint64(2), netflowEvents)
+		assert.NoError(c, err)
+	}, 15*time.Second, 10*time.Millisecond)
 }
 
 func TestNetFlow_IntegrationTest_NetFlow9(t *testing.T) {

--- a/comp/netflow/server/integration_test.go
+++ b/comp/netflow/server/integration_test.go
@@ -69,7 +69,7 @@ func TestNetFlow_IntegrationTest_NetFlow5(t *testing.T) {
 		err = testutil.SendUDPPacket(port, packetData)
 		require.NoError(c, err, "error sending udp packet")
 
-		netflowEvents, err := flowaggregator.WaitForFlowsToBeFlushed(srv.FlowAgg, 3*time.Second, 2)
+		netflowEvents, err := flowaggregator.WaitForFlowsToBeFlushed(srv.FlowAgg, 1*time.Second, 2)
 		assert.Equal(c, uint64(2), netflowEvents)
 		assert.NoError(c, err)
 	}, 15*time.Second, 10*time.Millisecond)

--- a/comp/netflow/server/integration_test.go
+++ b/comp/netflow/server/integration_test.go
@@ -61,8 +61,6 @@ func TestNetFlow_IntegrationTest_NetFlow5(t *testing.T) {
 	testutil.ExpectNetflow5Payloads(t, epForwarder)
 	epForwarder.EXPECT().SendEventPlatformEventBlocking(gomock.Any(), "network-devices-metadata").Return(nil).Times(1)
 
-	time.Sleep(100 * time.Millisecond) // wait to make sure goflow listener is started before sending
-
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		// Send netflowV5Data twice to test aggregator
 		// Flows will have 2x bytes/packets after aggregation

--- a/comp/netflow/server/integration_test.go
+++ b/comp/netflow/server/integration_test.go
@@ -48,7 +48,10 @@ var setTimeNow = fx.Invoke(func(c Component) {
 func assertFlowEventsCount(t *testing.T, port uint16, srv *Server, packetData []byte, expectedEvents uint64) bool {
 	return assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		err := testutil.SendUDPPacket(port, packetData)
-		require.NoError(c, err, "error sending udp packet")
+		assert.NoError(c, err, "error sending udp packet")
+		if err != nil {
+			return
+		}
 
 		netflowEvents, err := flowaggregator.WaitForFlowsToBeFlushed(srv.FlowAgg, 1*time.Second, 2)
 		assert.Equal(c, expectedEvents, netflowEvents)

--- a/comp/netflow/server/server_test.go
+++ b/comp/netflow/server/server_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/netsampler/goflow2/utils"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 	"go.uber.org/fx/fxtest"
 
@@ -80,7 +81,8 @@ var testOptions = fx.Options(
 )
 
 func TestStartServerAndStopServer(t *testing.T) {
-	port := testutil.GetFreePort()
+	port, err := testutil.GetFreePort()
+	require.NoError(t, err)
 	var component Component
 	app := fxtest.New(t, fx.Options(
 		testOptions,

--- a/comp/netflow/testutil/freeport.go
+++ b/comp/netflow/testutil/freeport.go
@@ -9,36 +9,20 @@ package testutil
 
 import (
 	"net"
-	"strconv"
 )
 
 // GetFreePort finds a free port to use for testing.
-func GetFreePort() uint16 {
-	var port uint16
-	for i := 0; i < 5; i++ {
-		conn, err := net.ListenPacket("udp", ":0")
-		if err != nil {
-			continue
-		}
-		conn.Close()
-		port, err = parsePort(conn.LocalAddr().String())
-		if err != nil {
-			continue
-		}
-		return port
-	}
-	panic("unable to find free port for starting the trap listener")
-}
-
-func parsePort(addr string) (uint16, error) {
-	_, portString, err := net.SplitHostPort(addr)
+// Borrowed from: https://github.com/phayes/freeport/blame/master/freeport.go#L8-L20
+func GetFreePort() (uint16, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
 	if err != nil {
 		return 0, err
 	}
 
-	port, err := strconv.ParseUint(portString, 10, 16)
+	l, err := net.ListenTCP("tcp", addr)
 	if err != nil {
 		return 0, err
 	}
-	return uint16(port), nil
+	defer l.Close()
+	return uint16(l.Addr().(*net.TCPAddr).Port), nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
[netflow] Use Eventually in tests to avoid time.Sleep

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Faster tests
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
