### PR TITLE
SLES-1358 fix: don't hang in waiting forever for any signal

### DIFF
--- a/cmd/serverless-init/initcontainer/initcontainer.go
+++ b/cmd/serverless-init/initcontainer/initcontainer.go
@@ -129,12 +129,7 @@ func handleSignals(
 					_ = syscall.Kill(process.Pid, sig.(syscall.Signal))
 				}
 				if sig == syscall.SIGTERM {
-					_, err := process.Wait()
-					if err != nil {
-						serverlessLog.Write(config, []byte(fmt.Sprintf("[datadog init process] exiting with code = %s", err)), false)
-					} else {
-						serverlessLog.Write(config, []byte("[datadog init process] exiting successfully"), false)
-					}
+					serverlessLog.Write(config, []byte("[datadog init process] child process received SIGTERM. Flushing shutdown metrics and terminate when/if the child process does"), false)
 					metric.AddShutdownMetric(cloudService.GetPrefix(), metricAgent.GetExtraTags(), time.Now(), metricAgent.Demux)
 					flush(config.FlushTimeout, metricAgent, traceAgent, logsAgent)
 				}

--- a/cmd/serverless-init/initcontainer/initcontainer.go
+++ b/cmd/serverless-init/initcontainer/initcontainer.go
@@ -156,7 +156,7 @@ func flush(flushTimeout time.Duration, metricAgent serverless.FlushableAgent, tr
 	return hasTimeout.Load() > 0
 }
 
-func flushWithContext(ctx context.Context, timeout time.Duration, timeoutchan chan struct{}, flushFunction func()) {
+func flushWithContext(ctx context.Context, timeoutchan chan struct{}, flushFunction func()) {
 	flushFunction()
 	select {
 	case timeoutchan <- struct{}{}:
@@ -171,7 +171,7 @@ func flushAndWait(flushTimeout time.Duration, wg *sync.WaitGroup, agent serverle
 	childCtx, cancel := context.WithTimeout(context.Background(), flushTimeout)
 	defer cancel()
 	ch := make(chan struct{}, 1)
-	go flushWithContext(childCtx, flushTimeout, ch, agent.Flush)
+	go flushWithContext(childCtx, ch, agent.Flush)
 	select {
 	case <-childCtx.Done():
 		hasTimeout.Inc()

--- a/cmd/serverless-init/initcontainer/initcontainer.go
+++ b/cmd/serverless-init/initcontainer/initcontainer.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/metric"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -93,7 +94,7 @@ func execute(
 	} else {
 		serverlessLog.Write(config, []byte("[datadog init process] exiting successfully"), false)
 	}
-
+	metric.AddShutdownMetric(cloudService.GetPrefix(), metricAgent.GetExtraTags(), time.Now(), metricAgent.Demux)
 	flush(config.FlushTimeout, metricAgent, traceAgent, logsAgent)
 	return err
 }

--- a/cmd/serverless-init/initcontainer/initcontainer_test.go
+++ b/cmd/serverless-init/initcontainer/initcontainer_test.go
@@ -8,6 +8,11 @@
 package initcontainer
 
 import (
+	serverlessLog "github.com/DataDog/datadog-agent/cmd/serverless-init/log"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
 	"testing"
 	"time"
 
@@ -62,4 +67,36 @@ func TestFlushTimeout(t *testing.T) {
 	flush(100*time.Millisecond, metricAgent, traceAgent, mockLogsAgent)
 	assert.Equal(t, false, metricAgent.hasBeenCalled)
 	assert.Equal(t, false, mockLogsAgent.DidFlush())
+}
+
+func TestPropagateChildSuccess(t *testing.T) {
+	err := execute(&serverlessLog.Config{}, []string{"bash", "-c", "exit 0"})
+	assert.Equal(t, nil, err)
+}
+
+func TestPropagateChildError(t *testing.T) {
+	expectedError := 123
+	err := execute(&serverlessLog.Config{}, []string{"bash", "-c", "exit " + strconv.Itoa(expectedError)})
+	assert.Equal(t, expectedError<<8, int(err.(*exec.ExitError).ProcessState.Sys().(syscall.WaitStatus)))
+}
+
+func TestForwardSignalToChild(t *testing.T) {
+	resultChan := make(chan error)
+	terminatingSignal := syscall.SIGUSR1
+	cmd := exec.Command("sleep", "2s")
+	cmd.Start()
+	sigs := make(chan os.Signal, 1)
+	go forwardSignals(cmd.Process, &serverlessLog.Config{}, sigs)
+
+	go func() {
+		err := cmd.Wait()
+		resultChan <- err
+	}()
+
+	sigs <- syscall.SIGSTOP
+	sigs <- syscall.SIGCONT
+	sigs <- terminatingSignal
+
+	err := <-resultChan
+	assert.Equal(t, int(terminatingSignal), int(err.(*exec.ExitError).ProcessState.Sys().(syscall.WaitStatus)))
 }


### PR DESCRIPTION
### What does this PR do?

Fixes a bug that prevents os signals to  be processed by the child process after the first signal is forwarder to it.

### Motivation

This PR https://github.com/DataDog/datadog-agent/pull/17127 introduced a wait for a child process (the instrumented customer application) to terminate in any signal except `syscall.SIGCHLD`, whenever the child process is alive. Most of linux signals do not require the application to terminate, so after the first signal  was received (e.g. `23` SIGURG) the go routine was hanging forever waiting for the child to exit, and not forwarding any more signals.
This was addressing the issue https://github.com/DataDog/datadog-agent/issues/17124, but that is likely caused by the  `os.exit(0)` at the end of the go routine. This PR should address that too, since the `os.exit(0)` is removed and the main process will terminate with the `cmd.wait`