### PR TITLE
[invoke] Revamp notify task to separate mandatory and optional jobs

### DIFF
--- a/tasks/libs/pipeline_data.py
+++ b/tasks/libs/pipeline_data.py
@@ -1,10 +1,10 @@
 import re
 
 from .common.gitlab import Gitlab, get_gitlab_token
-from .types import FailedJobReason, FailedJobType
+from .types import FailedJobReason, FailedJobs, FailedJobType
 
 
-def get_failed_jobs(project_name, pipeline_id):
+def get_failed_jobs(project_name: str, pipeline_id: str) -> FailedJobs:
     """
     Retrieves the list of failed jobs for a given pipeline id in a given project.
     """
@@ -25,7 +25,7 @@ def get_failed_jobs(project_name, pipeline_id):
 
     # There, we now have the following map:
     # job name -> list of jobs with that name, including at least one failed job
-    final_failed_jobs = []
+    processed_failed_jobs = FailedJobs()
     for job_name, jobs in failed_jobs.items():
         # We sort each list per creation date
         jobs.sort(key=lambda x: x["created_at"])
@@ -49,9 +49,9 @@ def get_failed_jobs(project_name, pipeline_id):
 
         # Also exclude jobs allowed to fail
         if final_status["status"] == "failed" and should_report_job(job_name, final_status["allow_failure"]):
-            final_failed_jobs.append(final_status)
+            processed_failed_jobs.add_failed_job(final_status)
 
-    return final_failed_jobs
+    return processed_failed_jobs
 
 
 infra_failure_logs = [
@@ -132,10 +132,10 @@ def truncate_job_name(job_name, max_char_per_job=48):
     return truncated_job_name
 
 
-# those jobs are `allow_failure: true` but still needs to be included
-# in fail reports
-jobs_allowed_to_fails_but_need_report = [re.compile(r'kitchen_test_security_agent.*')]
+# Those jobs have `allow_failure: true` but still need to be included
+# in failure reports
+jobs_allowed_to_fail_but_need_report = [re.compile(r'kitchen_test_security_agent.*')]
 
 
 def should_report_job(job_name, allow_failure):
-    return not allow_failure or any(pattern.fullmatch(job_name) for pattern in jobs_allowed_to_fails_but_need_report)
+    return not allow_failure or any(pattern.fullmatch(job_name) for pattern in jobs_allowed_to_fail_but_need_report)

--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -3,6 +3,7 @@ import os
 import re
 import subprocess
 from collections import defaultdict
+from typing import Dict
 
 from .common.gitlab import Gitlab, get_gitlab_token
 from .types import FailedJobs, Test
@@ -129,7 +130,7 @@ def get_failed_tests(project_name, job, owners_file=".github/CODEOWNERS"):
     return failed_tests.values()
 
 
-def find_job_owners(failed_jobs: FailedJobs, owners_file: str = ".gitlab/JOBOWNERS") -> dict[str, FailedJobs]:
+def find_job_owners(failed_jobs: FailedJobs, owners_file: str = ".gitlab/JOBOWNERS") -> Dict[str, FailedJobs]:
     owners = read_owners(owners_file)
     owners_to_notify = defaultdict(FailedJobs)
 

--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -5,7 +5,7 @@ import subprocess
 from collections import defaultdict
 
 from .common.gitlab import Gitlab, get_gitlab_token
-from .types import FailedJobType, Test
+from .types import FailedJobs, Test
 
 DEFAULT_SLACK_CHANNEL = "#agent-platform"
 DEFAULT_JIRA_PROJECT = "AGNTR"
@@ -129,28 +129,26 @@ def get_failed_tests(project_name, job, owners_file=".github/CODEOWNERS"):
     return failed_tests.values()
 
 
-def find_job_owners(failed_jobs, owners_file=".gitlab/JOBOWNERS"):
+def find_job_owners(failed_jobs: FailedJobs, owners_file: str = ".gitlab/JOBOWNERS") -> dict[str, FailedJobs]:
     owners = read_owners(owners_file)
-    owners_to_notify = defaultdict(list)
+    owners_to_notify = defaultdict(FailedJobs)
 
-    for job in failed_jobs:
-        # Exclude jobs that failed due to infrastructure failures
-        if job["failure_type"] == FailedJobType.INFRA_FAILURE:
-            continue
+    for job in failed_jobs.all_non_infra_failures():
         job_owners = owners.of(job["name"])
         # job_owners is a list of tuples containing the type of owner (eg. USERNAME, TEAM) and the name of the owner
         # eg. [('TEAM', '@DataDog/agent-platform')]
 
         for kind, owner in job_owners:
             if kind == "TEAM":
-                owners_to_notify[owner].append(job)
+                owners_to_notify[owner].add_failed_job(job)
 
     return owners_to_notify
 
 
 def base_message(header, state):
     project_title = os.getenv("CI_PROJECT_TITLE")
-    commit_title = os.getenv("CI_COMMIT_TITLE")
+    # commit_title needs a default string value, otherwise the re.search line below crashes
+    commit_title = os.getenv("CI_COMMIT_TITLE", "")
     pipeline_url = os.getenv("CI_PIPELINE_URL")
     pipeline_id = os.getenv("CI_PIPELINE_ID")
     commit_ref_name = os.getenv("CI_COMMIT_REF_NAME")

--- a/tasks/libs/pipeline_stats.py
+++ b/tasks/libs/pipeline_stats.py
@@ -25,14 +25,14 @@ def get_failed_jobs_stats(project_name, pipeline_id):
     # only due to infrastructure failures.
     global_failure_reason = None
 
-    for job in failed_jobs:
+    if failed_jobs.mandatory_job_failures:
+        global_failure_reason = FailedJobType.JOB_FAILURE.name
+    elif failed_jobs.mandatory_infra_job_failures:
+        global_failure_reason = FailedJobType.INFRA_FAILURE.name
+
+    for job in failed_jobs.all_mandatory_failures():
         failure_type = job["failure_type"]
         failure_reason = job["failure_reason"]
-
-        if failure_type == FailedJobType.JOB_FAILURE:
-            global_failure_reason = FailedJobType.JOB_FAILURE.name
-        elif failure_type == FailedJobType.INFRA_FAILURE and not global_failure_reason:
-            global_failure_reason = FailedJobType.INFRA_FAILURE.name
 
         key = tuple(sorted(job["tag_list"] + [f"type:{failure_type.name}", f"reason:{failure_reason.name}"]))
         job_failure_stats[key] += 1

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -34,7 +34,7 @@ from .libs.pipeline_tools import (
     trigger_agent_pipeline,
     wait_for_pipeline,
 )
-from .libs.types import SlackMessage, TeamMessage
+from .libs.types import FailedJobs, SlackMessage, TeamMessage
 from .utils import (
     DEFAULT_BRANCH,
     GITHUB_REPO_NAME,
@@ -376,7 +376,7 @@ Please check for typos in the JOBOWNERS file and/or add them to the Github <-> S
 """
 
 
-def generate_failure_messages(project_name, failed_jobs):
+def generate_failure_messages(project_name: str, failed_jobs: FailedJobs) -> dict[str, SlackMessage]:
     all_teams = "@DataDog/agent-all"
 
     # Generate messages for each team
@@ -594,7 +594,7 @@ def notify(_, notification_type="merge", print_to_stdout=False):
 
     # From the job failures, set whether the pipeline succeeded or failed and craft the
     # base message that will be sent.
-    if failed_jobs:  # At least one job failed
+    if failed_jobs.all_mandatory_failures():  # At least one mandatory job failed
         header_icon = ":host-red:"
         state = "failed"
         coda = "If there is something wrong with the notification please contact #agent-platform"

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -6,6 +6,7 @@ import time
 import traceback
 from collections import defaultdict
 from datetime import datetime
+from typing import Dict
 
 import yaml
 from invoke import task
@@ -376,7 +377,7 @@ Please check for typos in the JOBOWNERS file and/or add them to the Github <-> S
 """
 
 
-def generate_failure_messages(project_name: str, failed_jobs: FailedJobs) -> dict[str, SlackMessage]:
+def generate_failure_messages(project_name: str, failed_jobs: FailedJobs) -> Dict[str, SlackMessage]:
     all_teams = "@DataDog/agent-all"
 
     # Generate messages for each team


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Updates the `invoke pipeline.notify` task to separate mandatory and optional (allowed to fail) jobs:
- adds a new class, `FailedJobs`, to hold the list of failed jobs in a pipeline, triaged by job / infra failures and mandatory / optional failures,
- updates the base message to show a success if only optional jobs failed,
- removes repetitions in the `SlackMessage` class,
- adds type hints to all modified functions.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Better notification messages.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

n/a

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Run the `pipeline.notify` and `pipeline.send-stats` jobs:
```
# 21479289: One infra failure, one optional job failure => pipeline failure
CI_PIPELINE_ID=21479289 inv -e pipeline.notify --print-to-stdout
CI_PIPELINE_ID=21479289 inv -e pipeline.send-stats --print-to-stdout

# 21481085: One job failure => pipeline failure
CI_PIPELINE_ID=21481085 inv -e pipeline.notify --print-to-stdout
CI_PIPELINE_ID=21481085 inv -e pipeline.send-stats --print-to-stdout

# 21530419: Three optional failures => pipeline success
CI_PIPELINE_ID=21530419 inv -e pipeline.notify --print-to-stdout
CI_PIPELINE_ID=21530419 inv -e pipeline.send-stats --print-to-stdout

# 21486372: No failures => pipeline success
CI_PIPELINE_ID=21486372 inv -e pipeline.notify --print-to-stdout
CI_PIPELINE_ID=21486372 inv -e pipeline.send-stats --print-to-stdout
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
