### PR TITLE
[CWS] Add another metric to get the list of profile selectors

### DIFF
--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -250,7 +250,7 @@ var (
 	// Security Profile metrics
 
 	// MetricSecurityProfileSelector is the name of the metric used to report the list seen workloads
-	// Tags: selector (string of the workload selector), stable (true or false), anomalies_cpt (number of anomalies sent)
+	// Tags: selector (string of the workload selector), stable (true or false), anomalies_counter (number of anomalies sent)
 	//       last_uptime (0 if the profile is loaded, duration in secs of its last run otherwise)
 	MetricSecurityProfileSelector = newRuntimeMetric(".security_profile.profile_selector")
 	// MetricSecurityProfileProfiles is the name of the metric used to report the count of Security Profiles per category

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -251,6 +251,7 @@ var (
 
 	// MetricSecurityProfileSelector is the name of the metric used to report the list seen workloads
 	// Tags: selector (string of the workload selector), stable (true or false), anomalies_cpt (number of anomalies sent)
+	//       last_uptime (0 if the profile is loaded, duration in secs of its last run otherwise)
 	MetricSecurityProfileSelector = newRuntimeMetric(".security_profile.profile_selector")
 	// MetricSecurityProfileProfiles is the name of the metric used to report the count of Security Profiles per category
 	// Tags: in_kernel (true or false), anomaly_detection (true or false), auto_suppression (true or false), workload_hardening (true or false)

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -249,6 +249,9 @@ var (
 
 	// Security Profile metrics
 
+	// MetricSecurityProfileSelector is the name of the metric used to report the list seen workloads
+	// Tags: selector (string of the workload selector), stable (true or false), anomalies_cpt (number of anomalies sent)
+	MetricSecurityProfileSelector = newRuntimeMetric(".security_profile.profile_selector")
 	// MetricSecurityProfileProfiles is the name of the metric used to report the count of Security Profiles per category
 	// Tags: in_kernel (true or false), anomaly_detection (true or false), auto_suppression (true or false), workload_hardening (true or false)
 	MetricSecurityProfileProfiles = newRuntimeMetric(".security_profile.profiles")

--- a/pkg/security/security_profile/profile/manager.go
+++ b/pkg/security/security_profile/profile/manager.go
@@ -553,7 +553,7 @@ func (m *SecurityProfileManager) SendStats() error {
 
 		uptime := uint64(0)
 		if !profile.loadedInKernel {
-			uptime = (profile.unloadedNano - profile.loadedNano) / 1000000000
+			uptime = uint64(time.Duration(profile.unloadedNano - profile.loadedNano).Seconds())
 		}
 		tags := []string{
 			"selector:" + profile.selector.String(),

--- a/pkg/security/security_profile/profile/manager.go
+++ b/pkg/security/security_profile/profile/manager.go
@@ -558,7 +558,7 @@ func (m *SecurityProfileManager) SendStats() error {
 		tags := []string{
 			"selector:" + profile.selector.String(),
 			fmt.Sprintf("stable:%v", profile.IsStable()),
-			fmt.Sprintf("anomalies_cpt:%v", profile.anomaliesCpt.Swap(0)),
+			fmt.Sprintf("anomalies_counter:%v", profile.anomaliesCounter.Swap(0)),
 			fmt.Sprintf("last_uptime:%v", uptime),
 		}
 		if err := m.statsdClient.Count(metrics.MetricSecurityProfileSelector, 1, tags, 1.0); err != nil {
@@ -728,7 +728,7 @@ func (m *SecurityProfileManager) LookupEventInProfiles(event *model.Event) {
 			event.AddToFlags(model.EventFlagsSecurityProfileInProfile)
 			m.incrementEventFilteringStat(event.GetEventType(), profileState, InProfile)
 		} else {
-			profile.anomaliesCpt.Inc()
+			profile.anomaliesCounter.Inc()
 			m.incrementEventFilteringStat(event.GetEventType(), profileState, NotInProfile)
 		}
 	}

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -227,7 +227,8 @@ func (p *SecurityProfile) IsStable() bool {
 	p.eventTypeStateLock.Lock()
 	defer p.eventTypeStateLock.Unlock()
 	for _, evType := range p.anomalyDetectionEvents {
-		if p.eventTypeState[evType].state != StableEventType {
+		eventState, ok := p.eventTypeState[evType]
+		if !ok || eventState.state != StableEventType {
 			return false
 		}
 	}

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -48,7 +48,7 @@ type SecurityProfile struct {
 	anomalyDetectionEvents []model.EventType
 	eventTypeState         map[model.EventType]*EventTypeState
 	eventTypeStateLock     sync.Mutex
-	anomaliesCpt           *atomic.Uint64
+	anomaliesCounter       *atomic.Uint64
 
 	// Instances is the list of workload instances to witch the profile should apply
 	Instances []*cgroupModel.CacheEntry
@@ -83,7 +83,7 @@ func NewSecurityProfile(selector cgroupModel.WorkloadSelector, anomalyDetectionE
 		selector:               selector,
 		anomalyDetectionEvents: anomalyDetectionEvents,
 		eventTypeState:         make(map[model.EventType]*EventTypeState),
-		anomaliesCpt:           atomic.NewUint64(0),
+		anomaliesCounter:       atomic.NewUint64(0),
 	}
 }
 
@@ -95,7 +95,7 @@ func (p *SecurityProfile) reset() {
 	p.profileCookie = 0
 	p.eventTypeState = make(map[model.EventType]*EventTypeState)
 	p.Instances = nil
-	p.anomaliesCpt.Store(0)
+	p.anomaliesCounter.Store(0)
 }
 
 // generateCookies computes random cookies for all the entries in the profile that require one

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -42,6 +42,7 @@ type SecurityProfile struct {
 	sync.Mutex
 	loadedInKernel         bool
 	loadedNano             uint64
+	unloadedNano           uint64
 	selector               cgroupModel.WorkloadSelector
 	profileCookie          uint64
 	anomalyDetectionEvents []model.EventType
@@ -90,6 +91,7 @@ func NewSecurityProfile(selector cgroupModel.WorkloadSelector, anomalyDetectionE
 func (p *SecurityProfile) reset() {
 	p.loadedInKernel = false
 	p.loadedNano = 0
+	p.unloadedNano = 0
 	p.profileCookie = 0
 	p.eventTypeState = make(map[model.EventType]*EventTypeState)
 	p.Instances = nil


### PR DESCRIPTION
### What does this PR do?

This PR adds the new metric `datadog.runtime_security.security_profile.profile_selector`, which will be sent every stat cycle with those tags:
* `selector`: will represent the workload selector
* `stable`: true if the profile is stable for every eventTypes, false otherwise
* `anolalies_cpt`: count of all anomalies generated related to this profile
* `last_uptime`: the last uptime in sec of this workload (0 if it's still running)

### Motivation

Improve our vision of the quality of our secprofile/anomalies logic.


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
