### PR TITLE
[oracle] Document custom metrics metric_prefix parameter (DBMON-2971)

### DIFF
--- a/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle-dbm.d/conf.yaml.example
@@ -216,21 +216,35 @@ instances:
     ## @param custom_queries - list of mappings - optional
     ## Each query must have 2 fields, and can have a third optional field:
     ##
-    ## 1. query - The SQL to execute. It can be a simple statement or a multi-line script.
+    ## 1. metric_prefix - Each metric starts with the chosen prefix.
+    ## 2. query - The SQL to execute. It can be a simple statement or a multi-line script.
     ##            Use the pipe `|` if you require a multi-line script.
-    ## 2. columns - The list representing each column, ordered sequentially from left to right.
+    ## 3. columns - The list representing each column, ordered sequentially from left to right.
     ##              The number of columns must equal the number of columns returned in the query.
     ##              There are 2 required pieces of data:
-    ##                a. name - The suffix to append to `<INTEGRATION>.` to form
-    ##                          the full metric name. If `type` is a `tag` type, this column is
+    ##                a. name - The suffix to append to `metric_prefix` to form
+    ##                          the full metric name. If `type` is `tag`, this column is
     ##                          considered a tag and applied to every
     ##                          metric collected by this particular query.
-    ##                b. type - The submission method (gauge, monotonic_count, etc.) or tag.
-    ## 3. tags (optional) - A list of tags to apply to each metric.
-    ## 4. pdb (optional) - A PDB against which the query will be run. Default is CDB$ROOT.
-                           The parameter can be defined on a self-managed instance, which
-                           connects to CDB. The Agent needs to have `set container` privilege
-                           on the PDB where the custom query is running.
+    ##                b. type - The submission method (gauge, monotonic_count, etc.).
+    ##                          This can also be set to `tag` to tag each metric in the row
+    ##                          with the name and value of the item in this column. You can
+    ##                          use the `count` type to perform aggregation for queries that
+    ##                          return multiple rows with the same or no tags.
+    ##              Columns without a name are ignored. To skip a column, enter:
+    ##                - {}
+    ## 4. tags (optional) - A list of tags to apply to each metric.
+    #
+    custom_queries:
+      - metric_prefix: oracle.custom_query.table_events
+        query: SELECT program, COUNT(*) FROM table_events GROUP BY program
+        columns:
+        - name: foo
+          type: tag
+        - name: total
+          type: gauge
+        tags:
+        - tag1:value1
 
     ## WARNING: Running custom queries may result in additional costs or fees assessed by Oracle.
     

--- a/releasenotes/notes/oracle-conf-custom-query-prefix-3ca4482656458a4b.yaml
+++ b/releasenotes/notes/oracle-conf-custom-query-prefix-3ca4482656458a4b.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Add query metrics `metric_prefix` parameter.

--- a/releasenotes/notes/oracle-conf-custom-query-prefix-3ca4482656458a4b.yaml
+++ b/releasenotes/notes/oracle-conf-custom-query-prefix-3ca4482656458a4b.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Add query metrics `metric_prefix` parameter.
+    Document query metrics `metric_prefix` parameter.


### PR DESCRIPTION
### What does this PR do?

Adding `metric_prefix` to `confy.yaml.example`.

### Additional Notes

The legacy Oracle Python integration didn't have this parameter. The parameter was implemented in Oracle DBM to align it to other DBM database integrations. Since the `custom_queries` section in `conf.yaml.example` was taken over from the old Oracle integration, this parameter was missing.

### Describe how to test/QA your changes

Check `conf.yaml.example` in `main`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
