### PR TITLE
[CONS-3310, CONS-3314] Wait 2 minutes for agent pods to become ready

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -45,50 +45,82 @@ func (suite *k8sSuite) TestAgent() {
 	ctx := context.Background()
 
 	suite.Run("agent pods are ready and not restarting", func() {
-		linuxNodes, err := suite.K8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{
-			LabelSelector: fields.OneTermEqualSelector("kubernetes.io/os", "linux").String(),
-		})
-		suite.NoError(err)
+		suite.EventuallyWithTf(func(collect *assert.CollectT) {
 
-		windowsNodes, err := suite.K8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{
-			LabelSelector: fields.OneTermEqualSelector("kubernetes.io/os", "windows").String(),
-		})
-		suite.NoError(err)
+			linuxNodes, err := suite.K8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+				LabelSelector: fields.OneTermEqualSelector("kubernetes.io/os", "linux").String(),
+			})
+			if err != nil {
+				collect.Errorf("Failed to list Linux nodes: %w", err)
+				return
+			}
 
-		linuxPods, err := suite.K8sClient.CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
-			LabelSelector: fields.OneTermEqualSelector("app", suite.AgentLinuxHelmInstallName+"-datadog").String(),
-		})
-		suite.NoError(err)
+			windowsNodes, err := suite.K8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+				LabelSelector: fields.OneTermEqualSelector("kubernetes.io/os", "windows").String(),
+			})
+			if err != nil {
+				collect.Errorf("Failed to list Windows nodes: %w", err)
+				return
+			}
 
-		windowsPods, err := suite.K8sClient.CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
-			LabelSelector: fields.OneTermEqualSelector("app", suite.AgentWindowsHelmInstallName+"-datadog").String(),
-		})
-		suite.NoError(err)
+			linuxPods, err := suite.K8sClient.CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
+				LabelSelector: fields.OneTermEqualSelector("app", suite.AgentLinuxHelmInstallName+"-datadog").String(),
+			})
+			if err != nil {
+				collect.Errorf("Failed to list Linux datadog agent pods: %w", err)
+				return
+			}
 
-		clusterAgentPods, err := suite.K8sClient.CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
-			LabelSelector: fields.OneTermEqualSelector("app", suite.AgentLinuxHelmInstallName+"-datadog-cluster-agent").String(),
-		})
-		suite.NoError(err)
+			windowsPods, err := suite.K8sClient.CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
+				LabelSelector: fields.OneTermEqualSelector("app", suite.AgentWindowsHelmInstallName+"-datadog").String(),
+			})
+			if err != nil {
+				collect.Errorf("Failed to list Windows datadog agent pods: %w", err)
+				return
+			}
 
-		clusterChecksPods, err := suite.K8sClient.CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
-			LabelSelector: fields.OneTermEqualSelector("app", suite.AgentLinuxHelmInstallName+"-datadog-clusterchecks").String(),
-		})
-		suite.NoError(err)
+			clusterAgentPods, err := suite.K8sClient.CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
+				LabelSelector: fields.OneTermEqualSelector("app", suite.AgentLinuxHelmInstallName+"-datadog-cluster-agent").String(),
+			})
+			if err != nil {
+				collect.Errorf("Failed to list datadog cluster agent pods: %w", err)
+				return
+			}
 
-		suite.Equalf(len(linuxNodes.Items), len(linuxPods.Items), "There isn’t exactly one Linux pod per Linux node.")
-		suite.Equalf(len(windowsNodes.Items), len(windowsPods.Items), "There isn’t exactly one Windows pod per Windows node.")
-		suite.Greaterf(len(clusterAgentPods.Items), 0, "There isn’t any cluster agent pod.")
-		suite.Greaterf(len(clusterChecksPods.Items), 0, "There isn’t any cluster checks worker pod.")
+			clusterChecksPods, err := suite.K8sClient.CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
+				LabelSelector: fields.OneTermEqualSelector("app", suite.AgentLinuxHelmInstallName+"-datadog-clusterchecks").String(),
+			})
+			if err != nil {
+				collect.Errorf("Failed to list datadog cluster checks runner pods: %w", err)
+				return
+			}
 
-		for _, podList := range []*corev1.PodList{linuxPods, windowsPods, clusterAgentPods, clusterChecksPods} {
-			for _, pod := range podList.Items {
-				for _, containerStatus := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
-					suite.Truef(containerStatus.Ready, "Container %s of pod %s isn’t ready", containerStatus.Name, pod.Name)
-					suite.EqualValuesf(containerStatus.RestartCount, 0, "Container %s of pod %s has restarted %d times.", containerStatus.Name, pod.Name, containerStatus.RestartCount)
+			if len(linuxPods.Items) != len(linuxNodes.Items) {
+				collect.Errorf("There is only %d Linux datadog agent pods for %d Linux nodes.", len(linuxPods.Items), len(linuxNodes.Items))
+			}
+			if len(windowsPods.Items) != len(windowsNodes.Items) {
+				collect.Errorf("There is only %d Windows datadog agent pods for %d Windows nodes.", len(windowsPods.Items), len(windowsNodes.Items))
+			}
+			if len(clusterAgentPods.Items) == 0 {
+				collect.Errorf("There isn’t any cluster agent pod.")
+			}
+			if len(clusterChecksPods.Items) == 0 {
+				collect.Errorf("There isn’t any cluster checks worker pod.")
+			}
+
+			for _, podList := range []*corev1.PodList{linuxPods, windowsPods, clusterAgentPods, clusterChecksPods} {
+				for _, pod := range podList.Items {
+					for _, containerStatus := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
+						if !containerStatus.Ready {
+							collect.Errorf("Container %s of pod %s isn’t ready.", containerStatus.Name, pod.Name)
+						}
+						if containerStatus.RestartCount > 0 {
+							collect.Errorf("Container %s of pod %s has restarted %d times.", containerStatus.Name, pod.Name, containerStatus.RestartCount)
+						}
+					}
 				}
 			}
-		}
-
+		}, 2*time.Minute, 10*time.Second, "Not all agents eventually became ready in time.")
 	})
 
 	versionExtractor := regexp.MustCompile(`Commit: ([[:xdigit:]]+)`)


### PR DESCRIPTION
### What does this PR do?

In the `containers` new-e2e tests, wait 2 minutes for agent pods to become ready instead of checking only once.

### Motivation

Some test failures (like [this one for ex.](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/353185280)) are indicating that sometimes, the agent pods are not immediately ready.
The fact that there is no subsequent test failing suggests that the agent pods eventually became ready.
So, it seems that we cannot completely rely on Helm and Pulumi for waiting that everything is up and running before returning and letting the tests start.
It’s better to have a retry loop for waiting for the pods to become ready.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
