### PR TITLE
[corechecks/snmp] Support symbol modifiers for global metric tags and metadata tags

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
@@ -84,12 +84,16 @@ func (ms *MetricSender) GetCheckInstanceMetricTags(metricTags []profiledefinitio
 	var globalTags []string
 
 	for _, metricTag := range metricTags {
-		// TODO: Support extract value see II-635
 		value, err := values.GetScalarValue(metricTag.Symbol.OID)
 		if err != nil {
 			continue
 		}
-		strValue, err := value.ToString()
+		newValue, err := processValueUsingSymbolConfig(value, profiledefinition.SymbolConfig(metricTag.Symbol))
+		if err != nil {
+			log.Debugf("error processing value using symbol config (%#v) to string : %v", value, err)
+			continue
+		}
+		strValue, err := newValue.ToString()
 		if err != nil {
 			log.Debugf("error converting value (%#v) to string : %v", value, err)
 			continue

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
@@ -88,8 +88,10 @@ func (ms *MetricSender) GetCheckInstanceMetricTags(metricTags []profiledefinitio
 		if err != nil {
 			continue
 		}
+		// TODO: TEST ME
 		newValue, err := processValueUsingSymbolConfig(value, profiledefinition.SymbolConfig(metricTag.Symbol))
 		if err != nil {
+			// TODO: TEST ME
 			log.Debugf("error processing value using symbol config (%#v) to string : %v", value, err)
 			continue
 		}

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics.go
@@ -88,10 +88,8 @@ func (ms *MetricSender) GetCheckInstanceMetricTags(metricTags []profiledefinitio
 		if err != nil {
 			continue
 		}
-		// TODO: TEST ME
 		newValue, err := processValueUsingSymbolConfig(value, profiledefinition.SymbolConfig(metricTag.Symbol))
 		if err != nil {
-			// TODO: TEST ME
 			log.Debugf("error processing value using symbol config (%#v) to string : %v", value, err)
 			continue
 		}

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
@@ -497,6 +497,60 @@ func Test_metricSender_getCheckInstanceMetricTags(t *testing.T) {
 			expectedLogs: []logCount{},
 		},
 		{
+			name: "use extract_value to test symbol modifiers",
+			metricsTags: []profiledefinition.MetricTagConfig{
+				{
+					Tag: "my-tag-key",
+					Symbol: profiledefinition.SymbolConfigCompat{
+						OID:          "1.2.3",
+						Name:         "mySymbol",
+						ExtractValue: "\\w+-(\\w+)-.*",
+					},
+				},
+			},
+			values: &valuestore.ResultValueStore{
+				ScalarValues: valuestore.ScalarResultValuesType{
+					"1.2.3": valuestore.ResultValue{
+						Value: "aa-bb-cc;",
+					},
+				},
+			},
+			expectedTags: []string{"my-tag-key:bb"},
+			expectedLogs: []logCount{},
+		},
+		{
+			name: "one of the metric tags with regex error",
+			metricsTags: []profiledefinition.MetricTagConfig{
+				{
+					Tag: "my-tag-key",
+					Symbol: profiledefinition.SymbolConfigCompat{
+						OID:          "1.2.3",
+						Name:         "mySymbol",
+						ExtractValue: "\\w+-(\\w+)-.*",
+					},
+				},
+				{
+					Tag: "my-invalid-regex-key",
+					Symbol: profiledefinition.SymbolConfigCompat{
+						OID:          "1.2.3",
+						Name:         "mySymbol",
+						ExtractValue: ".*", // invalid regex without match group
+					},
+				},
+			},
+			values: &valuestore.ResultValueStore{
+				ScalarValues: valuestore.ScalarResultValuesType{
+					"1.2.3": valuestore.ResultValue{
+						Value: "aa-bb-cc;",
+					},
+				},
+			},
+			expectedTags: []string{"my-tag-key:bb"},
+			expectedLogs: []logCount{
+				{"error extracting value from", 1},
+			},
+		},
+		{
 			name: "error converting tag value",
 			metricsTags: []profiledefinition.MetricTagConfig{
 				{Tag: "my_symbol", Symbol: profiledefinition.SymbolConfigCompat{OID: "1.2.3", Name: "mySymbol"}},

--- a/releasenotes/notes/NDMII-1196-support-extract-value-for-scalar-metric-tag-66096ec04e0d029b.yaml
+++ b/releasenotes/notes/NDMII-1196-support-extract-value-for-scalar-metric-tag-66096ec04e0d029b.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    [corechecks/snmp] Support ``extract_value`` for global metric tags and metadata tags.

--- a/releasenotes/notes/NDMII-1196-support-extract-value-for-scalar-metric-tag-66096ec04e0d029b.yaml
+++ b/releasenotes/notes/NDMII-1196-support-extract-value-for-scalar-metric-tag-66096ec04e0d029b.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    [corechecks/snmp] Support ``extract_value`` for global metric tags and metadata tags.
+    [corechecks/snmp] Support symbol modifiers for global metric tags and metadata tags.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

[corechecks/snmp] Support symbol modifiers (e.g. `extract_value`, `format`, etc) for global metric tags and metadata tags


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
