### PR TITLE
[fakeintake] investigate faketintake oom logs cleanup

### DIFF
--- a/test/fakeintake/server/serverstore/store.go
+++ b/test/fakeintake/server/serverstore/store.go
@@ -70,26 +70,28 @@ func (s *Store) CleanUpPayloadsOlderThan(time time.Time) {
 	log.Println("Cleaning up payloads")
 	// clean up raw payloads
 	for route, payloads := range s.rawPayloads {
-		lastInvalidPayloadIndex := -1
+		firstValidIndex := len(payloads)
 		for i, payload := range payloads {
-			if payload.Timestamp.Before(time) {
-				lastInvalidPayloadIndex = i
+			if payload.Timestamp.After(time) {
+				firstValidIndex = i
+				break
 			}
 		}
-		s.rawPayloads[route] = s.rawPayloads[route][lastInvalidPayloadIndex+1:]
-		log.Printf("Cleaned %d payloads on raw store on route [%s]", lastInvalidPayloadIndex+1, route)
+		s.rawPayloads[route] = s.rawPayloads[route][firstValidIndex:]
+		log.Printf("Cleaned %d payloads on raw store on route [%s]", firstValidIndex, route)
 	}
 	// clean up parsed payloads
 	for route, payloads := range s.jsonPayloads {
 		// cleanup raw store
-		lastInvalidPayloadIndex := -1
+		firstValidIndex := len(payloads)
 		for i, payload := range payloads {
-			if payload.Timestamp.Before(time) {
-				lastInvalidPayloadIndex = i
+			if payload.Timestamp.After(time) {
+				firstValidIndex = i
+				break
 			}
 		}
-		s.jsonPayloads[route] = s.jsonPayloads[route][lastInvalidPayloadIndex+1:]
-		log.Printf("Cleaned %d payloads on json store on route [%s]", lastInvalidPayloadIndex+1, route)
+		s.jsonPayloads[route] = s.jsonPayloads[route][firstValidIndex:]
+		log.Printf("Cleaned %d payloads on json store on route [%s]", firstValidIndex, route)
 	}
 }
 

--- a/test/fakeintake/server/serverstore/store.go
+++ b/test/fakeintake/server/serverstore/store.go
@@ -67,7 +67,7 @@ func (s *Store) tryParseAndAppendPayload(rawPayload api.Payload, route string) e
 func (s *Store) CleanUpPayloadsOlderThan(time time.Time) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-	log.Printf("Cleaning up payloads")
+	log.Println("Cleaning up payloads")
 	// clean up raw payloads
 	for route, payloads := range s.rawPayloads {
 		lastInvalidPayloadIndex := -1
@@ -77,6 +77,7 @@ func (s *Store) CleanUpPayloadsOlderThan(time time.Time) {
 			}
 		}
 		s.rawPayloads[route] = s.rawPayloads[route][lastInvalidPayloadIndex+1:]
+		log.Printf("Cleaned %d payloads on raw store on route [%s]", lastInvalidPayloadIndex+1, route)
 	}
 	// clean up parsed payloads
 	for route, payloads := range s.jsonPayloads {
@@ -88,6 +89,7 @@ func (s *Store) CleanUpPayloadsOlderThan(time time.Time) {
 			}
 		}
 		s.jsonPayloads[route] = s.jsonPayloads[route][lastInvalidPayloadIndex+1:]
+		log.Printf("Cleaned %d payloads on json store on route [%s]", lastInvalidPayloadIndex+1, route)
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add logs to investigate why fakeintake is running OOM on EKS tests

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

EKS tests are failing because the fakeintake is killed every 15-20 minutes. This is unexpected as the memory should be stable, we clean up payloads older than 15 minutes every minute. Adding logs to monitor this routine, and invert the logic by early returning on the first valid payload

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
