### PR TITLE
Add LabelSelectors in admission controller for AKS to avoid conflict with AKS admissions enforcer

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/common.go
+++ b/pkg/clusteragent/admission/controllers/webhook/common.go
@@ -62,7 +62,7 @@ func aksSelectors(useNamespaceSelector bool, labelSelector metav1.LabelSelector)
 	if useNamespaceSelector {
 		labelSelector.MatchExpressions = append(
 			labelSelector.MatchExpressions,
-			azureAKSLabelSelectorRequirement(),
+			azureAKSLabelSelectorRequirement()...,
 		)
 		return &labelSelector, nil
 	}
@@ -70,15 +70,25 @@ func aksSelectors(useNamespaceSelector bool, labelSelector metav1.LabelSelector)
 	// Azure AKS adds the namespace selector even in Kubernetes versions that
 	// support object selectors, so we need to add it to avoid conflicts.
 	return &metav1.LabelSelector{
-		MatchExpressions: []metav1.LabelSelectorRequirement{
-			azureAKSLabelSelectorRequirement(),
-		},
+		MatchExpressions: azureAKSLabelSelectorRequirement(),
 	}, &labelSelector
 }
 
-func azureAKSLabelSelectorRequirement() metav1.LabelSelectorRequirement {
-	return metav1.LabelSelectorRequirement{
-		Key:      "control-plane",
-		Operator: metav1.LabelSelectorOpDoesNotExist,
+func azureAKSLabelSelectorRequirement() []metav1.LabelSelectorRequirement {
+	return []metav1.LabelSelectorRequirement{
+		{
+			Key:      "control-plane",
+			Operator: metav1.LabelSelectorOpDoesNotExist,
+		},
+		{
+			Key:      "control-plane",
+			Operator: metav1.LabelSelectorOpNotIn,
+			Values:   []string{"true"},
+		},
+		{
+			Key:      "kubernetes.azure.com/managedby",
+			Operator: metav1.LabelSelectorOpNotIn,
+			Values:   []string{"aks"},
+		},
 	}
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -445,6 +445,16 @@ func TestGenerateTemplatesV1(t *testing.T) {
 								Key:      "control-plane",
 								Operator: metav1.LabelSelectorOpDoesNotExist,
 							},
+							{
+								Key:      "control-plane",
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"true"},
+							},
+							{
+								Key:      "kubernetes.azure.com/managedby",
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"aks"},
+							},
 						},
 					},
 				)

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -477,6 +477,16 @@ func TestGenerateTemplatesV1(t *testing.T) {
 								Key:      "control-plane",
 								Operator: metav1.LabelSelectorOpDoesNotExist,
 							},
+							{
+								Key:      "control-plane",
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"true"},
+							},
+							{
+								Key:      "kubernetes.azure.com/managedby",
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"aks"},
+							},
 						},
 					},
 				)

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -488,6 +488,16 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 								Key:      "control-plane",
 								Operator: metav1.LabelSelectorOpDoesNotExist,
 							},
+							{
+								Key:      "control-plane",
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"true"},
+							},
+							{
+								Key:      "kubernetes.azure.com/managedby",
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"aks"},
+							},
 						},
 					},
 				)

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -445,6 +445,16 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 								Key:      "control-plane",
 								Operator: metav1.LabelSelectorOpDoesNotExist,
 							},
+							{
+								Key:      "control-plane",
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"true"},
+							},
+							{
+								Key:      "kubernetes.azure.com/managedby",
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"aks"},
+							},
 						},
 					},
 				)

--- a/releasenotes-dca/notes/fix-dca-admission-webhook-aks-b5a7e2a73141b0dc.yaml
+++ b/releasenotes-dca/notes/fix-dca-admission-webhook-aks-b5a7e2a73141b0dc.yaml
@@ -1,0 +1,4 @@
+
+fixes:
+  - |
+    Resolved a conflict between the admission controller and the AKS admissions enforcer that previously led to a loop in reconciling the webhook.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR https://github.com/DataDog/datadog-agent/pull/11367 fixed a problem that happens when enabling the DCA admission controller on Azure AKS.

AKS automatically injects label selectors creating a conflict with the DCA admission controller. To avoid this conflict, we also injected these labelSelectors however, AKS now injects even more labelSelectors:
```
    - key: control-plane
      operator: DoesNotExist
    - key: control-plane
      operator: NotIn
      values:
      - "true"
    - key: kubernetes.azure.com/managedby
      operator: NotIn
      values:
      - aks
```
This PR adds the new labelSelectors.
.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Update attempts put pressure on the kube apiserver and etcd.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Closes: https://github.com/DataDog/datadog-agent/issues/10413
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
None
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Follow the same steps as https://github.com/DataDog/datadog-agent/pull/11367
You can create an AKS cluster using the steps here https://learn.microsoft.com/en-us/azure/aks/learn/quick-kubernetes-deploy-cli. This bug should occur on 1.25.11+
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
