### PR TITLE
[CWS] Add rule kill action

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/raw_syscalls.h
+++ b/pkg/security/ebpf/c/include/hooks/raw_syscalls.h
@@ -11,6 +11,18 @@ int sys_enter(struct _tracepoint_raw_syscalls_sys_enter *args) {
     struct syscall_monitor_entry_t zero = {};
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
+
+    if (is_send_signal_available()) {
+        u32 *sig = bpf_map_lookup_elem(&kill_list, &pid);
+        if ((sig != NULL && *sig != 0)) {
+#ifdef DEBUG
+            bpf_printk("Sending signal %d to pid %d\n", *sig, pid);
+#endif
+            bpf_send_signal(*sig);
+            bpf_map_delete_elem(&kill_list, &pid);
+        }
+    }
+
     u64 now = bpf_ktime_get_ns();
     struct syscall_monitor_event_t event = {};
 

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -61,6 +61,7 @@ BPF_LRU_MAP(veth_device_name_to_ifindex, struct device_name_t, struct device_ifi
 BPF_LRU_MAP(exec_file_cache, u64, struct file_t, 4096)
 BPF_LRU_MAP(syscall_monitor, u32, struct syscall_monitor_entry_t, 2048)
 BPF_LRU_MAP(syscall_table, struct syscall_table_key_t, u8, 50)
+BPF_LRU_MAP(kill_list, u32, u32, 32)
 
 BPF_LRU_MAP_FLAGS(tasks_in_coredump, u64, u8, 64, BPF_F_NO_COMMON_LRU)
 BPF_LRU_MAP_FLAGS(syscalls, u64, struct syscall_cache_t, 1, BPF_F_NO_COMMON_LRU) // max entries will be overridden at runtime

--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -340,3 +340,8 @@ func (k *Version) HaveFentrySupport() bool {
 
 	return true
 }
+
+// SupportBPFSendSignal returns true if the eBPF function bpf_send_signal is available
+func (k *Version) SupportBPFSendSignal() bool {
+	return k.Code != 0 && k.Code >= Kernel5_3
+}

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -127,6 +127,7 @@ func AllMaps() []*manager.Map {
 		{Name: "enabled_events"},
 		// Syscall stats monitor (inflight syscall)
 		{Name: "syscalls_stats_enabled"},
+		{Name: "kill_list"},
 	}
 }
 

--- a/pkg/security/events/custom.go
+++ b/pkg/security/events/custom.go
@@ -57,6 +57,9 @@ const (
 	BrokenProcessLineageErrorRuleID = "broken_process_lineage"
 	// BrokenProcessLineageErrorRuleDesc is the rule description for events with a broken process lineage
 	BrokenProcessLineageErrorRuleDesc = "Broken process lineage detected"
+
+	// RefreshUserCacheRuleID is the rule ID used to refresh users and groups cache
+	RefreshUserCacheRuleID = "refresh_user_cache"
 )
 
 // CustomEventCommonFields represents the fields common to all custom events

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"syscall"
 	"time"
 
 	lib "github.com/cilium/ebpf"
@@ -61,6 +62,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/serializers"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	utilkernel "github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // EventStream describes the interface implemented by reordered perf maps or ring buffers
@@ -108,7 +110,8 @@ type PlatformProbe struct {
 	// Approvers / discarders section
 	notifyDiscarderPushedCallbacksLock sync.Mutex
 
-	killListMap *lib.Map
+	killListMap           *lib.Map
+	supportsBPFSendSignal bool
 
 	isRuntimeDiscarded bool
 	constantOffsets    map[string]uint64
@@ -281,6 +284,11 @@ func (p *Probe) Init() error {
 	p.profileManagers.AddActivityDumpHandler(p.activityDumpHandler)
 
 	p.eventStream.SetMonitor(p.monitors.eventStreamMonitor)
+
+	p.killListMap, err = managerhelper.Map(p.Manager, "kill_list")
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -1497,11 +1505,7 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 
 	p.Manager = ebpf.NewRuntimeSecurityManager(useRingBuffers, p.useFentry)
 
-	killListMap, err := managerhelper.Map(p.Manager, "kill_list")
-	if err != nil {
-		return nil, err
-	}
-	p.killListMap = killListMap
+	p.supportsBPFSendSignal = p.kernelVersion.SupportBPFSendSignal()
 
 	p.ensureConfigDefaults()
 
@@ -1613,7 +1617,7 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 		},
 		manager.ConstantEditor{
 			Name:  "send_signal",
-			Value: isBPFSendSignalHelperAvailable(p.kernelVersion),
+			Value: utils.BoolTouint64(p.kernelVersion.SupportBPFSendSignal()),
 		},
 		manager.ConstantEditor{
 			Name:  "anomaly_syscalls",
@@ -1808,14 +1812,6 @@ func getOvlPathInOvlInode(kernelVersion *kernel.Version) uint64 {
 	return 0
 }
 
-// isBPFSendSignalHelperAvailable returns true if the bpf_send_signal helper is available in the current kernel
-func isBPFSendSignalHelperAvailable(kernelVersion *kernel.Version) uint64 {
-	if kernelVersion.Code != 0 && kernelVersion.Code >= kernel.Kernel5_3 {
-		return uint64(1)
-	}
-	return uint64(0)
-}
-
 // getCGroupWriteConstants returns the value of the constant used to determine how cgroups should be captured in kernel
 // space
 func getCGroupWriteConstants() manager.ConstantEditor {
@@ -1929,5 +1925,32 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	// iouring
 	if kv.Code != 0 && (kv.Code >= kernel.Kernel5_1) {
 		constantFetcher.AppendOffsetofRequest(constantfetch.OffsetNameIoKiocbStructCtx, "struct io_kiocb", "ctx", "")
+	}
+}
+
+// HandleActions executes the actions of a triggered rule
+func (p *Probe) HandleActions(rule *rules.Rule, event eval.Event) {
+	ev := event.(*model.Event)
+	for _, action := range rule.Definition.Actions {
+		switch {
+		case action.InternalCallbackDefinition != nil && rule.ID == events.RefreshUserCacheRuleID:
+			_ = p.RefreshUserCache(ev.ContainerContext.ID)
+
+		case action.Kill != nil:
+			if pid := ev.ProcessContext.Pid; pid > 1 && pid != utils.Getpid() {
+				log.Debugf("Requesting signal %s to be sent to %d", action.Kill.Signal, pid)
+				sig := model.SignalConstants[action.Kill.Signal]
+
+				var err error
+				if p.supportsBPFSendSignal {
+					err = p.killListMap.Put(uint32(pid), uint32(sig))
+				} else {
+					err = syscall.Kill(int(pid), syscall.Signal(sig))
+				}
+				if err != nil {
+					seclog.Warnf("failed to kill process %d: %s", pid, err)
+				}
+			}
+		}
 	}
 }

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	lib "github.com/cilium/ebpf"
 	"github.com/hashicorp/go-multierror"
 	"github.com/moby/sys/mountinfo"
 	"golang.org/x/exp/slices"
@@ -107,11 +108,12 @@ type PlatformProbe struct {
 	// Approvers / discarders section
 	notifyDiscarderPushedCallbacksLock sync.Mutex
 
+	killListMap *lib.Map
+
 	isRuntimeDiscarded bool
 	constantOffsets    map[string]uint64
 	runtimeCompiled    bool
-
-	useFentry bool
+	useFentry          bool
 }
 
 func (p *Probe) detectKernelVersion() error {
@@ -297,7 +299,9 @@ func (p *Probe) Setup() error {
 
 	p.applyDefaultFilterPolicies()
 
-	if err := p.updateProbes(defaultEventTypes, true); err != nil {
+	needRawSyscalls := p.isNeededForActivityDump(model.SyscallsEventType.String())
+
+	if err := p.updateProbes(defaultEventTypes, true, needRawSyscalls); err != nil {
 		return err
 	}
 
@@ -1094,7 +1098,7 @@ func (p *Probe) validEventTypeForConfig(eventType string) bool {
 
 // updateProbes applies the loaded set of rules and returns a report
 // of the applied approvers for it.
-func (p *Probe) updateProbes(ruleEventTypes []eval.EventType, useSnapshotProbes bool) error {
+func (p *Probe) updateProbes(ruleEventTypes []eval.EventType, useSnapshotProbes, needRawSyscalls bool) error {
 	// event types enabled either by event handlers or by rules
 	eventTypes := append([]eval.EventType{}, defaultEventTypes...)
 	eventTypes = append(eventTypes, ruleEventTypes...)
@@ -1125,12 +1129,16 @@ func (p *Probe) updateProbes(ruleEventTypes []eval.EventType, useSnapshotProbes 
 
 	activatedProbes = append(activatedProbes, p.resolvers.TCResolver.SelectTCProbes())
 
-	// ActivityDumps
-	if p.Config.RuntimeSecurity.ActivityDumpEnabled {
-		for _, e := range p.profileManagers.GetActivityDumpTracedEventTypes() {
-			if e == model.SyscallsEventType {
-				activatedProbes = append(activatedProbes, probes.SyscallMonitorSelectors...)
-				break
+	if needRawSyscalls {
+		activatedProbes = append(activatedProbes, probes.SyscallMonitorSelectors...)
+	} else {
+		// ActivityDumps
+		if p.Config.RuntimeSecurity.ActivityDumpEnabled {
+			for _, e := range p.profileManagers.GetActivityDumpTracedEventTypes() {
+				if e == model.SyscallsEventType {
+					activatedProbes = append(activatedProbes, probes.SyscallMonitorSelectors...)
+					break
+				}
 			}
 		}
 	}
@@ -1408,7 +1416,21 @@ func (p *Probe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetReport, e
 		}
 	}
 
-	if err := p.updateProbes(rs.GetEventTypes(), false); err != nil {
+	needRawSyscalls := p.isNeededForActivityDump(model.SyscallsEventType.String())
+	if !needRawSyscalls {
+		// Add syscall monitor probes if it's either activated or
+		// there is an 'kill' action in the ruleset
+		for _, rule := range rs.GetRules() {
+			for _, action := range rule.Definition.Actions {
+				if action.Kill != nil {
+					needRawSyscalls = true
+					break
+				}
+			}
+		}
+	}
+
+	if err := p.updateProbes(rs.GetEventTypes(), false, needRawSyscalls); err != nil {
 		return nil, fmt.Errorf("failed to select probes: %w", err)
 	}
 
@@ -1474,6 +1496,12 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 	useMmapableMaps := p.kernelVersion.HaveMmapableMaps()
 
 	p.Manager = ebpf.NewRuntimeSecurityManager(useRingBuffers, p.useFentry)
+
+	killListMap, err := managerhelper.Map(p.Manager, "kill_list")
+	if err != nil {
+		return nil, err
+	}
+	p.killListMap = killListMap
 
 	p.ensureConfigDefaults()
 

--- a/pkg/security/probe/probe_others.go
+++ b/pkg/security/probe/probe_others.go
@@ -34,41 +34,41 @@ type Probe struct {
 }
 
 // AddEventHandler set the probe event handler
-func (p *Probe) AddEventHandler(eventType model.EventType, handler EventHandler) error { //nolint:revive // TODO fix revive unused-parameter
+func (p *Probe) AddEventHandler(_ model.EventType, _ EventHandler) error {
 	return nil
 }
 
 // AddFullAccessEventHandler sets a probe event handler for the UnknownEventType which requires access to all the struct fields
-func (p *Probe) AddFullAccessEventHandler(handler EventHandler) error { //nolint:revive // TODO fix revive unused-parameter
+func (p *Probe) AddFullAccessEventHandler(_ EventHandler) error {
 	return nil
 }
 
 // AddCustomEventHandler set the probe event handler
-func (p *Probe) AddCustomEventHandler(eventType model.EventType, handler CustomEventHandler) error { //nolint:revive // TODO fix revive unused-parameter
+func (p *Probe) AddCustomEventHandler(_ model.EventType, _ CustomEventHandler) error {
 	return nil
 }
 
 // NewEvaluationSet returns a new evaluation set with rule sets tagged by the passed-in tag values for the "ruleset" tag key
-func (p *Probe) NewEvaluationSet(eventTypeEnabled map[eval.EventType]bool, ruleSetTagValues []string) (*rules.EvaluationSet, error) { //nolint:revive // TODO fix revive unused-parameter
+func (p *Probe) NewEvaluationSet(_ map[eval.EventType]bool, _ []string) (*rules.EvaluationSet, error) {
 	return nil, nil
 }
 
 // ApplyRuleSet setup the probes for the provided set of rules and returns the policy report.
-func (p *Probe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetReport, error) { //nolint:revive // TODO fix revive unused-parameter
+func (p *Probe) ApplyRuleSet(_ *rules.RuleSet) (*kfilters.ApplyRuleSetReport, error) {
 	return nil, nil
 }
 
 // OnNewDiscarder is called when a new discarder is found. We currently don't generate discarders on Windows.
-func (p *Probe) OnNewDiscarder(rs *rules.RuleSet, ev *model.Event, field eval.Field, eventType eval.EventType) { //nolint:revive // TODO fix revive unused-parameter
+func (p *Probe) OnNewDiscarder(_ *rules.RuleSet, _ *model.Event, _ eval.Field, _ eval.EventType) {
 }
 
 // GetService returns the service name from the process tree
-func (p *Probe) GetService(ev *model.Event) string { //nolint:revive // TODO fix revive unused-parameter
+func (p *Probe) GetService(_ *model.Event) string {
 	return ""
 }
 
 // GetEventTags returns the event tags
-func (p *Probe) GetEventTags(containerID string) []string { //nolint:revive // TODO fix revive unused-parameter
+func (p *Probe) GetEventTags(_ string) []string {
 	return nil
 }
 
@@ -98,6 +98,10 @@ func (p *Probe) FlushDiscarders() error {
 }
 
 // RefreshUserCache refreshes the user cache
-func (p *Probe) RefreshUserCache(containerID string) error { //nolint:revive // TODO fix revive unused-parameter
+func (p *Probe) RefreshUserCache(_ string) error {
 	return nil
+}
+
+// HandleActions executes the actions of a triggered rule
+func (p *Probe) HandleActions(_ *rules.Rule, _ eval.Event) {
 }

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -232,7 +232,6 @@ func (p *Probe) FlushDiscarders() error {
 	return nil
 }
 
-// RefreshUserCache refreshes the user cache
-func (p *Probe) RefreshUserCache(containerID string) error { //nolint:revive // TODO fix revive unused-parameter
-	return nil
+// HandleActions executes the actions of a triggered rule
+func (p *Probe) HandleActions(_ *rules.Rule, _ eval.Event) {
 }

--- a/pkg/security/rules/bundled_policy_provider.go
+++ b/pkg/security/rules/bundled_policy_provider.go
@@ -12,8 +12,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
-const refreshUserCacheRuleID = "refresh_user_cache"
-
 // BundledPolicyProvider specify the policy provider for bundled policies
 type BundledPolicyProvider struct{}
 

--- a/pkg/security/rules/bundled_policy_provider_linux.go
+++ b/pkg/security/rules/bundled_policy_provider_linux.go
@@ -6,10 +6,13 @@
 // Package rules holds rules related files
 package rules
 
-import "github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+import (
+	"github.com/DataDog/datadog-agent/pkg/security/events"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+)
 
 var bundledPolicyRules = []*rules.RuleDefinition{{
-	ID:         refreshUserCacheRuleID,
+	ID:         events.RefreshUserCacheRuleID,
 	Expression: `rename.file.destination.path in [ "/etc/passwd", "/etc/group" ]`,
 	Actions: []rules.ActionDefinition{{
 		InternalCallbackDefinition: &rules.InternalCallbackDefinition{},

--- a/pkg/security/secl/model/consts_common.go
+++ b/pkg/security/secl/model/consts_common.go
@@ -844,11 +844,11 @@ func initMMapFlagsConstants() {
 }
 
 func initSignalConstants() {
-	for k, v := range signalConstants {
+	for k, v := range SignalConstants {
 		seclConstants[k] = &eval.IntEvaluator{Value: v}
 	}
 
-	for k, v := range signalConstants {
+	for k, v := range SignalConstants {
 		signalStrings[v] = k
 	}
 }

--- a/pkg/security/secl/model/consts_linux.go
+++ b/pkg/security/secl/model/consts_linux.go
@@ -356,9 +356,9 @@ var (
 		"MAP_HUGE_16GB":       34 << unix.MAP_HUGE_SHIFT,
 	}
 
-	// signalConstants are the supported signals for the kill syscall
+	// SignalConstants are the supported signals for the kill syscall
 	// generate_constants:Signal constants,Signal constants are the supported signals for the kill syscall.
-	signalConstants = map[string]int{
+	SignalConstants = map[string]int{
 		"SIGHUP":    int(unix.SIGHUP),
 		"SIGINT":    int(unix.SIGINT),
 		"SIGQUIT":   int(unix.SIGQUIT),

--- a/pkg/security/secl/model/consts_map_names.go
+++ b/pkg/security/secl/model/consts_map_names.go
@@ -40,6 +40,7 @@ var bpfMapNames = []string{
 	"io_uring_ctx_pi",
 	"is_discarded_by",
 	"is_new_kthread",
+	"kill_list",
 	"mmap_flags_appr",
 	"mmap_protection",
 	"mount_ref",

--- a/pkg/security/secl/model/consts_other.go
+++ b/pkg/security/secl/model/consts_other.go
@@ -20,6 +20,7 @@ var (
 	protConstants             = map[string]int{}
 	mmapFlagConstants         = map[string]uint64{}
 	mmapFlagArchConstants     = map[string]uint64{}
-	signalConstants           = map[string]int{}
-	addressFamilyConstants    = map[string]uint16{}
+	// SignalConstants list of signals
+	SignalConstants        = map[string]int{}
+	addressFamilyConstants = map[string]uint16{}
 )

--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -8,10 +8,11 @@ package rules
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/DataDog/datadog-agent/pkg/security/secl/validators"
 	"github.com/hashicorp/go-multierror"
 	"gopkg.in/yaml.v2"
-	"io"
 )
 
 // PolicyDef represents a policy file definition

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -121,15 +121,20 @@ func (rd *RuleDefinition) MergeWith(rd2 *RuleDefinition) error {
 type ActionDefinition struct {
 	Set                        *SetDefinition `yaml:"set"`
 	InternalCallbackDefinition *InternalCallbackDefinition
+	Kill                       *KillDefinition `yaml:"kill"`
 }
 
 // Check returns an error if the action in invalid
 func (a *ActionDefinition) Check() error {
-	if a.Set == nil && a.InternalCallbackDefinition == nil {
-		return errors.New("missing 'set' section in action")
+	if a.Set == nil && a.InternalCallbackDefinition == nil && a.Kill == nil {
+		return errors.New("either 'set' or 'kill' section of an action must be specified")
 	}
 
 	if a.Set != nil {
+		if a.Kill != nil {
+			return errors.New("only of 'set' or 'kill' section of an action can be specified")
+		}
+
 		if a.Set.Name == "" {
 			return errors.New("action name is empty")
 		}
@@ -137,6 +142,8 @@ func (a *ActionDefinition) Check() error {
 		if (a.Set.Value == nil && a.Set.Field == "") || (a.Set.Value != nil && a.Set.Field != "") {
 			return errors.New("either 'value' or 'field' must be specified")
 		}
+	} else if _, found := model.SignalConstants[a.Kill.Signal]; !found {
+		return fmt.Errorf("unsupported signal '%s'", a.Kill.Signal)
 	}
 
 	return nil
@@ -156,6 +163,11 @@ type SetDefinition struct {
 
 // InternalCallbackDefinition describes an internal rule action
 type InternalCallbackDefinition struct{}
+
+// KillDefinition describes the 'kill' section of a rule action
+type KillDefinition struct {
+	Signal string `yaml:"signal"`
+}
 
 // Rule describes a rule of a ruleset
 type Rule struct {
@@ -287,7 +299,8 @@ func (rs *RuleSet) populateFieldsWithRuleActionsData(policyRules []*RuleDefiniti
 				continue
 			}
 
-			if action.Set != nil {
+			switch {
+			case action.Set != nil:
 				varName := action.Set.Name
 				if action.Set.Scope != "" {
 					varName = string(action.Set.Scope) + "." + varName
@@ -608,9 +621,10 @@ func (rs *RuleSet) IsDiscarder(event eval.Event, field eval.Field) (bool, error)
 	return IsDiscarder(ctx, field, bucket.rules)
 }
 
-func (rs *RuleSet) runRuleActions(ctx *eval.Context, rule *Rule) error {
+func (rs *RuleSet) runRuleActions(_ eval.Event, ctx *eval.Context, rule *Rule) error {
 	for _, action := range rule.Definition.Actions {
 		switch {
+		// action.Kill has to handled by a ruleset listener
 		case action.Set != nil:
 			name := string(action.Set.Scope)
 			if name != "" {
@@ -676,7 +690,7 @@ func (rs *RuleSet) Evaluate(event eval.Event) bool {
 			rs.NotifyRuleMatch(rule, event)
 			result = true
 
-			if err := rs.runRuleActions(ctx, rule); err != nil {
+			if err := rs.runRuleActions(event, ctx, rule); err != nil {
 				rs.logger.Errorf("Error while executing rule actions: %s", err)
 			}
 		}

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -142,8 +142,14 @@ func (a *ActionDefinition) Check() error {
 		if (a.Set.Value == nil && a.Set.Field == "") || (a.Set.Value != nil && a.Set.Field != "") {
 			return errors.New("either 'value' or 'field' must be specified")
 		}
-	} else if _, found := model.SignalConstants[a.Kill.Signal]; !found {
-		return fmt.Errorf("unsupported signal '%s'", a.Kill.Signal)
+	} else if a.Kill != nil {
+		if a.Kill.Signal == "" {
+			a.Kill.Signal = "SIGTERM"
+		}
+
+		if _, found := model.SignalConstants[a.Kill.Signal]; !found {
+			return fmt.Errorf("unsupported signal '%s'", a.Kill.Signal)
+		}
 	}
 
 	return nil

--- a/pkg/security/tests/bpf_test.go
+++ b/pkg/security/tests/bpf_test.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,7 +44,7 @@ func TestBPFEventLoad(t *testing.T) {
 
 	t.Run("prog_load", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "-load-bpf")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "-load-bpf")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "bpf", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(model.BpfProgTypeKprobe), event.BPF.Program.Type, "wrong program type")
@@ -78,7 +79,7 @@ func TestBPFEventMap(t *testing.T) {
 
 	t.Run("map_lookup", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "-load-bpf", "-clone-bpf")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "-load-bpf", "-clone-bpf")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "bpf", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(model.BpfMapTypeHash), event.BPF.Map.Type, "wrong map type")
@@ -113,7 +114,7 @@ func TestBPFCwsMapConstant(t *testing.T) {
 
 	t.Run("map_lookup", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "-load-bpf")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "-load-bpf")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "bpf", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(model.BpfMapTypeArray), event.BPF.Map.Type, "wrong map type")

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -63,7 +64,7 @@ func TestChown32(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			// fchown syscall
-			return runSyscallTesterFunc(t, syscallTester, "chown", testFile, "100", "200")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "chown", testFile, "100", "200")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(100), event.Chown.UID, "wrong user")
@@ -90,7 +91,7 @@ func TestChown32(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			// fchown syscall
-			return runSyscallTesterFunc(t, syscallTester, "fchown", testFile, "101", "201")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "fchown", testFile, "101", "201")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(101), event.Chown.UID, "wrong user")
@@ -117,7 +118,7 @@ func TestChown32(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			// fchown syscall
-			return runSyscallTesterFunc(t, syscallTester, "fchownat", testFile, "102", "202")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "fchownat", testFile, "102", "202")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(102), event.Chown.UID, "wrong user")
@@ -149,7 +150,7 @@ func TestChown32(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			// fchown syscall
-			return runSyscallTesterFunc(t, syscallTester, "lchown", testSymlink, "103", "203")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "lchown", testSymlink, "103", "203")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(103), event.Chown.UID, "wrong user")
@@ -181,7 +182,7 @@ func TestChown32(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			// fchown syscall
-			return runSyscallTesterFunc(t, syscallTester, "lchown32", testSymlink, "104", "204")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "lchown32", testSymlink, "104", "204")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(104), event.Chown.UID, "wrong user")
@@ -209,7 +210,7 @@ func TestChown32(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			// fchown syscall
-			return runSyscallTesterFunc(t, syscallTester, "fchown32", testFile, "105", "205")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "fchown32", testFile, "105", "205")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(105), event.Chown.UID, "wrong user")
@@ -236,7 +237,7 @@ func TestChown32(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			// fchown syscall
-			return runSyscallTesterFunc(t, syscallTester, "chown32", testFile, "106", "206")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "chown32", testFile, "106", "206")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(106), event.Chown.UID, "wrong user")

--- a/pkg/security/tests/mkdir_test.go
+++ b/pkg/security/tests/mkdir_test.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -187,7 +188,7 @@ func TestMkdirError(t *testing.T) {
 		}
 
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "mkdirat-error", testatFile)
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "mkdirat-error", testatFile)
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_mkdirat_error")
 			assert.Equal(t, event.Mkdir.Retval, -int64(syscall.EACCES))

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -209,6 +209,12 @@ rules:
           scope: {{$Action.Set.Scope}}
           append: {{$Action.Set.Append}}
 {{- end}}
+{{- if $Action.Kill}}
+      - kill:
+          {{- if $Action.Kill.Signal}}
+          signal: {{$Action.Kill.Signal}}
+          {{- end}}
+{{- end}}
 {{- end}}
 {{end}}
 `

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -2276,8 +2276,18 @@ func TestKillAction(t *testing.T) {
 		sigpipeCh := make(chan os.Signal, 1)
 		signal.Notify(sigpipeCh, syscall.SIGUSR2)
 
-		if err := runSyscallTesterFunc(context.Background(), t, syscallTester, "set-signal-handler", ";", "mkdirat", testFile, ";", "wait-signal", ";", "signal", "sigusr2", strconv.Itoa(int(utils.Getpid()))); err != nil {
-			t.Error("no signal")
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := runSyscallTesterFunc(
+			timeoutCtx, t, syscallTester,
+			"set-signal-handler", ";",
+			"mkdirat", testFile, ";",
+			"sleep", "2", ";",
+			"wait-signal", ";",
+			"signal", "sigusr2", strconv.Itoa(int(os.Getpid())),
+		); err != nil {
+			t.Fatal("no signal")
 		}
 
 		select {

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -10,6 +10,7 @@ package tests
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1426,7 +1427,7 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 
 	t.Run("setuid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "process-credentials", "setuid", "1001", "0")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "process-credentials", "setuid", "1001", "0")
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setuid")
 			assert.Equal(t, uint32(1001), event.SetUID.UID, "wrong uid")
@@ -1435,7 +1436,7 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 
 	t.Run("setreuid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "process-credentials", "setreuid", "1002", "1003")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "process-credentials", "setreuid", "1002", "1003")
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setreuid")
 			assert.Equal(t, uint32(1002), event.SetUID.UID, "wrong uid")
@@ -1445,7 +1446,7 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 
 	t.Run("setresuid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "process-credentials", "setresuid", "1002", "1003")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "process-credentials", "setresuid", "1002", "1003")
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setreuid")
 			assert.Equal(t, uint32(1002), event.SetUID.UID, "wrong uid")
@@ -1455,7 +1456,7 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 
 	t.Run("setfsuid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "process-credentials", "setfsuid", "1004", "0")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "process-credentials", "setfsuid", "1004", "0")
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setfsuid")
 			assert.Equal(t, uint32(1004), event.SetUID.FSUID, "wrong fsuid")
@@ -1464,7 +1465,7 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 
 	t.Run("setgid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "process-credentials", "setgid", "1005", "0")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "process-credentials", "setgid", "1005", "0")
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setgid")
 			assert.Equal(t, uint32(1005), event.SetGID.GID, "wrong gid")
@@ -1473,7 +1474,7 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 
 	t.Run("setregid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "process-credentials", "setregid", "1006", "1007")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "process-credentials", "setregid", "1006", "1007")
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setregid")
 			assert.Equal(t, uint32(1006), event.SetGID.GID, "wrong gid")
@@ -1483,7 +1484,7 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 
 	t.Run("setresgid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "process-credentials", "setresgid", "1006", "1007")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "process-credentials", "setresgid", "1006", "1007")
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setregid")
 			assert.Equal(t, uint32(1006), event.SetGID.GID, "wrong gid")
@@ -1493,7 +1494,7 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 
 	t.Run("setfsgid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "process-credentials", "setfsgid", "1008", "0")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "process-credentials", "setfsgid", "1008", "0")
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setfsgid")
 			assert.Equal(t, uint32(1008), event.SetGID.FSGID, "wrong gid")
@@ -1514,7 +1515,7 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 		threadCapabilities.Unset(capability.EFFECTIVE, capability.CAP_WAKE_ALARM)
 
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, goSyscallTester, "-process-credentials-capset")
+			return runSyscallTesterFunc(context.Background(), t, goSyscallTester, "-process-credentials-capset")
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_capset")
 

--- a/pkg/security/tests/splice_test.go
+++ b/pkg/security/tests/splice_test.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,7 +39,7 @@ func TestSpliceEvent(t *testing.T) {
 
 	t.Run("test_splice", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			return runSyscallTesterFunc(t, syscallTester, "splice")
+			return runSyscallTesterFunc(context.Background(), t, syscallTester, "splice")
 		}, func(event *model.Event, r *rules.Rule) {
 			assert.Equal(t, "splice", event.GetType(), "wrong event type")
 			assert.Equal(t, uint32(0), event.Splice.PipeEntryFlag, "wrong pipe entry flag")

--- a/pkg/security/tests/syscall_tester.go
+++ b/pkg/security/tests/syscall_tester.go
@@ -9,6 +9,7 @@
 package tests
 
 import (
+	"context"
 	"embed"
 	"fmt"
 	"os"
@@ -55,9 +56,9 @@ func checkSyscallTester(t *testing.T, path string) error {
 	return nil
 }
 
-func runSyscallTesterFunc(t *testing.T, path string, args ...string) error {
+func runSyscallTesterFunc(ctx context.Context, t *testing.T, path string, args ...string) error {
 	t.Helper()
-	sideTester := exec.Command(path, args...)
+	sideTester := exec.CommandContext(ctx, path, args...)
 	output, err := sideTester.CombinedOutput()
 
 	if err != nil {

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -159,10 +159,6 @@ int ptrace_traceme() {
     return EXIT_SUCCESS;
 }
 
-void sig_handler(int signum){
-    exit(0);
-}
-
 int test_signal_sigusr(int child, int sig) {
     int do_fork = child == 0;
     if (do_fork) {
@@ -607,11 +603,6 @@ int test_sleep(int argc, char **argv) {
     }
     for (int i = 0; i < duration; i++)
         sleep(1);
-    return EXIT_SUCCESS;
-}
-
-int test_ioctl(int argc, char **argv) {
-    ioctl(666, 0);
     return EXIT_SUCCESS;
 }
 

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -163,20 +163,25 @@ void sig_handler(int signum){
     exit(0);
 }
 
-int test_signal_sigusr(int sig) {
-    pid_t child = fork();
-    if (child == 0) {
-        signal(sig, sig_handler);
-        sleep(60);
-
-        return EXIT_SUCCESS;
+int test_signal_sigusr(int child, int sig) {
+    int do_fork = child != 0;
+    if (do_fork) {
+        child = fork();
+        if (child == 0) {
+            sleep(5);
+            return EXIT_SUCCESS;
+        }
     }
 
     int ret = kill(child, sig);
     if (ret < 0) {
         return ret;
     }
-    return wait(NULL);
+
+    if (do_fork)
+        wait(NULL);
+
+    return ret;
 }
 
 int test_signal_eperm(void) {
@@ -202,10 +207,19 @@ int test_signal(int argc, char **argv) {
         return EXIT_FAILURE;
     }
 
+    int pid = 0;
+    if (argc > 2) {
+        pid = atoi(argv[2]);
+        if (pid < 1) {
+            fprintf(stderr, "invalid pid: %s\n", argv[2]);
+            return EXIT_FAILURE;
+        }
+    }
+
     if (!strcmp(argv[1], "sigusr"))
-        return test_signal_sigusr(SIGUSR1);
-    if (!strcmp(argv[1], "sigusr2"))
-        return test_signal_sigusr(SIGUSR2);
+        return test_signal_sigusr(pid, SIGUSR1);
+    else if (!strcmp(argv[1], "sigusr2"))
+        return test_signal_sigusr(pid, SIGUSR2);
     else if (!strcmp(argv[1], "eperm"))
         return test_signal_eperm();
     fprintf(stderr, "%s: Unknown argument: %s.\n", __FUNCTION__, argv[1]);

--- a/releasenotes/notes/cws-kill-action-9c6c61effc2a288e.yaml
+++ b/releasenotes/notes/cws-kill-action-9c6c61effc2a288e.yaml
@@ -1,0 +1,15 @@
+---
+features:
+  - |
+    A new rule post action - 'kill' - can now be used to send a specific
+    signal to a process that caused a rule to be triggered. By default, this
+    signal is SIGTERM.
+
+    ```
+    - id: my_rule
+      expression: ...
+      actions:
+        - kill:
+            signal: SIGUSR1
+    ```
+

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -574,7 +574,7 @@ RUN ln -s $(which llc-14) /opt/datadog-agent/embedded/bin/llc-bpf
     cmd += '-v /usr/lib/os-release:/host/usr/lib/os-release '
     cmd += '-v /etc/passwd:/etc/passwd '
     cmd += '-v /etc/group:/etc/group '
-    cmd += '-v {GOPATH}/src/{REPO_PATH}/pkg/security/tests:/tests {image_tag} sleep 3600'
+    cmd += '-v ./pkg/security/tests:/tests {image_tag} sleep 3600'
 
     args = {
         "GOPATH": get_gopath(ctx),


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

A new rule post action - 'kill' - can now be used to send a specific
signal to a process that caused a rule to be triggered. By default, this
signal is SIGTERM.
```
- id: my_rule
  expression: ...
  actions:
    - kill:
        signal: SIGUSR1
```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
