### PR TITLE
[CWS] move MountEventSerializer fields comments

### DIFF
--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -400,17 +400,28 @@ type BindEventSerializer struct {
 // MountEventSerializer serializes a mount event to JSON
 // easyjson:json
 type MountEventSerializer struct {
-	MountPoint                     *FileSerializer `json:"mp,omitempty"`                    // Mount point file information
-	Root                           *FileSerializer `json:"root,omitempty"`                  // Root file information
-	MountID                        uint32          `json:"mount_id"`                        // Mount ID of the new mount
-	ParentMountID                  uint32          `json:"parent_mount_id"`                 // Mount ID of the parent mount
-	BindSrcMountID                 uint32          `json:"bind_src_mount_id"`               // Mount ID of the source of a bind mount
-	Device                         uint32          `json:"device"`                          // Device associated with the file
-	FSType                         string          `json:"fs_type,omitempty"`               // Filesystem type
-	MountPointPath                 string          `json:"mountpoint.path,omitempty"`       // Mount point path
-	MountSourcePath                string          `json:"source.path,omitempty"`           // Mount source path
-	MountPointPathResolutionError  string          `json:"mountpoint.path_error,omitempty"` // Mount point path error
-	MountSourcePathResolutionError string          `json:"source.path_error,omitempty"`     // Mount source path error
+	// Mount point file information
+	MountPoint *FileSerializer `json:"mp,omitempty"`
+	// Root file information
+	Root *FileSerializer `json:"root,omitempty"`
+	// Mount ID of the new mount
+	MountID uint32 `json:"mount_id"`
+	// Mount ID of the parent mount
+	ParentMountID uint32 `json:"parent_mount_id"`
+	// Mount ID of the source of a bind mount
+	BindSrcMountID uint32 `json:"bind_src_mount_id"`
+	// Device associated with the file
+	Device uint32 `json:"device"`
+	// Filesystem type
+	FSType string `json:"fs_type,omitempty"`
+	// Mount point path
+	MountPointPath string `json:"mountpoint.path,omitempty"`
+	// Mount source path
+	MountSourcePath string `json:"source.path,omitempty"`
+	// Mount point path error
+	MountPointPathResolutionError string `json:"mountpoint.path_error,omitempty"`
+	// Mount source path error
+	MountSourcePathResolutionError string `json:"source.path_error,omitempty"`
 }
 
 // AnomalyDetectionSyscallEventSerializer serializes an anomaly detection for a syscall event


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Stay consistent across all serializers structs and allow generating the events documentation with jsonschema libs that don't support in-line comments. 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
