### PR TITLE
Add an `emacs.set-buildtags` `invoke` task to configure lsp-mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,7 @@ pkg/network/netlink/testdata/message_dump*
 
 # Emacs
 *~
+.dir-locals.el
 
 # etags
 TAGS

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -14,6 +14,7 @@ from . import (
     diff,
     docker_tasks,
     dogstatsd,
+    emacs,
     epforwarder,
     github_tasks,
     kmt,
@@ -124,6 +125,7 @@ ns.add_collection(bench)
 ns.add_collection(trace_agent)
 ns.add_collection(docker_tasks, "docker")
 ns.add_collection(dogstatsd)
+ns.add_collection(emacs)
 ns.add_collection(epforwarder)
 ns.add_collection(msi)
 ns.add_collection(github_tasks, "github")

--- a/tasks/emacs.py
+++ b/tasks/emacs.py
@@ -1,0 +1,43 @@
+"""
+Emacs namespaced tags
+
+Helpers for getting Emacs set up nicely
+"""
+from invoke import task
+
+from .build_tags import build_tags, filter_incompatible_tags, get_build_tags, get_default_build_tags
+from .flavor import AgentFlavor
+
+
+@task
+def set_buildtags(
+    _,
+    target="agent",
+    build_include=None,
+    build_exclude=None,
+    flavor=AgentFlavor.base.name,
+    arch="x64",
+):
+    """
+    Create Emacs .dir-locals.el settings file for this project to include correct build tags
+    """
+    flavor = AgentFlavor[flavor]
+
+    if target not in build_tags[flavor].keys():
+        print("Must choose a valid target.  Valid targets are: \n")
+        print(f'{", ".join(build_tags[flavor].keys())} \n')
+        return
+
+    build_include = (
+        get_default_build_tags(build=target, arch=arch, flavor=flavor)
+        if build_include is None
+        else filter_incompatible_tags(build_include.split(","), arch=arch)
+    )
+    build_exclude = [] if build_exclude is None else build_exclude.split(",")
+    use_tags = get_build_tags(build_include, build_exclude)
+
+    with open(".dir-locals.el", "w") as f:
+        f.write(f'((go-mode . ((lsp-go-build-flags . ["-tags", "{",".join(use_tags)}"])\n')
+        f.write(
+            '             (eval . (lsp-register-custom-settings \'(("gopls.allowImplicitNetworkAccess" t t)))))))\n'
+        )


### PR DESCRIPTION
### What does this PR do?

Add an `emacs.set-buildtags` `invoke` task that does for Emacs exactly what the already existing [`vscode.set-buildtags` task](https://github.com/DataDog/datadog-agent/blob/e6cc2fbc9dc897077892f062f131013b8c9ce507/tasks/vscode.py#L21-L60) does for VS Code: configure `gopls` with appropriate build tags.

### Motivation



### Additional Notes

https://github.com/golang/tools/blob/master/gopls/doc/emacs.md

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
