### PR TITLE
Update lading to 0.19.0, configurations

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -15,7 +15,7 @@ single-machine-performance-regression_detector:
     when: always
   variables:
     SMP_VERSION: 0.10.0
-    LADING_VERSION: 0.18.0
+    LADING_VERSION: 0.19.0
     CPUS: 7
     MEMORY: "30g"
   # At present we require two artifacts to exist for the 'baseline' and the

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -15,7 +15,7 @@ single-machine-performance-regression_detector:
     when: always
   variables:
     SMP_VERSION: 0.10.0
-    LADING_VERSION: 0.19.0
+    LADING_VERSION: 0.19.1
     CPUS: 7
     MEMORY: "30g"
   # At present we require two artifacts to exist for the 'baseline' and the

--- a/.gitlab/functional_test/workload_checks.yml
+++ b/.gitlab/functional_test/workload_checks.yml
@@ -14,7 +14,7 @@ single-machine-performance-workload-checks:
     when: always
   variables:
     SMP_VERSION: 0.10.0
-    LADING_VERSION: 0.18.0
+    LADING_VERSION: 0.19.0
     WARMUP_SECONDS: 45
     TOTAL_SAMPLES: 600
     REPLICAS: 5

--- a/.gitlab/functional_test/workload_checks.yml
+++ b/.gitlab/functional_test/workload_checks.yml
@@ -14,7 +14,7 @@ single-machine-performance-workload-checks:
     when: always
   variables:
     SMP_VERSION: 0.10.0
-    LADING_VERSION: 0.19.0
+    LADING_VERSION: 0.19.1
     WARMUP_SECONDS: 45
     TOTAL_SAMPLES: 600
     REPLICAS: 5

--- a/test/regression/cases/uds_dogstatsd_to_api/lading/lading.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api/lading/lading.yaml
@@ -7,18 +7,30 @@ generator:
       path: "/tmp/dsd.socket"
       variant:
         dogstatsd:
-          contexts_minimum: 1000
-          contexts_maximum: 10000
-          name_length_minimum: 1
-          name_length_maximum: 200
-          tag_key_length_minimum: 1
-          tag_key_length_maximum: 100
-          tag_value_length_minimum: 1
-          tag_value_length_maximum: 100
-          tags_per_msg_minimum: 2
-          tags_per_msg_maximum: 50
-          multivalue_count_minimum: 2
-          multivalue_count_maximum: 32
+          contexts:
+            inclusive:
+              min: 1000
+              max: 10000
+          name_length:
+            inclusive:
+              min: 1
+              max: 200
+          tag_key_length:
+            inclusive:
+              min: 1
+              max: 100
+          tag_value_length:
+            inclusive:
+              min: 1
+              max: 100
+          tags_per_msg:
+            inclusive:
+              min: 2
+              max: 50
+          multivalue_count:
+            inclusive:
+              min: 2
+              max: 32
           multivalue_pack_probability: 0.08
           kind_weights:
             metric: 90

--- a/test/regression/cases/uds_dogstatsd_to_api_nodist_100MiB/lading/lading.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api_nodist_100MiB/lading/lading.yaml
@@ -7,18 +7,30 @@ generator:
       path: "/tmp/dsd.socket"
       variant:
         dogstatsd:
-          contexts_minimum: 1000
-          contexts_maximum: 10000
-          name_length_minimum: 1
-          name_length_maximum: 200
-          tag_key_length_minimum: 1
-          tag_key_length_maximum: 100
-          tag_value_length_minimum: 1
-          tag_value_length_maximum: 100
-          tags_per_msg_minimum: 2
-          tags_per_msg_maximum: 50
-          multivalue_count_minimum: 2
-          multivalue_count_maximum: 32
+          contexts:
+            inclusive:
+              min: 1000
+              max: 10000
+          name_length:
+            inclusive:
+              min: 1
+              max: 200
+          tag_key_length:
+            inclusive:
+              min: 1
+              max: 100
+          tag_value_length:
+            inclusive:
+              min: 1
+              max: 100
+          tags_per_msg:
+            inclusive:
+              min: 2
+              max: 50
+          multivalue_count:
+            inclusive:
+              min: 2
+              max: 32
           multivalue_pack_probability: 0.08
           kind_weights:
             metric: 90

--- a/test/regression/cases/uds_dogstatsd_to_api_nodist_16MiB/lading/lading.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api_nodist_16MiB/lading/lading.yaml
@@ -8,23 +8,29 @@ generator:
       variant:
         dogstatsd:
           contexts:
-            min: 1000
-            max: 10000
+            inclusive:
+              min: 1000
+              max: 10000
           name_length:
-            min: 1
-            max: 200
+            inclusive:
+              min: 1
+              max: 200
           tag_key_length:
-            min: 1
-            max: 100
+            inclusive:
+              min: 1
+              max: 100
           tag_value_length:
-            min: 1
-            max: 100
+            inclusive:
+              min: 1
+              max: 100
           tags_per_msg:
-            min: 2
-            max: 50
+            inclusive:
+              min: 2
+              max: 50
           multivalue_count:
-            min: 2
-            max: 32
+            inclusive:
+              min: 2
+              max: 32
           multivalue_pack_probability: 0.08
           kind_weights:
             metric: 90

--- a/test/regression/cases/uds_dogstatsd_to_api_nodist_16MiB/lading/lading.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api_nodist_16MiB/lading/lading.yaml
@@ -7,18 +7,24 @@ generator:
       path: "/tmp/dsd.socket"
       variant:
         dogstatsd:
-          contexts_minimum: 1000
-          contexts_maximum: 10000
-          name_length_minimum: 1
-          name_length_maximum: 200
-          tag_key_length_minimum: 1
-          tag_key_length_maximum: 100
-          tag_value_length_minimum: 1
-          tag_value_length_maximum: 100
-          tags_per_msg_minimum: 2
-          tags_per_msg_maximum: 50
-          multivalue_count_minimum: 2
-          multivalue_count_maximum: 32
+          contexts:
+            min: 1000
+            max: 10000
+          name_length:
+            min: 1
+            max: 200
+          tag_key_length:
+            min: 1
+            max: 100
+          tag_value_length:
+            min: 1
+            max: 100
+          tags_per_msg:
+            min: 2
+            max: 50
+          multivalue_count:
+            min: 2
+            max: 32
           multivalue_pack_probability: 0.08
           kind_weights:
             metric: 90

--- a/test/regression/cases/uds_dogstatsd_to_api_nodist_1MiB/lading/lading.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api_nodist_1MiB/lading/lading.yaml
@@ -7,18 +7,30 @@ generator:
       path: "/tmp/dsd.socket"
       variant:
         dogstatsd:
-          contexts_minimum: 1000
-          contexts_maximum: 10000
-          name_length_minimum: 1
-          name_length_maximum: 200
-          tag_key_length_minimum: 1
-          tag_key_length_maximum: 100
-          tag_value_length_minimum: 1
-          tag_value_length_maximum: 100
-          tags_per_msg_minimum: 2
-          tags_per_msg_maximum: 50
-          multivalue_count_minimum: 2
-          multivalue_count_maximum: 32
+          contexts:
+            inclusive:
+              min: 1000
+              max: 10000
+          name_length:
+            inclusive:
+              min: 1
+              max: 200
+          tag_key_length:
+            inclusive:
+              min: 1
+              max: 100
+          tag_value_length:
+            inclusive:
+              min: 1
+              max: 100
+          tags_per_msg:
+            inclusive:
+              min: 2
+              max: 50
+          multivalue_count:
+            inclusive:
+              min: 2
+              max: 32
           multivalue_pack_probability: 0.08
           kind_weights:
             metric: 90

--- a/test/regression/cases/uds_dogstatsd_to_api_nodist_200MiB/lading/lading.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api_nodist_200MiB/lading/lading.yaml
@@ -7,18 +7,30 @@ generator:
       path: "/tmp/dsd.socket"
       variant:
         dogstatsd:
-          contexts_minimum: 1000
-          contexts_maximum: 10000
-          name_length_minimum: 1
-          name_length_maximum: 200
-          tag_key_length_minimum: 1
-          tag_key_length_maximum: 100
-          tag_value_length_minimum: 1
-          tag_value_length_maximum: 100
-          tags_per_msg_minimum: 2
-          tags_per_msg_maximum: 50
-          multivalue_count_minimum: 2
-          multivalue_count_maximum: 32
+          contexts:
+            inclusive:
+              min: 1000
+              max: 10000
+          name_length:
+            inclusive:
+              min: 1
+              max: 200
+          tag_key_length:
+            inclusive:
+              min: 1
+              max: 100
+          tag_value_length:
+            inclusive:
+              min: 1
+              max: 100
+          tags_per_msg:
+            inclusive:
+              min: 2
+              max: 50
+          multivalue_count:
+            inclusive:
+              min: 2
+              max: 32
           multivalue_pack_probability: 0
           kind_weights:
             metric: 90

--- a/test/regression/cases/uds_dogstatsd_to_api_nodist_32MiB/lading/lading.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api_nodist_32MiB/lading/lading.yaml
@@ -7,18 +7,30 @@ generator:
       path: "/tmp/dsd.socket"
       variant:
         dogstatsd:
-          contexts_minimum: 1000
-          contexts_maximum: 10000
-          name_length_minimum: 1
-          name_length_maximum: 200
-          tag_key_length_minimum: 1
-          tag_key_length_maximum: 100
-          tag_value_length_minimum: 1
-          tag_value_length_maximum: 100
-          tags_per_msg_minimum: 2
-          tags_per_msg_maximum: 50
-          multivalue_count_minimum: 2
-          multivalue_count_maximum: 32
+          contexts:
+            inclusive:
+              min: 1000
+              max: 10000
+          name_length:
+            inclusive:
+              min: 1
+              max: 200
+          tag_key_length:
+            inclusive:
+              min: 1
+              max: 100
+          tag_value_length:
+            inclusive:
+              min: 1
+              max: 100
+          tags_per_msg:
+            inclusive:
+              min: 2
+              max: 50
+          multivalue_count:
+            inclusive:
+              min: 2
+              max: 32
           multivalue_pack_probability: 0.08
           kind_weights:
             metric: 90

--- a/test/regression/cases/uds_dogstatsd_to_api_nodist_64MiB/lading/lading.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api_nodist_64MiB/lading/lading.yaml
@@ -7,18 +7,30 @@ generator:
       path: "/tmp/dsd.socket"
       variant:
         dogstatsd:
-          contexts_minimum: 1000
-          contexts_maximum: 10000
-          name_length_minimum: 1
-          name_length_maximum: 200
-          tag_key_length_minimum: 1
-          tag_key_length_maximum: 100
-          tag_value_length_minimum: 1
-          tag_value_length_maximum: 100
-          tags_per_msg_minimum: 2
-          tags_per_msg_maximum: 50
-          multivalue_count_minimum: 2
-          multivalue_count_maximum: 32
+          contexts:
+            inclusive:
+              min: 1000
+              max: 10000
+          name_length:
+            inclusive:
+              min: 1
+              max: 200
+          tag_key_length:
+            inclusive:
+              min: 1
+              max: 100
+          tag_value_length:
+            inclusive:
+              min: 1
+              max: 100
+          tags_per_msg:
+            inclusive:
+              min: 2
+              max: 50
+          multivalue_count:
+            inclusive:
+              min: 2
+              max: 32
           multivalue_pack_probability: 0.08
           kind_weights:
             metric: 90

--- a/test/workload-checks/typical/cases/apm_app_server/lading/lading.yaml
+++ b/test/workload-checks/typical/cases/apm_app_server/lading/lading.yaml
@@ -29,10 +29,14 @@ generator:
       throttle: stable
       variant:
         dogstatsd:
-          metric_names_minimum: 32
-          metric_names_maximum: 128
-          tag_keys_minimum: 0
-          tag_keys_maximum: 512
+          metric_names:
+            inclusive:
+              min: 32
+              max: 128
+          tag_keys:
+            inclusive:
+              min: 0
+              max: 512
           kind_weights:
             metric: 90
             event: 5

--- a/test/workload-checks/typical/cases/app_server/lading/lading.yaml
+++ b/test/workload-checks/typical/cases/app_server/lading/lading.yaml
@@ -29,10 +29,14 @@ generator:
       throttle: stable
       variant:
         dogstatsd:
-          metric_names_minimum: 32
-          metric_names_maximum: 128
-          tag_keys_minimum: 0
-          tag_keys_maximum: 512
+          metric_names:
+            inclusive:
+              min: 32
+              max: 128
+          tag_keys:
+            inclusive:
+              min: 0
+              max: 512
           kind_weights:
             metric: 90
             event: 5

--- a/test/workload-checks/typical/cases/otel_app_server/lading/lading.yaml
+++ b/test/workload-checks/typical/cases/otel_app_server/lading/lading.yaml
@@ -29,10 +29,14 @@ generator:
       throttle: stable
       variant:
         dogstatsd:
-          metric_names_minimum: 32
-          metric_names_maximum: 128
-          tag_keys_minimum: 0
-          tag_keys_maximum: 512
+          metric_names:
+            inclusive:
+              min: 32
+              max: 128
+          tag_keys:
+            inclusive:
+              min: 0
+              max: 512
           kind_weights:
             metric: 90
             event: 5


### PR DESCRIPTION
### What does this PR do?

This commit updates lading for the Regression Detector and Workload Checks to 0.19.0. This change primarily impacts how dogstatsd payloads are configured but it also allows the HTTP blackhole to return static byte content.

REF SMPTNG-12
REF PROCS-3242


