### PR TITLE
[CSM] Fix revive error

### DIFF
--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -1324,11 +1324,11 @@ func (tm *testModule) getSignal(tb testing.TB, action func() error, cb func(*mod
 			switch msg {
 			case Continue:
 				if err := cb(e, r); err != nil {
-					if errors.Is(err, errSkipEvent) {
+					if !errors.Is(err, errSkipEvent) {
+						tb.Error(err)
+					} else {
 						message <- Continue
 						return
-					} else {
-						tb.Error(err)
 					}
 				}
 				if tb.Skipped() || tb.Failed() {

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -1324,12 +1324,12 @@ func (tm *testModule) getSignal(tb testing.TB, action func() error, cb func(*mod
 			switch msg {
 			case Continue:
 				if err := cb(e, r); err != nil {
-					if !errors.Is(err, errSkipEvent) {
-						tb.Error(err)
-					} else {
+					if errors.Is(err, errSkipEvent) {
 						message <- Continue
 						return
 					}
+
+					tb.Error(err)
 				}
 				if tb.Skipped() || tb.Failed() {
 					failNow <- true


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixes this revive error when running a functional test
```
pkg/security/tests/module_tester.go:1330:13: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
                                        } else {
                                                tb.Error(err)
                                        }
```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
