### PR TITLE
direct docker image download on kitchen instances

### DIFF
--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -17,11 +17,27 @@
     AGENT_MAJOR_VERSION: 7
     DD_PIPELINE_ID: $CI_PIPELINE_ID-fnct
     CHEF_VERSION: 14.15.6
-  script:
+
+.kitchen_test_system_probe_linux:
+  extends:
+    - .kitchen_test_system_probe
+  before_script:
     - echo "CI_JOB_URL=${CI_JOB_URL}" >> $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/job_env.txt
     - echo "CI_JOB_ID=${CI_JOB_ID}" >> $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/job_env.txt
     - echo "CI_JOB_NAME=${CI_JOB_NAME}" >> $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/job_env.txt
     - echo "CI_JOB_STAGE=${CI_JOB_STAGE}" >> $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/job_env.txt
+    - cp $CI_PROJECT_DIR/minimized-btfs.tar.xz $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/minimized-btfs.tar.xz
+    - inv system-probe.test-docker-image-list > $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/docker-images.txt
+    - |
+      get_docker_secrets() {
+        if [ -o xtrace ]; then set +x; trap 'set -x' RETURN; fi
+        export DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+        export DOCKER_REGISTRY_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+      }
+      get_docker_secrets
+    - pushd $DD_AGENT_TESTING_DIR
+    - tasks/kitchen_setup.sh
+  script:
     - tasks/run-test-kitchen.sh system-probe-test $AGENT_MAJOR_VERSION
     - popd
     - inv system-probe.print-failed-tests --output-dir $DD_AGENT_TESTING_DIR/testjson
@@ -32,13 +48,6 @@
       - $DD_AGENT_TESTING_DIR/kitchen-junit-*.tar.gz
       - $DD_AGENT_TESTING_DIR/testjson
       - $CI_PROJECT_DIR/kitchen_logs
-
-.retrieve_test_dockers:
-  - mkdir -p $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
-  - mv $KITCHEN_DOCKERS/* $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/dockers
-
-.retrieve_minimized_btfs:
-  - cp $CI_PROJECT_DIR/minimized-btfs.tar.xz $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/minimized-btfs.tar.xz
 
 # This dummy job is added here because we want the functional_tests stage to start at the same time as kernel_matrix_testing stage.
 # The ebpf-platform team is trying to measure the time from the start of the pipeline to the completion of the kernel_matrix_testing and functional_tests stages, to measure improvement.
@@ -59,10 +68,10 @@ kitchen_test_dummy_job_tmp:
 
 kitchen_test_system_probe_linux_x64_ec2:
   extends:
-    - .kitchen_test_system_probe
+    - .kitchen_test_system_probe_linux
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2
-  needs: [ "tests_ebpf_x64", "prepare_ebpf_functional_tests_x64", "generate_minimized_btfs_x64", "pull_test_dockers_x64" ]
+  needs: [ "tests_ebpf_x64", "prepare_ebpf_functional_tests_x64", "generate_minimized_btfs_x64" ]
   retry: 0
   variables:
     ARCH: amd64
@@ -71,11 +80,6 @@ kitchen_test_system_probe_linux_x64_ec2:
     KITCHEN_CI_MOUNT_PATH: "/mnt/ci"
     KITCHEN_CI_ROOT_PATH: "/tmp/ci"
     KITCHEN_DOCKERS: $DD_AGENT_TESTING_DIR/kitchen-dockers-$ARCH
-  before_script:
-    - !reference [.retrieve_test_dockers]
-    - !reference [.retrieve_minimized_btfs]
-    - pushd $DD_AGENT_TESTING_DIR
-    - tasks/kitchen_setup.sh
   parallel:
     matrix:
       - KITCHEN_PLATFORM: "amazonlinux"
@@ -123,10 +127,10 @@ kitchen_test_system_probe_linux_x64_ec2:
 
 kitchen_test_system_probe_linux_arm64:
   extends:
-    - .kitchen_test_system_probe
+    - .kitchen_test_system_probe_linux
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2
-  needs: [ "tests_ebpf_arm64", "prepare_ebpf_functional_tests_arm64", "generate_minimized_btfs_arm64", "pull_test_dockers_arm64" ]
+  needs: [ "tests_ebpf_arm64", "prepare_ebpf_functional_tests_arm64", "generate_minimized_btfs_arm64" ]
   retry: 0
   variables:
     ARCH: arm64
@@ -135,11 +139,6 @@ kitchen_test_system_probe_linux_arm64:
     KITCHEN_CI_MOUNT_PATH: "/mnt/ci"
     KITCHEN_CI_ROOT_PATH: "/tmp/ci"
     KITCHEN_DOCKERS: $DD_AGENT_TESTING_DIR/kitchen-dockers-$ARCH
-  before_script:
-    - !reference [.retrieve_test_dockers]
-    - !reference [.retrieve_minimized_btfs]
-    - pushd $DD_AGENT_TESTING_DIR
-    - tasks/kitchen_setup.sh
   parallel:
     matrix:
       - KITCHEN_PLATFORM: "amazonlinux"

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1595,10 +1595,24 @@ def print_failed_tests(_, output_dir):
 
 @task
 def save_test_dockers(ctx, output_dir, arch, windows=is_windows):
-    import yaml
-
     if windows:
         return
+
+    images = _test_docker_image_list()
+    for image in images:
+        output_path = image.translate(str.maketrans('', '', string.punctuation))
+        ctx.run(f"docker pull --platform linux/{arch} {image}")
+        ctx.run(f"docker save {image} > {os.path.join(output_dir, output_path)}.tar")
+
+
+@task
+def test_docker_image_list(_):
+    images = _test_docker_image_list()
+    print('\n'.join(images))
+
+
+def _test_docker_image_list():
+    import yaml
 
     docker_compose_paths = glob.glob("./pkg/network/protocols/**/*/docker-compose.yml", recursive=True)
     # Add relative docker-compose paths
@@ -1619,10 +1633,7 @@ def save_test_dockers(ctx, output_dir, arch, windows=is_windows):
 
     # Special use-case in javatls
     images.remove("${IMAGE_VERSION}")
-    for image in images:
-        output_path = image.translate(str.maketrans('', '', string.punctuation))
-        ctx.run(f"docker pull --platform linux/{arch} {image}")
-        ctx.run(f"docker save {image} > {os.path.join(output_dir, output_path)}.tar")
+    return images
 
 
 @task

--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -113,6 +113,12 @@ platforms:
     <% if ENV["KITCHEN_CWS_PLATFORM"] %>
     cws_platform: <%= ENV["KITCHEN_CWS_PLATFORM"] %>
     <% end %>
+    <% if ENV["DOCKER_REGISTRY_LOGIN"] && ENV["DOCKER_REGISTRY_PASSWORD"] %>
+    docker:
+      registry: <%= ENV["DOCKER_REGISTRY_URL"] %>
+      username: <%= ENV["DOCKER_REGISTRY_LOGIN"] %>
+      password: <%%= ENV["DOCKER_REGISTRY_PASSWORD"] %>
+    <% end %>
   <% if ENV['KITCHEN_CI_MOUNT_PATH'] && ENV['KITCHEN_CI_ROOT_PATH'] %>
   provisioner:
     command_prefix: TMPDIR=<%= ENV['KITCHEN_CI_ROOT_PATH'] %>

--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -179,25 +179,23 @@ end
 
 # Install relevant packages for docker
 include_recipe "::docker_installation"
-docker_file_dir = "#{root_dir}/kitchen-dockers"
-remote_directory docker_file_dir do
-  source 'dockers'
-  files_owner 'root'
-  files_group 'root'
-  files_mode '0750'
+cookbook_file "/tmp/docker-images.txt" do
+  source "docker-images.txt"
+  mode '0444'
   action :create
-  recursive true
+  ignore_failure true
 end
 
-# Load docker images
-execute 'install docker-compose' do
-  cwd docker_file_dir
+file "/tmp/docker_password" do
+  content node[:docker][:password].to_s || ""
+  mode 400
+  sensitive true
+end
+
+execute 'pull docker images' do
   command <<-EOF
-    for docker_file in $(ls); do
-      echo docker load -i $docker_file
-      docker load -i $docker_file
-      rm -rf $docker_file
-    done
+    cat /tmp/docker_password | docker login --username #{node[:docker][:username].to_s} --password-stdin #{node[:docker][:registry]}
+    xargs -L1 -a /tmp/docker-images.txt docker pull
   EOF
   user "root"
   live_stream true


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Downloads docker images needed for kitchen tests directly on the kitchen EC2 instances

### Motivation

This ends up being faster than downloading them earlier and then copying the tarballs around.

Previous timing:
download to pull job (~2.5 minute)
save to job artifacts (~2 minute)
download job artifacts in kitchen_* (~70s)
upload image tarballs to each kitchen ec2 instance / upload to each metal instance (unknown time)

Timing now:
docker pull directly to kitchen instance: 90s
kitchen converge is 75 seconds _faster_

Overall this should be around a 5+ minute speed up.

### Additional Notes

In order to download directly on the kitchen instances, we need the docker credentials. Those are passed via environment variable and file, so should never be in the job logs.

https://datadoghq.atlassian.net/browse/EBPF-281

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
