### PR TITLE
[do not merge] poc local VM

### DIFF
--- a/test/new-e2e/pkg/utils/e2e/e2e.go
+++ b/test/new-e2e/pkg/utils/e2e/e2e.go
@@ -427,6 +427,10 @@ func (suite *Suite[Env]) initSuite(stackName string, stackDef *StackDefinition[E
 	for _, o := range options {
 		o(&suite.params)
 	}
+	if suite.params.LazyEnvironment {
+		return
+	}
+	suite.UpdateEnv(suite.defaultStackDef)
 }
 
 // Env returns the current environment.

--- a/test/new-e2e/pkg/utils/e2e/params/params.go
+++ b/test/new-e2e/pkg/utils/e2e/params/params.go
@@ -15,6 +15,8 @@ type Params struct {
 	DevMode bool
 
 	SkipDeleteOnFailure bool
+
+	LazyEnvironment bool
 }
 
 // Option is an optional function parameter type for e2e options
@@ -41,5 +43,12 @@ func WithDevMode() func(*Params) {
 func WithSkipDeleteOnFailure() func(*Params) {
 	return func(options *Params) {
 		options.SkipDeleteOnFailure = true
+	}
+}
+
+// WithLazyEnvironment creates the environment at first call to Env.
+func WithLazyEnvironment() func(*Params) {
+	return func(options *Params) {
+		options.LazyEnvironment = true
 	}
 }

--- a/test/new-e2e/tests/agent-subcommands/flare/flare_windows_test.go
+++ b/test/new-e2e/tests/agent-subcommands/flare/flare_windows_test.go
@@ -1,0 +1,127 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package flare contains helpers and e2e tests of the flare command
+package flare
+
+import (
+	_ "embed"
+	"testing"
+
+	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/params"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2params"
+)
+
+type winFlareSuite struct {
+	commandFlareSuite
+}
+
+// you can use an environment variable or a file
+const isLocalRun = false
+
+var (
+	localVM    client.VM
+	localAgent client.Agent
+)
+
+// getVM returns a vm client that can execute commands
+// TODO Can go in some common helpers
+func (s *winFlareSuite) getVM() client.VM {
+	if isLocalRun {
+		return localVM
+	}
+	return s.Env().VM
+}
+
+func (s *winFlareSuite) getAgent() client.Agent {
+	if isLocalRun {
+		return localAgent
+	}
+	return s.Env().Agent
+}
+
+func (s *winFlareSuite) getFakeintake() *fakeintake.Client {
+	return s.Env().Fakeintake.Cliet
+}
+
+func TestFlareWinSuite(t *testing.T) {
+	// TODO we could pass a different local stackDefinition with only fakeintake
+	e2e.Run(t, &winFlareSuite{}, e2e.FakeIntakeStackDef(e2e.WithVMParams(ec2params.WithOS(ec2os.WindowsOS))), params.WithLazyEnvironment())
+}
+
+func (v *winFlareSuite) TestFlareDefaultFiles() {
+	flare := requestAgentFlareAndFetchFromFakeIntake(v.T(), v.getAgent(),, v.getFakeintake() client.WithArgs([]string{"--email", "e2e@test.com", "--send"}))
+
+	assertFilesExist(v.T(), flare, defaultFlareFiles)
+	assertFilesExist(v.T(), flare, defaultLogFiles)
+	assertFilesExist(v.T(), flare, defaultConfigFiles)
+	assertFoldersExist(v.T(), flare, defaultFlareFolders)
+
+	assertFileContains(v.T(), flare, "process_check_output.json", "'process_config.process_collection.enabled' is disabled")
+	assertFileNotContains(v.T(), flare, "container_check_output.json", "'process_config.container_collection.enabled' is disabled")
+	assertFileNotContains(v.T(), flare, "process_discovery_check_output.json", "'process_config.process_discovery.enabled' is disabled")
+
+	assertLogsFolderOnlyContainsLogFile(v.T(), flare)
+	assertEtcFolderOnlyContainsConfigFile(v.T(), flare)
+}
+
+// //go:embed fixtures/datadog-agent.yaml
+// var agentConfiguration []byte
+
+// //go:embed fixtures/system-probe.yaml
+// var systemProbeConfiguration []byte
+
+// //go:embed fixtures/security-agent.yaml
+// var securityAgentConfiguration []byte
+
+// func (v *commandFlareSuite) TestFlareWithAllConfiguration() {
+
+// 	var scenarioExpectedFiles = []string{
+// 		"telemetry.log",       // if telemetry.enabled
+// 		"registry.json",       // if Logs Agent is running
+// 		"expvar/system-probe", // if system probe is enabled
+// 	}
+
+// 	systemProbeDummyFiles := []string{"/tmp/dummy_dir", "/tmp/dummy_system_probe_config_bpf_dir"}
+// 	v.Env().VM.Execute("sudo mkdir -p " + strings.Join(systemProbeDummyFiles, " "))
+
+// 	confdPath := "/opt/datadog-agent/bin/agent/dist/conf.d/"
+// 	useSudo := true
+
+// 	withFiles := []agentparams.Option{
+// 		// TODO: use dedicated functions when https://github.com/DataDog/test-infra-definitions/pull/309 is merged
+// 		agentparams.WithSystemProbeConfig(string(systemProbeConfiguration)),
+// 		agentparams.WithSecurityAgentConfig(string(securityAgentConfiguration)),
+// 		agentparams.WithFile(confdPath+"test.yaml", "dummy content", useSudo),
+// 		agentparams.WithFile(confdPath+"test.yml", "dummy content", useSudo),
+// 		agentparams.WithFile(confdPath+"test.yml.test", "dummy content", useSudo),
+// 		agentparams.WithFile("/opt/datadog-agent/checks.d/test.yml", "dummy content", useSudo),
+// 	}
+
+// 	agentOptions := append(withFiles, agentparams.WithAgentConfig(string(agentConfiguration)))
+
+// 	v.UpdateEnv(e2e.FakeIntakeStackDef(e2e.WithAgentParams(agentOptions...)))
+
+// 	flare := requestAgentFlareAndFetchFromFakeIntake(v, client.WithArgs([]string{"--email", "e2e@test.com", "--send"}))
+
+// 	assertFilesExist(v.T(), flare, scenarioExpectedFiles)
+// 	assertFilesExist(v.T(), flare, allLogFiles)
+// 	// XXX: this test is expected to fail because 'etc/security-agent.yaml' is not found. See #18463
+// 	assertFilesExist(v.T(), flare, allConfigFiles)
+
+// 	extraCustomConfigFiles := []string{"etc/confd/dist/test.yaml", "etc/confd/dist/test.yml", "etc/confd/dist/test.yml.test", "etc/confd/checksd/test.yml"}
+// 	assertFilesExist(v.T(), flare, extraCustomConfigFiles)
+
+// 	assertFileNotContains(v.T(), flare, "process_check_output.json", "'process_config.process_collection.enabled' is disabled")
+// 	assertFileContains(v.T(), flare, "container_check_output.json", "'process_config.container_collection.enabled' is disabled")
+// 	assertFileContains(v.T(), flare, "process_discovery_check_output.json", "'process_config.process_discovery.enabled' is disabled")
+
+// 	filesRegistredInPermissionsLog := append(systemProbeDummyFiles, "/etc/datadog-agent/auth_token")
+// 	assertFileContains(v.T(), flare, "permissions.log", filesRegistredInPermissionsLog...)
+// }

--- a/test/new-e2e/tests/wkit/vm_test.go
+++ b/test/new-e2e/tests/wkit/vm_test.go
@@ -1,0 +1,58 @@
+package wkit
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/params"
+	"github.com/DataDog/test-infra-definitions/common/utils"
+	commonos "github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2params"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type wkitVMSuite struct {
+	e2e.Suite[e2e.VMEnv]
+}
+
+// you can use an environment variable or a file
+const isLocalRun = false
+
+var localVM client.VM
+
+// GetVM returns a vm client that can execute commands
+func (s *wkitVMSuite) GetVM() client.VM {
+	if isLocalRun {
+		return localVM
+	}
+	return s.Env().VM
+}
+
+func TestWKITVMSuite(t *testing.T) {
+	e2e.Run(t, &wkitVMSuite{}, e2e.EC2VMStackDef(ec2params.WithOS(ec2os.WindowsOS)), params.WithLazyEnvironment())
+}
+
+func (s *wkitVMSuite) SetupSuite() {
+	t := s.T()
+	if isLocalRun {
+		// init local vm here
+		sshConnection := utils.Connection{
+			Host: "localhost",
+			User: "Admin",
+		}
+		vm, err := client.NewVMClient(t, &sshConnection, commonos.WindowsType)
+		require.NoError(t, err)
+		localVM = vm
+	}
+	s.Suite.SetupSuite()
+}
+
+func (s *wkitVMSuite) TestDir() {
+	t := s.T()
+	vm := s.GetVM()
+	output := vm.Execute("dir")
+	assert.NotEmpty(t, output)
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

POC for supporting local VM in e2e tests

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

WKIT team need support for local VM to migrate kitchen tests, this is a POC to support both local and remote tests sharing test code. 

The `wkitVMSuite` embeds the remote `e2e.Suite`, but that triggers infra creation lazily, at first `Env()` call. 

`GetVM` provides the abstraction over the common `vmClient`, that is now pulumi agnostic. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
