### PR TITLE
[ASCII-809] Remove unnecessary e2e.UpdateEnv calls from tests

### DIFF
--- a/test/new-e2e/tests/agent-subcommands/configcheck_test.go
+++ b/test/new-e2e/tests/agent-subcommands/configcheck_test.go
@@ -104,8 +104,6 @@ Config for instance ID: cpu:e331d61ed1323219
 
 // cpu, disk, file_handle, io, load, memory, network, ntp, uptime
 func (v *agentConfigCheckSuite) TestDefaultInstalledChecks() {
-	v.UpdateEnv(e2e.AgentStackDef())
-
 	testChecks := []CheckConfigOutput{
 		{
 			CheckName:  "cpu",

--- a/test/new-e2e/tests/agent-subcommands/flare/flare_test.go
+++ b/test/new-e2e/tests/agent-subcommands/flare/flare_test.go
@@ -43,7 +43,6 @@ func requestAgentFlareAndFetchFromFakeIntake(v *commandFlareSuite, flareArgs ...
 }
 
 func (v *commandFlareSuite) TestFlareDefaultFiles() {
-	v.UpdateEnv(e2e.FakeIntakeStackDef())
 	flare := requestAgentFlareAndFetchFromFakeIntake(v, client.WithArgs([]string{"--email", "e2e@test.com", "--send"}))
 
 	assertFilesExist(v.T(), flare, defaultFlareFiles)

--- a/test/new-e2e/tests/agent-subcommands/subcommands_test.go
+++ b/test/new-e2e/tests/agent-subcommands/subcommands_test.go
@@ -67,9 +67,6 @@ type expectedSection struct {
 }
 
 func (v *subcommandSuite) TestDefaultInstallStatus() {
-
-	v.UpdateEnv(e2e.FakeIntakeStackDef())
-
 	metadata := client.NewEC2Metadata(v.Env().VM)
 	resourceID := metadata.Get("instance-id")
 
@@ -217,7 +214,6 @@ func verifySectionContent(t *testing.T, statusOutput string, section expectedSec
 }
 
 func (v *subcommandSuite) TestDefaultInstallHealthy() {
-	v.UpdateEnv(e2e.FakeIntakeStackDef())
 	interval := 1 * time.Second
 
 	var output string


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

https://datadoghq.atlassian.net/browse/ASCII-809

https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/346941268#L364

Main branch flaky test failure investigation led to the finding [these UpdateEnv() calls with the default def are unnecessary](https://github.com/DataDog/datadog-agent/blob/main/test/new-e2e/pkg/utils/e2e/e2e.go#L439-L440) and possibly introduced an ordering failure where we never initialized the stack definition before trying to update it

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
