### PR TITLE
Follow symlinks in 89-copy-customfiles.sh

### DIFF
--- a/Dockerfiles/agent/cont-init.d/89-copy-customfiles.sh
+++ b/Dockerfiles/agent/cont-init.d/89-copy-customfiles.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # Copy the custom checks and confs in the /etc/datadog-agent folder
-find /conf.d -name '*.yaml' -exec cp --parents -fv {} /etc/datadog-agent/ \;
-find /checks.d -name '*.py' -exec cp --parents -fv {} /etc/datadog-agent/ \;
+find -L /conf.d -name '*.yaml' -exec cp --parents -fv {} /etc/datadog-agent/ \;
+find -L /checks.d -name '*.py' -exec cp --parents -fv {} /etc/datadog-agent/ \;


### PR DESCRIPTION
### What does this PR do?

Follow symlinks when copying `/conf.d` to `/etc/datadog-agent/conf.d/`

### Motivation

I am attempting to use the `[key].extraConfd.configMap.name` [property](https://github.com/DataDog/datadog-operator/blob/1a5623dde36f2cb48999b1b14909f8d431f83c4c/docs/configuration.v2alpha1.md?plain=1#L288) on the `DatadogAgent`, which mounts a configmap to `/conf.d` 

I am trying to set the related `path` to `openmetrics.d/file.yaml` so it ends up in the `/etc/datadog-agent/conf.d/openmetrics.d` directory. However, this subdirectory is a symlink in kubernetes:
![image](https://github.com/DataDog/datadog-agent/assets/130372585/55380f0a-30b4-4eb2-9ed2-23ee00fce2c2)

The existing `find` command doesn't copy this correctly:
![image](https://github.com/DataDog/datadog-agent/assets/130372585/3437447f-b1ca-4b23-82e2-7fa63d6cae88)

But it does if I add `-L`:
![image](https://github.com/DataDog/datadog-agent/assets/130372585/89db890b-eb57-4852-8a4d-de61919c9138)

I can't just name the file `openmetrics.yaml` because I have more than one configuration I wish to use for `openmetrics`, without using pod annotations for each one
