### PR TITLE
[USMON-581] usm: tests: Fix flakyness, and cut test time by 50s

### DIFF
--- a/pkg/network/usm/kafka_monitor_test.go
+++ b/pkg/network/usm/kafka_monitor_test.go
@@ -11,10 +11,10 @@ import (
 	"context"
 	"fmt"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
+	"github.com/stretchr/testify/suite"
 	"io"
 	"net"
 	nethttp "net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -77,24 +77,32 @@ func skipTestIfKernelNotSupported(t *testing.T) {
 	}
 }
 
-func TestKafkaProtocolParsing(t *testing.T) {
-	ebpftest.TestBuildModes(t, []ebpftest.BuildMode{ebpftest.Prebuilt, ebpftest.RuntimeCompiled, ebpftest.CORE}, "", testKafkaProtocolParsing)
+type KafkaProtocolParsingSuite struct {
+	suite.Suite
+	testIndex int
 }
 
-func testKafkaProtocolParsing(t *testing.T) {
+func (s *KafkaProtocolParsingSuite) getTopicName() string {
+	s.testIndex++
+	return fmt.Sprintf("%s-%d", "franz-kafka", s.testIndex)
+}
+
+func TestKafkaProtocolParsing(t *testing.T) {
 	skipTestIfKernelNotSupported(t)
+	serverHost := "127.0.0.1"
+	require.NoError(t, kafka.RunServer(t, serverHost, kafkaPort))
+
+	ebpftest.TestBuildModes(t, []ebpftest.BuildMode{ebpftest.Prebuilt, ebpftest.RuntimeCompiled, ebpftest.CORE}, "", func(t *testing.T) {
+		suite.Run(t, new(KafkaProtocolParsingSuite))
+	})
+}
+
+func (s *KafkaProtocolParsingSuite) TestKafkaProtocolParsing() {
+	t := s.T()
 
 	clientHost := "localhost"
 	targetHost := "127.0.0.1"
 	serverHost := "127.0.0.1"
-
-	testIndex := 0
-	// Kafka does not allow us to delete topic, but to mark them for deletion, so we have to generate a unique topic
-	// per a test.
-	getTopicName := func() string {
-		testIndex++
-		return fmt.Sprintf("%s-%d", "franz-kafka", testIndex)
-	}
 
 	kafkaTeardown := func(t *testing.T, ctx testContext) {
 		if _, ok := ctx.extras["client"]; !ok {
@@ -102,17 +110,11 @@ func testKafkaProtocolParsing(t *testing.T) {
 		}
 		if client, ok := ctx.extras["client"].(*kafka.Client); ok {
 			defer client.Client.Close()
-			for k, value := range ctx.extras {
-				if strings.HasPrefix(k, "topic_name") {
-					_ = client.DeleteTopic(value.(string))
-				}
-			}
 		}
 	}
 
 	serverAddress := net.JoinHostPort(serverHost, kafkaPort)
 	targetAddress := net.JoinHostPort(targetHost, kafkaPort)
-	require.NoError(t, kafka.RunServer(t, serverHost, kafkaPort))
 
 	defaultDialer := &net.Dialer{
 		LocalAddr: &net.TCPAddr{
@@ -128,7 +130,7 @@ func testKafkaProtocolParsing(t *testing.T) {
 				targetAddress: targetAddress,
 				serverAddress: serverAddress,
 				extras: map[string]interface{}{
-					"topic_name": getTopicName(),
+					"topic_name": s.getTopicName(),
 				},
 			},
 			testBody: func(t *testing.T, ctx testContext, monitor *Monitor) {
@@ -178,7 +180,7 @@ func testKafkaProtocolParsing(t *testing.T) {
 				targetAddress: targetAddress,
 				serverAddress: serverAddress,
 				extras: map[string]interface{}{
-					"topic_name": getTopicName(),
+					"topic_name": s.getTopicName(),
 				},
 			},
 			testBody: func(t *testing.T, ctx testContext, monitor *Monitor) {
@@ -220,7 +222,7 @@ func testKafkaProtocolParsing(t *testing.T) {
 				targetAddress: targetAddress,
 				serverAddress: serverAddress,
 				extras: map[string]interface{}{
-					"topic_name": getTopicName(),
+					"topic_name": s.getTopicName(),
 				},
 			},
 			testBody: func(t *testing.T, ctx testContext, monitor *Monitor) {
@@ -264,7 +266,7 @@ func testKafkaProtocolParsing(t *testing.T) {
 				targetAddress: targetAddress,
 				serverAddress: serverAddress,
 				extras: map[string]interface{}{
-					"topic_name": getTopicName(),
+					"topic_name": s.getTopicName(),
 				},
 			},
 			testBody: func(t *testing.T, ctx testContext, monitor *Monitor) {
@@ -359,7 +361,7 @@ func testKafkaProtocolParsing(t *testing.T) {
 				targetAddress: targetAddress,
 				serverAddress: serverAddress,
 				extras: map[string]interface{}{
-					"topic_name": getTopicName(),
+					"topic_name": s.getTopicName(),
 				},
 			},
 			testBody: func(t *testing.T, ctx testContext, monitor *Monitor) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Cuts 50s from kafka parsing tests 
- By not deleting the topic name in the end of the test (the topic name is unique per test, deleting it does not give us any benefit.)
- By creating the server only once.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Kitchen test time and reliability.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
