### PR TITLE
[omnibus] Don't destroy OVAL probe sessions in OpenSCAP

### DIFF
--- a/omnibus/config/patches/openscap/1001-Fix-probe_reset.patch
+++ b/omnibus/config/patches/openscap/1001-Fix-probe_reset.patch
@@ -1,0 +1,48 @@
+From 01600dce05253383f072463fda377a3e61da10d1 Mon Sep 17 00:00:00 2001
+From: David du Colombier <djc@datadoghq.com>
+Date: Wed, 4 Oct 2023 17:04:21 +0200
+Subject: [PATCH] Fix probe_reset
+
+The probe_reset function didn't work properly,
+because its second argument was always NULL.
+
+This changes fixes the probe_reset function by
+passing the probe as the second argument.
+
+This change also call probe_ncache_clear to clear
+the ncache instead of calling probe_ncache_free and
+probe_ncache_new, like it was done in change
+057873ac7c816b5e067c49442bd4f55b77121e9c.
+---
+ src/OVAL/probes/probe/probe_main.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/OVAL/probes/probe/probe_main.c b/src/OVAL/probes/probe/probe_main.c
+index 5968c9292..17bf7a0ac 100644
+--- a/src/OVAL/probes/probe/probe_main.c
++++ b/src/OVAL/probes/probe/probe_main.c
+@@ -87,10 +87,10 @@ static SEXP_t *probe_reset(SEXP_t *arg0, void *arg1)
+          * FIXME: implement main loop locking & worker waiting
+          */
+ 	probe_rcache_free(probe->rcache);
+-        probe_ncache_free(probe->ncache);
+ 
+         probe->rcache = probe_rcache_new();
+-        probe->ncache = probe_ncache_new();
++        probe_ncache_clear(OSCAP_GSYM(ncache));
++        probe->ncache = OSCAP_GSYM(ncache);
+ 
+         return(NULL);
+ }
+@@ -211,7 +211,7 @@ void *probe_common_main(void *arg)
+ 	if (probe.sd < 0)
+ 		fail(errno, "SEAP_openfd2", __LINE__ - 3);
+ 
+-	if (SEAP_cmd_register(probe.SEAP_ctx, PROBECMD_RESET, 0, &probe_reset) != 0)
++	if (SEAP_cmd_register(probe.SEAP_ctx, PROBECMD_RESET, SEAP_CMDREG_USEARG, &probe_reset, &probe) != 0)
+ 		fail(errno, "SEAP_cmd_register", __LINE__ - 1);
+ 
+ 	/*
+-- 
+2.34.1
+

--- a/omnibus/config/patches/openscap/dpkginfo-cache-close.patch
+++ b/omnibus/config/patches/openscap/dpkginfo-cache-close.patch
@@ -1,0 +1,38 @@
+--- a/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx
++++ b/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx
+@@ -64,6 +64,7 @@ struct dpkginfo_reply_t * dpkginfo_get_by_name(const char *name, int *err)
+         if (Pkg.end() == true) {
+                 /* not found, clear error flag */
+                 if (err) *err = 0;
++                cgCache->Close();
+                 return NULL;
+         }
+ 
+@@ -72,6 +73,7 @@ struct dpkginfo_reply_t * dpkginfo_get_by_name(const char *name, int *err)
+                 /* not installed, clear error flag */
+                 /* FIXME this should be different that not found */
+                 if (err) *err = 0;
++                cgCache->Close();
+                 return NULL;
+         }
+ 
+@@ -114,6 +116,8 @@ struct dpkginfo_reply_t * dpkginfo_get_by_name(const char *name, int *err)
+         reply->version = strdup(version.c_str());
+         reply->evr = strdup(evr_str.c_str());
+ 
++        cgCache->Close();
++
+         return reply;
+ }
+ 
+@@ -147,10 +151,6 @@ int dpkginfo_init()
+ 
+ int dpkginfo_fini()
+ {
+-        if (cgCache != NULL) {
+-                cgCache->Close();
+-        }
+-
+         return 0;
+ }
+ 

--- a/omnibus/config/patches/openscap/oval_probe_session_reset.patch
+++ b/omnibus/config/patches/openscap/oval_probe_session_reset.patch
@@ -1,0 +1,11 @@
+--- a/src/OVAL/oval_agent.c
++++ b/src/OVAL/oval_agent.c
+@@ -265,7 +265,7 @@ void oval_agent_reset_results(oval_agent_session_t * ag_sess) {
+ 		oval_results_model_free(ag_sess->res_model);
+ 		ag_sess->res_model = oval_results_model_new_with_probe_session(
+ 				ag_sess->def_model, ag_sess->sys_models, ag_sess->psess);
+-		oval_probe_session_reinit(ag_sess->psess, ag_sess->sys_model);
++		oval_probe_session_reset(ag_sess->psess, ag_sess->sys_model);
+ 	}
+ #endif
+ }

--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -61,6 +61,10 @@ build do
   patch source: "session-print-syschar.patch", env: env # add a function to print system characteristics
   patch source: "memusage-cgroup.patch", env: env # consider cgroup when determining memory usage
 
+  patch source: "1001-Fix-probe_reset.patch", env: env # fix probe_reset
+  patch source: "dpkginfo-cache-close.patch", env: env # close cache at the end of dpkginfo_get_by_name
+  patch source: "oval_probe_session_reset.patch", env: env # use oval_probe_session_reset instead of oval_probe_session_reinit
+
   patch source: "oscap-io.patch", env: env # add new oscap-io tool
 
   env["CC"] = "/opt/gcc-#{ENV['GCC_VERSION']}/bin/gcc"


### PR DESCRIPTION
### What does this PR do?

This change replaces the use of `oval_probe_session_reinit` by `oval_probe_session_reset` to reset the OVAL probe sessions.

Contrary to `oval_probe_session_reinit`, the `oval_probe_session_reset` function only resets the result and name caches, instead of destroying the probe threads.

The change also fixes the `probe_reset` function by passing the probe pointer, so it works as expected.

Finally, this change modifies the `dpkginfo_get_by_name` function to call `cgCache->Close` before returning, because the `dpkginfo_fini` function won't be called between every result evaluation anymore.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
