### PR TITLE
[CWS] fix edge case of syscall monitor

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/exec.h
+++ b/pkg/security/ebpf/c/include/helpers/exec.h
@@ -34,7 +34,7 @@ int __attribute__((always_inline)) handle_exec_event(ctx_t *ctx, struct syscall_
     resolve_dentry(ctx, DR_KPROBE_OR_FENTRY);
 
     // if the tail call fails, we need to pop the syscall cache entry
-    pop_syscall(EVENT_EXEC);
+    pop_current_or_impersonated_exec_syscall();
 
     return 0;
 }

--- a/pkg/security/ebpf/c/include/helpers/syscalls.h
+++ b/pkg/security/ebpf/c/include/helpers/syscalls.h
@@ -93,7 +93,7 @@ struct syscall_cache_t *__attribute__((always_inline)) pop_task_syscall(u64 pid_
     if (!type || syscall->type == type) {
         bpf_map_delete_elem(&syscalls, &pid_tgid);
 
-        monitor_syscalls(type, -1);
+        monitor_syscalls(syscall->type, -1);
         return syscall;
     }
     return NULL;

--- a/pkg/security/ebpf/c/include/helpers/syscalls.h
+++ b/pkg/security/ebpf/c/include/helpers/syscalls.h
@@ -180,23 +180,23 @@ struct syscall_cache_t *__attribute__((always_inline)) peek_current_or_impersona
 
 struct syscall_cache_t *__attribute__((always_inline)) pop_current_or_impersonated_exec_syscall() {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_EXEC);
-    if (!syscall) {
-        u64 pid_tgid = bpf_get_current_pid_tgid();
-        u32 tgid = pid_tgid >> 32;
-        u32 pid = pid_tgid;
-        u64 *pid_tgid_execing_ptr = (u64 *)bpf_map_lookup_elem(&exec_pid_transfer, &tgid);
-        if (!pid_tgid_execing_ptr) {
-            return NULL;
-        }
+
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 tgid = pid_tgid >> 32;
+    u32 pid = pid_tgid;
+    u64 *pid_tgid_execing_ptr = (u64 *)bpf_map_lookup_elem(&exec_pid_transfer, &tgid);
+    if (pid_tgid_execing_ptr) {
         u64 pid_tgid_execing = *pid_tgid_execing_ptr;
+        struct syscall_cache_t *imp_syscall = pop_task_syscall(pid_tgid_execing, EVENT_EXEC);
+
         u32 tgid_execing = pid_tgid_execing >> 32;
         u32 pid_execing = pid_tgid_execing;
-        if (tgid != tgid_execing || pid == pid_execing) {
-            return NULL;
+        if (tgid == tgid_execing && pid != pid_execing && !syscall) {
+            // the current task is impersonating its thread group leader
+            syscall = imp_syscall;
         }
-        // the current task is impersonating its thread group leader
-        syscall = pop_task_syscall(pid_tgid_execing, EVENT_EXEC);
     }
+
     return syscall;
 }
 

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -156,6 +156,9 @@ int sched_process_fork(struct _tracepoint_sched_process_fork *args) {
         u32 value = 1;
         // mark as ignored fork not from syscall, ex: kworkers
         bpf_map_update_elem(&pid_ignored, &pid, &value, BPF_ANY);
+        if (syscall) {
+            pop_syscall(EVENT_FORK);
+        }
         return 0;
     }
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes 2 issues with syscall in flight accounting:
- it fixes an issue where syscalls popped using `EVENT_ANY` were not correctly counted
- it fixes an issue where fork syscall were not popped if they were kthreads
- it fixes multiple issues when accounting for exec events, especially around current pid vs impersonated pid

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
