### PR TITLE
[CWS] Adding inv task to build security agent Docker image locally

### DIFF
--- a/tools/ebpf/Dockerfiles/Dockerfile-security-agent-dev
+++ b/tools/ebpf/Dockerfiles/Dockerfile-security-agent-dev
@@ -1,0 +1,26 @@
+ARG AGENT_BASE=datadog/agent:latest
+FROM $AGENT_BASE
+ARG CORE_AGENT_DEST
+
+# include some useful dev tools since this will be used or development
+RUN apt-get update -y && apt-get install -y jq conntrack netcat-openbsd dnsutils iproute2 net-tools
+
+# the core agent has the library path hardcoded, this allows the agent included below to find libs
+ENV LD_LIBRARY_PATH /opt/datadog-agent/embedded/lib
+
+# inv -e security-agent.build-dev-image will set up a temporary
+# build directory where this Dockerfile and the necessary binaries
+# are in the same directory
+COPY security-agent /opt/datadog-agent/embedded/bin/security-agent
+COPY system-probe /opt/datadog-agent/embedded/bin/system-probe
+COPY clang-bpf /opt/datadog-agent/embedded/bin/clang-bpf
+COPY llc-bpf /opt/datadog-agent/embedded/bin/llc-bpf
+
+# if you want to replace the base image's core agent binary, set $CORE_AGENT_DEST to
+# /opt/datadog-agent/bin/agent/agent; otherwise, set it to /dev/null
+COPY agent $CORE_AGENT_DEST
+
+COPY *.o /opt/datadog-agent/embedded/share/system-probe/ebpf/
+COPY co-re/*.o /opt/datadog-agent/embedded/share/system-probe/ebpf/co-re/
+COPY *.c /opt/datadog-agent/embedded/share/system-probe/ebpf/runtime/
+COPY agent-usm.jar /opt/datadog-agent/embedded/share/system-probe/java/

--- a/tools/ebpf/Dockerfiles/Dockerfile-security-agent-dev
+++ b/tools/ebpf/Dockerfiles/Dockerfile-security-agent-dev
@@ -3,7 +3,7 @@ FROM $AGENT_BASE
 ARG CORE_AGENT_DEST
 
 # include some useful dev tools since this will be used or development
-RUN apt-get update -y && apt-get install -y jq conntrack netcat-openbsd dnsutils iproute2 net-tools
+RUN apt-get update -y && apt-get install -y jq netcat-openbsd
 
 # the core agent has the library path hardcoded, this allows the agent included below to find libs
 ENV LD_LIBRARY_PATH /opt/datadog-agent/embedded/lib
@@ -23,4 +23,3 @@ COPY agent $CORE_AGENT_DEST
 COPY *.o /opt/datadog-agent/embedded/share/system-probe/ebpf/
 COPY co-re/*.o /opt/datadog-agent/embedded/share/system-probe/ebpf/co-re/
 COPY *.c /opt/datadog-agent/embedded/share/system-probe/ebpf/runtime/
-COPY agent-usm.jar /opt/datadog-agent/embedded/share/system-probe/java/


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
https://datadoghq.atlassian.net/browse/SEC-11029?atlOrigin=eyJpIjoiNTJlN2VjZGJmOGEzNDRlZTllMzE4MDMzNTQxMmViMmEiLCJwIjoiaiJ9

This basically copies the existing `process-agent.build-dev-image` invoke task (minus some resources unnecessary to CWS) to locally build a image that has the security-agent and the system-probe, and optionally the core agent. Instead of parameterizing the existing resources, I think it would be useful to have separate tasks for flexibility.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
