### PR TITLE
[NPM-3010] avoid potential flakes in TestConntrackExists

### DIFF
--- a/pkg/network/testutil/ping.go
+++ b/pkg/network/testutil/ping.go
@@ -65,6 +65,11 @@ func PingUDP(tb require.TestingT, ip net.IP, port int) net.Conn {
 		return nil
 	}
 
+	bs := make([]byte, 10)
+	n, err := conn.Read(bs)
+	require.NoError(tb, err)
+	require.Equal(tb, []byte("pong"), bs[:n])
+
 	return conn
 }
 

--- a/pkg/network/testutil/server.go
+++ b/pkg/network/testutil/server.go
@@ -110,14 +110,19 @@ func StartServerUDP(t *testing.T, ip net.IP, port int) io.Closer {
 		Port: port,
 	}
 
-	l, err := net.ListenUDP(network, addr)
+	udpConn, err := net.ListenUDP(network, addr)
 	require.NoError(t, err)
 	go func() {
 		close(ch)
 
 		for {
 			bs := make([]byte, 10)
-			_, err := l.Read(bs)
+			_, addr, err := udpConn.ReadFrom(bs)
+			if err != nil {
+				return
+			}
+
+			_, err = udpConn.WriteTo([]byte("pong"), addr)
 			if err != nil {
 				return
 			}
@@ -132,5 +137,5 @@ func StartServerUDP(t *testing.T, ip net.IP, port int) io.Closer {
 		}
 	}, 3*time.Second, 10*time.Millisecond, "timed out waiting for UDP server to come up")
 
-	return l
+	return udpConn
 }


### PR DESCRIPTION
### What does this PR do?

We saw a spike in failures for TestConntrackExists in which conntrack.Exists() returned false for UDP connections.

My guess is this is because the UDP connections didn't make it all the way through the kernel before checking if the connection exists.

This PR aims to solve the problem by having PingUDP wait for a response from the test UDP server to ensure the conntrack entry is initialized.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
