### PR TITLE
[gitlab] Update JOBOWNERS for eBPF Platform and Windows teams

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -2,14 +2,13 @@
 
 # Deps build
 build_clang_*                        @DataDog/ebpf-platform
-build_omnibus-nikos_*                @DataDog/ebpf-platform
 build_processed_btfhub_archive       @DataDog/ebpf-platform
 build_vcpkg_deps                     @DataDog/windows-agent
 
 # Source test
 # Notifications are handled separately for more fine-grained control on go tests
 tests_*                              @DataDog/multiple
-tests_ebpf                           @DataDog/ebpf-platform
+tests_ebpf*                          @DataDog/ebpf-platform
 security_go_generate_check           @DataDog/agent-security
 prepare_ebpf_functional_tests*       @DataDog/ebpf-platform
 
@@ -24,10 +23,12 @@ build_system-probe*                  @DataDog/ebpf-platform
 cluster_agent_cloudfoundry-build*    @Datadog/platform-integrations
 cluster_agent-build*                 @DataDog/container-integrations
 build_serverless*                    @DataDog/serverless
-check_serverless_*                   @DataDog/serverless
 
 # Package deps build
 generate_minimized_btfs_*            @DataDog/ebpf-platform
+
+# Kitchen tests
+kitchen_windows*                     @DataDog/windows-agent
 
 # Image build
 docker_build*                        @DataDog/container-integrations

--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -30,7 +30,7 @@ GITHUB_SLACK_MAP = {
     "@datadog/ebpf-platform": "#ebpf-platform-ops",
     "@datadog/networks": "#network-performance-monitoring",
     "@datadog/universal-service-monitoring": "#universal-service-monitoring",
-    "@datadog/windows-agent": "#windows-agent",
+    "@datadog/windows-agent": "#windows-agent-ops",
     "@datadog/windows-kernel-integrations": "#windows-kernel-integrations",
     "@datadog/opentelemetry": "#opentelemetry-ops",
     "@datadog/agent-e2e-testing": "#agent-testing-and-qa",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

For eBPF Platform:
- removes the `build_omnibus-nikos_*` line from the `JOBOWNERS` file, these jobs do not exist anymore.
- edits the `tests_ebpf` line to `tests_ebpf*` in the `JOBOWNERS` file, to explicitly match all jobs with this prefix.

For Windows Agent:
- adds `kitchen_windows*` jobs to their ownership in `JOBOWNERS`.
- updates the Slack channel to `#windows-agent-ops`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Keep notifications up-to-date.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

n/a

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
