### PR TITLE
[CWS] Support using tcp in addition to unix sockets

### DIFF
--- a/pkg/security/agent/client.go
+++ b/pkg/security/agent/client.go
@@ -9,6 +9,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"runtime"
 
@@ -16,6 +17,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 )
 
@@ -184,15 +186,17 @@ func NewRuntimeSecurityClient() (*RuntimeSecurityClient, error) {
 		return nil, errors.New("runtime_security_config.socket must be set")
 	}
 
+	family, _ := config.GetFamilyAddress(socketPath)
+	if runtime.GOOS == "windows" && family == "unix" {
+		return nil, fmt.Errorf("unix sockets are not supported on Windows")
+	}
+
 	conn, err := grpc.Dial(
 		socketPath,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(grpc.CallContentSubtype(api.VTProtoCodecName)),
 		grpc.WithContextDialer(func(ctx context.Context, url string) (net.Conn, error) {
-			if runtime.GOOS == "windows" {
-				return net.Dial("tcp", url)
-			}
-			return net.Dial("unix", url)
+			return net.Dial(family, url)
 		}),
 	)
 	if err != nil {

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -8,6 +8,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
@@ -464,6 +465,14 @@ func parseHashAlgorithmStringSlice(algorithms []string) []model.HashAlgorithm {
 		}
 	}
 	return output
+}
+
+// GetFamilyAddress returns the address famility to use for system-probe <-> security-agent communication
+func GetFamilyAddress(path string) (string, string) {
+	if strings.HasPrefix(path, "/") {
+		return "unix", path
+	}
+	return "tcp", path
 }
 
 var (

--- a/pkg/security/module/cws_linux.go
+++ b/pkg/security/module/cws_linux.go
@@ -10,10 +10,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 )
 
-func getFamilyAddress(config *config.RuntimeSecurityConfig) (string, string) {
-	return "unix", config.SocketPath
-}
-
 // UpdateEventMonitorOpts adapt the event monitor options
 func UpdateEventMonitorOpts(opts *eventmonitor.Opts, config *config.Config) {
 	opts.ProbeOpts.PathResolutionEnabled = true

--- a/pkg/security/module/cws_others.go
+++ b/pkg/security/module/cws_others.go
@@ -13,10 +13,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func getFamilyAddress(config *config.RuntimeSecurityConfig) (string, string) {
-	return "tcp", config.SocketPath
-}
-
 // UpdateEventMonitorOpts adapt the event monitor option
 func UpdateEventMonitorOpts(opts *eventmonitor.Opts, config *config.Config) {
 	if config.RuntimeSecurity.RemoteConfigurationEnabled {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Allow using TCP for security-agent <-> system-probe communication.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Right now, only UNIX sockets are supported are Linux, while only TCP
is supported on Windows. This PR makes it possible to use TCP sockets
in case security-agent and system-probe do not share a folder for the UNIX socket.


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Set `runtime_security_config.socket` to `127.0.0.1:9876` in both `system-probe.yaml`
and `security-agent.yaml`.
`security-agent status` should display that both components are connected.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
