### PR TITLE
usm: Do not allocate buffers for unused response bodies

### DIFF
--- a/pkg/network/protocols/tls/gotls/testutil/gotls_client/gotls_client.go
+++ b/pkg/network/protocols/tls/gotls/testutil/gotls_client/gotls_client.go
@@ -54,7 +54,7 @@ func main() {
 			log.Fatalf("could not do HTTPS request: %s", err)
 		}
 
-		_, err = io.ReadAll(resp.Body)
+		_, err = io.Copy(io.Discard, resp.Body)
 		if err != nil {
 			log.Fatalf("could not read response body: %s", err)
 		}

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -1691,7 +1691,7 @@ func testEdgeCasesProtocolClassification(t *testing.T, tr *Tracer, clientHost, t
 				require.NoError(t, err)
 				defer c.Close()
 				c.Write([]byte("hello\n"))
-				io.ReadAll(c)
+				io.Copy(io.Discard, c)
 			},
 			teardown:   teardown,
 			validation: validateProtocolConnection(&protocols.Stack{}),
@@ -1726,10 +1726,10 @@ func testEdgeCasesProtocolClassification(t *testing.T, tr *Tracer, clientHost, t
 				require.NoError(t, err)
 				defer c.Close()
 				c.Write([]byte("GET /200/foobar HTTP/1.1\n"))
-				io.ReadAll(c)
+				io.Copy(io.Discard, c)
 				// http2 prefix.
 				c.Write([]byte("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"))
-				io.ReadAll(c)
+				io.Copy(io.Discard, c)
 			},
 			teardown:   teardown,
 			validation: validateProtocolConnection(&protocols.Stack{Application: protocols.HTTP}),

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -575,7 +575,7 @@ func simpleGetRequestsGenerator(t *testing.T, targetAddr string) (*nethttp.Clien
 		resp, err := client.Do(req)
 		require.NoError(t, err)
 		require.Equal(t, status, resp.StatusCode)
-		io.ReadAll(resp.Body)
+		io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
 		return req
 	}

--- a/pkg/network/usm/kafka_monitor_test.go
+++ b/pkg/network/usm/kafka_monitor_test.go
@@ -299,7 +299,7 @@ func testKafkaProtocolParsing(t *testing.T) {
 					resp, err := httpClient.Do(req)
 					require.NoError(t, err)
 					// Have to read the response body to ensure the client will be able to properly close the connection.
-					io.ReadAll(resp.Body)
+					io.Copy(io.Discard, resp.Body)
 					resp.Body.Close()
 				}
 				srvDoneFn()

--- a/pkg/network/usm/monitor_test.go
+++ b/pkg/network/usm/monitor_test.go
@@ -130,7 +130,7 @@ func (s *HTTPTestSuite) TestHTTPMonitorCaptureRequestMultipleTimes() {
 				resp, err := client.Do(req)
 				require.NoError(t, err)
 				// Have to read the response body to ensure the client will be able to properly close the connection.
-				io.ReadAll(resp.Body)
+				io.Copy(io.Discard, resp.Body)
 				resp.Body.Close()
 			}
 			srvDoneFn()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Dropping unused response bodies in test.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

io.ReadAll performs redundant allocations, which we can spare in tests.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
