### PR TITLE
[USMON-583] usm: migrate tests to monitor

### DIFF
--- a/pkg/network/usm/monitor_test.go
+++ b/pkg/network/usm/monitor_test.go
@@ -117,6 +117,7 @@ func testHTTPStats(t *testing.T, aggregateByStatusCode bool) {
 	srvDoneFn := testutil.HTTPServer(t, serverAddr, testutil.Options{
 		EnableKeepAlive: true,
 	})
+	t.Cleanup(srvDoneFn)
 
 	cfg := networkconfig.New()
 	cfg.EnableHTTPStatsByStatusCode = aggregateByStatusCode

--- a/pkg/network/usm/monitor_test.go
+++ b/pkg/network/usm/monitor_test.go
@@ -101,6 +101,49 @@ func TestHTTP(t *testing.T) {
 	})
 }
 
+func (s *HTTPTestSuite) TestHTTPStats() {
+	t := s.T()
+	t.Run("status code", func(t *testing.T) {
+		testHTTPStats(t, true)
+	})
+	t.Run("status class", func(t *testing.T) {
+		testHTTPStats(t, false)
+	})
+}
+
+func testHTTPStats(t *testing.T, aggregateByStatusCode bool) {
+	// Start an HTTP server on localhost:8080
+	serverAddr := "127.0.0.1:8080"
+	srvDoneFn := testutil.HTTPServer(t, serverAddr, testutil.Options{
+		EnableKeepAlive: true,
+	})
+
+	cfg := networkconfig.New()
+	cfg.EnableHTTPStatsByStatusCode = aggregateByStatusCode
+	monitor := newHTTPMonitorWithCfg(t, cfg)
+
+	resp, err := nethttp.Get(fmt.Sprintf("http://%s/%d/test", serverAddr, nethttp.StatusNoContent))
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	srvDoneFn()
+
+	// Iterate through active connections until we find connection created above
+	require.Eventuallyf(t, func() bool {
+		stats := getHttpStats(t, monitor)
+
+		for key, reqStats := range stats {
+			if key.Method == http.MethodGet && strings.HasSuffix(key.Path.Content.Get(), "/test") && (key.SrcPort == 8080 || key.DstPort == 8080) {
+				currentStats := reqStats.Data[reqStats.NormalizeStatusCode(204)]
+				if currentStats != nil && currentStats.Count == 1 {
+					return true
+				}
+			}
+		}
+
+		return false
+	}, 3*time.Second, 100*time.Millisecond, "couldn't find http connection matching: %s", serverAddr)
+}
+
 func (s *HTTPTestSuite) TestHTTPMonitorCaptureRequestMultipleTimes() {
 	t := s.T()
 
@@ -880,9 +923,9 @@ func countRequestOccurrences(allStats map[http.Key]*http.RequestStats, req *neth
 	return occurrences
 }
 
-func newHTTPMonitor(t *testing.T) *Monitor {
-	cfg := networkconfig.New()
+func newHTTPMonitorWithCfg(t *testing.T, cfg *networkconfig.Config) *Monitor {
 	cfg.EnableHTTPMonitoring = true
+
 	monitor, err := NewMonitor(cfg, nil, nil, nil)
 	skipIfNotSupported(t, err)
 	require.NoError(t, err)
@@ -897,6 +940,10 @@ func newHTTPMonitor(t *testing.T) *Monitor {
 	skipIfNotSupported(t, err)
 	require.NoError(t, err)
 	return monitor
+}
+
+func newHTTPMonitor(t *testing.T) *Monitor {
+	return newHTTPMonitorWithCfg(t, networkconfig.New())
 }
 
 func skipIfNotSupported(t *testing.T, err error) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Cut 75s from test

The test didn't need a tracer, and we can use a monitor, which has much faster setup and teardown

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Faster kitchen tests
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
