### PR TITLE
Remove KUBERNETES_SERVICE_ACCOUNT_OVERWRITE as no more used

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,8 +95,6 @@ stages:
   - notify
 
 variables:
-  #Do not change this - must be the repository name for Kubernetes runners to work
-  KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: "datadog-agent"
   # Directory in which we execute the omnibus build.
   # For an unknown reason, it does not go well with
   # a ruby dependency if we build directly into $CI_PROJECT_DIR/.omnibus

--- a/.gitlab/benchmarks/benchmarks.yml
+++ b/.gitlab/benchmarks/benchmarks.yml
@@ -20,5 +20,4 @@ benchmark:
       - reports/
     expire_in: 3 months
   variables:
-    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: datadog-agent
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -27,7 +27,6 @@ variables:
   variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true" # Important tweak for stability of benchmarks
     K6_RUN_ID_PREFIX: ci
-    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: datadog-agent
 
     # Uncomment to force k8s memory limits for CI job container.
     # KUBERNETES_MEMORY_REQUEST: "4Gi"

--- a/tasks/unit-tests/testdata/fake_gitlab-ci.yml
+++ b/tasks/unit-tests/testdata/fake_gitlab-ci.yml
@@ -83,8 +83,6 @@ stages:
   - notify
 
 variables:
-  #Do not change this - must be the repository name for Kubernetes runners to work
-  KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: "datadog-agent"
   # Directory in which we execute the omnibus build.
   # For an unknown reason, it does not go well with
   # a ruby dependency if we build directly into $CI_PROJECT_DIR/.omnibus


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Remove useless variable
```
WARNING: KUBERNETES_SERVICE_ACCOUNT_OVERWRITE variable is no longer used.
WARNING: The service account is now auto-assigned.
```
See message in [this job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/352666840) for instance
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Remove a warning
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
