### PR TITLE
Prevent merging with non-empty BUILDIMAGES_SUFFIX gitlab variables

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,7 @@ include:
   - /.gitlab/source_test_junit_upload.yml
   - /.gitlab/binary_build.yml
   - /.gitlab/cancel-prev-pipelines.yml
+  - /.gitlab/do_not_merge.yml
   - /.gitlab/integration_test.yml
   - /.gitlab/package_build.yml
   - /.gitlab/kitchen_deploy.yml
@@ -166,6 +167,8 @@ variables:
   DATADOG_AGENT_NIKOS_BUILDIMAGES: v20878799-a2f77ae
   DATADOG_AGENT_BTF_GEN_BUILDIMAGES_SUFFIX: ""
   DATADOG_AGENT_BTF_GEN_BUILDIMAGES: v20878799-a2f77ae
+  # To use images from test-infra-definitions dev branches, set the SUFFIX variable to -dev
+  # and check the job creating the image to make sure you have the right SHA prefix
   TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: ""
   TEST_INFRA_DEFINITIONS_BUILDIMAGES: d2510f65b6fe
   DATADOG_AGENT_BUILDERS: v19474930-fe4bcd9

--- a/.gitlab/do_not_merge.yml
+++ b/.gitlab/do_not_merge.yml
@@ -1,0 +1,25 @@
+check-buildimages-suffix:
+  stage: .pre
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  rules: # this should only run on dev branches
+  - if: $CI_PIPELINE_SOURCE =~ /^schedule.*$/
+    when: never
+  - if: $CI_COMMIT_TAG
+    when: never
+  - !reference [.except_main_or_release_branch]
+  - if: |
+      $DATADOG_AGENT_BUILDIMAGES_SUFFIX != ""
+      || $DATADOG_AGENT_WINBUILDIMAGES_SUFFIX != ""
+      || $DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX != ""
+      || $DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX != ""
+      || $DATADOG_AGENT_KERNEL_MATRIX_TESTING_BUILDIMAGES_SUFFIX != ""
+      || $DATADOG_AGENT_NIKOS_BUILDIMAGES_SUFFIX != ""
+      || $DATADOG_AGENT_BTF_GEN_BUILDIMAGES_SUFFIX != ""
+      || $TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX != ""
+    when: always
+  - when: never
+  script:
+    - echo "Pull request uses non-empty BUILDIMAGES_SUFFIX variable"
+    - echo "This workflow fails so that the pull request cannot be merged"
+    - exit 1

--- a/.gitlab/do_not_merge.yml
+++ b/.gitlab/do_not_merge.yml
@@ -1,4 +1,4 @@
-check-buildimages-suffix:
+do-not-merge:
   stage: .pre
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
@@ -8,18 +8,19 @@ check-buildimages-suffix:
   - if: $CI_COMMIT_TAG
     when: never
   - !reference [.except_main_or_release_branch]
-  - if: |
-      $DATADOG_AGENT_BUILDIMAGES_SUFFIX != ""
-      || $DATADOG_AGENT_WINBUILDIMAGES_SUFFIX != ""
-      || $DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX != ""
-      || $DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX != ""
-      || $DATADOG_AGENT_KERNEL_MATRIX_TESTING_BUILDIMAGES_SUFFIX != ""
-      || $DATADOG_AGENT_NIKOS_BUILDIMAGES_SUFFIX != ""
-      || $DATADOG_AGENT_BTF_GEN_BUILDIMAGES_SUFFIX != ""
-      || $TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX != ""
-    when: always
-  - when: never
+  - when: always
   script:
-    - echo "Pull request uses non-empty BUILDIMAGES_SUFFIX variable"
-    - echo "This workflow fails so that the pull request cannot be merged"
-    - exit 1
+      - |
+          if [ ! -z "$DATADOG_AGENT_BUILDIMAGES_SUFFIX" ] ||
+             [ ! -z "$DATADOG_AGENT_WINBUILDIMAGES_SUFFIX" ] ||
+             [ ! -z "$DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX" ] ||
+             [ ! -z "$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX" ] ||
+             [ ! -z "$DATADOG_AGENT_KERNEL_MATRIX_TESTING_BUILDIMAGES_SUFFIX" ] ||
+             [ ! -z "$DATADOG_AGENT_NIKOS_BUILDIMAGES_SUFFIX" ] ||
+             [ ! -z "$DATADOG_AGENT_BTF_GEN_BUILDIMAGES_SUFFIX" ] ||
+             [ ! -z "$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX" ]; then
+            echo "Pull request uses non-empty BUILDIMAGES_SUFFIX variable"
+            echo "This workflow fails so that the pull request cannot be merged"
+            exit 1
+          fi
+      - exit 0


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Prevent merging with non-empty BUILDIMAGES_SUFFIX gitlab variable.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Those variables can be set to something else in order to test with dev branches, but we shouldn't merge to main in that case, the job just prevents merging the PR.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
This PR initially enabled using a dev branch for `test-infra-definitions`, but a similar change was actually merged as part of https://github.com/DataDog/datadog-agent/pull/20079, so all that is left is the job to prevent merging with a non-empty value.

When a `test-infra-definitions` image is released the format of its name changes a little: a dev image has a `-dev` prefix and its SHA is 4 characters smaller:
```
486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner-dev:19385035
vs
486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:47075a3ff188
```
Hence the comment in `.gitlab-ci.yml`.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
