### PR TITLE
Bump Python 3 to 3.11.5

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Python3
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9.16"
+          python-version: "3.11.5"
           cache: "pip"
       - run: pip3 install -r requirements.txt
 

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -296,10 +296,6 @@ if windows_target?
   if ENV['SIGN_WINDOWS_DD_WCS']
     BINARIES_TO_SIGN = GO_BINARIES + [
       "#{install_dir}\\bin\\agent\\ddtray.exe",
-      "#{install_dir}\\embedded3\\python.exe",
-      "#{install_dir}\\embedded3\\\\python3.dll",
-      "#{install_dir}\\embedded3\\\\python39.dll",
-      "#{install_dir}\\embedded3\\\\pythonw.exe",
       "#{install_dir}\\bin\\agent\\libdatadog-agent-three.dll"
     ]
     if with_python_runtime? "2"

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -59,7 +59,7 @@ build do
                 link "#{install_dir}/embedded/bin/python3", "#{install_dir}/embedded/bin/python"
 
                 delete "#{install_dir}/embedded/bin/2to3"
-                link "#{install_dir}/embedded/bin/2to3-3.9", "#{install_dir}/embedded/bin/2to3"
+                link "#{install_dir}/embedded/bin/2to3-3.11", "#{install_dir}/embedded/bin/2to3"
             end
             delete "#{install_dir}/embedded/lib/config_guess"
 

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -12,10 +12,10 @@ dependency 'datadog-agent'
 dependency 'datadog-agent-integrations-py3-dependencies'
 
 relative_path 'integrations-core'
-whitelist_file "embedded/lib/python3.9/site-packages/.libsaerospike"
-whitelist_file "embedded/lib/python3.9/site-packages/aerospike.libs"
-whitelist_file "embedded/lib/python3.9/site-packages/psycopg2"
-whitelist_file "embedded/lib/python3.9/site-packages/pymqi"
+whitelist_file "embedded/lib/python3.11/site-packages/.libsaerospike"
+whitelist_file "embedded/lib/python3.11/site-packages/aerospike.libs"
+whitelist_file "embedded/lib/python3.11/site-packages/psycopg2"
+whitelist_file "embedded/lib/python3.11/site-packages/pymqi"
 
 source git: 'https://github.com/DataDog/integrations-core.git'
 
@@ -481,7 +481,7 @@ build do
       if windows_target?
         patch :source => "remove-maxfile-maxpath-psutil.patch", :target => "#{python_3_embedded}/Lib/site-packages/psutil/__init__.py"
       else
-        patch :source => "remove-maxfile-maxpath-psutil.patch", :target => "#{install_dir}/embedded/lib/python3.9/site-packages/psutil/__init__.py"
+        patch :source => "remove-maxfile-maxpath-psutil.patch", :target => "#{install_dir}/embedded/lib/python3.11/site-packages/psutil/__init__.py"
       end
 
       # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
@@ -493,7 +493,7 @@ build do
       if windows_target?
         delete "#{python_3_embedded}/Lib/site-packages/Cryptodome/SelfTest/"
       else
-        delete "#{install_dir}/embedded/lib/python3.9/site-packages/Cryptodome/SelfTest/"
+        delete "#{install_dir}/embedded/lib/python3.11/site-packages/Cryptodome/SelfTest/"
       end
     end
   end

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -1,7 +1,8 @@
 name "python3"
 
+default_version "3.11.5"
+
 if ohai["platform"] != "windows"
-  default_version "3.9.18"
 
   dependency "libxcrypt"
   dependency "libffi"
@@ -14,7 +15,7 @@ if ohai["platform"] != "windows"
   dependency "libyaml"
 
   source :url => "https://python.org/ftp/python/#{version}/Python-#{version}.tgz",
-         :sha256 => "504ce8cfd59addc04c22f590377c6be454ae7406cb1ebf6f5a350149225a9354"
+         :sha256 => "a12a0a013a30b846c786c010f2c19dd36b7298d888f7c4bd1581d90ce18b5e58"
 
   relative_path "Python-#{version}"
 
@@ -43,10 +44,11 @@ if ohai["platform"] != "windows"
     configure(*python_configure_options, :env => env)
     command "make -j #{workers}", :env => env
     command "make install", :env => env
-    delete "#{install_dir}/embedded/lib/python3.9/test"
 
     # There exists no configure flag to tell Python to not compile readline support :(
     major, minor, bugfix = version.split(".")
+
+    delete "#{install_dir}/embedded/lib/python#{major}.#{minor}/test"
     block do
       FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python#{major}.#{minor}/lib-dynload/readline.*"))
       FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python#{major}.#{minor}/distutils/command/wininst-*.exe"))
@@ -54,21 +56,12 @@ if ohai["platform"] != "windows"
   end
 
 else
-  default_version "3.9.18-38f3b72"
   dependency "vc_redist_14"
 
-  if windows_arch_i386?
-    dependency "vc_ucrt_redist"
+  # note that starting with 3.7.3 on Windows, the zip should be created without the built-in pip
+  source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-amd64.zip",
+         :sha256 => "1BD44AC628CF39C61FF037C715B05D5E9A2980C2049031F73CF291F90E95A0F3".downcase
 
-    source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x86.zip",
-            :sha256 => "DC7069727454BC8FEED064FBD797076B7EAD93CAC1A482CE794BAB08214C42F3".downcase
-  else
-
-    # note that startring with 3.7.3 on Windows, the zip should be created without the built-in pip
-    source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x64.zip",
-           :sha256 => "6DA7EDD4D42D5A223D14BF80ABBBEA80F4F6D6939CD0AA769CF1BCD24CB54A1F".downcase
-
-  end
   vcrt140_root = "#{Omnibus::Config.source_dir()}/vc_redist_140/expanded"
   build do
     # 2.0 is the license version here, not the python version

--- a/releasenotes/notes/python311-b4bcd71d0ef722e9.yaml
+++ b/releasenotes/notes/python311-b4bcd71d0ef722e9.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    Upgrade the Python version from 3.9 to 3.11

--- a/releasenotes/notes/python311-b4bcd71d0ef722e9.yaml
+++ b/releasenotes/notes/python311-b4bcd71d0ef722e9.yaml
@@ -8,4 +8,4 @@
 ---
 upgrade:
   - |
-    Upgrade the Python version from 3.9 to 3.11
+    Upgrade the Python version from 3.9 to 3.11.

--- a/test/kitchen/test/integration/common/rspec_datadog/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec_datadog/spec_helper.rb
@@ -450,14 +450,13 @@ def is_file_signed(fullpath)
   puts "checking file #{fullpath}"
   expect(File).to exist(fullpath)
   output = `powershell -command "(get-authenticodesignature -FilePath '#{fullpath}').SignerCertificate.Thumbprint"`
-  ##
   ## signature below is for new cert acquired May 2023 using new hsm-backed signing method
   signature_hash = "B03F29CC07566505A718583E9270A6EE17678742"
   if output.upcase.strip == signature_hash.upcase.strip
     return true
   end
 
-  puts("expected hash = #{signature_hash}, msi's hash = #{output}")
+  puts("expected hash = #{signature_hash}, actual hash = #{output}")
   return false
 end
 
@@ -527,16 +526,10 @@ shared_examples_for "an installed Agent" do
       if File.file?(msi_path_upgrade)
         msi_path = msi_path_upgrade
       end
-      is_signed = is_file_signed(msi_path)
-      expect(is_signed).to be_truthy
 
       program_files = safe_program_files
-      # The glob in the bottom makes sure we add the full Python version dll, e.g.
-      # python39.dll or python310.dll. Thanks to this, we don't have to fix this test case
-      # manually when we upgrade the Python version. Additionally, some scenarios like
-      # win-upgrade-rollback might test two Agents with two different Python versions,
-      # so hardcoding just one dll wouldn't work in these cases.
       verify_signature_files = [
+        msi_path,
         # TODO: Uncomment this when we start shipping the security agent on Windows
         # "#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\security-agent.exe",
         "#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\process-agent.exe",
@@ -544,10 +537,7 @@ shared_examples_for "an installed Agent" do
         "#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\ddtray.exe",
         "#{program_files}\\DataDog\\Datadog Agent\\bin\\libdatadog-agent-three.dll",
         "#{program_files}\\DataDog\\Datadog Agent\\bin\\agent.exe",
-        "#{program_files}\\DataDog\\Datadog Agent\\embedded3\\python.exe",
-        "#{program_files}\\DataDog\\Datadog Agent\\embedded3\\pythonw.exe",
-        "#{program_files}\\DataDog\\Datadog Agent\\embedded3\\python3.dll",
-      ] + Dir.glob("#{program_files}\\DataDog\\Datadog Agent\\embedded3\\python3?*.dll")
+      ]
       libdatadog_agent_two = "#{program_files}\\DataDog\\Datadog Agent\\bin\\libdatadog-agent-two.dll"
       if File.file?(libdatadog_agent_two)
         verify_signature_files += [

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentBinaries.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentBinaries.cs
@@ -28,7 +28,7 @@ namespace WixSetup.Datadog
             {
                 $@"{installerSource}\embedded3\python.exe",
                 $@"{installerSource}\embedded3\python3.dll",
-                $@"{installerSource}\embedded3\python39.dll",
+                $@"{installerSource}\embedded3\python311.dll",
                 $@"{installerSource}\embedded3\pythonw.exe"
             };
             PythonTwoBinaries = new[]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

- Bump Python 3 to 3.11.5
- We do not build the Windows binary from our fork anymore, so we do not need to verify the signatures anymore

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

- https://datadoghq.atlassian.net/browse/AITS-265

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Relates to https://datadoghq.atlassian.net/browse/AITS-281

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
