### PR TITLE
Remove distributions from `dogstatsd_string_interner*` experiments

### DIFF
--- a/test/regression/cases/dogstatsd_string_interner_128MiB_100/lading/lading.yaml
+++ b/test/regression/cases/dogstatsd_string_interner_128MiB_100/lading/lading.yaml
@@ -38,9 +38,9 @@ generator:
             count: 100
             gauge: 10
             timer: 0
-            distribution: 50
+            distribution: 0
             set: 0
-            histogram: 1
+            histogram: 0
       bytes_per_second: "128 MiB"
       block_sizes: ["256b", "512b", "1Kb", "2Kb", "3Kb", "4Kb", "5Kb", "6Kb"]
       maximum_prebuild_cache_size_bytes: "500 Mb"

--- a/test/regression/cases/dogstatsd_string_interner_128MiB_1k/lading/lading.yaml
+++ b/test/regression/cases/dogstatsd_string_interner_128MiB_1k/lading/lading.yaml
@@ -38,9 +38,9 @@ generator:
             count: 100
             gauge: 10
             timer: 0
-            distribution: 50
+            distribution: 0
             set: 0
-            histogram: 1
+            histogram: 0
       bytes_per_second: "128 MiB"
       block_sizes: ["256b", "512b", "1Kb", "2Kb", "3Kb", "4Kb", "5Kb", "6Kb"]
       maximum_prebuild_cache_size_bytes: "500 Mb"

--- a/test/regression/cases/dogstatsd_string_interner_64MiB_100/lading/lading.yaml
+++ b/test/regression/cases/dogstatsd_string_interner_64MiB_100/lading/lading.yaml
@@ -38,9 +38,9 @@ generator:
             count: 100
             gauge: 10
             timer: 0
-            distribution: 50
+            distribution: 0
             set: 0
-            histogram: 1
+            histogram: 0
       bytes_per_second: "64 MiB"
       block_sizes: ["256b", "512b", "1Kb", "2Kb", "3Kb", "4Kb", "5Kb", "6Kb"]
       maximum_prebuild_cache_size_bytes: "500 Mb"

--- a/test/regression/cases/dogstatsd_string_interner_64MiB_1k/lading/lading.yaml
+++ b/test/regression/cases/dogstatsd_string_interner_64MiB_1k/lading/lading.yaml
@@ -38,9 +38,9 @@ generator:
             count: 100
             gauge: 10
             timer: 0
-            distribution: 50
+            distribution: 0
             set: 0
-            histogram: 1
+            histogram: 0
       bytes_per_second: "64 MiB"
       block_sizes: ["256b", "512b", "1Kb", "2Kb", "3Kb", "4Kb", "5Kb", "6Kb"]
       maximum_prebuild_cache_size_bytes: "500 Mb"

--- a/test/regression/cases/dogstatsd_string_interner_8MiB_100/lading/lading.yaml
+++ b/test/regression/cases/dogstatsd_string_interner_8MiB_100/lading/lading.yaml
@@ -38,9 +38,9 @@ generator:
             count: 100
             gauge: 10
             timer: 0
-            distribution: 50
+            distribution: 0
             set: 0
-            histogram: 1
+            histogram: 0
       bytes_per_second: "8 MiB"
       block_sizes: ["256b", "512b", "1Kb", "2Kb", "3Kb", "4Kb", "5Kb", "6Kb"]
       maximum_prebuild_cache_size_bytes: "500 Mb"

--- a/test/regression/cases/dogstatsd_string_interner_8MiB_100k/lading/lading.yaml
+++ b/test/regression/cases/dogstatsd_string_interner_8MiB_100k/lading/lading.yaml
@@ -38,9 +38,9 @@ generator:
             count: 100
             gauge: 10
             timer: 0
-            distribution: 50
+            distribution: 0
             set: 0
-            histogram: 1
+            histogram: 0
       bytes_per_second: "8 MiB"
       block_sizes: ["256b", "512b", "1Kb", "2Kb", "3Kb", "4Kb", "5Kb", "6Kb"]
       maximum_prebuild_cache_size_bytes: "500 Mb"

--- a/test/regression/cases/dogstatsd_string_interner_8MiB_10k/lading/lading.yaml
+++ b/test/regression/cases/dogstatsd_string_interner_8MiB_10k/lading/lading.yaml
@@ -38,9 +38,9 @@ generator:
             count: 100
             gauge: 10
             timer: 0
-            distribution: 50
+            distribution: 0
             set: 0
-            histogram: 1
+            histogram: 0
       bytes_per_second: "8 MiB"
       block_sizes: ["256b", "512b", "1Kb", "2Kb", "3Kb", "4Kb", "5Kb", "6Kb"]
       maximum_prebuild_cache_size_bytes: "500 Mb"

--- a/test/regression/cases/dogstatsd_string_interner_8MiB_1k/lading/lading.yaml
+++ b/test/regression/cases/dogstatsd_string_interner_8MiB_1k/lading/lading.yaml
@@ -38,9 +38,9 @@ generator:
             count: 100
             gauge: 10
             timer: 0
-            distribution: 50
+            distribution: 0
             set: 0
-            histogram: 1
+            histogram: 0
       bytes_per_second: "8 MiB"
       block_sizes: ["256b", "512b", "1Kb", "2Kb", "3Kb", "4Kb", "5Kb", "6Kb"]
       maximum_prebuild_cache_size_bytes: "500 Mb"

--- a/test/regression/cases/dogstatsd_string_interner_8MiB_50k/lading/lading.yaml
+++ b/test/regression/cases/dogstatsd_string_interner_8MiB_50k/lading/lading.yaml
@@ -38,9 +38,9 @@ generator:
             count: 100
             gauge: 10
             timer: 0
-            distribution: 50
+            distribution: 0
             set: 0
-            histogram: 1
+            histogram: 0
       bytes_per_second: "8 MiB"
       block_sizes: ["256b", "512b", "1Kb", "2Kb", "3Kb", "4Kb", "5Kb", "6Kb"]
       maximum_prebuild_cache_size_bytes: "500 Mb"


### PR DESCRIPTION
We are aware that distributions have performance implications -- see [this page](https://datadoghq.atlassian.net/wiki/spaces/SMP/pages/3210281178/Dogstatsd+Distributions) -- and including them in these experiments that are intended to focus on `stringInterner` is undesirable. As such, distribution generation is removed.

REF SMPTNG-12
REF #20211

