### PR TITLE
Use auto reset event in event log subscription

### DIFF
--- a/pkg/util/winutil/eventlog/subscription/subscription.go
+++ b/pkg/util/winutil/eventlog/subscription/subscription.go
@@ -89,8 +89,22 @@ type PullSubscriptionOption func(*pullSubscription)
 
 func newSubscriptionSignalEvent() (evtapi.WaitEventHandle, error) {
 	// https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createeventa
-	// Manual reset, must be initially set, Windows will not set it for old events
-	hEvent, err := windows.CreateEvent(nil, 1, 1, nil)
+	// Auto reset, must be initially set, Windows will not set it for old events
+	//
+	// The MSDN example uses a manual reset event, but the API docs don't specify that a manual
+	// reset event is required. The manual reset event is inherently racey, consider the following
+	// 1. We are waiting in WaitForMultipleObjects for the event handle to be set
+	// 2. (in background) Events arrive and the handle is set
+	// 3. WaitForMultipleObjects returns
+	// 4. EvtNext is called and returns the events and ERROR_NO_MORE_ITEMS
+	// 5. (in background) Events arrive and the handle is set
+	// 6. We handle the ERROR_NO_MOTE_ITEMS result and call ResetEvent to unset the event handle
+	// Now WaitForMultipleObjects will block and we won't see the second set of events until a third
+	// set arrives.
+	// Instead, to avoid this race we use an auto reset event, which is unset when WaitForMultipleObjects
+	// returns. When EvtNext returns more items we call SetEvent to unblock WaitForMultipleObjects again.
+	// When EvtNext returns ERROR_NO_MORE_ITEMS the event is already unset and we don't need to do anything.
+	hEvent, err := windows.CreateEvent(nil, 0, 1, nil)
 	return evtapi.WaitEventHandle(hEvent), err
 }
 
@@ -280,6 +294,7 @@ func (q *pullSubscription) getEventsLoop() {
 
 	waiters := []windows.Handle{windows.Handle(q.subscriptionSignalEventHandle), windows.Handle(q.stopEventHandle)}
 
+waitLoop:
 	for {
 		dwWait, err := windows.WaitForMultipleObjects(waiters, false, windows.INFINITE)
 		if err != nil {
@@ -291,32 +306,36 @@ func (q *pullSubscription) getEventsLoop() {
 		if dwWait == windows.WAIT_OBJECT_0 {
 			// We were signalled by the subscription, check for events
 			pkglog.Trace("Checking for events")
-			// We supply INFINITE for the Timeout parameter but if we are at the end of the log file/there are no more events EvtNext will return,
-			// it will not block forever.
-			// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-even6/cd4c258c-5a2c-4ba8-bce3-37eefaa416e7
-			eventRecordHandles, err := q.eventLogAPI.EvtNext(q.subscriptionHandle, q.evtNextStorage, uint(len(q.evtNextStorage)), windows.INFINITE)
-			if err == nil {
-				pkglog.Tracef("EvtNext returned %v handles", len(eventRecordHandles))
-				select {
-				case q.eventsChannel <- q.parseEventRecordHandles(eventRecordHandles):
-				case <-q.notifyStop:
-					q.err = fmt.Errorf("received stop signal")
-					pkglog.Info(q.err)
-					return
+			// loop calling EvtNext until it returns ERROR_NO_MORE_ITEMS, or an error, or stop event is set
+			for {
+				// We supply INFINITE for the Timeout parameter but if we are at the end of the log file/there are no more events EvtNext will return,
+				// it will not block forever.
+				// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-even6/cd4c258c-5a2c-4ba8-bce3-37eefaa416e7
+				eventRecordHandles, err := q.eventLogAPI.EvtNext(q.subscriptionHandle, q.evtNextStorage, uint(len(q.evtNextStorage)), windows.INFINITE)
+				if err == nil {
+					pkglog.Tracef("EvtNext returned %v handles", len(eventRecordHandles))
+					select {
+					case q.eventsChannel <- q.parseEventRecordHandles(eventRecordHandles):
+					case <-q.notifyStop:
+						q.err = fmt.Errorf("received stop signal")
+						pkglog.Info(q.err)
+						return
+					}
+					continue
 				}
-				continue
-			}
 
-			if err == windows.ERROR_NO_MORE_ITEMS || err == windows.ERROR_INVALID_OPERATION {
-				// EvtNext returns ERROR_NO_MORE_ITEMS when there are no more items available.
-				// EvtNext returns ERROR_INVALID_OPERATION when it is called when the notify event is not set.
-				pkglog.Tracef("EvtNext returned no more items")
-				_ = windows.ResetEvent(windows.Handle(q.subscriptionSignalEventHandle))
-				continue
-			}
+				if err == windows.ERROR_NO_MORE_ITEMS || err == windows.ERROR_INVALID_OPERATION {
+					// EvtNext returns ERROR_NO_MORE_ITEMS when there are no more items available.
+					// EvtNext returns ERROR_INVALID_OPERATION when it is called when the notify event is not set.
+					pkglog.Tracef("EvtNext returned no more items")
+					// We do not call ResetEvent here beause we use an auto-reset event instead, so the event is
+					// already unset when WaitForMultipleObjects returns.
+					continue waitLoop
+				}
 
-			q.logAndSetError(fmt.Errorf("EvtNext failed: %w", err))
-			return
+				q.logAndSetError(fmt.Errorf("EvtNext failed: %w", err))
+				return
+			}
 		} else if dwWait == (windows.WAIT_OBJECT_0 + 1) {
 			// Stop event is set
 			q.err = fmt.Errorf("received stop signal")

--- a/pkg/util/winutil/eventlog/subscription/subscription.go
+++ b/pkg/util/winutil/eventlog/subscription/subscription.go
@@ -102,8 +102,7 @@ func newSubscriptionSignalEvent() (evtapi.WaitEventHandle, error) {
 	// Now WaitForMultipleObjects will block and we won't see the second set of events until a third
 	// set arrives.
 	// Instead, to avoid this race we use an auto reset event, which is unset when WaitForMultipleObjects
-	// returns. When EvtNext returns more items we call SetEvent to unblock WaitForMultipleObjects again.
-	// When EvtNext returns ERROR_NO_MORE_ITEMS the event is already unset and we don't need to do anything.
+	// returns. When EvtNext returns ERROR_NO_MORE_ITEMS the event is already unset and we don't need to do anything.
 	hEvent, err := windows.CreateEvent(nil, 0, 1, nil)
 	return evtapi.WaitEventHandle(hEvent), err
 }

--- a/pkg/util/winutil/eventlog/subscription/subscription.go
+++ b/pkg/util/winutil/eventlog/subscription/subscription.go
@@ -98,7 +98,7 @@ func newSubscriptionSignalEvent() (evtapi.WaitEventHandle, error) {
 	// 3. WaitForMultipleObjects returns
 	// 4. EvtNext is called and returns the events and ERROR_NO_MORE_ITEMS
 	// 5. (in background) Events arrive and the handle is set
-	// 6. We handle the ERROR_NO_MOTE_ITEMS result and call ResetEvent to unset the event handle
+	// 6. We handle the ERROR_NO_MORE_ITEMS result and call ResetEvent to unset the event handle
 	// Now WaitForMultipleObjects will block and we won't see the second set of events until a third
 	// set arrives.
 	// Instead, to avoid this race we use an auto reset event, which is unset when WaitForMultipleObjects


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Switch from a manual reset event to an auto reset event for receiving the "events available" signal from the pull subscription. Also adds a loop around `EvtNext`, which is recommended by MSDN, so we don't have to go back to `WaitForMultipleObjects` while there are still events available.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
alleviate the race condition inherent in using a manual reset event

https://datadoghq.atlassian.net/browse/WINA-466

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
should resolve the hangs we are encountering in the integration tests, which seem to be hitting this race condition.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
