### PR TITLE
Always build `pyodbc` from source

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -140,7 +140,7 @@ build do
     # Some libraries (looking at you, aerospike-client-python) need EXT_CFLAGS instead of CFLAGS.
     nix_specific_build_env = {
       "aerospike" => nix_build_env.merge({"EXT_CFLAGS" => nix_build_env["CFLAGS"] + " -std=gnu99"}),
-      "pyodbc" => nix_build_env.merge({"CPPFLAGS" => "-L#{install_dir}/embedded/include"}),
+      "pyodbc" => nix_build_env.merge({"CPPFLAGS" => "-I#{install_dir}/embedded/include"}),
     }
     win_specific_build_env = {}
 

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -140,13 +140,8 @@ build do
     # Some libraries (looking at you, aerospike-client-python) need EXT_CFLAGS instead of CFLAGS.
     nix_specific_build_env = {
       "aerospike" => nix_build_env.merge({"EXT_CFLAGS" => nix_build_env["CFLAGS"] + " -std=gnu99"}),
-      "pyodbc" => nix_build_env.merge(
-        {
-            "CPPFLAGS" => "-I#{install_dir}/embedded/include",
-            "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig",
-            "PIP_NO_BINARY" => "pyodbc",
-        }
-      ),
+      # Always build pyodbc from source to link to the embedded version of libodbc
+      "pyodbc" => nix_build_env.merge({"PIP_NO_BINARY" => "pyodbc"}),
     }
     win_specific_build_env = {}
 

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -140,6 +140,7 @@ build do
     # Some libraries (looking at you, aerospike-client-python) need EXT_CFLAGS instead of CFLAGS.
     nix_specific_build_env = {
       "aerospike" => nix_build_env.merge({"EXT_CFLAGS" => nix_build_env["CFLAGS"] + " -std=gnu99"}),
+      "pyodbc" => nix_build_env.merge({"CPPFLAGS" => "-L#{install_dir}/embedded/include"}),
     }
     win_specific_build_env = {}
 

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -140,7 +140,13 @@ build do
     # Some libraries (looking at you, aerospike-client-python) need EXT_CFLAGS instead of CFLAGS.
     nix_specific_build_env = {
       "aerospike" => nix_build_env.merge({"EXT_CFLAGS" => nix_build_env["CFLAGS"] + " -std=gnu99"}),
-      "pyodbc" => nix_build_env.merge({"CPPFLAGS" => "-I#{install_dir}/embedded/include"}),
+      "pyodbc" => nix_build_env.merge(
+        {
+            "CPPFLAGS" => "-I#{install_dir}/embedded/include",
+            "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig",
+            "PIP_NO_BINARY" => "pyodbc",
+        }
+      ),
     }
     win_specific_build_env = {}
 

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -167,7 +167,7 @@ build do
     # Some libraries (looking at you, aerospike-client-python) need EXT_CFLAGS instead of CFLAGS.
     nix_specific_build_env = {
       "aerospike" => nix_build_env.merge({"EXT_CFLAGS" => nix_build_env["CFLAGS"] + " -std=gnu99"}),
-      "pyodbc" => nix_build_env.merge({"CPPFLAGS" => "-L#{install_dir}/embedded/include"}),
+      "pyodbc" => nix_build_env.merge({"CPPFLAGS" => "-I#{install_dir}/embedded/include"}),
     }
 
     win_specific_build_env = {}

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -167,6 +167,7 @@ build do
     # Some libraries (looking at you, aerospike-client-python) need EXT_CFLAGS instead of CFLAGS.
     nix_specific_build_env = {
       "aerospike" => nix_build_env.merge({"EXT_CFLAGS" => nix_build_env["CFLAGS"] + " -std=gnu99"}),
+      "pyodbc" => nix_build_env.merge({"CPPFLAGS" => "-L#{install_dir}/embedded/include"}),
     }
 
     win_specific_build_env = {}

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -167,7 +167,13 @@ build do
     # Some libraries (looking at you, aerospike-client-python) need EXT_CFLAGS instead of CFLAGS.
     nix_specific_build_env = {
       "aerospike" => nix_build_env.merge({"EXT_CFLAGS" => nix_build_env["CFLAGS"] + " -std=gnu99"}),
-      "pyodbc" => nix_build_env.merge({"CPPFLAGS" => "-I#{install_dir}/embedded/include"}),
+      "pyodbc" => nix_build_env.merge(
+        {
+            "CPPFLAGS" => "-I#{install_dir}/embedded/include",
+            "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig",
+            "PIP_NO_BINARY" => "pyodbc",
+        }
+      ),
     }
 
     win_specific_build_env = {}

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -167,13 +167,8 @@ build do
     # Some libraries (looking at you, aerospike-client-python) need EXT_CFLAGS instead of CFLAGS.
     nix_specific_build_env = {
       "aerospike" => nix_build_env.merge({"EXT_CFLAGS" => nix_build_env["CFLAGS"] + " -std=gnu99"}),
-      "pyodbc" => nix_build_env.merge(
-        {
-            "CPPFLAGS" => "-I#{install_dir}/embedded/include",
-            "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig",
-            "PIP_NO_BINARY" => "pyodbc",
-        }
-      ),
+      # Always build pyodbc from source to link to the embedded version of libodbc
+      "pyodbc" => nix_build_env.merge({"PIP_NO_BINARY" => "pyodbc"}),
     }
 
     win_specific_build_env = {}

--- a/release.json
+++ b/release.json
@@ -5,7 +5,7 @@
         "7": "7.47.1"
     },
     "nightly": {
-        "INTEGRATIONS_CORE_VERSION": "master",
+        "INTEGRATIONS_CORE_VERSION": "florentclarret/bump_pyodbc",
         "OMNIBUS_SOFTWARE_VERSION": "master",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
         "JMXFETCH_VERSION": "0.48.0",
@@ -25,7 +25,7 @@
         "WINDOWS_APMINJECT_SHASUM": "c5c228f6030ce2e19b8bfb28bd054dc246c7f1c799431e73018e6cb46ee59d2f"
     },
     "nightly-a7": {
-        "INTEGRATIONS_CORE_VERSION": "master",
+        "INTEGRATIONS_CORE_VERSION": "florentclarret/bump_pyodbc",
         "OMNIBUS_SOFTWARE_VERSION": "master",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
         "JMXFETCH_VERSION": "0.48.0",

--- a/release.json
+++ b/release.json
@@ -5,7 +5,7 @@
         "7": "7.47.1"
     },
     "nightly": {
-        "INTEGRATIONS_CORE_VERSION": "florentclarret/bump_pyodbc",
+        "INTEGRATIONS_CORE_VERSION": "master",
         "OMNIBUS_SOFTWARE_VERSION": "master",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
         "JMXFETCH_VERSION": "0.48.0",
@@ -25,7 +25,7 @@
         "WINDOWS_APMINJECT_SHASUM": "c5c228f6030ce2e19b8bfb28bd054dc246c7f1c799431e73018e6cb46ee59d2f"
     },
     "nightly-a7": {
-        "INTEGRATIONS_CORE_VERSION": "florentclarret/bump_pyodbc",
+        "INTEGRATIONS_CORE_VERSION": "master",
         "OMNIBUS_SOFTWARE_VERSION": "master",
         "OMNIBUS_RUBY_VERSION": "datadog-5.5.0",
         "JMXFETCH_VERSION": "0.48.0",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Always build `pyodbc` from source

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

- In [this PR](https://github.com/DataDog/integrations-core/pull/16021) we want to bump `pyodbc` from 4.0.32 to 4.0.39 to support py3.11
- All the agent builds except the rpm x64 (yeah that's unusual) started to fail with this new version: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/350400989
- With pyodbc 4.0.35+, they started to provide wheels for linux, we now just download the wheel, except on the rpm x64 build because there's no wheel for this one
- The path to `libodbc` is [hardcoded](https://github.com/mkleehammer/pyodbc/issues/681#issuecomment-574417846) in the wheel to the default path, which makes our health check fail
- We need to manually build the wheel with the right flags to be able to use a custom path for `libodbc`, this is exactly what we are doing with 4.0.32

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

- Link to a green CI job that uses pyodbc 4.0.39 (pinning the integrations-core version, see commit history if needed): https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/351113438
- Relates to https://datadoghq.atlassian.net/browse/AITS-277

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
