### PR TITLE
[Serverless] Change the default serverless.trace_enabled to true

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1224,7 +1224,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("enhanced_metrics", true)
 	config.BindEnvAndSetDefault("capture_lambda_payload", false)
 	config.BindEnvAndSetDefault("capture_lambda_payload_max_depth", 10)
-	config.BindEnvAndSetDefault("serverless.trace_enabled", false, "DD_TRACE_ENABLED")
+	config.BindEnvAndSetDefault("serverless.trace_enabled", true, "DD_TRACE_ENABLED")
 	config.BindEnvAndSetDefault("serverless.trace_managed_services", true, "DD_TRACE_MANAGED_SERVICES")
 	config.BindEnvAndSetDefault("serverless.service_mapping", nil, "DD_SERVICE_MAPPING")
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Set the default value of serverless.trace_enabled (`DD_TRACE_ENABLED`) to true.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Currently, there's some inconsistency of in the default case behavior (`DD_TRACE_ENABLED` not set).

When it comes to serverless's universal instrumentation (more details can be found in[ this doc](https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/3151233393/Universal+Instrumentation)), the extension (datadog agent in serverless case) is actually doing part of the “tracer” job, specifically it’s doing the [inferred span work](https://github.com/DataDog/datadog-agent/blob/48b9d4c727ed4c1311b152ee79e957095083b61f/pkg/serverless/trace/inferredspan/inferred_span.go#L169). 
However, the default setting for DD_TRACE_ENABLED is true for [dotnet](https://github.com/DataDog/dd-trace-dotnet/blob/ea58b37077b7520766df87e47a7d3b9194de730d/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs#L117) and [java](https://github.com/DataDog/dd-trace-java/blob/2ef484a1ab9136fd586ff0893cebea8af31ffb89/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java#L45) and [go](https://github.com/DataDog/dd-trace-go/blob/057a0eee4d4a133976265f3a6b8433d41f91e8ed/ddtrace/tracer/option.go#L337) tracers. So we end up a mixed behavior when there’s no DD_TRACE_ENABLED in an AWS lambda. We would end up having traces since the tracer is defaulted to be enabled but we also don’t infer spans because it’s defaulted to false in the extension. So we often end up two broken tracers. like these:
Upstream sender/producer trace
<img width="979" alt="Screenshot 2023-10-17 at 2 59 35 PM" src="https://github.com/DataDog/datadog-agent/assets/5253430/dd58e829-a661-46b9-bb8f-d2243fb2fb31">
and downstream receiver/consumer trace
<img width="839" alt="Screenshot 2023-10-17 at 2 59 48 PM" src="https://github.com/DataDog/datadog-agent/assets/5253430/d6c43ead-4e84-424a-8e2b-1ef0855a8c2d">
Whereas if we now change it to default as `true`, when user not specifying `DD_TRACE_ENABLED`, we will see

<img width="836" alt="Screenshot 2023-10-17 at 3 04 41 PM" src="https://github.com/DataDog/datadog-agent/assets/5253430/6c52420a-3de1-4f6a-9f70-0f446db792e9">


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
