### PR TITLE
[CWS][SEC-11042] Fix tc probes not being properly detached from interfaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.49.0-rc.1
 	github.com/DataDog/datadog-go/v5 v5.3.0
 	github.com/DataDog/datadog-operator v1.1.0
-	github.com/DataDog/ebpf-manager v0.3.1
+	github.com/DataDog/ebpf-manager v0.3.2-0.20231009174713-97fec664b3f4
 	github.com/DataDog/go-libddwaf v1.5.0
 	github.com/DataDog/go-tuf v1.0.2-0.5.2
 	github.com/DataDog/gopsutil v1.2.2

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.49.0-rc.1
 	github.com/DataDog/datadog-go/v5 v5.3.0
 	github.com/DataDog/datadog-operator v1.1.0
-	github.com/DataDog/ebpf-manager v0.3.2-0.20231009174713-97fec664b3f4
+	github.com/DataDog/ebpf-manager v0.3.2
 	github.com/DataDog/go-libddwaf v1.5.0
 	github.com/DataDog/go-tuf v1.0.2-0.5.2
 	github.com/DataDog/gopsutil v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/DataDog/datadog-go/v5 v5.3.0 h1:2q2qjFOb3RwAZNU+ez27ZVDwErJv5/VpbBPpr
 github.com/DataDog/datadog-go/v5 v5.3.0/go.mod h1:XRDJk1pTc00gm+ZDiBKsjh7oOOtJfYfglVCmFb8C2+Q=
 github.com/DataDog/datadog-operator v1.1.0 h1:cSZqKarzM66GR0T1pPPZVopz4oPm3ltcRyqJ/h/6eJg=
 github.com/DataDog/datadog-operator v1.1.0/go.mod h1:3aWOjI4EaE1jYVN6llOXygA9nasy70GCa1XnTIWNoCY=
-github.com/DataDog/ebpf-manager v0.3.1 h1:TfnK+ywLD8el4R9kUZxUKRgXnp4LCOt69BvY+xMA5Q8=
-github.com/DataDog/ebpf-manager v0.3.1/go.mod h1:K3nsU+9vdzpTCck3gdaUfKrA5Z2FoFrbrjXybwxQRLY=
+github.com/DataDog/ebpf-manager v0.3.2-0.20231009174713-97fec664b3f4 h1:0kGFbK7KVgDONfVltvB9+iZuOpxkA4QWUaER1uAJ/sU=
+github.com/DataDog/ebpf-manager v0.3.2-0.20231009174713-97fec664b3f4/go.mod h1:K3nsU+9vdzpTCck3gdaUfKrA5Z2FoFrbrjXybwxQRLY=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2 h1:uTE/QEU0oYtHnebKSMbxap7XMG5603WQxNP/UX63E7k=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2/go.mod h1:JgKVGTsjdTdtJjNyxRZjcs81/rng6LJ3XX/0D7Y12Gc=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe h1:RO40ywnX/vZLi4Pb4jRuFGgQQBYGIIoQ6u+P2MIgFOA=

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/DataDog/datadog-go/v5 v5.3.0 h1:2q2qjFOb3RwAZNU+ez27ZVDwErJv5/VpbBPpr
 github.com/DataDog/datadog-go/v5 v5.3.0/go.mod h1:XRDJk1pTc00gm+ZDiBKsjh7oOOtJfYfglVCmFb8C2+Q=
 github.com/DataDog/datadog-operator v1.1.0 h1:cSZqKarzM66GR0T1pPPZVopz4oPm3ltcRyqJ/h/6eJg=
 github.com/DataDog/datadog-operator v1.1.0/go.mod h1:3aWOjI4EaE1jYVN6llOXygA9nasy70GCa1XnTIWNoCY=
-github.com/DataDog/ebpf-manager v0.3.2-0.20231009174713-97fec664b3f4 h1:0kGFbK7KVgDONfVltvB9+iZuOpxkA4QWUaER1uAJ/sU=
-github.com/DataDog/ebpf-manager v0.3.2-0.20231009174713-97fec664b3f4/go.mod h1:K3nsU+9vdzpTCck3gdaUfKrA5Z2FoFrbrjXybwxQRLY=
+github.com/DataDog/ebpf-manager v0.3.2 h1:qeeFyHnhm+O9HByexHuQdyTsoqNmH8nYxYzt9E1yADA=
+github.com/DataDog/ebpf-manager v0.3.2/go.mod h1:K3nsU+9vdzpTCck3gdaUfKrA5Z2FoFrbrjXybwxQRLY=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2 h1:uTE/QEU0oYtHnebKSMbxap7XMG5603WQxNP/UX63E7k=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2/go.mod h1:JgKVGTsjdTdtJjNyxRZjcs81/rng6LJ3XX/0D7Y12Gc=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe h1:RO40ywnX/vZLi4Pb4jRuFGgQQBYGIIoQ6u+P2MIgFOA=

--- a/pkg/security/resolvers/netns/resolver.go
+++ b/pkg/security/resolvers/netns/resolver.go
@@ -39,10 +39,10 @@ var (
 	// namespace yet.
 	ErrNoNetworkNamespaceHandle = fmt.Errorf("no network namespace handle")
 
-	// lonelyTimeout is the timeout past which a lonely network namespace is expired
-	lonelyTimeout = 30 * time.Second
-	// flushNamespacesPeriod is the period at which the resolver checks if a namespace should be flushed
-	flushNamespacesPeriod = 30 * time.Second
+	// defaultLonelyTimeout is the timeout past which a lonely network namespace is expired
+	defaultLonelyTimeout = 30 * time.Second
+	// FlushNamespacesPeriod is the period at which the resolver checks if a namespace should be flushed
+	FlushNamespacesPeriod = 30 * time.Second
 )
 
 // NetworkNamespace is used to hold a handle to a network namespace
@@ -401,7 +401,7 @@ func (nr *Resolver) Start(ctx context.Context) error {
 }
 
 func (nr *Resolver) flushNamespaces(ctx context.Context) {
-	ticker := time.NewTicker(flushNamespacesPeriod)
+	ticker := time.NewTicker(FlushNamespacesPeriod)
 	defer ticker.Stop()
 
 	for {
@@ -416,7 +416,7 @@ func (nr *Resolver) flushNamespaces(ctx context.Context) {
 			// To detect this race, compute the list of namespaces that are in cache, but for which we do not have any
 			// device. Defer a snapshot process for each of those namespaces, and delete them if the snapshot yields
 			// no new device.
-			nr.preventNetworkNamespaceDrift(probesCount)
+			nr.PreventNetworkNamespaceDrift(probesCount, defaultLonelyTimeout)
 		}
 	}
 }
@@ -461,8 +461,8 @@ func (nr *Resolver) flushNetworkNamespace(netns *NetworkNamespace) {
 	_ = nr.manager.CleanupNetworkNamespace(netns.nsID)
 }
 
-// preventNetworkNamespaceDrift ensures that we do not keep network namespace handles indefinitely
-func (nr *Resolver) preventNetworkNamespaceDrift(probesCount map[uint32]int) {
+// PreventNetworkNamespaceDrift ensures that we do not keep network namespace handles indefinitely
+func (nr *Resolver) PreventNetworkNamespaceDrift(probesCount map[uint32]int, lonelyTimeout time.Duration) {
 	nr.Lock()
 	defer nr.Unlock()
 

--- a/pkg/security/tests/network_device_test.go
+++ b/pkg/security/tests/network_device_test.go
@@ -12,14 +12,19 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
+	netnsresolver "github.com/DataDog/datadog-agent/pkg/security/resolvers/netns"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
@@ -132,4 +137,151 @@ func TestNetDevice(t *testing.T) {
 			t.Error(err)
 		}
 	})
+}
+
+func TestTCFilters(t *testing.T) {
+	checkKernelCompatibility(t, "RHEL, SLES and Oracle kernels", func(kv *kernel.Version) bool {
+		// TODO: Oracle because we are missing offsets
+		return kv.IsRH7Kernel() || kv.IsOracleUEKKernel() || kv.IsSLESKernel()
+	})
+
+	// dummy rule to force the activation of netdev-related probes
+	rule := &rules.RuleDefinition{
+		ID:         "test_rule",
+		Expression: `dns.question.type == A`,
+	}
+
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var testModuleCleanedUp bool
+	defer func() {
+		if !testModuleCleanedUp {
+			test.Close()
+		}
+	}()
+
+	syscallTester, err := loadSyscallTester(t, test, "syscall_tester")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sleepExecutable := which(t, "sleep")
+
+	var newNetNSSleep *exec.Cmd
+	defer func() {
+		if newNetNSSleep != nil && newNetNSSleep.Process != nil {
+			_ = newNetNSSleep.Process.Kill()
+		}
+	}()
+
+	t.Run("attach_detach_filters", func(t *testing.T) {
+		newNetNSSleep = exec.Command(syscallTester, "new_netns_exec", sleepExecutable, "600")
+		err := newNetNSSleep.Start()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		sleepProcPid := uint32(newNetNSSleep.Process.Pid)
+		if sleepProcPid == 0 {
+			t.Fatal("pid of the sleep command is zero")
+		}
+
+		netNs := utils.NetNSPathFromPid(sleepProcPid)
+		time.Sleep(3 * time.Second) // wait a bit for the tc probes to be attach to the new interface
+		ingressExists, egressExists, err := tcFiltersExist(netNs, "lo", "classifier_ingress", "classifier_egress")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !ingressExists {
+			t.Error("Ingress tc classifier does not exist")
+		}
+		if !egressExists {
+			t.Fatalf("Egress tc classifier does not exist")
+		}
+
+		lonelyTimeoutDuration := 1 * time.Second
+		// force a first NetworkNamespaceDrift check to set the timeout for the newly created interface,
+		// basically mimicking what resolver.flushNamespaces() is doing
+		resolver := test.probe.GetResolvers().NamespaceResolver
+		probesCount := test.probe.GetResolvers().TCResolver.FlushInactiveProbes(test.probe.Manager, resolver.IsLazyDeletionInterface)
+		resolver.PreventNetworkNamespaceDrift(probesCount, lonelyTimeoutDuration)
+
+		// wait for the netns resolver go routine to perform the second NetworkNamespaceDrift check that will trigger the eviction of the lonely interface probes
+		sleepDuration := netnsresolver.FlushNamespacesPeriod + lonelyTimeoutDuration + 1*time.Second
+		t.Logf("Waiting %s for the NetworkNamespaceDrift netns resolver timeout to fire", sleepDuration.String())
+		time.Sleep(sleepDuration)
+
+		test.Close()
+		test.cleanup()
+		testModuleCleanedUp = true
+
+		ingressExists, egressExists, err = tcFiltersExist(netNs, "lo", "classifier_ingress", "classifier_egress")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if ingressExists {
+			t.Error("Ingress tc classifier wasn't properly detached")
+		}
+
+		if egressExists {
+			t.Fatal("Egress tc classifier wasn't properly detached")
+		}
+	})
+}
+
+func tcFiltersExist(netNs *utils.NetNSPath, linkName string, ingressFilterNamePrefix, egressFilterNamePrefix string) (ingressExists bool, egressExists bool, err error) {
+	netNsFile, err := os.Open(netNs.GetPath())
+	if err != nil {
+		return
+	}
+	defer netNsFile.Close()
+
+	netlinkHandle, err := netlink.NewHandleAt(netns.NsHandle(int(netNsFile.Fd())), unix.NETLINK_ROUTE)
+	if err != nil {
+		return
+	}
+
+	link, err := netlinkHandle.LinkByName(linkName)
+	if err != nil {
+		return
+	}
+
+	bpfFilterExists := func(parentHandle uint32, expectedFilterNamePrefix string) (bool, error) {
+		filters, err := netlinkHandle.FilterList(link, parentHandle)
+		if err != nil {
+			return false, err
+		}
+
+		var found bool
+		bpfType := (&netlink.BpfFilter{}).Type()
+		for _, elem := range filters {
+			if elem.Type() != bpfType {
+				continue
+			}
+
+			bpfFilter, ok := elem.(*netlink.BpfFilter)
+			if !ok {
+				continue
+			}
+
+			if strings.HasPrefix(bpfFilter.Name, expectedFilterNamePrefix) {
+				found = true
+				break
+			}
+		}
+		return found, nil
+	}
+
+	ingressExists, err = bpfFilterExists(netlink.HANDLE_MIN_INGRESS, ingressFilterNamePrefix)
+	if err != nil {
+		return
+	}
+
+	egressExists, err = bpfFilterExists(netlink.HANDLE_MIN_EGRESS, egressFilterNamePrefix)
+	return
 }

--- a/pkg/security/tests/network_device_test.go
+++ b/pkg/security/tests/network_device_test.go
@@ -217,6 +217,7 @@ func TestTCFilters(t *testing.T) {
 
 		test.Close()
 		test.cleanup()
+		testMod = nil // force a full testModule reinitialization
 		testModuleCleanedUp = true
 
 		ingressExists, egressExists, err = tcFiltersExist(netNs, "lo", "classifier_ingress", "classifier_egress")

--- a/pkg/security/tests/network_device_test.go
+++ b/pkg/security/tests/network_device_test.go
@@ -251,6 +251,7 @@ func tcFiltersExist(netNs *utils.NetNSPath, linkName string, ingressFilterNamePr
 	if err != nil {
 		return
 	}
+	defer netlinkHandle.Close()
 
 	link, err := netlinkHandle.LinkByName(linkName)
 	if err != nil {

--- a/pkg/security/tests/network_device_test.go
+++ b/pkg/security/tests/network_device_test.go
@@ -145,6 +145,11 @@ func TestTCFilters(t *testing.T) {
 		return kv.IsRH7Kernel() || kv.IsOracleUEKKernel() || kv.IsSLESKernel()
 	})
 
+	// skip the test to avoid nested namespaces issues
+	if testEnvironment == DockerEnvironment {
+		t.Skip("skipping tc filters test in docker")
+	}
+
 	// dummy rule to force the activation of netdev-related probes
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -640,6 +640,22 @@ int test_memfd_create(int argc, char **argv) {
     return EXIT_SUCCESS;
 }
 
+int test_new_netns_exec(int argc, char **argv) {
+    if (argc < 2) {
+        fprintf(stderr, "Please specify at least an executable path\n");
+        return EXIT_FAILURE;
+    }
+
+    if (unshare(CLONE_NEWNET)) {
+        perror("unshare");
+        return EXIT_FAILURE;
+    }
+
+    execv(argv[1], argv + 1);
+    fprintf(stderr, "execv failed: %s\n", argv[1]);
+    return EXIT_FAILURE;
+}
+
 int main(int argc, char **argv) {
     if (argc <= 1) {
         fprintf(stderr, "Please pass a command\n");
@@ -707,6 +723,8 @@ int main(int argc, char **argv) {
             exit_code = test_sleep(sub_argc, sub_argv);
         } else if (strcmp(cmd, "fileless") == 0) {
             exit_code = test_memfd_create(sub_argc, sub_argv);
+        } else if (strcmp(cmd, "new_netns_exec") == 0) {
+            exit_code = test_new_netns_exec(sub_argc, sub_argv);
         } else {
             fprintf(stderr, "Unknown command `%s`\n", cmd);
             exit_code = EXIT_FAILURE;


### PR DESCRIPTION
This PR adds a test to make sure that tc eBPF programs are properly detached when system-probe is stopped.
It also updates the ebpf-manager dependency to include [the relevant fix](https://github.com/DataDog/ebpf-manager/pull/154).


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
