### PR TITLE
Make security agent running test more robust with eventually

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -463,6 +463,7 @@
 /test/new-e2e/scenarios/system-probe    @DataDog/ebpf-platform
 /test/new-e2e/tests/containers          @DataDog/container-integrations
 /test/new-e2e/tests/npm                 @DataDog/Networks
+/test/new-e2e/tests/agent-platform      @DataDog/agent-platform
 /test/system/                           @DataDog/agent-shared-components
 /test/system/dogstatsd/                 @DataDog/agent-metrics-logs
 /test/benchmarks/apm_scripts/           @DataDog/agent-apm

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -173,13 +173,20 @@ func CheckCWSBehaviour(t *testing.T, client *TestClient) {
 	})
 
 	t.Run("security-agent is running", func(tt *testing.T) {
-		_, err := client.VMClient.ExecuteWithError("pgrep -f security-agent")
-		require.NoError(tt, err, "security-agent should be running")
+		var err error
+		require.Eventually(tt, func() bool {
+			_, err = client.VMClient.ExecuteWithError("pgrep -f security-agent")
+			return err == nil
+		}, 10*time.Second, 500*time.Millisecond, "security-agent should be running ", err)
+
 	})
 
 	t.Run("system-probe is running", func(tt *testing.T) {
-		_, err := client.VMClient.ExecuteWithError("pgrep -f system-probe")
-		require.NoError(tt, err, "security-agent should be running")
+		var err error
+		require.Eventually(tt, func() bool {
+			_, err = client.VMClient.ExecuteWithError("pgrep -f system-probe")
+			return err == nil
+		}, 10*time.Second, 500*time.Millisecond, "system-probe should be running ", err)
 	})
 
 	t.Run("system-probe and security-agent communicate", func(tt *testing.T) {

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -186,7 +186,7 @@ func CheckCWSBehaviour(t *testing.T, client *TestClient) {
 		require.Eventually(tt, func() bool {
 			_, err = client.VMClient.ExecuteWithError("pgrep -f system-probe")
 			return err == nil
-		}, 10*time.Second, 500*time.Millisecond, "system-probe should be running ", err)
+		}, 1*time.Minute, 500*time.Millisecond, "system-probe should be running ", err)
 	})
 
 	t.Run("system-probe and security-agent communicate", func(tt *testing.T) {

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -177,7 +177,7 @@ func CheckCWSBehaviour(t *testing.T, client *TestClient) {
 		require.Eventually(tt, func() bool {
 			_, err = client.VMClient.ExecuteWithError("pgrep -f security-agent")
 			return err == nil
-		}, 10*time.Second, 500*time.Millisecond, "security-agent should be running ", err)
+		}, 1*time.Minute, 500*time.Millisecond, "security-agent should be running ", err)
 
 	})
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fix first flake detected on new-e2e install script tests.
It should let more time to the security-agent to restarted when CWS is enabled

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fix flakiness
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
