### PR TITLE
Bind system probe and security agent configs to env

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1187,8 +1187,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("security_agent.internal_profiling.block_profile_rate", 0)
 	config.BindEnvAndSetDefault("security_agent.internal_profiling.enable_goroutine_stacktraces", false)
 	config.BindEnvAndSetDefault("security_agent.internal_profiling.delta_profiles", true)
-	config.BindEnvAndSetDefault("security_agent.internal_profiling.unix_socket", "")
-	config.BindEnvAndSetDefault("security_agent.internal_profiling.extra_tags", []string{})
+	config.BindEnvAndSetDefault("security_agent.internal_profiling.unix_socket", "", "DD_SECURITY_AGENT_INTERNAL_PROFILING_UNIX_SOCKET")
+	config.BindEnvAndSetDefault("security_agent.internal_profiling.extra_tags", []string{}, "DD_SECURITY_AGENT_INTERNAL_PROFILING_EXTRA_TAGS")
 
 	// Datadog security agent (compliance)
 	config.BindEnvAndSetDefault("compliance_config.enabled", false)

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -123,8 +123,8 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.enable_goroutine_stacktraces"), false)
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.delta_profiles"), true)
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.custom_attributes"), []string{"module"})
-	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.unix_socket"), "")
-	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.extra_tags"), []string{})
+	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.unix_socket"), "", "DD_SYSTEM_PROBE_INTERNAL_PROFILING_UNIX_SOCKET")
+	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.extra_tags"), []string{}, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_EXTRA_TAGS")
 
 	cfg.BindEnvAndSetDefault(join(spNS, "memory_controller.enabled"), false)
 	cfg.BindEnvAndSetDefault(join(spNS, "memory_controller.hierarchy"), "v1")


### PR DESCRIPTION
### What does this PR do?

Binds internal profiling configs to environment variables.

### Motivation

This enables profiling in the SMP environment.

Ref: https://github.com/DataDog/datadog-agent/pull/19453