### PR TITLE
[SMP] Preallocate in counter metric flush

### DIFF
--- a/pkg/metrics/context_metrics.go
+++ b/pkg/metrics/context_metrics.go
@@ -80,8 +80,12 @@ func (m ContextMetrics) AddSample(contextKey ckey.ContextKey, sample *MetricSamp
 // Flush flushes every metrics in the ContextMetrics.
 // Returns the slice of Series and a map of errors by context key.
 func (m ContextMetrics) Flush(timestamp float64) ([]*Serie, map[ckey.ContextKey]error) {
-	var series []*Serie
-	errors := make(map[ckey.ContextKey]error)
+	// NOTE in practice this function and its call-chain are allocation
+	// hotspots in Agent when counter metrics are dominate. We pre-allocate
+	// these structures to arbitrary, smallish sizes to avoid needing to
+	// grow from 0-size.
+	series := make([]*Serie, 0, 32)
+	errors := make(map[ckey.ContextKey]error, 32)
 
 	for contextKey, metric := range m {
 		series = flushToSeries(
@@ -101,6 +105,7 @@ func flushToSeries(
 	bucketTimestamp float64,
 	series []*Serie,
 	errors map[ckey.ContextKey]error) []*Serie {
+
 	metricSeries, err := metric.flush(bucketTimestamp)
 
 	if err == nil {
@@ -116,6 +121,7 @@ func flushToSeries(
 			errors[contextKey] = err
 		}
 	}
+
 	return series
 }
 

--- a/pkg/metrics/context_metrics_flusher.go
+++ b/pkg/metrics/context_metrics_flusher.go
@@ -42,8 +42,12 @@ func (f *ContextMetricsFlusher) Append(bucketTimestamp float64, contextMetrics C
 // `callback`. Any errors encountered flushing the Metric instances are returned,
 // but such errors do not interrupt the flushing operation.
 func (f *ContextMetricsFlusher) FlushAndClear(callback func([]*Serie)) map[ckey.ContextKey][]error {
-	errors := make(map[ckey.ContextKey][]error)
-	var series []*Serie
+	// NOTE in practice this function and its call-chain are allocation
+	// hotspots in Agent when counter metrics are dominate. We pre-allocate
+	// these structures to arbitrary, smallish sizes to avoid needing to
+	// grow from 0-size.
+	series := make([]*Serie, 0, 32)
+	errors := make(map[ckey.ContextKey][]error, 32)
 
 	contextMetricsCollection := make([]ContextMetrics, 0, len(f.metrics))
 	for _, m := range f.metrics {

--- a/pkg/metrics/counter.go
+++ b/pkg/metrics/counter.go
@@ -5,6 +5,8 @@
 
 package metrics
 
+var emptySeries = []*Serie{}
+
 // Counter tracks how many times something happened per second. Counters are
 // only used by DogStatsD and are very similar to Count: the main diffence is
 // that they are sent as Rate.
@@ -32,7 +34,7 @@ func (c *Counter) flush(timestamp float64) ([]*Serie, error) {
 	c.value, c.sampled = 0, false
 
 	if !sampled {
-		return []*Serie{}, NoSerieError{}
+		return emptySeries, NoSerieError{}
 	}
 
 	return []*Serie{


### PR DESCRIPTION
### What does this PR do?

This commit introduces a small preallocation change in counter flushing. This is intended to reduce allocation pressure in flushing.

### Motivation

Discovered while quantifying [context overhead](https://app.datadoghq.com/notebook/6688195/agent-dogstatsd-metric-overhead?range=589716&view=view-mode&start=1696982581795&live=false&comment_id=669780).

REF SMPTNG-26
