### PR TITLE
Enable github jobs in merge queue

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 7.[0-9][0-9].x
+      - mq-working-branch-*
   pull_request:
     branches:
       - main
@@ -23,8 +24,8 @@ jobs:
       - name: Setup Python3
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9.16'
-          cache: 'pip'
+          python-version: "3.9.16"
+          cache: "pip"
       - run: pip3 install -r requirements.txt
 
       - name: Setup env variables
@@ -36,7 +37,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version-file: '.go-version'
+          go-version-file: ".go-version"
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
@@ -50,7 +51,7 @@ jobs:
         uses: pierotofy/set-swap-space@49819abfb41bd9b44fb781159c033dba90353a7c
         with:
           swap-size-gb: 10
-      
+
       - name: Build DataDog agent
         run: |
           invoke install-tools

--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -6,6 +6,9 @@ name: Do Not Merge
 on:
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]
+  push:
+    branches:
+      - mq-working-branch-*
 
 jobs:
   do-not-merge:

--- a/.github/workflows/go_mod_tidy.yml
+++ b/.github/workflows/go_mod_tidy.yml
@@ -3,10 +3,13 @@ on:
   pull_request:
     types:
       - labeled
+  push:
+    branches:
+      - mq-working-branch-*
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'PR number'
+        description: "PR number"
         required: true
         type: number
 permissions:
@@ -16,41 +19,40 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies-go')) }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        ref: ${{ github.head_ref }}
-    - name: Checkout PR
-      # run only if triggered manually, otherwise we are already on the right branch and we won't have `pr_number`
-      if: ${{ github.event_name == 'workflow_dispatch' }}
-      run: gh pr checkout ${{ github.event.inputs.pr_number }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Install go
-      uses: actions/setup-go@v3
-      with:
-        go-version-file: '.go-version'
-    - name: Install python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.9.12'
-        cache: 'pip'
-    - name: Install python requirements.txt
-      run: python3 -m pip install -r requirements.txt
-    - name: Go mod tidy
-      run: inv -e tidy-all
-    - name: Update LICENSE-3rdparty.csv
-      if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'dependencies-go-tools') }}
-      run: |
-        inv -e install-tools
-        inv -e generate-licenses
-    - name: Update mocks
-      if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'dependencies-go-tools') }}
-      run:
-        inv -e security-agent.gen-mocks # generate both security agent and process mocks
-    - uses: stefanzweifel/git-auto-commit-action@v4
-      id: autocommit
-      with:
-        commit_message: Auto-generate go.sum and LICENSE-3rdparty.csv changes
-    - name: changes
-      run: |
-        echo "Changes detected: ${{ steps.autocommit.outputs.changes_detected }}"
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Checkout PR
+        # run only if triggered manually, otherwise we are already on the right branch and we won't have `pr_number`
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: gh pr checkout ${{ github.event.inputs.pr_number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: ".go-version"
+      - name: Install python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9.12"
+          cache: "pip"
+      - name: Install python requirements.txt
+        run: python3 -m pip install -r requirements.txt
+      - name: Go mod tidy
+        run: inv -e tidy-all
+      - name: Update LICENSE-3rdparty.csv
+        if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'dependencies-go-tools') }}
+        run: |
+          inv -e install-tools
+          inv -e generate-licenses
+      - name: Update mocks
+        if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'dependencies-go-tools') }}
+        run: inv -e security-agent.gen-mocks # generate both security agent and process mocks
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        id: autocommit
+        with:
+          commit_message: Auto-generate go.sum and LICENSE-3rdparty.csv changes
+      - name: changes
+        run: |
+          echo "Changes detected: ${{ steps.autocommit.outputs.changes_detected }}"

--- a/.github/workflows/gohai.yml
+++ b/.github/workflows/gohai.yml
@@ -3,28 +3,33 @@ name: "Gohai Test"
 # Only run the tests if pkg/gohai was changed
 on:
   push:
-    branches:
-      - main
-      - 7.[0-9][0-9].x
     paths:
-      - 'pkg/gohai/**'
+      - "pkg/gohai/**"
   pull_request:
     paths:
-      - 'pkg/gohai/**'
+      - "pkg/gohai/**"
 
 jobs:
   gohai_test:
     strategy:
       matrix:
         # Use oldest and latest available ubuntu, macos and windows
-        os: [ubuntu-20.04, ubuntu-latest, macos-11, macos-latest, windows-2019, windows-latest]
+        os:
+          [
+            ubuntu-20.04,
+            ubuntu-latest,
+            macos-11,
+            macos-latest,
+            windows-2019,
+            windows-latest,
+          ]
         # Run tests with both the agent's version and gohai's pinned version
         go-file: [.go-version, pkg/gohai/go.mod]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
-      with:
-        go-version-file: ${{ matrix.go-file }}
-    - name: Test
-      run: cd pkg/gohai && go test ./...
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: ${{ matrix.go-file }}
+      - name: Test
+        run: cd pkg/gohai && go test ./...

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 7.[0-9][0-9].x
+      - mq-working-branch-*
 
 jobs:
   label:

--- a/.github/workflows/serverless-binary-size.yml
+++ b/.github/workflows/serverless-binary-size.yml
@@ -2,9 +2,12 @@ name: "Serverless Binary Size"
 
 on:
   pull_request:
+  push:
+    branches:
+      - mq-working-branch-*
 
 env:
-  SIZE_ALLOWANCE: fromJSON(1000000)  # 1 MB
+  SIZE_ALLOWANCE: fromJSON(1000000) # 1 MB
 
 jobs:
   comment:

--- a/.github/workflows/windows-linters.yml
+++ b/.github/workflows/windows-linters.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 7.[0-9][0-9].x
+      - mq-working-branch-*
   pull_request:
 
 concurrency:
@@ -23,8 +24,8 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9.5'
-          cache: 'pip'
+          python-version: "3.9.5"
+          cache: "pip"
       - run: |
           python -m pip install -r requirements.txt
           If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
@@ -32,7 +33,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v3
         with:
-          go-version-file: '.go-version'
+          go-version-file: ".go-version"
 
       - name: Install Dotnet
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/windows-unittests.yml
+++ b/.github/workflows/windows-unittests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 7.[0-9][0-9].x
+      - mq-working-branch-*
   pull_request:
 
 concurrency:
@@ -23,8 +24,8 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9.5'
-          cache: 'pip'
+          python-version: "3.9.5"
+          cache: "pip"
       - run: |
           python -m pip install -r requirements.txt
           If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
@@ -32,7 +33,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v3
         with:
-          go-version-file: '.go-version'
+          go-version-file: ".go-version"
 
       - name: Set up runner
         run: |


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Change triggers on github jobs so that they will run on merge queue
before:
nothing launched
now:
![image](https://github.com/DataDog/datadog-agent/assets/24426034/1c1afcb6-45d2-4e57-b4c2-15327c4b2f8f)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Enable a relevant merge queue for datadog-agent repo
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Sorry for the additional formatting...
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
