### PR TITLE
[ASCII-730] Subcommand `gohai` displays full gohai data, including processes

### DIFF
--- a/cmd/agent/api/internal/agent/agent.go
+++ b/cmd/agent/api/internal/agent/agent.go
@@ -35,6 +35,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/diagnose"
 	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
 	"github.com/DataDog/datadog-agent/pkg/epforwarder"
+	"github.com/DataDog/datadog-agent/pkg/gohai"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
 	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 	v5 "github.com/DataDog/datadog-agent/pkg/metadata/v5"
@@ -448,6 +449,19 @@ func metadataPayload(w http.ResponseWriter, r *http.Request) {
 		scrubbed, err = scrubber.ScrubBytes(jsonPayload)
 		if err != nil {
 			setJSONError(w, log.Errorf("Unable to scrub metadata payload: %s", err), 500)
+			return
+		}
+	case "gohai":
+		payload := gohai.GetPayloadWithProcesses(config.IsContainerized())
+		jsonPayload, err := json.MarshalIndent(payload, "", "  ")
+		if err != nil {
+			setJSONError(w, log.Errorf("Unable to marshal gohai metadata payload: %s", err), 500)
+			return
+		}
+
+		scrubbed, err = scrubber.ScrubBytes(jsonPayload)
+		if err != nil {
+			setJSONError(w, log.Errorf("Unable to scrub gohai metadata payload: %s", err), 500)
 			return
 		}
 	case "inventory":

--- a/cmd/agent/subcommands/diagnose/command.go
+++ b/cmd/agent/subcommands/diagnose/command.go
@@ -126,6 +126,21 @@ This command print the V5 metadata payload for the Agent. This payload is used t
 		},
 	}
 
+	payloadGohaiCmd := &cobra.Command{
+		Use:   "gohai",
+		Short: "Print the gohai payload for the agent.",
+		Long: `
+This command prints the gohai data sent by the Agent, including current processes running on the machine.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliParams.payloadName = "gohai"
+			return fxutil.OneShot(printPayload,
+				fx.Supply(cliParams),
+				fx.Supply(command.GetDefaultCoreBundleParams(cliParams.GlobalParams)),
+				core.Bundle,
+			)
+		},
+	}
+
 	payloadInventoriesCmd := &cobra.Command{
 		Use:   "inventory",
 		Short: "Print the Inventory metadata payload for the agent.",
@@ -141,6 +156,7 @@ This command print the last Inventory metadata payload sent by the Agent. This p
 		},
 	}
 	showPayloadCommand.AddCommand(payloadV5Cmd)
+	showPayloadCommand.AddCommand(payloadGohaiCmd)
 	showPayloadCommand.AddCommand(payloadInventoriesCmd)
 	diagnoseCommand.AddCommand(showPayloadCommand)
 

--- a/cmd/agent/subcommands/diagnose/command_test.go
+++ b/cmd/agent/subcommands/diagnose/command_test.go
@@ -36,6 +36,17 @@ func TestShowMetadataV5Command(t *testing.T) {
 		})
 }
 
+func TestShowMetadataGohaiCommand(t *testing.T) {
+	fxutil.TestOneShotSubcommand(t,
+		Commands(&command.GlobalParams{}),
+		[]string{"diagnose", "show-metadata", "gohai"},
+		printPayload,
+		func(cliParams *cliParams, coreParams core.BundleParams) {
+			require.Equal(t, false, coreParams.ConfigLoadSecrets())
+			require.Equal(t, "gohai", cliParams.payloadName)
+		})
+}
+
 func TestShowMetadataInventoryCommand(t *testing.T) {
 	fxutil.TestOneShotSubcommand(t,
 		Commands(&command.GlobalParams{}),

--- a/pkg/gohai/gohai.go
+++ b/pkg/gohai/gohai.go
@@ -57,6 +57,7 @@ func GetPayload(isContainerized bool) *Payload {
 	}
 }
 
+// GetPayloadWithProcesses builds a pyaload of all metdata including processes
 func GetPayloadWithProcesses(isContainerized bool) *Payload {
 	return &Payload{
 		Gohai: getGohaiInfo(isContainerized, true),

--- a/releasenotes/notes/gohai-subcommand-3d071a92b480ca73.yaml
+++ b/releasenotes/notes/gohai-subcommand-3d071a92b480ca73.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add subcommand `diagnose show-metadata gohai` for gohai data


### PR DESCRIPTION
### What does this PR do?

Adds a subcommand to show full gohai data. It can be run like this:

```
datadog-agent diagnose show-metadata gohai
```

### Motivation

This used to be in the gohai binary but was removed: https://github.com/DataDog/datadog-agent/pull/19231/files. It useful to have around for debugging purposes.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Run this command:
```
datadog-agent diagnose show-metadata gohai
```

Verify that stats are shown as indented JSON, including a top-level "processes" key.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
