### PR TITLE
Add metrics for AD providers

### DIFF
--- a/pkg/autodiscovery/providers/container.go
+++ b/pkg/autodiscovery/providers/container.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -145,6 +146,7 @@ func (k *ContainerConfigProvider) processEvents(evBundle workloadmeta.EventBundl
 			delete(k.configErrors, entityName)
 
 		default:
+			telemetry.Errors.Inc(names.KubeContainer)
 			log.Errorf("cannot handle event of type %d", event.Type)
 		}
 	}
@@ -184,6 +186,7 @@ func (k *ContainerConfigProvider) generateConfig(e workloadmeta.Entity) ([]integ
 		for _, podContainer := range entity.GetAllContainers() {
 			container, err := k.workloadmetaStore.GetContainer(podContainer.ID)
 			if err != nil {
+				telemetry.Errors.Inc(names.KubeContainer)
 				log.Debugf("Pod %q has reference to non-existing container %q", entity.Name, podContainer.ID)
 				continue
 			}
@@ -243,6 +246,7 @@ func (k *ContainerConfigProvider) generateConfig(e workloadmeta.Entity) ([]integ
 			containerNames)...)
 
 	default:
+		telemetry.Errors.Inc(names.KubeContainer)
 		log.Errorf("cannot handle entity of kind %s", e.GetID().Kind)
 	}
 

--- a/pkg/autodiscovery/providers/endpointschecks.go
+++ b/pkg/autodiscovery/providers/endpointschecks.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
@@ -46,6 +47,7 @@ func NewEndpointsChecksConfigProvider(providerConfig *config.ConfigurationProvid
 	var err error
 	c.nodeName, err = getNodename(context.TODO())
 	if err != nil {
+		telemetry.Errors.Inc(names.EndpointsChecks)
 		log.Errorf("Cannot get node name: %s", err)
 		return nil, err
 	}
@@ -95,6 +97,7 @@ func (c *EndpointsChecksConfigProvider) Collect(ctx context.Context) ([]integrat
 			return nil, nil
 		}
 
+		telemetry.Errors.Inc(names.EndpointsChecks)
 		return nil, err
 	}
 
@@ -116,6 +119,7 @@ func getNodename(ctx context.Context) (string, error) {
 	}
 	ku, err := kubelet.GetKubeUtil()
 	if err != nil {
+		telemetry.Errors.Inc(names.EndpointsChecks)
 		log.Errorf("Cannot get kubeUtil object: %s", err)
 		return "", err
 	}
@@ -128,6 +132,7 @@ func (c *EndpointsChecksConfigProvider) initClient() error {
 	if err == nil {
 		c.dcaClient = dcaClient
 	}
+	telemetry.Errors.Inc(names.EndpointsChecks)
 	return err
 }
 

--- a/pkg/autodiscovery/providers/etcd.go
+++ b/pkg/autodiscovery/providers/etcd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -54,6 +55,7 @@ func NewEtcdConfigProvider(providerConfig *config.ConfigurationProviders) (Confi
 
 	cl, err := client.New(clientCfg)
 	if err != nil {
+		telemetry.Errors.Inc(names.Etcd)
 		return nil, fmt.Errorf("Unable to instantiate the etcd client: %s", err)
 	}
 	cache := newProviderCache()
@@ -85,6 +87,7 @@ func (p *EtcdConfigProvider) getIdentifiers(ctx context.Context, key string) []s
 	identifiers := make([]string, 0)
 	resp, err := p.Client.Get(ctx, key, &client.GetOptions{Recursive: true})
 	if err != nil {
+		telemetry.Errors.Inc(names.Etcd)
 		log.Error("Can't get templates keys from etcd: ", err)
 		return identifiers
 	}
@@ -107,18 +110,21 @@ func (p *EtcdConfigProvider) getTemplates(ctx context.Context, key string) []int
 
 	checkNames, err := p.getCheckNames(ctx, checkNameKey)
 	if err != nil {
+		telemetry.Errors.Inc(names.Etcd)
 		log.Errorf("Failed to retrieve check names at %s. Error: %s", checkNameKey, err)
 		return nil
 	}
 
 	initConfigs, err := p.getJSONValue(ctx, initKey)
 	if err != nil {
+		telemetry.Errors.Inc(names.Etcd)
 		log.Errorf("Failed to retrieve init configs at %s. Error: %s", initKey, err)
 		return nil
 	}
 
 	instances, err := p.getJSONValue(ctx, instanceKey)
 	if err != nil {
+		telemetry.Errors.Inc(names.Etcd)
 		log.Errorf("Failed to retrieve instances at %s. Error: %s", instanceKey, err)
 		return nil
 	}
@@ -163,6 +169,7 @@ func (p *EtcdConfigProvider) IsUpToDate(ctx context.Context) (bool, error) {
 
 	resp, err := p.Client.Get(ctx, p.templateDir, &client.GetOptions{Recursive: true})
 	if err != nil {
+		telemetry.Errors.Inc(names.Etcd)
 		return false, err
 	}
 	identifiers := resp.Node.Nodes

--- a/pkg/autodiscovery/providers/file.go
+++ b/pkg/autodiscovery/providers/file.go
@@ -30,6 +30,7 @@ func NewFileConfigProvider() *FileConfigProvider {
 func (c *FileConfigProvider) Collect(ctx context.Context) ([]integration.Config, error) {
 	configs, errors, err := ReadConfigFiles(WithoutAdvancedAD)
 	if err != nil {
+		telemetry.Errors.Inc(names.File)
 		return nil, err
 	}
 

--- a/pkg/autodiscovery/providers/kube_endpoints_file.go
+++ b/pkg/autodiscovery/providers/kube_endpoints_file.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -75,11 +76,13 @@ func NewKubeEndpointsFileConfigProvider(*config.ConfigurationProviders) (ConfigP
 
 	ac, err := apiserver.GetAPIClient()
 	if err != nil {
+		telemetry.Errors.Inc(names.KubeEndpointsFile)
 		return nil, fmt.Errorf("cannot connect to apiserver: %s", err)
 	}
 
 	epInformer := ac.InformerFactory.Core().V1().Endpoints()
 	if epInformer == nil {
+		telemetry.Errors.Inc(names.KubeEndpointsFile)
 		return nil, fmt.Errorf("cannot get endpoint informer: %s", err)
 	}
 
@@ -89,6 +92,7 @@ func NewKubeEndpointsFileConfigProvider(*config.ConfigurationProviders) (ConfigP
 		UpdateFunc: provider.updateHandler,
 		DeleteFunc: provider.deleteHandler,
 	}); err != nil {
+		telemetry.Errors.Inc(names.KubeEndpointsFile)
 		return nil, fmt.Errorf("cannot add event handler to endpoint informer: %s", err)
 	}
 
@@ -131,6 +135,7 @@ func (p *KubeEndpointsFileConfigProvider) setUpToDate(v bool) {
 func (p *KubeEndpointsFileConfigProvider) addHandler(obj interface{}) {
 	ep, ok := obj.(*v1.Endpoints)
 	if !ok {
+		telemetry.Errors.Inc(names.KubeEndpointsFile)
 		log.Errorf("Expected an Endpoints type, got: %T", obj)
 		return
 	}
@@ -144,6 +149,7 @@ func (p *KubeEndpointsFileConfigProvider) addHandler(obj interface{}) {
 func (p *KubeEndpointsFileConfigProvider) updateHandler(old, new interface{}) {
 	newEp, ok := new.(*v1.Endpoints)
 	if !ok {
+		telemetry.Errors.Inc(names.KubeEndpointsFile)
 		log.Errorf("Expected an Endpoints type, got: %T", new)
 		return
 	}
@@ -154,6 +160,7 @@ func (p *KubeEndpointsFileConfigProvider) updateHandler(old, new interface{}) {
 
 	oldEp, ok := old.(*v1.Endpoints)
 	if !ok {
+		telemetry.Errors.Inc(names.KubeEndpointsFile)
 		log.Errorf("Expected a Endpoints type, got: %T", old)
 		return
 	}
@@ -173,6 +180,7 @@ func (p *KubeEndpointsFileConfigProvider) updateHandler(old, new interface{}) {
 func (p *KubeEndpointsFileConfigProvider) deleteHandler(obj interface{}) {
 	ep, ok := obj.(*v1.Endpoints)
 	if !ok {
+		telemetry.Errors.Inc(names.KubeEndpointsFile)
 		log.Errorf("Expected an Endpoints type, got: %T", obj)
 		return
 	}

--- a/pkg/autodiscovery/providers/kube_services.go
+++ b/pkg/autodiscovery/providers/kube_services.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -42,11 +43,13 @@ func NewKubeServiceConfigProvider(*config.ConfigurationProviders) (ConfigProvide
 	// Using GetAPIClient() (no retry)
 	ac, err := apiserver.GetAPIClient()
 	if err != nil {
+		telemetry.Errors.Inc(names.KubeServices)
 		return nil, fmt.Errorf("cannot connect to apiserver: %s", err)
 	}
 
 	servicesInformer := ac.InformerFactory.Core().V1().Services()
 	if servicesInformer == nil {
+		telemetry.Errors.Inc(names.KubeServices)
 		return nil, fmt.Errorf("cannot get service informer: %s", err)
 	}
 
@@ -59,6 +62,7 @@ func NewKubeServiceConfigProvider(*config.ConfigurationProviders) (ConfigProvide
 		UpdateFunc: p.invalidateIfChanged,
 		DeleteFunc: p.invalidate,
 	}); err != nil {
+		telemetry.Errors.Inc(names.KubeServices)
 		return nil, fmt.Errorf("cannot add event handler to services informer: %s", err)
 	}
 
@@ -98,12 +102,14 @@ func (k *KubeServiceConfigProvider) invalidateIfChanged(old, obj interface{}) {
 	// nil pointers are safely handled by the casting logic.
 	castedObj, ok := obj.(*v1.Service)
 	if !ok {
+		telemetry.Errors.Inc(names.KubeServices)
 		log.Errorf("Expected a *v1.Service type, got: %T", obj)
 		return
 	}
 	// Cast the old object, invalidate on casting error
 	castedOld, ok := old.(*v1.Service)
 	if !ok {
+		telemetry.Errors.Inc(names.KubeServices)
 		log.Errorf("Expected a *v1.Service type, got: %T", old)
 		k.upToDate = false
 		return
@@ -158,6 +164,7 @@ func parseServiceAnnotations(services []*v1.Service) ([]integration.Config, erro
 		serviceID := apiserver.EntityForService(svc)
 		svcConf, errors := utils.ExtractTemplatesFromPodAnnotations(serviceID, svc.Annotations, kubeServiceID)
 		for _, err := range errors {
+			telemetry.Errors.Inc(names.KubeServices)
 			log.Errorf("Cannot parse service template for service %s/%s: %s", svc.Namespace, svc.Name, err)
 		}
 

--- a/pkg/autodiscovery/providers/kube_services_file.go
+++ b/pkg/autodiscovery/providers/kube_services_file.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 )
@@ -30,6 +31,7 @@ func NewKubeServiceFileConfigProvider(*config.ConfigurationProviders) (ConfigPro
 func (c *KubeServiceFileConfigProvider) Collect(ctx context.Context) ([]integration.Config, error) {
 	configs, _, err := ReadConfigFiles(WithAdvancedADOnly)
 	if err != nil {
+		telemetry.Errors.Inc(names.KubeServicesFile)
 		return nil, err
 	}
 

--- a/pkg/autodiscovery/providers/prometheus_pods.go
+++ b/pkg/autodiscovery/providers/prometheus_pods.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
@@ -30,6 +31,7 @@ type PrometheusPodsConfigProvider struct {
 func NewPrometheusPodsConfigProvider(*config.ConfigurationProviders) (ConfigProvider, error) {
 	checks, err := getPrometheusConfigs()
 	if err != nil {
+		telemetry.Errors.Inc(names.PrometheusPods)
 		return nil, err
 	}
 
@@ -50,12 +52,14 @@ func (p *PrometheusPodsConfigProvider) Collect(ctx context.Context) ([]integrati
 	if p.kubelet == nil {
 		p.kubelet, err = kubelet.GetKubeUtil()
 		if err != nil {
+			telemetry.Errors.Inc(names.PrometheusPods)
 			return []integration.Config{}, err
 		}
 	}
 
 	pods, err := p.kubelet.GetLocalPodList(ctx)
 	if err != nil {
+		telemetry.Errors.Inc(names.PrometheusPods)
 		return []integration.Config{}, err
 	}
 

--- a/pkg/autodiscovery/providers/zookeeper.go
+++ b/pkg/autodiscovery/providers/zookeeper.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -49,6 +50,7 @@ func NewZookeeperConfigProvider(providerConfig *config.ConfigurationProviders) (
 
 	c, _, err := zk.Connect(urls, sessionTimeout)
 	if err != nil {
+		telemetry.Errors.Inc(names.Zookeeper)
 		return nil, fmt.Errorf("ZookeeperConfigProvider: couldn't connect to %q (%s): %s", providerConfig.TemplateURL, strings.Join(urls, ", "), err)
 	}
 	cache := newProviderCache()
@@ -70,6 +72,7 @@ func (z *ZookeeperConfigProvider) Collect(ctx context.Context) ([]integration.Co
 	configs := make([]integration.Config, 0)
 	identifiers, err := z.getIdentifiers(z.templateDir)
 	if err != nil {
+		telemetry.Errors.Inc(names.Zookeeper)
 		return nil, err
 	}
 	for _, id := range identifiers {
@@ -89,6 +92,7 @@ func (z *ZookeeperConfigProvider) IsUpToDate(ctx context.Context) (bool, error) 
 
 	identifiers, err := z.getIdentifiers(z.templateDir)
 	if err != nil {
+		telemetry.Errors.Inc(names.Zookeeper)
 		return false, err
 	}
 	outdated := z.cache.mostRecentMod
@@ -113,6 +117,7 @@ func (z *ZookeeperConfigProvider) IsUpToDate(ctx context.Context) (bool, error) 
 			gcnPath := path.Join(identifier, gcn)
 			_, stat, err := z.client.Get(gcnPath)
 			if err != nil {
+				telemetry.Errors.Inc(names.Zookeeper)
 				return false, fmt.Errorf("couldn't get key '%s' from zookeeper: %s", identifier, err)
 			}
 			outdated = math.Max(float64(stat.Mtime), outdated)
@@ -171,24 +176,28 @@ func (z *ZookeeperConfigProvider) getTemplates(key string) []integration.Config 
 
 	rawNames, _, err := z.client.Get(checkNameKey)
 	if err != nil {
+		telemetry.Errors.Inc(names.Zookeeper)
 		log.Errorf("Couldn't get check names from key '%s' in zookeeper: %s", key, err)
 		return nil
 	}
 
 	checkNames, err := utils.ParseCheckNames(string(rawNames))
 	if err != nil {
+		telemetry.Errors.Inc(names.Zookeeper)
 		log.Errorf("Failed to retrieve check names at %s. Error: %s", checkNameKey, err)
 		return nil
 	}
 
 	initConfigs, err := z.getJSONValue(initKey)
 	if err != nil {
+		telemetry.Errors.Inc(names.Zookeeper)
 		log.Errorf("Failed to retrieve init configs at %s. Error: %s", initKey, err)
 		return nil
 	}
 
 	instances, err := z.getJSONValue(instanceKey)
 	if err != nil {
+		telemetry.Errors.Inc(names.Zookeeper)
 		log.Errorf("Failed to retrieve instances at %s. Error: %s", instanceKey, err)
 		return nil
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Add more metrics for Autodiscovery providers like the file provider.

https://github.com/DataDog/datadog-agent/blob/1be5f3cc712a1c950ffec79b018f178e34194d5b/pkg/autodiscovery/telemetry/telemetry.go#L47-L54

### Motivation

See [CONS-5875](https://datadoghq.atlassian.net/browse/CONS-5875).

Approximately one month had passed from the occurrence of the error until the customer noticed its negative impact that Agent stopped fetching integration configs from Kubernetes Endpoints, then no checks run. Due to this, there were no logs present in Agent Flare, leaving almost no clues for troubleshooting. With the metrics added in this PR, it will be easier to discover similar events in the future. When the AD Provider fails to initialize, no continuous errors occur afterwards, making it difficult to identify the root cause.

Hope these metrics would help future troubleshooting!

### Additional Notes

Is there any intention to have this type of metrics recorded only when there is a file provider error?

https://github.com/DataDog/datadog-agent/blob/1be5f3cc712a1c950ffec79b018f178e34194d5b/pkg/autodiscovery/providers/file.go#L37

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Enabling to record error count metrics, so no behavior changes.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.


[CONS-5875]: https://datadoghq.atlassian.net/browse/CONS-5875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ