### PR TITLE
feat(serverless/appsec/httpsec): parse XML request bodies

### DIFF
--- a/pkg/serverless/appsec/httpsec/http.go
+++ b/pkg/serverless/appsec/httpsec/http.go
@@ -264,6 +264,9 @@ func toMultiValueMap(m map[string]string) map[string][]string {
 // xmlMap is used to parse XML documents into a schema-agnostic format (essentially, a `map[string]any`).
 type xmlMap map[string]any
 
+// UnmarshalXML implements custom parsing from XML documents into a map-based generic format, because encoding/xml does
+// not provide a built-in unmarshal to map (any data that does not fit an `xml` tagged field, or that does not fit the
+// shape of that field, is silently ignored).
 func (m *xmlMap) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	var children []any
 out:

--- a/pkg/serverless/appsec/httpsec/http.go
+++ b/pkg/serverless/appsec/httpsec/http.go
@@ -12,8 +12,8 @@ package httpsec
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -21,6 +21,8 @@ import (
 	"net/textproto"
 	"net/url"
 	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Monitorer is the interface type expected by the httpsec invocation
@@ -115,6 +117,14 @@ func tryParseBody(headers textproto.MIMEHeader, raw string) (body any, err error
 			return nil, err
 		}
 		return map[string][]string(values), nil
+
+	case "application/xml", "text/xml":
+		var value xmlMap
+		if err := xml.Unmarshal([]byte(raw), &value); err != nil {
+			return nil, err
+		}
+		// Unwrap the value to avoid surfacing our implementation details out
+		return map[string]any(value), nil
 
 	case "multipart/form-data":
 		boundary, ok := params["boundary"]
@@ -249,4 +259,65 @@ func toMultiValueMap(m map[string]string) map[string][]string {
 		res[k] = []string{v}
 	}
 	return res
+}
+
+// xmlMap is used to parse XML documents into a schema-agnostic format (essentially, a `map[string]any`).
+type xmlMap map[string]any
+
+func (m *xmlMap) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var children []any
+out:
+	for {
+		token, err := d.Token()
+		if err != nil {
+			return err
+		}
+
+		switch token := token.(type) {
+		case xml.StartElement:
+			var child xmlMap
+			if err := child.UnmarshalXML(d, token); err != nil {
+				return err
+			}
+			// Unwrap so we don't surface our implementation details out to the world...
+			children = append(children, map[string]any(child))
+		case xml.EndElement:
+			if token.Name.Local != start.Name.Local || token.Name.Space != start.Name.Space {
+				return fmt.Errorf("unexpected end of element %s", token.Name.Local)
+			}
+			break out
+		case xml.CharData:
+			str := strings.TrimSpace(string(token))
+			if str != "" {
+				children = append(children, str)
+			}
+		case xml.Comment:
+			str := strings.TrimSpace(string(token))
+			children = append(children, map[string]string{"#": str})
+		case xml.ProcInst:
+			children = append(children, map[string]any{"?": map[string]string{
+				"target":      token.Target,
+				"instruction": string(token.Inst),
+			}})
+		case xml.Directive:
+			children = append(children, map[string]any{"!": string(token)})
+		default:
+			return fmt.Errorf("not implemented: %T", token)
+		}
+	}
+
+	element := map[string]any{"children": children}
+	if start.Name.Space != "" {
+		element[":ns"] = start.Name.Space
+	}
+	for _, attr := range start.Attr {
+		prefix := ""
+		if attr.Name.Space != "" {
+			prefix = attr.Name.Space + ":"
+		}
+		element[fmt.Sprintf("@%s%s", prefix, attr.Name.Local)] = attr.Value
+	}
+
+	*m = xmlMap{start.Name.Local: element}
+	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Adds support for parsing `text/xml`/`application/xml` ahead of the in-app WAF so that those payloads can also be inspected.

### Motivation

Increases the domain of payloads that can be inspected by the in-app WAF to drive security signals and blocking. XML remains a fairly popular format for web-service APIs.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
