### PR TITLE
[APMON-298] Bug fix: Inject standard tags when labels specified

### DIFF
--- a/pkg/clusteragent/admission/mutate/tags.go
+++ b/pkg/clusteragent/admission/mutate/tags.go
@@ -73,7 +73,7 @@ func injectTags(pod *corev1.Pod, ns string, dc dynamic.Interface) error {
 		return errors.New("cannot inject tags into nil pod")
 	}
 
-	if shouldInject(pod) {
+	if !shouldInject(pod) {
 		// Ignore pod if it has the label admission.datadoghq.com/enabled=false or Single step configuration is disabled
 		return nil
 	}

--- a/pkg/clusteragent/admission/mutate/tags_test.go
+++ b/pkg/clusteragent/admission/mutate/tags_test.go
@@ -152,6 +152,17 @@ func Test_injectTags(t *testing.T) {
 				return *pod
 			},
 		},
+		{
+			name: "tag label found but not injected, injection label not set",
+			pod: withLabels(
+				fakePodWithEnv("foo-pod", "DD_ENV"),
+				map[string]string{"tags.datadoghq.com/env": "dev"},
+			),
+			wantPodFunc: func() corev1.Pod {
+				pod := fakePodWithEnv("foo-pod", "DD_ENV")
+				return *pod
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/clusteragent/admission/mutate/tags_test.go
+++ b/pkg/clusteragent/admission/mutate/tags_test.go
@@ -95,6 +95,75 @@ func Test_injectTagsFromLabels(t *testing.T) {
 	}
 }
 
+func Test_injectTags(t *testing.T) {
+	tests := []struct {
+		name        string
+		labels      map[string]string
+		pod         *corev1.Pod
+		wantPodFunc func() corev1.Pod
+	}{
+		{
+			name: "tag labels and injection on",
+			pod: withLabels(
+				fakePod("foo-pod"),
+				map[string]string{
+					"admission.datadoghq.com/enabled": "true",
+					"tags.datadoghq.com/env":          "dev",
+					"tags.datadoghq.com/service":      "dd-agent",
+					"tags.datadoghq.com/version":      "7",
+				},
+			),
+			wantPodFunc: func() corev1.Pod {
+				pod := withLabels(fakePod("foo-pod"), map[string]string{"admission.datadoghq.com/enabled": "true"})
+				pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, fakeEnvWithValue("DD_ENV", "dev"))
+				pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, fakeEnvWithValue("DD_SERVICE", "dd-agent"))
+				pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, fakeEnvWithValue("DD_VERSION", "7"))
+				return *pod
+			},
+		},
+		{
+			name: "no labels and injectione on",
+			pod:  withLabels(fakePod("foo-pod"), map[string]string{"admission.datadoghq.com/enabled": "true"}),
+			wantPodFunc: func() corev1.Pod {
+				pod := withLabels(fakePod("foo-pod"), map[string]string{"admission.datadoghq.com/enabled": "true"})
+				return *pod
+			},
+		},
+		{
+			name: "env only and injectione on",
+			pod: withLabels(
+				fakePod("foo-pod"),
+				map[string]string{"admission.datadoghq.com/enabled": "true", "tags.datadoghq.com/env": "dev"},
+			),
+			wantPodFunc: func() corev1.Pod {
+				pod := withLabels(fakePod("foo-pod"), map[string]string{"admission.datadoghq.com/enabled": "true"})
+				pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, fakeEnvWithValue("DD_ENV", "dev"))
+				return *pod
+			},
+		},
+		{
+			name: "label found but not injected",
+			pod: withLabels(
+				fakePodWithEnv("foo-pod", "DD_ENV"),
+				map[string]string{"admission.datadoghq.com/enabled": "true", "tags.datadoghq.com/env": "dev"},
+			),
+			wantPodFunc: func() corev1.Pod {
+				pod := withLabels(fakePodWithEnv("foo-pod", "DD_ENV"), map[string]string{"admission.datadoghq.com/enabled": "true"})
+				return *pod
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := injectTags(tt.pod, "ns", nil)
+			assert.NoError(t, err)
+			assert.Len(t, tt.pod.Spec.Containers, 1)
+			assert.Len(t, tt.wantPodFunc().Spec.Containers, 1)
+			assert.ElementsMatch(t, tt.wantPodFunc().Spec.Containers[0].Env, tt.pod.Spec.Containers[0].Env)
+		})
+	}
+}
+
 func Test_getOwnerInfo(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/clusteragent/admission/mutate/tags_test.go
+++ b/pkg/clusteragent/admission/mutate/tags_test.go
@@ -122,7 +122,7 @@ func Test_injectTags(t *testing.T) {
 			},
 		},
 		{
-			name: "no labels and injectione on",
+			name: "no labels and injection on",
 			pod:  withLabels(fakePod("foo-pod"), map[string]string{"admission.datadoghq.com/enabled": "true"}),
 			wantPodFunc: func() corev1.Pod {
 				pod := withLabels(fakePod("foo-pod"), map[string]string{"admission.datadoghq.com/enabled": "true"})
@@ -130,7 +130,7 @@ func Test_injectTags(t *testing.T) {
 			},
 		},
 		{
-			name: "env only and injectione on",
+			name: "env only and injection on",
 			pod: withLabels(
 				fakePod("foo-pod"),
 				map[string]string{"admission.datadoghq.com/enabled": "true", "tags.datadoghq.com/env": "dev"},
@@ -142,7 +142,7 @@ func Test_injectTags(t *testing.T) {
 			},
 		},
 		{
-			name: "label found but not injected",
+			name: "tag label found but not injected, injection on",
 			pod: withLabels(
 				fakePodWithEnv("foo-pod", "DD_ENV"),
 				map[string]string{"admission.datadoghq.com/enabled": "true", "tags.datadoghq.com/env": "dev"},


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
