### PR TITLE
[oracle] Add inactive_seconds metric (DBMON-2967)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -55,6 +55,10 @@ type ProcessMemoryConfig struct {
 	Enabled bool `yaml:"enabled"`
 }
 
+type InactiveSessionsConfig struct {
+	Enabled bool `yaml:"enabled"`
+}
+
 type SharedMemoryConfig struct {
 	Enabled bool `yaml:"enabled"`
 }
@@ -87,33 +91,34 @@ type CustomQuery struct {
 
 // InstanceConfig is used to deserialize integration instance config.
 type InstanceConfig struct {
-	Server                             string               `yaml:"server"`
-	Port                               int                  `yaml:"port"`
-	ServiceName                        string               `yaml:"service_name"`
-	Username                           string               `yaml:"username"`
-	Password                           string               `yaml:"password"`
-	TnsAlias                           string               `yaml:"tns_alias"`
-	TnsAdmin                           string               `yaml:"tns_admin"`
-	Protocol                           string               `yaml:"protocol"`
-	Wallet                             string               `yaml:"wallet"`
-	DBM                                bool                 `yaml:"dbm"`
-	Tags                               []string             `yaml:"tags"`
-	LogUnobfuscatedQueries             bool                 `yaml:"log_unobfuscated_queries"`
-	ObfuscatorOptions                  obfuscate.SQLConfig  `yaml:"obfuscator_options"`
-	InstantClient                      bool                 `yaml:"instant_client"`
-	ReportedHostname                   string               `yaml:"reported_hostname"`
-	QuerySamples                       QuerySamplesConfig   `yaml:"query_samples"`
-	QueryMetrics                       QueryMetricsConfig   `yaml:"query_metrics"`
-	SysMetrics                         SysMetricsConfig     `yaml:"sysmetrics"`
-	Tablespaces                        TablespacesConfig    `yaml:"tablespaces"`
-	ProcessMemory                      ProcessMemoryConfig  `yaml:"process_memory"`
-	SharedMemory                       SharedMemoryConfig   `yaml:"shared_memory"`
-	ExecutionPlans                     ExecutionPlansConfig `yaml:"execution_plans"`
-	AgentSQLTrace                      AgentSQLTrace        `yaml:"agent_sql_trace"`
-	UseGlobalCustomQueries             string               `yaml:"use_global_custom_queries"`
-	CustomQueries                      []CustomQuery        `yaml:"custom_queries"`
-	MetricCollectionInterval           int64                `yaml:"metric_collection_interval"`
-	DatabaseInstanceCollectionInterval uint64               `yaml:"database_instance_collection_interval"`
+	Server                             string                 `yaml:"server"`
+	Port                               int                    `yaml:"port"`
+	ServiceName                        string                 `yaml:"service_name"`
+	Username                           string                 `yaml:"username"`
+	Password                           string                 `yaml:"password"`
+	TnsAlias                           string                 `yaml:"tns_alias"`
+	TnsAdmin                           string                 `yaml:"tns_admin"`
+	Protocol                           string                 `yaml:"protocol"`
+	Wallet                             string                 `yaml:"wallet"`
+	DBM                                bool                   `yaml:"dbm"`
+	Tags                               []string               `yaml:"tags"`
+	LogUnobfuscatedQueries             bool                   `yaml:"log_unobfuscated_queries"`
+	ObfuscatorOptions                  obfuscate.SQLConfig    `yaml:"obfuscator_options"`
+	InstantClient                      bool                   `yaml:"instant_client"`
+	ReportedHostname                   string                 `yaml:"reported_hostname"`
+	QuerySamples                       QuerySamplesConfig     `yaml:"query_samples"`
+	QueryMetrics                       QueryMetricsConfig     `yaml:"query_metrics"`
+	SysMetrics                         SysMetricsConfig       `yaml:"sysmetrics"`
+	Tablespaces                        TablespacesConfig      `yaml:"tablespaces"`
+	ProcessMemory                      ProcessMemoryConfig    `yaml:"process_memory"`
+	InactiveSessions                   InactiveSessionsConfig `yaml:"inactive_sessions"`
+	SharedMemory                       SharedMemoryConfig     `yaml:"shared_memory"`
+	ExecutionPlans                     ExecutionPlansConfig   `yaml:"execution_plans"`
+	AgentSQLTrace                      AgentSQLTrace          `yaml:"agent_sql_trace"`
+	UseGlobalCustomQueries             string                 `yaml:"use_global_custom_queries"`
+	CustomQueries                      []CustomQuery          `yaml:"custom_queries"`
+	MetricCollectionInterval           int64                  `yaml:"metric_collection_interval"`
+	DatabaseInstanceCollectionInterval uint64                 `yaml:"database_instance_collection_interval"`
 }
 
 // CheckConfig holds the config needed for an integration instance to run.
@@ -157,6 +162,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	instance.Tablespaces.Enabled = true
 	instance.ProcessMemory.Enabled = true
 	instance.SharedMemory.Enabled = true
+	instance.InactiveSessions.Enabled = true
 
 	instance.ExecutionPlans.Enabled = true
 

--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -55,7 +55,7 @@ type ProcessMemoryConfig struct {
 	Enabled bool `yaml:"enabled"`
 }
 
-type InactiveSessionsConfig struct {
+type inactiveSessionsConfig struct {
 	Enabled bool `yaml:"enabled"`
 }
 
@@ -111,7 +111,7 @@ type InstanceConfig struct {
 	SysMetrics                         SysMetricsConfig       `yaml:"sysmetrics"`
 	Tablespaces                        TablespacesConfig      `yaml:"tablespaces"`
 	ProcessMemory                      ProcessMemoryConfig    `yaml:"process_memory"`
-	InactiveSessions                   InactiveSessionsConfig `yaml:"inactive_sessions"`
+	InactiveSessions                   inactiveSessionsConfig `yaml:"inactive_sessions"`
 	SharedMemory                       SharedMemoryConfig     `yaml:"shared_memory"`
 	ExecutionPlans                     ExecutionPlansConfig   `yaml:"execution_plans"`
 	AgentSQLTrace                      AgentSQLTrace          `yaml:"agent_sql_trace"`

--- a/pkg/collector/corechecks/oracle-dbm/init.go
+++ b/pkg/collector/corechecks/oracle-dbm/init.go
@@ -61,7 +61,6 @@ func (c *Check) init() error {
 		tags = append(tags, fmt.Sprintf("host:%s", c.dbHostname), fmt.Sprintf("db_server:%s", c.dbHostname))
 	}
 	tags = append(tags, fmt.Sprintf("oracle_version:%s", c.dbVersion))
-	tags = append(tags, fmt.Sprintf("dd.internal.resource:database_instance:%s/%s", c.dbHostname, c.cdbName))
 
 	var d vDatabase
 	if isDbVersionGreaterOrEqualThan(c, minMultitenantVersion) {
@@ -75,6 +74,7 @@ func (c *Check) init() error {
 	}
 	c.cdbName = d.Name
 	tags = append(tags, fmt.Sprintf("cdb:%s", c.cdbName))
+	tags = append(tags, fmt.Sprintf("dd.internal.resource:database_instance:%s/%s", c.dbHostname, c.cdbName))
 	isMultitenant := true
 	if d.Cdb == "NO" {
 		isMultitenant = false

--- a/pkg/collector/corechecks/oracle-dbm/metadata.go
+++ b/pkg/collector/corechecks/oracle-dbm/metadata.go
@@ -43,7 +43,7 @@ func sendDbInstanceMetadata(c *Check) error {
 		ConnectionHost: config.GetConnectData(c.config.InstanceConfig),
 	}
 	e := dbInstanceEvent{
-		Host:               c.dbHostname,
+		Host:               fmt.Sprintf("%s/%s", c.dbHostname, c.cdbName),
 		AgentVersion:       c.agentVersion,
 		Dbms:               common.IntegrationName,
 		Kind:               "database_instance",

--- a/pkg/collector/corechecks/oracle-dbm/metadata.go
+++ b/pkg/collector/corechecks/oracle-dbm/metadata.go
@@ -43,7 +43,7 @@ func sendDbInstanceMetadata(c *Check) error {
 		ConnectionHost: config.GetConnectData(c.config.InstanceConfig),
 	}
 	e := dbInstanceEvent{
-		Host:               fmt.Sprintf("%s/%s", c.dbHostname, c.cdbName),
+		Host:               c.dbHostname,
 		AgentVersion:       c.agentVersion,
 		Dbms:               common.IntegrationName,
 		Kind:               "database_instance",

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -189,7 +189,7 @@ func (c *Check) Run() error {
 				return fmt.Errorf("%s %w", c.logPrompt, err)
 			}
 		}
-		if c.config.ProcessMemory.Enabled {
+		if c.config.ProcessMemory.Enabled || c.config.InactiveSessions.Enabled {
 			err := c.ProcessMemory()
 			if err != nil {
 				return fmt.Errorf("%s %w", c.logPrompt, err)

--- a/pkg/collector/corechecks/oracle-dbm/processes.go
+++ b/pkg/collector/corechecks/oracle-dbm/processes.go
@@ -16,34 +16,48 @@ import (
 )
 
 const pgaQuery12 = `SELECT 
-	name pdb_name, 
-	pid, 
-	program, 
-	nvl(pga_used_mem,0) pga_used_mem, 
-	nvl(pga_alloc_mem,0) pga_alloc_mem, 
-	nvl(pga_freeable_mem,0) pga_freeable_mem, 
-	nvl(pga_max_mem,0) pga_max_mem
-  FROM v$process p, v$containers c
+  c.name as pdb_name, 
+  p.pid as pid, p.program as server_process,
+  s.sid as sid, s.username as username, s.program as program, s.machine as machine, s.osuser as osuser,
+  s.status as status, last_call_et,
+  module, client_info,
+  FROM v$process p, v$containers c, v$session s
   WHERE
-  	c.con_id(+) = p.con_id`
+  	c.con_id(+) = p.con_id
+		AND s.paddr(+) = p.addr`
+
+type sessionTagColumns struct {
+	Sid      sql.NullInt64  `db:"SID"`
+	Username sql.NullString `db:"USERNAME"`
+	Program  sql.NullString `db:"PROGRAM"`
+	Machine  sql.NullString `db:"MACHINE"`
+	OsUser   sql.NullString `db:"OSUSER"`
+}
 
 const pgaQuery11 = `SELECT  
-	pid, 
-	program, 
+  p.pid as pid, p.program as server_process,
+  s.sid as sid, s.username as username, s.program as program, s.machine as machine, s.osuser as osuser,
+  s.status as status, last_call_et,
+  module, client_info,
 	nvl(pga_used_mem,0) pga_used_mem, 
 	nvl(pga_alloc_mem,0) pga_alloc_mem, 
 	nvl(pga_freeable_mem,0) pga_freeable_mem, 
 	nvl(pga_max_mem,0) pga_max_mem
-  FROM v$process p`
+  FROM v$process p, v$session s`
 
 type ProcessesRowDB struct {
 	PdbName        sql.NullString `db:"PDB_NAME"`
 	PID            uint64         `db:"PID"`
-	Program        sql.NullString `db:"PROGRAM"`
+	ServerProcess  sql.NullString `db:"SERVER_PROCESS"`
 	PGAUsedMem     float64        `db:"PGA_USED_MEM"`
 	PGAAllocMem    float64        `db:"PGA_ALLOC_MEM"`
 	PGAFreeableMem float64        `db:"PGA_FREEABLE_MEM"`
 	PGAMaxMem      float64        `db:"PGA_MAX_MEM"`
+	LastCallEt     sql.NullInt64  `db:"LAST_CALL_ET"`
+	Status         sql.NullString `db:"STATUS"`
+	Module         sql.NullString `db:"MODULE"`
+	ClientInfo     sql.NullString `db:"CLIENT_INFO"`
+	sessionTagColumns
 }
 
 func (c *Check) ProcessMemory() error {
@@ -65,14 +79,41 @@ func (c *Check) ProcessMemory() error {
 	}
 	for _, r := range rows {
 		tags := appendPDBTag(c.tags, r.PdbName)
-		tags = append(tags, "pid:"+strconv.FormatUint(r.PID, 10))
+		if r.Sid.Valid {
+			tags = append(tags, "sid:"+strconv.FormatInt(r.Sid.Int64, 10))
+		} else {
+			tags = append(tags, "pid:"+strconv.FormatUint(r.PID, 10))
+		}
+		if r.Username.Valid {
+			tags = append(tags, "username:"+r.Username.String)
+		}
 		if r.Program.Valid {
 			tags = append(tags, "program:"+r.Program.String)
+		} else if r.ServerProcess.Valid {
+			tags = append(tags, "program:"+r.ServerProcess.String)
 		}
-		sender.Gauge(fmt.Sprintf("%s.process.pga_used_memory", common.IntegrationName), r.PGAUsedMem, "", tags)
-		sender.Gauge(fmt.Sprintf("%s.process.pga_allocated_memory", common.IntegrationName), r.PGAAllocMem, "", tags)
-		sender.Gauge(fmt.Sprintf("%s.process.pga_freeable_memory", common.IntegrationName), r.PGAFreeableMem, "", tags)
-		sender.Gauge(fmt.Sprintf("%s.process.pga_max_memory", common.IntegrationName), r.PGAMaxMem, "", tags)
+		if r.Machine.Valid {
+			tags = append(tags, "machine:"+r.Machine.String)
+		}
+		if r.OsUser.Valid {
+			tags = append(tags, "osuser:"+r.OsUser.String)
+		}
+		if c.config.ProcessMemory.Enabled {
+			sender.Gauge(fmt.Sprintf("%s.process.pga_used_memory", common.IntegrationName), r.PGAUsedMem, "", tags)
+			sender.Gauge(fmt.Sprintf("%s.process.pga_allocated_memory", common.IntegrationName), r.PGAAllocMem, "", tags)
+			sender.Gauge(fmt.Sprintf("%s.process.pga_freeable_memory", common.IntegrationName), r.PGAFreeableMem, "", tags)
+			sender.Gauge(fmt.Sprintf("%s.process.pga_max_memory", common.IntegrationName), r.PGAMaxMem, "", tags)
+		}
+
+		if c.config.InactiveSessions.Enabled && r.Status.Valid && r.Status.String == "INACTIVE" && r.LastCallEt.Valid {
+			if r.Module.Valid {
+				tags = append(tags, "module:"+r.Module.String)
+			}
+			if r.ClientInfo.Valid {
+				tags = append(tags, "client_info:"+r.ClientInfo.String)
+			}
+			sender.Gauge(fmt.Sprintf("%s.session.inactive_seconds", common.IntegrationName), float64(r.LastCallEt.Int64), "", tags)
+		}
 	}
 	sender.Commit()
 	return nil

--- a/pkg/collector/corechecks/oracle-dbm/processes.go
+++ b/pkg/collector/corechecks/oracle-dbm/processes.go
@@ -16,15 +16,30 @@ import (
 )
 
 const pgaQuery12 = `SELECT 
-  c.name as pdb_name, 
-  p.pid as pid, p.program as server_process,
-  s.sid as sid, s.username as username, s.program as program, s.machine as machine, s.osuser as osuser,
-  s.status as status, last_call_et,
-  module, client_info,
-  FROM v$process p, v$containers c, v$session s
-  WHERE
-  	c.con_id(+) = p.con_id
-		AND s.paddr(+) = p.addr`
+	c.name as pdb_name, 
+	p.pid as pid, p.program as server_process,
+	s.sid as sid, s.username as username, s.program as program, s.machine as machine, s.osuser as osuser,
+	s.status as status, last_call_et,
+	module, client_info,
+	nvl(pga_used_mem,0) pga_used_mem, 
+	nvl(pga_alloc_mem,0) pga_alloc_mem, 
+	nvl(pga_freeable_mem,0) pga_freeable_mem, 
+	nvl(pga_max_mem,0) pga_max_mem
+FROM v$process p, v$containers c, v$session s
+WHERE
+  c.con_id(+) = p.con_id
+	AND s.paddr(+) = p.addr`
+
+const pgaQuery11 = `SELECT  
+	p.pid as pid, p.program as server_process,
+	s.sid as sid, s.username as username, s.program as program, s.machine as machine, s.osuser as osuser,
+	s.status as status, last_call_et,
+	nvl(pga_used_mem,0) pga_used_mem, 
+	nvl(pga_alloc_mem,0) pga_alloc_mem, 
+	nvl(pga_freeable_mem,0) pga_freeable_mem, 
+	nvl(pga_max_mem,0) pga_max_mem
+FROM v$process p, v$session s
+WHERE s.paddr(+) = p.addr`
 
 type sessionTagColumns struct {
 	Sid      sql.NullInt64  `db:"SID"`
@@ -35,15 +50,13 @@ type sessionTagColumns struct {
 }
 
 const pgaQuery11 = `SELECT  
-  p.pid as pid, p.program as server_process,
-  s.sid as sid, s.username as username, s.program as program, s.machine as machine, s.osuser as osuser,
-  s.status as status, last_call_et,
-  module, client_info,
+	pid, 
+	program, 
 	nvl(pga_used_mem,0) pga_used_mem, 
 	nvl(pga_alloc_mem,0) pga_alloc_mem, 
 	nvl(pga_freeable_mem,0) pga_freeable_mem, 
 	nvl(pga_max_mem,0) pga_max_mem
-  FROM v$process p, v$session s`
+  FROM v$process p`
 
 type ProcessesRowDB struct {
 	PdbName        sql.NullString `db:"PDB_NAME"`

--- a/pkg/collector/corechecks/oracle-dbm/processes.go
+++ b/pkg/collector/corechecks/oracle-dbm/processes.go
@@ -49,15 +49,6 @@ type sessionTagColumns struct {
 	OsUser   sql.NullString `db:"OSUSER"`
 }
 
-const pgaQuery11 = `SELECT  
-	pid, 
-	program, 
-	nvl(pga_used_mem,0) pga_used_mem, 
-	nvl(pga_alloc_mem,0) pga_alloc_mem, 
-	nvl(pga_freeable_mem,0) pga_freeable_mem, 
-	nvl(pga_max_mem,0) pga_max_mem
-  FROM v$process p`
-
 type ProcessesRowDB struct {
 	PdbName        sql.NullString `db:"PDB_NAME"`
 	PID            uint64         `db:"PID"`

--- a/releasenotes/notes/oracle-session-explorer-9b6e6b445263fe94.yaml
+++ b/releasenotes/notes/oracle-session-explorer-9b6e6b445263fe94.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add `oracle.inactive_seconds` metric. Add tags with session attributes to `oracle.process_pga*` metrics.


### PR DESCRIPTION
### What does this PR do?

This PR adds two enhancements for understanding the session behaviour.

1. Adding `inactive_seconds` metric. The metric measures the time elapsed since the session was last time active. 

2. Adding sessions attributes `SID`, `PROGRAM`, `MACHINE` and `OSUSER` as tags to the existing PGA memory usage (`oracle.process.pga*`) metrics.

### Motivation

1. The purpose of this metric is to detect idle sessions. The metric was requested by Heartland.

2. In Oracle DBM, we took over PGA usage metrics from the existing Oracle integration written in Python. While those metrics provided the relevant data for the session memory usage, it wasn't possible to identify the session without querying the database. Also, aggregations based on username, client or program weren't possible. We are extending the query and adding those tags to the database. The idea came in discussion with Raymond James, and also Heartland requested those tags as well.

### Possible Drawbacks / Trade-offs

The agent emits several metrics for each session. The tags are static, i.e. they shouldn't change over time. If, however, the sessions constantly log on and log off to the database, that might cause higher metric/tag cardinality. If that becomes a problem, we need to start thinking about alternative solutions, for example, generating events for this data.

### Describe how to test/QA your changes

Check if the metric `oracle.session.inactive_seconds` is being emitted. Check the tags for `oracle.process.pga*` metrics.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
