### PR TITLE
[CWS] remove common rate limiter when sending events

### DIFF
--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -121,12 +121,8 @@ func (a *APIServer) GetEvents(params *api.GetEventParams, stream api.SecurityMod
 		case <-a.stopChan:
 			return nil
 		case msg := <-a.msgs:
-			if a.limiter.Allow(nil) {
-				if err := stream.Send(msg); err != nil {
-					return err
-				}
-			} else {
-				a.expireEvent(msg)
+			if err := stream.Send(msg); err != nil {
+				return err
 			}
 		}
 	}

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -22,7 +22,6 @@ import (
 	easyjson "github.com/mailru/easyjson"
 	jwriter "github.com/mailru/easyjson/jwriter"
 	"go.uber.org/atomic"
-	"golang.org/x/time/rate"
 
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
@@ -447,7 +446,6 @@ func NewAPIServer(cfg *config.RuntimeSecurityConfig, probe *sprobe.Probe, client
 		activityDumps:  make(chan *api.ActivityDumpStreamMessage, model.MaxTracedCgroupsCount*2),
 		expiredEvents:  make(map[rules.RuleID]*atomic.Int64),
 		expiredDumps:   atomic.NewInt64(0),
-		limiter:        events.NewStdLimiter(rate.Limit(cfg.EventServerRate), cfg.EventServerBurst),
 		statsdClient:   client,
 		probe:          probe,
 		retention:      cfg.EventServerRetention,


### PR DESCRIPTION
### What does this PR do?

This PR removes the "common" rate limiter completely (in favor of the per rules rate limiters), allowing to reduce the amount of events dropped by this rate limiter and incorrectly tagged as expired.

This PR also cleans up the activity dump streaming code (as https://github.com/DataDog/datadog-agent/pull/19973 did for events).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

In order to QA this change the metrics regarding `event server expired`, `events rate limited` should be monitored

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
