### PR TITLE
Fix TestJavaInjection to run on read-only filesystem

### DIFF
--- a/pkg/network/protocols/tls/java/testdata/docker-compose.yml
+++ b/pkg/network/protocols/tls/java/testdata/docker-compose.yml
@@ -13,4 +13,4 @@ services:
         soft: 1024
         hard: 524288
     volumes:
-      - ./:/v:z
+      - ${TESTDIR}:/v:z

--- a/pkg/network/protocols/tls/java/testutil/inject.go
+++ b/pkg/network/protocols/tls/java/testutil/inject.go
@@ -28,7 +28,7 @@ import (
 )
 
 // RunJavaVersion run class under java version
-func RunJavaVersion(t testing.TB, version, class string, waitForParam ...*regexp.Regexp) error {
+func RunJavaVersion(t testing.TB, version, class string, testdir string, waitForParam ...*regexp.Regexp) error {
 	t.Helper()
 	var waitFor *regexp.Regexp
 	if len(waitForParam) == 0 {
@@ -44,6 +44,7 @@ func RunJavaVersion(t testing.TB, version, class string, waitForParam ...*regexp
 		"IMAGE_VERSION=" + version,
 		"ENTRYCLASS=" + class,
 		"EXTRA_HOSTS=host.docker.internal:" + addr,
+		"TESTDIR=" + testdir,
 	}
 
 	return protocolsUtils.RunDockerServer(t, version, dir+"/../testdata/docker-compose.yml", env, waitFor, protocolsUtils.DefaultTimeout)
@@ -77,7 +78,7 @@ func FindProcessByCommandLine(procName, command string) ([]int, error) {
 // RunJavaVersionAndWaitForRejection is running a java version program, waiting for it to successfully load, and then
 // checking the java TLS program didn't attach to it (rejected the injection). The last part is done using log scanner
 // we're registering a new log scanner and looking for a specific log (java pid (\d+) attachment rejected).
-func RunJavaVersionAndWaitForRejection(t testing.TB, version, class string, waitForCondition *regexp.Regexp) {
+func RunJavaVersionAndWaitForRejection(t testing.TB, version, class string, testdir string, waitForCondition *regexp.Regexp) {
 	t.Helper()
 
 	dir, _ := testutil.CurDir()
@@ -86,6 +87,7 @@ func RunJavaVersionAndWaitForRejection(t testing.TB, version, class string, wait
 		"IMAGE_VERSION=" + version,
 		"ENTRYCLASS=" + class,
 		"EXTRA_HOSTS=host.docker.internal:" + addr,
+		"TESTDIR=" + testdir,
 	}
 
 	l := javaInjectionRejectionLogger{

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -703,7 +703,7 @@ func (s *USMSuite) TestJavaInjection() {
 				t.Cleanup(serverDoneFn)
 			},
 			postTracerSetup: func(t *testing.T, ctx testContext) {
-				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:15-oraclelinux8", "Wget https://host.docker.internal:5443/200/anything/java-tls-request", regexp.MustCompile("Response code = .*")), "Failed running Java version")
+				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:15-oraclelinux8", "Wget https://host.docker.internal:5443/200/anything/java-tls-request", "./", regexp.MustCompile("Response code = .*")), "Failed running Java version")
 			},
 			validation: func(t *testing.T, ctx testContext, tr *Tracer) {
 				// Iterate through active connections until we find connection created above

--- a/pkg/network/usm/ebpf_javatls_test.go
+++ b/pkg/network/usm/ebpf_javatls_test.go
@@ -22,8 +22,8 @@ import (
 	nettestutil "github.com/DataDog/datadog-agent/pkg/network/testutil"
 )
 
-func createJavaTempFile(t *testing.T, dir string) string {
-	tempfile, err := os.CreateTemp(dir, "TestAgentLoaded.agentmain.*")
+func createJavaTempFile(t *testing.T) string {
+	tempfile, err := os.CreateTemp("", "TestAgentLoaded.agentmain.*")
 	require.NoError(t, err)
 	tempfile.Close()
 	os.Remove(tempfile.Name())
@@ -81,8 +81,7 @@ func TestJavaInjection(t *testing.T) {
 			preTracerSetup: func(t *testing.T, ctx map[string]interface{}) {
 				cfg.JavaDir = fakeAgentDir
 				ctx["JavaAgentArgs"] = cfg.JavaAgentArgs
-
-				ctx["testfile"] = createJavaTempFile(t, testdataDir)
+				ctx["testfile"] = createJavaTempFile(t)
 				cfg.JavaAgentArgs += ",testfile=/v/" + filepath.Base(ctx["testfile"].(string))
 			},
 			postTracerSetup: func(t *testing.T, ctx map[string]interface{}) {
@@ -99,8 +98,7 @@ func TestJavaInjection(t *testing.T) {
 			preTracerSetup: func(t *testing.T, ctx map[string]interface{}) {
 				cfg.JavaDir = fakeAgentDir
 				ctx["JavaAgentArgs"] = cfg.JavaAgentArgs
-
-				ctx["testfile"] = createJavaTempFile(t, testdataDir)
+				ctx["testfile"] = createJavaTempFile(t)
 				cfg.JavaAgentArgs += ",testfile=/v/" + filepath.Base(ctx["testfile"].(string))
 
 				// testing allow/block list, as Allow list have higher priority
@@ -122,8 +120,7 @@ func TestJavaInjection(t *testing.T) {
 			context: make(map[string]interface{}),
 			preTracerSetup: func(t *testing.T, ctx map[string]interface{}) {
 				ctx["JavaAgentArgs"] = cfg.JavaAgentArgs
-
-				ctx["testfile"] = createJavaTempFile(t, testdataDir)
+				ctx["testfile"] = createJavaTempFile(t)
 				cfg.JavaAgentArgs += ",testfile=/v/" + filepath.Base(ctx["testfile"].(string))
 
 				// block the agent attachment
@@ -143,8 +140,7 @@ func TestJavaInjection(t *testing.T) {
 			context: make(map[string]interface{}),
 			preTracerSetup: func(t *testing.T, ctx map[string]interface{}) {
 				ctx["JavaAgentArgs"] = cfg.JavaAgentArgs
-
-				ctx["testfile"] = createJavaTempFile(t, testdataDir)
+				ctx["testfile"] = createJavaTempFile(t)
 				cfg.JavaAgentArgs += ",testfile=/v/" + filepath.Base(ctx["testfile"].(string))
 
 				// block the agent attachment
@@ -163,8 +159,7 @@ func TestJavaInjection(t *testing.T) {
 			context: make(map[string]interface{}),
 			preTracerSetup: func(t *testing.T, ctx map[string]interface{}) {
 				ctx["JavaAgentArgs"] = cfg.JavaAgentArgs
-
-				ctx["testfile"] = createJavaTempFile(t, testdataDir)
+				ctx["testfile"] = createJavaTempFile(t)
 				cfg.JavaAgentArgs += ",testfile=/v/" + filepath.Base(ctx["testfile"].(string))
 
 				// allow has a higher priority

--- a/pkg/network/usm/ebpf_javatls_test.go
+++ b/pkg/network/usm/ebpf_javatls_test.go
@@ -169,7 +169,7 @@ func TestJavaInjection(t *testing.T) {
 				cfg.JavaAgentBlockRegex = ".*JustWait.*"
 			},
 			postTracerSetup: func(t *testing.T, ctx map[string]interface{}) {
-				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", fakeAgentDir, "Wait JustWait"), "Failed running Java version")
+				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", "Wait JustWait", fakeAgentDir), "Failed running Java version")
 			},
 			validation: commonValidation,
 			teardown:   commonTearDown,

--- a/pkg/network/usm/ebpf_javatls_test.go
+++ b/pkg/network/usm/ebpf_javatls_test.go
@@ -49,6 +49,8 @@ func TestJavaInjection(t *testing.T) {
 	defer os.RemoveAll(fakeAgentDir)
 	_, err = nettestutil.RunCommand("install -m444 " + filepath.Join(testdataDir, "TestAgentLoaded.jar") + " " + filepath.Join(fakeAgentDir, "agent-usm.jar"))
 	require.NoError(t, err)
+	_, err = nettestutil.RunCommand("install -m444 " + filepath.Join(testdataDir, "Wait.class") + " " + filepath.Join(fakeAgentDir, "Wait.class"))
+	require.NoError(t, err)
 
 	commonTearDown := func(t *testing.T, ctx map[string]interface{}) {
 		cfg.JavaAgentArgs = ctx["JavaAgentArgs"].(string)

--- a/pkg/network/usm/ebpf_javatls_test.go
+++ b/pkg/network/usm/ebpf_javatls_test.go
@@ -22,8 +22,8 @@ import (
 	nettestutil "github.com/DataDog/datadog-agent/pkg/network/testutil"
 )
 
-func createJavaTempFile(t *testing.T) string {
-	tempfile, err := os.CreateTemp("", "TestAgentLoaded.agentmain.*")
+func createJavaTempFile(t *testing.T, dir string) string {
+	tempfile, err := os.CreateTemp(dir, "TestAgentLoaded.agentmain.*")
 	require.NoError(t, err)
 	tempfile.Close()
 	os.Remove(tempfile.Name())
@@ -81,7 +81,7 @@ func TestJavaInjection(t *testing.T) {
 			preTracerSetup: func(t *testing.T, ctx map[string]interface{}) {
 				cfg.JavaDir = fakeAgentDir
 				ctx["JavaAgentArgs"] = cfg.JavaAgentArgs
-				ctx["testfile"] = createJavaTempFile(t)
+				ctx["testfile"] = createJavaTempFile(t, fakeAgentDir)
 				cfg.JavaAgentArgs += ",testfile=/v/" + filepath.Base(ctx["testfile"].(string))
 			},
 			postTracerSetup: func(t *testing.T, ctx map[string]interface{}) {
@@ -98,7 +98,7 @@ func TestJavaInjection(t *testing.T) {
 			preTracerSetup: func(t *testing.T, ctx map[string]interface{}) {
 				cfg.JavaDir = fakeAgentDir
 				ctx["JavaAgentArgs"] = cfg.JavaAgentArgs
-				ctx["testfile"] = createJavaTempFile(t)
+				ctx["testfile"] = createJavaTempFile(t, fakeAgentDir)
 				cfg.JavaAgentArgs += ",testfile=/v/" + filepath.Base(ctx["testfile"].(string))
 
 				// testing allow/block list, as Allow list have higher priority
@@ -120,7 +120,7 @@ func TestJavaInjection(t *testing.T) {
 			context: make(map[string]interface{}),
 			preTracerSetup: func(t *testing.T, ctx map[string]interface{}) {
 				ctx["JavaAgentArgs"] = cfg.JavaAgentArgs
-				ctx["testfile"] = createJavaTempFile(t)
+				ctx["testfile"] = createJavaTempFile(t, fakeAgentDir)
 				cfg.JavaAgentArgs += ",testfile=/v/" + filepath.Base(ctx["testfile"].(string))
 
 				// block the agent attachment
@@ -140,7 +140,7 @@ func TestJavaInjection(t *testing.T) {
 			context: make(map[string]interface{}),
 			preTracerSetup: func(t *testing.T, ctx map[string]interface{}) {
 				ctx["JavaAgentArgs"] = cfg.JavaAgentArgs
-				ctx["testfile"] = createJavaTempFile(t)
+				ctx["testfile"] = createJavaTempFile(t, fakeAgentDir)
 				cfg.JavaAgentArgs += ",testfile=/v/" + filepath.Base(ctx["testfile"].(string))
 
 				// block the agent attachment
@@ -159,7 +159,7 @@ func TestJavaInjection(t *testing.T) {
 			context: make(map[string]interface{}),
 			preTracerSetup: func(t *testing.T, ctx map[string]interface{}) {
 				ctx["JavaAgentArgs"] = cfg.JavaAgentArgs
-				ctx["testfile"] = createJavaTempFile(t)
+				ctx["testfile"] = createJavaTempFile(t, fakeAgentDir)
 				cfg.JavaAgentArgs += ",testfile=/v/" + filepath.Base(ctx["testfile"].(string))
 
 				// allow has a higher priority

--- a/pkg/network/usm/ebpf_javatls_test.go
+++ b/pkg/network/usm/ebpf_javatls_test.go
@@ -86,7 +86,7 @@ func TestJavaInjection(t *testing.T) {
 			},
 			postTracerSetup: func(t *testing.T, ctx map[string]interface{}) {
 				// if RunJavaVersion failing to start it's probably because the java process has not been injected
-				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:8u151-jre", "Wait JustWait"), "Failed running Java version")
+				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:8u151-jre", "Wait JustWait", fakeAgentDir), "Failed running Java version")
 			},
 			validation: commonValidation,
 			teardown:   commonTearDown,
@@ -108,8 +108,8 @@ func TestJavaInjection(t *testing.T) {
 			},
 			postTracerSetup: func(t *testing.T, ctx map[string]interface{}) {
 				// if RunJavaVersion failing to start it's probably because the java process has not been injected
-				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", "Wait JustWait"), "Failed running Java version")
-				javatestutil.RunJavaVersionAndWaitForRejection(t, "openjdk:21-oraclelinux8", "Wait AnotherWait", regexp.MustCompile(`AnotherWait pid.*`))
+				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", "Wait JustWait", fakeAgentDir), "Failed running Java version")
+				javatestutil.RunJavaVersionAndWaitForRejection(t, "openjdk:21-oraclelinux8", "Wait AnotherWait", fakeAgentDir, regexp.MustCompile(`AnotherWait pid.*`))
 			},
 			validation: commonValidation,
 			teardown:   commonTearDown,
@@ -129,8 +129,8 @@ func TestJavaInjection(t *testing.T) {
 			},
 			postTracerSetup: func(t *testing.T, ctx map[string]interface{}) {
 				// if RunJavaVersion failing to start it's probably because the java process has not been injected
-				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", "Wait AnotherWait"), "Failed running Java version")
-				javatestutil.RunJavaVersionAndWaitForRejection(t, "openjdk:21-oraclelinux8", "Wait JustWait", regexp.MustCompile(`JustWait pid.*`))
+				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", "Wait AnotherWait", fakeAgentDir), "Failed running Java version")
+				javatestutil.RunJavaVersionAndWaitForRejection(t, "openjdk:21-oraclelinux8", "Wait JustWait", fakeAgentDir, regexp.MustCompile(`JustWait pid.*`))
 			},
 			validation: commonValidation,
 			teardown:   commonTearDown,
@@ -148,8 +148,8 @@ func TestJavaInjection(t *testing.T) {
 				cfg.JavaAgentBlockRegex = ".*AnotherWait.*"
 			},
 			postTracerSetup: func(t *testing.T, ctx map[string]interface{}) {
-				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", "Wait JustWait"), "Failed running Java version")
-				javatestutil.RunJavaVersionAndWaitForRejection(t, "openjdk:21-oraclelinux8", "Wait AnotherWait", regexp.MustCompile(`AnotherWait pid.*`))
+				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", "Wait JustWait", fakeAgentDir), "Failed running Java version")
+				javatestutil.RunJavaVersionAndWaitForRejection(t, "openjdk:21-oraclelinux8", "Wait AnotherWait", fakeAgentDir, regexp.MustCompile(`AnotherWait pid.*`))
 			},
 			validation: commonValidation,
 			teardown:   commonTearDown,
@@ -167,7 +167,7 @@ func TestJavaInjection(t *testing.T) {
 				cfg.JavaAgentBlockRegex = ".*JustWait.*"
 			},
 			postTracerSetup: func(t *testing.T, ctx map[string]interface{}) {
-				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", "Wait JustWait"), "Failed running Java version")
+				require.NoError(t, javatestutil.RunJavaVersion(t, "openjdk:21-oraclelinux8", fakeAgentDir, "Wait JustWait"), "Failed running Java version")
 			},
 			validation: commonValidation,
 			teardown:   commonTearDown,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixes `TestJavaInjection` to run from a temp directory.

### Motivation

The source tree will be read-only in KMT.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
