### PR TITLE
Updated the version Python to 3.9.18 as needed for OpenSSL Windows up…

### DIFF
--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -1,7 +1,7 @@
 name "python3"
 
 if ohai["platform"] != "windows"
-  default_version "3.9.17"
+  default_version "3.9.18"
 
   dependency "libxcrypt"
   dependency "libffi"
@@ -15,7 +15,7 @@ if ohai["platform"] != "windows"
   dependency "libyaml"
 
   source :url => "https://python.org/ftp/python/#{version}/Python-#{version}.tgz",
-         :sha256 => "8ead58f669f7e19d777c3556b62fae29a81d7f06a7122ff9bc57f7dd82d7e014"
+         :sha256 => "504ce8cfd59addc04c22f590377c6be454ae7406cb1ebf6f5a350149225a9354"
 
   relative_path "Python-#{version}"
 
@@ -68,19 +68,19 @@ if ohai["platform"] != "windows"
   end
 
 else
-  default_version "3.9.17-26e6052"
+  default_version "3.9.18-38f3b72"
   dependency "vc_redist_14"
 
   if windows_arch_i386?
     dependency "vc_ucrt_redist"
 
     source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x86.zip",
-            :sha256 => "007FC4DB517599FB4DFF4D68FFA7C6B3BE9674F584AA513600A2539AF7CDD07B".downcase
+            :sha256 => "DC7069727454BC8FEED064FBD797076B7EAD93CAC1A482CE794BAB08214C42F3".downcase
   else
 
     # note that startring with 3.7.3 on Windows, the zip should be created without the built-in pip
     source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x64.zip",
-           :sha256 => "E6E38E5A6B768E9EF6E2F3F31448873657251B32B6CEB99B99D76BF47279A36D".downcase
+           :sha256 => "6DA7EDD4D42D5A223D14BF80ABBBEA80F4F6D6939CD0AA769CF1BCD24CB54A1F".downcase
 
   end
   vcrt140_root = "#{Omnibus::Config.source_dir()}/vc_redist_140/expanded"

--- a/releasenotes/notes/update-python-openssl-on-windows-to-1.1.1w-0a00d9c8a0cfde12.yaml
+++ b/releasenotes/notes/update-python-openssl-on-windows-to-1.1.1w-0a00d9c8a0cfde12.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    Upgraded Python 3.9 to Python 3.9.18
+
+security:
+  - |
+    Updated the version of OpenSSL used by Python on Windows to `1.1.1w`; addressed CVE-2023-4807, CVE-2023-3817, and CVE-2023-3446


### PR DESCRIPTION
### What does this PR do?

Upgrades the version of OpenSSL being used to `1.1.1w`. Fixes CVE-2023-4807, CVE-2023-3817 and CVE-2023-3446.
See https://www.openssl.org/news/openssl-1.1.1-notes.html for more details.

Windows OpenSSL upgrade: [OpenSSL 1.1.1w](https://github.com/DataDog/cpython/pull/29).

### Motivation

The current version of OpenSSL being used on Windows (version `1.1.1u`) has some reported CVEs that are mitigated by version `1.1.1w`.

### Describe how to test/QA your changes

* Run an Agent with Python 3 (either Agent 6 configured with py3 or an Agent 7)
* Execute agent status and validate Python version
* Validate the Python integrations are working properly


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature. 
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
