### PR TITLE
Add support for filtering tags in k8s workloads.

### DIFF
--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -374,6 +374,13 @@ func (c *WorkloadMetaCollector) handleKubePod(ev workloadmeta.Event) []*TagInfo 
 		tags.AddLow(tag, value)
 	}
 
+	for _, disabledTag := range config.Datadog.GetStringSlice("kubernetes_ad_tags_disabled") {
+		tags.RemoveTag(disabledTag)
+	}
+	for _, disabledTag := range strings.Split(pod.Annotations["tags.datadoghq.com/disable"], ",") {
+		tags.RemoveTag(disabledTag)
+	}
+
 	low, orch, high, standard := tags.Compute()
 	tagInfos := []*TagInfo{
 		{

--- a/pkg/tagger/collectors/workloadmeta_test.go
+++ b/pkg/tagger/collectors/workloadmeta_test.go
@@ -422,6 +422,108 @@ func TestHandleKubePod(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "disable single tag",
+			pod: workloadmeta.KubernetesPod{
+				EntityID: podEntityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:      podName,
+					Namespace: podNamespace,
+					Annotations: map[string]string{
+						"tags.datadoghq.com/disable": "pod_name",
+					},
+				},
+			},
+			expected: []*TagInfo{
+				{
+					Source:               podSource,
+					Entity:               podTaggerEntityID,
+					HighCardTags:         []string{},
+					OrchestratorCardTags: []string{}, // No pod_name tag
+					LowCardTags: []string{
+						fmt.Sprintf("kube_namespace:%s", podNamespace),
+					},
+					StandardTags: []string{},
+				},
+			},
+		},
+		{
+			name: "disable multiple tags",
+			pod: workloadmeta.KubernetesPod{
+				EntityID: podEntityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:      podName,
+					Namespace: podNamespace,
+					Annotations: map[string]string{
+						"tags.datadoghq.com/disable": "pod_name,kube_namespace",
+					},
+				},
+			},
+			expected: []*TagInfo{
+				{
+					Source:               podSource,
+					Entity:               podTaggerEntityID,
+					HighCardTags:         []string{},
+					OrchestratorCardTags: []string{}, // No pod_name tag
+					LowCardTags:          []string{}, // No kube_namespace tag
+					StandardTags:         []string{},
+				},
+			},
+		},
+		{
+			name: "disable non-existing tag",
+			pod: workloadmeta.KubernetesPod{
+				EntityID: podEntityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:      podName,
+					Namespace: podNamespace,
+					Annotations: map[string]string{
+						"tags.datadoghq.com/disable": "non_existing_tag",
+					},
+				},
+			},
+			expected: []*TagInfo{
+				{
+					Source:       podSource,
+					Entity:       podTaggerEntityID,
+					HighCardTags: []string{},
+					OrchestratorCardTags: []string{
+						fmt.Sprintf("pod_name:%s", podName),
+					},
+					LowCardTags: []string{
+						fmt.Sprintf("kube_namespace:%s", podNamespace),
+					},
+					StandardTags: []string{},
+				},
+			},
+		},
+		{
+			name: "disable tag with empty value",
+			pod: workloadmeta.KubernetesPod{
+				EntityID: podEntityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:      podName,
+					Namespace: podNamespace,
+					Annotations: map[string]string{
+						"tags.datadoghq.com/disable": "",
+					},
+				},
+			},
+			expected: []*TagInfo{
+				{
+					Source:       podSource,
+					Entity:       podTaggerEntityID,
+					HighCardTags: []string{},
+					OrchestratorCardTags: []string{
+						fmt.Sprintf("pod_name:%s", podName),
+					},
+					LowCardTags: []string{
+						fmt.Sprintf("kube_namespace:%s", podNamespace),
+					},
+					StandardTags: []string{},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/tagger/utils/taglist.go
+++ b/pkg/tagger/utils/taglist.go
@@ -84,6 +84,23 @@ func (l *TagList) AddAuto(name, value string) {
 	l.AddLow(name, value)
 }
 
+// RemoveTag removes a tag from the list
+func (l *TagList) RemoveTag(tag string) {
+	l.lowCardTags = removeTagFromMap(l.lowCardTags, tag)
+	l.orchestratorCardTags = removeTagFromMap(l.orchestratorCardTags, tag)
+	l.highCardTags = removeTagFromMap(l.highCardTags, tag)
+	l.standardTags = removeTagFromMap(l.standardTags, tag)
+}
+
+func removeTagFromMap(tagMap map[string]bool, tag string) map[string]bool {
+	for k := range tagMap {
+		if strings.HasPrefix(k, tag+":") {
+			delete(tagMap, k)
+		}
+	}
+	return tagMap
+}
+
 // Compute returns four string arrays in the format "tag:value"
 // - low cardinality
 // - orchestrator cardinality

--- a/pkg/tagger/utils/taglist_test.go
+++ b/pkg/tagger/utils/taglist_test.go
@@ -219,3 +219,48 @@ func TestCopy(t *testing.T) {
 	require.Contains(t, standard3, "env:dev")
 	require.Contains(t, standard3, "service:foo")
 }
+
+func TestRemoveTag(t *testing.T) {
+	list := NewTagList()
+	list.splitList = map[string]string{
+		"values":  ",",
+		"missing": " ",
+	}
+
+	// Add some tags
+	list.AddLow("removelow", "yes")
+	list.AddHigh("removehigh", "no")
+	list.AddStandard("env", "dev")
+
+	// Check if tag is removed from low
+	// Standard should still be in low
+	list.RemoveTag("removelow")
+	require.Len(t, list.lowCardTags, 1)
+	require.Contains(t, list.lowCardTags, "env:dev")
+
+	// Check if high is empty after removing
+	list.RemoveTag("removehigh")
+	require.Empty(t, list.highCardTags)
+
+	// Check if the standard tag is still in the list
+	require.Len(t, list.standardTags, 1)
+	require.Contains(t, list.standardTags, "env:dev")
+
+	// Remove standard tag and check
+	list.RemoveTag("env")
+	require.Len(t, list.standardTags, 0)
+	require.Empty(t, list.highCardTags)
+	require.Empty(t, list.lowCardTags)
+
+	// Add some tags
+	list.AddLow("removelow", "yes")
+	list.AddLow("donotremovelow", "yes")
+	list.AddLow("somethingelse", "no")
+	list.AddHigh("donotremovehigh", "yes")
+	list.RemoveTag("removelow")
+	require.Len(t, list.lowCardTags, 2)
+	low, _, high, _ := list.Compute()
+	require.Contains(t, low, "donotremovelow:yes")
+	require.Contains(t, low, "somethingelse:no")
+	require.Contains(t, high, "donotremovehigh:yes")
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Just add the anotation tags.datadog.com/disable: "comma,separated,tags,to,be,disabled"

Add support in taglist to remove tags.

The idea is to use this before calling the tags.Compute() method The current implementation is done for k8s workloads, but it could be expanded to other places.

(ps: I am still learning go, please forgive any mistakes. )

### Motivation

Wanted to exclude tags from the kubernetes workload for specific pods, this pr allows to do that during runtime. 

Example: pod_name is high cardinality, I want it enabled for some services, but not for others. 

### Additional Notes

It reuses an existing annotation and is compatible with previous use cases of the annotation (only kube_service was supported before my change.) 

### Possible Drawbacks / Trade-offs



### Describe how to test/QA your changes

Tested using unit testing and planning to rollout the agent with the changes in a subset of our infrastructure.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
