### PR TITLE
[CONTINT-3380] Make sure every SBOM has a repodigest

### DIFF
--- a/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -69,9 +69,9 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 					if len(image.RepoDigests) == 0 {
 						// Skip images without RepoDigest because:
 						// 1- Back-end does not process images without repodigest
-						// 2- For each image, it is possible to have multiple Create/Update events, some with a repodigest
-						// and some without. If the first processed event does not have the repodigest then the SBOM
-						// will not be updated with the RepoDigest later and image scans will be thrown away.
+						// 2- For a given image, it is possible to have multiple Create/Update events.
+						// It is possible that the first event the scanner processes does not have a repodigest.
+						// In that case SBOM will not have a RepoDigest, it won't be updated later and image scans will be ignored by the back-end.
 						log.Debugf("Image: %s/%s (id %s) doesn't have a repodigest", image.Namespace, image.Name, image.ID)
 						continue
 					}

--- a/pkg/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
@@ -75,9 +75,9 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 					if len(image.RepoDigests) == 0 {
 						// Skip images without RepoDigest because:
 						// 1- Back-end does not process images without repodigest
-						// 2- For each image, it is possible to have multiple Create/Update events, some with a repodigest
-						// and some without. If the first processed event does not have the repodigest then the SBOM
-						// will not be updated with the RepoDigest later and image scans will be thrown away.
+						// 2- For a given image, it is possible to have multiple Create/Update events.
+						// It is possible that the first event the scanner processes does not have a repodigest.
+						// In that case SBOM will not have a RepoDigest, it won't be updated later and image scans will be ignored by the back-end.
 						log.Debugf("Image: %s/%s (id %s) doesn't have a repodigest", image.Namespace, image.Name, image.ID)
 						continue
 					}

--- a/pkg/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
@@ -72,6 +72,16 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 						continue
 					}
 
+					if len(image.RepoDigests) == 0 {
+						// Skip images without RepoDigest because:
+						// 1- Back-end does not process images without repodigest
+						// 2- For each image, it is possible to have multiple Create/Update events, some with a repodigest
+						// and some without. If the first processed event does not have the repodigest then the SBOM
+						// will not be updated with the RepoDigest later and image scans will be thrown away.
+						log.Debugf("Image: %s/%s (id %s) doesn't have a repodigest", image.Namespace, image.Name, image.ID)
+						continue
+					}
+
 					if err := c.extractSBOMWithTrivy(ctx, image, resultChan); err != nil {
 						log.Warnf("Error extracting SBOM for image: namespace=%s name=%s, err: %s", image.Namespace, image.Name, err)
 					}

--- a/releasenotes/notes/fix-bug-repodigest-missing-in-sbom-7f2265ebc1f26e77.yaml
+++ b/releasenotes/notes/fix-bug-repodigest-missing-in-sbom-7f2265ebc1f26e77.yaml
@@ -1,0 +1,4 @@
+
+fixes:
+  - |
+    Fixed an issue where the Agent could emit SBOMs without the ``RepoDigest`` field, despite it being available.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR ensures that every SBOM has a repodigest.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Skip images without RepoDigest because:
1- Back-end does not process images without repodigest
2- For a given image, it is possible to have multiple Create/Update events. It is possible that the first event the scanner processes does not have a repodigest. In that case SBOM will not have a RepoDigest, it won't be updated later and image scans will be ignored by the back-end.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
I guess that an image can have multiple repodigests. In that case we keep only one. Changing this behavior would require triggering a new scan everytime an event is observed which can be a bit costly, even with the cache, considering that a scan involves many serializations/deserializations.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
There are two different things to test. Both require to run the agent with container image collection enabled and sbom collection enabled. These env variables can enable SBOM collection:
```
    - name: DD_SBOM_ENABLED
      value: "true"
    - name: DD_CONTAINER_IMAGE_ENABLED
      value: "true"
    - name: DD_SBOM_CONTAINER_IMAGE_ENABLED
      value: "true"
```


1. Run the agent with images that do not have a repodigest and make sure that those without repodigest do not get scanned `agent workload-list -v`. Some kind images do not have a repodigest. `registry.k8s.io/coredns/coredns:v1.10.1` for example.
2. Make sure every SBOM emitted has the field `aquasecurity:trivy:RepoDigest`. You can use `agent stream-event-platform --type container-sbom` for that. However, it might be difficult to reproduce the issue because it depends on the order of creation event received. In that case, it is also possible to deploy it internally and look at the logs (check associated jira card).
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
