### PR TITLE
[CWS] improve syscalls stats monitor

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/syscalls.h
+++ b/pkg/security/ebpf/c/include/helpers/syscalls.h
@@ -100,10 +100,11 @@ struct syscall_cache_t *__attribute__((always_inline)) pop_task_syscall(u64 pid_
     if (!syscall) {
         return NULL;
     }
-    if (!type || syscall->type == type) {
+    u64 event_type = syscall->type; // fixes 4.14 verifier issue
+    if (!type || event_type == type) {
         bpf_map_delete_elem(&syscalls, &pid_tgid);
 
-        monitor_syscalls(syscall->type, -1);
+        monitor_syscalls(event_type, -1);
         return syscall;
     }
     return NULL;

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -66,7 +66,6 @@ BPF_LRU_MAP_FLAGS(tasks_in_coredump, u64, u8, 64, BPF_F_NO_COMMON_LRU)
 BPF_LRU_MAP_FLAGS(syscalls, u64, struct syscall_cache_t, 1, BPF_F_NO_COMMON_LRU) // max entries will be overridden at runtime
 
 BPF_PERCPU_ARRAY_MAP(dr_erpc_state, u32, struct dr_erpc_state_t, 1)
-BPF_PERCPU_ARRAY_MAP(syscalls_stats, u32, struct syscalls_stats_t, EVENT_MAX)
 BPF_PERCPU_ARRAY_MAP(cgroup_tracing_event_gen, u32, struct cgroup_tracing_event_t, EVENT_GEN_SIZE)
 BPF_PERCPU_ARRAY_MAP(fb_discarder_stats, u32, struct discarder_stats_t, EVENT_LAST_DISCARDER)
 BPF_PERCPU_ARRAY_MAP(bb_discarder_stats, u32, struct discarder_stats_t, EVENT_LAST_DISCARDER)
@@ -81,6 +80,7 @@ BPF_PERCPU_ARRAY_MAP(dns_event, u32, struct dns_event_t, 1)
 BPF_PERCPU_ARRAY_MAP(packets, u32, struct packet_t, 1)
 BPF_PERCPU_ARRAY_MAP(selinux_write_buffer, u32, struct selinux_write_buffer_t, 1)
 BPF_PERCPU_ARRAY_MAP(is_new_kthread, u32, u32, 1)
+BPF_PERCPU_ARRAY_MAP(syscalls_stats, u32, struct syscalls_stats_t, EVENT_MAX)
 
 BPF_PROG_ARRAY(args_envs_progs, 3)
 BPF_PROG_ARRAY(dentry_resolver_kprobe_or_fentry_callbacks, EVENT_MAX)

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -22,6 +22,7 @@ BPF_ARRAY_MAP(open_flags_approvers, u32, 1)
 BPF_ARRAY_MAP(selinux_enforce_status, u16, 2)
 BPF_ARRAY_MAP(splice_entry_flags_approvers, u32, 1)
 BPF_ARRAY_MAP(splice_exit_flags_approvers, u32, 1)
+BPF_ARRAY_MAP(syscalls_stats_enabled, u32, 1)
 
 BPF_HASH_MAP(activity_dumps_config, u64, struct activity_dump_config, 1) // max entries will be overridden at runtime
 BPF_HASH_MAP(activity_dump_config_defaults, u32, struct activity_dump_config, 1)
@@ -65,7 +66,7 @@ BPF_LRU_MAP_FLAGS(tasks_in_coredump, u64, u8, 64, BPF_F_NO_COMMON_LRU)
 BPF_LRU_MAP_FLAGS(syscalls, u64, struct syscall_cache_t, 1, BPF_F_NO_COMMON_LRU) // max entries will be overridden at runtime
 
 BPF_PERCPU_ARRAY_MAP(dr_erpc_state, u32, struct dr_erpc_state_t, 1)
-BPF_PERCPU_ARRAY_MAP(syscalls_stats, u32, u32, EVENT_MAX)
+BPF_PERCPU_ARRAY_MAP(syscalls_stats, u32, struct syscalls_stats_t, EVENT_MAX)
 BPF_PERCPU_ARRAY_MAP(cgroup_tracing_event_gen, u32, struct cgroup_tracing_event_t, EVENT_GEN_SIZE)
 BPF_PERCPU_ARRAY_MAP(fb_discarder_stats, u32, struct discarder_stats_t, EVENT_LAST_DISCARDER)
 BPF_PERCPU_ARRAY_MAP(bb_discarder_stats, u32, struct discarder_stats_t, EVENT_LAST_DISCARDER)

--- a/pkg/security/ebpf/c/include/structs/syscalls.h
+++ b/pkg/security/ebpf/c/include/structs/syscalls.h
@@ -15,7 +15,7 @@ struct syscall_monitor_entry_t {
 };
 
 struct syscalls_stats_t {
-    u32 count;
+    s32 count;
     u32 active;
 };
 

--- a/pkg/security/ebpf/c/include/structs/syscalls.h
+++ b/pkg/security/ebpf/c/include/structs/syscalls.h
@@ -14,6 +14,11 @@ struct syscall_monitor_entry_t {
     u8 dirty;
 };
 
+struct syscalls_stats_t {
+    u32 count;
+    u32 active;
+};
+
 struct syscall_table_key_t {
     u64 id;
     u64 syscall_key;

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -125,6 +125,8 @@ func AllMaps() []*manager.Map {
 		{Name: "selinux_enforce_status"},
 		// Enabled event mask
 		{Name: "enabled_events"},
+		// Syscall stats monitor (inflight syscall)
+		{Name: "syscalls_stats_enabled"},
 	}
 }
 

--- a/pkg/security/probe/monitors/syscalls/syscalls_monitor.go
+++ b/pkg/security/probe/monitors/syscalls/syscalls_monitor.go
@@ -54,7 +54,7 @@ func (d *Monitor) SendStats() error {
 		tagsEvents := []string{
 			eventTypeTag,
 		}
-		_ = d.statsdClient.Count(metrics.MetricSyscallsInFlight, int64(inflight), tagsEvents, 1.0)
+		_ = d.statsdClient.Gauge(metrics.MetricSyscallsInFlight, float64(inflight), tagsEvents, 1.0)
 	}
 
 	return nil

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -1407,6 +1407,17 @@ func (p *Probe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetReport, e
 		return nil, fmt.Errorf("failed to select probes: %w", err)
 	}
 
+	// kprobes & kretprobes should be now all installed
+	table, err := managerhelper.Map(p.Manager, "syscalls_stats_enabled")
+	if err != nil {
+		return nil, err
+	}
+
+	enabled := uint32(1)
+	if err := table.Put(ebpf.ZeroUint32MapItem, enabled); err != nil {
+		return nil, err
+	}
+
 	return ars, nil
 }
 

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -89,7 +89,7 @@ type PlatformProbe struct {
 	kernelVersion  *kernel.Version
 
 	// internals
-	monitor         *Monitor
+	monitors        *Monitors
 	profileManagers *SecurityProfileManagers
 
 	// Ring
@@ -268,7 +268,7 @@ func (p *Probe) Init() error {
 		return err
 	}
 
-	err = p.monitor.Init()
+	err = p.monitors.Init()
 	if err != nil {
 		return err
 	}
@@ -279,7 +279,7 @@ func (p *Probe) Init() error {
 	}
 	p.profileManagers.AddActivityDumpHandler(p.activityDumpHandler)
 
-	p.eventStream.SetMonitor(p.monitor.eventStreamMonitor)
+	p.eventStream.SetMonitor(p.monitors.eventStreamMonitor)
 
 	return nil
 }
@@ -392,7 +392,7 @@ func (p *Probe) DispatchEvent(event *model.Event) {
 			p.profileManagers.activityDumpManager.ProcessEvent(event)
 		}
 	}
-	p.monitor.ProcessEvent(event)
+	p.monitors.ProcessEvent(event)
 }
 
 func (p *Probe) sendEventToWildcardHandlers(event *model.Event) {
@@ -447,12 +447,12 @@ func (p *Probe) SendStats() error {
 		return err
 	}
 
-	return p.monitor.SendStats()
+	return p.monitors.SendStats()
 }
 
-// GetMonitor returns the monitor of the probe
-func (p *Probe) GetMonitor() *Monitor {
-	return p.monitor
+// GetMonitors returns the monitor of the probe
+func (p *Probe) GetMonitors() *Monitors {
+	return p.monitors
 }
 
 // EventMarshallerCtor returns the event marshaller ctor
@@ -553,7 +553,7 @@ func (p *Probe) handleEvent(CPU int, data []byte) {
 		return
 	}
 
-	p.monitor.eventStreamMonitor.CountEvent(eventType, event.TimestampRaw, 1, dataLen, eventstream.EventStreamMap, CPU)
+	p.monitors.eventStreamMonitor.CountEvent(eventType, event.TimestampRaw, 1, dataLen, eventstream.EventStreamMap, CPU)
 
 	// no need to dispatch events
 	switch eventType {
@@ -1389,6 +1389,10 @@ func (p *Probe) applyDefaultFilterPolicies() {
 
 // ApplyRuleSet setup the probes for the provided set of rules and returns the policy report.
 func (p *Probe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetReport, error) {
+	if err := p.monitors.syscallsMonitor.Disable(); err != nil {
+		return nil, err
+	}
+
 	ars, err := kfilters.NewApplyRuleSetReport(p.Config.Probe, rs)
 	if err != nil {
 		return nil, err
@@ -1407,14 +1411,10 @@ func (p *Probe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetReport, e
 		return nil, fmt.Errorf("failed to select probes: %w", err)
 	}
 
-	// kprobes & kretprobes should be now all installed
-	table, err := managerhelper.Map(p.Manager, "syscalls_stats_enabled")
-	if err != nil {
+	if err := p.monitors.syscallsMonitor.Flush(); err != nil {
 		return nil, err
 	}
-
-	enabled := uint32(1)
-	if err := table.Put(ebpf.ZeroUint32MapItem, enabled); err != nil {
+	if err := p.monitors.syscallsMonitor.Enable(); err != nil {
 		return nil, err
 	}
 
@@ -1474,7 +1474,7 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 
 	p.ensureConfigDefaults()
 
-	p.monitor = NewMonitor(p)
+	p.monitors = NewMonitors(p)
 
 	numCPU, err := utils.NumCPU()
 	if err != nil {

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -1389,8 +1389,10 @@ func (p *Probe) applyDefaultFilterPolicies() {
 
 // ApplyRuleSet setup the probes for the provided set of rules and returns the policy report.
 func (p *Probe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetReport, error) {
-	if err := p.monitors.syscallsMonitor.Disable(); err != nil {
-		return nil, err
+	if p.Opts.SyscallsMonitorEnabled {
+		if err := p.monitors.syscallsMonitor.Disable(); err != nil {
+			return nil, err
+		}
 	}
 
 	ars, err := kfilters.NewApplyRuleSetReport(p.Config.Probe, rs)
@@ -1411,11 +1413,13 @@ func (p *Probe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetReport, e
 		return nil, fmt.Errorf("failed to select probes: %w", err)
 	}
 
-	if err := p.monitors.syscallsMonitor.Flush(); err != nil {
-		return nil, err
-	}
-	if err := p.monitors.syscallsMonitor.Enable(); err != nil {
-		return nil, err
+	if p.Opts.SyscallsMonitorEnabled {
+		if err := p.monitors.syscallsMonitor.Flush(); err != nil {
+			return nil, err
+		}
+		if err := p.monitors.syscallsMonitor.Enable(); err != nil {
+			return nil, err
+		}
 	}
 
 	return ars, nil

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Monitor regroups all the work we want to do to monitor the probes we pushed in the kernel
-type Monitor struct {
+type Monitors struct {
 	probe *Probe
 
 	eventStreamMonitor *eventstream.Monitor
@@ -36,15 +36,15 @@ type Monitor struct {
 	syscallsMonitor    *syscalls.Monitor
 }
 
-// NewMonitor returns a new instance of a ProbeMonitor
-func NewMonitor(p *Probe) *Monitor {
-	return &Monitor{
+// NewMonitors returns a new instance of a ProbeMonitor
+func NewMonitors(p *Probe) *Monitors {
+	return &Monitors{
 		probe: p,
 	}
 }
 
 // Init initializes the monitor
-func (m *Monitor) Init() error {
+func (m *Monitors) Init() error {
 	var err error
 	p := m.probe
 
@@ -80,12 +80,12 @@ func (m *Monitor) Init() error {
 }
 
 // GetEventStreamMonitor returns the perf buffer monitor
-func (m *Monitor) GetEventStreamMonitor() *eventstream.Monitor {
+func (m *Monitors) GetEventStreamMonitor() *eventstream.Monitor {
 	return m.eventStreamMonitor
 }
 
 // SendStats sends statistics about the probe to Datadog
-func (m *Monitor) SendStats() error {
+func (m *Monitors) SendStats() error {
 	// delay between two send in order to reduce the statsd pool presure
 	const delay = time.Second
 	time.Sleep(delay)
@@ -150,7 +150,7 @@ func (m *Monitor) SendStats() error {
 }
 
 // ProcessEvent processes an event through the various monitors and controllers of the probe
-func (m *Monitor) ProcessEvent(event *model.Event) {
+func (m *Monitors) ProcessEvent(event *model.Event) {
 	if !m.probe.Config.RuntimeSecurity.InternalMonitoringEnabled {
 		return
 	}

--- a/pkg/security/secl/model/consts_map_names.go
+++ b/pkg/security/secl/model/consts_map_names.go
@@ -69,6 +69,7 @@ var bpfMapNames = []string{
 	"syscall_table",
 	"syscalls",
 	"syscalls_stats",
+	"syscalls_stats_",
 	"tasks_in_coredu",
 	"tgid_fd_map_id",
 	"tgid_fd_prog_id",

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -1172,11 +1172,11 @@ func GetStatusMetrics(probe *sprobe.Probe) string {
 	if probe == nil {
 		return ""
 	}
-	monitor := probe.GetMonitor()
-	if monitor == nil {
+	monitors := probe.GetMonitors()
+	if monitors == nil {
 		return ""
 	}
-	eventStreamMonitor := monitor.GetEventStreamMonitor()
+	eventStreamMonitor := monitors.GetEventStreamMonitor()
 	if eventStreamMonitor == nil {
 		return ""
 	}

--- a/pkg/security/tests/stress_test.go
+++ b/pkg/security/tests/stress_test.go
@@ -53,7 +53,7 @@ func stressOpen(t *testing.T, rule *rules.RuleDefinition, pathname string, size 
 		t.Fatal(err)
 	}
 
-	eventStreamMonitor := test.probe.GetMonitor().GetEventStreamMonitor()
+	eventStreamMonitor := test.probe.GetMonitors().GetEventStreamMonitor()
 	eventStreamMonitor.GetAndResetLostCount("events", -1)
 	eventStreamMonitor.GetKernelLostCount("events", -1, model.MaxKernelEventType)
 
@@ -195,7 +195,7 @@ func stressExec(t *testing.T, rule *rules.RuleDefinition, pathname string, execu
 		t.Fatal(err)
 	}
 
-	eventStreamMonitor := test.probe.GetMonitor().GetEventStreamMonitor()
+	eventStreamMonitor := test.probe.GetMonitors().GetEventStreamMonitor()
 	eventStreamMonitor.GetAndResetLostCount("events", -1)
 	eventStreamMonitor.GetKernelLostCount("events", -1, model.MaxKernelEventType)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Start counting the syscall once all the kprobes and kretprobes are inserted. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Check the inflight section in the dashboard

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
