### PR TITLE
[windows] fix crash detection parsing problems found in testing.

### DIFF
--- a/comp/checks/agentcrashdetect/agentcrashdetect.go
+++ b/comp/checks/agentcrashdetect/agentcrashdetect.go
@@ -151,6 +151,11 @@ func (wcd *AgentCrashDetect) Run() error {
 	}
 
 	// check to see if the crash is one of ours
+	if len(crash.Offender) == 0 {
+		// weren't able to determine crashing driver.  Don't log internally.
+		log.Warnf("Crash detected, but module could not be determined.  Not reporting crash")
+		return nil
+	}
 	offender := strings.Split(crash.Offender, "+")[0]
 	if _, ok := ddDrivers[offender]; !ok {
 		log.Infof("non-dd crash detected %s", offender)

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse.go
@@ -38,6 +38,7 @@ const (
 	retAddrPrefix          = "RetAddr"
 	unableToLoadPrefix     = "Unable to"
 	ntBangPrefix           = "nt!"
+	keBugCheckPrefix       = "nt!KeBugCheckEx"
 )
 
 func min(a, b int) int {
@@ -169,6 +170,9 @@ func parseCrashDump(wcs *WinCrashStatus) {
 			continue
 		}
 
+		// some versions of the OS have the `BugcheckCode line`, some don't.  If we get into
+		// the actual call stack, read the keBugCheck stack trace line, and get the bug check
+		// code from the first argument on the stack
 		if strings.HasPrefix(line, bugcheckCodePrefix) {
 			codeAsString := strings.TrimSpace(line[len(bugcheckCodePrefix)+1:])
 			wcs.BugCheck = codeAsString
@@ -178,6 +182,7 @@ func parseCrashDump(wcs *WinCrashStatus) {
 		if strings.HasPrefix(line, retAddrPrefix) {
 			continue
 		}
+		
 		// as shown above, there might be a stray "symbols could not be loaded line".  This would then
 		// cause the split on ":" below  to not work, and then things would get worse from there.  so
 		// just skip this line because it's expected.
@@ -189,6 +194,31 @@ func parseCrashDump(wcs *WinCrashStatus) {
 			continue
 		}
 		callsite := strings.TrimSpace(parts[2])
+
+		if len(wcs.BugCheck) == 0 {
+			if strings.HasPrefix(callsite, keBugCheckPrefix) {
+				// line looks like this
+				// fffff800`457f4db0 : 00000000`0000007e ffffffff`c0000005 fffff806`f7e010e6 ffffb481`789326a8 : nt!KeBugCheckEx
+
+				// first, get the args section (between the `:`)
+				sections := strings.Split(line, ":")
+				if len(sections) == 3 {
+					// otherwise don't try to parse it
+					args := strings.TrimSpace(sections[1]) // the middle section
+
+					// now split it along space lines; we only need the first one
+					firstarg, _, found := strings.Cut(args, " ")
+					if found {
+						// now we should be down to 00000000`0000007e
+						_, code, found := strings.Cut(firstarg, "`")
+						if found {
+							wcs.BugCheck = code
+						}
+					}
+				}
+			}
+		}
+
 		if strings.HasPrefix(callsite, ntBangPrefix) {
 			// we're still in ntoskernel, keep looking
 			continue

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse.go
@@ -182,7 +182,7 @@ func parseCrashDump(wcs *WinCrashStatus) {
 		if strings.HasPrefix(line, retAddrPrefix) {
 			continue
 		}
-		
+
 		// as shown above, there might be a stray "symbols could not be loaded line".  This would then
 		// cause the split on ":" below  to not work, and then things would get worse from there.  so
 		// just skip this line because it's expected.

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse_test.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/crashparse_test.go
@@ -84,3 +84,42 @@ func TestCrashParserWithLineSplits(t *testing.T) {
 	assert.Equal(t, "0000007E", wcs.BugCheck)
 
 }
+
+func TestCrashParserWithNoBugcheck(t *testing.T) {
+
+	wcs := &WinCrashStatus{
+		FileName: "testdata/crashsample2.txt",
+	}
+	// first read in the sample data
+
+	readfn = testCrashReader
+
+	parseCrashDump(wcs)
+
+	assert.True(t, wcs.Success)
+	assert.Empty(t, wcs.ErrString)
+	assert.Equal(t, "Mon Jun 26 22:07:25.382 2023 (UTC - 7:00)", wcs.DateString)
+	before, _, _ := strings.Cut(wcs.Offender, "+")
+	assert.Equal(t, "ddapmcrash", before)
+	assert.Equal(t, "0000007E", strings.ToUpper(wcs.BugCheck))
+
+}
+
+func TestCrashParserWithNoOffender(t *testing.T) {
+
+	wcs := &WinCrashStatus{
+		FileName: "testdata/dump_no_offender.txt",
+	}
+	// first read in the sample data
+
+	readfn = testCrashReader
+
+	parseCrashDump(wcs)
+
+	assert.True(t, wcs.Success)
+	assert.Empty(t, wcs.ErrString)
+	assert.Equal(t, "Thu Oct 12 14:48:06.609 2023 (UTC - 7:00)", wcs.DateString)
+	assert.NotEmpty(t, wcs.Offender)
+	assert.Equal(t, "0000013A", strings.ToUpper(wcs.BugCheck))
+
+}

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/testdata/crashsample2.txt
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/testdata/crashsample2.txt
@@ -1,0 +1,105 @@
+No .natvis files found at C:\Windows\SYSTEM32\Visualizers.
+No .natvis files found at C:\Users\db\AppData\Local\Dbg\Visualizers.
+
+Microsoft (R) Windows Debugger Version 10.0.22621.755 AMD64
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+
+Loading Dump File [D:\tmp\dump\active.dmp]
+Kernel Bitmap Dump File: Active memory is available
+
+Symbol search path is: srv*
+Executable search path is: 
+Unable to load image \SystemRoot\system32\ntoskrnl.exe, Win32 error 0n2
+*************************************************************************
+***                                                                   ***
+***                                                                   ***
+***    Either you specified an unqualified symbol, or your debugger   ***
+***    doesn't have full symbol information.  Unqualified symbol      ***
+***    resolution is turned off by default. Please either specify a   ***
+***    fully qualified symbol module!symbolname, or enable resolution ***
+***    of unqualified symbols by typing ".symopt- 100". Note that     ***
+***    enabling unqualified symbol resolution with network symbol     ***
+***    server shares in the symbol path may cause the debugger to     ***
+***    appear to hang for long periods of time when an incorrect      ***
+***    symbol name is typed or the network symbol server is down.     ***
+***                                                                   ***
+***    For some commands to work properly, your symbol path           ***
+***    must point to .pdb files that have full type information.      ***
+***                                                                   ***
+***    Certain .pdb files (such as the public OS symbols) do not      ***
+***    contain the required information.  Contact the group that      ***
+***    provided you with these symbols if you need this command to    ***
+***    work.                                                          ***
+***                                                                   ***
+***    Type referenced: nt!_MMPTE_TRANSITION                          ***
+***                                                                   ***
+*************************************************************************
+Windows 10 Kernel Version 14393 MP (2 procs) Free x64
+Product: Server, suite: TerminalServer SingleUserTS
+Edition build lab: 14393.5989.amd64fre.GitEnlistment.230602-1907
+Machine Name:
+Kernel base = 0xfffff800`5701a000 PsLoadedModuleList = 0xfffff800`5731fcf0
+Debug session time: Mon Jun 26 22:07:25.382 2023 (UTC - 7:00)
+System Uptime: 0 days 0:00:23.613
+Unable to load image \SystemRoot\system32\ntoskrnl.exe, Win32 error 0n2
+*************************************************************************
+***                                                                   ***
+***                                                                   ***
+***    Either you specified an unqualified symbol, or your debugger   ***
+***    doesn't have full symbol information.  Unqualified symbol      ***
+***    resolution is turned off by default. Please either specify a   ***
+***    fully qualified symbol module!symbolname, or enable resolution ***
+***    of unqualified symbols by typing ".symopt- 100". Note that     ***
+***    enabling unqualified symbol resolution with network symbol     ***
+***    server shares in the symbol path may cause the debugger to     ***
+***    appear to hang for long periods of time when an incorrect      ***
+***    symbol name is typed or the network symbol server is down.     ***
+***                                                                   ***
+***    For some commands to work properly, your symbol path           ***
+***    must point to .pdb files that have full type information.      ***
+***                                                                   ***
+***    Certain .pdb files (such as the public OS symbols) do not      ***
+***    contain the required information.  Contact the group that      ***
+***    provided you with these symbols if you need this command to    ***
+***    work.                                                          ***
+***                                                                   ***
+***    Type referenced: nt!_MMPTE_TRANSITION                          ***
+***                                                                   ***
+*************************************************************************
+Loading Kernel Symbols
+...............................................................
+................................................................
+........................
+Loading User Symbols
+
+Loading unloaded module list
+.......
+
+************* Symbol Loading Error Summary **************
+Module name            Error
+ntkrnlmp               The system cannot find the file specified
+
+You can troubleshoot most symbol related issues by turning on symbol loading diagnostics (!sym noisy) and repeating the command that caused symbols to be loaded.
+You should also verify that your symbol search path (.sympath) is correct.
+Unable to add extension DLL: kdexts
+Unable to add extension DLL: kext
+Unable to add extension DLL: exts
+For analysis of this file, run !analyze -v
+RetAddr               : Args to Child                                                           : Call Site
+fffff800`5718fdb0     : 00000000`0000007e ffffffff`c0000005 fffff801`ecc210e6 ffffad80`081306a8 : nt!KeBugCheckEx
+fffff800`571667bf     : 00000000`00000004 00000000`00000000 00007fff`ffff0000 ffffd883`1adf9040 : nt!memset+0x5530
+fffff800`5718102d     : ffffad80`08131000 ffffad80`0812f8c0 00000000`00000000 00000000`00000050 : nt!_C_specific_handler+0x9f
+fffff800`5710f2a1     : ffffad80`08131000 00000000`00000000 ffffad80`0812b000 00000000`00000000 : nt!_chkstk+0x5d
+fffff800`5710e0c4     : ffffad80`081306a8 ffffad80`081303f0 ffffad80`081306a8 ffffad80`08130570 : nt!KeQuerySystemTimePrecise+0x27d1
+fffff800`57189482     : 0000186c`00000000 fffff800`5723cd00 00000000`00000000 fffff800`5772f0c4 : nt!KeQuerySystemTimePrecise+0x15f4
+fffff800`57185fc0     : 00000000`00000000 fffff800`57432fe0 ffff8903`13e0dc50 ffffd883`1cb53080 : nt!setjmpex+0x7622
+fffff801`ecc210e6     : 00000000`00000001 00000000`00000000 ffffd883`19e08000 fffff800`57081511 : nt!setjmpex+0x4160
+Unable to load image \??\c:\users\Administrator\ddapmcrash.sys, Win32 error 0n2
+fffff801`ecc27020     : ffffd883`1cb53080 ffffd883`1cb85000 ffffd883`1cb53080 ffff0c05`3d3c7a54 : ddapmcrash+0x10e6
+fffff800`574ce8f7     : 00000000`00000000 00000000`00000000 ffffd883`1cb53080 ffffffff`000001c8 : ddapmcrash+0x7020
+fffff800`5746c40e     : ffffd883`1b20d180 00000000`00000000 00000000`00000000 fffff800`573d92c0 : nt!FsRtlNotifyVolumeEventEx+0x243b
+fffff800`570b0dc9     : fffff800`00000000 ffffffff`80000dc8 ffffd883`1adf9040 fffff800`573d92c0 : nt!MmGetPhysicalMemoryRangesEx+0xb56
+fffff800`57061f85     : ffffd883`1adf9040 00000000`00000080 ffffd883`19e6d040 ffffd883`1adf9040 : nt!KdPollBreakIn+0x8059
+fffff800`5717fdf6     : fffff800`5735d180 ffffd883`1adf9040 fffff800`57061f44 00000000`00000000 : nt!PsGetProcessSessionIdEx+0x2d5
+00000000`00000000     : ffffad80`08131000 ffffad80`0812b000 00000000`00000000 00000000`00000000 : nt!KeSynchronizeExecution+0x7756

--- a/pkg/collector/corechecks/system/wincrashdetect/probe/testdata/dump_no_offender.txt
+++ b/pkg/collector/corechecks/system/wincrashdetect/probe/testdata/dump_no_offender.txt
@@ -1,0 +1,61 @@
+No .natvis files found at C:\WINDOWS\SYSTEM32\Visualizers.
+No .natvis files found at C:\Users\Administrator\AppData\Local\Dbg\Visualizers.
+
+Microsoft (R) Windows Debugger Version 10.0.20348.859 AMD64
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+
+Loading Dump File [C:\users\Administrator\MEMORY1.DMP]
+Kernel Bitmap Dump File: Kernel address space is available, User address space may not be available.
+
+Symbol search path is: srv*
+Executable search path is: 
+Unable to load image \SystemRoot\system32\ntoskrnl.exe, Win32 error 0n2
+Windows 10 Kernel Version 20348 MP (2 procs) Free x64
+Product: Server, suite: TerminalServer SingleUserTS
+Edition build lab: 20348.859.amd64fre.fe_release_svc_prod2.220707-1832
+Machine Name:
+Kernel base = 0xfffff802`71000000 PsLoadedModuleList = 0xfffff802`71c33dc0
+Debug session time: Thu Oct 12 14:48:06.609 2023 (UTC - 7:00)
+System Uptime: 0 days 0:01:53.439
+Unable to load image \SystemRoot\system32\ntoskrnl.exe, Win32 error 0n2
+Loading Kernel Symbols
+...............................................................
+........Page 102e00 not present in the dump file. Type ".hh dbgerr004" for details
+........................................................
+..............................
+Loading User Symbols
+PEB is paged out (Peb.Ldr = 00000030`7aadd018).  Type ".hh dbgerr001" for details
+Loading unloaded module list
+.......
+
+************* Symbol Loading Error Summary **************
+Module name            Error
+ntkrnlmp               The system cannot find the file specified
+
+You can troubleshoot most symbol related issues by turning on symbol loading diagnostics (!sym noisy) and repeating the command that caused symbols to be loaded.
+You should also verify that your symbol search path (.sympath) is correct.
+Unable to add extension DLL: kdexts
+Unable to add extension DLL: kext
+Unable to add extension DLL: exts
+SECURE: File not allowed to be loaded - C:\WINDOWS\SYSTEM32\dbghelp.dll
+Error code: Win32 error 0n5
+The call to LoadLibrary(ext) failed, Win32 error 0n2
+    "The system cannot find the file specified."
+Please check your debugger configuration and/or network access.
+For analysis of this file, run !analyze -v
+RetAddr               : Args to Child                                                           : Call Site
+fffff802`715dc7dc     : 00000000`0000013a 00000000`00000008 ffffd084`c1202140 ffffd084`c51effe0 : nt!KeBugCheckEx
+fffff802`715dc83c     : 00000000`00000008 ffffca03`84d837f9 ffffd084`c1202140 ffffd084`c62b7980 : nt!RtlTraceDatabaseValidate+0x3b3c
+fffff802`715dc469     : ffffd084`c51e1000 00000000`00002bed 00000000`00000000 ffffd084`c51eff80 : nt!RtlTraceDatabaseValidate+0x3b9c
+fffff802`71471519     : ffffd084`c51e1000 ffffca03`84d837f9 00000000`000000da ffffca03`84d83768 : nt!RtlTraceDatabaseValidate+0x37c9
+fffff802`71236b84     : ffffd084`00000000 00000000`00000000 00000000`00000000 00000000`00000000 : nt!WmiTraceMessageVa+0x20e69
+fffff802`71a47019     : 00000000`00000910 01000000`00000a10 00000000`00000910 00000000`00000000 : nt!IoGetStackLimits+0x814
+fffff802`716a68f7     : ffffd084`c5ff7050 ffffd084`c5ff7050 ffffd084`c18df820 ffffd084`c46b7d40 : nt!ExFreePool+0x9
+fffff802`716a6708     : 00000000`00000000 00000000`00000000 00000000`00000000 00000000`00000000 : nt!ObWaitForMultipleObjects+0x887
+fffff802`712360a7     : 00000000`00000000 00000000`00000000 ffffca03`84d83a49 ffffd084`c5ff7080 : nt!ObWaitForMultipleObjects+0x698
+fffff802`716a46bd     : 00000000`00000001 ffffd084`c5ff7050 ffffffff`ffffffff ffffd084`c5ff7050 : nt!ObfDereferenceObjectWithTag+0xc7
+fffff802`716a2e29     : ffffd084`c5ffb080 000001dc`65bfe900 00000000`0000036c ffffd084`c5b672c0 : nt!NtClose+0x18cd
+fffff802`71434685     : ffffd084`c5ffb080 ffffd084`c531e660 00007ff8`084dcf20 ffffd084`00000000 : nt!NtClose+0x39
+00007ff8`093a03b4     : 00000000`00000000 00000000`00000000 00000000`00000000 00000000`00000000 : nt!setjmpex+0x8985
+00000000`00000000     : 00000000`00000000 00000000`00000000 00000000`00000000 00000000`00000000 : 0x00007ff8`093a03b4

--- a/pkg/collector/corechecks/system/wincrashdetect/wincrashdetect.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/wincrashdetect.go
@@ -115,9 +115,13 @@ func formatTitle(c *probe.WinCrashStatus) string {
 }
 
 func formatText(c *probe.WinCrashStatus) string {
+	offender := c.Offender
+	if len(offender) == 0 {
+		offender = "unknown"
+	}
 	baseString := `A system crash was detected.
 	The crash occurred at %s.
-	The offending moudule is %s.
+	The offending module is %s.
 	The bugcheck code is %s`
-	return fmt.Sprintf(baseString, c.DateString, c.Offender, c.BugCheck)
+	return fmt.Sprintf(baseString, c.DateString, offender, c.BugCheck)
 }


### PR DESCRIPTION


    Testing found two problems, based on different environment and crash
    types.

    The first is that we may not get an offending module.  Accept that,
    and add a test for that type of crash.

    Also, some crash outputs don't call out the bugcheck code, but it can
    be parsed out from the call stack.  in that case, parse the output so
    we can still retrieve the bugcheck code

### Motivation

Testing found gaps in coverage

### Additional Notes


### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

As before; generate a BSOD.  Ensure that in the heap corruption case, the proper (tbd) notifications are sent.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
