### PR TITLE
[status] Add autodiscovery section in DCA status output

### DIFF
--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -174,6 +174,9 @@ func FormatDCAStatus(data []byte) (string, error) {
 			errs = append(errs, err)
 		}
 	}
+	if err := renderAutodiscoveryStats(b, stats["adEnabledFeatures"], stats["adConfigErrors"], stats["filterErrors"]); err != nil {
+		errs = append(errs, err)
+	}
 	if config.Datadog.GetBool("orchestrator_explorer.enabled") {
 		if err := RenderStatusTemplate(b, "/orchestrator.tmpl", orchestratorStats); err != nil {
 			errs = append(errs, err)

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -198,6 +198,12 @@ func GetDCAStatus(verbose bool) (map[string]interface{}, error) {
 		}
 	}
 
+	stats["adEnabledFeatures"] = config.GetDetectedFeatures()
+	if common.AC != nil {
+		stats["adConfigErrors"] = common.AC.GetAutodiscoveryErrors()
+	}
+	stats["filterErrors"] = containers.GetFilterErrors()
+
 	if config.Datadog.GetBool("orchestrator_explorer.enabled") {
 		if apiErr != nil {
 			stats["orchestrator"] = map[string]string{"Error": apiErr.Error()}

--- a/pkg/status/templates/orchestrator.tmpl
+++ b/pkg/status/templates/orchestrator.tmpl
@@ -1,5 +1,6 @@
 {{/*
-*/}}=====================
+*/}}
+=====================
 Orchestrator Explorer
 =====================
   Collection Status: {{ .CollectionWorking }}

--- a/releasenotes-dca/notes/dca-status-render-ad-section-7d41d6563a1829c9.yaml
+++ b/releasenotes-dca/notes/dca-status-render-ad-section-7d41d6563a1829c9.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Show Autodiscovery information in the output of ``datadog-cluster-agent status``.


### PR DESCRIPTION
### What does this PR do?

Adds a new section with information about Autodiscovery in the output of the `datadog-cluster-agent status` command.

The new section is the same as the one already shown in the node agent status.

It's useful to identify issues in the cluster check configurations fetched from Kubernetes services and endpoints. Currently we need to check the logs to get the same information.

This is what the new section looks like when there's an invalid JSON in the autodiscovery annotations of a Kubernetes service:

```
=============
Autodiscovery
=============
  Enabled Features
  ================
    kubernetes
    orchestratorexplorer

  Configuration Errors
  ====================
    kube_service://default/nginx
    ----------------------------
        cannot parse check configuration: invalid character '"' after object key:value pair

```


### Describe how to test/QA your changes

Deploy on Kubernetes. Create a Kubernetes service that contains a check in the annotations. Use an invalid JSON and check that the output of `datadog-cluster-agent status` in the DCA pod contains the section shown above. Make sure that the errors goes away when the service is deleted or fixed.

Do the same with an endpoint check.

Docs for service and endpoint checks:
- https://docs.datadoghq.com/containers/cluster_agent/clusterchecks/?tab=helm
- https://docs.datadoghq.com/containers/cluster_agent/endpointschecks/?tab=helm

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
