### PR TITLE
[CONTINT-53] Make ECS e2e tests target the fake intake

### DIFF
--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -30,7 +30,6 @@ require (
 	golang.org/x/sys v0.10.0
 	golang.org/x/term v0.10.0
 	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/zorkian/go-datadog-api.v2 v2.30.0
 )
 
 require (
@@ -170,7 +169,6 @@ require (
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/zclconf/go-cty v1.13.2 // indirect
-	github.com/zorkian/go-datadog-api v2.30.0+incompatible // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20230725093048-515e97ebf090 // indirect
 	golang.org/x/mod v0.12.0 // indirect

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -511,8 +511,6 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.13.2 h1:4GvrUxe/QUDYuJKAav4EYqdM47/kZa672LwmXFmEKT0=
 github.com/zclconf/go-cty v1.13.2/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
-github.com/zorkian/go-datadog-api v2.30.0+incompatible h1:R4ryGocppDqZZbnNc5EDR8xGWF/z/MxzWnqTUijDQes=
-github.com/zorkian/go-datadog-api v2.30.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
@@ -738,8 +736,6 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/zorkian/go-datadog-api.v2 v2.30.0 h1:umQdVO0Ytx+kYadhuJNjFtDgIsIEBnKrOTvNuu8ClKI=
-gopkg.in/zorkian/go-datadog-api.v2 v2.30.0/go.mod h1:kx0CSMRpzEZfx/nFH62GLU4stZjparh/BRpM89t4XCQ=
 gotest.tools/v3 v3.5.0 h1:Ljk6PdHdOhAb5aDMWXjDLMMhph+BpztA4v1QdqEW2eY=
 gotest.tools/v3 v3.5.0/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/test/new-e2e/tests/containers/base_test.go
+++ b/test/new-e2e/tests/containers/base_test.go
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package containers
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
+	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
+)
+
+type baseSuite struct {
+	suite.Suite
+
+	Fakeintake *fakeintake.Client
+}
+
+func (suite *baseSuite) testMetric(metricName string, filterTags []string, expectedTags []*regexp.Regexp) {
+	suite.Run(fmt.Sprintf("%s{%s}", metricName, strings.Join(filterTags, ",")), func() {
+		suite.EventuallyWithTf(func(collect *assert.CollectT) {
+			metrics, err := suite.Fakeintake.FilterMetrics(
+				metricName,
+				fakeintake.WithTags[*aggregator.MetricSeries](filterTags),
+			)
+			if err != nil {
+				collect.Errorf("%w", err)
+				return
+			}
+			if len(metrics) == 0 {
+				collect.Errorf("No `%s{%s}` metrics yet", metricName, strings.Join(filterTags, ","))
+				return
+			}
+
+			// Check tags
+			if err := assertTags(metrics[len(metrics)-1].GetTags(), expectedTags); err != nil {
+				collect.Errorf("Tags mismatch on `%s`: %w", metricName, err)
+				return
+			}
+		}, 2*time.Minute, 10*time.Second, "Failed finding %s{%s} with proper tags", metricName, strings.Join(filterTags, ","))
+	})
+}

--- a/test/new-e2e/tests/containers/ecs_test.go
+++ b/test/new-e2e/tests/containers/ecs_test.go
@@ -7,21 +7,20 @@ package containers
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
+	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/infra"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ecs"
 
-	"github.com/cenkalti/backoff"
 	"github.com/fatih/color"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/stretchr/testify/require"
-	datadog "gopkg.in/zorkian/go-datadog-api.v2"
+	"github.com/stretchr/testify/suite"
 )
 
 func TestECSSuite(t *testing.T) {
@@ -37,50 +36,23 @@ func TestECSSuite(t *testing.T) {
 		"ddtestworkload:deploy":                      auto.ConfigValue{Value: "true"},
 	}
 
-	_, stackOutput, err := infra.GetStackManager().GetStack(context.Background(), "ecs-cluster", stackConfig, ecs.Run, false)
+	_, stackOutput, err := infra.GetStackManager().GetStack(ctx, "ecs-cluster", stackConfig, ecs.Run, false)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		infra.GetStackManager().DeleteStack(ctx, "ecs-cluster")
 	})
 
-	ecsClusterName := stackOutput.Outputs["ecs-cluster-name"].Value.(string)
-	ecsTaskFamily := stackOutput.Outputs["agent-fargate-task-family"].Value.(string)
-	ecsTaskVersion := stackOutput.Outputs["agent-fargate-task-version"].Value.(float64)
+	fakeintakeHost := stackOutput.Outputs["fakeintake-host"].Value.(string)
 
 	startTime := time.Now()
 
-	// Check content in Datadog
-	apiKey, err := runner.GetProfile().SecretStore().Get(parameters.APIKey)
-	require.NoError(t, err)
-	appKey, err := runner.GetProfile().SecretStore().Get(parameters.APPKey)
-	require.NoError(t, err)
-	datadogClient := datadog.NewClient(apiKey, appKey)
-	query := fmt.Sprintf("avg:ecs.fargate.cpu.user{ecs_cluster_name:%s,ecs_task_family:%s,ecs_task_version:%.0f} by {ecs_container_name}", ecsClusterName, ecsTaskFamily, ecsTaskVersion)
-	t.Log(query)
-
-	err = backoff.Retry(func() error {
-		currentTime := time.Now().Unix()
-		series, err := datadogClient.QueryMetrics(currentTime-120, currentTime, query)
-		if err != nil {
-			return err
-		}
-
-		if len(series) == 0 {
-			return errors.New("No data yet")
-		}
-
-		if len(series) != 3 {
-			return errors.New("Not all containers")
-		}
-
-		if series[0].Points[0][1] == nil || *series[0].Points[0][1] == 0 {
-			return errors.New("0-value")
-		}
-
-		return nil
-	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(20*time.Second), 20))
-	require.NoError(t, err)
+	suite.Run(t, &ecsSuite{
+		baseSuite: baseSuite{
+			Fakeintake: fakeintake.NewClient(fmt.Sprintf("http://%s", fakeintakeHost)),
+		},
+		ecsClusterName: stackOutput.Outputs["ecs-cluster-name"].Value.(string),
+	})
 
 	endTime := time.Now()
 
@@ -93,4 +65,118 @@ func TestECSSuite(t *testing.T) {
 		startTime.UnixMilli(),
 		endTime.UnixMilli(),
 	))
+}
+
+type ecsSuite struct {
+	baseSuite
+
+	ecsClusterName string
+}
+
+func (suite *ecsSuite) TestNginx() {
+	// `nginx` check is configured via docker labels
+	// Test it is properly scheduled
+	suite.testMetric("nginx.net.request_per_s",
+		[]string{},
+		[]*regexp.Regexp{
+			regexp.MustCompile(`^cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`),
+			regexp.MustCompile(`^container_id:`),
+			regexp.MustCompile(`^container_name:ecs-.*-nginx-ec2-`),
+			regexp.MustCompile(`^docker_image:ghcr.io/datadog/apps-nginx-server:main$`),
+			regexp.MustCompile(`^ecs_cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`),
+			regexp.MustCompile(`^ecs_container_name:nginx$`),
+			regexp.MustCompile(`^git.commit.sha:`),                                                       // org.opencontainers.image.revision docker image label
+			regexp.MustCompile(`^git.repository_url:https://github.com/DataDog/test-infra-definitions$`), // org.opencontainers.image.source   docker image label
+			regexp.MustCompile(`^image_id:sha256:`),
+			regexp.MustCompile(`^image_name:ghcr.io/datadog/apps-nginx-server$`),
+			regexp.MustCompile(`^image_tag:main$`),
+			regexp.MustCompile(`^nginx_cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`),
+			regexp.MustCompile(`^short_image:apps-nginx-server$`),
+			regexp.MustCompile(`^task_arn:`),
+			regexp.MustCompile(`^task_family:.*-nginx-ec2$`),
+			regexp.MustCompile(`^task_name:.*-nginx-ec2$`),
+			regexp.MustCompile(`^task_version:[[:digit:]]+$`),
+		},
+	)
+}
+
+func (suite *ecsSuite) TestRedis() {
+	// `redis` check is auto-configured due to image name
+	// Test it is properly scheduled
+	suite.testMetric("redis.net.instantaneous_ops_per_sec",
+		[]string{},
+		[]*regexp.Regexp{
+			regexp.MustCompile(`^cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`),
+			regexp.MustCompile(`^container_id:`),
+			regexp.MustCompile(`^container_name:ecs-.*-redis-ec2-`),
+			regexp.MustCompile(`^docker_image:redis:latest$`),
+			regexp.MustCompile(`^ecs_cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`),
+			regexp.MustCompile(`^ecs_container_name:redis$`),
+			regexp.MustCompile(`^image_id:sha256:`),
+			regexp.MustCompile(`^image_name:redis$`),
+			regexp.MustCompile(`^image_tag:latest$`),
+			regexp.MustCompile(`^redis_host:`),
+			regexp.MustCompile(`^redis_port:6379$`),
+			regexp.MustCompile(`^redis_role:master$`),
+			regexp.MustCompile(`^short_image:redis$`),
+			regexp.MustCompile(`^task_arn:`),
+			regexp.MustCompile(`^task_family:.*-redis-ec2$`),
+			regexp.MustCompile(`^task_name:.*-redis-ec2$`),
+			regexp.MustCompile(`^task_version:[[:digit:]]+$`),
+		},
+	)
+
+}
+
+func (suite *ecsSuite) TestDogstatsd() {
+	// Test dogstatsd origin detection with UDS
+	suite.testMetric("custom.metric",
+		[]string{},
+		[]*regexp.Regexp{
+			regexp.MustCompile(`^cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`),
+			regexp.MustCompile(`^container_id:`),
+			regexp.MustCompile(`^container_name:ecs-.*-dogstatsd-uds-ec2-`),
+			regexp.MustCompile(`^docker_image:ghcr.io/datadog/apps-dogstatsd:main$`),
+			regexp.MustCompile(`^ecs_cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`),
+			regexp.MustCompile(`^ecs_container_name:dogstatsd$`),
+			regexp.MustCompile(`^git.commit.sha:`),                                                       // org.opencontainers.image.revision docker image label
+			regexp.MustCompile(`^git.repository_url:https://github.com/DataDog/test-infra-definitions$`), // org.opencontainers.image.source   docker image label
+			regexp.MustCompile(`^image_id:sha256:`),
+			regexp.MustCompile(`^image_name:ghcr.io/datadog/apps-dogstatsd$`),
+			regexp.MustCompile(`^image_tag:main$`),
+			regexp.MustCompile(`^series:`),
+			regexp.MustCompile(`^short_image:apps-dogstatsd$`),
+			regexp.MustCompile(`^task_arn:`),
+			regexp.MustCompile(`^task_family:.*-dogstatsd-uds-ec2$`),
+			regexp.MustCompile(`^task_name:.*-dogstatsd-uds-ec2$`),
+			regexp.MustCompile(`^task_version:[[:digit:]]+$`),
+		},
+	)
+}
+
+func (suite *ecsSuite) TestPrometheus() {
+	// Test Prometheus check
+	suite.testMetric("prometheus.prom_gauge",
+		[]string{},
+		[]*regexp.Regexp{
+			regexp.MustCompile(`^cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`),
+			regexp.MustCompile(`^container_id:`),
+			regexp.MustCompile(`^container_name:ecs-.*-prometheus-ec2-`),
+			regexp.MustCompile(`^docker_image:ghcr.io/datadog/apps-prometheus:main$`),
+			regexp.MustCompile(`^ecs_cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`),
+			regexp.MustCompile(`^ecs_container_name:prometheus$`),
+			regexp.MustCompile(`^endpoint:http://.*:8080/metrics$`),
+			regexp.MustCompile(`^git.commit.sha:`),                                                       // org.opencontainers.image.revision docker image label
+			regexp.MustCompile(`^git.repository_url:https://github.com/DataDog/test-infra-definitions$`), // org.opencontainers.image.source   docker image label
+			regexp.MustCompile(`^image_id:sha256:`),
+			regexp.MustCompile(`^image_name:ghcr.io/datadog/apps-prometheus$`),
+			regexp.MustCompile(`^image_tag:main$`),
+			regexp.MustCompile(`^series:`),
+			regexp.MustCompile(`^short_image:apps-prometheus$`),
+			regexp.MustCompile(`^task_arn:`),
+			regexp.MustCompile(`^task_family:.*-prometheus-ec2$`),
+			regexp.MustCompile(`^task_name:.*-prometheus-ec2$`),
+			regexp.MustCompile(`^task_version:[[:digit:]]+$`),
+		},
+	)
 }

--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -61,9 +61,11 @@ func TestEKSSuite(t *testing.T) {
 
 	suite.Run(t, &eksSuite{
 		k8sSuite: k8sSuite{
+			baseSuite: baseSuite{
+				Fakeintake: fakeintake.NewClient(fmt.Sprintf("http://%s", fakeintakeHost)),
+			},
 			AgentLinuxHelmInstallName:   stackOutput.Outputs["agent-linux-helm-install-name"].Value.(string),
 			AgentWindowsHelmInstallName: stackOutput.Outputs["agent-windows-helm-install-name"].Value.(string),
-			Fakeintake:                  fakeintake.NewClient(fmt.Sprintf("http://%s", fakeintakeHost)),
 			K8sConfig:                   config,
 			K8sClient:                   kubernetes.NewForConfigOrDie(config),
 		},

--- a/test/new-e2e/tests/containers/kindvm_test.go
+++ b/test/new-e2e/tests/containers/kindvm_test.go
@@ -59,9 +59,11 @@ func TestKindSuite(t *testing.T) {
 
 	suite.Run(t, &kindSuite{
 		k8sSuite: k8sSuite{
+			baseSuite: baseSuite{
+				Fakeintake: fakeintake.NewClient(fmt.Sprintf("http://%s", fakeintakeHost)),
+			},
 			AgentLinuxHelmInstallName:   stackOutput.Outputs["agent-linux-helm-install-name"].Value.(string),
 			AgentWindowsHelmInstallName: "none",
-			Fakeintake:                  fakeintake.NewClient(fmt.Sprintf("http://%s", fakeintakeHost)),
 			K8sConfig:                   config,
 			K8sClient:                   kubernetes.NewForConfigOrDie(config),
 		},


### PR DESCRIPTION
### What does this PR do?

Move the `testMetric` function away from the Kubernetes-specific `k8sSuite` object so that it can be used for non-Kubernetes tests.

### Motivation

Be able to use the same function to assert metrics for ECS and K8S scenarios.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
