### PR TITLE
[omnibus] Work around memory leak with usage of libapt in OpenSCAP

### DIFF
--- a/omnibus/config/patches/openscap/dpkginfo-cache-no-close.patch
+++ b/omnibus/config/patches/openscap/dpkginfo-cache-no-close.patch
@@ -1,0 +1,39 @@
+--- a/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx
++++ b/src/OVAL/probes/unix/linux/dpkginfo-helper.cxx
+@@ -64,7 +64,6 @@ struct dpkginfo_reply_t * dpkginfo_get_by_name(const char *name, int *err)
+         if (Pkg.end() == true) {
+                 /* not found, clear error flag */
+                 if (err) *err = 0;
+-                cgCache->Close();
+                 return NULL;
+         }
+ 
+@@ -73,7 +72,6 @@ struct dpkginfo_reply_t * dpkginfo_get_by_name(const char *name, int *err)
+                 /* not installed, clear error flag */
+                 /* FIXME this should be different that not found */
+                 if (err) *err = 0;
+-                cgCache->Close();
+                 return NULL;
+         }
+ 
+@@ -116,8 +114,6 @@ struct dpkginfo_reply_t * dpkginfo_get_by_name(const char *name, int *err)
+         reply->version = strdup(version.c_str());
+         reply->evr = strdup(evr_str.c_str());
+ 
+-        cgCache->Close();
+-
+         return reply;
+ }
+ 
+@@ -151,6 +147,10 @@ int dpkginfo_init()
+ 
+ int dpkginfo_fini()
+ {
+-        return 0;
++        if (cgCache != NULL) {
++		cgCache->Close();
++        }
++
++	return 0;
+ }
+ 

--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -63,6 +63,7 @@ build do
 
   patch source: "1001-Fix-probe_reset.patch", env: env # fix probe_reset
   patch source: "dpkginfo-cache-close.patch", env: env # close cache at the end of dpkginfo_get_by_name
+  patch source: "dpkginfo-cache-no-close.patch", env: env # work around memory leak in libapt
   patch source: "oval_probe_session_reset.patch", env: env # use oval_probe_session_reset instead of oval_probe_session_reinit
 
   patch source: "oscap-io.patch", env: env # add new oscap-io tool


### PR DESCRIPTION
### What does this PR do?

On some systems, we noticed memory leak with our usage of the APT library.

This change modifies the dpkginfo probe to remove the call to cgCache->Close in the dpkginfo_get_by_name function. This works around the memory leak, which is caused by the re-loading of the dpkg cache after
cgCache->Close has been called.

Functionally, this change is not correct, because
the result of dpkginfo_get_by_name will be based on a cache of the dpkg database, which could potentially be outdated.

However, since the oscap-io process is now terminated each execution of an XCCDF benchmark, a new cache will be loaded with during the next execution of the oscap-io process.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
