### PR TITLE
dogstatsd: improve telemetry for inflight packets

### DIFF
--- a/comp/dogstatsd/listeners/named_pipe_windows.go
+++ b/comp/dogstatsd/listeners/named_pipe_windows.go
@@ -189,7 +189,7 @@ func (l *NamedPipeListener) listenConnection(conn net.Conn, buffer []byte) {
 		}
 
 		t2 = time.Now()
-		tlmListener.Observe(float64(t2.Sub(t1).Nanoseconds()), "named_pipe", "named_pipe")
+		tlmListener.Observe(float64(t2.Sub(t1).Nanoseconds()), "named_pipe", "named_pipe", "named_pipe")
 	}
 	l.connections.connToClose <- conn
 }

--- a/comp/dogstatsd/listeners/telemetry.go
+++ b/comp/dogstatsd/listeners/telemetry.go
@@ -18,13 +18,13 @@ var (
 
 	// UDS
 	tlmUDSPackets = telemetry.NewCounter("dogstatsd", "uds_packets",
-		[]string{"transport", "state"}, "Dogstatsd UDS packets count")
+		[]string{"listener_id", "transport", "state"}, "Dogstatsd UDS packets count")
 	tlmUDSOriginDetectionError = telemetry.NewCounter("dogstatsd", "uds_origin_detection_error",
-		[]string{"transport"}, "Dogstatsd UDS origin detection error count")
+		[]string{"listener_id", "transport"}, "Dogstatsd UDS origin detection error count")
 	tlmUDSPacketsBytes = telemetry.NewCounter("dogstatsd", "uds_packets_bytes",
-		[]string{"transport"}, "Dogstatsd UDS packets bytes")
+		[]string{"listener_id", "transport"}, "Dogstatsd UDS packets bytes")
 	tlmUDSConnections = telemetry.NewGauge("dogstatsd", "uds_connections",
-		[]string{"transport"}, "Dogstatsd UDS connections count")
+		[]string{"listener_id", "transport"}, "Dogstatsd UDS connections count")
 
 	tlmListener            = telemetry.NewHistogramNoOp()
 	defaultListenerBuckets = []float64{300, 500, 1000, 1500, 2000, 2500, 3000, 10000, 20000, 50000}
@@ -41,7 +41,7 @@ func InitTelemetry(buckets []float64) {
 	tlmListener = telemetry.NewHistogram(
 		"dogstatsd",
 		"listener_read_latency",
-		[]string{"transport", "listener_type"},
+		[]string{"listener_id", "transport", "listener_type"},
 		"Time in nanoseconds while the listener is not reading data",
 		buckets)
 }

--- a/comp/dogstatsd/listeners/udp.go
+++ b/comp/dogstatsd/listeners/udp.go
@@ -83,7 +83,7 @@ func NewUDPListener(packetOut chan packets.Packets, sharedPacketPoolManager *pac
 	flushTimeout := cfg.GetDuration("dogstatsd_packet_buffer_flush_timeout")
 
 	buffer := make([]byte, bufferSize)
-	packetsBuffer := packets.NewBuffer(uint(packetsBufferSize), flushTimeout, packetOut)
+	packetsBuffer := packets.NewBuffer(uint(packetsBufferSize), flushTimeout, packetOut, "udp")
 	packetAssembler := packets.NewAssembler(flushTimeout, packetsBuffer, sharedPacketPoolManager, packets.UDP)
 
 	listener := &UDPListener{
@@ -131,7 +131,7 @@ func (l *UDPListener) Listen() {
 		}
 
 		t2 = time.Now()
-		tlmListener.Observe(float64(t2.Sub(t1).Nanoseconds()), "udp", "udp")
+		tlmListener.Observe(float64(t2.Sub(t1).Nanoseconds()), "udp", "udp", "udp")
 	}
 }
 

--- a/comp/dogstatsd/packets/assembler_test.go
+++ b/comp/dogstatsd/packets/assembler_test.go
@@ -18,7 +18,7 @@ const sampleBatchSize = 32
 
 func buildPacketAssembler() (*Assembler, chan Packets) {
 	out := make(chan Packets, 16)
-	psb := NewBuffer(1, 1*time.Hour, out)
+	psb := NewBuffer(1, 1*time.Hour, out, "")
 	pp := NewPool(sampleBatchSize)
 	pb := NewAssembler(100*time.Millisecond, psb, NewPoolManager(pp), UDP)
 	return pb, out

--- a/comp/dogstatsd/packets/packet_manager_windows.go
+++ b/comp/dogstatsd/packets/packet_manager_windows.go
@@ -36,7 +36,7 @@ func NewPacketManager(
 	packetOut chan Packets,
 	sharedPacketPoolManager *PoolManager) *PacketManager {
 
-	packetsBuffer := NewBuffer(uint(packetsBufferSize), flushTimeout, packetOut)
+	packetsBuffer := NewBuffer(uint(packetsBufferSize), flushTimeout, packetOut, "named_pipe")
 
 	return &PacketManager{
 		bufferSize:      bufferSize,

--- a/comp/dogstatsd/packets/telemetry.go
+++ b/comp/dogstatsd/packets/telemetry.go
@@ -11,17 +11,22 @@ import (
 
 var (
 	// packet buffer
+	// This is the size of the output channel of the packet buffer. Even
+	// though all buffers currently share a single channel it's still worth
+	// tagging it with listener_id in case this changes later.
 	tlmChannelSize = telemetry.NewGauge("dogstatsd", "packets_channel_size",
-		nil, "Number of packets in the packets channel")
+		[]string{"listener_id"}, "Number of packets in the packets channel")
 
 	tlmListenerChannel    = telemetry.NewHistogramNoOp()
 	defaultChannelBuckets = []float64{250, 500, 750, 1000, 10000}
 
 	// buffer flush
 	tlmBufferFlushedTimer = telemetry.NewCounter("dogstatsd", "packets_buffer_flush_timer",
-		nil, "Count of packets buffer flush triggered by the timer")
+		[]string{"listener_id"}, "Count of packets buffer flush triggered by the timer")
 	tlmBufferFlushedFull = telemetry.NewCounter("dogstatsd", "packets_buffer_flush_full",
-		nil, "Count of packets buffer flush triggered because the buffer is full")
+		[]string{"listener_id"}, "Count of packets buffer flush triggered because the buffer is full")
+	tlmBufferSize = telemetry.NewGauge("dogstatsd", "packets_buffer_size",
+		[]string{"listener_id"}, "Size of the packets buffer")
 
 	// packet pool
 	tlmPoolGet = telemetry.NewCounter("dogstatsd", "packet_pool_get",
@@ -43,7 +48,7 @@ func InitTelemetry(buckets []float64) {
 	tlmListenerChannel = telemetry.NewHistogram(
 		"dogstatsd",
 		"listener_channel_latency",
-		nil,
+		[]string{"listener_id"},
 		"Time in nanoseconds to push a packets from a listeners to dogstatsd pipeline",
 		buckets)
 }

--- a/comp/dogstatsd/packets/types.go
+++ b/comp/dogstatsd/packets/types.go
@@ -24,10 +24,11 @@ const (
 // underlying buffer reference to avoid re-sizing the slice
 // before reading
 type Packet struct {
-	Contents []byte     // Contents, might contain several messages
-	Buffer   []byte     // Underlying buffer for data read
-	Origin   string     // Origin container if identified
-	Source   SourceType // Type of listener that produced the packet
+	Contents   []byte     // Contents, might contain several messages
+	Buffer     []byte     // Underlying buffer for data read
+	Origin     string     // Origin container if identified
+	ListenerID string     // Listener ID
+	Source     SourceType // Type of listener that produced the packet
 }
 
 // Packets is a slice of packet pointers

--- a/comp/dogstatsd/server/batch.go
+++ b/comp/dogstatsd/server/batch.go
@@ -7,6 +7,7 @@
 package server
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -148,12 +149,14 @@ func (b *batcher) appendSample(sample metrics.MetricSample) {
 		// it in the sample?) would reduce CPU usage, avoiding to recompute
 		// the tags hashes while generating the context key.
 		b.tagsBuffer.Append(sample.Tags...)
+		// TODO: for better isolation we might want an option to user listenerID or origin here.
+		// TODO: shuffle-sharding might be interesting too
 		h := b.keyGenerator.Generate(sample.Name, sample.Host, b.tagsBuffer)
 		b.tagsBuffer.Reset()
 		shardKey = fastrange(h, b.pipelineCount)
 	}
 
-	if b.samplesCount[shardKey] == len(b.samples[shardKey]) {
+	if b.samplesCount[shardKey] >= len(b.samples[shardKey]) {
 		b.flushSamples(shardKey)
 	}
 
@@ -193,7 +196,7 @@ func (b *batcher) flushSamples(shard uint32) {
 		t1 := time.Now()
 		b.demux.AggregateSamples(aggregator.TimeSamplerID(shard), b.samples[shard][:b.samplesCount[shard]])
 		t2 := time.Now()
-		tlmChannel.Observe(float64(t2.Sub(t1).Nanoseconds()), "metrics")
+		tlmChannel.Observe(float64(t2.Sub(t1).Nanoseconds()), strconv.Itoa(int(shard)), "metrics")
 
 		b.samplesCount[shard] = 0
 		b.samples[shard] = b.metricSamplePool.GetBatch()
@@ -205,7 +208,7 @@ func (b *batcher) flushSamplesWithTs() {
 		t1 := time.Now()
 		b.demux.SendSamplesWithoutAggregation(b.samplesWithTs[:b.samplesWithTsCount])
 		t2 := time.Now()
-		tlmChannel.Observe(float64(t2.Sub(t1).Nanoseconds()), "late_metrics")
+		tlmChannel.Observe(float64(t2.Sub(t1).Nanoseconds()), "", "late_metrics")
 
 		b.samplesWithTsCount = 0
 		b.samplesWithTs = b.metricSamplePool.GetBatch()
@@ -227,7 +230,7 @@ func (b *batcher) flush() {
 		t1 := time.Now()
 		b.choutEvents <- b.events
 		t2 := time.Now()
-		tlmChannel.Observe(float64(t2.Sub(t1).Nanoseconds()), "events")
+		tlmChannel.Observe(float64(t2.Sub(t1).Nanoseconds()), "", "events")
 
 		b.events = []*event.Event{}
 	}
@@ -237,7 +240,7 @@ func (b *batcher) flush() {
 		t1 := time.Now()
 		b.choutServiceChecks <- b.serviceChecks
 		t2 := time.Now()
-		tlmChannel.Observe(float64(t2.Sub(t1).Nanoseconds()), "service_checks")
+		tlmChannel.Observe(float64(t2.Sub(t1).Nanoseconds()), "", "service_checks")
 
 		b.serviceChecks = []*servicecheck.ServiceCheck{}
 	}

--- a/comp/dogstatsd/server/enrich.go
+++ b/comp/dogstatsd/server/enrich.go
@@ -159,7 +159,7 @@ func tsToFloatForSamples(ts time.Time) float64 {
 	return float64(ts.Unix())
 }
 
-func enrichMetricSample(dest []metrics.MetricSample, ddSample dogstatsdMetricSample, origin string, conf enrichConfig) []metrics.MetricSample {
+func enrichMetricSample(dest []metrics.MetricSample, ddSample dogstatsdMetricSample, origin string, listenerID string, conf enrichConfig) []metrics.MetricSample {
 	metricName := ddSample.name
 	tags, hostnameFromTags, udsOrigin, clientOrigin, cardinality, metricSource := extractTagsMetadata(ddSample.tags, origin, ddSample.containerID, conf)
 
@@ -194,6 +194,7 @@ func enrichMetricSample(dest []metrics.MetricSample, ddSample dogstatsdMetricSam
 					Timestamp:        tsToFloatForSamples(ddSample.ts),
 					OriginFromUDS:    udsOrigin,
 					OriginFromClient: clientOrigin,
+					ListenerID:       listenerID,
 					Cardinality:      cardinality,
 					Source:           metricSource,
 				})
@@ -213,6 +214,7 @@ func enrichMetricSample(dest []metrics.MetricSample, ddSample dogstatsdMetricSam
 		Timestamp:        tsToFloatForSamples(ddSample.ts),
 		OriginFromUDS:    udsOrigin,
 		OriginFromClient: clientOrigin,
+		ListenerID:       listenerID,
 		Cardinality:      cardinality,
 		Source:           metricSource,
 	})

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -128,6 +128,7 @@ type server struct {
 	cachedTlmLock sync.Mutex
 	// cachedOriginCounters caches telemetry counter per origin
 	// (when dogstatsd origin telemetry is enabled)
+	// TODO: use lru.Cache and track listenerId too
 	cachedOriginCounters map[string]cachedOriginCounter
 	cachedOrder          []cachedOriginCounter // for cache eviction
 
@@ -176,7 +177,7 @@ func initTelemetry(cfg config.Reader, logger logComponent.Component) {
 	tlmChannel = telemetry.NewHistogram(
 		"dogstatsd",
 		"channel_latency",
-		[]string{"message_type"},
+		[]string{"shard", "message_type"},
 		"Time in millisecond to push metrics to the aggregator input buffer",
 		buckets)
 
@@ -635,7 +636,7 @@ func (s *server) parsePackets(batcher *batcher, parser *parser, packets []*packe
 
 				samples = samples[0:0]
 
-				samples, err = s.parseMetricMessage(samples, parser, message, packet.Origin, s.originTelemetry)
+				samples, err = s.parseMetricMessage(samples, parser, message, packet.Origin, packet.ListenerID, s.originTelemetry)
 				if err != nil {
 					s.errLog("Dogstatsd: error parsing metric message '%q': %s", message, err)
 					continue
@@ -710,7 +711,7 @@ func (s *server) getOriginCounter(origin string) (okCnt telemetry.SimpleCounter,
 // which will be slower when processing millions of samples. It could use a boolean returned by `parseMetricSample` which
 // is the first part aware of processing a late metric. Also, it may help us having a telemetry of a "late_metrics" type here
 // which we can't do today.
-func (s *server) parseMetricMessage(metricSamples []metrics.MetricSample, parser *parser, message []byte, origin string, originTelemetry bool) ([]metrics.MetricSample, error) {
+func (s *server) parseMetricMessage(metricSamples []metrics.MetricSample, parser *parser, message []byte, origin string, listenerID string, originTelemetry bool) ([]metrics.MetricSample, error) {
 	okCnt := tlmProcessedOk
 	errorCnt := tlmProcessedError
 	if origin != "" && originTelemetry {
@@ -733,7 +734,7 @@ func (s *server) parseMetricMessage(metricSamples []metrics.MetricSample, parser
 		}
 	}
 
-	metricSamples = enrichMetricSample(metricSamples, sample, origin, s.enrichConfig)
+	metricSamples = enrichMetricSample(metricSamples, sample, origin, listenerID, s.enrichConfig)
 
 	if len(sample.values) > 0 {
 		s.sharedFloat64List.put(sample.values)

--- a/comp/dogstatsd/server/server_test.go
+++ b/comp/dogstatsd/server/server_test.go
@@ -678,7 +678,7 @@ func TestNoMappingsConfig(t *testing.T) {
 	assert.Nil(t, s.mapper)
 
 	parser := newParser(deps.Config, newFloat64ListPool())
-	samples, err := s.parseMetricMessage(samples, parser, []byte("test.metric:666|g"), "", false)
+	samples, err := s.parseMetricMessage(samples, parser, []byte("test.metric:666|g"), "", "", false)
 	assert.NoError(t, err)
 	assert.Len(t, samples, 1)
 }
@@ -792,7 +792,7 @@ dogstatsd_mapper_profiles:
 			var actualSamples []MetricSample
 			for _, p := range scenario.packets {
 				parser := newParser(deps.Config, newFloat64ListPool())
-				samples, err := s.parseMetricMessage(samples, parser, []byte(p), "", false)
+				samples, err := s.parseMetricMessage(samples, parser, []byte(p), "", "", false)
 				assert.NoError(t, err, "Case `%s` failed. parseMetricMessage should not return error %v", err)
 				for _, sample := range samples {
 					actualSamples = append(actualSamples, MetricSample{Name: sample.Name, Tags: sample.Tags, Mtype: sample.Mtype, Value: sample.Value})
@@ -868,12 +868,12 @@ func TestProcessedMetricsOrigin(t *testing.T) {
 
 		parser := newParser(deps.Config, newFloat64ListPool())
 		samples := []metrics.MetricSample{}
-		samples, err := s.parseMetricMessage(samples, parser, []byte("test.metric:666|g"), "container_id://test_container", false)
+		samples, err := s.parseMetricMessage(samples, parser, []byte("test.metric:666|g"), "container_id://test_container", "1", false)
 		assert.NoError(err)
 		assert.Len(samples, 1)
 
 		// one thing should have been stored when we parse a metric
-		samples, err = s.parseMetricMessage(samples, parser, []byte("test.metric:555|g"), "container_id://test_container", true)
+		samples, err = s.parseMetricMessage(samples, parser, []byte("test.metric:555|g"), "container_id://test_container", "1", true)
 		assert.NoError(err)
 		assert.Len(samples, 2)
 		assert.Len(s.cachedOriginCounters, 1, "one entry should have been cached")
@@ -881,7 +881,7 @@ func TestProcessedMetricsOrigin(t *testing.T) {
 		assert.Equal(s.cachedOrder[0].origin, "container_id://test_container")
 
 		// when we parse another metric (different value) with same origin, cache should contain only one entry
-		samples, err = s.parseMetricMessage(samples, parser, []byte("test.second_metric:525|g"), "container_id://test_container", true)
+		samples, err = s.parseMetricMessage(samples, parser, []byte("test.second_metric:525|g"), "container_id://test_container", "2", true)
 		assert.NoError(err)
 		assert.Len(samples, 3)
 		assert.Len(s.cachedOriginCounters, 1, "one entry should have been cached")
@@ -891,7 +891,7 @@ func TestProcessedMetricsOrigin(t *testing.T) {
 		assert.Equal(s.cachedOrder[0].err, map[string]string{"message_type": "metrics", "state": "error", "origin": "container_id://test_container"})
 
 		// when we parse another metric (different value) but with a different origin, we should store a new entry
-		samples, err = s.parseMetricMessage(samples, parser, []byte("test.second_metric:525|g"), "container_id://another_container", true)
+		samples, err = s.parseMetricMessage(samples, parser, []byte("test.second_metric:525|g"), "container_id://another_container", "3", true)
 		assert.NoError(err)
 		assert.Len(samples, 4)
 		assert.Len(s.cachedOriginCounters, 2, "two entries should have been cached")
@@ -905,7 +905,7 @@ func TestProcessedMetricsOrigin(t *testing.T) {
 
 		// oldest one should be removed once we reach the limit of the cache
 		maxOriginCounters = 2
-		samples, err = s.parseMetricMessage(samples, parser, []byte("yetanothermetric:525|g"), "third_origin", true)
+		samples, err = s.parseMetricMessage(samples, parser, []byte("yetanothermetric:525|g"), "third_origin", "3", true)
 		assert.NoError(err)
 		assert.Len(samples, 5)
 		assert.Len(s.cachedOriginCounters, 2, "two entries should have been cached, one has been evicted already")
@@ -919,7 +919,7 @@ func TestProcessedMetricsOrigin(t *testing.T) {
 
 		// oldest one should be removed once we reach the limit of the cache
 		maxOriginCounters = 2
-		samples, err = s.parseMetricMessage(samples, parser, []byte("blablabla:555|g"), "fourth_origin", true)
+		samples, err = s.parseMetricMessage(samples, parser, []byte("blablabla:555|g"), "fourth_origin", "4", true)
 		assert.NoError(err)
 		assert.Len(samples, 6)
 		assert.Len(s.cachedOriginCounters, 2, "two entries should have been cached, two have been evicted already")
@@ -944,7 +944,7 @@ func testContainerIDParsing(t *testing.T, cfg map[string]interface{}) {
 	parser.dsdOriginEnabled = true
 
 	// Metric
-	metrics, err := s.parseMetricMessage(nil, parser, []byte("metric.name:123|g|c:metric-container"), "", false)
+	metrics, err := s.parseMetricMessage(nil, parser, []byte("metric.name:123|g|c:metric-container"), "", "", false)
 	assert.NoError(err)
 	assert.Len(metrics, 1)
 	assert.Equal("container_id://metric-container", metrics[0].OriginFromClient)
@@ -986,7 +986,7 @@ func testOriginOptout(t *testing.T, cfg map[string]interface{}, enabled bool) {
 	parser.dsdOriginEnabled = true
 
 	// Metric
-	metrics, err := s.parseMetricMessage(nil, parser, []byte("metric.name:123|g|c:metric-container|#dd.internal.card:none"), "", false)
+	metrics, err := s.parseMetricMessage(nil, parser, []byte("metric.name:123|g|c:metric-container|#dd.internal.card:none"), "", "", false)
 	assert.NoError(err)
 	assert.Len(metrics, 1)
 	if enabled {

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -127,12 +127,17 @@ var (
 
 	tlmFlush = telemetry.NewCounter("aggregator", "flush",
 		[]string{"data_type", "state"}, "Number of metrics/service checks/events flushed")
+
+	tlmChannelSize = telemetry.NewGauge("aggregator", "channel_size",
+		[]string{"shard"}, "Size of the aggregator channel")
 	tlmProcessed = telemetry.NewCounter("aggregator", "processed",
-		[]string{"data_type"}, "Amount of metrics/services_checks/events processed by the aggregator")
+		[]string{"shard", "data_type"}, "Amount of metrics/services_checks/events processed by the aggregator")
+	tlmDogstatsdTimeBuckets = telemetry.NewGauge("aggregator", "dogstatsd_time_buckets",
+		[]string{"shard"}, "Number of time buckets in the dogstatsd sampler")
 	tlmDogstatsdContexts = telemetry.NewGauge("aggregator", "dogstatsd_contexts",
-		nil, "Count the number of dogstatsd contexts in the aggregator")
+		[]string{"shard"}, "Count the number of dogstatsd contexts in the aggregator")
 	tlmDogstatsdContextsByMtype = telemetry.NewGauge("aggregator", "dogstatsd_contexts_by_mtype",
-		[]string{"metric_type"}, "Count the number of dogstatsd contexts in the aggregator, by metric type")
+		[]string{"shard", "metric_type"}, "Count the number of dogstatsd contexts in the aggregator, by metric type")
 
 	// Hold series to be added to aggregated series on each flush
 	recurrentSeries     metrics.Series
@@ -388,7 +393,7 @@ func (agg *BufferedAggregator) handleSenderSample(ss senderMetricSample) {
 	defer agg.mu.Unlock()
 
 	aggregatorChecksMetricSample.Add(1)
-	tlmProcessed.Inc("metrics")
+	tlmProcessed.Inc("", "metrics")
 
 	if checkSampler, ok := agg.checkSamplers[ss.id]; ok {
 		if ss.commit {
@@ -407,7 +412,7 @@ func (agg *BufferedAggregator) handleSenderBucket(checkBucket senderHistogramBuc
 	defer agg.mu.Unlock()
 
 	aggregatorCheckHistogramBucketMetricSample.Add(1)
-	tlmProcessed.Inc("histogram_bucket")
+	tlmProcessed.Inc("", "histogram_bucket")
 
 	if checkSampler, ok := agg.checkSamplers[checkBucket.id]; ok {
 		checkBucket.bucket.Tags = util.SortUniqInPlace(checkBucket.bucket.Tags)
@@ -725,11 +730,11 @@ func (agg *BufferedAggregator) run() {
 			checkItem.handle(agg)
 		case event := <-agg.eventIn:
 			aggregatorEvent.Add(1)
-			tlmProcessed.Inc("events")
+			tlmProcessed.Inc("", "events")
 			agg.addEvent(event)
 		case serviceCheck := <-agg.serviceCheckIn:
 			aggregatorServiceCheck.Add(1)
-			tlmProcessed.Inc("service_checks")
+			tlmProcessed.Inc("", "service_checks")
 			agg.addServiceCheck(serviceCheck)
 		case serviceChecks := <-agg.bufferedServiceCheckIn:
 			aggregatorServiceCheck.Add(int64(len(serviceChecks)))

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -548,7 +548,7 @@ func (d *AgentDemultiplexer) SendSamplesWithoutAggregation(samples metrics.Metri
 		return
 	}
 
-	tlmProcessed.Add(float64(len(samples)), "late_metrics")
+	tlmProcessed.Add(float64(len(samples)), "", "late_metrics")
 	d.statsd.noAggStreamWorker.addSamples(samples)
 }
 

--- a/pkg/aggregator/no_aggregation_stream_worker.go
+++ b/pkg/aggregator/no_aggregation_stream_worker.go
@@ -102,6 +102,7 @@ func (w *noAggregationStreamWorker) addSamples(samples metrics.MetricSampleBatch
 	if len(samples) == 0 {
 		return
 	}
+	// FIXME: instrument
 	w.samplesChan <- samples
 }
 

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -67,6 +67,7 @@ func NewTimeSampler(id TimeSamplerID, interval int64, cache *tags.Store, context
 	return s
 }
 
+// TimeSamplerID returns the ID of the time sampler
 func (s *TimeSampler) TimeSamplerID() TimeSamplerID {
 	return s.id
 }

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -7,6 +7,7 @@ package aggregator
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/internal/limiter"
@@ -38,7 +39,8 @@ type TimeSampler struct {
 
 	// id is a number to differentiate multiple time samplers
 	// since we start running more than one with the demultiplexer introduction
-	id TimeSamplerID
+	id       TimeSamplerID
+	idString string
 
 	hostname string
 }
@@ -58,10 +60,15 @@ func NewTimeSampler(id TimeSamplerID, interval int64, cache *tags.Store, context
 		counterLastSampledByContext: map[ckey.ContextKey]float64{},
 		sketchMap:                   make(sketchMap),
 		id:                          id,
+		idString:                    strconv.Itoa(int(id)),
 		hostname:                    hostname,
 	}
 
 	return s
+}
+
+func (s *TimeSampler) TimeSamplerID() TimeSamplerID {
+	return s.id
 }
 
 func (s *TimeSampler) calculateBucketStart(timestamp float64) int64 {
@@ -233,13 +240,14 @@ func (s *TimeSampler) flush(timestamp float64, series metrics.SerieSink, sketche
 
 	totalContexts := s.contextResolver.length()
 	aggregatorDogstatsdContexts.Set(int64(totalContexts))
-	tlmDogstatsdContexts.Set(float64(totalContexts))
+	tlmDogstatsdContexts.Set(float64(totalContexts), s.idString)
+	tlmDogstatsdTimeBuckets.Set(float64(len(s.metricsByTimestamp)), s.idString)
 
 	byMtype := s.contextResolver.countsByMtype()
 	for i, count := range byMtype {
 		mtype := metrics.MetricType(i).String()
 		aggregatorDogstatsdContextsByMtype[i].Set(int64(count))
-		tlmDogstatsdContextsByMtype.Set(float64(count), mtype)
+		tlmDogstatsdContextsByMtype.Set(float64(count), s.idString, mtype)
 	}
 
 	s.sendTelemetry(timestamp, series)

--- a/pkg/aggregator/time_sampler_worker.go
+++ b/pkg/aggregator/time_sampler_worker.go
@@ -6,6 +6,7 @@
 package aggregator
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/internal/tags"
@@ -67,13 +68,16 @@ func newTimeSamplerWorker(sampler *TimeSampler, flushInterval time.Duration, buf
 // If we want to move to a design where we can flush while we are processing samples,
 // we could consider implementing double-buffering or locking for every sample reception.
 func (w *timeSamplerWorker) run() {
+	shard := strconv.Itoa(int(w.sampler.TimeSamplerID()))
+
 	for {
+		tlmChannelSize.Set(float64(len(w.samplesChan)), shard)
 		select {
 		case <-w.stopChan:
 			return
 		case ms := <-w.samplesChan:
 			aggregatorDogstatsdMetricSample.Add(int64(len(ms)))
-			tlmProcessed.Add(float64(len(ms)), "dogstatsd_metrics")
+			tlmProcessed.Add(float64(len(ms)), shard, "dogstatsd_metrics")
 			t := timeNowNano()
 			for i := 0; i < len(ms); i++ {
 				w.sampler.sample(&ms[i], t)

--- a/pkg/metrics/metric_sample.go
+++ b/pkg/metrics/metric_sample.go
@@ -97,6 +97,7 @@ type MetricSample struct {
 	FlushFirstValue  bool
 	OriginFromUDS    string
 	OriginFromClient string
+	ListenerID       string
 	Cardinality      string
 	NoIndex          bool
 	Source           MetricSource


### PR DESCRIPTION
### What does this PR do?

- Adds listener_id (which is unique per stream / connection) as a label for most telemetry metrics
- Use a per-stream packet buffer to allow per stream-telemetry (and as a side effect provide more isolation)
- Propagate listener_id up to the aggregated (to be use later for memory based rate-limiting)
- Add some missing telemetry for channel sizes

### Motivation

We need to be able to track which stream/listener contributes to the agent's usage. This is per listener/stream because this is what we will eventually be able to act on (and not necessarily the origin).

### Additional Notes

The `listener_id` label are volatile and the metrics are removed from the registries when the connections are closed.

### Possible Drawbacks / Trade-offs

`listener_id` cardinality might become relatively high (it contains the file descriptor) but since the kernel tries to allocate the lowest available file descriptor number, in practice this will stay relatively low.

### Describe how to test/QA your changes

Start the agent, check :5000/telemetry

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
