### PR TITLE
Backport CO-RE telemetry reporting fix

### DIFF
--- a/pkg/ebpf/btf.go
+++ b/pkg/ebpf/btf.go
@@ -62,8 +62,8 @@ type orderedBTFLoader struct {
 	delayedFlusher *time.Timer
 }
 
-func initBTFLoader(cfg *Config) orderedBTFLoader {
-	btfLoader := orderedBTFLoader{
+func initBTFLoader(cfg *Config) *orderedBTFLoader {
+	btfLoader := &orderedBTFLoader{
 		userBTFPath: cfg.BTFPath,
 		embeddedDir: filepath.Join(cfg.BPFDir, "co-re", "btf"),
 		result:      btfNotFound,

--- a/pkg/ebpf/btf_test.go
+++ b/pkg/ebpf/btf_test.go
@@ -54,6 +54,14 @@ func TestEmbeddedBTFMatch(t *testing.T) {
 	}
 }
 
+func TestBTFTelemetry(t *testing.T) {
+	loader := initBTFLoader(&Config{})
+	spec, result, err := loader.Get()
+	require.NoError(t, err)
+	require.NotNil(t, spec)
+	require.NotEqual(t, COREResult(btfNotFound), result)
+}
+
 func curDir() (string, error) {
 	_, file, _, ok := runtime.Caller(0)
 	if !ok {

--- a/pkg/ebpf/btf_test.go
+++ b/pkg/ebpf/btf_test.go
@@ -55,7 +55,7 @@ func TestEmbeddedBTFMatch(t *testing.T) {
 }
 
 func TestBTFTelemetry(t *testing.T) {
-	loader := initBTFLoader(&Config{})
+	loader := initBTFLoader(NewConfig())
 	spec, result, err := loader.Get()
 	require.NoError(t, err)
 	require.NotNil(t, spec)

--- a/pkg/ebpf/co_re.go
+++ b/pkg/ebpf/co_re.go
@@ -21,7 +21,7 @@ import (
 
 type coreAssetLoader struct {
 	coreDir   string
-	btfLoader orderedBTFLoader
+	btfLoader *orderedBTFLoader
 }
 
 // LoadCOREAsset attempts to find kernel BTF, reads the CO-RE object file, and then calls the callback function with the


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Backport of #20280 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
