### PR TITLE
Making the write of the logs registry file more atomic (#19766)

### DIFF
--- a/releasenotes/notes/atomic-registry-write-761c66a9ab323803.yaml
+++ b/releasenotes/notes/atomic-registry-write-761c66a9ab323803.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On some slow drives, when the Agent shuts down suddenly the Logs Agent registry file can become corrupt.
+    This means that when the Agent starts again the registry file can't be read and therefore the Logs Agent reads logs from the beginning again.
+    With this update, the Agent now attempts to update the registry file atomically to reduce the chances of a corrupted file.


### PR DESCRIPTION
### What does this PR do?

This PR updates the way the auditor for the Logs Agent writes the registry file. It is now updated in an atomic way.

### Motivation

If the Logs Agent is tailing several sources and is suddenly shutdown (i.e. the process is killed or the system goes down quickly) then the registry file can be left in a corrupt state (see Golang doc notes [here](https://pkg.go.dev/os#WriteFile)).  

### Additional Notes

The operation could be made more atomic by adding a calling [Sync](https://pkg.go.dev/os#File.Sync) on the file but this increases the operation time. This should only be an issue when a host is turned off suddenly (such as losing power).

### Possible Drawbacks / Trade-offs

Increased disk IO but it should not be noticeable.

### Describe how to test/QA your changes

- Spin up the Agent on Linux *AND* Windows and then tail several log sources.
- Find the Agent process and SIGKILL it.
- Check the registry file is still valid JSON.
- Repeat the process a few more times as the registry file only written every second till you see a `registry.json.tmp.<random chars>` file can be found where the registry lives.
- Once you find a tmp file, check the main registry file is still valid JSON.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
