### PR TITLE
[GitLab] Fix `e2e_test_junit_upload` job when filenames contain whitespace

### DIFF
--- a/.gitlab/e2e_test_junit_upload.yml
+++ b/.gitlab/e2e_test_junit_upload.yml
@@ -20,4 +20,4 @@ e2e_test_junit_upload:
     - export DATADOG_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
     - export JIRA_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.jira_read_api_token --with-decryption --query "Parameter.Value" --out text)
     - set -x
-    - for f in junit-new-e2e-*.tgz; do inv -e junit-upload --tgz-path $f; done
+    - for f in junit-new-e2e-*.tgz; do inv -e junit-upload --tgz-path "$f"; done


### PR DESCRIPTION
### What does this PR do?

Fix the GitLab `e2e_test_junit_upload` job when the Junit tarball filenames contain spaces.

### Motivation

Since the migration of the `new-e2e-containers-main` job to a matrix job by #19987, the `e2e_test_junit_upload` job is failing with this error:
```
++ for f in junit-new-e2e-*.tgz
++ inv -e junit-upload --tgz-path junit-new-e2e-containers-main: '[--run' 'TestECSSuite].tgz'
No idea what '[--run' is!
```

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Check that the results of the `new-e2e-containers-main` tests are visible in the datadog CI app.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
