### PR TITLE
Fix the setting of `host` field in contlcycle, contimage and sbom events

### DIFF
--- a/pkg/collector/corechecks/containerimage/processor_test.go
+++ b/pkg/collector/corechecks/containerimage/processor_test.go
@@ -6,6 +6,7 @@
 package containerimage
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/epforwarder"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
@@ -435,9 +437,11 @@ func TestProcessEvents(t *testing.T) {
 				return imagesSent.Load() == int32(len(test.expectedImages))
 			}, 1*time.Second, 5*time.Millisecond)
 
+			hname, _ := hostname.Get(context.TODO())
 			for _, expectedImage := range test.expectedImages {
 				encoded, err := proto.Marshal(&model.ContainerImagePayload{
 					Version: "v1",
+					Host:    hname,
 					Source:  &sourceAgent,
 					Images:  []*model.ContainerImage{expectedImage},
 				})

--- a/pkg/collector/corechecks/containerlifecycle/event.go
+++ b/pkg/collector/corechecks/containerlifecycle/event.go
@@ -6,11 +6,14 @@
 package containerlifecycle
 
 import (
+	"context"
 	"fmt"
 
 	model "github.com/DataDog/agent-payload/v5/contlcycle"
 
 	types "github.com/DataDog/datadog-agent/pkg/containerlifecycle"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type event interface {
@@ -80,7 +83,15 @@ func (e *eventTransformer) withOwnerID(id string) {
 }
 
 func (e *eventTransformer) toPayloadModel() (*model.EventsPayload, error) {
-	payload := &model.EventsPayload{Version: types.PayloadV1}
+	hname, err := hostname.Get(context.TODO())
+	if err != nil {
+		log.Warnf("Error getting hostname: %v", err)
+	}
+
+	payload := &model.EventsPayload{
+		Version: types.PayloadV1,
+		Host:    hname,
+	}
 	kind, err := e.kind(e.objectKind)
 	if err != nil {
 		return nil, err

--- a/pkg/collector/corechecks/containerlifecycle/processor_test.go
+++ b/pkg/collector/corechecks/containerlifecycle/processor_test.go
@@ -14,11 +14,14 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 
 	"github.com/stretchr/testify/mock"
 )
 
 func TestProcessQueues(t *testing.T) {
+	hname, _ := hostname.Get(context.TODO())
+
 	tests := []struct {
 		name            string
 		containersQueue *queue
@@ -34,7 +37,7 @@ func TestProcessQueues(t *testing.T) {
 		{
 			name: "one container",
 			containersQueue: &queue{data: []*model.EventsPayload{
-				{Version: "v1", Events: modelEvents("cont1")},
+				{Version: "v1", Host: hname, Events: modelEvents("cont1")},
 			}},
 			podsQueue: &queue{},
 			wantFunc: func(t *testing.T, s *mocksender.MockSender) {
@@ -44,12 +47,12 @@ func TestProcessQueues(t *testing.T) {
 		{
 			name: "multiple chunks per types",
 			containersQueue: &queue{data: []*model.EventsPayload{
-				{Version: "v1", Events: modelEvents("cont1", "cont2")},
-				{Version: "v1", Events: modelEvents("cont3")},
+				{Version: "v1", Host: hname, Events: modelEvents("cont1", "cont2")},
+				{Version: "v1", Host: hname, Events: modelEvents("cont3")},
 			}},
 			podsQueue: &queue{data: []*model.EventsPayload{
-				{Version: "v1", Events: modelEvents("pod1", "pod2")},
-				{Version: "v1", Events: modelEvents("pod3")},
+				{Version: "v1", Host: hname, Events: modelEvents("pod1", "pod2")},
+				{Version: "v1", Host: hname, Events: modelEvents("pod3")},
 			}},
 			wantFunc: func(t *testing.T, s *mocksender.MockSender) {
 				s.AssertNumberOfCalls(t, "EventPlatformEvent", 4)

--- a/pkg/collector/corechecks/containerlifecycle/queue_test.go
+++ b/pkg/collector/corechecks/containerlifecycle/queue_test.go
@@ -6,10 +6,12 @@
 package containerlifecycle
 
 import (
+	"context"
 	"strconv"
 	"testing"
 
 	model "github.com/DataDog/agent-payload/v5/contlcycle"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,6 +34,7 @@ func modelEvents(objIDs ...string) []*model.Event {
 }
 
 func TestSingleQueueAdd(t *testing.T) {
+	hname, _ := hostname.Get(context.TODO())
 	commonChunkSize := 2
 
 	tests := []struct {
@@ -44,21 +47,21 @@ func TestSingleQueueAdd(t *testing.T) {
 			name: "empty queue",
 			data: []*model.EventsPayload{},
 			ev:   fakeContainerEvent("obj1"),
-			want: []*model.EventsPayload{{Version: "v1", Events: modelEvents("obj1")}},
+			want: []*model.EventsPayload{{Version: "v1", Host: hname, Events: modelEvents("obj1")}},
 		},
 		{
 			name: "last payload not full",
-			data: []*model.EventsPayload{{Version: "v1", Events: modelEvents("obj1")}},
+			data: []*model.EventsPayload{{Version: "v1", Host: hname, Events: modelEvents("obj1")}},
 			ev:   fakeContainerEvent("obj2"),
-			want: []*model.EventsPayload{{Version: "v1", Events: modelEvents("obj1", "obj2")}},
+			want: []*model.EventsPayload{{Version: "v1", Host: hname, Events: modelEvents("obj1", "obj2")}},
 		},
 		{
 			name: "last payload full",
-			data: []*model.EventsPayload{{Version: "v1", Events: modelEvents("obj1", "obj2")}},
+			data: []*model.EventsPayload{{Version: "v1", Host: hname, Events: modelEvents("obj1", "obj2")}},
 			ev:   fakeContainerEvent("obj3"),
 			want: []*model.EventsPayload{
-				{Version: "v1", Events: modelEvents("obj1", "obj2")},
-				{Version: "v1", Events: modelEvents("obj3")},
+				{Version: "v1", Host: hname, Events: modelEvents("obj1", "obj2")},
+				{Version: "v1", Host: hname, Events: modelEvents("obj3")},
 			},
 		},
 	}

--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -8,6 +8,7 @@
 package sbom
 
 import (
+	"context"
 	"errors"
 	"os"
 	"strings"
@@ -20,10 +21,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/sbom"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors/host"
 	sbomscanner "github.com/DataDog/datadog-agent/pkg/sbom/scanner"
-	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	queue "github.com/DataDog/datadog-agent/pkg/util/aggregatingqueue"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
@@ -59,16 +60,19 @@ func newProcessor(workloadmetaStore workloadmeta.Store, sender sender.Sender, ma
 	if sbomScanner == nil {
 		return nil, errors.New("failed to get global SBOM scanner")
 	}
-	hostname, _ := utils.GetHostname()
+	hname, err := hostname.Get(context.TODO())
+	if err != nil {
+		log.Warnf("Error getting hostname: %v", err)
+	}
 
 	return &processor{
 		queue: queue.NewQueue(maxNbItem, maxRetentionTime, func(entities []*model.SBOMEntity) {
 			encoded, err := proto.Marshal(&model.SBOMPayload{
 				Version:  1,
+				Host:     hname,
 				Source:   &sourceAgent,
 				Entities: entities,
 				DdEnv:    &envVarEnv,
-				Host:     hostname,
 			})
 			if err != nil {
 				log.Errorf("Unable to encode message: %+v", err)
@@ -83,7 +87,7 @@ func newProcessor(workloadmetaStore workloadmeta.Store, sender sender.Sender, ma
 		sbomScanner:           sbomScanner,
 		hostSBOM:              hostSBOM,
 		hostScanOpts:          hostScanOpts,
-		hostname:              hostname,
+		hostname:              hname,
 		hostHeartbeatValidity: hostHeartbeatValidity,
 	}, nil
 }

--- a/pkg/collector/corechecks/sbom/processor_test.go
+++ b/pkg/collector/corechecks/sbom/processor_test.go
@@ -8,6 +8,7 @@
 package sbom
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -26,12 +27,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/epforwarder"
 	sbomscanner "github.com/DataDog/datadog-agent/pkg/sbom/scanner"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	fakeworkloadmeta "github.com/DataDog/datadog-agent/pkg/workloadmeta/testing"
 )
 
 func TestProcessEvents(t *testing.T) {
+	hname, _ := hostname.Get(context.TODO())
 	sbomGenerationTime := time.Now()
 
 	tests := []struct {
@@ -632,6 +635,7 @@ func TestProcessEvents(t *testing.T) {
 			for _, expectedSBOM := range test.expectedSBOMs {
 				encoded, err := proto.Marshal(&model.SBOMPayload{
 					Version:  1,
+					Host:     hname,
 					Source:   &sourceAgent,
 					Entities: []*model.SBOMEntity{expectedSBOM},
 					DdEnv:    &envVarEnv,


### PR DESCRIPTION
### What does this PR do?

Fix the setting of the `host` field in `containerlifecyclevents`, `containerimage` and `sbom` messages.

### Motivation

Prior to #16084, this `host` field was set inside “specific” serializers:
* https://github.com/DataDog/datadog-agent/pull/16084/files#diff-48e34036e300e812317a3c51b1e6bd4ad63d8db0757ca6a6cee9925c7fff7fb8L481
* https://github.com/DataDog/datadog-agent/pull/16084/files#diff-48e34036e300e812317a3c51b1e6bd4ad63d8db0757ca6a6cee9925c7fff7fb8L517
* https://github.com/DataDog/datadog-agent/pull/16084/files#diff-48e34036e300e812317a3c51b1e6bd4ad63d8db0757ca6a6cee9925c7fff7fb8L553

Now that those “specific” serializers have been superseded by the generic Event Platform pipeline, the `host` field needs to be set elsewhere.
It needs to be set before being marshaled and the marshaling in now happening in the checks themselves.

#20025 was using `"github.com/DataDog/datadog-agent/pkg/security/utils".GetHostname()`.
https://github.com/DataDog/datadog-agent/blob/5b58fa2173f320abda557592c556b138fe7a46da/pkg/security/utils/hostname.go#L26-L44
But this function is doing a gRPC call to the core agent to get the hostname. It’s useless as this piece of code is already in the core agent. So, no need to do a gRPC call.

### Additional Notes

Followup of #20025.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Look for the `host` field in the output of `agent stream-event-platform`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
