### PR TITLE
Change parameter name from target to head

### DIFF
--- a/tasks/libs/common/github_api.py
+++ b/tasks/libs/common/github_api.py
@@ -51,7 +51,7 @@ class GithubAPI:
         """
         Creates a PR in the given Github repository.
         """
-        return self._repository.create_pull(title=pr_title, body=pr_body, base=base_branch, target=target_branch)
+        return self._repository.create_pull(title=pr_title, body=pr_body, base=base_branch, head=target_branch)
 
     def update_pr(self, pull_number, milestone_number, labels):
         """


### PR DESCRIPTION
### What does this PR do?

This PR changes the attribute name that we use when calling `create_pull` method from PyGithub module.

### Motivation

Probably after https://github.com/DataDog/datadog-agent/pull/18592 invoke task used to create new RC PR stopped working on github PR creation step:

> Creating PR
> Traceback (most recent call last):
>   File "/Users/kacper.murzyn/Library/Python/3.9/bin/inv", line 8, in <module>
>     sys.exit(program.run())
>   File "/Users/kacper.murzyn/Library/Python/3.9/lib/python/site-packages/invoke/program.py", line 398, in run
>     self.execute()
>   File "/Users/kacper.murzyn/Library/Python/3.9/lib/python/site-packages/invoke/program.py", line 583, in execute
>     executor.execute(*self.tasks)
>   File "/Users/kacper.murzyn/Library/Python/3.9/lib/python/site-packages/invoke/executor.py", line 140, in execute
>     result = call.task(*args, **call.kwargs)
>   File "/Users/kacper.murzyn/Library/Python/3.9/lib/python/site-packages/invoke/tasks.py", line 138, in __call__
>     result = self.body(*args, **kwargs)
>   File "/Users/kacper.murzyn/dd/datadog-agent/tasks/release.py", line 1115, in create_rc
>     pr = github.create_pr(
>   File "/Users/kacper.murzyn/dd/datadog-agent/tasks/libs/common/github_api.py", line 54, in create_pr
>     return self._repository.create_pull(title=pr_title, body=pr_body, base=base_branch, target=target_branch)
>   File "/Users/kacper.murzyn/Library/Python/3.9/lib/python/site-packages/github/Repository.py", line 1469, in create_pull
>     return self.__create_pull_1(*args, **kwds)
> TypeError: __create_pull_1() got an unexpected keyword argument 'target'

According to the documentation the keyword argument is called 'head' instead of 'target'.


### Describe how to test/QA your changes

I tested it locally and now PR is created properly. Next production opportunity will be available with next RC build. Worst case - all changes made by task are done correctly but PR is not automatically created, just like now.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
