### PR TITLE
[windows][cws] Make security-agent run as service

### DIFF
--- a/tools/windows/DatadogAgentInstaller/CustomActions/ServiceCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ServiceCustomAction.cs
@@ -145,6 +145,11 @@ namespace Datadog.CustomActions
                 // LocalSystem is a SCM specific shorthand that doesn't need to be localized
                 _serviceController.SetCredentials(Constants.SystemProbeServiceName, "LocalSystem", "");
                 _serviceController.SetCredentials(Constants.ProcessAgentServiceName, "LocalSystem", "");
+
+                 var installCWS = _session.Property("INSTALL_CWS")
+                 if(!string.IsNullOrEmpty(installCWS)){
+                    _serviceController.SetCredentials(Constants.SecurityAgentServiceName, ddAgentUserName, ddAgentUserPassword);
+                 }
             }
             catch (Exception e)
             {

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ServiceCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ServiceCustomAction.cs
@@ -146,7 +146,7 @@ namespace Datadog.CustomActions
                 _serviceController.SetCredentials(Constants.SystemProbeServiceName, "LocalSystem", "");
                 _serviceController.SetCredentials(Constants.ProcessAgentServiceName, "LocalSystem", "");
 
-                 var installCWS = _session.Property("INSTALL_CWS")
+                 var installCWS = _session.Property("INSTALL_CWS");
                  if(!string.IsNullOrEmpty(installCWS)){
                     _serviceController.SetCredentials(Constants.SecurityAgentServiceName, ddAgentUserName, ddAgentUserPassword);
                  }

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentCustomActions.cs
@@ -413,7 +413,8 @@ namespace WixSetup.Datadog
                     Impersonate = false
                 }
                 .SetProperties("DDAGENTUSER_PROCESSED_PASSWORD=[DDAGENTUSER_PROCESSED_PASSWORD], " +
-                               "DDAGENTUSER_PROCESSED_FQ_NAME=[DDAGENTUSER_PROCESSED_FQ_NAME]")
+                               "DDAGENTUSER_PROCESSED_FQ_NAME=[DDAGENTUSER_PROCESSED_FQ_NAME], " +
+                               "INSTALL_CWS=[INSTALL_CWS]")
                 .HideTarget(true);
 
             // WiX built-in StopServices only stops services if the component is changing.

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -58,6 +58,13 @@ namespace WixSetup.Datadog
 
         public Project ConfigureProject()
         {
+             // Conditionally include the PROCMON MSM while it is in active development to make it easier
+            // to build/ship without it.
+            Property cwsProperty = null;
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WINDOWS_DDPROCMON_DRIVER")))
+            {
+                cwsProperty = new Property("INSTALL_CWS", "1");
+            }
             var project = new ManagedProject("Datadog Agent",
                 // Use 2 LaunchConditions, one for server versions,
                 // one for client versions.
@@ -121,15 +128,12 @@ namespace WixSetup.Datadog
                 )
                 {
                     Win64 = true
-                }
+                },
+                // cwsProperty is conditionally declared above, it is either NULL
+                // or the property indicating that cws is to be included.
+                cwsProperty
             );
-            // Conditionally include the PROCMON MSM while it is in active development to make it easier
-            // to build/ship without it.
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WINDOWS_DDPROCMON_DRIVER")))
-            {
-                var cws = new Property("INSTALL_CWS", "1")
-                project.Add(cws)
-            }
+           
             // Always generate a new GUID otherwise WixSharp will generate one based on
             // the version
             project.ProductId = Guid.NewGuid();

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -123,6 +123,13 @@ namespace WixSetup.Datadog
                     Win64 = true
                 }
             );
+            // Conditionally include the PROCMON MSM while it is in active development to make it easier
+            // to build/ship without it.
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WINDOWS_DDPROCMON_DRIVER")))
+            {
+                var cws = new Property("INSTALL_CWS", "1")
+                project.Add(cws)
+            }
             // Always generate a new GUID otherwise WixSharp will generate one based on
             // the version
             project.ProductId = Guid.NewGuid();


### PR DESCRIPTION
### What does this PR do?

Fixes security agent to be able to start properly when run as a service.
Fixes decoding of some config defaults so that security agent and process agent function properly when not explicitly configured.
Fixes config template for windows to show proper windows values.

### Motivation


### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
- Install build
- Enable CWS with defaults
  - runtime_security_config.enabled = true in both system-probe.yaml and security-agent.yaml
- restart (core) agent
- ensure security agent starts


Check sample `system-probe.yaml` and `security-agent.yaml` for platform specific entries that they make sense on windows
(they're currently TCP addresses, not UDS names)

e.g.:
```
## @param sysprobe_socket - string - optional - default: localhost:3334
  ## @env DD_SYSTEM_PROBE_CONFIG_SYSPROBE_SOCKET - string - optional - default: localhost:3334
  ## The TCP address where the security runtime module is accessed.
  #
  # socket: localhost:3334
```
On linux, the `socket` entry is a path to a UDS.  On windows, it should be as above.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
