### PR TITLE
[ASCII-848][Component] Remove platform specific run functions

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -34,6 +34,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/subcommands/run/internal/clcrunnerapi"
 	"github.com/DataDog/datadog-agent/cmd/manager"
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
+	netflowServer "github.com/DataDog/datadog-agent/comp/netflow/server"
 
 	// checks implemented as components
 
@@ -173,9 +174,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 // run starts the main loop.
 //
 // This is exported because it also used from the deprecated `agent start` command.
-//
-// run now has different parameters on Linux & Windows
-func commonRun(log log.Component,
+func run(log log.Component,
 	config config.Component,
 	flare flare.Component,
 	telemetry telemetry.Component,
@@ -192,6 +191,7 @@ func commonRun(log log.Component,
 	logsAgent util.Optional[logsAgent.Component],
 	otelcollector otelcollector.Component,
 	hostMetadata host.Component,
+	_ netflowServer.Component,
 ) error {
 	defer func() {
 		stopAgent(cliParams, server, demultiplexer)

--- a/cmd/agent/subcommands/run/command_notwin.go
+++ b/cmd/agent/subcommands/run/command_notwin.go
@@ -5,61 +5,9 @@
 
 //go:build !windows
 
-// Package run implements 'agent run' (and deprecated 'agent start').
 package run
 
-import (
-	_ "expvar"         // Blank import used because this isn't directly used in this file
-	_ "net/http/pprof" // Blank import used because this isn't directly used in this file
-
-	// core components
-
-	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
-	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/flare"
-	"github.com/DataDog/datadog-agent/comp/core/log"
-	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
-	"github.com/DataDog/datadog-agent/comp/core/telemetry"
-	"github.com/DataDog/datadog-agent/comp/dogstatsd/replay"
-	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
-	dogstatsdDebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug"
-	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
-	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
-	"github.com/DataDog/datadog-agent/comp/metadata/host"
-	"github.com/DataDog/datadog-agent/comp/metadata/runner"
-	netflowServer "github.com/DataDog/datadog-agent/comp/netflow/server"
-	otelcollector "github.com/DataDog/datadog-agent/comp/otelcol/collector"
-	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
-	"github.com/DataDog/datadog-agent/pkg/serializer"
-	"github.com/DataDog/datadog-agent/pkg/util"
-	"go.uber.org/fx"
-	// runtime init routines
-)
-
-func run(log log.Component,
-	config config.Component,
-	flare flare.Component,
-	telemetry telemetry.Component,
-	sysprobeconfig sysprobeconfig.Component,
-	server dogstatsdServer.Component,
-	capture replay.Component,
-	serverDebug dogstatsdDebug.Component,
-	forwarder defaultforwarder.Component,
-	rcclient rcclient.Component,
-	metadataRunner runner.Component,
-	demux demultiplexer.Component,
-	sharedSerializer serializer.MetricSerializer,
-	cliParams *cliParams,
-	logsAgent util.Optional[logsAgent.Component],
-	otelcollector otelcollector.Component,
-	hostMetadata host.Component,
-	_ netflowServer.Component,
-) error {
-	// commonRun provides a mechanism to have the shared run function not require the unused components
-	// (i.e. here `_ netflowServer`).  The run function can have different parameters on different platforms
-	// based on platform-specific components.  commonRun is the shared initialization.
-	return commonRun(log, config, flare, telemetry, sysprobeconfig, server, capture, serverDebug, forwarder, rcclient, metadataRunner, demux, sharedSerializer, cliParams, logsAgent, otelcollector, hostMetadata)
-}
+import "go.uber.org/fx"
 
 func getPlatformModules() fx.Option {
 	return fx.Options()

--- a/cmd/agent/subcommands/run/command_windows.go
+++ b/cmd/agent/subcommands/run/command_windows.go
@@ -22,6 +22,7 @@ import (
 	// checks implemented as components
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/checks/agentcrashdetect"
+	comptraceconfig "github.com/DataDog/datadog-agent/comp/trace/config"
 
 	// core components
 	"github.com/DataDog/datadog-agent/comp/core"
@@ -40,7 +41,6 @@ import (
 	netflowServer "github.com/DataDog/datadog-agent/comp/netflow/server"
 	otelcollector "github.com/DataDog/datadog-agent/comp/otelcol/collector"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
-	comptraceconfig "github.com/DataDog/datadog-agent/comp/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -78,8 +78,6 @@ func StartAgentWithDefaults(ctxChan <-chan context.Context) (<-chan error, error
 			demultiplexer demultiplexer.Component,
 			hostMetadata host.Component,
 			_ netflowServer.Component,
-			_ agentcrashdetect.Component,
-			_ comptraceconfig.Component,
 		) error {
 
 			defer StopAgentWithDefaults(server, demultiplexer)
@@ -130,34 +128,6 @@ func StartAgentWithDefaults(ctxChan <-chan context.Context) (<-chan error, error
 	return errChan, nil
 }
 
-func run(log log.Component,
-	config config.Component,
-	flare flare.Component,
-	telemetry telemetry.Component,
-	sysprobeconfig sysprobeconfig.Component,
-	server dogstatsdServer.Component,
-	capture replay.Component,
-	serverDebug dogstatsdDebug.Component,
-	forwarder defaultforwarder.Component,
-	rcclient rcclient.Component,
-	metadataRunner runner.Component,
-	demux demultiplexer.Component,
-	sharedSerializer serializer.MetricSerializer,
-	cliParams *cliParams,
-	logsAgent util.Optional[logsAgent.Component],
-	otelcollector otelcollector.Component,
-	hostMetadata host.Component,
-	_ netflowServer.Component,
-	_ agentcrashdetect.Component,
-	_ comptraceconfig.Component,
-) error {
-	// commonRun provides a mechanism to have the shared run function not require the unused components
-	// (i.e. here `_ netflowServer`, `_ agentcrashdetect`, etc.).  The run function can have different
-	// parameters on different platforms based on platform-specific components.  commonRun is the shared initialization.
-
-	return commonRun(log, config, flare, telemetry, sysprobeconfig, server, capture, serverDebug, forwarder, rcclient, metadataRunner, demux, sharedSerializer, cliParams, logsAgent, otelcollector, hostMetadata)
-}
-
 func getPlatformModules() fx.Option {
 	return fx.Options(
 		agentcrashdetect.Module,
@@ -165,5 +135,6 @@ func getPlatformModules() fx.Option {
 		fx.Replace(comptraceconfig.Params{
 			FailIfAPIKeyMissing: false,
 		}),
+		fx.Invoke(func(_ agentcrashdetect.Component) {}), // Force the instanciation of the component
 	)
 }

--- a/cmd/agent/subcommands/run/command_windows_test.go
+++ b/cmd/agent/subcommands/run/command_windows_test.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package run
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartAgentWithDefaults(t *testing.T) {
+	fxutil.TestOneShot(t,
+		func() {
+			ctxChan := make(<-chan context.Context)
+			_, err := StartAgentWithDefaults(ctxChan)
+			require.NoError(t, err)
+		})
+}

--- a/pkg/util/fxutil/test.go
+++ b/pkg/util/fxutil/test.go
@@ -136,6 +136,29 @@ func TestOneShotSubcommand(
 	require.True(t, oneShotRan, "fxutil.OneShot wasn't called")
 }
 
+// TestOneShot is a helper for testing there is no missing dependencies when calling
+// fxutil.OneShot.
+//
+// The function passed as the first argument of fx.OneShot is not called. It
+// is validated with fx.ValidateApp, however.
+func TestOneShot(t *testing.T, fct func()) {
+	var oneShotRan bool
+	oneShotTestOverride = func(oneShotFunc interface{}, opts []fx.Option) error {
+		oneShotRan = true
+		// validate the app with the original oneShotFunc, to ensure that
+		// any types it requires are provided.
+		require.NoError(t,
+			fx.ValidateApp(
+				append(opts,
+					fx.Invoke(oneShotFunc))...))
+		return nil
+	}
+	defer func() { oneShotTestOverride = nil }()
+
+	fct()
+	require.True(t, oneShotRan, "fxutil.OneShot wasn't called")
+}
+
 // TestBundle is an helper to test Bundle.
 //
 // This function checks that all components built with fx.Provide inside a bundle can be instanciated.

--- a/tasks/components.py
+++ b/tasks/components.py
@@ -337,21 +337,20 @@ def lint_fxutil_oneshot_test(_):
             if "cmd/system-probe/subcommands/run/command.go" in str(file):
                 continue
 
-            # remove this file from the linting check pending a solution to the
-            # tests not being run properly due to mismatched arguments
-            if "cmd/agent/subcommands/run/command_windows.go" in str(file):
-                continue
-
             one_shot_count = file.read_text().count("fxutil.OneShot(")
             if one_shot_count > 0:
                 test_path = file.parent.joinpath(f"{file.stem}_test.go")
                 if not test_path.exists():
                     errors.append(f"The file {file} contains fxutil.OneShot but the file {test_path} doesn't exist.")
                 else:
-                    test_one_shot_count = test_path.read_text().count("fxutil.TestOneShotSubcommand(")
-                    if one_shot_count > test_one_shot_count:
+                    content = test_path.read_text()
+                    sub_cmd_count = content.count("fxutil.TestOneShotSubcommand(")
+                    test_one_shot_count = content.count("fxutil.TestOneShot(")
+                    if one_shot_count > sub_cmd_count + test_one_shot_count:
                         errors.append(
-                            f"The file {file} contains {one_shot_count} call(s) to `fxutil.OneShot` but {test_path} contains only {test_one_shot_count} call(s) to `fxutil.TestOneShotSubcommand`"
+                            f"The file {file} contains {one_shot_count} call(s) to `fxutil.OneShot`"
+                            + f"but {test_path} contains only {sub_cmd_count} call(s) to `fxutil.TestOneShotSubcommand`"
+                            + f"and {test_one_shot_count} call(s) to `fxutil.TestOneShot`"
                         )
     if len(errors) > 0:
         msg = '\n'.join(errors)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR simplifies the code by removing platform specific run functions for `agent run` command.
It also adds an unit test to make sure there is no missing dependencies.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Check `AgentCrashDetect` still works when running the agent with `agent run` and when running as a service.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
