### PR TITLE
Reorder tests to not restart the agent service too much in a row

### DIFF
--- a/.gitlab/new-e2e_testing/debian.yml
+++ b/.gitlab/new-e2e_testing/debian.yml
@@ -23,4 +23,3 @@ new-e2e-agent-platform-install-script-debian-a7-x64:
     TARGETS: ./tests/agent-platform/install-script
     TEAM: agent-platform
     EXTRA_PARAMS: --osversion $E2E_OSVERS --platform $E2E_PLATFORM --cws-supported-osversion $E2E_CWS_SUPPORTED_OSVERS
-  allow_failure: true

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -169,15 +169,6 @@ func CheckCWSBehaviour(t *testing.T, client *TestClient) {
 		require.NoError(tt, err)
 
 		_, err = client.SvcManager.Restart("datadog-agent")
-		// DEBUG: Will be removed, used to try to understand why the test is flaky
-		if err != nil {
-			time.Sleep(10 * time.Second)
-			output, _ := client.VMClient.ExecuteWithError("sudo cat /var/log/datadog/agent.log")
-			output2, _ := client.VMClient.ExecuteWithError("sudo journalctl -xe")
-			t.Log("AGENT LOG: ", output)
-			t.Log("JOURNALCTL LOG: ", output2)
-		}
-
 		require.NoError(tt, err, "datadog-agent should restart after CWS is enabled")
 	})
 

--- a/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
+++ b/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
@@ -84,9 +84,9 @@ func (is *installScriptSuite) TestInstallAgent() {
 
 	common.CheckInstallation(is.T(), client)
 	common.CheckAgentBehaviour(is.T(), client)
-	common.CheckIntegrationInstall(is.T(), client)
 	common.CheckAgentStops(is.T(), client)
 	common.CheckAgentRestarts(is.T(), client)
+	common.CheckIntegrationInstall(is.T(), client)
 	common.CheckAgentPython(is.T(), client, "3")
 	common.CheckApmEnabled(is.T(), client)
 	common.CheckApmDisabled(is.T(), client)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fix e2e install script test flakiness, by reordering test, to not have more than 5 restarts of the agent within 10 seconds
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
