### PR TITLE
omnibus: krb5: remove binaries & disable i18n

### DIFF
--- a/omnibus/config/software/libkrb5.rb
+++ b/omnibus/config/software/libkrb5.rb
@@ -36,4 +36,21 @@ build do
   # are properly linked. Must whitelist for build to succeed.
   whitelist_file "#{install_dir}/embedded/lib/krb5/plugins/tls/k5tls.so"
   whitelist_file "#{install_dir}/embedded/lib/krb5/plugins/preauth/pkinit.so"
+
+  delete "#{install_dir}/embedded/bin/compile_et"
+  delete "#{install_dir}/embedded/bin/gss-client"
+  delete "#{install_dir}/embedded/bin/k5srvutil"
+  delete "#{install_dir}/embedded/bin/kadmin"
+  delete "#{install_dir}/embedded/bin/kdestroy"
+  delete "#{install_dir}/embedded/bin/kinit"
+  delete "#{install_dir}/embedded/bin/klist"
+  delete "#{install_dir}/embedded/bin/kpasswd"
+  delete "#{install_dir}/embedded/bin/krb5-config"
+  delete "#{install_dir}/embedded/bin/ksu"
+  delete "#{install_dir}/embedded/bin/kswitch"
+  delete "#{install_dir}/embedded/bin/ktutil"
+  delete "#{install_dir}/embedded/bin/kvno"
+  delete "#{install_dir}/embedded/bin/sclient"
+  delete "#{install_dir}/embedded/bin/sim_client"
+  delete "#{install_dir}/embedded/bin/uuclient"
 end

--- a/omnibus/config/software/libkrb5.rb
+++ b/omnibus/config/software/libkrb5.rb
@@ -24,7 +24,8 @@ build do
   configure_options = ["--without-keyutils", # this would require additional deps/system deps, disable it
          "--without-system-verto", # do not prefer libverto from the system, if installed
          "--without-libedit", # we don't want to link with libraries outside of the install dir
-         "--disable-static"
+         "--disable-static",
+         "--disable-nls"
   ]
   env = with_standard_compiler_flags(with_embedded_path)
   configure(*configure_options, :env => env)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR disables i18n support and removes binaries from our krb5 builds

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Save a bit of space in our artifacts (APL-2283)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
