### PR TITLE
remove map mmap RSS reporting in eBPF check

### DIFF
--- a/pkg/collector/corechecks/ebpf/ebpf.go
+++ b/pkg/collector/corechecks/ebpf/ebpf.go
@@ -125,24 +125,6 @@ func (m *EBPFCheck) Run() error {
 		reportBaseMap(mapInfo)
 	}
 
-	for _, pbInfo := range stats.PerfBuffers {
-		reportBaseMap(pbInfo.EBPFMapStats)
-		for _, cpub := range pbInfo.CPUBuffers {
-			cputags := []string{
-				"map_name:" + pbInfo.Name,
-				"map_type:" + pbInfo.Type.String(),
-				"module:" + pbInfo.Module,
-				fmt.Sprintf("cpu_num:%d", cpub.CPU),
-			}
-			if cpub.RSS > 0 {
-				sender.Gauge("ebpf.maps.memory_rss_percpu", float64(cpub.RSS), "", cputags)
-			}
-			if cpub.Size > 0 {
-				sender.Gauge("ebpf.maps.memory_max_percpu", float64(cpub.Size), "", cputags)
-			}
-		}
-	}
-
 	if totalMapMaxSize > 0 {
 		sender.Gauge("ebpf.maps.memory_max_total", float64(totalMapMaxSize), "", nil)
 	}

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/dedup.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/dedup.go
@@ -49,12 +49,9 @@ func deduplicateProgramNames(stats *model.EBPFStats) {
 
 // deduplicateMapNames disambiguates ebpf maps by adding a numeric ID if necessary
 func deduplicateMapNames(stats *model.EBPFStats) {
-	allMaps := make([]*model.EBPFMapStats, 0, len(stats.Maps)+len(stats.PerfBuffers))
+	allMaps := make([]*model.EBPFMapStats, 0, len(stats.Maps))
 	for i := range stats.Maps {
 		allMaps = append(allMaps, &stats.Maps[i])
-	}
-	for i := range stats.PerfBuffers {
-		allMaps = append(allMaps, &stats.PerfBuffers[i].EBPFMapStats)
 	}
 
 	cmpFunc := func(a, b *model.EBPFMapStats) int {

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/model/types.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/model/types.go
@@ -14,52 +14,35 @@ import (
 
 // EBPFStats contains the statistics from the ebpf check
 type EBPFStats struct {
-	Maps        []EBPFMapStats
-	PerfBuffers []EBPFPerfBufferStats
-	Programs    []EBPFProgramStats
+	Maps     []EBPFMapStats
+	Programs []EBPFProgramStats
 }
 
 // EBPFMapStats are the basic statistics for ebpf maps
 type EBPFMapStats struct {
 	ID         uint32
+	MaxEntries uint32
 	Name       string
 	Module     string
 	RSS        uint64
 	MaxSize    uint64
-	MaxEntries uint32
 	Type       ebpf.MapType
+
+	// used only for tests
+	NumCPUs uint32
 }
 
 // EBPFProgramStats are the basic statistics for ebpf programs
 type EBPFProgramStats struct {
 	ID              uint32
+	XlatedProgLen   uint32
 	Name            string
 	Module          string
 	Tag             string
 	RSS             uint64
 	RunCount        uint64
 	RecursionMisses uint64
-	XlatedProgLen   uint32
-	VerifiedInsns   uint32
 	Runtime         time.Duration
+	VerifiedInsns   uint32
 	Type            ebpf.ProgramType
-}
-
-// EBPFMmapStats is the detailed statistics for mmap-ed regions
-type EBPFMmapStats struct {
-	Addr uintptr
-	Size uint64
-	RSS  uint64
-}
-
-// EBPFCPUPerfBufferStats is the per-CPU statistics of a mmap region for a perf buffer
-type EBPFCPUPerfBufferStats struct {
-	EBPFMmapStats
-	CPU uint32
-}
-
-// EBPFPerfBufferStats is the detailed statistics for a perf buffer
-type EBPFPerfBufferStats struct {
-	CPUBuffers []EBPFCPUPerfBufferStats
-	EBPFMapStats
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Remove mmap RSS tracking for perf buffers and ring buffers.

### Motivation

Remove extra work that has no/little value. The full RSS value is quickly paged in and never goes down.

### Additional Notes

https://datadoghq.atlassian.net/browse/EBPF-288

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
