### PR TITLE
[omnibus] Fix premature termination of probe workers in OpenSCAP

### DIFF
--- a/omnibus/config/patches/openscap/dpkginfo-config-arch.patch
+++ b/omnibus/config/patches/openscap/dpkginfo-config-arch.patch
@@ -1,0 +1,16 @@
+--- a/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx
++++ b/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx
+@@ -42,6 +42,13 @@ static int opencache (void) {
+             if (SrcCacheFileName.empty() == false) {
+                 _config->Set("Dir::Cache::srcpkgcache","srcpkgcache.bin");
+             }
++
++            string const arch = _config->Find("APT::Architecture");
++            std::vector<std::string> static archs = _config->FindVector("APT::Architectures");
++
++            if (archs.empty()) {
++                _config->Set("APT::Architectures",arch);
++            }
+         }
+ 
+         if (pkgInitSystem (*_config, _system) == false) return 0;

--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -54,6 +54,7 @@ build do
 
   patch source: "010_perlpm_install_fix.patch", env: env # fix build of perl bindings
   patch source: "dpkginfo-cacheconfig.patch", env: env # work around incomplete pkgcache path
+  patch source: "dpkginfo-config-arch.patch", env: env # work around empty list of architectures
   patch source: "dpkginfo-cache-fixes.patch", env: env # reduce memory footprint of dpkginfo probe
   patch source: "fsdev-ignore-host.patch", env: env # ignore /host directory in fsdev probe
   patch source: "systemd-dbus-address.patch", env: env # fix dbus address in systemd probe


### PR DESCRIPTION
### What does this PR do?

On some systems, we noticed that the `oscap-io` tool was leaking a large amount of memory, because of a premature termination of probe workers.

The dpkginfo probe calls the `pkgCacheFile->GetPkgCache` method to build the APT cache. The list of the architectures the system supports should be defined in the `APT::Architectures` configuration option. If it's not the case, the APT library executes `/usr/bin/dpkg --print-foreign-architectures` to retrieve the list of supported architectures.

However, for some reason, the thread executing the `dpkg` tool leads to a conflict with the probe worker threads, causing their premature termination and leaking memory.

This change fixes this issue by recopying the `APT::Architecture` configuration into `APT::Architectures` when the list of supported architectures is empty.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
