### PR TITLE
Add ability to skip instances without an error in check loader

### DIFF
--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -6,6 +6,7 @@
 package check
 
 import (
+	"errors"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
@@ -69,3 +70,17 @@ type Info interface {
 	// InstanceConfig returns the instance configuration of the check
 	InstanceConfig() string
 }
+
+// ErrSkipCheckInstance is returned from Configure() when a check is intentionally refusing to load a
+// check instance, and NOT due to an error. The distinction is important for deciding whether or not
+// to log the error and report it on the status page.
+//
+// Loaders should check for this error after calling Configure() and should not log it as an error.
+// The scheduler reports this error to the agent status if and only if all loaders fail to load the
+// check instance.
+//
+// Usage example: one version of the check is written in Python, and another is written in Golang. Each
+// loader is called on the given configuration, and will reject the configuration if it does not
+// match the right version, without raising errors to the log or agent status. If another error is
+// returned then the errors will be properly logged and reported in the agent status.
+var ErrSkipCheckInstance = errors.New("refused to load the check instance")

--- a/pkg/collector/corechecks/loader.go
+++ b/pkg/collector/corechecks/loader.go
@@ -6,6 +6,7 @@
 package corechecks
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
@@ -61,6 +62,9 @@ func (gl *GoCheckLoader) Load(senderManger sender.SenderManager, config integrat
 
 	c = factory()
 	if err := c.Configure(senderManger, config.FastDigest(), instance, config.InitConfig, config.Source); err != nil {
+		if errors.Is(err, check.ErrSkipCheckInstance) {
+			return c, err
+		}
 		log.Errorf("core.loader: could not configure check %s: %s", c, err)
 		msg := fmt.Sprintf("Could not configure check %s: %s", c, err)
 		return c, fmt.Errorf(msg)

--- a/pkg/collector/corechecks/loader_test.go
+++ b/pkg/collector/corechecks/loader_test.go
@@ -6,6 +6,7 @@
 package corechecks
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -24,6 +25,9 @@ type TestCheck struct {
 func (c *TestCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, data integration.Data, initData integration.Data, source string) error {
 	if string(data) == "err" {
 		return fmt.Errorf("testError")
+	}
+	if string(data) == "skip" {
+		return check.ErrSkipCheckInstance
 	}
 	return nil
 }
@@ -71,6 +75,18 @@ func TestLoad(t *testing.T) {
 
 	if err == nil {
 		t.Fatalf("Expected error, found: nil")
+	}
+
+	// check is in catalog, pass 1 skip instance
+	i = []integration.Data{
+		integration.Data("skip"),
+	}
+	cc = integration.Config{Name: "foo", Instances: i}
+
+	_, err = l.Load(aggregator.NewNoOpSenderManager(), cc, i[0])
+
+	if !errors.Is(err, check.ErrSkipCheckInstance) {
+		t.Fatalf("Expected ErrSkipCheckInstance, found: %v", err)
 	}
 
 	// check not in catalog

--- a/pkg/collector/python/check.go
+++ b/pkg/collector/python/check.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"strings"
 	"time"
 	"unsafe"
 
@@ -19,6 +20,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	checkbase "github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/stats"
@@ -37,6 +39,11 @@ import (
 char *getStringAddr(char **array, unsigned int idx);
 */
 import "C"
+
+const (
+	// Keep this pattern in sync with SkipInstanceError in integrations-core
+	skipInstanceErrorPattern = "The integration refused to load the check configuration, it may be too old or too new."
+)
 
 // PythonCheck represents a Python check, implements `Check` interface
 type PythonCheck struct {
@@ -276,6 +283,10 @@ func (c *PythonCheck) Configure(senderManager sender.SenderManager, integrationC
 	var rtLoaderError error
 	if res == 0 {
 		rtLoaderError = getRtLoaderError()
+		if rtLoaderError != nil && strings.Contains(rtLoaderError.Error(), skipInstanceErrorPattern) {
+			return fmt.Errorf("%w: %w", checkbase.ErrSkipCheckInstance, rtLoaderError)
+		}
+
 		log.Warnf("could not get a '%s' check instance with the new api: %s", c.ModuleName, rtLoaderError)
 		log.Warn("trying to instantiate the check with the old api, passing agentConfig to the constructor")
 
@@ -290,10 +301,14 @@ func (c *PythonCheck) Configure(senderManager sender.SenderManager, integrationC
 
 		res := C.get_check_deprecated(rtloader, c.class, cInitConfig, cInstance, cAgentConfig, cCheckID, cCheckName, &check)
 		if res == 0 {
-			if rtLoaderError != nil {
-				return fmt.Errorf("could not invoke '%s' python check constructor. New constructor API returned:\n%sDeprecated constructor API returned:\n%s", c.ModuleName, rtLoaderError, getRtLoaderError())
+			rtLoaderDeprecatedCheckError := getRtLoaderError()
+			if strings.Contains(rtLoaderDeprecatedCheckError.Error(), skipInstanceErrorPattern) {
+				return fmt.Errorf("%w: %w", checkbase.ErrSkipCheckInstance, rtLoaderDeprecatedCheckError)
 			}
-			return fmt.Errorf("could not invoke '%s' python check constructor: %s", c.ModuleName, getRtLoaderError())
+			if rtLoaderError != nil {
+				return fmt.Errorf("could not invoke '%s' python check constructor. New constructor API returned:\n%wDeprecated constructor API returned:\n%w", c.ModuleName, rtLoaderError, rtLoaderDeprecatedCheckError)
+			}
+			return fmt.Errorf("could not invoke '%s' python check constructor: %w", c.ModuleName, rtLoaderDeprecatedCheckError)
 		}
 		log.Warnf("passing `agentConfig` to the constructor is deprecated, please use the `get_config` function from the 'datadog_agent' package (%s).", c.ModuleName)
 	}

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -206,6 +206,10 @@ func (cl *PythonCheckLoader) Load(senderManager sender.SenderManager, config int
 		C.rtloader_decref(rtloader, checkClass)
 		C.rtloader_decref(rtloader, checkModule)
 
+		if errors.Is(err, check.ErrSkipCheckInstance) {
+			return nil, err
+		}
+
 		addExpvarConfigureError(fmt.Sprintf("%s (%s)", moduleName, wheelVersion), err.Error())
 		return c, fmt.Errorf("could not configure check instance for python check %s: %s", moduleName, err.Error())
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Add new `ErrSkipCheckInstance` error to be raised by a check to indicate it wants to skip the provided configuration. Used in the win32_event_log check to switch between the Python and Go versions of the check based on the check configuration version.

See https://github.com/DataDog/integrations-core/pull/16012

If no loader successfully loads the check instance, errors are still raised.
example `agent check win32_event_log` output
```
Error: could not load win32_event_log:
* JMX Check Loader: check is not a jmx check, or unable to determine if it's so
* Python Check Loader: refused to load the check instance: Traceback (most recent call last):
  File "C:\Users\ContainerAdministrator\win32_event_log\datadog_checks\win32_event_log\check.py", line 84, in __new__
    raise SkipInstanceError(
datadog_checks.base.errors.SkipInstanceError: The integration refused to load the check configuration, it may be too old or too new. Set the legacy_mode and legacy_mode_v2 options to configure the implementation to use.

* Core Check Loader: Check win32_event_log not found in Catalog
Error: no valid check found
```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
To enable using the Go check as the new default implementation, and require setting a configuration option to use the previous version.
Also to remove errors in agent log and agent status when one loader skips/refuses to load the instance but then another loader successfully loads it.

https://datadoghq.atlassian.net/browse/WINA-475

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
