### PR TITLE
[CONTINT-3310] Make the e2e dca docker image multi-arch amd64+arm64

### DIFF
--- a/.gitlab/binary_build/cluster_agent.yml
+++ b/.gitlab/binary_build/cluster_agent.yml
@@ -28,7 +28,7 @@ cluster_agent-build_amd64:
 cluster_agent-build_arm64:
   extends: .cluster_agent-build_common
   rules:
-    !reference [.on_tag_or_a7_all_builds]
+    !reference [.on_tag_or_a7]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:arm64"]
   needs: ["go_mod_tidy_check", "go_deps"]

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -188,7 +188,7 @@ docker_build_cluster_agent_amd64:
 docker_build_cluster_agent_arm64:
   extends: .docker_build_job_definition_arm64
   rules:
-    !reference [.on_tag_or_a7_all_builds]
+    !reference [.on_tag_or_a7]
   needs:
     - job: cluster_agent-build_arm64
       artifacts: false

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -265,9 +265,10 @@ dev_nightly-dogstatsd:
   stage: dev_container_deploy
   needs:
     - docker_build_cluster_agent_amd64
+    - docker_build_cluster_agent_arm64
   variables:
     IMG_REGISTRIES: agent-qa
-    IMG_SOURCES: ${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
+    IMG_SOURCES: ${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     IMG_DESTINATIONS: cluster-agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
 
 .qa_dogstatsd:


### PR DESCRIPTION
### What does this PR do?

Make the cluster-agent docker image used by new-e2e tests multi-arch amd64+arm64.

### Motivation

Whereas the `Kind` tests are passing, the `EKS` tests were randomly failing.
It turned out that it was when the cluster agent was scheduled on an ARM node.

See the following jobs to see the `ImagePullBackOff` error happening only on the cluster agent, when scheduled on an `arm64` node:
* https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/352419868
* https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/352586423

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Check the `TestEKSSuite` e2e test and validate that the `dda-linux` Helm release can always be installed by Pulumi.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
