### PR TITLE
[CSM] Add a way to resolve hostname based on a parent context.Context

### DIFF
--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -213,7 +213,7 @@ func RunAgent(ctx context.Context, log log.Component, config config.Component, s
 		}
 	}()
 
-	hostnameDetected, err := utils.GetHostname()
+	hostnameDetected, err := utils.GetHostnameWithContext(ctx)
 	if err != nil {
 		log.Warnf("Could not resolve hostname from core-agent: %v", err)
 		hostnameDetected, err = hostname.Get(ctx)

--- a/pkg/security/utils/hostname.go
+++ b/pkg/security/utils/hostname.go
@@ -23,12 +23,18 @@ const (
 	maxAttempts = 6
 )
 
-// GetHostname attempts to acquire a hostname by connecting to the core agent's
-// gRPC endpoints
+// GetHostname attempts to acquire a hostname by connecting to the core
+// agent's gRPC endpoints.
 func GetHostname() (string, error) {
+	return GetHostnameWithContext(context.Background())
+}
+
+// GetHostnameWithContext attempts to acquire a hostname by connecting to the
+// core agent's gRPC endpoints extending the given context.
+func GetHostnameWithContext(ctx context.Context) (string, error) {
 	var hostname string
 	err := retry.Do(func() error {
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 		defer cancel()
 
 		client, err := grpc.GetDDAgentClient(ctx)
@@ -45,6 +51,6 @@ func GetHostname() (string, error) {
 
 		hostname = reply.Hostname
 		return nil
-	}, retry.LastErrorOnly(true), retry.Attempts(maxAttempts))
+	}, retry.LastErrorOnly(true), retry.Attempts(maxAttempts), retry.Context(ctx))
 	return hostname, err
 }


### PR DESCRIPTION
### What does this PR do?

Add a `GetHostnameWithContext` to allow for aborting the hostname retrieval based on a parent context.

### Motivation

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
