### PR TITLE
8888 dns server

### DIFF
--- a/pkg/network/testutil/ping.go
+++ b/pkg/network/testutil/ping.go
@@ -65,6 +65,11 @@ func PingUDP(tb require.TestingT, ip net.IP, port int) net.Conn {
 		return nil
 	}
 
+	bs := make([]byte, 10)
+	n, err := conn.Read(bs)
+	require.NoError(tb, err)
+	require.Equal(tb, []byte("pong"), bs[:n])
+
 	return conn
 }
 

--- a/pkg/network/testutil/server.go
+++ b/pkg/network/testutil/server.go
@@ -110,14 +110,19 @@ func StartServerUDP(t *testing.T, ip net.IP, port int) io.Closer {
 		Port: port,
 	}
 
-	l, err := net.ListenUDP(network, addr)
+	udpConn, err := net.ListenUDP(network, addr)
 	require.NoError(t, err)
 	go func() {
 		close(ch)
 
 		for {
 			bs := make([]byte, 10)
-			_, err := l.Read(bs)
+			_, addr, err := udpConn.ReadFrom(bs)
+			if err != nil {
+				return
+			}
+
+			_, err = udpConn.WriteTo([]byte("pong"), addr)
 			if err != nil {
 				return
 			}
@@ -132,5 +137,5 @@ func StartServerUDP(t *testing.T, ip net.IP, port int) io.Closer {
 		}
 	}, 3*time.Second, 10*time.Millisecond, "timed out waiting for UDP server to come up")
 
-	return l
+	return udpConn
 }

--- a/pkg/network/tracer/testutil/testdns/foo_test.go
+++ b/pkg/network/tracer/testutil/testdns/foo_test.go
@@ -1,0 +1,23 @@
+package testdns
+
+//func TestMe(t *testing.T) {
+//	srv := NewServer()
+//
+//	srv.Start()
+//
+//	var dnsClient dns.Client
+//
+//	q := dns.Msg{
+//		Question: []dns.Question{{
+//			Name:   "good.com.",
+//			Qclass: dns.ClassINET,
+//			Qtype:  dns.TypeA,
+//		}},
+//	}
+//	a, _, err := dnsClient.Exchange(&q, "192.1.1.1:53")
+//	fmt.Println(a)
+//
+//	require.NoError(t, err)
+//
+//	fmt.Println("here")
+//}

--- a/pkg/network/tracer/testutil/testdns/test_dns_server.go
+++ b/pkg/network/tracer/testutil/testdns/test_dns_server.go
@@ -1,0 +1,68 @@
+package testdns
+
+import (
+	"fmt"
+	"github.com/miekg/dns"
+	"net"
+	"os/exec"
+	"sync"
+	"testing"
+)
+
+var globalServer *Server
+var globalServerError error
+var serverOnce sync.Once
+
+func GetServerIP(t *testing.T) net.IP {
+	serverOnce.Do(func() {
+		server := NewServer()
+		server.Start()
+		globalServer = server
+	})
+	return net.ParseIP("192.1.1.1")
+}
+
+type Server struct{}
+
+func NewServer() *Server {
+	// TODO: error check?
+	c := exec.Command("ip", "link", "add", "dnstestdummy", "type", "dummy")
+	c.Run()
+
+	exec.Command("ip", "addr", "add", "dnstestdummy", "dev", "192.1.1.1").Run()
+	return nil
+}
+
+func (s *Server) Start() {
+	started := make(chan struct{}, 1)
+	srv := dns.Server{
+		Addr: "192.1.1.1:53",
+		Net:  "udp",
+		Handler: dns.HandlerFunc(func(writer dns.ResponseWriter, msg *dns.Msg) {
+			fmt.Println("in handler", msg.Question[0].Name)
+			switch msg.Question[0].Name {
+			case "good.com.":
+				resp := &dns.Msg{}
+				resp.SetReply(msg)
+
+				rr, err := dns.NewRR("good.com. 60   IN A 10.0.0.1")
+				if err != nil {
+					panic(err)
+				}
+				resp.Answer = []dns.RR{rr}
+				writer.WriteMsg(resp)
+			default:
+				resp := &dns.Msg{}
+				resp.SetReply(msg)
+				resp.Rcode = dns.RcodeServerFailure
+				writer.WriteMsg(resp)
+
+			}
+		}),
+		NotifyStartedFunc: func() {
+			started <- struct{}{}
+		},
+	}
+	go srv.ListenAndServe()
+	<-started
+}

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/network/tracer/testutil/testdns"
 	"io"
 	"math"
 	"math/rand"
@@ -1354,14 +1355,14 @@ func (s *TracerSuite) TestDNSStatsWithNAT() {
 	t := s.T()
 	testutil.IptablesSave(t)
 	// Setup a NAT rule to translate 2.2.2.2 to 8.8.8.8 and issue a DNS request to 2.2.2.2
-	cmds := []string{"iptables -t nat -A OUTPUT -d 2.2.2.2 -j DNAT --to-destination 8.8.8.8"}
+	cmds := []string{"iptables -t nat -A OUTPUT -d 2.2.2.2 -j DNAT --to-destination " + testdns.GetServerIP(t).String()}
 	testutil.RunCommands(t, cmds, true)
 
 	cfg := testConfig()
 	cfg.CollectDNSStats = true
 	cfg.DNSTimeout = 1 * time.Second
 	tr := setupTracer(t, cfg)
-	testDNSStats(t, tr, "golang.org", 1, 0, 0, "2.2.2.2")
+	testDNSStats(t, tr, "good.com", 1, 0, 0, "2.2.2.2")
 }
 
 func iptablesWrapper(t *testing.T, f func()) {

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/network/tracer/testutil/testdns"
 	"io"
 	"math/rand"
 	"net"
@@ -999,10 +1000,6 @@ func getConnections(t require.TestingT, tr *Tracer) *network.Connections {
 	return connections
 }
 
-const (
-	validDNSServer = "8.8.8.8"
-)
-
 func testDNSStats(t *testing.T, tr *Tracer, domain string, success, failure, timeout int, serverIP string) {
 	tr.removeClient(clientID)
 	initTracerState(t, tr)
@@ -1070,10 +1067,10 @@ func (s *TracerSuite) TestDNSStats() {
 	cfg.DNSTimeout = 1 * time.Second
 	tr := setupTracer(t, cfg)
 	t.Run("valid domain", func(t *testing.T) {
-		testDNSStats(t, tr, "golang.org", 1, 0, 0, validDNSServer)
+		testDNSStats(t, tr, "good.com", 1, 0, 0, testdns.GetServerIP(t).String())
 	})
 	t.Run("invalid domain", func(t *testing.T) {
-		testDNSStats(t, tr, "abcdedfg", 0, 1, 0, validDNSServer)
+		testDNSStats(t, tr, "abcdedfg", 0, 1, 0, testdns.GetServerIP(t).String())
 	})
 	t.Run("timeout", func(t *testing.T) {
 		testDNSStats(t, tr, "golang.org", 0, 0, 1, "1.2.3.4")

--- a/pkg/util/filesystem/go.mod
+++ b/pkg/util/filesystem/go.mod
@@ -17,7 +17,7 @@ require (
 )
 
 require (
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.49.0-rc.1 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.49.0-rc.2 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect


### PR DESCRIPTION
### What does this PR do?

Replace 8.8.8.8 with a machine-local DNS server. This should reduce flakes in tests where 8.8.8.8 get dropped. 
### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
