### PR TITLE
Uses forked pkg/util/interner for dogstatsd workload

### DIFF
--- a/comp/dogstatsd/server/intern.go
+++ b/comp/dogstatsd/server/intern.go
@@ -7,6 +7,8 @@ package server
 
 import (
 	"fmt"
+	"runtime"
+	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
@@ -16,9 +18,7 @@ var (
 	// There are multiple instances of the interner, one per worker (depends on # of virtual CPUs).
 	// Most metrics are tagged with the instance ID, however some are left as global
 	// Note `New` vs `NewSimple`
-	tlmSIResets = telemetry.NewCounter("dogstatsd", "string_interner_resets", []string{"interner_id"},
-		"Amount of resets of the string interner used in dogstatsd")
-	tlmSIRSize = telemetry.NewGauge("dogstatsd", "string_interner_entries", []string{"interner_id"},
+	tlmSIREntries = telemetry.NewGauge("dogstatsd", "string_interner_entries", []string{"interner_id"},
 		"Number of entries in the string interner")
 	tlmSIRBytes = telemetry.NewGauge("dogstatsd", "string_interner_bytes", []string{"interner_id"},
 		"Number of bytes stored in the string interner")
@@ -28,72 +28,85 @@ var (
 		"Number of times string interner created a new string object")
 	tlmSIRNew = telemetry.NewSimpleCounter("dogstatsd", "string_interner_new",
 		"Number of times string interner was created")
-	tlmSIRStrBytes = telemetry.NewSimpleHistogram("dogstatsd", "string_interner_str_bytes",
-		"Number of times string with specific length were added",
-		[]float64{1, 2, 4, 8, 16, 32, 64, 128})
 )
 
-// stringInterner is a string cache providing a longer life for strings,
-// helping to avoid GC runs because they're re-used many times instead of
-// created every time.
-type stringInterner struct {
-	strings    map[string]string
-	maxSize    int
-	curBytes   int
-	tlmEnabled bool
-	id         string
+// A StringValue pointer is the handle to the underlying string value.
+// See Get how Value pointers may be used.
+type StringValue struct {
+	_           [0]func() // prevent people from accidentally using value type as comparable
+	cmpVal      string
+	resurrected bool
 }
 
-func newStringInterner(maxSize int, internerID int) *stringInterner {
+// Get the underlying string value
+func (v *StringValue) Get() string {
+	return v.cmpVal
+}
+
+// stringInterner interns strings while allowing them to be cleaned up by the GC.
+// It can handle both string and []byte types without allocation.
+type stringInterner struct {
+	tlmEnabled   bool
+	valMap       map[string]uintptr
+	id           string
+	totalBytes   uint32
+	totalEntries uint32
+}
+
+// newStringInterner creates a new StringInterner
+func newStringInterner(internerID int) *stringInterner {
 	i := &stringInterner{
-		strings:    make(map[string]string),
-		id:         fmt.Sprintf("interner_%d", internerID),
-		maxSize:    maxSize,
+		valMap:     make(map[string]uintptr),
 		tlmEnabled: utils.IsTelemetryEnabled(),
+		id:         fmt.Sprintf("interner_%d", internerID),
 	}
+
 	if i.tlmEnabled {
 		tlmSIRNew.Inc()
 	}
 	return i
 }
 
-// LoadOrStore always returns the string from the cache, adding it into the
-// cache if needed.
-// If we need to store a new entry and the cache is at its maximum capacity,
-// it is reset.
-func (i *stringInterner) LoadOrStore(key []byte) string {
-	// here is the string interner trick: the map lookup using
-	// string(key) doesn't actually allocate a string, but is
-	// returning the string value -> no new heap allocation
-	// for this string.
-	// See https://github.com/golang/go/commit/f5f5a8b6209f84961687d993b93ea0d397f5d5bf
-	if s, found := i.strings[string(key)]; found {
-		if i.tlmEnabled {
-			tlmSIRHits.WithTags(map[string]string{"interner_id": i.id}).Inc()
+// Get returns a pointer representing the []byte k
+//
+// The returned pointer will be the same for Get(v) and Get(v2)
+// if and only if v == v2. The returned pointer will also be the same
+// for a string with same contents as the byte slice.
+//
+//go:nocheckptr
+func (s *stringInterner) LoadOrStore(k []byte) *StringValue {
+	var v *StringValue
+	// the compiler will optimize the following map lookup to not alloc a string
+	if addr, ok := s.valMap[string(k)]; ok {
+		//goland:noinspection GoVetUnsafePointer
+		v = (*StringValue)((unsafe.Pointer)(addr))
+		v.resurrected = true
+		if s.tlmEnabled {
+			tlmSIRHits.WithTags(map[string]string{"interner_id": s.id}).Inc()
+			tlmSIRBytes.WithTags(map[string]string{"interner_id": s.id}).Add(float64(len(k)))
+			tlmSIREntries.WithTags(map[string]string{"interner_id": s.id}).Add(1)
 		}
-		return s
-	}
-	if len(i.strings) >= i.maxSize {
-		if i.tlmEnabled {
-			tlmSIResets.WithTags(map[string]string{"interner_id": i.id}).Inc()
-			tlmSIRBytes.WithTags(map[string]string{"interner_id": i.id}).Sub(float64(i.curBytes))
-			tlmSIRSize.WithTags(map[string]string{"interner_id": i.id}).Sub(float64(len(i.strings)))
-			i.curBytes = 0
-		}
-
-		i.strings = make(map[string]string)
+		return v
 	}
 
-	s := string(key)
-	i.strings[s] = s
+	v = &StringValue{cmpVal: string(k)}
+	runtime.SetFinalizer(v, s.finalize)
+	s.valMap[string(k)] = uintptr(unsafe.Pointer(v))
+	tlmSIRMiss.WithTags(map[string]string{"interner_id": s.id}).Inc()
+	return v
+}
 
-	if i.tlmEnabled {
-		tlmSIRMiss.WithTags(map[string]string{"interner_id": i.id}).Inc()
-		tlmSIRSize.WithTags(map[string]string{"interner_id": i.id}).Inc()
-		tlmSIRBytes.WithTags(map[string]string{"interner_id": i.id}).Add(float64(len(s)))
-		tlmSIRStrBytes.Observe(float64(len(s)))
-		i.curBytes += len(s)
+func (s *stringInterner) finalize(v *StringValue) {
+	if v.resurrected {
+		// We lost the race. Somebody resurrected it while we
+		// were about to finalize it. Try again next round.
+		v.resurrected = false
+		runtime.SetFinalizer(v, s.finalize)
+		return
 	}
 
-	return s
+	deadValue := v.Get()
+	tlmSIRBytes.WithTags(map[string]string{"interner_id": s.id}).Sub(float64(len(deadValue)))
+	tlmSIREntries.WithTags(map[string]string{"interner_id": s.id}).Sub(1)
+	delete(s.valMap, v.Get())
 }

--- a/comp/dogstatsd/server/intern_test.go
+++ b/comp/dogstatsd/server/intern_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestInternLoadOrStoreValue(t *testing.T) {
 	assert := assert.New(t)
-	sInterner := newStringInterner(3, 1)
+	sInterner := newStringInterner(1)
 
 	foo := []byte("foo")
 	bar := []byte("bar")
@@ -22,19 +22,19 @@ func TestInternLoadOrStoreValue(t *testing.T) {
 
 	// first test that the good value is returned.
 
-	v := sInterner.LoadOrStore(foo)
+	v := sInterner.LoadOrStore(foo).Get()
 	assert.Equal("foo", v)
-	v = sInterner.LoadOrStore(bar)
+	v = sInterner.LoadOrStore(bar).Get()
 	assert.Equal("bar", v)
-	v = sInterner.LoadOrStore(far)
+	v = sInterner.LoadOrStore(far).Get()
 	assert.Equal("far", v)
-	v = sInterner.LoadOrStore(boo)
+	v = sInterner.LoadOrStore(boo).Get()
 	assert.Equal("boo", v)
 }
 
 func TestInternLoadOrStorePointer(t *testing.T) {
 	assert := assert.New(t)
-	sInterner := newStringInterner(4, 1)
+	sInterner := newStringInterner(1)
 
 	foo := []byte("foo")
 	bar := []byte("bar")
@@ -42,16 +42,16 @@ func TestInternLoadOrStorePointer(t *testing.T) {
 
 	// first test that the good value is returned.
 
-	v := sInterner.LoadOrStore(foo)
+	v := sInterner.LoadOrStore(foo).Get()
 	assert.Equal("foo", v)
-	v2 := sInterner.LoadOrStore(foo)
+	v2 := sInterner.LoadOrStore(foo).Get()
 	assert.Equal(&v, &v2, "must point to the same address")
-	v2 = sInterner.LoadOrStore(bar)
+	v2 = sInterner.LoadOrStore(bar).Get()
 	assert.NotEqual(&v, &v2, "must point to a different address")
-	v3 := sInterner.LoadOrStore(bar)
+	v3 := sInterner.LoadOrStore(bar).Get()
 	assert.Equal(&v2, &v3, "must point to the same address")
 
-	v4 := sInterner.LoadOrStore(boo)
+	v4 := sInterner.LoadOrStore(boo).Get()
 	assert.NotEqual(&v, &v4, "must point to a different address")
 	assert.NotEqual(&v2, &v4, "must point to a different address")
 	assert.NotEqual(&v3, &v4, "must point to a different address")
@@ -59,22 +59,22 @@ func TestInternLoadOrStorePointer(t *testing.T) {
 
 func TestInternLoadOrStoreReset(t *testing.T) {
 	assert := assert.New(t)
-	sInterner := newStringInterner(4, 1)
+	sInterner := newStringInterner(1)
 
 	// first test that the good value is returned.
 	sInterner.LoadOrStore([]byte("foo"))
-	assert.Equal(1, len(sInterner.strings))
+	assert.Equal(1, len(sInterner.valMap))
 	sInterner.LoadOrStore([]byte("bar"))
 	sInterner.LoadOrStore([]byte("bar"))
-	assert.Equal(2, len(sInterner.strings))
+	assert.Equal(2, len(sInterner.valMap))
 	sInterner.LoadOrStore([]byte("boo"))
-	assert.Equal(3, len(sInterner.strings))
+	assert.Equal(3, len(sInterner.valMap))
 	sInterner.LoadOrStore([]byte("far"))
 	sInterner.LoadOrStore([]byte("far"))
 	sInterner.LoadOrStore([]byte("far"))
-	assert.Equal(4, len(sInterner.strings))
+	assert.Equal(4, len(sInterner.valMap))
 	sInterner.LoadOrStore([]byte("val"))
-	assert.Equal(1, len(sInterner.strings))
+	assert.Equal(5, len(sInterner.valMap))
 	sInterner.LoadOrStore([]byte("val"))
-	assert.Equal(1, len(sInterner.strings))
+	assert.Equal(5, len(sInterner.valMap))
 }

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -28,6 +28,7 @@ from . import (
     rtloader,
     security_agent,
     selinux,
+    smp,
     system_probe,
     systray,
     trace_agent,
@@ -134,6 +135,7 @@ ns.add_collection(package)
 ns.add_collection(pipeline)
 ns.add_collection(pylauncher)
 ns.add_collection(selinux)
+ns.add_collection(smp)
 ns.add_collection(systray)
 ns.add_collection(release)
 ns.add_collection(rtloader)

--- a/tasks/smp.py
+++ b/tasks/smp.py
@@ -1,0 +1,74 @@
+"""
+SMP namespaced tasks
+"""
+
+
+from .agent import build, BIN_PATH
+from .flavor import AgentFlavor
+from invoke import task
+from .utils import (
+    bin_name,
+)
+import os
+
+
+@task
+def run_regression(
+    ctx,
+    rebuild=False,
+    race=False,
+    build_include=None,
+    build_exclude=None,
+    flavor=AgentFlavor.base.name,
+    skip_build=False,
+    regression_case="uds_dogstatsd_to_api",
+    run_telemetry_agent=True,
+):
+    """
+    Run the specified regression test against the locally built agent.
+
+    By default it builds the agent before executing it, unless --skip-build was
+    passed. It accepts the same set of options as agent.build.
+    """
+    if not skip_build:
+        build(ctx, rebuild, race, build_include, build_exclude, flavor)
+
+    agent_bin = os.path.join(BIN_PATH, bin_name("agent"))
+
+    # TODO attempt to run  `cargo install --git https://github.com/DataDog/lading/ lading`
+    # Would be nice to support custom lading version for development, either custom git version or directory on disk
+    # Detect errors with incorrect rust version and offer advice to update/install via rustup
+
+    regression_test_dir = os.path.join(".", "test", "regression")
+    telemetry_agent_name = "agnt-smp-regression-localrun" # TODO maybe add random ID to avoid collisions
+
+    dd_api_key_set = os.environ.get("DD_API_KEY") is not None
+    if not dd_api_key_set:
+        print("Warn: $DD_API_KEY not set, not running telemetry agent")
+
+    if run_telemetry_agent and dd_api_key_set:
+        # Run with inherit environment so that $DD_API_KEY is available
+        openmetrics_confd = os.path.join(regression_test_dir, "local-telemetry-agent-confd", "openmetrics.d")
+
+        # TODO turn off more componenst of the agent.
+        # Only want to be running:
+        # - python openmetrics checks
+        # - trace-agent listening on 8126
+        # CMD_PORT and EXPVAR_PORT are set to arbitrary values that are unlikely to conflict
+        telemetry_agent_docker_cmd = f"docker run -d --rm --name {telemetry_agent_name} -e DD_CMD_PORT=8008 -e DD_EXPVAR_PORT=8009 -v {openmetrics_confd}:/etc/datadog-agent/conf.d/openmetrics.d -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro --network host datadog/agent"
+        print("Running dockerized telemetry agent configured to scrape lading/agent metrics")
+        ctx.run(telemetry_agent_docker_cmd)
+        # TODO this doesn't work yet
+
+
+    lading_cmd = f"lading --target-path {agent_bin} --config-path {regression_test_dir}/cases/{regression_case}/lading/lading.yaml -- -c {regression_test_dir}/cases/{regression_case}/datadog-agent/datadog.yaml run"
+    lading_env = {'DD_HOSTNAME': 'smp-regression-local', 'RUST_LOG': "lading=debug,lading::blackhole::http=warn"}
+
+    print(f"Running lading regression experiment locally in the background. full cmd: {lading_cmd}")
+    ctx.run(lading_cmd, env=lading_env)
+
+    if run_telemetry_agent:
+        ctx.run(f"docker stop {telemetry_agent_name}")
+
+
+

--- a/tasks/smp.py
+++ b/tasks/smp.py
@@ -10,6 +10,12 @@ from .utils import (
     bin_name,
 )
 import os
+import time
+import shutil
+
+def check_for_lading_binary(ctx):
+    if shutil.which("lading") is None:
+        print(f"'lading' is not found. Consider installing via by running 'cargo install --git https://github.com/DataDog/lading/ lading'")
 
 
 @task
@@ -33,42 +39,48 @@ def run_regression(
     if not skip_build:
         build(ctx, rebuild, race, build_include, build_exclude, flavor)
 
-    agent_bin = os.path.join(BIN_PATH, bin_name("agent"))
+    telemetry_agent_name = "agnt-smp-regression-localrun"
 
-    # TODO attempt to run  `cargo install --git https://github.com/DataDog/lading/ lading`
-    # Would be nice to support custom lading version for development, either custom git version or directory on disk
-    # Detect errors with incorrect rust version and offer advice to update/install via rustup
+    try:
+        agent_bin = os.path.join(BIN_PATH, bin_name("agent"))
 
-    regression_test_dir = os.path.join(".", "test", "regression")
-    telemetry_agent_name = "agnt-smp-regression-localrun" # TODO maybe add random ID to avoid collisions
+        check_for_lading_binary(ctx)
 
-    dd_api_key_set = os.environ.get("DD_API_KEY") is not None
-    if not dd_api_key_set:
-        print("Warn: $DD_API_KEY not set, not running telemetry agent")
+        regression_test_dir = os.path.join(".", "test", "regression")
 
-    if run_telemetry_agent and dd_api_key_set:
-        # Run with inherit environment so that $DD_API_KEY is available
-        openmetrics_confd = os.path.join(regression_test_dir, "local-telemetry-agent-confd", "openmetrics.d")
+        dd_api_key_set = os.environ.get("DD_API_KEY") is not None
+        if not dd_api_key_set:
+            print("Warn: $DD_API_KEY not set, not running telemetry agent")
 
-        # TODO turn off more componenst of the agent.
-        # Only want to be running:
-        # - python openmetrics checks
-        # - trace-agent listening on 8126
-        # CMD_PORT and EXPVAR_PORT are set to arbitrary values that are unlikely to conflict
-        telemetry_agent_docker_cmd = f"docker run -d --rm --name {telemetry_agent_name} -e DD_CMD_PORT=8008 -e DD_EXPVAR_PORT=8009 -v {openmetrics_confd}:/etc/datadog-agent/conf.d/openmetrics.d -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro --network host datadog/agent"
-        print("Running dockerized telemetry agent configured to scrape lading/agent metrics")
-        ctx.run(telemetry_agent_docker_cmd)
-        # TODO this doesn't work yet
+        if run_telemetry_agent and dd_api_key_set:
+            openmetrics_confd = os.path.join(regression_test_dir, "local-telemetry-agent-confd", "openmetrics.d")
+
+            # TODO turn off more components of the agent.
+            # Only want to be running:
+            # - python openmetrics checks
+            # - trace-agent listening on 8126
+            # CMD_PORT and EXPVAR_PORT are set to arbitrary values that are unlikely to conflict
+            telemetry_agent_docker_cmd = f"docker run -d --rm --name {telemetry_agent_name} -e DD_CMD_PORT=8008 -e DD_EXPVAR_PORT=8009 -e DD_API_KEY=$DD_API_KEY -v {openmetrics_confd}:/etc/datadog-agent/conf.d/openmetrics.d -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro --network host datadog/agent"
+            print(f"Running dockerized telemetry agent configured to scrape lading/agent metrics. cmd: {telemetry_agent_docker_cmd}")
+            ctx.run(telemetry_agent_docker_cmd)
 
 
-    lading_cmd = f"lading --target-path {agent_bin} --config-path {regression_test_dir}/cases/{regression_case}/lading/lading.yaml -- -c {regression_test_dir}/cases/{regression_case}/datadog-agent/datadog.yaml run"
-    lading_env = {'DD_HOSTNAME': 'smp-regression-local', 'RUST_LOG': "lading=debug,lading::blackhole::http=warn"}
+        start_ts = int(round(time.time() * 1000))
+        lading_cmd = f"lading --target-path {agent_bin} --config-path {regression_test_dir}/cases/{regression_case}/lading/lading.yaml -- -c {regression_test_dir}/cases/{regression_case}/datadog-agent/datadog.yaml run"
+        lading_env = {'DD_HOSTNAME': 'smp-regression-local', 'RUST_LOG': "lading=debug,lading::blackhole::http=warn"}
 
-    print(f"Running lading regression experiment locally in the background. full cmd: {lading_cmd}")
-    ctx.run(lading_cmd, env=lading_env)
+        print(f"Running lading regression experiment locally in the background. full cmd: {lading_cmd}")
+        ctx.run(lading_cmd, env=lading_env)
 
-    if run_telemetry_agent:
-        ctx.run(f"docker stop {telemetry_agent_name}")
+
+        end_ts = int(round(time.time() * 1000))
+        # This dashboard is uds/dogstatsd specific.
+        # Future improvement would be to allow some yaml config in the regression_case dir to define the dashboard to run
+        print(f"Run completed! View results in https://dddev.datadoghq.com/dashboard/ri8-xin-2k4?from_ts={start_ts}&to_ts={end_ts}&live=false")
+
+    finally:
+        if run_telemetry_agent:
+            ctx.run(f"docker stop {telemetry_agent_name}")
 
 
 

--- a/tasks/smp.py
+++ b/tasks/smp.py
@@ -11,9 +11,13 @@ from .utils import (
 )
 import os
 import time
+from pathlib import Path
+import secrets
 import shutil
+import logging
 
 ONE_SEC_IN_NS = 1_000_000_000
+LOG_DIR = "smp-local-run-logs"
 
 # Install non-released versions of lading via
 # cargo install --rev=my-feature-branch --git https://github.com/DataDog/lading/ lading
@@ -21,6 +25,35 @@ ONE_SEC_IN_NS = 1_000_000_000
 def check_for_lading_binary(ctx):
     if shutil.which("lading") is None:
         print(f"'lading' is not found. Consider installing via by running 'cargo install --git https://github.com/DataDog/lading/ lading'")
+
+def configure_logger():
+    # create logger
+    logger = logging.getLogger('smp-local-run')
+    logger.setLevel(logging.DEBUG)
+
+    # create console handler and set level to debug
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.DEBUG)
+
+    if not os.path.exists(LOG_DIR):
+        os.makedirs(LOG_DIR)
+    # create file handler and set level to debug
+    fh = logging.FileHandler(f"{LOG_DIR}/run.log")
+    fh.setLevel(logging.DEBUG)
+
+    # create formatter
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+    # add formatter to ch and fh
+    ch.setFormatter(formatter)
+    fh.setFormatter(formatter)
+
+    # add ch and fh to logger
+    logger.addHandler(ch)
+    logger.addHandler(fh)
+
+    return logger
+
 
 
 @task
@@ -47,6 +80,9 @@ def run_regression(
         build(ctx, rebuild, race, build_include, build_exclude, flavor)
 
     telemetry_agent_name = "agnt-smp-regression-localrun"
+    logger = configure_logger()
+    run_id = secrets.token_hex(16)
+    logger.info(f"Starting local run of scenario '{regression_case}'. Run ID for reference: {run_id}")
 
     try:
         agent_bin = os.path.join(BIN_PATH, bin_name("agent"))
@@ -57,43 +93,61 @@ def run_regression(
 
         dd_api_key_set = os.environ.get("DD_API_KEY") is not None
         if not dd_api_key_set:
-            print("Warn: $DD_API_KEY not set, not running telemetry agent")
+            logger.warn("$DD_API_KEY not set, not running telemetry agent")
 
         lading_env = {'DD_HOSTNAME': 'smp-regression-local', 'RUST_LOG': "lading=debug,lading::blackhole::http=warn"}
 
+        logs_dir = os.path.join(os.getcwd(), LOG_DIR)
+
         if run_telemetry_agent and dd_api_key_set:
             openmetrics_confd = os.path.join(regression_test_dir, "local-telemetry-agent-confd", "openmetrics.d")
+            logs_confd = os.path.join(regression_test_dir, "local-telemetry-agent-confd", "logs.d")
+
 
             # TODO turn off more components of the agent.
             # Only want to be running:
             # - python openmetrics checks
             # - trace-agent listening on 8126
             # CMD_PORT and EXPVAR_PORT are set to arbitrary values that are unlikely to conflict
-            telemetry_agent_docker_cmd = f"docker run -d --rm --name {telemetry_agent_name} -e DD_CMD_PORT=8008 -e DD_EXPVAR_PORT=8009 -e DD_API_KEY=$DD_API_KEY -v {openmetrics_confd}:/etc/datadog-agent/conf.d/openmetrics.d -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro --network host datadog/agent"
-            print(f"Running dockerized telemetry agent configured to scrape lading/agent metrics. cmd: {telemetry_agent_docker_cmd}")
+            telemetry_agent_docker_cmd = f"docker run -d --rm --name {telemetry_agent_name} -e DD_LOGS_ENABLED=true -e DD_CMD_PORT=8008 -e DD_EXPVAR_PORT=8009 -e DD_API_KEY=$DD_API_KEY -v {logs_confd}:/etc/datadog-agent/conf.d/logs.d -v {openmetrics_confd}:/etc/datadog-agent/conf.d/openmetrics.d -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -v {logs_dir}:/mnt/smp-logs --network host datadog/agent"
+            logger.info(f"Running dockerized telemetry agent configured to scrape lading/agent metrics. cmd: {telemetry_agent_docker_cmd}")
             ctx.run(telemetry_agent_docker_cmd)
             lading_env['DD_TELEMETRY_ENABLED'] = "true"
             if enable_profiler:
                 lading_env['DD_INTERNAL_PROFILING_ENABLED'] = "true"
+                user = os.getlogin()
+                lading_env['DD_INTERNAL_PROFILING_EXTRA_TAGS'] = "[\"env:smp-local-run\", \"service:{regression_case}\", \"user:{user}\"]"
                 # sets profiling period to half the total experiment duration to collect
                 lading_env['DD_INTERNAL_PROFILING_PERIOD'] = str(experiment_duration_seconds * ONE_SEC_IN_NS)
                 lading_env['DD_INTERNAL_PROFILING_CPU_DURATION'] = str(30 * ONE_SEC_IN_NS)
                 experiment_duration_seconds *= 2
 
         start_ts = int(round(time.time() * 1000))
-        lading_cmd = f"lading --target-path {agent_bin} --target-inherit-environment --target-stdout-path=./stdout.log --target-stderr-path=./stderr.log --experiment-duration-seconds {experiment_duration_seconds} --config-path {regression_test_dir}/cases/{regression_case}/lading/lading.yaml -- -c {regression_test_dir}/cases/{regression_case}/datadog-agent/datadog.yaml run"
+        lading_cmd = f"lading --target-path {agent_bin} --target-inherit-environment --target-stdout-path={logs_dir}/stdout.log --target-stderr-path={logs_dir}/stderr.log --experiment-duration-seconds {experiment_duration_seconds} --config-path {regression_test_dir}/cases/{regression_case}/lading/lading.yaml -- -c {regression_test_dir}/cases/{regression_case}/datadog-agent/datadog.yaml run"
 
-        print(f"Running lading regression experiment locally in the background. Duration is {experiment_duration_seconds} seconds. Full cmd: {lading_cmd}")
+
+        logger.info(f"Running lading regression experiment locally in the background. Duration is {experiment_duration_seconds} seconds. Full cmd: {lading_cmd}")
+
+        agent_config_path = f"{regression_test_dir}/cases/{regression_case}/datadog-agent/datadog.yaml"
+        agent_config_str = Path(agent_config_path).read_text()
+        logger.info(f"===================== Start Agent Config =====================\n{agent_config_str}\n===================== End Agent Config =====================")
+
+        lading_config_path = f"{regression_test_dir}/cases/{regression_case}/lading/lading.yaml"
+        lading_config_str = Path(lading_config_path).read_text()
+        logger.info(f"===================== Start Lading Config =====================\n{lading_config_str}\n===================== End Lading Config =====================")
+
         ctx.run(lading_cmd, env=lading_env)
 
 
         end_ts = int(round(time.time() * 1000))
         # This dashboard is uds/dogstatsd specific.
         # Future improvement would be to allow some yaml config in the regression_case dir to define the dashboard to run
-        print(f"Run completed! View results in https://dddev.datadoghq.com/dashboard/ri8-xin-2k4?from_ts={start_ts}&to_ts={end_ts}&live=false")
+        logger.info(f"Run completed! View results in https://app.datadoghq.com/dashboard/bvi-a7a-spq?from_ts={start_ts}&to_ts={end_ts}&live=false&tpl_var_zocf={run_id}  Run ID: {run_id}")
+        logging.shutdown()
 
     finally:
         if run_telemetry_agent:
+            time.sleep(5) # Give the telemetry agent time to fully read all logs
             ctx.run(f"docker stop {telemetry_agent_name}")
 
 

--- a/test/regression/cases/uds_dogstatsd_to_api/datadog-agent/datadog.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api/datadog-agent/datadog.yaml
@@ -12,3 +12,6 @@ confd_path: /etc/datadog-agent/conf.d
 cloud_provider_metadata: []
 
 dogstatsd_socket: '/tmp/dsd.socket'
+  #dogstatsd_context_expiry_seconds: 100
+  # config.BindEnvAndSetDefault("histogram_aggregates", []string{"max", "median", "avg", "count"})
+  # config.BindEnvAndSetDefault("histogram_percentiles", []string{"0.95"})

--- a/test/regression/cases/uds_dogstatsd_to_api/lading/lading.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api/lading/lading.yaml
@@ -43,7 +43,7 @@ generator:
             histogram: 0
       bytes_per_second: "100 MiB"
       block_sizes: ["256b", "512b", "1Kb", "2Kb", "3Kb", "4Kb", "5Kb", "6Kb"]
-      maximum_prebuild_cache_size_bytes: "500 Mb"
+      maximum_prebuild_cache_size_bytes: "1000 Mb"
 
 blackhole:
   - http:

--- a/test/regression/local-telemetry-agent-confd/logs.d/conf.yaml
+++ b/test/regression/local-telemetry-agent-confd/logs.d/conf.yaml
@@ -1,0 +1,13 @@
+logs:
+  - type: file
+    path: "/mnt/smp-logs/stdout.log"
+    tags:
+      - "env:smp-local-run"
+  - type: file
+    path: "/mnt/smp-logs/stderr.log"
+    tags:
+      - "env:smp-local-run"
+  - type: file
+    path: "/mnt/smp-logs/run.log"
+    tags:
+      - "env:smp-local-run"

--- a/test/regression/local-telemetry-agent-confd/openmetrics.d/conf.yaml
+++ b/test/regression/local-telemetry-agent-confd/openmetrics.d/conf.yaml
@@ -1,0 +1,14 @@
+
+init_config:
+instances:
+  - metrics: [ '*' ]
+    prometheus_url: http://localhost:5000/telemetry
+    namespace: datadog.agent
+    send_distribution_buckets: true
+    service: dd-agent
+  - metrics: [ '*' ]
+    prometheus_url: http://localhost:9000
+    namespace: lading
+    send_distribution_buckets: true
+    service: lading
+

--- a/test/regression/local-telemetry-agent-confd/openmetrics.d/conf.yaml
+++ b/test/regression/local-telemetry-agent-confd/openmetrics.d/conf.yaml
@@ -1,14 +1,13 @@
-
 init_config:
 instances:
   - metrics: [ '*' ]
     prometheus_url: http://localhost:5000/telemetry
-    namespace: datadog.agent
+    namespace: smp.local.agent
     send_distribution_buckets: true
     service: dd-agent
   - metrics: [ '*' ]
     prometheus_url: http://localhost:9000
-    namespace: lading
+    namespace: smp.local.lading
     send_distribution_buckets: true
     service: lading
 


### PR DESCRIPTION

### What does this PR do?

Replaces the dogstatsd string interner with a gc-friendlier version that doesn't require dumping the cache.

### Motivation

Testing out differences in string interning.

### Additional Notes

This will not be merged as-is as it copy-pastas most of `pkg/util/intern` instead of using it directly.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
