### PR TITLE
[Netflow] Netflow Status Supports 'Flow Counts'

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -512,6 +512,7 @@
         <br>Port: {{$NetflowListenerStatus.Config.Port}}
         <br>Workers: {{$NetflowListenerStatus.Config.Workers}}
         <br>Namespace: {{$NetflowListenerStatus.Config.Namespace}}
+        <br>Flows Received: {{$NetflowListenerStatus.FlowCount}}
         <br>
         <br>
         {{- end }}

--- a/comp/netflow/flowaggregator/aggregator_test.go
+++ b/comp/netflow/flowaggregator/aggregator_test.go
@@ -285,8 +285,9 @@ func TestAggregator_withMockPayload(t *testing.T) {
 
 	// Create an error channel to pass to StartFlowRoutine
 	listenerErr := atomic.NewString("")
+	listenerFlowCount := atomic.NewInt64(0)
 
-	flowState, err := goflowlib.StartFlowRoutine(common.TypeNetFlow5, "127.0.0.1", port, 1, "default", aggregator.GetFlowInChan(), logger, listenerErr, nil)
+	flowState, err := goflowlib.StartFlowRoutine(common.TypeNetFlow5, "127.0.0.1", port, 1, "default", aggregator.GetFlowInChan(), logger, listenerErr, listenerFlowCount)
 	assert.NoError(t, err)
 
 	time.Sleep(100 * time.Millisecond) // wait to make sure goflow listener is started before sending

--- a/comp/netflow/flowaggregator/aggregator_test.go
+++ b/comp/netflow/flowaggregator/aggregator_test.go
@@ -286,7 +286,7 @@ func TestAggregator_withMockPayload(t *testing.T) {
 	// Create an error channel to pass to StartFlowRoutine
 	listenerErr := atomic.NewString("")
 
-	flowState, err := goflowlib.StartFlowRoutine(common.TypeNetFlow5, "127.0.0.1", port, 1, "default", aggregator.GetFlowInChan(), logger, listenerErr)
+	flowState, err := goflowlib.StartFlowRoutine(common.TypeNetFlow5, "127.0.0.1", port, 1, "default", aggregator.GetFlowInChan(), logger, listenerErr, nil)
 	assert.NoError(t, err)
 
 	time.Sleep(100 * time.Millisecond) // wait to make sure goflow listener is started before sending

--- a/comp/netflow/goflowlib/flowstate.go
+++ b/comp/netflow/goflowlib/flowstate.go
@@ -41,10 +41,19 @@ type FlowRunnableState interface {
 }
 
 // StartFlowRoutine starts one of the goflow flow routine depending on the flow type
-func StartFlowRoutine(flowType common.FlowType, hostname string, port uint16, workers int, namespace string, flowInChan chan *common.Flow, logger log.Component, atomicErr *atomic.String) (*FlowStateWrapper, error) {
+func StartFlowRoutine(
+	flowType common.FlowType,
+	hostname string,
+	port uint16,
+	workers int,
+	namespace string,
+	flowInChan chan *common.Flow,
+	logger log.Component,
+	atomicErr *atomic.String,
+	listenerFlowCount *atomic.Int64) (*FlowStateWrapper, error) {
 	var flowState FlowRunnableState
 
-	formatDriver := NewAggregatorFormatDriver(flowInChan, namespace)
+	formatDriver := NewAggregatorFormatDriver(flowInChan, namespace, listenerFlowCount)
 	logrusLogger := GetLogrusLevel(logger)
 	ctx := context.Background()
 

--- a/comp/netflow/goflowlib/flowstate_test.go
+++ b/comp/netflow/goflowlib/flowstate_test.go
@@ -20,7 +20,7 @@ func TestStartFlowRoutine_invalidType(t *testing.T) {
 	logger := fxutil.Test[log.Component](t, log.MockModule)
 	listenerErr := atomic.NewString("")
 
-	state, err := StartFlowRoutine("invalid", "my-hostname", 1234, 1, "my-ns", make(chan *common.Flow), logger, listenerErr)
+	state, err := StartFlowRoutine("invalid", "my-hostname", 1234, 1, "my-ns", make(chan *common.Flow), logger, listenerErr, nil)
 
 	assert.EqualError(t, err, "unknown flow type: invalid")
 	assert.Nil(t, state)

--- a/comp/netflow/goflowlib/flowstate_test.go
+++ b/comp/netflow/goflowlib/flowstate_test.go
@@ -19,8 +19,9 @@ import (
 func TestStartFlowRoutine_invalidType(t *testing.T) {
 	logger := fxutil.Test[log.Component](t, log.MockModule)
 	listenerErr := atomic.NewString("")
+	listenerFlowCount := atomic.NewInt64(0)
 
-	state, err := StartFlowRoutine("invalid", "my-hostname", 1234, 1, "my-ns", make(chan *common.Flow), logger, listenerErr, nil)
+	state, err := StartFlowRoutine("invalid", "my-hostname", 1234, 1, "my-ns", make(chan *common.Flow), logger, listenerErr, listenerFlowCount)
 
 	assert.EqualError(t, err, "unknown flow type: invalid")
 	assert.Nil(t, state)

--- a/comp/netflow/server/listener.go
+++ b/comp/netflow/server/listener.go
@@ -7,6 +7,7 @@ package server
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/comp/netflow/common"
 	"github.com/DataDog/datadog-agent/comp/netflow/config"
 	"github.com/DataDog/datadog-agent/comp/netflow/flowaggregator"
 	"github.com/DataDog/datadog-agent/comp/netflow/goflowlib"
@@ -17,18 +18,31 @@ type netflowListener struct {
 	flowState *goflowlib.FlowStateWrapper
 	config    config.ListenerConfig
 	error     *atomic.String
+	flowCount *atomic.Int64
+}
+
+func (l *netflowListener) listen(inputChan <-chan *common.Flow, flowAgg *flowaggregator.FlowAggregator) {
+	for flow := range inputChan {
+		l.flowCount.Add(1)
+		flowAgg.GetFlowInChan() <- flow
+	}
 }
 
 func startFlowListener(listenerConfig config.ListenerConfig, flowAgg *flowaggregator.FlowAggregator, logger log.Component) (*netflowListener, error) {
 	atomicErr := atomic.NewString("")
+	flowCount := atomic.NewInt64(0)
+	inputChan := make(chan *common.Flow)
 
-	flowState, err := goflowlib.StartFlowRoutine(listenerConfig.FlowType, listenerConfig.BindHost, listenerConfig.Port, listenerConfig.Workers, listenerConfig.Namespace, flowAgg.GetFlowInChan(), logger, atomicErr)
+	flowState, err := goflowlib.StartFlowRoutine(listenerConfig.FlowType, listenerConfig.BindHost, listenerConfig.Port, listenerConfig.Workers, listenerConfig.Namespace, inputChan, logger, atomicErr)
 
 	listener := &netflowListener{
 		flowState: flowState,
 		config:    listenerConfig,
 		error:     atomicErr,
+		flowCount: flowCount,
 	}
+
+	go listener.listen(inputChan, flowAgg)
 
 	return listener, err
 }

--- a/comp/netflow/server/server.go
+++ b/comp/netflow/server/server.go
@@ -44,8 +44,9 @@ type NetflowServerStatus struct {
 
 // NetflowListenerStatus handles logic related to pulling config information and associating it to an error.
 type NetflowListenerStatus struct {
-	Config nfconfig.ListenerConfig
-	Error  string
+	Config    nfconfig.ListenerConfig
+	Error     string
+	FlowCount int64
 }
 
 // TODO: (components)
@@ -188,7 +189,8 @@ func GetStatus() NetflowServerStatus {
 			})
 		} else {
 			workingListeners = append(workingListeners, NetflowListenerStatus{
-				Config: listener.config,
+				Config:    listener.config,
+				FlowCount: listener.flowCount.Load(),
 			})
 		}
 	}

--- a/pkg/status/templates/netflow.tmpl
+++ b/pkg/status/templates/netflow.tmpl
@@ -14,6 +14,7 @@ FlowType: {{$NetflowListenerStatus.Config.FlowType}}
 Port: {{$NetflowListenerStatus.Config.Port}}
 Workers: {{$NetflowListenerStatus.Config.Workers}}
 Namespace: {{$NetflowListenerStatus.Config.Namespace}}
+Flows Received: {{$NetflowListenerStatus.FlowCount}}
 ---------
 {{- end }}
 {{ end }}


### PR DESCRIPTION
### What does this PR do?
This PR creates a channel to intercept the flows to increment flow count. This allows us to provide the flow count to the datadog-agent status for Netflow. 

### Motivation
This is an extension to my embed. 

### Additional Notes
N/A

### Possible Drawbacks / Trade-offs
N/A - happy to discuss the impact my code has on performance if any.

### Describe how to test/QA your changes
Compile the agent, and run datadog-agent status to see results.
