### PR TITLE
[CWS] sample open FDs when snapshotting

### DIFF
--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -10,6 +10,7 @@ package activitytree
 
 import (
 	"fmt"
+	"math/rand"
 	"net"
 	"os"
 	"path"
@@ -58,6 +59,10 @@ func (pn *ProcessNode) snapshot(owner Owner, stats *Stats, newEvent func() *mode
 	}
 }
 
+// MAX_FDS_PER_PROCESS_SNAPSHOT represents the maximum number of FDs we will collect per process while snapshotting
+// this value was selected because it represents the default upper bound for the number of FDs a linux process can have
+const MAX_FDS_PER_PROCESS_SNAPSHOT = 1024
+
 func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *Stats, newEvent func() *model.Event, reducer *PathsReducer) {
 	// list the files opened by the process
 	fileFDs, err := p.OpenFiles()
@@ -65,9 +70,21 @@ func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *Stats, newEvent 
 		seclog.Warnf("error while listing files (pid: %v): %s", p.Pid, err)
 	}
 
-	var files []string
+	var (
+		isSampling = false
+		preAlloc   = len(fileFDs)
+	)
+
+	if len(fileFDs) > MAX_FDS_PER_PROCESS_SNAPSHOT {
+		isSampling = true
+		preAlloc = 1024
+	}
+
+	files := make([]string, 0, preAlloc)
 	for _, fd := range fileFDs {
-		files = append(files, fd.Path)
+		if !isSampling || rand.Int63n(int64(len(fileFDs))) < MAX_FDS_PER_PROCESS_SNAPSHOT {
+			files = append(files, fd.Path)
+		}
 	}
 
 	// list the mmaped files of the process

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -59,9 +59,9 @@ func (pn *ProcessNode) snapshot(owner Owner, stats *Stats, newEvent func() *mode
 	}
 }
 
-// MAX_FDS_PER_PROCESS_SNAPSHOT represents the maximum number of FDs we will collect per process while snapshotting
+// maxFDsPerProcessSnapshot represents the maximum number of FDs we will collect per process while snapshotting
 // this value was selected because it represents the default upper bound for the number of FDs a linux process can have
-const MAX_FDS_PER_PROCESS_SNAPSHOT = 1024
+const maxFDsPerProcessSnapshot = 1024
 
 func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *Stats, newEvent func() *model.Event, reducer *PathsReducer) {
 	// list the files opened by the process
@@ -75,14 +75,14 @@ func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *Stats, newEvent 
 		preAlloc   = len(fileFDs)
 	)
 
-	if len(fileFDs) > MAX_FDS_PER_PROCESS_SNAPSHOT {
+	if len(fileFDs) > maxFDsPerProcessSnapshot {
 		isSampling = true
 		preAlloc = 1024
 	}
 
 	files := make([]string, 0, preAlloc)
 	for _, fd := range fileFDs {
-		if !isSampling || rand.Int63n(int64(len(fileFDs))) < MAX_FDS_PER_PROCESS_SNAPSHOT {
+		if !isSampling || rand.Int63n(int64(len(fileFDs))) < maxFDsPerProcessSnapshot {
 			files = append(files, fd.Path)
 		}
 	}

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -82,6 +82,10 @@ func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *Stats, newEvent 
 
 	files := make([]string, 0, preAlloc)
 	for _, fd := range fileFDs {
+		if len(files) >= maxFDsPerProcessSnapshot {
+			break
+		}
+
 		if !isSampling || rand.Int63n(int64(len(fileFDs))) < maxFDsPerProcessSnapshot {
 			files = append(files, fd.Path)
 		}


### PR DESCRIPTION
### What does this PR do?

In some rare cases (especially around databases) the snapshotting of open files can allocate a huge amount of memory because of the amount of files collected and added to the activity dump.

This PR implements a sampling solution for this issue by sampling the amount of added files when the amount is `> 1024`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- create a normal workload (with the default limit of FDs), before starting the agent (since this PR touches the snapshot)
- start the agent, and an activity dump of the workload and check that the dump contains all expected files
- stop the agent
- create a workload with an increased limit of FDs and open a lot of files (> 1024), before starting the agent (since this PR touches the snapshot)
- start the agent, and an activity dump of the workload and check that the dump contains some files but not all of them (around 1024)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
