### PR TITLE
[CWS] Lazy initialization of SECL constants

### DIFF
--- a/pkg/security/probe/discarders_test.go
+++ b/pkg/security/probe/discarders_test.go
@@ -30,7 +30,7 @@ func TestIsParentDiscarder(t *testing.T) {
 
 	var evalOpts eval.Opts
 	evalOpts.
-		WithConstants(model.SECLConstants).
+		WithConstants(model.SECLConstants()).
 		WithLegacyFields(model.SECLLegacyFields).
 		WithVariables(model.SECLVariables)
 
@@ -228,7 +228,7 @@ func TestIsGrandParentDiscarder(t *testing.T) {
 
 	var evalOpts eval.Opts
 	evalOpts.
-		WithConstants(model.SECLConstants).
+		WithConstants(model.SECLConstants()).
 		WithLegacyFields(model.SECLLegacyFields)
 
 	var opts rules.Opts
@@ -360,7 +360,7 @@ func TestIsDiscarderOverride(t *testing.T) {
 
 	var evalOpts eval.Opts
 	evalOpts.
-		WithConstants(model.SECLConstants).
+		WithConstants(model.SECLConstants()).
 		WithLegacyFields(model.SECLLegacyFields)
 
 	var opts rules.Opts
@@ -407,7 +407,7 @@ func BenchmarkParentDiscarder(b *testing.B) {
 
 	var evalOpts eval.Opts
 	evalOpts.
-		WithConstants(model.SECLConstants).
+		WithConstants(model.SECLConstants()).
 		WithLegacyFields(model.SECLLegacyFields)
 
 	var opts rules.Opts

--- a/pkg/security/secl/model/consts_common.go
+++ b/pkg/security/secl/model/consts_common.go
@@ -13,6 +13,7 @@ import (
 	"math/bits"
 	"sort"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
@@ -539,9 +540,9 @@ var (
 		"CLASS_ANY":    255,
 	}
 
-	// SECLConstants are constants supported in runtime security agent rules
+	// seclConstants are constants supported in runtime security agent rules
 	// generate_constants:SecL constants,SecL constants are the supported generic SecL constants.
-	SECLConstants = map[string]interface{}{
+	seclConstants = map[string]interface{}{
 		// boolean
 		"true":  &eval.BoolEvaluator{Value: true},
 		"false": &eval.BoolEvaluator{Value: false},
@@ -715,7 +716,7 @@ const (
 
 func initOpenConstants() {
 	for k, v := range openFlagsConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: v}
+		seclConstants[k] = &eval.IntEvaluator{Value: v}
 	}
 
 	for k, v := range openFlagsConstants {
@@ -725,35 +726,35 @@ func initOpenConstants() {
 
 func initFileModeConstants() {
 	for k, v := range fileModeConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: v}
+		seclConstants[k] = &eval.IntEvaluator{Value: v}
 		fileModeStrings[v] = k
 	}
 }
 
 func initInodeModeConstants() {
 	for k, v := range inodeModeConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: v}
+		seclConstants[k] = &eval.IntEvaluator{Value: v}
 		inodeModeStrings[v] = k
 	}
 }
 
 func initUnlinkConstanst() {
 	for k, v := range unlinkFlagsConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: v}
+		seclConstants[k] = &eval.IntEvaluator{Value: v}
 		unlinkFlagsStrings[v] = k
 	}
 }
 
 func initErrorConstants() {
 	for k, v := range errorConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: v}
+		seclConstants[k] = &eval.IntEvaluator{Value: v}
 	}
 }
 
 func initKernelCapabilityConstants() {
 	for k, v := range KernelCapabilityConstants {
 		if bits.UintSize == 64 || v < math.MaxInt32 {
-			SECLConstants[k] = &eval.IntEvaluator{Value: int(v)}
+			seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
 		}
 		kernelCapabilitiesStrings[v] = k
 	}
@@ -761,35 +762,35 @@ func initKernelCapabilityConstants() {
 
 func initBPFCmdConstants() {
 	for k, v := range BPFCmdConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: int(v)}
+		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
 		bpfCmdStrings[uint32(v)] = k
 	}
 }
 
 func initBPFHelperFuncConstants() {
 	for k, v := range BPFHelperFuncConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: int(v)}
+		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
 		bpfHelperFuncStrings[uint32(v)] = k
 	}
 }
 
 func initBPFMapTypeConstants() {
 	for k, v := range BPFMapTypeConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: int(v)}
+		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
 		bpfMapTypeStrings[uint32(v)] = k
 	}
 }
 
 func initBPFProgramTypeConstants() {
 	for k, v := range BPFProgramTypeConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: int(v)}
+		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
 		bpfProgramTypeStrings[uint32(v)] = k
 	}
 }
 
 func initBPFAttachTypeConstants() {
 	for k, v := range BPFAttachTypeConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: int(v)}
+		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
 		bpfAttachTypeStrings[uint32(v)] = k
 	}
 }
@@ -800,7 +801,7 @@ func initPtraceConstants() {
 	}
 
 	for k, v := range ptraceConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: int(v)}
+		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
 	}
 
 	for k, v := range ptraceConstants {
@@ -810,7 +811,7 @@ func initPtraceConstants() {
 
 func initVMConstants() {
 	for k, v := range vmConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: int(v)}
+		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
 	}
 
 	for k, v := range vmConstants {
@@ -820,7 +821,7 @@ func initVMConstants() {
 
 func initProtConstansts() {
 	for k, v := range protConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: v}
+		seclConstants[k] = &eval.IntEvaluator{Value: v}
 	}
 
 	for k, v := range protConstants {
@@ -834,7 +835,7 @@ func initMMapFlagsConstants() {
 	}
 
 	for k, v := range mmapFlagConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: int(v)}
+		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
 	}
 
 	for k, v := range mmapFlagConstants {
@@ -844,7 +845,7 @@ func initMMapFlagsConstants() {
 
 func initSignalConstants() {
 	for k, v := range signalConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: v}
+		seclConstants[k] = &eval.IntEvaluator{Value: v}
 	}
 
 	for k, v := range signalConstants {
@@ -854,42 +855,42 @@ func initSignalConstants() {
 
 func initPipeBufFlagConstants() {
 	for k, v := range PipeBufFlagConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: int(v)}
+		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
 		pipeBufFlagStrings[int(v)] = k
 	}
 }
 
 func initDNSQClassConstants() {
 	for k, v := range DNSQClassConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: v}
+		seclConstants[k] = &eval.IntEvaluator{Value: v}
 		dnsQClassStrings[uint32(v)] = k
 	}
 }
 
 func initDNSQTypeConstants() {
 	for k, v := range DNSQTypeConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: v}
+		seclConstants[k] = &eval.IntEvaluator{Value: v}
 		dnsQTypeStrings[uint32(v)] = k
 	}
 }
 
 func initL3ProtocolConstants() {
 	for k, v := range L3ProtocolConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: int(v)}
+		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
 		l3ProtocolStrings[v] = k
 	}
 }
 
 func initL4ProtocolConstants() {
 	for k, v := range L4ProtocolConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: int(v)}
+		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
 		l4ProtocolStrings[v] = k
 	}
 }
 
 func initAddressFamilyConstants() {
 	for k, v := range addressFamilyConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: int(v)}
+		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
 	}
 
 	for k, v := range addressFamilyConstants {
@@ -899,13 +900,13 @@ func initAddressFamilyConstants() {
 
 func initExitCauseConstants() {
 	for k, v := range exitCauseConstants {
-		SECLConstants[k] = &eval.IntEvaluator{Value: int(v)}
+		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
 		exitCauseStrings[v] = k
 	}
 }
 
 func initBPFMapNamesConstants() {
-	SECLConstants["CWS_MAP_NAMES"] = &eval.StringArrayEvaluator{Values: bpfMapNames}
+	seclConstants["CWS_MAP_NAMES"] = &eval.StringArrayEvaluator{Values: bpfMapNames}
 }
 
 func initConstants() {
@@ -1059,8 +1060,18 @@ func (f RetValError) String() string {
 
 var capsStringArrayCache *lru.Cache[KernelCapability, []string]
 
+var constantsInitialized sync.Once
+
+// SECLConstants returns the constants supported in runtime security agent rules,
+// initializing these constants during the first call
+func SECLConstants() map[string]interface{} {
+	constantsInitialized.Do(func() {
+		initConstants()
+	})
+	return seclConstants
+}
+
 func init() {
-	initConstants()
 	capsStringArrayCache, _ = lru.New[KernelCapability, []string](4)
 }
 

--- a/pkg/security/secl/model/consts_test.go
+++ b/pkg/security/secl/model/consts_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestFlagsToString(t *testing.T) {
+	initConstants()
+
 	str := OpenFlags(syscall.O_EXCL | syscall.O_TRUNC).String()
 	if str != "O_RDONLY | O_EXCL | O_TRUNC" {
 		t.Errorf("expected flags not found, got: %s", str)

--- a/pkg/security/secl/rules/opts.go
+++ b/pkg/security/secl/rules/opts.go
@@ -90,7 +90,7 @@ func NewEvalOpts(eventTypeEnabled map[eval.EventType]bool) (*Opts, *eval.Opts) {
 
 	var evalOpts eval.Opts
 	evalOpts.
-		WithConstants(model.SECLConstants).
+		WithConstants(model.SECLConstants()).
 		WithLegacyFields(model.SECLLegacyFields).
 		WithVariables(model.SECLVariables)
 

--- a/pkg/security/secl/rules/rule_filters.go
+++ b/pkg/security/secl/rules/rule_filters.go
@@ -120,7 +120,7 @@ func (r *SECLRuleFilter) IsRuleAccepted(rule *RuleDefinition) (bool, error) {
 
 	evalOpts := &eval.Opts{}
 	evalOpts.
-		WithConstants(model.SECLConstants)
+		WithConstants(model.SECLConstants())
 
 	evaluator, err := eval.NewRuleEvaluator(astRule, r.model, evalOpts)
 	if err != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Initialize SECL constants at first use.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation



<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
