### PR TITLE
Updates file to blackhole to rescan disk every 1 second and rotate logs every 2 seconds

### DIFF
--- a/test/regression/cases/file_to_blackhole/datadog-agent/datadog.yaml
+++ b/test/regression/cases/file_to_blackhole/datadog-agent/datadog.yaml
@@ -10,3 +10,4 @@ cloud_provider_metadata: []
 logs_enabled: true
 logs_config:
   logs_dd_url: 127.0.0.1:9091
+  file_scan_period: 1

--- a/test/regression/cases/file_to_blackhole/datadog-agent/datadog.yaml
+++ b/test/regression/cases/file_to_blackhole/datadog-agent/datadog.yaml
@@ -11,3 +11,4 @@ logs_enabled: true
 logs_config:
   logs_dd_url: 127.0.0.1:9091
   file_scan_period: 1
+  logs_no_ssl: true

--- a/test/regression/cases/file_to_blackhole/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole/lading/lading.yaml
@@ -6,7 +6,7 @@ generator:
       duplicates: 4
       variant: "ascii"
       bytes_per_second: "100Mb"
-      maximum_bytes_per_file: "100Mb"
+      maximum_bytes_per_file: "200Mb"
       maximum_prebuild_cache_size_bytes: "400Mb"
 
 blackhole:

--- a/test/regression/cases/tcp_syslog_to_blackhole/datadog-agent/datadog.yaml
+++ b/test/regression/cases/tcp_syslog_to_blackhole/datadog-agent/datadog.yaml
@@ -9,5 +9,5 @@ cloud_provider_metadata: []
 
 logs_enabled: true
 logs_config:
-  logs_dd_url: 127.0.0.1:9091
+  logs_dd_url: 127.0.0.1:9092
   logs_no_ssl: true

--- a/test/regression/cases/tcp_syslog_to_blackhole/lading/lading.yaml
+++ b/test/regression/cases/tcp_syslog_to_blackhole/lading/lading.yaml
@@ -9,7 +9,5 @@ generator:
       maximum_prebuild_cache_size_bytes: "256 Mb"
 
 blackhole:
-  - tcp:
-      binding_addr: "127.0.0.1:9091"
   - http:
       binding_addr: "127.0.0.1:9092"


### PR DESCRIPTION

### What does this PR do?

Updates file tailing regression detector experiment

### Motivation

give the agent a fighting chance

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
