### PR TITLE
[e2] Downgrade pulumi-random to the last version supporting GO 1.20

### DIFF
--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -150,7 +150,10 @@ require (
 	github.com/pulumi/pulumi-eks/sdk v1.0.2 // indirect
 	github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.30.2 // indirect
 	github.com/pulumi/pulumi-libvirt/sdk v0.4.0 // indirect
-	github.com/pulumi/pulumi-random/sdk/v4 v4.14.0 // indirect
+	// pulumi-random v4.14.0 uses GO 1.21:
+	// https://github.com/pulumi/pulumi-random/blob/v4.14.0/sdk/go.mod#L3
+	// So, do not upgrade pulumi-random to v4.14.0 or above before migration to GO 1.21.
+	github.com/pulumi/pulumi-random/sdk/v4 v4.13.4 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -411,8 +411,8 @@ github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.30.2 h1:xJu48+RW+BHHnKtBni6Vj5vKqO
 github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.30.2/go.mod h1:7yCJFC/jnUwFs566f0FAY2iAzc4G1mQP8H6K+40FK4Y=
 github.com/pulumi/pulumi-libvirt/sdk v0.4.0 h1:wq1Ox8FRKQ1kc2DPq3m5DGQgZEhE7kp4mtG556HxJLs=
 github.com/pulumi/pulumi-libvirt/sdk v0.4.0/go.mod h1:tjjyDajp6Pb1pRCdaIugknIfzxw3Prev3o/k2nade+I=
-github.com/pulumi/pulumi-random/sdk/v4 v4.14.0 h1:ljy/gUeur2kZZWL3JPy0J9zLDYKKA0zMd1mT7xrpI7s=
-github.com/pulumi/pulumi-random/sdk/v4 v4.14.0/go.mod h1:XqGATLB6KKuWRDhWvHO6YVwv0DRW/cK/pWzNkuhMB24=
+github.com/pulumi/pulumi-random/sdk/v4 v4.13.4 h1:g3jdktE5L5IDrOw4OiB+yhgxSw0okRPJnyV6PlIzTEQ=
+github.com/pulumi/pulumi-random/sdk/v4 v4.13.4/go.mod h1:cFlJw0eQnqN+62QpITEF9M08gVyzNCeXrKRsuJptFak=
 github.com/pulumi/pulumi/sdk/v3 v3.16.0/go.mod h1:252ou/zAU1g6E8iTwe2Y9ht7pb5BDl2fJlOuAgZCHiA=
 github.com/pulumi/pulumi/sdk/v3 v3.50.1/go.mod h1:tqQ4z9ocyM/UI2VQ7ZReWR3w6dF5ffEozoHipOMcDh4=
 github.com/pulumi/pulumi/sdk/v3 v3.83.0 h1:Qjek0K/GaHYAMahMR5m5v/JWQuWg6eG0M/7swy9Ls8U=


### PR DESCRIPTION
### What does this PR do?

Downgrade `pulumi-random` to the last version using GO 1.20.
We cannot use `pulumi-random` `v4.14.0` because it uses GO 1.21:
https://github.com/pulumi/pulumi-random/blob/v4.14.0/sdk/go.mod#L3
and we’re still on GO 1.20:
https://github.com/DataDog/datadog-agent/blob/main/test/new-e2e/go.mod#L3

### Motivation

With `pulumi-random` `v4.14.0`, the GO compiler notices a dependency to GO 1.21 and updates the `test/new-e2e/go.mod` accordingly. And this is breaking `gopls`.

### Additional Notes

A comment at the top of `test/new-e2e/go.mod` says: https://github.com/DataDog/datadog-agent/blob/11657d2c13027f31a693c63a7a38665c7c7c98fe/test/new-e2e/go.mod#L5-L6

And, in `test-infra-definitions`, `pulumi-random` has been downgraded to `v4.13.4` by DataDog/test-infra-definitions#377.

In `datadog-agent/test/new-e2e`, it was downgraded a first time by #20067: https://github.com/DataDog/datadog-agent/pull/20067/files#diff-fee3041315eef2d6446d1e0f565e42851503923fb40e53cf4c91ac5641ebc4e0R151.
But it was then upgraded again by #20079: https://github.com/DataDog/datadog-agent/pull/20079/files#diff-fee3041315eef2d6446d1e0f565e42851503923fb40e53cf4c91ac5641ebc4e0R153.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
