### PR TITLE
[CWS] add windows field accessors

### DIFF
--- a/pkg/security/secl/model/field_accessors_windows.go
+++ b/pkg/security/secl/model/field_accessors_windows.go
@@ -1,0 +1,1005 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+// Code generated - DO NOT EDIT.
+
+//go:build windows
+// +build windows
+
+package model
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"net"
+	"time"
+)
+
+// GetContainerCreatedAt returns the value of the field, resolving if necessary
+func (ev *Event) GetContainerCreatedAt() int {
+	zeroValue := 0
+	if ev.BaseEvent.ContainerContext == nil {
+		return zeroValue
+	}
+	return ev.FieldHandlers.ResolveContainerCreatedAt(ev, ev.BaseEvent.ContainerContext)
+}
+
+// GetContainerId returns the value of the field, resolving if necessary
+func (ev *Event) GetContainerId() string {
+	zeroValue := ""
+	if ev.BaseEvent.ContainerContext == nil {
+		return zeroValue
+	}
+	return ev.FieldHandlers.ResolveContainerID(ev, ev.BaseEvent.ContainerContext)
+}
+
+// GetContainerTags returns the value of the field, resolving if necessary
+func (ev *Event) GetContainerTags() []string {
+	zeroValue := []string{}
+	if ev.BaseEvent.ContainerContext == nil {
+		return zeroValue
+	}
+	resolvedField := ev.FieldHandlers.ResolveContainerTags(ev, ev.BaseEvent.ContainerContext)
+	fieldCopy := make([]string, len(resolvedField))
+	copy(fieldCopy, resolvedField)
+	return fieldCopy
+}
+
+// GetEventTimestamp returns the value of the field, resolving if necessary
+func (ev *Event) GetEventTimestamp() int {
+	return ev.FieldHandlers.ResolveEventTimestamp(ev, &ev.BaseEvent)
+}
+
+// GetExecArgs returns the value of the field, resolving if necessary
+func (ev *Event) GetExecArgs() string {
+	zeroValue := ""
+	if ev.GetEventType().String() != "exec" {
+		return zeroValue
+	}
+	if ev.Exec.Process == nil {
+		return zeroValue
+	}
+	return ev.Exec.Process.Args
+}
+
+// GetExecContainerId returns the value of the field, resolving if necessary
+func (ev *Event) GetExecContainerId() string {
+	zeroValue := ""
+	if ev.GetEventType().String() != "exec" {
+		return zeroValue
+	}
+	if ev.Exec.Process == nil {
+		return zeroValue
+	}
+	return ev.Exec.Process.ContainerID
+}
+
+// GetExecCreatedAt returns the value of the field, resolving if necessary
+func (ev *Event) GetExecCreatedAt() int {
+	zeroValue := 0
+	if ev.GetEventType().String() != "exec" {
+		return zeroValue
+	}
+	if ev.Exec.Process == nil {
+		return zeroValue
+	}
+	return ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.Exec.Process)
+}
+
+// GetExecEnvp returns the value of the field, resolving if necessary
+func (ev *Event) GetExecEnvp(desiredKeys map[string]bool) []string {
+	zeroValue := []string{}
+	if ev.GetEventType().String() != "exec" {
+		return zeroValue
+	}
+	if ev.Exec.Process == nil {
+		return zeroValue
+	}
+	resolvedField := ev.FieldHandlers.ResolveProcessEnvp(ev, ev.Exec.Process)
+	resolvedField = filterEnvs(resolvedField, desiredKeys)
+	fieldCopy := make([]string, len(resolvedField))
+	copy(fieldCopy, resolvedField)
+	return fieldCopy
+}
+
+// GetExecEnvs returns the value of the field, resolving if necessary
+func (ev *Event) GetExecEnvs(desiredKeys map[string]bool) []string {
+	zeroValue := []string{}
+	if ev.GetEventType().String() != "exec" {
+		return zeroValue
+	}
+	if ev.Exec.Process == nil {
+		return zeroValue
+	}
+	resolvedField := ev.FieldHandlers.ResolveProcessEnvs(ev, ev.Exec.Process)
+	resolvedField = filterEnvs(resolvedField, desiredKeys)
+	fieldCopy := make([]string, len(resolvedField))
+	copy(fieldCopy, resolvedField)
+	return fieldCopy
+}
+
+// GetExecFileName returns the value of the field, resolving if necessary
+func (ev *Event) GetExecFileName() string {
+	zeroValue := ""
+	if ev.GetEventType().String() != "exec" {
+		return zeroValue
+	}
+	if ev.Exec.Process == nil {
+		return zeroValue
+	}
+	return ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exec.Process.FileEvent)
+}
+
+// GetExecFileNameLength returns the value of the field, resolving if necessary
+func (ev *Event) GetExecFileNameLength() int {
+	zeroValue := 0
+	if ev.GetEventType().String() != "exec" {
+		return zeroValue
+	}
+	if ev.Exec.Process == nil {
+		return zeroValue
+	}
+	return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exec.Process.FileEvent))
+}
+
+// GetExecFilePath returns the value of the field, resolving if necessary
+func (ev *Event) GetExecFilePath() string {
+	zeroValue := ""
+	if ev.GetEventType().String() != "exec" {
+		return zeroValue
+	}
+	if ev.Exec.Process == nil {
+		return zeroValue
+	}
+	return ev.FieldHandlers.ResolveFilePath(ev, &ev.Exec.Process.FileEvent)
+}
+
+// GetExecFilePathLength returns the value of the field, resolving if necessary
+func (ev *Event) GetExecFilePathLength() int {
+	zeroValue := 0
+	if ev.GetEventType().String() != "exec" {
+		return zeroValue
+	}
+	if ev.Exec.Process == nil {
+		return zeroValue
+	}
+	return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.Exec.Process.FileEvent))
+}
+
+// GetExecPid returns the value of the field, resolving if necessary
+func (ev *Event) GetExecPid() uint32 {
+	zeroValue := uint32(0)
+	if ev.GetEventType().String() != "exec" {
+		return zeroValue
+	}
+	if ev.Exec.Process == nil {
+		return zeroValue
+	}
+	return ev.Exec.Process.PIDContext.Pid
+}
+
+// GetExecPpid returns the value of the field, resolving if necessary
+func (ev *Event) GetExecPpid() uint32 {
+	zeroValue := uint32(0)
+	if ev.GetEventType().String() != "exec" {
+		return zeroValue
+	}
+	if ev.Exec.Process == nil {
+		return zeroValue
+	}
+	return ev.Exec.Process.PPid
+}
+
+// GetExecTid returns the value of the field, resolving if necessary
+func (ev *Event) GetExecTid() uint32 {
+	zeroValue := uint32(0)
+	if ev.GetEventType().String() != "exec" {
+		return zeroValue
+	}
+	if ev.Exec.Process == nil {
+		return zeroValue
+	}
+	return ev.Exec.Process.PIDContext.Tid
+}
+
+// GetExitArgs returns the value of the field, resolving if necessary
+func (ev *Event) GetExitArgs() string {
+	zeroValue := ""
+	if ev.GetEventType().String() != "exit" {
+		return zeroValue
+	}
+	if ev.Exit.Process == nil {
+		return zeroValue
+	}
+	return ev.Exit.Process.Args
+}
+
+// GetExitCause returns the value of the field, resolving if necessary
+func (ev *Event) GetExitCause() uint32 {
+	zeroValue := uint32(0)
+	if ev.GetEventType().String() != "exit" {
+		return zeroValue
+	}
+	return ev.Exit.Cause
+}
+
+// GetExitCode returns the value of the field, resolving if necessary
+func (ev *Event) GetExitCode() uint32 {
+	zeroValue := uint32(0)
+	if ev.GetEventType().String() != "exit" {
+		return zeroValue
+	}
+	return ev.Exit.Code
+}
+
+// GetExitContainerId returns the value of the field, resolving if necessary
+func (ev *Event) GetExitContainerId() string {
+	zeroValue := ""
+	if ev.GetEventType().String() != "exit" {
+		return zeroValue
+	}
+	if ev.Exit.Process == nil {
+		return zeroValue
+	}
+	return ev.Exit.Process.ContainerID
+}
+
+// GetExitCreatedAt returns the value of the field, resolving if necessary
+func (ev *Event) GetExitCreatedAt() int {
+	zeroValue := 0
+	if ev.GetEventType().String() != "exit" {
+		return zeroValue
+	}
+	if ev.Exit.Process == nil {
+		return zeroValue
+	}
+	return ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.Exit.Process)
+}
+
+// GetExitEnvp returns the value of the field, resolving if necessary
+func (ev *Event) GetExitEnvp(desiredKeys map[string]bool) []string {
+	zeroValue := []string{}
+	if ev.GetEventType().String() != "exit" {
+		return zeroValue
+	}
+	if ev.Exit.Process == nil {
+		return zeroValue
+	}
+	resolvedField := ev.FieldHandlers.ResolveProcessEnvp(ev, ev.Exit.Process)
+	resolvedField = filterEnvs(resolvedField, desiredKeys)
+	fieldCopy := make([]string, len(resolvedField))
+	copy(fieldCopy, resolvedField)
+	return fieldCopy
+}
+
+// GetExitEnvs returns the value of the field, resolving if necessary
+func (ev *Event) GetExitEnvs(desiredKeys map[string]bool) []string {
+	zeroValue := []string{}
+	if ev.GetEventType().String() != "exit" {
+		return zeroValue
+	}
+	if ev.Exit.Process == nil {
+		return zeroValue
+	}
+	resolvedField := ev.FieldHandlers.ResolveProcessEnvs(ev, ev.Exit.Process)
+	resolvedField = filterEnvs(resolvedField, desiredKeys)
+	fieldCopy := make([]string, len(resolvedField))
+	copy(fieldCopy, resolvedField)
+	return fieldCopy
+}
+
+// GetExitFileName returns the value of the field, resolving if necessary
+func (ev *Event) GetExitFileName() string {
+	zeroValue := ""
+	if ev.GetEventType().String() != "exit" {
+		return zeroValue
+	}
+	if ev.Exit.Process == nil {
+		return zeroValue
+	}
+	return ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exit.Process.FileEvent)
+}
+
+// GetExitFileNameLength returns the value of the field, resolving if necessary
+func (ev *Event) GetExitFileNameLength() int {
+	zeroValue := 0
+	if ev.GetEventType().String() != "exit" {
+		return zeroValue
+	}
+	if ev.Exit.Process == nil {
+		return zeroValue
+	}
+	return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.Exit.Process.FileEvent))
+}
+
+// GetExitFilePath returns the value of the field, resolving if necessary
+func (ev *Event) GetExitFilePath() string {
+	zeroValue := ""
+	if ev.GetEventType().String() != "exit" {
+		return zeroValue
+	}
+	if ev.Exit.Process == nil {
+		return zeroValue
+	}
+	return ev.FieldHandlers.ResolveFilePath(ev, &ev.Exit.Process.FileEvent)
+}
+
+// GetExitFilePathLength returns the value of the field, resolving if necessary
+func (ev *Event) GetExitFilePathLength() int {
+	zeroValue := 0
+	if ev.GetEventType().String() != "exit" {
+		return zeroValue
+	}
+	if ev.Exit.Process == nil {
+		return zeroValue
+	}
+	return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.Exit.Process.FileEvent))
+}
+
+// GetExitPid returns the value of the field, resolving if necessary
+func (ev *Event) GetExitPid() uint32 {
+	zeroValue := uint32(0)
+	if ev.GetEventType().String() != "exit" {
+		return zeroValue
+	}
+	if ev.Exit.Process == nil {
+		return zeroValue
+	}
+	return ev.Exit.Process.PIDContext.Pid
+}
+
+// GetExitPpid returns the value of the field, resolving if necessary
+func (ev *Event) GetExitPpid() uint32 {
+	zeroValue := uint32(0)
+	if ev.GetEventType().String() != "exit" {
+		return zeroValue
+	}
+	if ev.Exit.Process == nil {
+		return zeroValue
+	}
+	return ev.Exit.Process.PPid
+}
+
+// GetExitTid returns the value of the field, resolving if necessary
+func (ev *Event) GetExitTid() uint32 {
+	zeroValue := uint32(0)
+	if ev.GetEventType().String() != "exit" {
+		return zeroValue
+	}
+	if ev.Exit.Process == nil {
+		return zeroValue
+	}
+	return ev.Exit.Process.PIDContext.Tid
+}
+
+// GetNetworkDestinationIp returns the value of the field, resolving if necessary
+func (ev *Event) GetNetworkDestinationIp() net.IPNet {
+	zeroValue := net.IPNet{}
+	if ev.GetEventType().String() != "dns" {
+		return zeroValue
+	}
+	return ev.BaseEvent.NetworkContext.Destination.IPNet
+}
+
+// GetNetworkDestinationPort returns the value of the field, resolving if necessary
+func (ev *Event) GetNetworkDestinationPort() uint16 {
+	zeroValue := uint16(0)
+	if ev.GetEventType().String() != "dns" {
+		return zeroValue
+	}
+	return ev.BaseEvent.NetworkContext.Destination.Port
+}
+
+// GetNetworkL3Protocol returns the value of the field, resolving if necessary
+func (ev *Event) GetNetworkL3Protocol() uint16 {
+	zeroValue := uint16(0)
+	if ev.GetEventType().String() != "dns" {
+		return zeroValue
+	}
+	return ev.BaseEvent.NetworkContext.L3Protocol
+}
+
+// GetNetworkL4Protocol returns the value of the field, resolving if necessary
+func (ev *Event) GetNetworkL4Protocol() uint16 {
+	zeroValue := uint16(0)
+	if ev.GetEventType().String() != "dns" {
+		return zeroValue
+	}
+	return ev.BaseEvent.NetworkContext.L4Protocol
+}
+
+// GetNetworkSize returns the value of the field, resolving if necessary
+func (ev *Event) GetNetworkSize() uint32 {
+	zeroValue := uint32(0)
+	if ev.GetEventType().String() != "dns" {
+		return zeroValue
+	}
+	return ev.BaseEvent.NetworkContext.Size
+}
+
+// GetNetworkSourceIp returns the value of the field, resolving if necessary
+func (ev *Event) GetNetworkSourceIp() net.IPNet {
+	zeroValue := net.IPNet{}
+	if ev.GetEventType().String() != "dns" {
+		return zeroValue
+	}
+	return ev.BaseEvent.NetworkContext.Source.IPNet
+}
+
+// GetNetworkSourcePort returns the value of the field, resolving if necessary
+func (ev *Event) GetNetworkSourcePort() uint16 {
+	zeroValue := uint16(0)
+	if ev.GetEventType().String() != "dns" {
+		return zeroValue
+	}
+	return ev.BaseEvent.NetworkContext.Source.Port
+}
+
+// GetProcessAncestorsArgs returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsArgs() []string {
+	zeroValue := []string{}
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return zeroValue
+	}
+	var values []string
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := element.ProcessContext.Process.Args
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsContainerId returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsContainerId() []string {
+	zeroValue := []string{}
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return zeroValue
+	}
+	var values []string
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := element.ProcessContext.Process.ContainerID
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsCreatedAt returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsCreatedAt() []int {
+	zeroValue := []int{}
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return zeroValue
+	}
+	var values []int
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := int(ev.FieldHandlers.ResolveProcessCreatedAt(ev, &element.ProcessContext.Process))
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsEnvp returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsEnvp(desiredKeys map[string]bool) []string {
+	zeroValue := []string{}
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return zeroValue
+	}
+	var values []string
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := ev.FieldHandlers.ResolveProcessEnvp(ev, &element.ProcessContext.Process)
+		result = filterEnvs(result, desiredKeys)
+		values = append(values, result...)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsEnvs returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsEnvs(desiredKeys map[string]bool) []string {
+	zeroValue := []string{}
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return zeroValue
+	}
+	var values []string
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := ev.FieldHandlers.ResolveProcessEnvs(ev, &element.ProcessContext.Process)
+		result = filterEnvs(result, desiredKeys)
+		values = append(values, result...)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsFileName returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsFileName() []string {
+	zeroValue := []string{}
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return zeroValue
+	}
+	var values []string
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := ev.FieldHandlers.ResolveFileBasename(ev, &element.ProcessContext.Process.FileEvent)
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsFileNameLength returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsFileNameLength() []int {
+	zeroValue := []int{}
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return zeroValue
+	}
+	var values []int
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := len(ev.FieldHandlers.ResolveFileBasename(ev, &element.ProcessContext.Process.FileEvent))
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsFilePath returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsFilePath() []string {
+	zeroValue := []string{}
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return zeroValue
+	}
+	var values []string
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := ev.FieldHandlers.ResolveFilePath(ev, &element.ProcessContext.Process.FileEvent)
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsFilePathLength returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsFilePathLength() []int {
+	zeroValue := []int{}
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return zeroValue
+	}
+	var values []int
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := len(ev.FieldHandlers.ResolveFilePath(ev, &element.ProcessContext.Process.FileEvent))
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsPid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsPid() []uint32 {
+	zeroValue := []uint32{}
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return zeroValue
+	}
+	var values []uint32
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := element.ProcessContext.Process.PIDContext.Pid
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsPpid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsPpid() []uint32 {
+	zeroValue := []uint32{}
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return zeroValue
+	}
+	var values []uint32
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := element.ProcessContext.Process.PPid
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessAncestorsTid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsTid() []uint32 {
+	zeroValue := []uint32{}
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Ancestor == nil {
+		return zeroValue
+	}
+	var values []uint32
+	ctx := eval.NewContext(ev)
+	iterator := &ProcessAncestorsIterator{}
+	ptr := iterator.Front(ctx)
+	for ptr != nil {
+		element := (*ProcessCacheEntry)(ptr)
+		result := element.ProcessContext.Process.PIDContext.Tid
+		values = append(values, result)
+		ptr = iterator.Next()
+	}
+	return values
+}
+
+// GetProcessArgs returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessArgs() string {
+	zeroValue := ""
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	return ev.BaseEvent.ProcessContext.Process.Args
+}
+
+// GetProcessContainerId returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessContainerId() string {
+	zeroValue := ""
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	return ev.BaseEvent.ProcessContext.Process.ContainerID
+}
+
+// GetProcessCreatedAt returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessCreatedAt() int {
+	zeroValue := 0
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	return ev.FieldHandlers.ResolveProcessCreatedAt(ev, &ev.BaseEvent.ProcessContext.Process)
+}
+
+// GetProcessEnvp returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessEnvp(desiredKeys map[string]bool) []string {
+	zeroValue := []string{}
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	resolvedField := ev.FieldHandlers.ResolveProcessEnvp(ev, &ev.BaseEvent.ProcessContext.Process)
+	resolvedField = filterEnvs(resolvedField, desiredKeys)
+	fieldCopy := make([]string, len(resolvedField))
+	copy(fieldCopy, resolvedField)
+	return fieldCopy
+}
+
+// GetProcessEnvs returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessEnvs(desiredKeys map[string]bool) []string {
+	zeroValue := []string{}
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	resolvedField := ev.FieldHandlers.ResolveProcessEnvs(ev, &ev.BaseEvent.ProcessContext.Process)
+	resolvedField = filterEnvs(resolvedField, desiredKeys)
+	fieldCopy := make([]string, len(resolvedField))
+	copy(fieldCopy, resolvedField)
+	return fieldCopy
+}
+
+// GetProcessFileName returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessFileName() string {
+	zeroValue := ""
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	return ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
+}
+
+// GetProcessFileNameLength returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessFileNameLength() int {
+	zeroValue := 0
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent))
+}
+
+// GetProcessFilePath returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessFilePath() string {
+	zeroValue := ""
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	return ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent)
+}
+
+// GetProcessFilePathLength returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessFilePathLength() int {
+	zeroValue := 0
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent))
+}
+
+// GetProcessParentArgs returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentArgs() string {
+	zeroValue := ""
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return zeroValue
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return ""
+	}
+	return ev.BaseEvent.ProcessContext.Parent.Args
+}
+
+// GetProcessParentContainerId returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentContainerId() string {
+	zeroValue := ""
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return zeroValue
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return ""
+	}
+	return ev.BaseEvent.ProcessContext.Parent.ContainerID
+}
+
+// GetProcessParentCreatedAt returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentCreatedAt() int {
+	zeroValue := 0
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return zeroValue
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return 0
+	}
+	return ev.FieldHandlers.ResolveProcessCreatedAt(ev, ev.BaseEvent.ProcessContext.Parent)
+}
+
+// GetProcessParentEnvp returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentEnvp(desiredKeys map[string]bool) []string {
+	zeroValue := []string{}
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return zeroValue
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return []string{}
+	}
+	resolvedField := ev.FieldHandlers.ResolveProcessEnvp(ev, ev.BaseEvent.ProcessContext.Parent)
+	resolvedField = filterEnvs(resolvedField, desiredKeys)
+	fieldCopy := make([]string, len(resolvedField))
+	copy(fieldCopy, resolvedField)
+	return fieldCopy
+}
+
+// GetProcessParentEnvs returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentEnvs(desiredKeys map[string]bool) []string {
+	zeroValue := []string{}
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return zeroValue
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return []string{}
+	}
+	resolvedField := ev.FieldHandlers.ResolveProcessEnvs(ev, ev.BaseEvent.ProcessContext.Parent)
+	resolvedField = filterEnvs(resolvedField, desiredKeys)
+	fieldCopy := make([]string, len(resolvedField))
+	copy(fieldCopy, resolvedField)
+	return fieldCopy
+}
+
+// GetProcessParentFileName returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentFileName() string {
+	zeroValue := ""
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return zeroValue
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
+}
+
+// GetProcessParentFileNameLength returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentFileNameLength() int {
+	zeroValue := 0
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return zeroValue
+	}
+	return len(ev.FieldHandlers.ResolveFileBasename(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent))
+}
+
+// GetProcessParentFilePath returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentFilePath() string {
+	zeroValue := ""
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return zeroValue
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return ""
+	}
+	return ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent)
+}
+
+// GetProcessParentFilePathLength returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentFilePathLength() int {
+	zeroValue := 0
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return zeroValue
+	}
+	return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Parent.FileEvent))
+}
+
+// GetProcessParentPid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentPid() uint32 {
+	zeroValue := uint32(0)
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return zeroValue
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return uint32(0)
+	}
+	return ev.BaseEvent.ProcessContext.Parent.PIDContext.Pid
+}
+
+// GetProcessParentPpid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentPpid() uint32 {
+	zeroValue := uint32(0)
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return zeroValue
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return uint32(0)
+	}
+	return ev.BaseEvent.ProcessContext.Parent.PPid
+}
+
+// GetProcessParentTid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentTid() uint32 {
+	zeroValue := uint32(0)
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	if ev.BaseEvent.ProcessContext.Parent == nil {
+		return zeroValue
+	}
+	if !ev.BaseEvent.ProcessContext.HasParent() {
+		return uint32(0)
+	}
+	return ev.BaseEvent.ProcessContext.Parent.PIDContext.Tid
+}
+
+// GetProcessPid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessPid() uint32 {
+	zeroValue := uint32(0)
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	return ev.BaseEvent.ProcessContext.Process.PIDContext.Pid
+}
+
+// GetProcessPpid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessPpid() uint32 {
+	zeroValue := uint32(0)
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	return ev.BaseEvent.ProcessContext.Process.PPid
+}
+
+// GetProcessTid returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessTid() uint32 {
+	zeroValue := uint32(0)
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	return ev.BaseEvent.ProcessContext.Process.PIDContext.Tid
+}
+
+// GetTimestamp returns the value of the field, resolving if necessary
+func (ev *Event) GetTimestamp() time.Time {
+	return ev.FieldHandlers.ResolveEventTime(ev)
+}

--- a/pkg/security/secl/model/field_accessors_windows.go
+++ b/pkg/security/secl/model/field_accessors_windows.go
@@ -50,8 +50,8 @@ func (ev *Event) GetEventTimestamp() int {
 	return ev.FieldHandlers.ResolveEventTimestamp(ev, &ev.BaseEvent)
 }
 
-// GetExecArgs returns the value of the field, resolving if necessary
-func (ev *Event) GetExecArgs() string {
+// GetExecCmdline returns the value of the field, resolving if necessary
+func (ev *Event) GetExecCmdline() string {
 	zeroValue := ""
 	if ev.GetEventType().String() != "exec" {
 		return zeroValue
@@ -59,7 +59,7 @@ func (ev *Event) GetExecArgs() string {
 	if ev.Exec.Process == nil {
 		return zeroValue
 	}
-	return ev.Exec.Process.Args
+	return ev.Exec.Process.CmdLine
 }
 
 // GetExecContainerId returns the value of the field, resolving if necessary
@@ -116,6 +116,30 @@ func (ev *Event) GetExecEnvs(desiredKeys map[string]bool) []string {
 	fieldCopy := make([]string, len(resolvedField))
 	copy(fieldCopy, resolvedField)
 	return fieldCopy
+}
+
+// GetExecExecTime returns the value of the field, resolving if necessary
+func (ev *Event) GetExecExecTime() time.Time {
+	zeroValue := time.Time{}
+	if ev.GetEventType().String() != "exec" {
+		return zeroValue
+	}
+	if ev.Exec.Process == nil {
+		return zeroValue
+	}
+	return ev.Exec.Process.ExecTime
+}
+
+// GetExecExitTime returns the value of the field, resolving if necessary
+func (ev *Event) GetExecExitTime() time.Time {
+	zeroValue := time.Time{}
+	if ev.GetEventType().String() != "exec" {
+		return zeroValue
+	}
+	if ev.Exec.Process == nil {
+		return zeroValue
+	}
+	return ev.Exec.Process.ExitTime
 }
 
 // GetExecFileName returns the value of the field, resolving if necessary
@@ -202,18 +226,6 @@ func (ev *Event) GetExecTid() uint32 {
 	return ev.Exec.Process.PIDContext.Tid
 }
 
-// GetExitArgs returns the value of the field, resolving if necessary
-func (ev *Event) GetExitArgs() string {
-	zeroValue := ""
-	if ev.GetEventType().String() != "exit" {
-		return zeroValue
-	}
-	if ev.Exit.Process == nil {
-		return zeroValue
-	}
-	return ev.Exit.Process.Args
-}
-
 // GetExitCause returns the value of the field, resolving if necessary
 func (ev *Event) GetExitCause() uint32 {
 	zeroValue := uint32(0)
@@ -221,6 +233,18 @@ func (ev *Event) GetExitCause() uint32 {
 		return zeroValue
 	}
 	return ev.Exit.Cause
+}
+
+// GetExitCmdline returns the value of the field, resolving if necessary
+func (ev *Event) GetExitCmdline() string {
+	zeroValue := ""
+	if ev.GetEventType().String() != "exit" {
+		return zeroValue
+	}
+	if ev.Exit.Process == nil {
+		return zeroValue
+	}
+	return ev.Exit.Process.CmdLine
 }
 
 // GetExitCode returns the value of the field, resolving if necessary
@@ -286,6 +310,30 @@ func (ev *Event) GetExitEnvs(desiredKeys map[string]bool) []string {
 	fieldCopy := make([]string, len(resolvedField))
 	copy(fieldCopy, resolvedField)
 	return fieldCopy
+}
+
+// GetExitExecTime returns the value of the field, resolving if necessary
+func (ev *Event) GetExitExecTime() time.Time {
+	zeroValue := time.Time{}
+	if ev.GetEventType().String() != "exit" {
+		return zeroValue
+	}
+	if ev.Exit.Process == nil {
+		return zeroValue
+	}
+	return ev.Exit.Process.ExecTime
+}
+
+// GetExitExitTime returns the value of the field, resolving if necessary
+func (ev *Event) GetExitExitTime() time.Time {
+	zeroValue := time.Time{}
+	if ev.GetEventType().String() != "exit" {
+		return zeroValue
+	}
+	if ev.Exit.Process == nil {
+		return zeroValue
+	}
+	return ev.Exit.Process.ExitTime
 }
 
 // GetExitFileName returns the value of the field, resolving if necessary
@@ -435,8 +483,8 @@ func (ev *Event) GetNetworkSourcePort() uint16 {
 	return ev.BaseEvent.NetworkContext.Source.Port
 }
 
-// GetProcessAncestorsArgs returns the value of the field, resolving if necessary
-func (ev *Event) GetProcessAncestorsArgs() []string {
+// GetProcessAncestorsCmdline returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessAncestorsCmdline() []string {
 	zeroValue := []string{}
 	if ev.BaseEvent.ProcessContext == nil {
 		return zeroValue
@@ -450,7 +498,7 @@ func (ev *Event) GetProcessAncestorsArgs() []string {
 	ptr := iterator.Front(ctx)
 	for ptr != nil {
 		element := (*ProcessCacheEntry)(ptr)
-		result := element.ProcessContext.Process.Args
+		result := element.ProcessContext.Process.CmdLine
 		values = append(values, result)
 		ptr = iterator.Next()
 	}
@@ -701,13 +749,13 @@ func (ev *Event) GetProcessAncestorsTid() []uint32 {
 	return values
 }
 
-// GetProcessArgs returns the value of the field, resolving if necessary
-func (ev *Event) GetProcessArgs() string {
+// GetProcessCmdline returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessCmdline() string {
 	zeroValue := ""
 	if ev.BaseEvent.ProcessContext == nil {
 		return zeroValue
 	}
-	return ev.BaseEvent.ProcessContext.Process.Args
+	return ev.BaseEvent.ProcessContext.Process.CmdLine
 }
 
 // GetProcessContainerId returns the value of the field, resolving if necessary
@@ -754,6 +802,24 @@ func (ev *Event) GetProcessEnvs(desiredKeys map[string]bool) []string {
 	return fieldCopy
 }
 
+// GetProcessExecTime returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessExecTime() time.Time {
+	zeroValue := time.Time{}
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	return ev.BaseEvent.ProcessContext.Process.ExecTime
+}
+
+// GetProcessExitTime returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessExitTime() time.Time {
+	zeroValue := time.Time{}
+	if ev.BaseEvent.ProcessContext == nil {
+		return zeroValue
+	}
+	return ev.BaseEvent.ProcessContext.Process.ExitTime
+}
+
 // GetProcessFileName returns the value of the field, resolving if necessary
 func (ev *Event) GetProcessFileName() string {
 	zeroValue := ""
@@ -790,8 +856,8 @@ func (ev *Event) GetProcessFilePathLength() int {
 	return len(ev.FieldHandlers.ResolveFilePath(ev, &ev.BaseEvent.ProcessContext.Process.FileEvent))
 }
 
-// GetProcessParentArgs returns the value of the field, resolving if necessary
-func (ev *Event) GetProcessParentArgs() string {
+// GetProcessParentCmdline returns the value of the field, resolving if necessary
+func (ev *Event) GetProcessParentCmdline() string {
 	zeroValue := ""
 	if ev.BaseEvent.ProcessContext == nil {
 		return zeroValue
@@ -802,7 +868,7 @@ func (ev *Event) GetProcessParentArgs() string {
 	if !ev.BaseEvent.ProcessContext.HasParent() {
 		return ""
 	}
-	return ev.BaseEvent.ProcessContext.Parent.Args
+	return ev.BaseEvent.ProcessContext.Parent.CmdLine
 }
 
 // GetProcessParentContainerId returns the value of the field, resolving if necessary

--- a/pkg/security/secl/model/model_windows.go
+++ b/pkg/security/secl/model/model_windows.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:generate go run github.com/DataDog/datadog-agent/pkg/security/secl/compiler/generators/accessors -tags windows -types-file model.go -output accessors_windows.go -field-handlers field_handlers_windows.go
+//go:generate go run github.com/DataDog/datadog-agent/pkg/security/secl/compiler/generators/accessors -tags windows -types-file model.go -output accessors_windows.go -field-handlers field_handlers_windows.go -field-accessors-output field_accessors_windows.go
 
 // Package model holds model related files
 package model

--- a/pkg/security/secl/model/model_windows.go
+++ b/pkg/security/secl/model/model_windows.go
@@ -50,8 +50,8 @@ type Process struct {
 	SpanID  uint64 `field:"-"`
 	TraceID uint64 `field:"-"`
 
-	ExitTime time.Time `field:"-" json:"-"`
-	ExecTime time.Time `field:"-" json:"-"`
+	ExitTime time.Time `field:"exit_time,opts:getters_only" json:"-"`
+	ExecTime time.Time `field:"exec_time,opts:getters_only" json:"-"`
 
 	CreatedAt uint64 `field:"created_at,handler:ResolveProcessCreatedAt"` // SECLDoc[created_at] Definition:`Timestamp of the creation of the process`
 

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -590,6 +590,7 @@ def cws_go_generate(ctx):
 
     ctx.run("go generate ./pkg/security/...")
 
+
 @task
 def generate_syscall_table(ctx):
     def single_run(ctx, table_url, output_file, output_string_file, abis=None):

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -590,7 +590,6 @@ def cws_go_generate(ctx):
 
     ctx.run("go generate ./pkg/security/...")
 
-
 @task
 def generate_syscall_table(ctx):
     def single_run(ctx, table_url, output_file, output_string_file, abis=None):


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Add missing field accessors for Windows. This fixes event monitors for process compilation issues on Windows
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
