### PR TITLE
[CI] Silence 2 `revive` errors from `otlp` and `tcpqueuelength` packages

### DIFF
--- a/comp/otelcol/otlp/no_otlp.go
+++ b/comp/otelcol/otlp/no_otlp.go
@@ -5,6 +5,7 @@
 
 //go:build !otlp
 
+//nolint:revive // TODO package-comments: should have a package comment
 package otlp
 
 import (

--- a/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/tcp_queue_length_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/tcp_queue_length_test.go
@@ -98,7 +98,7 @@ func extractGlobalStats(t *testing.T, tracer *Tracer) model.TCPQueueLengthStatsV
 // - reading small chunks at a time
 // - reducing the RECV buffer size
 
-var Addr *net.TCPAddr = &net.TCPAddr{
+var Addr *net.TCPAddr = &net.TCPAddr{ //nolint:revive // TODO var-declaration: should omit type *net.TCPAddr from declaration of var Addr; it will be inferred from the right-hand side
 	Port: 25568,
 }
 

--- a/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/tcp_queue_length_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/tcp_queue_length_test.go
@@ -98,7 +98,7 @@ func extractGlobalStats(t *testing.T, tracer *Tracer) model.TCPQueueLengthStatsV
 // - reading small chunks at a time
 // - reducing the RECV buffer size
 
-var Addr *net.TCPAddr = &net.TCPAddr{ //nolint:revive // TODO var-declaration: should omit type *net.TCPAddr from declaration of var Addr; it will be inferred from the right-hand side
+var Addr = &net.TCPAddr{
 	Port: 25568,
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR silence 2 `revive` errors  from `otlp` and `tcpqueuelength` packages.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

As of now we're using the `new_from_rev` `golangci-lint` config keyword to lint all commits [after f40667d commit on main].(https://github.com/DataDog/datadog-agent/blob/bb8fa52975b16f3859bb9390120890fa042e275d/.golangci.yml#L68). This is sometimes creating ghost linter issues (e.g when moving files). We think something like this is happening in #19785, so I'm silencing them on `main` while we're fixing it.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
