### PR TITLE
Use repo go version for KMT

### DIFF
--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -316,6 +316,7 @@ kernel_matrix_testing_setup_env:
     - INSTANCE_IP=$(cat $CI_PROJECT_DIR/stack.outputs | grep $ARCH-instance-ip | cut -d ' ' -f 2)
     - MICRO_VM_IP=$(cat $CI_PROJECT_DIR/stack.outputs | grep $ARCH-$TAG | cut -d ' ' -f 2)
     - MICRO_VM_NAME=$(cat $CI_PROJECT_DIR/stack.outputs | grep $ARCH-$TAG | cut -d ' ' -f 1)
+    - GO_VERSION=$(inv go-version)
     # ssh into each micro-vm and run initialization script. This script will also run the tests.
     - ssh -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP "ssh -o StrictHostKeyChecking=no -i /home/kernel-version-testing/ddvm_rsa root@${MICRO_VM_IP} 'bash /root/fetch_dependencies.sh ${ARCH} && /micro-vm-init.sh ${GO_VERSION} ${RETRY} ${ARCH}'"
     - ssh -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE ubuntu@$INSTANCE_IP "scp -o StrictHostKeyChecking=no -i /home/kernel-version-testing/ddvm_rsa root@${MICRO_VM_IP}:/ci-visibility/junit.tar.gz /home/ubuntu/junit.tar.gz"

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -69,7 +69,7 @@ from .test import (
     lint_teamassignment,
     test,
 )
-from .update_go import update_go
+from .update_go import go_version, update_go
 from .utils import generate_config
 from .windows_resources import build_messagetable
 
@@ -97,6 +97,7 @@ ns.add_task(lint_filenames)
 ns.add_task(lint_python)
 ns.add_task(lint_go)
 ns.add_task(show_linters_issues)
+ns.add_task(go_version)
 ns.add_task(update_go)
 ns.add_task(audit_tag_impact)
 ns.add_task(print_default_build_tags)

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -360,7 +360,10 @@ def prepare(ctx, vms, stack=None, arch=None, ssh_key="", rebuild_deps=False, pac
 
 
 @task
-def test(ctx, vms, stack=None, packages="", run=None, retry=2, rebuild_deps=False, ssh_key="", go_version=_get_repo_go_version()):
+def test(ctx, vms, stack=None, packages="", run=None, retry=2, rebuild_deps=False, ssh_key="", go_version=None):
+    if not go_version:
+        go_version = _get_repo_go_version()
+
     stack = check_and_get_stack(stack)
     if not stacks.stack_exists(stack):
         raise Exit(f"Stack {stack} does not exist. Please create with 'inv kmt.stack-create --stack=<name>'")

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -20,6 +20,7 @@ from .kernel_matrix_testing.init_kmt import (
 )
 from .kernel_matrix_testing.tool import Exit, ask, info, warn
 from .system_probe import EMBEDDED_SHARE_DIR
+from .update_go import _get_repo_go_version
 
 try:
     from tabulate import tabulate
@@ -28,7 +29,6 @@ except ImportError:
 
 X86_AMI_ID_SANDBOX = "ami-0d1f81cfdbd5b0188"
 ARM_AMI_ID_SANDBOX = "ami-02cb18e91afb3777c"
-GOVERSION = 1.20
 
 
 @task
@@ -360,7 +360,7 @@ def prepare(ctx, vms, stack=None, arch=None, ssh_key="", rebuild_deps=False, pac
 
 
 @task
-def test(ctx, vms, stack=None, packages="", run=None, retry=2, rebuild_deps=False, ssh_key="", go_version=GOVERSION):
+def test(ctx, vms, stack=None, packages="", run=None, retry=2, rebuild_deps=False, ssh_key="", go_version=_get_repo_go_version()):
     stack = check_and_get_stack(stack)
     if not stacks.stack_exists(stack):
         raise Exit(f"Stack {stack} does not exist. Please create with 'inv kmt.stack-create --stack=<name>'")

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -11,6 +11,12 @@ from .pipeline import update_circleci_config, update_gitlab_config
 GO_VERSION_FILE = "./.go-version"
 
 
+@task
+def go_version(_):
+    current_version = _get_repo_go_version()
+    print(current_version)
+
+
 @task(
     help={
         "version": "The version of Go to use",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Uses the go version defined in `.go_version` for KMT by default

### Motivation

Better sync of agent repo go version with KMT

### Additional Notes

https://datadoghq.atlassian.net/browse/EBPF-262
https://datadoghq.atlassian.net/browse/EBPF-282

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
