### PR TITLE
[CWS] fix snapshot timestamp for proc cache

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -626,7 +626,7 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
                 },
                 .flags = syscall->exec.file.flags
             },
-            .exec_timestamp = bpf_ktime_get_ns(),
+            .exec_timestamp = now,
         },
         .container = {},
     };

--- a/pkg/security/resolvers/process/resolver_linux.go
+++ b/pkg/security/resolvers/process/resolver_linux.go
@@ -1184,9 +1184,11 @@ func (p *Resolver) syncCache(proc *process.Process, filledProc *utils.FilledProc
 
 	p.insertEntry(entry, p.entryCache[pid], model.ProcessCacheEntryFromSnapshot)
 
+	bootTime := p.timeResolver.GetBootTime()
+
 	// insert new entry in kernel maps
 	procCacheEntryB := make([]byte, 224)
-	_, err := entry.Process.MarshalProcCache(procCacheEntryB)
+	_, err := entry.Process.MarshalProcCache(procCacheEntryB, bootTime)
 	if err != nil {
 		seclog.Errorf("couldn't marshal proc_cache entry: %s", err)
 	} else {
@@ -1195,7 +1197,7 @@ func (p *Resolver) syncCache(proc *process.Process, filledProc *utils.FilledProc
 		}
 	}
 	pidCacheEntryB := make([]byte, 72)
-	_, err = entry.Process.MarshalPidCache(pidCacheEntryB)
+	_, err = entry.Process.MarshalPidCache(pidCacheEntryB, bootTime)
 	if err != nil {
 		seclog.Errorf("couldn't marshal pid_cache entry: %s", err)
 	} else {

--- a/pkg/security/resolvers/time/resolver.go
+++ b/pkg/security/resolvers/time/resolver.go
@@ -63,8 +63,12 @@ func (tr *Resolver) ApplyBootTime(timestamp time.Time) time.Time {
 // ComputeMonotonicTimestamp converts an absolute time to a kernel monotonic timestamp
 func (tr *Resolver) ComputeMonotonicTimestamp(timestamp time.Time) int64 {
 	if !timestamp.IsZero() {
-		offset := tr.getUptimeOffset()
-		return timestamp.Sub(tr.bootTime.Add(offset)).Nanoseconds()
+		return timestamp.Sub(tr.GetBootTime()).Nanoseconds()
 	}
 	return 0
+}
+
+// GetBootTime returns boot time
+func (tr *Resolver) GetBootTime() time.Time {
+	return tr.bootTime.Add(tr.getUptimeOffset())
 }

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -193,7 +193,7 @@ func (e *Process) UnmarshalPidCacheBinary(data []byte) (int, error) {
 	var read int
 
 	// Unmarshal pid_cache_t
-	cookie := ByteOrder.Uint64(data[0:8])
+	cookie := ByteOrder.Uint64(data[0:SizeOfCookie])
 	if cookie > 0 {
 		e.Cookie = cookie
 	}

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -2093,6 +2093,11 @@ func TestProcessResolution(t *testing.T) {
 			assert.Equal(t, entry1.Pid, entry2.Pid)
 			assert.Equal(t, entry1.PPid, entry2.PPid)
 			assert.Equal(t, entry1.ContainerID, entry2.ContainerID)
+			assert.Equal(t, entry1.Cookie, entry2.Cookie)
+
+			// may not be exaclty equal because of clock drift between two boot time resolution, see time resolver
+			assert.Greater(t, time.Second, entry1.ExecTime.Sub(entry2.ExecTime).Abs())
+			assert.Greater(t, time.Second, entry1.ForkTime.Sub(entry2.ForkTime).Abs())
 		}
 
 		cacheEntry := resolvers.ProcessResolver.ResolveFromCache(pid, pid, inode)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fix the timestamp push in the proc cache map from the snapshot. It subtracts boot time.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
