### PR TITLE
[SMP] Attempt to reduce allocation pressure in counter metrics flush

### DIFF
--- a/pkg/metrics/context_metrics_flusher.go
+++ b/pkg/metrics/context_metrics_flusher.go
@@ -47,7 +47,7 @@ func (f *ContextMetricsFlusher) FlushAndClear(callback func([]*Serie)) map[ckey.
 	// these structures to arbitrary, smallish sizes to avoid needing to
 	// grow from 0-size.
 	series := make([]*Serie, 0, 32)
-	errors := make(map[ckey.ContextKey]error, 32)
+	errors := make(map[ckey.ContextKey][]error, 32)
 
 	contextMetricsCollection := make([]ContextMetrics, 0, len(f.metrics))
 	for _, m := range f.metrics {

--- a/pkg/metrics/counter.go
+++ b/pkg/metrics/counter.go
@@ -5,6 +5,8 @@
 
 package metrics
 
+var emptySeries = []*Serie{}
+
 // Counter tracks how many times something happened per second. Counters are
 // only used by DogStatsD and are very similar to Count: the main diffence is
 // that they are sent as Rate.
@@ -23,8 +25,9 @@ func NewCounter(interval int64) *Counter {
 }
 
 func (c *Counter) addSample(sample *MetricSample, timestamp float64) {
-	c.value += sample.Value * (1 / sample.SampleRate)
-	c.sampled = true
+	counter := *c
+	counter.value += sample.Value * (1 / sample.SampleRate)
+	counter.sampled = true
 }
 
 func (c *Counter) flush(timestamp float64) ([]*Serie, error) {
@@ -32,7 +35,7 @@ func (c *Counter) flush(timestamp float64) ([]*Serie, error) {
 	c.value, c.sampled = 0, false
 
 	if !sampled {
-		return []*Serie{}, NoSerieError{}
+		return emptySeries, NoSerieError{}
 	}
 
 	return []*Serie{


### PR DESCRIPTION
### What does this PR do?

This commit introduces small changes to hopefully remove some allocation pressure in counter flushing. It's not entirely clear to me if these changes will prove beneficial, the code is already fairly spare and a more comprehensive look might be needed.

### Motivation

Discovered while quantifying [context overhead](https://app.datadoghq.com/notebook/6688195/agent-dogstatsd-metric-overhead?range=589716&view=view-mode&start=1696982581795&live=false&comment_id=669780).

REF SMPTNG-26

