### PR TITLE
Add dependabot config for new e2e tests and fakeintake

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -127,6 +127,37 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 100
+  - package-ecosystem: gomod
+    directory: /test/new-e2e
+    labels:
+      - dependencies
+      - dependencies-go
+      - team/agent-e2e-test
+      - changelog/no-changelog
+      - qa/skip-qa
+      - dev/testing
+    milestone: 22
+    ignore:
+      # Ignore test-infra-definitions because bumping the GO package inside `go.mod`
+      # requires to also bump `TEST_INFRA_DEFINITIONS_BUILDIMAGES` inside `.gitlab-ci.yml`
+      # and dependabot isn’t able to keep those two synchronized.
+      - dependency-name: github.com/DataDog/test-infra-definitions
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 100
+  - package-ecosystem: gomod
+    directory: /test/fakeintake
+    labels:
+      - dependencies
+      - dependencies-go
+      - team/agent-e2e-test
+      - changelog/no-changelog
+      - qa/skip-qa
+      - dev/testing
+    milestone: 22
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 100
   - package-ecosystem: "pip"
     directory: "/.circleci"
     labels:


### PR DESCRIPTION
### What does this PR do?

Configure dependabot :dependabot: to propose updates to [`test/new-e2e/go.mod`](https://github.com/DataDog/datadog-agent/blob/main/test/new-e2e/go.mod) and [`test/fakeintake/go.mod`](https://github.com/DataDog/datadog-agent/blob/main/test/fakeintake/go.mod).

### Motivation

Keep our dependencies up-to-date.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
