### PR TITLE
Fix change on except_release_main rule behavior

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -752,7 +752,6 @@ workflow:
     when: never
   - <<: *if_release_branch
     when: never
-  - when: on_success
 
 .on_main_or_release_branch_or_deploy_always:
   - <<: *if_deploy

--- a/.gitlab/source_test/golang_deps_diff.yml
+++ b/.gitlab/source_test/golang_deps_diff.yml
@@ -7,6 +7,8 @@ golang_deps_diff:
   tags: ["arch:amd64"]
   rules: # this should only run on dev branches
     - !reference [ .except_main_or_release_branch ]
+    - when: on_success
+
   needs: ["go_deps"]
   before_script:
     - source /root/.bashrc
@@ -24,6 +26,7 @@ golang_deps_commenter:
   tags: ["arch:amd64"]
   rules: # this should only run on dev branches
     - !reference [ .except_main_or_release_branch ]
+    - when: on_success
   needs: ["golang_deps_diff"]
   script: # ignore error message about no PR, because it happens for dev branches without PRs
     - echo "${CI_COMMIT_REF_NAME}"

--- a/.gitlab/source_test/golang_deps_diff.yml
+++ b/.gitlab/source_test/golang_deps_diff.yml
@@ -8,7 +8,6 @@ golang_deps_diff:
   rules: # this should only run on dev branches
     - !reference [ .except_main_or_release_branch ]
     - when: on_success
-
   needs: ["go_deps"]
   before_script:
     - source /root/.bashrc


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fix a change in the behaviour of except_main_or_release_branch rule introduced in #19353 

cc @brycekahle 
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Do not break existing job using this rule

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
