### PR TITLE
[CONTINT-695] Modify generic metrics provider to allow per-function granularity in collector selection

### DIFF
--- a/pkg/collector/corechecks/containers/docker/check_linux_test.go
+++ b/pkg/collector/corechecks/containers/docker/check_linux_test.go
@@ -105,11 +105,7 @@ func TestDockerNetworkExtension(t *testing.T) {
 	// container4 is a normal docker container connected to 2 networks 0 linked to PID 200
 	container1 := generic.CreateContainerMeta("docker", "kube-host-network")
 	mockCollector.SetContainerEntry(container1.ID, mock.ContainerEntry{
-		ContainerStats: &metrics.ContainerStats{
-			PID: &metrics.ContainerPIDStats{
-				PIDs: []int{100},
-			},
-		},
+		PIDs: []int{100},
 		NetworkStats: &metrics.ContainerNetworkStats{
 			Interfaces: map[string]metrics.InterfaceNetStats{
 				"eth0": {
@@ -157,11 +153,7 @@ func TestDockerNetworkExtension(t *testing.T) {
 
 	container2 := generic.CreateContainerMeta("docker", "kube-app")
 	mockCollector.SetContainerEntry(container2.ID, mock.ContainerEntry{
-		ContainerStats: &metrics.ContainerStats{
-			PID: &metrics.ContainerPIDStats{
-				PIDs: []int{101},
-			},
-		},
+		PIDs: []int{101},
 		NetworkStats: &metrics.ContainerNetworkStats{
 			Interfaces: map[string]metrics.InterfaceNetStats{
 				"eth0": {
@@ -203,11 +195,7 @@ func TestDockerNetworkExtension(t *testing.T) {
 
 	container4 := generic.CreateContainerMeta("docker", "docker-app")
 	mockCollector.SetContainerEntry(container4.ID, mock.ContainerEntry{
-		ContainerStats: &metrics.ContainerStats{
-			PID: &metrics.ContainerPIDStats{
-				PIDs: []int{200},
-			},
-		},
+		PIDs: []int{200},
 		NetworkStats: &metrics.ContainerNetworkStats{
 			Interfaces: map[string]metrics.InterfaceNetStats{
 				"eth0": {

--- a/pkg/collector/corechecks/containers/docker/check_network.go
+++ b/pkg/collector/corechecks/containers/docker/check_network.go
@@ -106,8 +106,11 @@ func (dn *dockerNetworkExtension) Process(tags []string, container *workloadmeta
 		tags:         tags,
 	}
 
-	if containerStats.PID != nil {
-		containerEntry.pids = containerStats.PID.PIDs
+	pids, err := collector.GetPIDs(container.Namespace, container.ID, cacheValidity)
+	if err == nil && pids != nil {
+		containerEntry.pids = pids
+	} else if err != nil {
+		log.Debugf("Metrics provider returned nil pids for container: %v", container)
 	}
 
 	dn.containerNetworkEntries[container.ID] = containerEntry

--- a/pkg/collector/corechecks/containers/docker/check_network.go
+++ b/pkg/collector/corechecks/containers/docker/check_network.go
@@ -77,18 +77,6 @@ func (dn *dockerNetworkExtension) PreProcess(sender generic.SenderFunc, aggSende
 // Process is called after core process (regardless of encountered error)
 func (dn *dockerNetworkExtension) Process(tags []string, container *workloadmeta.Container, collector metrics.Collector, cacheValidity time.Duration) {
 	// Duplicate call with generic.Processor, but cache should allow for a fast response.
-	// We only need it for PIDs
-	containerStats, err := collector.GetContainerStats(container.Namespace, container.ID, cacheValidity)
-	if err != nil {
-		log.Debugf("Gathering container metrics for container: %v failed, metrics may be missing, err: %v", container, err)
-		return
-	}
-
-	if containerStats == nil {
-		log.Debugf("Metrics provider returned nil stats for container: %v", container)
-		return
-	}
-
 	containerNetworkStats, err := collector.GetContainerNetworkStats(container.Namespace, container.ID, cacheValidity)
 	if err != nil {
 		log.Debugf("Gathering network metrics for container: %v failed, metrics may be missing, err: %v", container, err)

--- a/pkg/collector/corechecks/containers/generic/processor.go
+++ b/pkg/collector/corechecks/containers/generic/processor.go
@@ -60,19 +60,6 @@ func (p *Processor) Run(sender sender.Sender, cacheValidity time.Duration) error
 		return nil
 	}
 
-	collectorsCache := make(map[workloadmeta.ContainerRuntime]metrics.Collector)
-	getCollector := func(runtime workloadmeta.ContainerRuntime) metrics.Collector {
-		if collector, found := collectorsCache[runtime]; found {
-			return collector
-		}
-
-		collector := p.metricsProvider.GetCollector(string(runtime))
-		if collector != nil {
-			collectorsCache[runtime] = collector
-		}
-		return collector
-	}
-
 	// Extensions: PreProcess hook
 	for _, extension := range p.extensions {
 		extension.PreProcess(p.sendMetric, sender)
@@ -92,7 +79,7 @@ func (p *Processor) Run(sender sender.Sender, cacheValidity time.Duration) error
 		}
 		tags = p.metricsAdapter.AdaptTags(tags, container)
 
-		collector := getCollector(container.Runtime)
+		collector := p.metricsProvider.GetCollector(string(container.Runtime))
 		if collector == nil {
 			log.Warnf("Collector not found for container: %v, metrics will ne missing", container)
 			continue
@@ -100,7 +87,7 @@ func (p *Processor) Run(sender sender.Sender, cacheValidity time.Duration) error
 
 		containerStats, err := collector.GetContainerStats(container.Namespace, container.ID, cacheValidity)
 		if err != nil {
-			log.Debugf("Container stats for: %v not available through collector %q, err: %v", container, collector.ID(), err)
+			log.Debugf("Container stats for: %v not available, err: %v", container, err)
 			continue
 		}
 
@@ -113,7 +100,7 @@ func (p *Processor) Run(sender sender.Sender, cacheValidity time.Duration) error
 		if err == nil {
 			p.sendMetric(sender.Gauge, "container.pid.open_files", pointer.UIntPtrToFloatPtr(openFiles), tags)
 		} else {
-			log.Debugf("OpenFiles count for: %v not available through collector %q, err: %v", container, collector.ID(), err)
+			log.Debugf("OpenFiles count for: %v not available, err: %v", container, err)
 		}
 
 		// TODO: Implement container stats. We currently don't have enough information from Metadata service to do it.

--- a/pkg/process/util/containers/containers.go
+++ b/pkg/process/util/containers/containers.go
@@ -161,10 +161,11 @@ func (p *containerProvider) GetContainers(cacheValidity time.Duration, previousC
 		// Building PID to CID mapping for NPM
 		pids, err := collector.GetPIDs(container.Namespace, container.ID, cacheValidity)
 		if err == nil && pids != nil {
-			log.Debugf("PIDs for: %+v not available, err: %v", err)
 			for _, pid := range pids {
 				pidToCid[pid] = container.ID
 			}
+		} else {
+			log.Debugf("PIDs for: %+v not available, err: %v", container, err)
 		}
 
 		containerNetworkStats, err := collector.GetContainerNetworkStats(container.Namespace, container.ID, cacheValidity)

--- a/pkg/process/util/containers/containers.go
+++ b/pkg/process/util/containers/containers.go
@@ -152,22 +152,24 @@ func (p *containerProvider) GetContainers(cacheValidity time.Duration, previousC
 
 		containerStats, err := collector.GetContainerStats(container.Namespace, container.ID, cacheValidity)
 		if err != nil || containerStats == nil {
-			log.Debugf("Container stats for: %+v not available through collector %q, err: %v", container, collector.ID(), err)
+			log.Debugf("Container stats for: %+v not available, err: %v", container, err)
 			// If main container stats are missing, we skip the container
 			continue
 		}
 		computeContainerStats(hostCPUCount, containerStats, previousContainerRates, &outPreviousStats, processContainer)
 
 		// Building PID to CID mapping for NPM
-		if containerStats.PID != nil {
-			for _, pid := range containerStats.PID.PIDs {
+		pids, err := collector.GetPIDs(container.Namespace, container.ID, cacheValidity)
+		if err == nil && pids != nil {
+			log.Debugf("PIDs for: %+v not available, err: %v", err)
+			for _, pid := range pids {
 				pidToCid[pid] = container.ID
 			}
 		}
 
 		containerNetworkStats, err := collector.GetContainerNetworkStats(container.Namespace, container.ID, cacheValidity)
 		if err != nil {
-			log.Debugf("Container network stats for: %+v not available through collector %q, err: %v", container, collector.ID(), err)
+			log.Debugf("Container network stats for: %+v not available, err: %v", container, err)
 		}
 		computeContainerNetworkStats(containerNetworkStats, previousContainerRates, &outPreviousStats, processContainer)
 

--- a/pkg/process/util/containers/containers_test.go
+++ b/pkg/process/util/containers/containers_test.go
@@ -58,7 +58,7 @@ func TestGetContainers(t *testing.T) {
 	cID1Metrics := mock.GetFullSampleContainerEntry()
 	cID1Metrics.ContainerStats.Timestamp = testTime
 	cID1Metrics.NetworkStats.Timestamp = testTime
-	cID1Metrics.ContainerStats.PID.PIDs = []int{1, 2, 3}
+	cID1Metrics.PIDs = []int{1, 2, 3}
 	metricsCollector.SetContainerEntry("cID1", cID1Metrics)
 	metadataProvider.SetEntity(&workloadmeta.Container{
 		EntityID: workloadmeta.EntityID{
@@ -137,7 +137,7 @@ func TestGetContainers(t *testing.T) {
 	cID4Metrics := mock.GetFullSampleContainerEntry()
 	cID4Metrics.ContainerStats.Timestamp = testTime
 	cID4Metrics.NetworkStats.Timestamp = testTime
-	cID4Metrics.ContainerStats.PID.PIDs = []int{4, 5}
+	cID4Metrics.PIDs = []int{4, 5}
 	metricsCollector.SetContainerEntry("cID4", cID4Metrics)
 	metadataProvider.SetEntity(&workloadmeta.Container{
 		EntityID: workloadmeta.EntityID{
@@ -173,7 +173,7 @@ func TestGetContainers(t *testing.T) {
 	cID5Metrics.ContainerStats.CPU.DefaultedLimit = true
 	cID5Metrics.ContainerStats.Timestamp = testTime
 	cID5Metrics.NetworkStats.Timestamp = testTime
-	cID5Metrics.ContainerStats.PID.PIDs = []int{6, 7}
+	cID5Metrics.PIDs = []int{6, 7}
 	cID5Metrics.ContainerStats.Memory.WorkingSet = nil
 	cID5Metrics.ContainerStats.Memory.CommitBytes = pointer.Ptr(355.0)
 	metricsCollector.SetContainerEntry("cID5", cID5Metrics)
@@ -236,7 +236,7 @@ func TestGetContainers(t *testing.T) {
 	cID7Metrics := mock.GetFullSampleContainerEntry()
 	cID7Metrics.ContainerStats.Timestamp = testTime
 	cID7Metrics.NetworkStats.Timestamp = testTime
-	cID7Metrics.ContainerStats.PID.PIDs = []int{1, 2, 3}
+	cID7Metrics.PIDs = []int{1, 2, 3}
 	metricsCollector.SetContainerEntry("cID7", cID7Metrics)
 	metadataProvider.SetEntity(&workloadmeta.KubernetesPod{
 		EntityID: workloadmeta.EntityID{

--- a/pkg/util/cgroups/pid_mapper_test.go
+++ b/pkg/util/cgroups/pid_mapper_test.go
@@ -99,6 +99,18 @@ var dindProcCgroup = `14:name=systemd:/docker/88ea268ece65a02d68b169fd74bcbcb427
 1:cpuset:/docker/88ea268ece65a02d68b169fd74bcbcb427eb7f28900db0e3b906fb2eeb7341df/kubelet/kubepods/burstable/poda5ea884f-9e60-4912-bd62-fef9a31db47a/a51a9f7d073f848e7fc59e56e8f11524f330a2175a4ed26327da2dfe0d28015e
 0::/docker/88ea268ece65a02d68b169fd74bcbcb427eb7f28900db0e3b906fb2eeb7341df/system.slice/containerd.service`
 
+var ecsFargateCgroup = `11:perf_event:/ecs/8474ac4cec7a4f488834b00591271ec3/8474ac4cec7a4f488834b00591271ec3-3054012820
+10:hugetlb:/ecs/8474ac4cec7a4f488834b00591271ec3/8474ac4cec7a4f488834b00591271ec3-3054012820
+9:memory:/ecs/8474ac4cec7a4f488834b00591271ec3/8474ac4cec7a4f488834b00591271ec3-3054012820
+8:net_cls,net_prio:/ecs/8474ac4cec7a4f488834b00591271ec3/8474ac4cec7a4f488834b00591271ec3-3054012820
+7:freezer:/ecs/8474ac4cec7a4f488834b00591271ec3/8474ac4cec7a4f488834b00591271ec3-3054012820
+6:devices:/ecs/8474ac4cec7a4f488834b00591271ec3/8474ac4cec7a4f488834b00591271ec3-3054012820
+5:cpu,cpuacct:/ecs/8474ac4cec7a4f488834b00591271ec3/8474ac4cec7a4f488834b00591271ec3-3054012820
+4:blkio:/ecs/8474ac4cec7a4f488834b00591271ec3/8474ac4cec7a4f488834b00591271ec3-3054012820
+3:pids:/ecs/8474ac4cec7a4f488834b00591271ec3/8474ac4cec7a4f488834b00591271ec3-3054012820
+2:cpuset:/ecs/8474ac4cec7a4f488834b00591271ec3/8474ac4cec7a4f488834b00591271ec3-3054012820
+1:name=systemd:/ecs/8474ac4cec7a4f488834b00591271ec3/8474ac4cec7a4f488834b00591271ec3-3054012820`
+
 func TestProcPidMapperCgroupV1(t *testing.T) {
 	fakeFsPath := t.TempDir()
 	paths := []string{
@@ -198,6 +210,11 @@ func TestIdentiferFromCgroupReferences(t *testing.T) {
 			name:        "docker in docker",
 			fileContent: dindProcCgroup,
 			expectedID:  "a51a9f7d073f848e7fc59e56e8f11524f330a2175a4ed26327da2dfe0d28015e",
+		},
+		{
+			name:        "ecs fargate",
+			fileContent: ecsFargateCgroup,
+			expectedID:  "8474ac4cec7a4f488834b00591271ec3-3054012820",
 		},
 	}
 

--- a/pkg/util/cgroups/reader.go
+++ b/pkg/util/cgroups/reader.go
@@ -18,7 +18,10 @@ import (
 
 const (
 	// ContainerRegexpStr defines the regexp used to match container IDs
-	ContainerRegexpStr = "([0-9a-f]{64})|([0-9a-f]{8}(-[0-9a-f]{4}){4}$)"
+	// ([0-9a-f]{64}) is standard container id used pretty much everywhere
+	// ([0-9a-f]{32}-[0-9]{10}) is container id used by AWS ECS
+	// ([0-9a-f]{8}(-[0-9a-f]{4}){4}$) is container id used by Garden
+	ContainerRegexpStr = "([0-9a-f]{64})|([0-9a-f]{32}-[0-9]{10})|([0-9a-f]{8}(-[0-9a-f]{4}){4}$)"
 )
 
 // Reader is the main interface to scrape data from cgroups

--- a/pkg/util/containers/metrics/containerd/collector.go
+++ b/pkg/util/containers/metrics/containerd/collector.go
@@ -82,7 +82,7 @@ func newContainerdCollector(cache *provider.Cache) (provider.CollectorMetadata, 
 }
 
 // GetContainerStats returns stats by container ID.
-func (c *containerdCollector) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
+func (c *containerdCollector) GetContainerStats(containerNS, containerID string, _ time.Duration) (*provider.ContainerStats, error) {
 	metrics, err := c.getContainerdMetrics(containerNS, containerID)
 	if err != nil {
 		return nil, err
@@ -117,7 +117,7 @@ func (c *containerdCollector) GetContainerStats(containerNS, containerID string,
 }
 
 // GetContainerNetworkStats returns network stats by container ID.
-func (c *containerdCollector) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
+func (c *containerdCollector) GetContainerNetworkStats(containerNS, containerID string, _ time.Duration) (*provider.ContainerNetworkStats, error) {
 	metrics, err := c.getContainerdMetrics(containerNS, containerID)
 	if err != nil {
 		return nil, err
@@ -127,7 +127,7 @@ func (c *containerdCollector) GetContainerNetworkStats(containerNS, containerID 
 }
 
 // GetPIDs returns the list of PIDs by container ID.
-func (c *containerdCollector) GetPIDs(containerNS, containerID string, cacheValidity time.Duration) ([]int, error) {
+func (c *containerdCollector) GetPIDs(containerNS, containerID string, _ time.Duration) ([]int, error) {
 	container, err := c.client.Container(containerNS, containerID)
 	if err != nil {
 		log.Debugf("Could not fetch container with ID %s: %v", containerID, err)

--- a/pkg/util/containers/metrics/cri/collector.go
+++ b/pkg/util/containers/metrics/cri/collector.go
@@ -19,18 +19,16 @@ import (
 )
 
 const (
-	criCollectorID = "cri"
+	collectorID       = "cri"
+	collectorPriority = 3
 )
 
 func init() {
-	provider.GetProvider().RegisterCollector(provider.CollectorMetadata{
-		ID:       criCollectorID,
-		Priority: 1, // Less than the "system" collector, so we can rely on cgroups directly if possible
-		Runtimes: []string{provider.RuntimeNameCRIO},
-		Factory: func() (provider.Collector, error) {
-			return newCRICollector()
+	provider.RegisterCollector(provider.CollectorFactory{
+		ID: collectorID,
+		Constructor: func(cache *provider.Cache) (provider.CollectorMetadata, error) {
+			return newCRICollector(cache)
 		},
-		DelegateCache: true,
 	})
 }
 
@@ -38,22 +36,29 @@ type criCollector struct {
 	client cri.CRIClient
 }
 
-func newCRICollector() (*criCollector, error) {
+func newCRICollector(cache *provider.Cache) (provider.CollectorMetadata, error) {
+	var collectorMetadata provider.CollectorMetadata
+
 	if !config.IsFeaturePresent(config.Cri) {
-		return nil, provider.ErrPermaFail
+		return collectorMetadata, provider.ErrPermaFail
 	}
 
 	client, err := cri.GetUtil()
 	if err != nil {
-		return nil, provider.ConvertRetrierErr(err)
+		return collectorMetadata, provider.ConvertRetrierErr(err)
 	}
 
-	return &criCollector{client: client}, nil
-}
+	collector := &criCollector{client: client}
+	collectors := &provider.Collectors{
+		Stats: provider.MakeRef[provider.ContainerStatsGetter](collector, collectorPriority),
+	}
 
-// ID returns the collector ID.
-func (collector *criCollector) ID() string {
-	return criCollectorID
+	return provider.CollectorMetadata{
+		ID: collectorID,
+		Collectors: provider.CollectorCatalog{
+			provider.RuntimeNameCRIO: provider.MakeCached(collectorID, cache, collectors),
+		},
+	}, nil
 }
 
 // GetContainerStats returns stats by container ID.
@@ -82,30 +87,6 @@ func (collector *criCollector) GetContainerStats(containerNS, containerID string
 	}
 
 	return containerStats, nil
-}
-
-// GetContainerOpenFilesCount returns open files count by container ID.
-func (collector *criCollector) GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error) {
-	// Not available
-	return nil, nil
-}
-
-// GetContainerNetworkStats returns network stats by container ID.
-func (collector *criCollector) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
-	// Not available
-	return nil, nil
-}
-
-// GetContainerIDForPID returns the container ID for given PID
-func (collector *criCollector) GetContainerIDForPID(pid int, cacheValidity time.Duration) (string, error) {
-	// Not available
-	return "", nil
-}
-
-// GetSelfContainerID returns current process container ID
-func (collector *criCollector) GetSelfContainerID() (string, error) {
-	// Not available
-	return "", nil
 }
 
 func (collector *criCollector) getCriContainerStats(containerID string) (*v1.ContainerStats, error) {

--- a/pkg/util/containers/metrics/cri/collector_test.go
+++ b/pkg/util/containers/metrics/cri/collector_test.go
@@ -59,10 +59,3 @@ func TestGetContainerStats(t *testing.T) {
 	assert.Equal(t, pointer.Ptr(2048.0), stats.Memory.UsageTotal)
 	assert.Equal(t, pointer.Ptr(512.0), stats.Memory.RSS)
 }
-
-func TestGetContainerNetworkStats(t *testing.T) {
-	collector := criCollector{}
-	stats, err := collector.GetContainerNetworkStats("", "123", time.Second)
-	assert.NoError(t, err)
-	assert.Nil(t, stats) // The CRI collector does not return any network data
-}

--- a/pkg/util/containers/metrics/docker/collector.go
+++ b/pkg/util/containers/metrics/docker/collector.go
@@ -81,7 +81,7 @@ func newDockerCollector(cache *provider.Cache) (provider.CollectorMetadata, erro
 }
 
 // GetContainerStats returns stats by container ID.
-func (d *dockerCollector) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
+func (d *dockerCollector) GetContainerStats(_, containerID string, _ time.Duration) (*provider.ContainerStats, error) {
 	stats, err := d.stats(containerID)
 	if err != nil {
 		return nil, err
@@ -98,7 +98,7 @@ func (d *dockerCollector) GetContainerStats(containerNS, containerID string, cac
 }
 
 // GetContainerNetworkStats returns network stats by container ID.
-func (d *dockerCollector) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
+func (d *dockerCollector) GetContainerNetworkStats(_, containerID string, _ time.Duration) (*provider.ContainerNetworkStats, error) {
 	stats, err := d.stats(containerID)
 	if err != nil {
 		return nil, err
@@ -108,14 +108,13 @@ func (d *dockerCollector) GetContainerNetworkStats(containerNS, containerID stri
 }
 
 // GetPIDs returns the list of PIDs by container ID.
-func (d *dockerCollector) GetPIDs(containerNS, containerID string, cacheValidity time.Duration) ([]int, error) {
+func (d *dockerCollector) GetPIDs(_, containerID string, _ time.Duration) ([]int, error) {
 	// Try to collect the container's PIDs via Docker API, if we can't spec() will fill in the entry PID
 	pids, err := d.pids(containerID)
 	if err == nil {
 		return pids, nil
-	} else {
-		log.Warnf("Unable to collect container's PIDs via Docker API, PID list will be incomplete, cid: %s, err: %v", containerID, err)
 	}
+	log.Warnf("Unable to collect container's PIDs via Docker API, PID list will be incomplete, cid: %s, err: %v", containerID, err)
 
 	spec, err := d.spec(containerID)
 	if err != nil {

--- a/pkg/util/containers/metrics/ecsfargate/collector.go
+++ b/pkg/util/containers/metrics/ecsfargate/collector.go
@@ -23,8 +23,10 @@ import (
 )
 
 const (
-	ecsFargateCollectorID = "ecs_fargate"
-	ecsTaskTimeout        = 2 * time.Second
+	collectorID       = "ecs_fargate"
+	collectorPriority = 0
+
+	ecsTaskTimeout = 2 * time.Second
 	// cpuKey represents the cpu key used in the resource limits map returned by the ECS API
 	cpuKey = "CPU"
 	// memoryKey represents the memory key used in the resource limits map returned by the ECS API
@@ -34,12 +36,11 @@ const (
 var ecsUnsetMemoryLimit = uint64(math.Pow(2, 62))
 
 func init() {
-	provider.GetProvider().RegisterCollector(provider.CollectorMetadata{
-		ID:            ecsFargateCollectorID,
-		Priority:      0,
-		Runtimes:      []string{provider.RuntimeNameECSFargate},
-		Factory:       func() (provider.Collector, error) { return newEcsFargateCollector() },
-		DelegateCache: true,
+	provider.RegisterCollector(provider.CollectorFactory{
+		ID: collectorID,
+		Constructor: func(cache *provider.Cache) (provider.CollectorMetadata, error) {
+			return newEcsFargateCollector(cache)
+		},
 	})
 }
 
@@ -51,21 +52,34 @@ type ecsFargateCollector struct {
 }
 
 // newEcsFargateCollector returns a new *ecsFargateCollector.
-func newEcsFargateCollector() (*ecsFargateCollector, error) {
+func newEcsFargateCollector(cache *provider.Cache) (provider.CollectorMetadata, error) {
+	var collectorMetadata provider.CollectorMetadata
+
 	if !config.IsFeaturePresent(config.ECSFargate) {
-		return nil, provider.ErrPermaFail
+		return collectorMetadata, provider.ErrPermaFail
 	}
 
 	client, err := metadata.V2()
 	if err != nil {
-		return nil, provider.ConvertRetrierErr(err)
+		return collectorMetadata, provider.ConvertRetrierErr(err)
 	}
 
-	return &ecsFargateCollector{client: client}, nil
+	collector := &ecsFargateCollector{client: client}
+	collectors := &provider.Collectors{
+		Stats:   provider.MakeRef[provider.ContainerStatsGetter](collector, collectorPriority),
+		Network: provider.MakeRef[provider.ContainerNetworkStatsGetter](collector, collectorPriority),
+	}
+
+	return provider.CollectorMetadata{
+		ID: collectorID,
+		Collectors: provider.CollectorCatalog{
+			provider.RuntimeNameECSFargate: provider.MakeCached(collectorID, cache, collectors),
+		},
+	}, nil
 }
 
 // ID returns the collector ID.
-func (e *ecsFargateCollector) ID() string { return ecsFargateCollectorID }
+func (e *ecsFargateCollector) ID() string { return collectorID }
 
 // GetContainerStats returns stats by container ID.
 func (e *ecsFargateCollector) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
@@ -85,18 +99,6 @@ func (e *ecsFargateCollector) GetContainerStats(containerNS, containerID string,
 	return containerStats, nil
 }
 
-// GetContainerPIDStats returns pid stats by container ID.
-func (e *ecsFargateCollector) GetContainerPIDStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerPIDStats, error) {
-	// Not available
-	return nil, nil
-}
-
-// GetContainerOpenFilesCount returns open files count by container ID.
-func (e *ecsFargateCollector) GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error) {
-	// Not available
-	return nil, nil
-}
-
 // GetContainerNetworkStats returns network stats by container ID.
 func (e *ecsFargateCollector) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
 	stats, err := e.stats(containerID)
@@ -105,18 +107,6 @@ func (e *ecsFargateCollector) GetContainerNetworkStats(containerNS, containerID 
 	}
 
 	return convertNetworkStats(stats), nil
-}
-
-// GetContainerIDForPID returns the container ID for given PID
-func (e *ecsFargateCollector) GetContainerIDForPID(pid int, cacheValidity time.Duration) (string, error) {
-	// Not available
-	return "", nil
-}
-
-// GetSelfContainerID returns current process container ID
-func (e *ecsFargateCollector) GetSelfContainerID() (string, error) {
-	// Not available
-	return "", nil
 }
 
 // stats returns stats by container ID, it uses an in-memory cache to reduce the number of api calls.

--- a/pkg/util/containers/metrics/facade.go
+++ b/pkg/util/containers/metrics/facade.go
@@ -19,6 +19,9 @@ import (
 	_ "github.com/DataDog/datadog-agent/pkg/util/containers/metrics/system"
 )
 
+// Runtime is a typed string with all supported runtimes
+type Runtime = provider.Runtime
+
 // Collector defines an interface allowing to get stats from a containerID.
 type Collector = provider.Collector
 

--- a/pkg/util/containers/metrics/kubelet/collector.go
+++ b/pkg/util/containers/metrics/kubelet/collector.go
@@ -24,26 +24,23 @@ import (
 )
 
 const (
+	collectorID       = "kubelet"
+	collectorPriority = 2
+
 	contStatsCachePrefix    = "cs-"
 	contNetStatsCachePrefix = "cns-"
 	refreshCacheKey         = "refresh"
 
-	kubeletCollectorID     = "kubelet"
 	kubeletCallTimeout     = 10 * time.Second
 	kubeletCacheGCInterval = 30 * time.Second
 )
 
 func init() {
-	provider.GetProvider().RegisterCollector(provider.CollectorMetadata{
-		ID: kubeletCollectorID,
-		// Lowest priority as Kubelet stats are less detailed as we don't rely on cAdvisor
-		Priority: 2,
-		// Only runtimes implementing the CRI interface
-		Runtimes: []string{provider.RuntimeNameCRIO, provider.RuntimeNameContainerd, provider.RuntimeNameDocker},
-		Factory: func() (provider.Collector, error) {
-			return newKubeletCollector()
+	provider.RegisterCollector(provider.CollectorFactory{
+		ID: collectorID,
+		Constructor: func(cache *provider.Cache) (provider.CollectorMetadata, error) {
+			return newKubeletCollector(cache)
 		},
-		DelegateCache: false,
 	})
 }
 
@@ -54,39 +51,37 @@ type kubeletCollector struct {
 	refreshLock   sync.Mutex
 }
 
-func newKubeletCollector() (*kubeletCollector, error) {
+func newKubeletCollector(*provider.Cache) (provider.CollectorMetadata, error) {
+	var collectorMetadata provider.CollectorMetadata
+
 	if !config.IsFeaturePresent(config.Kubernetes) {
-		return nil, provider.ErrPermaFail
+		return collectorMetadata, provider.ErrPermaFail
 	}
 
 	client, err := kutil.GetKubeUtil()
 	if err != nil {
-		return nil, provider.ConvertRetrierErr(err)
+		return collectorMetadata, provider.ConvertRetrierErr(err)
 	}
 
-	return &kubeletCollector{
+	collector := &kubeletCollector{
 		kubeletClient: client,
 		statsCache:    *provider.NewCache(kubeletCacheGCInterval),
 		metadataStore: workloadmeta.GetGlobalStore(),
+	}
+
+	collectors := &provider.Collectors{
+		Stats:   provider.MakeRef[provider.ContainerStatsGetter](collector, collectorPriority),
+		Network: provider.MakeRef[provider.ContainerNetworkStatsGetter](collector, collectorPriority),
+	}
+
+	return provider.CollectorMetadata{
+		ID: collectorID,
+		Collectors: provider.CollectorCatalog{
+			provider.RuntimeNameContainerd: collectors,
+			provider.RuntimeNameCRIO:       collectors,
+			provider.RuntimeNameDocker:     collectors,
+		},
 	}, nil
-}
-
-// ID returns the collector ID.
-func (kc *kubeletCollector) ID() string {
-	return kubeletCollectorID
-}
-
-// GetContainerIDForPID returns a container ID for given PID.
-// ("", nil) will be returned if no error but the containerd ID was not found.
-func (kc *kubeletCollector) GetContainerIDForPID(pid int, cacheValidity time.Duration) (string, error) { //nolint:revive // TODO fix revive unused-parameter
-	// Not implemented
-	return "", nil
-}
-
-// GetSelfContainerID returns the container ID for current container.
-// ("", nil) will be returned if not possible to get ID for current container.
-func (kc *kubeletCollector) GetSelfContainerID() (string, error) {
-	return "", nil
 }
 
 // GetContainerStats returns stats by container ID.
@@ -114,18 +109,6 @@ func (kc *kubeletCollector) GetContainerStats(containerNS, containerID string, c
 		return nil, err
 	}
 
-	return nil, nil
-}
-
-// GetContainerPIDStats returns pid stats by container ID.
-func (kc *kubeletCollector) GetContainerPIDStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerPIDStats, error) { //nolint:revive // TODO fix revive unused-parameter
-	// Not available
-	return nil, nil
-}
-
-// GetContainerOpenFilesCount returns open files count by container ID.
-func (kc *kubeletCollector) GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error) { //nolint:revive // TODO fix revive unused-parameter
-	// Not available
 	return nil, nil
 }
 

--- a/pkg/util/containers/metrics/mock/doc.go
+++ b/pkg/util/containers/metrics/mock/doc.go
@@ -1,0 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+package mock

--- a/pkg/util/containers/metrics/mock/mock.go
+++ b/pkg/util/containers/metrics/mock/mock.go
@@ -39,7 +39,7 @@ func (mp *MetricsProvider) GetMetaCollector() provider.MetaCollector {
 }
 
 // RegisterCollector registers a collector
-func (mp *MetricsProvider) RegisterCollector(collectorFactory provider.CollectorFactory) {
+func (mp *MetricsProvider) RegisterCollector(provider.CollectorFactory) {
 }
 
 // RegisterConcreteCollector registers a collector
@@ -108,7 +108,7 @@ func (mp *Collector) Clear() {
 }
 
 // GetContainerStats returns stats from MockContainerEntry
-func (mp *Collector) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) { //nolint:revive // TODO fix revive unused-parameter
+func (mp *Collector) GetContainerStats(_, containerID string, _ time.Duration) (*provider.ContainerStats, error) {
 	if entry, found := mp.containers[containerID]; found {
 		return entry.ContainerStats, entry.Error
 	}
@@ -117,7 +117,7 @@ func (mp *Collector) GetContainerStats(containerNS, containerID string, cacheVal
 }
 
 // GetContainerOpenFilesCount returns stats from MockContainerEntry
-func (mp *Collector) GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error) { //nolint:revive // TODO fix revive unused-parameter
+func (mp *Collector) GetContainerOpenFilesCount(_, containerID string, _ time.Duration) (*uint64, error) {
 	if entry, found := mp.containers[containerID]; found {
 		return entry.OpenFiles, entry.Error
 	}
@@ -126,7 +126,7 @@ func (mp *Collector) GetContainerOpenFilesCount(containerNS, containerID string,
 }
 
 // GetContainerNetworkStats returns stats from MockContainerEntry
-func (mp *Collector) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) { //nolint:revive // TODO fix revive unused-parameter
+func (mp *Collector) GetContainerNetworkStats(_, containerID string, _ time.Duration) (*provider.ContainerNetworkStats, error) {
 	if entry, found := mp.containers[containerID]; found {
 		return entry.NetworkStats, entry.Error
 	}
@@ -135,7 +135,7 @@ func (mp *Collector) GetContainerNetworkStats(containerNS, containerID string, c
 }
 
 // GetPIDs returns pids from MockContainerEntry
-func (mp *Collector) GetPIDs(containerNS, containerID string, cacheValidity time.Duration) ([]int, error) {
+func (mp *Collector) GetPIDs(_, containerID string, _ time.Duration) ([]int, error) {
 	if entry, found := mp.containers[containerID]; found {
 		return entry.PIDs, entry.Error
 	}
@@ -144,7 +144,7 @@ func (mp *Collector) GetPIDs(containerNS, containerID string, cacheValidity time
 }
 
 // GetContainerIDForPID returns a container ID for given PID.
-func (mp *Collector) GetContainerIDForPID(pid int, cacheValidity time.Duration) (string, error) { //nolint:revive // TODO fix revive unused-parameter
+func (mp *Collector) GetContainerIDForPID(int, time.Duration) (string, error) {
 	return "", nil
 }
 

--- a/pkg/util/containers/metrics/mock/mock_samples.go
+++ b/pkg/util/containers/metrics/mock/mock_samples.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
+
 package mock
 
 import (
@@ -76,11 +78,11 @@ func GetFullSampleContainerEntry() ContainerEntry {
 				PartialStallTime: pointer.Ptr(98000.0),
 			},
 			PID: &metrics.ContainerPIDStats{
-				PIDs:        []int{4, 2},
 				ThreadCount: pointer.Ptr(10.0),
 				ThreadLimit: pointer.Ptr(20.0),
 			},
 		},
 		OpenFiles: pointer.Ptr(uint64(200)),
+		PIDs:      []int{4, 2},
 	}
 }

--- a/pkg/util/containers/metrics/provider/cache.go
+++ b/pkg/util/containers/metrics/provider/cache.go
@@ -10,6 +10,8 @@ import (
 	"time"
 )
 
+const cacheGCInterval = 30 * time.Second
+
 type cacheEntry struct {
 	value     interface{}
 	err       error

--- a/pkg/util/containers/metrics/provider/collector.go
+++ b/pkg/util/containers/metrics/provider/collector.go
@@ -31,7 +31,7 @@ func (pc CollectorRef[T]) bestCollector(runtime Runtime, otherID string, oth Col
 	// T is always an interface, so zero is nil, but currently we cannot express nillable in a constraint
 	var zero T
 
-	if pc.Collector == zero || (oth.Collector != zero && oth.Priority < pc.Priority) {
+	if oth.Collector != zero && (pc.Collector == zero || oth.Priority < pc.Priority) {
 		log.Debugf("Using collector id: %s for type: %T and runtime: %s", otherID, pc, runtime)
 		return oth
 	}

--- a/pkg/util/containers/metrics/provider/collector.go
+++ b/pkg/util/containers/metrics/provider/collector.go
@@ -19,6 +19,7 @@ type CollectorRef[T comparable] struct {
 	Priority  uint8
 }
 
+// MakeRef returns a CollectorRef[T] given a T and a priority
 func MakeRef[T comparable](collector T, priority uint8) CollectorRef[T] {
 	return CollectorRef[T]{
 		Collector: collector,
@@ -31,7 +32,7 @@ func (pc CollectorRef[T]) bestCollector(runtime Runtime, otherID string, oth Col
 	var zero T
 
 	if pc.Collector == zero || (oth.Collector != zero && oth.Priority < pc.Priority) {
-		log.Debugf("Using collector id: %s for type: %T and runtime: %s", otherID, zero, runtime)
+		log.Debugf("Using collector id: %s for type: %T and runtime: %s", otherID, pc, runtime)
 		return oth
 	}
 
@@ -64,19 +65,19 @@ func (c *Collectors) merge(runtime Runtime, otherID string, oth *Collectors) {
 // noImplCollector implements the Collector interface with all not implemented responses
 type noImplCollector struct{}
 
-func (noImplCollector) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerStats, error) {
+func (noImplCollector) GetContainerStats(_, _ string, _ time.Duration) (*ContainerStats, error) {
 	return nil, nil
 }
 
-func (noImplCollector) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerNetworkStats, error) {
+func (noImplCollector) GetContainerNetworkStats(_, _ string, _ time.Duration) (*ContainerNetworkStats, error) {
 	return nil, nil
 }
 
-func (noImplCollector) GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error) {
+func (noImplCollector) GetContainerOpenFilesCount(_, _ string, _ time.Duration) (*uint64, error) {
 	return nil, nil
 }
 
-func (noImplCollector) GetPIDs(containerNS, containerID string, cacheValidity time.Duration) ([]int, error) {
+func (noImplCollector) GetPIDs(_, _ string, _ time.Duration) ([]int, error) {
 	return nil, nil
 }
 

--- a/pkg/util/containers/metrics/provider/collector.go
+++ b/pkg/util/containers/metrics/provider/collector.go
@@ -5,15 +5,132 @@
 
 package provider
 
-import "time"
+import (
+	"time"
 
-// Collector defines an interface allowing to get stats from a containerID.
-// All implementations should allow for concurrent access.
-type Collector interface {
-	ID() string
-	GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerStats, error)
-	GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerNetworkStats, error)
-	// OpenFiles count has been splitted of as it incurs a high performance penalty on Linux
-	GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error)
-	MetaCollector
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// CollectorRef holds a collector interface reference with metadata
+// T is always an interface. Collectors implementing this interface need
+// to be comparable, often means that it should be a pointer receiver.
+type CollectorRef[T comparable] struct {
+	Collector T
+	Priority  uint8
+}
+
+func MakeRef[T comparable](collector T, priority uint8) CollectorRef[T] {
+	return CollectorRef[T]{
+		Collector: collector,
+		Priority:  priority,
+	}
+}
+
+func (pc CollectorRef[T]) bestCollector(runtime Runtime, otherID string, oth CollectorRef[T]) CollectorRef[T] {
+	// T is always an interface, so zero is nil, but currently we cannot express nillable in a constraint
+	var zero T
+
+	if pc.Collector == zero || (oth.Collector != zero && oth.Priority < pc.Priority) {
+		log.Debugf("Using collector id: %s for type: %T and runtime: %s", otherID, zero, runtime)
+		return oth
+	}
+
+	return pc
+}
+
+// Collectors is used by implementation to set their capabilities
+// and by registry to store current version
+// Priority fields: lowest gets higher priority (0 more prioritary than 1)
+type Collectors struct {
+	Stats          CollectorRef[ContainerStatsGetter]
+	Network        CollectorRef[ContainerNetworkStatsGetter]
+	OpenFilesCount CollectorRef[ContainerOpenFilesCountGetter]
+	PIDs           CollectorRef[ContainerPIDsGetter]
+
+	// These collectors are used in the meta collector
+	ContainerIDForPID CollectorRef[ContainerIDForPIDRetriever]
+	SelfContainerID   CollectorRef[SelfContainerIDRetriever]
+}
+
+func (c *Collectors) merge(runtime Runtime, otherID string, oth *Collectors) {
+	c.Stats = c.Stats.bestCollector(runtime, otherID, oth.Stats)
+	c.Network = c.Network.bestCollector(runtime, otherID, oth.Network)
+	c.OpenFilesCount = c.OpenFilesCount.bestCollector(runtime, otherID, oth.OpenFilesCount)
+	c.PIDs = c.PIDs.bestCollector(runtime, otherID, oth.PIDs)
+	c.ContainerIDForPID = c.ContainerIDForPID.bestCollector(runtime, otherID, oth.ContainerIDForPID)
+	c.SelfContainerID = c.SelfContainerID.bestCollector(runtime, otherID, oth.SelfContainerID)
+}
+
+// noImplCollector implements the Collector interface with all not implemented responses
+type noImplCollector struct{}
+
+func (noImplCollector) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerStats, error) {
+	return nil, nil
+}
+
+func (noImplCollector) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerNetworkStats, error) {
+	return nil, nil
+}
+
+func (noImplCollector) GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error) {
+	return nil, nil
+}
+
+func (noImplCollector) GetPIDs(containerNS, containerID string, cacheValidity time.Duration) ([]int, error) {
+	return nil, nil
+}
+
+// collectorImpl is used by provider for fast read calls
+type collectorImpl struct {
+	stats     ContainerStatsGetter
+	network   ContainerNetworkStatsGetter
+	openFiles ContainerOpenFilesCountGetter
+	pids      ContainerPIDsGetter
+}
+
+func newCollectorImpl() *collectorImpl {
+	noImpl := noImplCollector{}
+	return &collectorImpl{
+		stats:     noImpl,
+		network:   noImpl,
+		openFiles: noImpl,
+		pids:      noImpl,
+	}
+}
+
+func fromCollectors(c *Collectors) *collectorImpl {
+	collectorImpl := newCollectorImpl()
+	if c.Stats.Collector != nil {
+		collectorImpl.stats = c.Stats.Collector
+	}
+
+	if c.Network.Collector != nil {
+		collectorImpl.network = c.Network.Collector
+	}
+
+	if c.OpenFilesCount.Collector != nil {
+		collectorImpl.openFiles = c.OpenFilesCount.Collector
+	}
+
+	if c.PIDs.Collector != nil {
+		collectorImpl.pids = c.PIDs.Collector
+	}
+
+	return collectorImpl
+}
+
+func (c *collectorImpl) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerStats, error) {
+	return c.stats.GetContainerStats(containerNS, containerID, cacheValidity)
+}
+
+func (c *collectorImpl) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerNetworkStats, error) {
+	return c.network.GetContainerNetworkStats(containerNS, containerID, cacheValidity)
+}
+
+func (c *collectorImpl) GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error) {
+	return c.openFiles.GetContainerOpenFilesCount(containerNS, containerID, cacheValidity)
+}
+
+func (c *collectorImpl) GetPIDs(containerNS, containerID string, cacheValidity time.Duration) ([]int, error) {
+	return c.pids.GetPIDs(containerNS, containerID, cacheValidity)
 }

--- a/pkg/util/containers/metrics/provider/collector_cache.go
+++ b/pkg/util/containers/metrics/provider/collector_cache.go
@@ -15,137 +15,95 @@ const (
 	contOpenFilesCachePrefix = "of-"
 	contNetStatsCachePrefix  = "cns-"
 	contPidToCidCachePrefix  = "pid-"
-
-	cacheGCInterval = 30 * time.Second
+	contPidsCachePrefix      = "pids-"
 )
 
 // collectorCache is a wrapper handling cache for collectors.
-// this cache is fully synchronized to minimize locking. If a method is called multiple times in parallel for the same cachey key,
-// it may result in multiple calls to the underlying collector
+//
+// The underlying cache is fully synchronized to avoid locking at this layer.
+// It means that if a method is called multiple times in parallel for the same cachey key,
+// it may result in multiple calls to the underlying collector.
+//
+// The collectors referenced in *Collectors may be changed, no synchronization is done.
 type collectorCache struct {
-	collector            Collector
+	providerID           string
+	collectors           *Collectors
 	cache                *Cache
 	selfContainerIDCache string
 }
 
-// NewCollectorCache returns a new cache dedicated to a collector
-func NewCollectorCache(collector Collector) Collector {
-	return &collectorCache{
-		collector: collector,
-		cache:     NewCache(cacheGCInterval),
-	}
-}
+// Make sure all methods are implemented
+var (
+	_ Collector     = &collectorCache{}
+	_ MetaCollector = &collectorCache{}
+)
 
-// ID returns the actual collector ID, no cache
-func (cc *collectorCache) ID() string {
-	return cc.collector.ID()
+// MakeCached modifies `collectors` to go through a caching layer
+func MakeCached(providerID string, cache *Cache, collectors *Collectors) *Collectors {
+	collectorCache := &collectorCache{
+		providerID: providerID,
+		cache:      cache,
+		collectors: collectors,
+	}
+
+	return &Collectors{
+		Stats:             makeCached(collectors.Stats, ContainerStatsGetter(collectorCache)),
+		Network:           makeCached(collectors.Network, ContainerNetworkStatsGetter(collectorCache)),
+		OpenFilesCount:    makeCached(collectors.OpenFilesCount, ContainerOpenFilesCountGetter(collectorCache)),
+		PIDs:              makeCached(collectors.PIDs, ContainerPIDsGetter(collectorCache)),
+		ContainerIDForPID: makeCached(collectors.ContainerIDForPID, ContainerIDForPIDRetriever(collectorCache)),
+		SelfContainerID:   makeCached(collectors.SelfContainerID, SelfContainerIDRetriever(collectorCache)),
+	}
 }
 
 // GetContainerStats returns the stats if in cache and within cacheValidity
 // errors are cached as well to avoid hammering underlying collector
 func (cc *collectorCache) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerStats, error) {
-	currentTime := time.Now()
-	cacheKey := contCoreStatsCachePrefix + containerNS + containerID
+	cacheKey := cc.providerID + "-" + contCoreStatsCachePrefix + containerNS + containerID
 
-	entry, found, err := cc.cache.Get(currentTime, cacheKey, cacheValidity)
-	if found {
-		if err != nil {
-			return nil, err
-		}
-
-		return entry.(*ContainerStats), nil
-	}
-
-	// No cache, cacheValidity is 0 or too old value
-	cstats, err := cc.collector.GetContainerStats(containerNS, containerID, cacheValidity)
-	if err != nil {
-		cc.cache.Store(currentTime, cacheKey, nil, err)
-		return nil, err
-	}
-
-	cc.cache.Store(currentTime, cacheKey, cstats, nil)
-	return cstats, nil
-}
-
-// GetContainerOpenFilesCount returns the count of open files if in cache and within cacheValidity
-// errors are cached as well to avoid hammering underlying collector
-func (cc *collectorCache) GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error) {
-	// Generics could be useful. Meanwhile copy-paste.
-	currentTime := time.Now()
-	cacheKey := contOpenFilesCachePrefix + containerNS + containerID
-
-	entry, found, err := cc.cache.Get(currentTime, cacheKey, cacheValidity)
-	if found {
-		if err != nil {
-			return nil, err
-		}
-
-		return entry.(*uint64), nil
-	}
-
-	// No cache, cacheValidity is 0 or too old value
-	openFilesCount, err := cc.collector.GetContainerOpenFilesCount(containerNS, containerID, cacheValidity)
-	if err != nil {
-		cc.cache.Store(currentTime, cacheKey, nil, err)
-		return nil, err
-	}
-
-	cc.cache.Store(currentTime, cacheKey, openFilesCount, nil)
-	return openFilesCount, nil
+	return getOrFallback(cc.cache, cacheKey, cacheValidity, func() (*ContainerStats, error) {
+		return cc.collectors.Stats.Collector.GetContainerStats(containerNS, containerID, cacheValidity)
+	})
 }
 
 // GetContainerNetworkStats returns the stats if in cache and within cacheValidity
 // errors are cached as well to avoid hammering underlying collector
 func (cc *collectorCache) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerNetworkStats, error) {
-	// Generics could be useful. Meanwhile copy-paste.
-	currentTime := time.Now()
-	cacheKey := contNetStatsCachePrefix + containerNS + containerID
+	cacheKey := cc.providerID + "-" + contNetStatsCachePrefix + containerNS + containerID
 
-	entry, found, err := cc.cache.Get(currentTime, cacheKey, cacheValidity)
-	if found {
-		if err != nil {
-			return nil, err
-		}
+	return getOrFallback(cc.cache, cacheKey, cacheValidity, func() (*ContainerNetworkStats, error) {
+		return cc.collectors.Network.Collector.GetContainerNetworkStats(containerNS, containerID, cacheValidity)
+	})
+}
 
-		return entry.(*ContainerNetworkStats), nil
-	}
+// GetContainerOpenFilesCount returns the count of open files if in cache and within cacheValidity
+// errors are cached as well to avoid hammering underlying collector
+func (cc *collectorCache) GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error) {
+	cacheKey := cc.providerID + "-" + contOpenFilesCachePrefix + containerNS + containerID
 
-	// No cache, cacheValidity is 0 or too old value
-	val, err := cc.collector.GetContainerNetworkStats(containerNS, containerID, cacheValidity)
-	if err != nil {
-		cc.cache.Store(currentTime, cacheKey, nil, err)
-		return nil, err
-	}
+	return getOrFallback(cc.cache, cacheKey, cacheValidity, func() (*uint64, error) {
+		return cc.collectors.OpenFilesCount.Collector.GetContainerOpenFilesCount(containerNS, containerID, cacheValidity)
+	})
+}
 
-	cc.cache.Store(currentTime, cacheKey, val, nil)
-	return val, nil
+// GetPIDs returns the container ID for given PID
+// errors are cached as well to avoid hammering underlying collector
+func (cc *collectorCache) GetPIDs(containerNS, containerID string, cacheValidity time.Duration) ([]int, error) {
+	cacheKey := cc.providerID + "-" + contPidsCachePrefix + containerNS + containerID
+
+	return getOrFallback(cc.cache, cacheKey, cacheValidity, func() ([]int, error) {
+		return cc.collectors.PIDs.Collector.GetPIDs(containerNS, containerID, cacheValidity)
+	})
 }
 
 // GetContainerIDForPID returns the container ID for given PID
 // errors are cached as well to avoid hammering underlying collector
 func (cc *collectorCache) GetContainerIDForPID(pid int, cacheValidity time.Duration) (string, error) {
-	// Generics could be useful. Meanwhile copy-paste.
-	currentTime := time.Now()
-	cacheKey := contPidToCidCachePrefix + strconv.FormatInt(int64(pid), 10)
+	cacheKey := cc.providerID + "-" + contPidToCidCachePrefix + strconv.FormatInt(int64(pid), 10)
 
-	entry, found, err := cc.cache.Get(currentTime, cacheKey, cacheValidity)
-	if found {
-		if err != nil {
-			return "", err
-		}
-
-		return entry.(string), nil
-	}
-
-	// No cache, cacheValidity is 0 or too old value
-	val, err := cc.collector.GetContainerIDForPID(pid, cacheValidity)
-	if err != nil {
-		cc.cache.Store(currentTime, cacheKey, nil, err)
-		return "", err
-	}
-
-	cc.cache.Store(currentTime, cacheKey, val, nil)
-	return val, nil
+	return getOrFallback(cc.cache, cacheKey, cacheValidity, func() (string, error) {
+		return cc.collectors.ContainerIDForPID.Collector.GetContainerIDForPID(pid, cacheValidity)
+	})
 }
 
 // GetSelfContainerID returns current process container ID
@@ -155,10 +113,42 @@ func (cc *collectorCache) GetSelfContainerID() (string, error) {
 		return cc.selfContainerIDCache, nil
 	}
 
-	selfID, err := cc.collector.GetSelfContainerID()
+	selfID, err := cc.collectors.SelfContainerID.Collector.GetSelfContainerID()
 	if err == nil {
 		cc.selfContainerIDCache = selfID
 	}
 
 	return selfID, err
+}
+
+func makeCached[T comparable](cr CollectorRef[T], cache T) CollectorRef[T] {
+	var zero T
+	if cr.Collector != zero {
+		cr.Collector = cache
+	}
+
+	return cr
+}
+
+func getOrFallback[T any](cache *Cache, cacheKey string, cacheValidity time.Duration, collect func() (T, error)) (T, error) {
+	currentTime := time.Now()
+
+	entry, found, err := cache.Get(currentTime, cacheKey, cacheValidity)
+	if found {
+		if err != nil {
+			return *new(T), err
+		}
+
+		return entry.(T), nil
+	}
+
+	// No cache, cacheValidity is 0 or too old value
+	val, err := collect()
+	if err != nil {
+		cache.Store(currentTime, cacheKey, nil, err)
+		return *new(T), err
+	}
+
+	cache.Store(currentTime, cacheKey, val, nil)
+	return val, nil
 }

--- a/pkg/util/containers/metrics/provider/collector_types.go
+++ b/pkg/util/containers/metrics/provider/collector_types.go
@@ -10,28 +10,35 @@ import (
 )
 
 // Individual interfaces, used to dynamically register available implementations
+
+// ContainerStatsGetter interface
 type ContainerStatsGetter interface {
 	GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerStats, error)
 }
 
+// ContainerNetworkStatsGetter interface
 type ContainerNetworkStatsGetter interface {
 	GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerNetworkStats, error)
 }
 
+// ContainerOpenFilesCountGetter interface
 type ContainerOpenFilesCountGetter interface {
 	GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error)
 }
 
+// ContainerPIDsGetter interface
 type ContainerPIDsGetter interface {
 	GetPIDs(containerNS, containerID string, cacheValidity time.Duration) ([]int, error)
 }
 
+// ContainerIDForPIDRetriever interface
 type ContainerIDForPIDRetriever interface {
 	// GetContainerIDForPID returns a container ID for given PID.
 	// ("", nil) will be returned if no error but the containerd ID was not found.
 	GetContainerIDForPID(pid int, cacheValidity time.Duration) (string, error)
 }
 
+// SelfContainerIDRetriever interface
 type SelfContainerIDRetriever interface {
 	// GetSelfContainerID returns the container ID for current container.
 	// ("", nil) will be returned if not possible to get ID for current container.

--- a/pkg/util/containers/metrics/provider/collector_types.go
+++ b/pkg/util/containers/metrics/provider/collector_types.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+package provider
+
+import (
+	"time"
+)
+
+// Individual interfaces, used to dynamically register available implementations
+type ContainerStatsGetter interface {
+	GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerStats, error)
+}
+
+type ContainerNetworkStatsGetter interface {
+	GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerNetworkStats, error)
+}
+
+type ContainerOpenFilesCountGetter interface {
+	GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error)
+}
+
+type ContainerPIDsGetter interface {
+	GetPIDs(containerNS, containerID string, cacheValidity time.Duration) ([]int, error)
+}
+
+type ContainerIDForPIDRetriever interface {
+	// GetContainerIDForPID returns a container ID for given PID.
+	// ("", nil) will be returned if no error but the containerd ID was not found.
+	GetContainerIDForPID(pid int, cacheValidity time.Duration) (string, error)
+}
+
+type SelfContainerIDRetriever interface {
+	// GetSelfContainerID returns the container ID for current container.
+	// ("", nil) will be returned if not possible to get ID for current container.
+	GetSelfContainerID() (string, error)
+}
+
+// Collector defines the public interface
+type Collector interface {
+	ContainerStatsGetter
+	ContainerNetworkStatsGetter
+	ContainerOpenFilesCountGetter
+	ContainerPIDsGetter
+}
+
+// MetaCollector is a special collector that uses all available collectors, by priority order.
+type MetaCollector interface {
+	ContainerIDForPIDRetriever
+	SelfContainerIDRetriever
+}

--- a/pkg/util/containers/metrics/provider/metacollector.go
+++ b/pkg/util/containers/metrics/provider/metacollector.go
@@ -6,50 +6,29 @@
 package provider
 
 import (
+	"sort"
 	"time"
 )
 
 // MetaCollector is a special collector that uses all available collectors, by priority order.
-type MetaCollector interface {
-	// GetContainerIDForPID returns a container ID for given PID.
-	// ("", nil) will be returned if no error but the containerd ID was not found.
-	GetContainerIDForPID(pid int, cacheValidity time.Duration) (string, error)
-
-	// GetSelfContainerID returns the container ID for current container.
-	// ("", nil) will be returned if not possible to get ID for current container.
-	GetSelfContainerID() (string, error)
-}
-
 type metaCollector struct {
-	orderedCollectorLister func() []*collectorReference
+	selfContainerIDcollectors    []CollectorRef[SelfContainerIDRetriever]
+	containerIDFromPIDcollectors []CollectorRef[ContainerIDForPIDRetriever]
 }
 
-func newMetaCollector(collectorLister func() []*collectorReference) *metaCollector {
-	return &metaCollector{
-		orderedCollectorLister: collectorLister,
-	}
+func newMetaCollector() *metaCollector {
+	return &metaCollector{}
 }
 
-// GetContainerIDForPID returns a container ID for given PID.
-func (mc *metaCollector) GetContainerIDForPID(pid int, cacheValidity time.Duration) (string, error) {
-	for _, collector := range mc.orderedCollectorLister() {
-		val, err := collector.collector.GetContainerIDForPID(pid, cacheValidity)
-		if err != nil {
-			return "", err
-		}
-
-		if val != "" {
-			return val, nil
-		}
-	}
-
-	return "", nil
+func (mc *metaCollector) collectorsUpdatedCallback(collectorsCatalog CollectorCatalog) {
+	mc.selfContainerIDcollectors = buildUniqueCollectors(collectorsCatalog, func(c *Collectors) CollectorRef[SelfContainerIDRetriever] { return c.SelfContainerID })
+	mc.containerIDFromPIDcollectors = buildUniqueCollectors(collectorsCatalog, func(c *Collectors) CollectorRef[ContainerIDForPIDRetriever] { return c.ContainerIDForPID })
 }
 
 // GetSelfContainerID returns the container ID for current container.
 func (mc *metaCollector) GetSelfContainerID() (string, error) {
-	for _, collector := range mc.orderedCollectorLister() {
-		val, err := collector.collector.GetSelfContainerID()
+	for _, collectorRef := range mc.selfContainerIDcollectors {
+		val, err := collectorRef.Collector.GetSelfContainerID()
 		if err != nil {
 			return "", err
 		}
@@ -62,15 +41,44 @@ func (mc *metaCollector) GetSelfContainerID() (string, error) {
 	return "", nil
 }
 
-// Not implemented as metaCollector implements Collector interface to allow wrapping in collectorCache
-func (mc *metaCollector) ID() string {
-	panic("Should never be called")
+// GetContainerIDForPID returns a container ID for given PID.
+func (mc *metaCollector) GetContainerIDForPID(pid int, cacheValidity time.Duration) (string, error) {
+	for _, collectorRef := range mc.containerIDFromPIDcollectors {
+		val, err := collectorRef.Collector.GetContainerIDForPID(pid, cacheValidity)
+		if err != nil {
+			return "", err
+		}
+
+		if val != "" {
+			return val, nil
+		}
+	}
+
+	return "", nil
 }
 
-func (mc *metaCollector) GetContainerStats(containerID string, cacheValidity time.Duration) (*ContainerStats, error) { //nolint:revive // TODO fix revive unused-parameter
-	panic("Should never be called")
-}
+func buildUniqueCollectors[T comparable](collectorsCatalog CollectorCatalog, getter func(*Collectors) CollectorRef[T]) []CollectorRef[T] {
+	// We don't need to optimize performances too much as this is called only a handful of times
+	var zero T
+	uniqueCollectors := make(map[CollectorRef[T]]struct{})
+	var sortedCollectors []CollectorRef[T]
 
-func (mc *metaCollector) GetContainerNetworkStats(containerID string, cacheValidity time.Duration) (*ContainerNetworkStats, error) { //nolint:revive // TODO fix revive unused-parameter
-	panic("Should never be called")
+	for _, collectors := range collectorsCatalog {
+		if collectors != nil {
+			collectorRef := getter(collectors)
+			if collectorRef.Collector != zero {
+				uniqueCollectors[collectorRef] = struct{}{}
+			}
+		}
+	}
+
+	for collectorRef := range uniqueCollectors {
+		sortedCollectors = append(sortedCollectors, collectorRef)
+	}
+
+	sort.Slice(sortedCollectors, func(i, j int) bool {
+		return sortedCollectors[i].Priority < sortedCollectors[j].Priority
+	})
+
+	return sortedCollectors
 }

--- a/pkg/util/containers/metrics/provider/metacollector_test.go
+++ b/pkg/util/containers/metrics/provider/metacollector_test.go
@@ -13,21 +13,21 @@ import (
 )
 
 func TestMetaCollector(t *testing.T) {
-	actualCollector1 := dummyCollector{
+	actualCollector1 := &dummyCollector{
 		id: "foo1",
 		cIDForPID: map[int]string{
 			1: "foo1",
 		},
 		selfContainerID: "agent1",
 	}
-	actualCollector2 := dummyCollector{
+	actualCollector2 := &dummyCollector{
 		id: "foo2",
 		cIDForPID: map[int]string{
 			2: "foo2",
 		},
 		selfContainerID: "agent2",
 	}
-	actualCollector3 := dummyCollector{
+	actualCollector3 := &dummyCollector{
 		id: "foo3",
 		cIDForPID: map[int]string{
 			3: "",
@@ -35,12 +35,29 @@ func TestMetaCollector(t *testing.T) {
 		err: errors.New("FailingCollector"),
 	}
 
-	collectors := []*collectorReference{
-		{id: actualCollector1.id, priority: 0, collector: actualCollector1},
-		{id: actualCollector2.id, priority: 1, collector: actualCollector2},
-	}
-
-	metaCollector := newMetaCollector(func() []*collectorReference { return collectors })
+	metaCollector := newMetaCollector()
+	metaCollector.collectorsUpdatedCallback(CollectorCatalog{
+		RuntimeNameContainerd: &Collectors{
+			ContainerIDForPID: CollectorRef[ContainerIDForPIDRetriever]{
+				Collector: actualCollector1,
+				Priority:  0,
+			},
+			SelfContainerID: CollectorRef[SelfContainerIDRetriever]{
+				Collector: actualCollector1,
+				Priority:  0,
+			},
+		},
+		RuntimeNameDocker: &Collectors{
+			ContainerIDForPID: CollectorRef[ContainerIDForPIDRetriever]{
+				Collector: actualCollector2,
+				Priority:  1,
+			},
+			SelfContainerID: CollectorRef[SelfContainerIDRetriever]{
+				Collector: actualCollector2,
+				Priority:  1,
+			},
+		},
+	})
 
 	cID1, err := metaCollector.GetContainerIDForPID(1, 0)
 	assert.NoError(t, err)
@@ -55,7 +72,40 @@ func TestMetaCollector(t *testing.T) {
 	assert.Equal(t, "", cID3)
 
 	// Add the failing collector
-	collectors = append(collectors, &collectorReference{id: actualCollector3.id, priority: 2, collector: actualCollector3})
+	metaCollector.collectorsUpdatedCallback(
+		CollectorCatalog{
+			RuntimeNameContainerd: &Collectors{
+				ContainerIDForPID: CollectorRef[ContainerIDForPIDRetriever]{
+					Collector: actualCollector1,
+					Priority:  0,
+				},
+				SelfContainerID: CollectorRef[SelfContainerIDRetriever]{
+					Collector: actualCollector1,
+					Priority:  0,
+				},
+			},
+			RuntimeNameDocker: &Collectors{
+				ContainerIDForPID: CollectorRef[ContainerIDForPIDRetriever]{
+					Collector: actualCollector2,
+					Priority:  1,
+				},
+				SelfContainerID: CollectorRef[SelfContainerIDRetriever]{
+					Collector: actualCollector2,
+					Priority:  1,
+				},
+			},
+			RuntimeNameCRIO: &Collectors{
+				ContainerIDForPID: CollectorRef[ContainerIDForPIDRetriever]{
+					Collector: actualCollector3,
+					Priority:  2,
+				},
+				SelfContainerID: CollectorRef[SelfContainerIDRetriever]{
+					Collector: actualCollector3,
+					Priority:  2,
+				},
+			},
+		},
+	)
 
 	cID4, err := metaCollector.GetContainerIDForPID(50, 0)
 	assert.Equal(t, err, actualCollector3.err)

--- a/pkg/util/containers/metrics/provider/mock.go
+++ b/pkg/util/containers/metrics/provider/mock.go
@@ -39,27 +39,27 @@ func (d *dummyCollector) constructor(priority uint8, runtimes ...Runtime) (Colle
 	return metadata, d.err
 }
 
-func (d *dummyCollector) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerStats, error) {
+func (d *dummyCollector) GetContainerStats(containerNS, containerID string, _ time.Duration) (*ContainerStats, error) {
 	return d.cStats[containerNS+containerID], d.err
 }
 
-func (d *dummyCollector) GetContainerPIDStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerPIDStats, error) {
+func (d *dummyCollector) GetContainerPIDStats(containerNS, containerID string, _ time.Duration) (*ContainerPIDStats, error) {
 	return d.cPIDStats[containerNS+containerID], d.err
 }
 
-func (d *dummyCollector) GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error) {
+func (d *dummyCollector) GetContainerOpenFilesCount(containerNS, containerID string, _ time.Duration) (*uint64, error) {
 	return d.cOpenFilesCount[containerNS+containerID], d.err
 }
 
-func (d *dummyCollector) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerNetworkStats, error) {
+func (d *dummyCollector) GetContainerNetworkStats(containerNS, containerID string, _ time.Duration) (*ContainerNetworkStats, error) {
 	return d.cNetStats[containerNS+containerID], d.err
 }
 
-func (d *dummyCollector) GetContainerIDForPID(pid int, cacheValidity time.Duration) (string, error) {
+func (d *dummyCollector) GetContainerIDForPID(pid int, _ time.Duration) (string, error) {
 	return d.cIDForPID[pid], d.err
 }
 
-func (d *dummyCollector) GetPIDs(containerNS, containerID string, cacheValidity time.Duration) ([]int, error) {
+func (d *dummyCollector) GetPIDs(containerNS, containerID string, _ time.Duration) ([]int, error) {
 	return d.cPIDs[containerNS+containerID], nil
 }
 

--- a/pkg/util/containers/metrics/provider/mock.go
+++ b/pkg/util/containers/metrics/provider/mock.go
@@ -3,16 +3,21 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
+
 package provider
 
 import (
 	"time"
 )
 
+var _ Collector = &dummyCollector{}
+
 type dummyCollector struct {
 	id              string
 	cStats          map[string]*ContainerStats
 	cPIDStats       map[string]*ContainerPIDStats
+	cPIDs           map[string][]int
 	cOpenFilesCount map[string]*uint64
 	cNetStats       map[string]*ContainerNetworkStats
 	cIDForPID       map[int]string
@@ -20,30 +25,74 @@ type dummyCollector struct {
 	err             error
 }
 
-func (d dummyCollector) ID() string {
-	return d.id
+func (d *dummyCollector) constructor(priority uint8, runtimes ...Runtime) (CollectorMetadata, error) {
+	metadata := CollectorMetadata{
+		ID:         d.id,
+		Collectors: make(CollectorCatalog),
+	}
+	collectors := d.getCollectors(priority)
+
+	for _, runtime := range runtimes {
+		metadata.Collectors[runtime] = collectors
+	}
+
+	return metadata, d.err
 }
 
-func (d dummyCollector) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerStats, error) { //nolint:revive // TODO fix revive unused-parameter
+func (d *dummyCollector) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerStats, error) {
 	return d.cStats[containerNS+containerID], d.err
 }
 
-func (d dummyCollector) GetContainerPIDStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerPIDStats, error) { //nolint:revive // TODO fix revive unused-parameter
+func (d *dummyCollector) GetContainerPIDStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerPIDStats, error) {
 	return d.cPIDStats[containerNS+containerID], d.err
 }
 
-func (d dummyCollector) GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error) { //nolint:revive // TODO fix revive unused-parameter
+func (d *dummyCollector) GetContainerOpenFilesCount(containerNS, containerID string, cacheValidity time.Duration) (*uint64, error) {
 	return d.cOpenFilesCount[containerNS+containerID], d.err
 }
 
-func (d dummyCollector) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerNetworkStats, error) { //nolint:revive // TODO fix revive unused-parameter
+func (d *dummyCollector) GetContainerNetworkStats(containerNS, containerID string, cacheValidity time.Duration) (*ContainerNetworkStats, error) {
 	return d.cNetStats[containerNS+containerID], d.err
 }
 
-func (d dummyCollector) GetContainerIDForPID(pid int, cacheValidity time.Duration) (string, error) { //nolint:revive // TODO fix revive unused-parameter
+func (d *dummyCollector) GetContainerIDForPID(pid int, cacheValidity time.Duration) (string, error) {
 	return d.cIDForPID[pid], d.err
 }
 
-func (d dummyCollector) GetSelfContainerID() (string, error) {
+func (d *dummyCollector) GetPIDs(containerNS, containerID string, cacheValidity time.Duration) ([]int, error) {
+	return d.cPIDs[containerNS+containerID], nil
+}
+
+func (d *dummyCollector) GetSelfContainerID() (string, error) {
 	return d.selfContainerID, nil
+}
+
+// Helpers not part of Collector interface
+func (d *dummyCollector) getCollectors(priority uint8) *Collectors {
+	return &Collectors{
+		Stats: CollectorRef[ContainerStatsGetter]{
+			Collector: d,
+			Priority:  priority,
+		},
+		Network: CollectorRef[ContainerNetworkStatsGetter]{
+			Collector: d,
+			Priority:  priority,
+		},
+		OpenFilesCount: CollectorRef[ContainerOpenFilesCountGetter]{
+			Collector: d,
+			Priority:  priority,
+		},
+		PIDs: CollectorRef[ContainerPIDsGetter]{
+			Collector: d,
+			Priority:  priority,
+		},
+		ContainerIDForPID: CollectorRef[ContainerIDForPIDRetriever]{
+			Collector: d,
+			Priority:  priority,
+		},
+		SelfContainerID: CollectorRef[SelfContainerIDRetriever]{
+			Collector: d,
+			Priority:  priority,
+		},
+	}
 }

--- a/pkg/util/containers/metrics/provider/provider.go
+++ b/pkg/util/containers/metrics/provider/provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
 )
 
+// Runtime is a typed string for supported container runtimes
 type Runtime string
 
 // Known container runtimes

--- a/pkg/util/containers/metrics/provider/provider.go
+++ b/pkg/util/containers/metrics/provider/provider.go
@@ -9,29 +9,23 @@
 package provider
 
 import (
+	"context"
 	"errors"
-	"sort"
 	"sync"
-	"time"
 
-	"go.uber.org/atomic"
-
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
 )
 
+type Runtime string
+
 // Known container runtimes
 const (
-	RuntimeNameDocker     string = "docker"
-	RuntimeNameContainerd string = "containerd"
-	RuntimeNameCRIO       string = "cri-o"
-	RuntimeNameGarden     string = "garden"
-	RuntimeNamePodman     string = "podman"
-	RuntimeNameECSFargate string = "ecsfargate"
-)
-
-const (
-	minRetryInterval = 2 * time.Second
+	RuntimeNameDocker     Runtime = "docker"
+	RuntimeNameContainerd Runtime = "containerd"
+	RuntimeNameCRIO       Runtime = "cri-o"
+	RuntimeNameGarden     Runtime = "garden"
+	RuntimeNamePodman     Runtime = "podman"
+	RuntimeNameECSFargate Runtime = "ecsfargate"
 )
 
 var (
@@ -51,20 +45,22 @@ var (
 	}
 
 	// AllLinuxRuntimes lists all runtimes available on Linux
-	//nolint: deadcode, unused
-	AllLinuxRuntimes = []string{
+	// nolint: deadcode, unused
+	AllLinuxRuntimes = []Runtime{
 		RuntimeNameDocker,
 		RuntimeNameContainerd,
 		RuntimeNameCRIO,
 		RuntimeNameGarden,
 		RuntimeNamePodman,
+		RuntimeNameECSFargate,
 	}
 
 	// AllWindowsRuntimes lists all runtimes available on Windows
-	//nolint: deadcode, unused
-	AllWindowsRuntimes = []string{
+	// nolint: deadcode, unused
+	AllWindowsRuntimes = []Runtime{
 		RuntimeNameDocker,
 		RuntimeNameContainerd,
+		RuntimeNameECSFargate,
 	}
 )
 
@@ -72,52 +68,35 @@ var (
 type Provider interface {
 	GetCollector(runtime string) Collector
 	GetMetaCollector() MetaCollector
-	RegisterCollector(collectorMeta CollectorMetadata)
 }
 
-type collectorFactory func() (Collector, error)
-
-// CollectorMetadata contains the characteristics of a collector to be registered with RegisterCollector
-type CollectorMetadata struct {
-	ID            string
-	Priority      int // lowest gets higher priority (0 more prioritary than 1)
-	Runtimes      []string
-	Factory       collectorFactory
-	DelegateCache bool
-}
-
-type collectorReference struct {
-	id        string
-	priority  int
-	collector Collector
-}
+var (
+	metricsProvider     *GenericProvider
+	initMetricsProvider sync.Once
+)
 
 // GenericProvider offers an interface to retrieve a metrics collector
 type GenericProvider struct {
-	collectors              map[string]CollectorMetadata // key is catalogEntry.id
-	collectorsLock          sync.Mutex
-	effectiveCollectors     map[string]*collectorReference // key is runtime
-	effectiveCollectorsList []*collectorReference
-	effectiveLock           sync.RWMutex
-	lastRetryTimestamp      time.Time
-	remainingCandidates     *atomic.Uint32
-	metaCollector           MetaCollector
+	collectors    map[Runtime]*collectorImpl
+	cache         *Cache
+	metaCollector *metaCollector
 }
-
-var metricsProvider = newProvider()
 
 // GetProvider returns the metrics provider singleton
 func GetProvider() Provider {
+	initMetricsProvider.Do(func() {
+		metricsProvider = newProvider()
+	})
+
 	return metricsProvider
 }
 
 func newProvider() *GenericProvider {
 	provider := &GenericProvider{
-		collectors:          make(map[string]CollectorMetadata),
-		effectiveCollectors: make(map[string]*collectorReference),
-		remainingCandidates: atomic.NewUint32(0),
+		cache:         NewCache(cacheGCInterval),
+		metaCollector: newMetaCollector(),
 	}
-	provider.metaCollector = newMetaCollector(provider.getCollectors)
+	registry.run(context.TODO(), provider.cache, provider.collectorsUpdatedCallback)
 
 	return provider
 }
@@ -126,8 +105,7 @@ func newProvider() *GenericProvider {
 // The best collector may change depending on other collectors availability.
 // You should not cache the result from this function.
 func (mp *GenericProvider) GetCollector(runtime string) Collector {
-	mp.retryCollectors(minRetryInterval)
-	return mp.getCollector(runtime)
+	return mp.collectors[Runtime(runtime)]
 }
 
 // GetMetaCollector returns the meta collector.
@@ -135,100 +113,15 @@ func (mp *GenericProvider) GetMetaCollector() MetaCollector {
 	return mp.metaCollector
 }
 
-// RegisterCollector registers a collector
-func (mp *GenericProvider) RegisterCollector(collectorMeta CollectorMetadata) {
-	mp.collectorsLock.Lock()
-	defer mp.collectorsLock.Unlock()
-
-	mp.collectors[collectorMeta.ID] = collectorMeta
-	mp.remainingCandidates.Store(uint32(len(mp.collectors)))
-}
-
-func (mp *GenericProvider) getCollector(runtime string) Collector {
-	mp.effectiveLock.RLock()
-	defer mp.effectiveLock.RUnlock()
-
-	if entry, found := mp.effectiveCollectors[runtime]; found {
-		return entry.collector
+func (mp *GenericProvider) collectorsUpdatedCallback(collectorsCatalog CollectorCatalog) {
+	// Update local collectors
+	newCollectors := make(map[Runtime]*collectorImpl, len(collectorsCatalog))
+	for runtime, collectors := range collectorsCatalog {
+		newCollectors[runtime] = fromCollectors(collectors)
 	}
 
-	return nil
-}
+	mp.collectors = newCollectors
 
-func (mp *GenericProvider) getCollectors() []*collectorReference {
-	mp.retryCollectors(minRetryInterval)
-	return mp.effectiveCollectorsList
-}
-
-func (mp *GenericProvider) retryCollectors(cacheValidity time.Duration) {
-	if mp.remainingCandidates.Load() == 0 {
-		return
-	}
-
-	mp.collectorsLock.Lock()
-	defer mp.collectorsLock.Unlock()
-
-	currentTime := time.Now()
-
-	// Only refresh if last attempt is too old (incl. processing time)
-	if currentTime.Sub(mp.lastRetryTimestamp) < cacheValidity {
-		return
-	}
-
-	mp.lastRetryTimestamp = currentTime
-
-	for _, collectorEntry := range mp.collectors {
-		collector, err := collectorEntry.Factory()
-		if err == nil {
-			if collectorEntry.DelegateCache {
-				collector = NewCollectorCache(collector)
-			}
-
-			mp.updateEffectiveCollectors(collector, collectorEntry)
-			delete(mp.collectors, collectorEntry.ID)
-		} else {
-			if errors.Is(err, ErrPermaFail) {
-				delete(mp.collectors, collectorEntry.ID)
-				log.Debugf("Metrics collector: %s went into PermaFail, removed from candidates", collectorEntry.ID)
-			}
-		}
-	}
-
-	mp.remainingCandidates.Store(uint32(len(mp.collectors)))
-}
-
-func (mp *GenericProvider) updateEffectiveCollectors(newCollector Collector, newCollectorDesc CollectorMetadata) {
-	mp.effectiveLock.Lock()
-	defer mp.effectiveLock.Unlock()
-
-	newRef := collectorReference{
-		id:        newCollectorDesc.ID,
-		priority:  newCollectorDesc.Priority,
-		collector: newCollector,
-	}
-
-	for _, runtime := range newCollectorDesc.Runtimes {
-		currentCollector := mp.effectiveCollectors[runtime]
-		if currentCollector == nil {
-			log.Infof("Using metrics collector: %s for runtime: %s", newRef.id, runtime)
-			mp.effectiveCollectors[runtime] = &newRef
-		} else if currentCollector.priority > newCollectorDesc.Priority { // do not replace on same priority to favor consistency
-			log.Infof("Replaced old collector: %s by new collector: %s for runtime: %s", currentCollector.id, newRef.id, runtime)
-			mp.effectiveCollectors[runtime] = &newRef
-		}
-	}
-
-	// Compute unique, ordered list of collectors to be used by metaCollector
-	uniqueCollectors := make(map[string]struct{})
-	var effectiveCollectorsList []*collectorReference
-	for _, collector := range mp.effectiveCollectors {
-		if _, found := uniqueCollectors[collector.id]; !found {
-			uniqueCollectors[collector.id] = struct{}{}
-			effectiveCollectorsList = append(effectiveCollectorsList, collector)
-		}
-	}
-	sort.Slice(effectiveCollectorsList, func(i, j int) bool {
-		return effectiveCollectorsList[i].priority < effectiveCollectorsList[j].priority
-	})
-	mp.effectiveCollectorsList = effectiveCollectorsList
+	// Update metacollectors
+	mp.metaCollector.collectorsUpdatedCallback(collectorsCatalog)
 }

--- a/pkg/util/containers/metrics/provider/provider_test.go
+++ b/pkg/util/containers/metrics/provider/provider_test.go
@@ -1,116 +1,142 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2021-present Datadog, Inc.
 
 package provider
 
 import (
-	"fmt"
 	"testing"
-	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMetricsProvider(t *testing.T) {
-	c := newProvider()
-	assert.Equal(t, nil, c.getCollector("foo"))
+func TestGenericProvider(t *testing.T) {
+	provider := newProvider()
 
-	c.retryCollectors(0)
-	assert.Equal(t, nil, c.getCollector("foo"))
-
-	c.RegisterCollector(CollectorMetadata{
-		ID:       "dummy1",
-		Priority: 10,
-		Runtimes: []string{"foo", "bar", "baz"},
-		Factory: func() (Collector, error) {
-			return dummyCollector{
-				id: "dummy1",
-			}, nil
+	// First collector is going to be priority 1 on stats and 2 on network
+	statsCollector := &dummyCollector{
+		id: "statsNet",
+		cStats: map[string]*ContainerStats{
+			"cID1": {
+				CPU: &ContainerCPUStats{
+					Total: pointer.Ptr(100.0),
+				},
+			},
+			"cID2": {
+				CPU: &ContainerCPUStats{
+					Total: pointer.Ptr(200.0),
+				},
+			},
 		},
-	})
-	c.RegisterCollector(CollectorMetadata{
-		ID:       "dummy2",
-		Priority: 9,
-		Runtimes: []string{"foo"},
-		Factory: func() (Collector, error) {
-			return nil, ErrPermaFail
+		cNetStats: map[string]*ContainerNetworkStats{
+			"cID1": {
+				BytesSent: pointer.Ptr(110.0),
+			},
+			"cID2": {
+				BytesSent: pointer.Ptr(210.0),
+			},
 		},
-	})
+	}
 
-	var dummy3Retries int
-	c.RegisterCollector(CollectorMetadata{
-		ID:       "dummy3",
-		Priority: 9,
-		Runtimes: []string{"baz"},
-		Factory: func() (Collector, error) {
-			if dummy3Retries < 2 {
-				dummy3Retries++
-				return nil, fmt.Errorf("not yet okay")
-			}
-
-			return dummyCollector{
-				id: "dummy3",
-			}, nil
+	// Second collector is going to be implementing process at priority 1 and stats at priority 0 later
+	processCollector := &dummyCollector{
+		id: "process",
+		cStats: map[string]*ContainerStats{
+			"cID1": {
+				CPU: &ContainerCPUStats{
+					Total: pointer.Ptr(200.0),
+				},
+			},
+			"cID2": {
+				CPU: &ContainerCPUStats{
+					Total: pointer.Ptr(400.0),
+				},
+			},
 		},
-	})
+		cOpenFilesCount: map[string]*uint64{
+			"cID1": pointer.Ptr[uint64](10),
+			"cID2": pointer.Ptr[uint64](20),
+		},
+	}
 
-	// No retry, should still fail
-	assert.Equal(t, nil, c.getCollector("foo"))
+	// Verify that at first we get nothing
+	actualCollector := provider.GetCollector(string(RuntimeNameDocker))
+	assert.Nil(t, actualCollector)
 
-	// dummy1 should answer to everything
-	c.retryCollectors(0)
-	fooCollector := c.getCollector("foo")
-	barCollector := c.getCollector("bar")
-	bazCollector := c.getCollector("baz")
-	assert.Equal(t, "dummy1", fooCollector.(dummyCollector).id)
-	assert.Equal(t, "dummy1", barCollector.(dummyCollector).id)
-	assert.Equal(t, "dummy1", bazCollector.(dummyCollector).id)
-
-	// dummy3 still not there, dummy2 never ok
-	c.retryCollectors(0)
-	fooCollector = c.getCollector("foo")
-	barCollector = c.getCollector("bar")
-	bazCollector = c.getCollector("baz")
-	assert.Equal(t, "dummy1", fooCollector.(dummyCollector).id)
-	assert.Equal(t, "dummy1", barCollector.(dummyCollector).id)
-	assert.Equal(t, "dummy1", bazCollector.(dummyCollector).id)
-
-	// dummy3 still not there as retry did not really happen due to cache validity
-	c.retryCollectors(42 * time.Second)
-	fooCollector = c.getCollector("foo")
-	barCollector = c.getCollector("bar")
-	bazCollector = c.getCollector("baz")
-	assert.Equal(t, "dummy1", fooCollector.(dummyCollector).id)
-	assert.Equal(t, "dummy1", barCollector.(dummyCollector).id)
-	assert.Equal(t, "dummy1", bazCollector.(dummyCollector).id)
-
-	c.retryCollectors(0)
-	fooCollector = c.getCollector("foo")
-	barCollector = c.getCollector("bar")
-	bazCollector = c.getCollector("baz")
-	assert.Equal(t, "dummy1", fooCollector.(dummyCollector).id)
-	assert.Equal(t, "dummy1", barCollector.(dummyCollector).id)
-	assert.Equal(t, "dummy3", bazCollector.(dummyCollector).id)
-
-	// Registering a new collector
-	c.RegisterCollector(CollectorMetadata{
-		ID:       "dummy4",
-		Priority: 8,
-		Runtimes: []string{"foo"},
-		Factory: func() (Collector, error) {
-			return dummyCollector{
-				id: "dummy4",
-			}, nil
+	// Register collectors, one is empty (PIDs)
+	provider.collectorsUpdatedCallback(CollectorCatalog{
+		RuntimeNameDocker: &Collectors{
+			Stats: CollectorRef[ContainerStatsGetter]{
+				Collector: statsCollector,
+				Priority:  1,
+			},
+			Network: CollectorRef[ContainerNetworkStatsGetter]{
+				Collector: statsCollector,
+				Priority:  2,
+			},
+			OpenFilesCount: CollectorRef[ContainerOpenFilesCountGetter]{
+				Collector: processCollector,
+				Priority:  1,
+			},
 		},
 	})
 
-	c.retryCollectors(0)
-	fooCollector = c.getCollector("foo")
-	barCollector = c.getCollector("bar")
-	bazCollector = c.getCollector("baz")
-	assert.Equal(t, "dummy4", fooCollector.(dummyCollector).id)
-	assert.Equal(t, "dummy1", barCollector.(dummyCollector).id)
-	assert.Equal(t, "dummy3", bazCollector.(dummyCollector).id)
+	actualCollector = provider.GetCollector(string(RuntimeNameDocker))
+	assert.NotNil(t, actualCollector)
+
+	// Verify that we get the data
+	statsC1, err := actualCollector.GetContainerStats("", "cID1", 0)
+	assert.NoError(t, err)
+	assert.Equal(t, 100.0, *statsC1.CPU.Total)
+
+	statsC2, err := actualCollector.GetContainerStats("", "cID2", 0)
+	assert.NoError(t, err)
+	assert.Equal(t, 200.0, *statsC2.CPU.Total)
+
+	netStatsC1, err := actualCollector.GetContainerNetworkStats("", "cID1", 0)
+	assert.NoError(t, err)
+	assert.Equal(t, 110.0, *netStatsC1.BytesSent)
+
+	netStatsC2, err := actualCollector.GetContainerNetworkStats("", "cID2", 0)
+	assert.NoError(t, err)
+	assert.Equal(t, 210.0, *netStatsC2.BytesSent)
+
+	ofC1, err := actualCollector.GetContainerOpenFilesCount("", "cID1", 0)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 10, *ofC1)
+
+	ofC2, err := actualCollector.GetContainerOpenFilesCount("", "cID2", 0)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 20, *ofC2)
+
+	// Update priority of the second collector
+	provider.collectorsUpdatedCallback(CollectorCatalog{
+		RuntimeNameDocker: &Collectors{
+			Stats: CollectorRef[ContainerStatsGetter]{
+				Collector: processCollector,
+				Priority:  0,
+			},
+			Network: CollectorRef[ContainerNetworkStatsGetter]{
+				Collector: statsCollector,
+				Priority:  2,
+			},
+			OpenFilesCount: CollectorRef[ContainerOpenFilesCountGetter]{
+				Collector: processCollector,
+				Priority:  1,
+			},
+		},
+	})
+
+	actualCollector = provider.GetCollector(string(RuntimeNameDocker))
+	assert.NotNil(t, actualCollector)
+
+	statsC1, err = actualCollector.GetContainerStats("", "cID1", 0)
+	assert.NoError(t, err)
+	assert.Equal(t, 200.0, *statsC1.CPU.Total)
+
+	statsC2, err = actualCollector.GetContainerStats("", "cID2", 0)
+	assert.NoError(t, err)
+	assert.Equal(t, 400.0, *statsC2.CPU.Total)
 }

--- a/pkg/util/containers/metrics/provider/registry.go
+++ b/pkg/util/containers/metrics/provider/registry.go
@@ -120,7 +120,7 @@ func (cr *collectorRegistry) retryCollectors(cache *Cache) int {
 		if err == nil {
 			// No need to register a collector without actual collectors
 			if collectorMetadata.Collectors == nil {
-				log.Debugf("Skipped registering collector %s as no collectors")
+				log.Debugf("Skipped registering collector %s as no collectors", collectorFactory.ID)
 				continue
 			}
 
@@ -135,7 +135,7 @@ func (cr *collectorRegistry) retryCollectors(cache *Cache) int {
 		}
 	}
 
-	if collectorsUpdated {
+	if collectorsUpdated && cr.catalogUpdatedCallback != nil {
 		cr.catalogUpdatedCallback(cr.effectiveCollectors)
 	}
 	return len(cr.registeredCollectors)

--- a/pkg/util/containers/metrics/provider/registry.go
+++ b/pkg/util/containers/metrics/provider/registry.go
@@ -78,14 +78,16 @@ func newCollectorRegistry() *collectorRegistry {
 func (cr *collectorRegistry) run(c context.Context, cache *Cache, catalogUpdatedCallback func(CollectorCatalog)) {
 	cr.discoveryOnce.Do(func() {
 		cr.catalogUpdatedCallback = catalogUpdatedCallback
+
+		// Always run discovery at least once synchronously
+		cr.retryCollectors(cache)
+
+		// Now, we can run the discovery in background
 		go cr.collectorDiscovery(c, cache)
 	})
 }
 
 func (cr *collectorRegistry) collectorDiscovery(c context.Context, cache *Cache) {
-	// Always run discovery at least once synchronously
-	cr.retryCollectors(cache)
-
 	ticker := time.NewTicker(minRetryInterval)
 	for {
 		select {

--- a/pkg/util/containers/metrics/provider/registry.go
+++ b/pkg/util/containers/metrics/provider/registry.go
@@ -1,0 +1,154 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+// Package provider defines the Provider interface which allows to get metrics
+// collectors for the different container runtimes supported (Docker,
+// containerd, etc.).
+package provider
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	minRetryInterval = 2 * time.Second
+)
+
+// CollectorCatalog defines the enabled Collectors for a given runtime
+type CollectorCatalog map[Runtime]*Collectors
+
+func (cc CollectorCatalog) merge(otherID string, othCatalog CollectorCatalog) {
+	for runtime, othCollectors := range othCatalog {
+		if othCollectors == nil {
+			continue
+		}
+
+		currCollectors := cc[runtime]
+		if currCollectors == nil {
+			// We cannot use directly external `currCollectors` as it may be externally modified
+			currCollectors = &Collectors{}
+			cc[runtime] = currCollectors
+		}
+
+		currCollectors.merge(runtime, otherID, othCollectors)
+	}
+}
+
+// CollectorMetadata contains the characteristics of a collector to be registered with RegisterCollector
+type CollectorMetadata struct {
+	ID         string
+	Collectors CollectorCatalog
+}
+
+// CollectorFactory allows to register a factory to dynamically create Collector at startup
+type CollectorFactory struct {
+	ID          string
+	Constructor func(*Cache) (CollectorMetadata, error)
+}
+
+// GenericProvider offers an interface to retrieve a metrics collector
+type collectorRegistry struct {
+	discoveryOnce sync.Once
+
+	catalogUpdatedCallback func(CollectorCatalog)
+
+	registeredCollectors     map[string]CollectorFactory // key is catalogEntry.id
+	registeredCollectorsLock sync.Mutex
+
+	effectiveCollectors CollectorCatalog
+}
+
+func newCollectorRegistry() *collectorRegistry {
+	registry := &collectorRegistry{
+		registeredCollectors: make(map[string]CollectorFactory),
+		effectiveCollectors:  make(CollectorCatalog),
+	}
+
+	return registry
+}
+
+// catalogUpdatedCallback : blocking call in the retryCollectors() function (background goroutine)
+func (cr *collectorRegistry) run(c context.Context, cache *Cache, catalogUpdatedCallback func(CollectorCatalog)) {
+	cr.discoveryOnce.Do(func() {
+		cr.catalogUpdatedCallback = catalogUpdatedCallback
+		go cr.collectorDiscovery(c, cache)
+	})
+}
+
+func (cr *collectorRegistry) collectorDiscovery(c context.Context, cache *Cache) {
+	// Always run discovery at least once synchronously
+	cr.retryCollectors(cache)
+
+	ticker := time.NewTicker(minRetryInterval)
+	for {
+		select {
+		case <-c.Done():
+			return
+
+		case <-ticker.C:
+			if remainingCollectors := cr.retryCollectors(cache); remainingCollectors == 0 {
+				log.Info("Container metrics provider discovery process finished")
+				return
+			}
+		}
+	}
+}
+
+// RegisterCollector registers a collector
+func (cr *collectorRegistry) registerCollector(collectorFactory CollectorFactory) {
+	cr.registeredCollectorsLock.Lock()
+	defer cr.registeredCollectorsLock.Unlock()
+
+	cr.registeredCollectors[collectorFactory.ID] = collectorFactory
+}
+
+// retryCollectors is not thread safe on purpose. It's only called by a single goroutine from `cr.run`
+func (cr *collectorRegistry) retryCollectors(cache *Cache) int {
+	cr.registeredCollectorsLock.Lock()
+	defer cr.registeredCollectorsLock.Unlock()
+
+	collectorsUpdated := false
+	for _, collectorFactory := range cr.registeredCollectors {
+		collectorMetadata, err := collectorFactory.Constructor(cache)
+		if err == nil {
+			// No need to register a collector without actual collectors
+			if collectorMetadata.Collectors == nil {
+				log.Debugf("Skipped registering collector %s as no collectors")
+				continue
+			}
+
+			cr.effectiveCollectors.merge(collectorMetadata.ID, collectorMetadata.Collectors)
+			collectorsUpdated = true
+			delete(cr.registeredCollectors, collectorFactory.ID)
+		} else {
+			if errors.Is(err, ErrPermaFail) {
+				delete(cr.registeredCollectors, collectorFactory.ID)
+				log.Debugf("Metrics collector: %s went into PermaFail, removed from candidates", collectorFactory.ID)
+			}
+		}
+	}
+
+	if collectorsUpdated {
+		cr.catalogUpdatedCallback(cr.effectiveCollectors)
+	}
+	return len(cr.registeredCollectors)
+}
+
+// Global registry
+var registry *collectorRegistry
+
+func init() {
+	registry = newCollectorRegistry()
+}
+
+// RegisterCollector registers a collector
+func RegisterCollector(collectorFactory CollectorFactory) {
+	registry.registerCollector(collectorFactory)
+}

--- a/pkg/util/containers/metrics/provider/registry_test.go
+++ b/pkg/util/containers/metrics/provider/registry_test.go
@@ -1,0 +1,131 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCollectorRegistry(t *testing.T) {
+	c := newCollectorRegistry()
+
+	assert.Nil(t, c.effectiveCollectors[RuntimeNameDocker])
+
+	// Check for collectors (none are registered, should not change output)
+	c.retryCollectors(nil)
+	assert.Nil(t, c.effectiveCollectors[RuntimeNameDocker])
+
+	c.registerCollector(
+		CollectorFactory{
+			ID: "dummy1",
+			Constructor: func(*Cache) (CollectorMetadata, error) {
+				collector := dummyCollector{
+					id:              "dummy1",
+					selfContainerID: "dummy1",
+				}
+
+				return collector.constructor(10, RuntimeNameDocker, RuntimeNameContainerd, RuntimeNameCRIO)
+			},
+		},
+	)
+
+	c.registerCollector(
+		CollectorFactory{
+			ID: "dummy2",
+			Constructor: func(*Cache) (CollectorMetadata, error) {
+				return CollectorMetadata{}, ErrPermaFail
+			},
+		},
+	)
+
+	var dummy3Retries int
+	c.registerCollector(
+		CollectorFactory{
+			ID: "dummy3",
+			Constructor: func(*Cache) (CollectorMetadata, error) {
+				if dummy3Retries < 2 {
+					dummy3Retries++
+					return CollectorMetadata{}, fmt.Errorf("not yet okay")
+				}
+
+				collector := dummyCollector{
+					id:              "dummy3",
+					selfContainerID: "dummy3",
+				}
+
+				return collector.constructor(9, RuntimeNameCRIO)
+			},
+		},
+	)
+
+	// No retry, should still fail
+	assert.Nil(t, c.effectiveCollectors[RuntimeNameDocker])
+
+	// dummy1 should answer to everything
+	assertCollectors := func(expected map[Runtime]string) {
+		actual := make(map[Runtime]string)
+
+		for _, runtime := range []Runtime{RuntimeNameDocker, RuntimeNameContainerd, RuntimeNameCRIO} {
+			val, err := c.effectiveCollectors[runtime].SelfContainerID.Collector.GetSelfContainerID()
+			assert.NoError(t, err)
+			actual[runtime] = val
+		}
+
+		assert.Equal(t, expected, actual)
+	}
+
+	collectorsToRetry := c.retryCollectors(nil)
+	assert.Equal(t, 1, collectorsToRetry)
+	assertCollectors(map[Runtime]string{
+		RuntimeNameDocker:     "dummy1",
+		RuntimeNameContainerd: "dummy1",
+		RuntimeNameCRIO:       "dummy1",
+	})
+
+	// dummy3 still not there, dummy2 never ok
+	collectorsToRetry = c.retryCollectors(nil)
+	assert.Equal(t, 1, collectorsToRetry)
+	assertCollectors(map[Runtime]string{
+		RuntimeNameDocker:     "dummy1",
+		RuntimeNameContainerd: "dummy1",
+		RuntimeNameCRIO:       "dummy1",
+	})
+
+	// dummy3 should pop up
+	collectorsToRetry = c.retryCollectors(nil)
+	assert.Equal(t, 0, collectorsToRetry)
+	assertCollectors(map[Runtime]string{
+		RuntimeNameDocker:     "dummy1",
+		RuntimeNameContainerd: "dummy1",
+		RuntimeNameCRIO:       "dummy3",
+	})
+
+	// Registering a new collector
+	c.registerCollector(
+		CollectorFactory{
+			ID: "dummy4",
+			Constructor: func(*Cache) (CollectorMetadata, error) {
+				collector := dummyCollector{
+					id:              "dummy4",
+					selfContainerID: "dummy4",
+				}
+
+				return collector.constructor(8, RuntimeNameDocker)
+			},
+		},
+	)
+
+	collectorsToRetry = c.retryCollectors(nil)
+	assert.Equal(t, 0, collectorsToRetry)
+	assertCollectors(map[Runtime]string{
+		RuntimeNameDocker:     "dummy4",
+		RuntimeNameContainerd: "dummy1",
+		RuntimeNameCRIO:       "dummy3",
+	})
+}

--- a/pkg/util/containers/metrics/provider/types.go
+++ b/pkg/util/containers/metrics/provider/types.go
@@ -81,7 +81,6 @@ type ContainerIOStats struct {
 // ContainerPIDStats stores stats about threads & processes.
 type ContainerPIDStats struct {
 	// Common fields
-	PIDs        []int
 	ThreadCount *float64
 	ThreadLimit *float64
 }

--- a/pkg/util/containers/metrics/system/collector_linux.go
+++ b/pkg/util/containers/metrics/system/collector_linux.go
@@ -25,19 +25,18 @@ import (
 )
 
 const (
-	systemCollectorID      = "system"
-	cgroupV1BaseController = "memory"
+	collectorHighPriority  uint8 = 0
+	collectorLowPriority   uint8 = 10
+	systemCollectorID            = "system"
+	cgroupV1BaseController       = "memory"
 )
 
 func init() {
-	provider.GetProvider().RegisterCollector(provider.CollectorMetadata{
-		ID:       systemCollectorID,
-		Priority: 0,
-		Runtimes: provider.AllLinuxRuntimes,
-		Factory: func() (provider.Collector, error) {
-			return newSystemCollector()
+	provider.RegisterCollector(provider.CollectorFactory{
+		ID: systemCollectorID,
+		Constructor: func(cache *provider.Cache) (provider.CollectorMetadata, error) {
+			return newSystemCollector(cache)
 		},
-		DelegateCache: true,
 	})
 }
 
@@ -48,14 +47,10 @@ type systemCollector struct {
 	hostCgroupNamespace bool
 }
 
-func newSystemCollector() (*systemCollector, error) {
+func newSystemCollector(cache *provider.Cache) (provider.CollectorMetadata, error) {
 	var err error
 	var hostPrefix string
-
-	if !config.IsHostProcAvailable() || !config.IsHostSysAvailable() {
-		log.Debug("Container metrics system collector not available as host paths not mounted")
-		return nil, provider.ErrPermaFail
-	}
+	var collectorMetadata provider.CollectorMetadata
 
 	procPath := config.Datadog.GetString("container_proc_root")
 	if strings.HasPrefix(procPath, "/host") {
@@ -71,7 +66,7 @@ func newSystemCollector() (*systemCollector, error) {
 	if err != nil {
 		// Cgroup provider is pretty static. Except not having required mounts, it should always work.
 		log.Errorf("Unable to initialize cgroup provider (cgroups not mounted?), err: %v", err)
-		return nil, provider.ErrPermaFail
+		return collectorMetadata, provider.ErrPermaFail
 	}
 
 	systemCollector := &systemCollector{
@@ -94,11 +89,70 @@ func newSystemCollector() (*systemCollector, error) {
 		}
 	}
 
-	return systemCollector, nil
-}
+	// Build available Collectors based on environment
+	var collectors *provider.Collectors
+	if config.IsContainerized() {
+		collectors = &provider.Collectors{}
 
-func (c *systemCollector) ID() string {
-	return systemCollectorID
+		// When the Agent runs as a sidecar (e.g. Fargate) with shared PID namespace, we can use the system collector in some cases.
+		// TODO: Check how we could detect shared PID namespace instead of makeing assumption
+		isAgentSidecar := config.IsFeaturePresent(config.ECSFargate) || config.IsFeaturePresent(config.EKSFargate)
+
+		// With sysfs we can always get cgroup stats
+		if config.IsHostSysAvailable() {
+			collectors.Stats = provider.MakeRef[provider.ContainerStatsGetter](systemCollector, collectorHighPriority)
+		}
+
+		// With host proc we can always get network stats and pids
+		if config.IsHostProcAvailable() {
+			collectors.Network = provider.MakeRef[provider.ContainerNetworkStatsGetter](systemCollector, collectorHighPriority)
+			collectors.OpenFilesCount = provider.MakeRef[provider.ContainerOpenFilesCountGetter](systemCollector, collectorHighPriority)
+			collectors.PIDs = provider.MakeRef[provider.ContainerPIDsGetter](systemCollector, collectorHighPriority)
+			collectors.ContainerIDForPID = provider.MakeRef[provider.ContainerIDForPIDRetriever](systemCollector, collectorHighPriority)
+		} else if isAgentSidecar {
+			// When side car with sharedPIDNamespace, we can get the same data.
+			// As we don't know if we are sharedPIDNamespace, adding as low priority.
+			collectors.Network = provider.MakeRef[provider.ContainerNetworkStatsGetter](systemCollector, collectorLowPriority)
+			collectors.OpenFilesCount = provider.MakeRef[provider.ContainerOpenFilesCountGetter](systemCollector, collectorLowPriority)
+			collectors.PIDs = provider.MakeRef[provider.ContainerPIDsGetter](systemCollector, collectorLowPriority)
+			collectors.ContainerIDForPID = provider.MakeRef[provider.ContainerIDForPIDRetriever](systemCollector, collectorLowPriority)
+		}
+
+		// We can retrieve self PID with cgroupv1 or cgroupv2 with host ns
+		// We may be able to get it in some case from cgroupv2 from mountinfo
+		if reader.CgroupVersion() == 1 || systemCollector.hostCgroupNamespace {
+			collectors.SelfContainerID = provider.MakeRef[provider.SelfContainerIDRetriever](systemCollector, collectorHighPriority)
+		} else {
+			collectors.SelfContainerID = provider.MakeRef[provider.SelfContainerIDRetriever](systemCollector, collectorLowPriority)
+		}
+	} else {
+		// When not running in a container, we can use everything
+		collectors = &provider.Collectors{
+			Stats:             provider.MakeRef[provider.ContainerStatsGetter](systemCollector, collectorHighPriority),
+			Network:           provider.MakeRef[provider.ContainerNetworkStatsGetter](systemCollector, collectorHighPriority),
+			OpenFilesCount:    provider.MakeRef[provider.ContainerOpenFilesCountGetter](systemCollector, collectorHighPriority),
+			PIDs:              provider.MakeRef[provider.ContainerPIDsGetter](systemCollector, collectorHighPriority),
+			ContainerIDForPID: provider.MakeRef[provider.ContainerIDForPIDRetriever](systemCollector, collectorHighPriority),
+			SelfContainerID:   provider.MakeRef[provider.SelfContainerIDRetriever](systemCollector, collectorHighPriority),
+		}
+	}
+	log.Debugf("Chosen system collectors: %+v", collectors)
+
+	// Build metadata
+	metadata := provider.CollectorMetadata{
+		ID:         systemCollectorID,
+		Collectors: make(provider.CollectorCatalog),
+	}
+
+	// Always cache results
+	collectors = provider.MakeCached(systemCollectorID, cache, collectors)
+
+	// Finally add to catalog
+	for _, runtime := range provider.AllLinuxRuntimes {
+		metadata.Collectors[runtime] = collectors
+	}
+
+	return metadata, nil
 }
 
 func (c *systemCollector) GetContainerStats(containerNS, containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) { //nolint:revive // TODO fix revive unused-parameter
@@ -144,7 +198,21 @@ func (c *systemCollector) GetContainerNetworkStats(containerNS, containerID stri
 	return buildNetworkStats(c.procPath, pids)
 }
 
-func (c *systemCollector) GetContainerIDForPID(pid int, cacheValidity time.Duration) (string, error) { //nolint:revive // TODO fix revive unused-parameter
+func (c *systemCollector) GetPIDs(containerNS, containerID string, cacheValidity time.Duration) ([]int, error) {
+	cg, err := c.getCgroup(containerID, cacheValidity)
+	if err != nil {
+		return nil, err
+	}
+
+	pids, err := cg.GetPIDs(cacheValidity)
+	if err != nil {
+		log.Debugf("Unable to get PIDs for cgroup id: %s. Metrics will be missing", cg.Identifier())
+	}
+
+	return pids, err
+}
+
+func (c *systemCollector) GetContainerIDForPID(pid int, cacheValidity time.Duration) (string, error) {
 	containerID, err := cgroups.IdentiferFromCgroupReferences(c.procPath, strconv.Itoa(pid), c.baseController, cgroups.ContainerFilter)
 	return containerID, err
 }
@@ -197,19 +265,6 @@ func (c *systemCollector) buildContainerMetrics(cg cgroups.Cgroup, cacheValidity
 		CPU:       buildCPUStats(stats.CPU, parentCPUStatRetriever),
 		IO:        buildIOStats(c.procPath, stats.IO),
 		PID:       buildPIDStats(stats.PID),
-	}
-
-	// Get PIDs
-	var err error
-	pids, err := cg.GetPIDs(cacheValidity)
-	if err == nil {
-		if cs.PID == nil {
-			cs.PID = &provider.ContainerPIDStats{}
-		}
-
-		cs.PID.PIDs = pids
-	} else {
-		log.Debugf("Unable to get PIDs for cgroup id: %s. Metrics will be missing", cg.Identifier())
 	}
 
 	return cs, nil

--- a/pkg/util/containers/metrics/system/collector_linux_test.go
+++ b/pkg/util/containers/metrics/system/collector_linux_test.go
@@ -130,7 +130,6 @@ func TestBuildContainerMetrics(t *testing.T) {
 					PartialStallTime: pointer.Ptr(98000.0),
 				},
 				PID: &provider.ContainerPIDStats{
-					PIDs:        []int{4, 2},
 					ThreadCount: pointer.Ptr(10.0),
 					ThreadLimit: pointer.Ptr(20.0),
 				},

--- a/releasenotes/notes/fix-pid-container-mapping-057f1c8baf0b9411.yaml
+++ b/releasenotes/notes/fix-pid-container-mapping-057f1c8baf0b9411.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fix an issue that prevented process id (PID) to be associated with containers in Live Container View when the Agent is deployed in AWS Fargate.

--- a/releasenotes/notes/fix-pid-container-mapping-057f1c8baf0b9411.yaml
+++ b/releasenotes/notes/fix-pid-container-mapping-057f1c8baf0b9411.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    Fix an issue that prevented process id (PID) to be associated with containers in Live Container View when the Agent is deployed in AWS Fargate.
+    Fix an issue that prevented process ID (PID) from being associated with containers in Live Container View when the Agent is deployed in AWS Fargate.


### PR DESCRIPTION
### What does this PR do?

This change introduce a new logic in generic metrics provider that allows to use different collectors for different methods of the `Collector` interface.

This allows to, say, get `ContainerStats` from the Kubelet and `GetPIDs` from the system collector.

### Motivation

Fix Container<>PID mapping in environments where the Agent runs as a side car with shared PID namespace but without access to a shared or host cgroup namespace (for instance, Fargate)

### Additional Notes

This change is a significant architectural change inside the metrics provider (even though it's not visible from outside the package).
As such, we need to be extra careful during QA.

### Possible Drawbacks / Trade-offs

We define single method interfaces instead of type alias on fonction signature. This is because functions are non comparable in Go, making it impossible to implement the meta collector in a way that would avoid calling multiple times the same function.

### Describe how to test/QA your changes

Deploy on EKS Fargate with shared PID namespace: the processes of each container should be visible in the Live Container View.
Deploy on ECS Fargate with shared PID namespace (new option), verify the same thing.

Non-regression QA: the generic metrics provider is used in all environments, be extra careful about `container` metrics.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
