### PR TITLE
[pkg/networkdevice] Move GetFreePort to pkg/networkdevice

### DIFF
--- a/comp/netflow/flowaggregator/aggregator_test.go
+++ b/comp/netflow/flowaggregator/aggregator_test.go
@@ -36,6 +36,7 @@ import (
 	ddlog "github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
+	ndmtestutils "github.com/DataDog/datadog-agent/pkg/networkdevice/testutils"
 
 	"github.com/DataDog/datadog-agent/comp/netflow/common"
 	"github.com/DataDog/datadog-agent/comp/netflow/config"
@@ -214,7 +215,7 @@ stopLoop:
 }
 
 func TestAggregator_withMockPayload(t *testing.T) {
-	port, err := testutil.GetFreePort()
+	port, err := ndmtestutils.GetFreePort()
 	require.NoError(t, err)
 	flushTime, _ := time.Parse(time.RFC3339, "2019-02-18T16:00:06Z")
 

--- a/comp/netflow/server/integration_test.go
+++ b/comp/netflow/server/integration_test.go
@@ -16,14 +16,17 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/pkg/epforwarder"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+
 	"github.com/DataDog/datadog-agent/comp/ndmtmp/forwarder"
+
+	ndmtestutils "github.com/DataDog/datadog-agent/pkg/networkdevice/testutils"
+
 	"github.com/DataDog/datadog-agent/comp/netflow/common"
 	nfconfig "github.com/DataDog/datadog-agent/comp/netflow/config"
 	"github.com/DataDog/datadog-agent/comp/netflow/flowaggregator"
 	"github.com/DataDog/datadog-agent/comp/netflow/testutil"
-	"github.com/DataDog/datadog-agent/pkg/epforwarder"
-	ndmtestutils "github.com/DataDog/datadog-agent/pkg/networkdevice/testutils"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func singleListenerConfig(flowType common.FlowType, port uint16) *nfconfig.NetflowConfig {

--- a/comp/netflow/server/integration_test.go
+++ b/comp/netflow/server/integration_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/netflow/flowaggregator"
 	"github.com/DataDog/datadog-agent/comp/netflow/testutil"
 	"github.com/DataDog/datadog-agent/pkg/epforwarder"
+	ndmtestutils "github.com/DataDog/datadog-agent/pkg/networkdevice/testutils"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -60,7 +61,7 @@ func assertFlowEventsCount(t *testing.T, port uint16, srv *Server, packetData []
 }
 
 func TestNetFlow_IntegrationTest_NetFlow5(t *testing.T) {
-	port, err := testutil.GetFreePort()
+	port, err := ndmtestutils.GetFreePort()
 	require.NoError(t, err)
 	var epForwarder forwarder.MockComponent
 	srv := fxutil.Test[Component](t, fx.Options(
@@ -85,7 +86,7 @@ func TestNetFlow_IntegrationTest_NetFlow5(t *testing.T) {
 }
 
 func TestNetFlow_IntegrationTest_NetFlow9(t *testing.T) {
-	port, err := testutil.GetFreePort()
+	port, err := ndmtestutils.GetFreePort()
 	require.NoError(t, err)
 	var epForwarder forwarder.MockComponent
 	srv := fxutil.Test[Component](t, fx.Options(
@@ -108,7 +109,7 @@ func TestNetFlow_IntegrationTest_NetFlow9(t *testing.T) {
 }
 
 func TestNetFlow_IntegrationTest_SFlow5(t *testing.T) {
-	port, err := testutil.GetFreePort()
+	port, err := ndmtestutils.GetFreePort()
 	require.NoError(t, err)
 	var epForwarder forwarder.MockComponent
 	srv := fxutil.Test[Component](t, fx.Options(

--- a/comp/netflow/server/server_test.go
+++ b/comp/netflow/server/server_test.go
@@ -24,9 +24,11 @@ import (
 	"github.com/DataDog/datadog-agent/comp/ndmtmp/aggregator"
 	"github.com/DataDog/datadog-agent/comp/ndmtmp/forwarder"
 	"github.com/DataDog/datadog-agent/comp/ndmtmp/sender"
+
+	ndmtestutils "github.com/DataDog/datadog-agent/pkg/networkdevice/testutils"
+
 	nfconfig "github.com/DataDog/datadog-agent/comp/netflow/config"
 	"github.com/DataDog/datadog-agent/comp/netflow/goflowlib"
-	ndmtestutils "github.com/DataDog/datadog-agent/pkg/networkdevice/testutils"
 )
 
 type dummyFlowProcessor struct {

--- a/comp/netflow/server/server_test.go
+++ b/comp/netflow/server/server_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/ndmtmp/sender"
 	nfconfig "github.com/DataDog/datadog-agent/comp/netflow/config"
 	"github.com/DataDog/datadog-agent/comp/netflow/goflowlib"
-	"github.com/DataDog/datadog-agent/comp/netflow/testutil"
+	ndmtestutils "github.com/DataDog/datadog-agent/pkg/networkdevice/testutils"
 )
 
 type dummyFlowProcessor struct {
@@ -81,7 +81,7 @@ var testOptions = fx.Options(
 )
 
 func TestStartServerAndStopServer(t *testing.T) {
-	port, err := testutil.GetFreePort()
+	port, err := ndmtestutils.GetFreePort()
 	require.NoError(t, err)
 	var component Component
 	app := fxtest.New(t, fx.Options(

--- a/pkg/networkdevice/testutils/doc.go
+++ b/pkg/networkdevice/testutils/doc.go
@@ -1,0 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+//go:build test
+
+// Package testutils contains utils function for testing ndm features (snmp/traps/netflow)
+package testutils

--- a/pkg/networkdevice/testutils/freeport.go
+++ b/pkg/networkdevice/testutils/freeport.go
@@ -5,7 +5,7 @@
 
 //go:build test
 
-package testutil
+package testutils
 
 import (
 	"net"

--- a/pkg/snmp/traps/forwarder_test.go
+++ b/pkg/snmp/traps/forwarder_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/gob"
 	"encoding/hex"
+	ndmtestutils "github.com/DataDog/datadog-agent/pkg/networkdevice/testutils"
 	"net"
 	"testing"
 	"time"
@@ -41,6 +42,9 @@ func (f DummyFormatter) FormatPacket(packet *SnmpPacket) ([]byte, error) {
 }
 
 func createForwarder(t *testing.T) (forwarder *TrapForwarder, err error) {
+	serverPort, err := ndmtestutils.GetFreePort()
+	require.NoError(t, err)
+
 	packetsIn := make(PacketsChannel)
 	mockSender := mocksender.NewMockSender("snmp-traps-listener")
 	mockSender.SetupAcceptAll()

--- a/pkg/snmp/traps/forwarder_test.go
+++ b/pkg/snmp/traps/forwarder_test.go
@@ -10,7 +10,6 @@ import (
 	"crypto/sha256"
 	"encoding/gob"
 	"encoding/hex"
-	ndmtestutils "github.com/DataDog/datadog-agent/pkg/networkdevice/testutils"
 	"net"
 	"testing"
 	"time"
@@ -20,6 +19,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/epforwarder"
+
+	ndmtestutils "github.com/DataDog/datadog-agent/pkg/networkdevice/testutils"
 )
 
 type DummyFormatter struct{}

--- a/pkg/snmp/traps/listener_test.go
+++ b/pkg/snmp/traps/listener_test.go
@@ -7,16 +7,18 @@ package traps
 
 import (
 	"errors"
-	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"testing"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+
+	ndmtestutils "github.com/DataDog/datadog-agent/pkg/networkdevice/testutils"
 )
 
-var serverPort = getFreePort()
 var initialTrapsPacketsAuthErrors int64
 
 const defaultTimeout = 1 * time.Second
@@ -38,6 +40,8 @@ func listenerTestSetup(t *testing.T, config Config) (*mocksender.MockSender, *Tr
 }
 
 func TestListenV1GenericTrap(t *testing.T) {
+	serverPort, err := ndmtestutils.GetFreePort()
+	require.NoError(t, err)
 	config := Config{Port: serverPort, CommunityStrings: []string{"public"}, Namespace: "totoro"}
 	_, trapListener := listenerTestSetup(t, config)
 	defer trapListener.Stop()
@@ -50,6 +54,8 @@ func TestListenV1GenericTrap(t *testing.T) {
 }
 
 func TestServerV1SpecificTrap(t *testing.T) {
+	serverPort, err := ndmtestutils.GetFreePort()
+	require.NoError(t, err)
 	config := Config{Port: serverPort, CommunityStrings: []string{"public"}}
 	_, trapListener := listenerTestSetup(t, config)
 	defer trapListener.Stop()
@@ -62,6 +68,8 @@ func TestServerV1SpecificTrap(t *testing.T) {
 }
 
 func TestServerV2(t *testing.T) {
+	serverPort, err := ndmtestutils.GetFreePort()
+	require.NoError(t, err)
 	config := Config{Port: serverPort, CommunityStrings: []string{"public"}}
 	_, trapListener := listenerTestSetup(t, config)
 	defer trapListener.Stop()
@@ -74,6 +82,8 @@ func TestServerV2(t *testing.T) {
 }
 
 func TestServerV2BadCredentials(t *testing.T) {
+	serverPort, err := ndmtestutils.GetFreePort()
+	require.NoError(t, err)
 	config := Config{Port: serverPort, CommunityStrings: []string{"public"}, Namespace: "totoro"}
 	mockSender, trapListener := listenerTestSetup(t, config)
 	defer trapListener.Stop()
@@ -87,6 +97,8 @@ func TestServerV2BadCredentials(t *testing.T) {
 }
 
 func TestServerV3(t *testing.T) {
+	serverPort, err := ndmtestutils.GetFreePort()
+	require.NoError(t, err)
 	userV3 := UserV3{Username: "user", AuthKey: "password", AuthProtocol: "sha", PrivKey: "password", PrivProtocol: "aes"}
 	config := Config{Port: serverPort, Users: []UserV3{userV3}}
 	_, trapListener := listenerTestSetup(t, config)
@@ -106,6 +118,8 @@ func TestServerV3(t *testing.T) {
 }
 
 func TestServerV3BadCredentials(t *testing.T) {
+	serverPort, err := ndmtestutils.GetFreePort()
+	require.NoError(t, err)
 	userV3 := UserV3{Username: "user", AuthKey: "password", AuthProtocol: "sha", PrivKey: "password", PrivProtocol: "aes"}
 	config := Config{Port: serverPort, Users: []UserV3{userV3}}
 	_, trapListener := listenerTestSetup(t, config)
@@ -123,6 +137,8 @@ func TestServerV3BadCredentials(t *testing.T) {
 }
 
 func TestListenerTrapsReceivedTelemetry(t *testing.T) {
+	serverPort, err := ndmtestutils.GetFreePort()
+	require.NoError(t, err)
 	config := Config{Port: serverPort, CommunityStrings: []string{"public"}, Namespace: "totoro"}
 	mockSender, trapListener := listenerTestSetup(t, config)
 	defer trapListener.Stop()

--- a/pkg/snmp/traps/server_test.go
+++ b/pkg/snmp/traps/server_test.go
@@ -6,12 +6,13 @@
 package traps
 
 import (
-	ndmtestutils "github.com/DataDog/datadog-agent/pkg/networkdevice/testutils"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+
+	ndmtestutils "github.com/DataDog/datadog-agent/pkg/networkdevice/testutils"
 )
 
 func TestStartFailure(t *testing.T) {

--- a/pkg/snmp/traps/server_test.go
+++ b/pkg/snmp/traps/server_test.go
@@ -6,6 +6,7 @@
 package traps
 
 import (
+	ndmtestutils "github.com/DataDog/datadog-agent/pkg/networkdevice/testutils"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,13 +14,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 )
 
-var freePort = getFreePort()
-
 func TestStartFailure(t *testing.T) {
 	/*
 		Start two servers with the same config to trigger an "address already in use" error.
 	*/
 
+	freePort, err := ndmtestutils.GetFreePort()
+	require.NoError(t, err)
 	config := Config{Port: freePort, CommunityStrings: []string{"public"}}
 	Configure(t, config)
 

--- a/pkg/snmp/traps/traps_test.go
+++ b/pkg/snmp/traps/traps_test.go
@@ -8,9 +8,6 @@
 package traps
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
-	"net"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -83,43 +80,6 @@ var (
 		},
 	}
 )
-
-func getFreePort() uint16 {
-	sender := mocksender.NewMockSender("")
-
-	var port uint16
-	for i := 0; i < 5; i++ {
-		conn, err := net.ListenPacket("udp", ":0")
-		if err != nil {
-			continue
-		}
-		conn.Close()
-		port, err = parsePort(conn.LocalAddr().String())
-		if err != nil {
-			continue
-		}
-		listener, err := startSNMPTrapListener(Config{Port: port}, sender, nil)
-		if err != nil {
-			continue
-		}
-		listener.Stop()
-		return port
-	}
-	panic("unable to find free port for starting the trap listener")
-}
-
-func parsePort(addr string) (uint16, error) {
-	_, portString, err := net.SplitHostPort(addr)
-	if err != nil {
-		return 0, err
-	}
-
-	port, err := strconv.ParseUint(portString, 10, 16)
-	if err != nil {
-		return 0, err
-	}
-	return uint16(port), nil
-}
 
 // Configure sets Datadog Agent configuration from a config object.
 func Configure(t *testing.T, trapConfig Config) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

[pkg/networkdevice] Move GetFreePort to pkg/networkdevice

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Avoid duplication of getFreePort code.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
