### PR TITLE
[clcrunnerapi] Return check IDs known by the DCA when config contains secrets

### DIFF
--- a/cmd/agent/subcommands/run/internal/clcrunnerapi/v1/clcrunner.go
+++ b/cmd/agent/subcommands/run/internal/clcrunnerapi/v1/clcrunner.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -46,10 +47,11 @@ func getCLCRunnerStats(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, string(body), 500)
 		return
 	}
-	s := flattenCLCStats(stats)
-	jsonStats, err := json.Marshal(s)
+	flattenedStats := flattenCLCStats(stats)
+	statsWithIDsKnownByDCA := replaceIDsWithIDsKnownByDCA(flattenedStats)
+	jsonStats, err := json.Marshal(statsWithIDsKnownByDCA)
 	if err != nil {
-		log.Errorf("Error marshalling stats. Error: %v, Stats: %v", err, s)
+		log.Errorf("Error marshalling stats. Error: %v, Stats: %v", err, statsWithIDsKnownByDCA)
 		body, _ := json.Marshal(map[string]string{"error": err.Error()})
 		http.Error(w, string(body), 500)
 		return
@@ -68,6 +70,29 @@ func flattenCLCStats(stats status.CLCChecks) map[string]status.CLCStats {
 	}
 
 	return flatened
+}
+
+// replaceIDsWithIDsKnownByDCA replaces the check IDs in the map received with
+// the ID that those checks had before decrypting their secrets. This is needed
+// because if the Cluster Agent does not decrypt secrets and the runner does,
+// the check ID seen by both of them is going to be different and the Cluster
+// Agent won't recognize the check as a cluster check.
+// The API defined in this file is only used by the Cluster Agent, so it makes
+// sense to use the IDs that it recognizes.
+func replaceIDsWithIDsKnownByDCA(stats map[string]status.CLCStats) map[string]status.CLCStats {
+	res := make(map[string]status.CLCStats, len(stats))
+
+	for checkID, checkStats := range stats {
+		originalID := common.AC.GetIDOfCheckWithEncryptedSecrets(checkid.ID(checkID))
+
+		if originalID != "" {
+			res[string(originalID)] = checkStats
+		} else {
+			res[checkID] = checkStats
+		}
+	}
+
+	return res
 }
 
 func getCLCRunnerWorkers(w http.ResponseWriter, r *http.Request) {

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/scheduler"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
@@ -254,7 +255,9 @@ func (ac *AutoConfig) processNewConfig(config integration.Config) integration.Co
 		}
 	}
 
-	return ac.cfgMgr.processNewConfig(config)
+	changes, changedIDsOfSecretsWithConfigs := ac.cfgMgr.processNewConfig(config)
+	ac.store.setIDsOfChecksWithSecrets(changedIDsOfSecretsWithConfigs)
+	return changes
 }
 
 // AddListeners tries to initialise the listeners listed in the given configs. A first
@@ -360,6 +363,7 @@ func (ac *AutoConfig) RemoveScheduler(name string) {
 func (ac *AutoConfig) processRemovedConfigs(configs []integration.Config) {
 	changes := ac.cfgMgr.processDelConfigs(configs)
 	ac.applyChanges(changes)
+	ac.deleteMappingsOfCheckIDsWithSecrets(changes.Unschedule)
 }
 
 // MapOverLoadedConfigs calls the given function with the map of all
@@ -397,6 +401,13 @@ func (ac *AutoConfig) LoadedConfigs() []integration.Config {
 // state.
 func (ac *AutoConfig) GetUnresolvedTemplates() map[string][]integration.Config {
 	return ac.store.templateCache.getUnresolvedTemplates()
+}
+
+// GetIDOfCheckWithEncryptedSecrets returns the ID that a checkID had before
+// decrypting its secrets.
+// Returns empty if the check with the given ID does not have any secrets.
+func (ac *AutoConfig) GetIDOfCheckWithEncryptedSecrets(checkID checkid.ID) checkid.ID {
+	return ac.store.getIDOfCheckWithEncryptedSecrets(checkID)
 }
 
 // processNewService takes a service, tries to match it against templates and
@@ -460,6 +471,18 @@ func (ac *AutoConfig) applyChanges(changes integration.ConfigChanges) {
 
 		ac.scheduler.Schedule(changes.Schedule)
 	}
+}
+
+func (ac *AutoConfig) deleteMappingsOfCheckIDsWithSecrets(configs []integration.Config) {
+	var checkIDsToDelete []checkid.ID
+	for _, configToDelete := range configs {
+		for _, instance := range configToDelete.Instances {
+			checkID := checkid.BuildID(configToDelete.Name, configToDelete.FastDigest(), instance, configToDelete.InitConfig)
+			checkIDsToDelete = append(checkIDsToDelete, checkID)
+		}
+	}
+
+	ac.store.deleteMappingsOfCheckIDsWithSecrets(checkIDsToDelete)
 }
 
 // getConfigPollers gets a slice of config pollers that can be used without holding

--- a/pkg/autodiscovery/configmgr_test.go
+++ b/pkg/autodiscovery/configmgr_test.go
@@ -13,11 +13,14 @@ import (
 	"testing"
 
 	"github.com/mohae/deepcopy"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	"github.com/DataDog/datadog-agent/pkg/util/testutil"
 )
 
@@ -99,10 +102,15 @@ func matchSvc(serviceID string) func(integration.Config) bool {
 }
 
 var (
-	nonTemplateConfig            = integration.Config{Name: "non-template"}
-	nonTemplateConfigWithSecrets = integration.Config{Name: "non-template-with-secrets", Instances: []integration.Data{integration.Data("foo: ENC[bar]")}}
-	templateConfig               = integration.Config{Name: "template", LogsConfig: []byte("source: %%host%%"), ADIdentifiers: []string{"my-service"}}
-	myService                    = &dummyService{ID: "my-service", ADIdentifiers: []string{"my-service"}, Hosts: map[string]string{"main": "myhost"}}
+	nonTemplateConfig             = integration.Config{Name: "non-template"}
+	nonTemplateConfigWithSecrets  = integration.Config{Name: "non-template-with-secrets", Instances: []integration.Data{integration.Data("foo: ENC[bar]")}}
+	clusterCheckConfigWithSecrets = integration.Config{
+		Provider:  names.ClusterChecks,
+		Name:      "non-template-with-secrets-cluster-check",
+		Instances: []integration.Data{integration.Data("foo: ENC[bar]")},
+	}
+	templateConfig = integration.Config{Name: "template", LogsConfig: []byte("source: %%host%%"), ADIdentifiers: []string{"my-service"}}
+	myService      = &dummyService{ID: "my-service", ADIdentifiers: []string{"my-service"}, Hosts: map[string]string{"main": "myhost"}}
 )
 
 type ConfigManagerSuite struct {
@@ -118,7 +126,7 @@ func (suite *ConfigManagerSuite) SetupTest() {
 // A new, non-template config is scheduled immediately and unscheduled when
 // deleted
 func (suite *ConfigManagerSuite) TestNewNonTemplateScheduled() {
-	changes := suite.cm.processNewConfig(nonTemplateConfig)
+	changes, _ := suite.cm.processNewConfig(nonTemplateConfig)
 	assertConfigsMatch(suite.T(), changes.Schedule, matchName("non-template"))
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 
@@ -147,7 +155,10 @@ func (suite *ConfigManagerSuite) TestNewNonTemplateWithSecretsScheduled() {
 	defer mockDecrypt.install()()
 
 	inputNewConfig := deepcopy.Copy(nonTemplateConfigWithSecrets).(integration.Config)
-	changes := suite.cm.processNewConfig(inputNewConfig)
+	changes, changedIDs := suite.cm.processNewConfig(inputNewConfig)
+
+	assert.Empty(suite.T(), changedIDs) // Only returned if the config provider is cluster-checks.
+
 	assertConfigsMatch(suite.T(), changes.Schedule, matchName(nonTemplateConfigWithSecrets.Name))
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 	// Verify content is actually decoded
@@ -162,10 +173,59 @@ func (suite *ConfigManagerSuite) TestNewNonTemplateWithSecretsScheduled() {
 	require.True(suite.T(), strings.Contains(string(changes.Unschedule[0].Instances[0]), "barDecoded"))
 }
 
+func (suite *ConfigManagerSuite) TestNewClusterCheckWithSecretsScheduled() {
+	mockDecrypt := MockSecretDecrypt{suite.T(), []mockSecretScenario{
+		{
+			expectedData:   []byte("foo: ENC[bar]"),
+			expectedOrigin: clusterCheckConfigWithSecrets.Name,
+			returnedData:   []byte("foo: barDecoded"),
+			returnedError:  nil,
+		},
+		{
+			expectedData:   []byte{},
+			expectedOrigin: clusterCheckConfigWithSecrets.Name,
+			returnedData:   []byte{},
+			returnedError:  nil,
+		},
+	}}
+	defer mockDecrypt.install()()
+
+	inputNewConfig := deepcopy.Copy(clusterCheckConfigWithSecrets).(integration.Config)
+	changes, changedIDs := suite.cm.processNewConfig(inputNewConfig)
+
+	// Check that changedIDs contains the correct mapping of IDs
+	originalCheckID := checkid.BuildID(
+		clusterCheckConfigWithSecrets.Name,
+		clusterCheckConfigWithSecrets.FastDigest(),
+		clusterCheckConfigWithSecrets.Instances[0],
+		clusterCheckConfigWithSecrets.InitConfig,
+	)
+	newCheckID := checkid.BuildID(
+		changes.Schedule[0].Name,
+		changes.Schedule[0].FastDigest(),
+		changes.Schedule[0].Instances[0],
+		changes.Schedule[0].InitConfig,
+	)
+	assert.Equal(suite.T(), map[checkid.ID]checkid.ID{newCheckID: originalCheckID}, changedIDs)
+
+	assertConfigsMatch(suite.T(), changes.Schedule, matchName(clusterCheckConfigWithSecrets.Name))
+	assertConfigsMatch(suite.T(), changes.Unschedule)
+	// Verify content is actually decoded
+	require.True(suite.T(), strings.Contains(string(changes.Schedule[0].Instances[0]), "barDecoded"))
+	newConfigDigest := changes.Schedule[0].Digest()
+
+	inputDelConfig := deepcopy.Copy(clusterCheckConfigWithSecrets).(integration.Config)
+	changes = suite.cm.processDelConfigs([]integration.Config{inputDelConfig})
+	assertConfigsMatch(suite.T(), changes.Schedule)
+	assertConfigsMatch(suite.T(), changes.Unschedule, matchName(clusterCheckConfigWithSecrets.Name))
+	assertConfigsMatch(suite.T(), changes.Unschedule, matchDigest(newConfigDigest))
+	require.True(suite.T(), strings.Contains(string(changes.Unschedule[0].Instances[0]), "barDecoded"))
+}
+
 // A new template config is not scheduled when there is no matching service, and
 // not unscheduled when removed
 func (suite *ConfigManagerSuite) TestNewTemplateNotScheduled() {
-	changes := suite.cm.processNewConfig(templateConfig)
+	changes, _ := suite.cm.processNewConfig(templateConfig)
 	assertConfigsMatch(suite.T(), changes.Schedule)
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 
@@ -178,7 +238,7 @@ func (suite *ConfigManagerSuite) TestNewTemplateNotScheduled() {
 // is resolved and scheduled when such a service arrives; deleting the config
 // unschedules the resolved configs.
 func (suite *ConfigManagerSuite) TestNewTemplateBeforeService_ConfigRemovedFirst() {
-	changes := suite.cm.processNewConfig(templateConfig)
+	changes, _ := suite.cm.processNewConfig(templateConfig)
 	assertConfigsMatch(suite.T(), changes.Schedule)
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 
@@ -199,7 +259,7 @@ func (suite *ConfigManagerSuite) TestNewTemplateBeforeService_ConfigRemovedFirst
 // is resolved and scheduled when such a service arrives; deleting the service
 // unschedules the resolved configs.
 func (suite *ConfigManagerSuite) TestNewTemplateBeforeService_ServiceRemovedFirst() {
-	changes := suite.cm.processNewConfig(templateConfig)
+	changes, _ := suite.cm.processNewConfig(templateConfig)
 	assertConfigsMatch(suite.T(), changes.Schedule)
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 
@@ -224,7 +284,7 @@ func (suite *ConfigManagerSuite) TestNewServiceBeforeTemplate_ConfigRemovedFirst
 	assertConfigsMatch(suite.T(), changes.Schedule)
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 
-	changes = suite.cm.processNewConfig(templateConfig)
+	changes, _ = suite.cm.processNewConfig(templateConfig)
 	assertConfigsMatch(suite.T(), changes.Schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 
@@ -245,7 +305,7 @@ func (suite *ConfigManagerSuite) TestNewServiceBeforeTemplate_ServiceRemovedFirs
 	assertConfigsMatch(suite.T(), changes.Schedule)
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 
-	changes = suite.cm.processNewConfig(templateConfig)
+	changes, _ = suite.cm.processNewConfig(templateConfig)
 	assertConfigsMatch(suite.T(), changes.Schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 
@@ -341,7 +401,8 @@ func (suite *ConfigManagerSuite) TestFuzz() {
 				if _, found := configs[digest]; !found {
 					configs[digest] = cfg
 					fmt.Printf("add non-template config %s (digest %s)\n", cfg.Name, digest)
-					applyChanges(cm.processNewConfig(cfg))
+					changes, _ := cm.processNewConfig(cfg)
+					applyChanges(changes)
 				}
 			case p < 60 && op < removeAfterOps: // add template config
 				cfg := makeTemplateConfig(r)
@@ -350,7 +411,8 @@ func (suite *ConfigManagerSuite) TestFuzz() {
 					configs[digest] = cfg
 					fmt.Printf("add template config %s (digest %s) with AD idents [%s]\n",
 						cfg.Name, digest, strings.Join(cfg.ADIdentifiers, ", "))
-					applyChanges(cm.processNewConfig(cfg))
+					changes, _ := cm.processNewConfig(cfg)
+					applyChanges(changes)
 				}
 			case p < 70 && len(services) > 0: // remove service
 				i := rand.Intn(len(services))
@@ -443,14 +505,14 @@ func (suite *ReconcilingConfigManagerSuite) TestServiceTemplateFiltering() {
 
 	// adding a template that does not end in -keep only matches my-service
 	cfg1 := integration.Config{Name: "cfg1", ADIdentifiers: []string{"my-service", "filter"}}
-	changes = suite.cm.processNewConfig(cfg1)
+	changes, _ = suite.cm.processNewConfig(cfg1)
 	assertConfigsMatch(suite.T(), changes.Schedule, matchAll(matchName("cfg1"), matchSvc("my-service")))
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 	assertLoadedConfigsMatch(suite.T(), suite.cm, matchAll(matchName("cfg1"), matchSvc("my-service")))
 
 	// adding a template that ends in -keep matches both services
 	cfg2 := integration.Config{Name: "cfg2-keep", ADIdentifiers: []string{"my-service", "filter"}}
-	changes = suite.cm.processNewConfig(cfg2)
+	changes, _ = suite.cm.processNewConfig(cfg2)
 	assertConfigsMatch(suite.T(), changes.Schedule,
 		matchAll(matchName("cfg2-keep"), matchSvc("my-service")),
 		matchAll(matchName("cfg2-keep"), matchSvc("filter")),

--- a/releasenotes-dca/notes/mismatch-ids-dca-clc-0c3d5915127d6820.yaml
+++ b/releasenotes-dca/notes/mismatch-ids-dca-clc-0c3d5915127d6820.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a bug in the rebalancing of cluster checks. Checks that contained
+    secrets were never rebalanced when the Cluster Agent was configured to not
+    resolve check secrets (option ``secret_backend_skip_checks`` set to true).


### PR DESCRIPTION

### What does this PR do?

Fixes a bug in the rebalance of cluster checks.

Cluster checks that contain secrets are not rebalanced when the Cluster Agent is configured to not resolved secrets (config option `secret_backend_skip_checks` is set to true).

The ID of a check changes when its secrets are decrypted. So the ID known by the Cluster Agent and the Cluster Check Runner is different in that case. When fetching stats from the Runner, the Cluster Agent sees a check ID that it does not recognize, so it incorrectly assumes that it's not a cluster check, and never tries to move it when rebalancing cluster checks.

This PR fixes the issue by making sure that the CLC API queried by the Cluster Agent returns the IDs that the check had before resolving its secrets so that the Cluster Agent recognizes it. To do that, this PR makes some changes in the autodiscovery package to keep a map that matches both IDs.


### Describe how to test/QA your changes

The goal is to verify that Cluster checks that contain secrets are rebalanced even when the Cluster Agent is configured with `secret_backend_skip_checks` true.

Use a config like this to enable rebalancing, set the secret reader, skip secret resolving in the DCA, and set just 1 replica for the runners:
```yaml
datadog:
  kubelet:
    tlsVerify: false
  secretBackend:
    command: "/readsecret_multiple_providers.sh"
clusterAgent:
  env:
    - name: "DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED"
      value: "true"
    - name: "DD_CLUSTER_CHECKS_REBALANCE_WITH_UTILIZATION"
      value: "true"
    - name: "DD_SECRET_BACKEND_SKIP_CHECKS"
      value: "true"
clusterChecksRunner:
  enabled: true
  replicas: 1
```

Go to the runner pod and create a `/tmp/test.txt` file or similar that will be used as a secret.

Deploy 2 cluster checks. For example this one: https://docs.datadoghq.com/containers/cluster_agent/clusterchecks/?tab=helm#example-http-check-on-an-nginx-backed-service but also add a field with a secret in a check instance. For example: `"test": "ENC[file@/tmp/test.txt]"`.

To verify that the setup is correct, we need to check that the ID shown in the cluster-agent with `agent clusterchecks` do not match the ID seen by the runner with `agent configcheck`.

Now to force a rebalance, we can edit the runners deployment, set 2 replicas, and run `agent clusterchecks rebalance` from the Cluster Agent. Each runner should be assigned one check. Before this PR the 2 checks remained in the same runner.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
