### PR TITLE
[oracle] DBMON-2951 Adding query metrics workflow tracking

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -30,12 +30,17 @@ type QuerySamplesConfig struct {
 	IncludeAllSessions bool `yaml:"include_all_sessions"`
 }
 
+type QueryMetricsTrackerConfig struct {
+	ContainsText []string `yaml:"contains_text"`
+}
+
 type QueryMetricsConfig struct {
-	Enabled            bool  `yaml:"enabled"`
-	CollectionInterval int64 `yaml:"collection_interval"`
-	DBRowsLimit        int   `yaml:"db_rows_limit"`
-	DisableLastActive  bool  `yaml:"disable_last_active"`
-	Lookback           int64 `yaml:"lookback"`
+	Enabled            bool                        `yaml:"enabled"`
+	CollectionInterval int64                       `yaml:"collection_interval"`
+	DBRowsLimit        int                         `yaml:"db_rows_limit"`
+	DisableLastActive  bool                        `yaml:"disable_last_active"`
+	Lookback           int64                       `yaml:"lookback"`
+	Trackers           []QueryMetricsTrackerConfig `yaml:"trackers"`
 }
 
 type SysMetricsConfig struct {

--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -30,7 +30,7 @@ type QuerySamplesConfig struct {
 	IncludeAllSessions bool `yaml:"include_all_sessions"`
 }
 
-type QueryMetricsTrackerConfig struct {
+type queryMetricsTrackerConfig struct {
 	ContainsText []string `yaml:"contains_text"`
 }
 
@@ -40,7 +40,7 @@ type QueryMetricsConfig struct {
 	DBRowsLimit        int                         `yaml:"db_rows_limit"`
 	DisableLastActive  bool                        `yaml:"disable_last_active"`
 	Lookback           int64                       `yaml:"lookback"`
-	Trackers           []QueryMetricsTrackerConfig `yaml:"trackers"`
+	Trackers           []queryMetricsTrackerConfig `yaml:"trackers"`
 }
 
 type SysMetricsConfig struct {

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -444,9 +444,34 @@ func (c *Check) StatementMetrics() (int, error) {
 		var diff OracleRowMonotonicCount
 		planErrors = 0
 		for _, statementMetricRow := range statementMetricsAll {
+
+			var trace bool
+			for _, t := range c.config.QueryMetrics.Trackers {
+				if len(t.ContainsText) > 0 {
+					for _, q := range t.ContainsText {
+						if strings.Contains(statementMetricRow.SQLText, q) {
+							trace = true
+						} else {
+							trace = false
+							break
+						}
+					}
+					if trace {
+						break
+					}
+				}
+			}
+
+			if trace {
+				log.Infof("%s queried: %+v", c.logPrompt, statementMetricRow)
+			}
+
 			newCache[statementMetricRow.StatementMetricsKeyDB] = statementMetricRow.StatementMetricsMonotonicCountDB
 			previousMonotonic, exists := c.statementMetricsMonotonicCountsPrevious[statementMetricRow.StatementMetricsKeyDB]
 			if exists {
+				if trace {
+					log.Infof("%s previous: %+v", c.logPrompt, statementMetricRow)
+				}
 				diff = OracleRowMonotonicCount{}
 				if diff.ParseCalls = statementMetricRow.ParseCalls - previousMonotonic.ParseCalls; diff.ParseCalls < 0 {
 					continue
@@ -586,6 +611,9 @@ func (c *Check) StatementMetrics() (int, error) {
 			}
 
 			oracleRows = append(oracleRows, oracleRow)
+			if trace {
+				log.Infof("%s payload: %+v", c.logPrompt, oracleRow)
+			}
 
 			if c.fqtEmitted == nil {
 				c.fqtEmitted = getFqtEmittedCache()

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -470,7 +470,7 @@ func (c *Check) StatementMetrics() (int, error) {
 			previousMonotonic, exists := c.statementMetricsMonotonicCountsPrevious[statementMetricRow.StatementMetricsKeyDB]
 			if exists {
 				if trace {
-					log.Infof("%s previous: %+v", c.logPrompt, statementMetricRow)
+					log.Infof("%s previous: %+v %+v", c.logPrompt, statementMetricRow.StatementMetricsKeyDB, previousMonotonic)
 				}
 				diff = OracleRowMonotonicCount{}
 				if diff.ParseCalls = statementMetricRow.ParseCalls - previousMonotonic.ParseCalls; diff.ParseCalls < 0 {


### PR DESCRIPTION
### What does this PR do?

Instrumenting the query metrics processing on the Agent.

### Motivation

Producing query metrics relies on some not commonly understood heuristics, which under certain border conditions might yield funky outcomes, such as inflated or missing metrics. In the current implementation, we can trace the payloads, but since they can be huge, they are often being truncated by the logger. As an alternative, we can configure the very light-weight tracking of a small fraction of the payload, which is sufficient to identify the problem.

### Additional Notes

The following configuration will trace all the statements containing the string `select` and `dual`:

```
    query_metrics:
      trackers:
        - contains_text:
          - select
          - dual
```

The following phases are currently being tracked:
- queried statistics
- cache content
- payload.

We aren't generating a changelog entry because we don't want to expose the feature to the general public.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Configure tracking and check the log entries in the agent.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
