### PR TITLE
chore: make @DataDog/asm-go team own `pkg/serverless/appsec`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -231,6 +231,7 @@
 /pkg/metrics/                           @DataDog/agent-metrics-logs
 /pkg/serializer/                        @DataDog/agent-metrics-logs
 /pkg/serverless/                        @DataDog/serverless
+/pkg/serverless/appsec/                 @DataDog/asm-go
 /pkg/status/                            @DataDog/agent-shared-components
 /pkg/status/templates/trace-agent.tmpl  @DataDog/agent-apm
 /pkg/status/templates/process-agent.tmpl    @DataDog/processes

--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -42,6 +42,7 @@ GITHUB_SLACK_MAP = {
     "@datadog/database-monitoring": "#database-monitoring",
     "@datadog/agent-cspm": "#k9-cspm-ops",
     "@datadog/telemetry-and-analytics": "#instrumentation-telemetry",
+    "@datadog/asm-go": "#k9-asm-library-go",
 }
 
 GITHUB_JIRA_MAP = {
@@ -74,6 +75,7 @@ GITHUB_JIRA_MAP = {
     "@datadog/database-monitoring": "DBMON",
     "@datadog/agent-cspm": "SEC",
     "@datadog/telemetry-and-analytics": DEFAULT_JIRA_PROJECT,
+    "@datadog/asm-go": "APPSEC",
 }
 
 


### PR DESCRIPTION
### What does this PR do?

This will simplify future code maintenance without necesarily always requiring the serverless team to be involved.

### Motivation

Avoids forcing the serverless team to be involved in all serverless appsec modifications.
