### PR TITLE
[CWS] open files snapshotting improvements

### DIFF
--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -91,7 +91,7 @@ func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *Stats, newEvent 
 		}
 	}
 	if isSampling {
-		seclog.Warnf("sampled open files while snapshotting: kept %d of %d files", len(files), len(fileFDs))
+		seclog.Warnf("sampled open files while snapshotting (pid: %v): kept %d of %d files", p.Pid, len(files), len(fileFDs))
 	}
 
 	// list the mmaped files of the process

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -99,14 +99,15 @@ func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *Stats, newEvent 
 	if err != nil {
 		seclog.Warnf("error while listing memory maps (pid: %v): %s", p.Pid, err)
 	}
+	// often the mmaped files are already nearly sorted, so we take the quick win and de-duplicate without sorting
+	mmapedFiles = slices.Compact(mmapedFiles)
 
 	files = append(files, mmapedFiles...)
-
 	if len(files) == 0 {
 		return
 	}
 
-	// often the mmaped files are already nearly sorted, so we take the quick win and de-duplicate without sorting
+	slices.Sort(files)
 	files = slices.Compact(files)
 
 	// insert files

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -90,6 +90,9 @@ func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *Stats, newEvent 
 			files = append(files, fd.Path)
 		}
 	}
+	if isSampling {
+		seclog.Warnf("sampled open files while snapshotting: kept %d of %d files", len(files), len(fileFDs))
+	}
 
 	// list the mmaped files of the process
 	mmapedFiles, err := snapshotMemoryMappedFiles(p.Pid, pn.Process.FileEvent.PathnameStr)

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -100,10 +100,11 @@ func (pn *ProcessNode) snapshotFiles(p *process.Process, stats *Stats, newEvent 
 		seclog.Warnf("error while listing memory maps (pid: %v): %s", p.Pid, err)
 	}
 
+	files = append(files, mmapedFiles...)
+
 	if len(files) == 0 {
 		return
 	}
-	files = append(files, mmapedFiles...)
 
 	// often the mmaped files are already nearly sorted, so we take the quick win and de-duplicate without sorting
 	files = slices.Compact(files)


### PR DESCRIPTION
### What does this PR do?

This PR adds multiple improvements to the open files collection done during activity dumps snapshotting:
- improve visibility that a sampling occured
- ensure that we deduplicate opened files before creating `FileEvents`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
