### PR TITLE
Fix string interner size telemetry

### DIFF
--- a/comp/dogstatsd/server/convert_bench_test.go
+++ b/comp/dogstatsd/server/convert_bench_test.go
@@ -33,7 +33,7 @@ var (
 
 func runParseMetricBenchmark(b *testing.B, multipleValues bool) {
 	cfg := fxutil.Test[config.Component](b, config.MockModule)
-	parser := newParser(cfg, newFloat64ListPool())
+	parser := newParser(cfg, newFloat64ListPool(), 1)
 
 	conf := enrichConfig{
 		defaultHostname:           "default-hostname",

--- a/comp/dogstatsd/server/enrich_test.go
+++ b/comp/dogstatsd/server/enrich_test.go
@@ -33,7 +33,7 @@ var (
 
 func parseAndEnrichSingleMetricMessage(t *testing.T, message []byte, conf enrichConfig) (metrics.MetricSample, error) {
 	cfg := fxutil.Test[config.Component](t, config.MockModule)
-	parser := newParser(cfg, newFloat64ListPool())
+	parser := newParser(cfg, newFloat64ListPool(), 1)
 	parsed, err := parser.parseMetricSample(message)
 	if err != nil {
 		return metrics.MetricSample{}, err
@@ -49,7 +49,7 @@ func parseAndEnrichSingleMetricMessage(t *testing.T, message []byte, conf enrich
 
 func parseAndEnrichMultipleMetricMessage(t *testing.T, message []byte, conf enrichConfig) ([]metrics.MetricSample, error) {
 	cfg := fxutil.Test[config.Component](t, config.MockModule)
-	parser := newParser(cfg, newFloat64ListPool())
+	parser := newParser(cfg, newFloat64ListPool(), 1)
 	parsed, err := parser.parseMetricSample(message)
 	if err != nil {
 		return []metrics.MetricSample{}, err
@@ -61,7 +61,7 @@ func parseAndEnrichMultipleMetricMessage(t *testing.T, message []byte, conf enri
 
 func parseAndEnrichServiceCheckMessage(t *testing.T, message []byte, conf enrichConfig) (*servicecheck.ServiceCheck, error) {
 	cfg := fxutil.Test[config.Component](t, config.MockModule)
-	parser := newParser(cfg, newFloat64ListPool())
+	parser := newParser(cfg, newFloat64ListPool(), 1)
 	parsed, err := parser.parseServiceCheck(message)
 	if err != nil {
 		return nil, err
@@ -71,7 +71,7 @@ func parseAndEnrichServiceCheckMessage(t *testing.T, message []byte, conf enrich
 
 func parseAndEnrichEventMessage(t *testing.T, message []byte, conf enrichConfig) (*event.Event, error) {
 	cfg := fxutil.Test[config.Component](t, config.MockModule)
-	parser := newParser(cfg, newFloat64ListPool())
+	parser := newParser(cfg, newFloat64ListPool(), 1)
 	parsed, err := parser.parseEvent(message)
 	if err != nil {
 		return nil, err
@@ -959,7 +959,7 @@ func TestMetricBlocklistShouldBlock(t *testing.T) {
 	}
 
 	cfg := fxutil.Test[config.Component](t, config.MockModule)
-	parser := newParser(cfg, newFloat64ListPool())
+	parser := newParser(cfg, newFloat64ListPool(), 1)
 	parsed, err := parser.parseMetricSample(message)
 	assert.NoError(t, err)
 	samples := []metrics.MetricSample{}
@@ -976,7 +976,7 @@ func TestServerlessModeShouldSetEmptyHostname(t *testing.T) {
 
 	message := []byte("custom.metric.a:21|ms")
 	cfg := fxutil.Test[config.Component](t, config.MockModule)
-	parser := newParser(cfg, newFloat64ListPool())
+	parser := newParser(cfg, newFloat64ListPool(), 1)
 	parsed, err := parser.parseMetricSample(message)
 	assert.NoError(t, err)
 	samples := []metrics.MetricSample{}
@@ -996,7 +996,7 @@ func TestMetricBlocklistShouldNotBlock(t *testing.T) {
 		defaultHostname: "default",
 	}
 	cfg := fxutil.Test[config.Component](t, config.MockModule)
-	parser := newParser(cfg, newFloat64ListPool())
+	parser := newParser(cfg, newFloat64ListPool(), 1)
 	parsed, err := parser.parseMetricSample(message)
 	assert.NoError(t, err)
 	samples := []metrics.MetricSample{}

--- a/comp/dogstatsd/server/intern.go
+++ b/comp/dogstatsd/server/intern.go
@@ -6,24 +6,25 @@
 package server
 
 import (
+	"fmt"
+
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var (
-	// There are multiple instances of the interner, one per worker. Counters are normally fine,
-	// gauges require special care to make sense. We don't need to clean up when an instance is
-	// dropped, because it only happens on agent shutdown.
-	tlmSIResets = telemetry.NewSimpleCounter("dogstatsd", "string_interner_resets",
+	// There are multiple instances of the interner, one per worker (depends on # of virtual CPUs).
+	// Most metrics are tagged with the instance ID, however some are left as global
+	// Note `New` vs `NewSimple`
+	tlmSIResets = telemetry.NewCounter("dogstatsd", "string_interner_resets", []string{"internerId"},
 		"Amount of resets of the string interner used in dogstatsd")
-	tlmSIRSize = telemetry.NewSimpleGauge("dogstatsd", "string_interner_entries",
+	tlmSIRSize = telemetry.NewGauge("dogstatsd", "string_interner_entries", []string{"internerId"},
 		"Number of entries in the string interner")
-	tlmSIRBytes = telemetry.NewSimpleGauge("dogstatsd", "string_interner_bytes",
+	tlmSIRBytes = telemetry.NewGauge("dogstatsd", "string_interner_bytes", []string{"internerId"},
 		"Number of bytes stored in the string interner")
-	tlmSIRHits = telemetry.NewSimpleCounter("dogstatsd", "string_interner_hits",
+	tlmSIRHits = telemetry.NewCounter("dogstatsd", "string_interner_hits", []string{"internerId"},
 		"Number of times string interner returned an existing string")
-	tlmSIRMiss = telemetry.NewSimpleCounter("dogstatsd", "string_interner_miss",
+	tlmSIRMiss = telemetry.NewCounter("dogstatsd", "string_interner_miss", []string{"internerId"},
 		"Number of times string interner created a new string object")
 	tlmSIRNew = telemetry.NewSimpleCounter("dogstatsd", "string_interner_new",
 		"Number of times string interner was created")
@@ -40,11 +41,13 @@ type stringInterner struct {
 	maxSize    int
 	curBytes   int
 	tlmEnabled bool
+	id         string
 }
 
-func newStringInterner(maxSize int) *stringInterner {
+func newStringInterner(maxSize int, internerId int) *stringInterner {
 	i := &stringInterner{
 		strings:    make(map[string]string),
+		id:         fmt.Sprintf("interner_%d", internerId),
 		maxSize:    maxSize,
 		tlmEnabled: utils.IsTelemetryEnabled(),
 	}
@@ -66,30 +69,28 @@ func (i *stringInterner) LoadOrStore(key []byte) string {
 	// See https://github.com/golang/go/commit/f5f5a8b6209f84961687d993b93ea0d397f5d5bf
 	if s, found := i.strings[string(key)]; found {
 		if i.tlmEnabled {
-			tlmSIRHits.Inc()
+			tlmSIRHits.WithTags(map[string]string{"internerId": i.id}).Inc()
 		}
 		return s
 	}
 	if len(i.strings) >= i.maxSize {
 		if i.tlmEnabled {
-			tlmSIResets.Inc()
-			tlmSIRBytes.Sub(float64(i.curBytes))
-			tlmSIRSize.Sub(float64(len(i.strings)))
+			tlmSIResets.WithTags(map[string]string{"internerId": i.id}).Inc()
+			tlmSIRBytes.WithTags(map[string]string{"internerId": i.id}).Sub(float64(i.curBytes))
+			tlmSIRSize.WithTags(map[string]string{"internerId": i.id}).Sub(float64(len(i.strings)))
 			i.curBytes = 0
 		}
 
 		i.strings = make(map[string]string)
-		log.Debug("clearing the string interner cache")
-
 	}
 
 	s := string(key)
 	i.strings[s] = s
 
 	if i.tlmEnabled {
-		tlmSIRMiss.Inc()
-		tlmSIRSize.Inc()
-		tlmSIRBytes.Add(float64(len(s)))
+		tlmSIRMiss.WithTags(map[string]string{"internerId": i.id}).Inc()
+		tlmSIRSize.WithTags(map[string]string{"internerId": i.id}).Inc()
+		tlmSIRBytes.WithTags(map[string]string{"internerId": i.id}).Add(float64(len(s)))
 		tlmSIRStrBytes.Observe(float64(len(s)))
 		i.curBytes += len(s)
 	}

--- a/comp/dogstatsd/server/intern.go
+++ b/comp/dogstatsd/server/intern.go
@@ -44,10 +44,10 @@ type stringInterner struct {
 	id         string
 }
 
-func newStringInterner(maxSize int, internerId int) *stringInterner {
+func newStringInterner(maxSize int, internerID int) *stringInterner {
 	i := &stringInterner{
 		strings:    make(map[string]string),
-		id:         fmt.Sprintf("interner_%d", internerId),
+		id:         fmt.Sprintf("interner_%d", internerID),
 		maxSize:    maxSize,
 		tlmEnabled: utils.IsTelemetryEnabled(),
 	}

--- a/comp/dogstatsd/server/intern.go
+++ b/comp/dogstatsd/server/intern.go
@@ -16,15 +16,15 @@ var (
 	// There are multiple instances of the interner, one per worker (depends on # of virtual CPUs).
 	// Most metrics are tagged with the instance ID, however some are left as global
 	// Note `New` vs `NewSimple`
-	tlmSIResets = telemetry.NewCounter("dogstatsd", "string_interner_resets", []string{"internerId"},
+	tlmSIResets = telemetry.NewCounter("dogstatsd", "string_interner_resets", []string{"interner_id"},
 		"Amount of resets of the string interner used in dogstatsd")
-	tlmSIRSize = telemetry.NewGauge("dogstatsd", "string_interner_entries", []string{"internerId"},
+	tlmSIRSize = telemetry.NewGauge("dogstatsd", "string_interner_entries", []string{"interner_id"},
 		"Number of entries in the string interner")
-	tlmSIRBytes = telemetry.NewGauge("dogstatsd", "string_interner_bytes", []string{"internerId"},
+	tlmSIRBytes = telemetry.NewGauge("dogstatsd", "string_interner_bytes", []string{"interner_id"},
 		"Number of bytes stored in the string interner")
-	tlmSIRHits = telemetry.NewCounter("dogstatsd", "string_interner_hits", []string{"internerId"},
+	tlmSIRHits = telemetry.NewCounter("dogstatsd", "string_interner_hits", []string{"interner_id"},
 		"Number of times string interner returned an existing string")
-	tlmSIRMiss = telemetry.NewCounter("dogstatsd", "string_interner_miss", []string{"internerId"},
+	tlmSIRMiss = telemetry.NewCounter("dogstatsd", "string_interner_miss", []string{"interner_id"},
 		"Number of times string interner created a new string object")
 	tlmSIRNew = telemetry.NewSimpleCounter("dogstatsd", "string_interner_new",
 		"Number of times string interner was created")
@@ -69,15 +69,15 @@ func (i *stringInterner) LoadOrStore(key []byte) string {
 	// See https://github.com/golang/go/commit/f5f5a8b6209f84961687d993b93ea0d397f5d5bf
 	if s, found := i.strings[string(key)]; found {
 		if i.tlmEnabled {
-			tlmSIRHits.WithTags(map[string]string{"internerId": i.id}).Inc()
+			tlmSIRHits.WithTags(map[string]string{"interner_id": i.id}).Inc()
 		}
 		return s
 	}
 	if len(i.strings) >= i.maxSize {
 		if i.tlmEnabled {
-			tlmSIResets.WithTags(map[string]string{"internerId": i.id}).Inc()
-			tlmSIRBytes.WithTags(map[string]string{"internerId": i.id}).Sub(float64(i.curBytes))
-			tlmSIRSize.WithTags(map[string]string{"internerId": i.id}).Sub(float64(len(i.strings)))
+			tlmSIResets.WithTags(map[string]string{"interner_id": i.id}).Inc()
+			tlmSIRBytes.WithTags(map[string]string{"interner_id": i.id}).Sub(float64(i.curBytes))
+			tlmSIRSize.WithTags(map[string]string{"interner_id": i.id}).Sub(float64(len(i.strings)))
 			i.curBytes = 0
 		}
 
@@ -88,9 +88,9 @@ func (i *stringInterner) LoadOrStore(key []byte) string {
 	i.strings[s] = s
 
 	if i.tlmEnabled {
-		tlmSIRMiss.WithTags(map[string]string{"internerId": i.id}).Inc()
-		tlmSIRSize.WithTags(map[string]string{"internerId": i.id}).Inc()
-		tlmSIRBytes.WithTags(map[string]string{"internerId": i.id}).Add(float64(len(s)))
+		tlmSIRMiss.WithTags(map[string]string{"interner_id": i.id}).Inc()
+		tlmSIRSize.WithTags(map[string]string{"interner_id": i.id}).Inc()
+		tlmSIRBytes.WithTags(map[string]string{"interner_id": i.id}).Add(float64(len(s)))
 		tlmSIRStrBytes.Observe(float64(len(s)))
 		i.curBytes += len(s)
 	}

--- a/comp/dogstatsd/server/intern_test.go
+++ b/comp/dogstatsd/server/intern_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestInternLoadOrStoreValue(t *testing.T) {
 	assert := assert.New(t)
-	sInterner := newStringInterner(3)
+	sInterner := newStringInterner(3, 1)
 
 	foo := []byte("foo")
 	bar := []byte("bar")
@@ -34,7 +34,7 @@ func TestInternLoadOrStoreValue(t *testing.T) {
 
 func TestInternLoadOrStorePointer(t *testing.T) {
 	assert := assert.New(t)
-	sInterner := newStringInterner(4)
+	sInterner := newStringInterner(4, 1)
 
 	foo := []byte("foo")
 	bar := []byte("bar")
@@ -59,7 +59,7 @@ func TestInternLoadOrStorePointer(t *testing.T) {
 
 func TestInternLoadOrStoreReset(t *testing.T) {
 	assert := assert.New(t)
-	sInterner := newStringInterner(4)
+	sInterner := newStringInterner(4, 1)
 
 	// first test that the good value is returned.
 	sInterner.LoadOrStore([]byte("foo"))

--- a/comp/dogstatsd/server/parse.go
+++ b/comp/dogstatsd/server/parse.go
@@ -50,16 +50,17 @@ type parser struct {
 	readTimestamps bool
 }
 
-func newParser(cfg config.Reader, float64List *float64ListPool) *parser {
+func newParser(cfg config.Reader, float64List *float64ListPool, workerNum int) *parser {
 	stringInternerCacheSize := cfg.GetInt("dogstatsd_string_interner_size")
 	readTimestamps := cfg.GetBool("dogstatsd_no_aggregation_pipeline")
 
-	return &parser{
-		interner:         newStringInterner(stringInternerCacheSize),
+	p := &parser{
+		interner:         newStringInterner(stringInternerCacheSize, workerNum),
 		readTimestamps:   readTimestamps,
 		float64List:      float64List,
 		dsdOriginEnabled: cfg.GetBool("dogstatsd_origin_detection_client"),
 	}
+	return p
 }
 
 func findMessageType(message []byte) messageType {

--- a/comp/dogstatsd/server/parse.go
+++ b/comp/dogstatsd/server/parse.go
@@ -54,13 +54,12 @@ func newParser(cfg config.Reader, float64List *float64ListPool, workerNum int) *
 	stringInternerCacheSize := cfg.GetInt("dogstatsd_string_interner_size")
 	readTimestamps := cfg.GetBool("dogstatsd_no_aggregation_pipeline")
 
-	p := &parser{
+	return &parser{
 		interner:         newStringInterner(stringInternerCacheSize, workerNum),
 		readTimestamps:   readTimestamps,
 		float64List:      float64List,
 		dsdOriginEnabled: cfg.GetBool("dogstatsd_origin_detection_client"),
 	}
-	return p
 }
 
 func findMessageType(message []byte) messageType {

--- a/comp/dogstatsd/server/parse_events_test.go
+++ b/comp/dogstatsd/server/parse_events_test.go
@@ -16,7 +16,7 @@ import (
 
 func parseEvent(t *testing.T, rawEvent []byte) (dogstatsdEvent, error) {
 	cfg := fxutil.Test[config.Component](t, config.MockModule)
-	parser := newParser(cfg, newFloat64ListPool())
+	parser := newParser(cfg, newFloat64ListPool(), 1)
 	return parser.parseEvent(rawEvent)
 }
 

--- a/comp/dogstatsd/server/parse_metrics_test.go
+++ b/comp/dogstatsd/server/parse_metrics_test.go
@@ -21,7 +21,7 @@ func parseMetricSample(t *testing.T, overrides map[string]any, rawSample []byte)
 		config.MockModule,
 		fx.Replace(config.MockParams{Overrides: overrides}),
 	))
-	parser := newParser(cfg, newFloat64ListPool())
+	parser := newParser(cfg, newFloat64ListPool(), 1)
 	return parser.parseMetricSample(rawSample)
 }
 

--- a/comp/dogstatsd/server/parse_service_checks_test.go
+++ b/comp/dogstatsd/server/parse_service_checks_test.go
@@ -16,7 +16,7 @@ import (
 
 func parseServiceCheck(t *testing.T, rawServiceCheck []byte) (dogstatsdServiceCheck, error) {
 	cfg := fxutil.Test[config.Component](t, config.MockModule)
-	parser := newParser(cfg, newFloat64ListPool())
+	parser := newParser(cfg, newFloat64ListPool(), 1)
 	return parser.parseServiceCheck(rawServiceCheck)
 }
 

--- a/comp/dogstatsd/server/parse_test.go
+++ b/comp/dogstatsd/server/parse_test.go
@@ -40,7 +40,7 @@ func TestIdentifyRandomString(t *testing.T) {
 
 func TestParseTags(t *testing.T) {
 	cfg := fxutil.Test[config.Component](t, config.MockModule)
-	p := newParser(cfg, newFloat64ListPool())
+	p := newParser(cfg, newFloat64ListPool(), 1)
 	rawTags := []byte("tag:test,mytag,good:boy")
 	tags := p.parseTags(rawTags)
 	expectedTags := []string{"tag:test", "mytag", "good:boy"}
@@ -49,7 +49,7 @@ func TestParseTags(t *testing.T) {
 
 func TestParseTagsEmpty(t *testing.T) {
 	cfg := fxutil.Test[config.Component](t, config.MockModule)
-	p := newParser(cfg, newFloat64ListPool())
+	p := newParser(cfg, newFloat64ListPool(), 1)
 	rawTags := []byte("")
 	tags := p.parseTags(rawTags)
 	assert.Nil(t, tags)
@@ -68,7 +68,7 @@ func TestUnsafeParseFloat(t *testing.T) {
 
 func TestUnsafeParseFloatList(t *testing.T) {
 	cfg := fxutil.Test[config.Component](t, config.MockModule)
-	p := newParser(cfg, newFloat64ListPool())
+	p := newParser(cfg, newFloat64ListPool(), 1)
 	unsafeFloats, err := p.parseFloat64List([]byte("1.1234:21.5:13"))
 	assert.NoError(t, err)
 	assert.Len(t, unsafeFloats, 3)

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -488,7 +488,7 @@ func (s *server) handleMessages() {
 	s.log.Debug("DogStatsD will run", workersCount, "workers")
 
 	for i := 0; i < workersCount; i++ {
-		worker := newWorker(s)
+		worker := newWorker(s, i)
 		go worker.run()
 		s.workers = append(s.workers, worker)
 	}

--- a/comp/dogstatsd/server/server_bench_test.go
+++ b/comp/dogstatsd/server/server_bench_test.go
@@ -70,7 +70,7 @@ func benchParsePackets(b *testing.B, rawPacket []byte) {
 
 	b.RunParallel(func(pb *testing.PB) {
 		batcher := newBatcher(demux.AgentDemultiplexer)
-		parser := newParser(deps.Config, newFloat64ListPool())
+		parser := newParser(deps.Config, newFloat64ListPool(), 1)
 		packet := packets.Packet{
 			Contents: rawPacket,
 			Origin:   packets.NoOrigin,
@@ -116,7 +116,7 @@ func BenchmarkPbarseMetricMessage(b *testing.B) {
 	}()
 	defer close(done)
 
-	parser := newParser(deps.Config, newFloat64ListPool())
+	parser := newParser(deps.Config, newFloat64ListPool(), 1)
 	message := []byte("daemon:666|h|@0.5|#sometag1:somevalue1,sometag2:somevalue2")
 
 	b.RunParallel(func(pb *testing.PB) {
@@ -170,7 +170,7 @@ func benchmarkMapperControl(b *testing.B, yaml string) {
 	defer close(done)
 
 	batcher := newBatcher(demux.AgentDemultiplexer)
-	parser := newParser(deps.Config, newFloat64ListPool())
+	parser := newParser(deps.Config, newFloat64ListPool(), 1)
 
 	samples := make([]metrics.MetricSample, 0, 512)
 	for n := 0; n < b.N; n++ {

--- a/comp/dogstatsd/server/server_test.go
+++ b/comp/dogstatsd/server/server_test.go
@@ -677,7 +677,7 @@ func TestNoMappingsConfig(t *testing.T) {
 
 	assert.Nil(t, s.mapper)
 
-	parser := newParser(deps.Config, newFloat64ListPool())
+	parser := newParser(deps.Config, newFloat64ListPool(), 1)
 	samples, err := s.parseMetricMessage(samples, parser, []byte("test.metric:666|g"), "", false)
 	assert.NoError(t, err)
 	assert.Len(t, samples, 1)
@@ -791,7 +791,7 @@ dogstatsd_mapper_profiles:
 
 			var actualSamples []MetricSample
 			for _, p := range scenario.packets {
-				parser := newParser(deps.Config, newFloat64ListPool())
+				parser := newParser(deps.Config, newFloat64ListPool(), 1)
 				samples, err := s.parseMetricMessage(samples, parser, []byte(p), "", false)
 				assert.NoError(t, err, "Case `%s` failed. parseMetricMessage should not return error %v", err)
 				for _, sample := range samples {
@@ -866,7 +866,7 @@ func TestProcessedMetricsOrigin(t *testing.T) {
 		assert.Len(s.cachedOriginCounters, 0, "this cache must be empty")
 		assert.Len(s.cachedOrder, 0, "this cache list must be empty")
 
-		parser := newParser(deps.Config, newFloat64ListPool())
+		parser := newParser(deps.Config, newFloat64ListPool(), 1)
 		samples := []metrics.MetricSample{}
 		samples, err := s.parseMetricMessage(samples, parser, []byte("test.metric:666|g"), "container_id://test_container", false)
 		assert.NoError(err)
@@ -940,7 +940,7 @@ func testContainerIDParsing(t *testing.T, cfg map[string]interface{}) {
 	requireStart(t, s, mockDemultiplexer(deps.Config, deps.Log))
 	s.Stop()
 
-	parser := newParser(deps.Config, newFloat64ListPool())
+	parser := newParser(deps.Config, newFloat64ListPool(), 1)
 	parser.dsdOriginEnabled = true
 
 	// Metric
@@ -982,7 +982,7 @@ func testOriginOptout(t *testing.T, cfg map[string]interface{}, enabled bool) {
 	requireStart(t, s, mockDemultiplexer(deps.Config, deps.Log))
 	s.Stop()
 
-	parser := newParser(deps.Config, newFloat64ListPool())
+	parser := newParser(deps.Config, newFloat64ListPool(), 1)
 	parser.dsdOriginEnabled = true
 
 	// Metric

--- a/comp/dogstatsd/server/server_worker.go
+++ b/comp/dogstatsd/server/server_worker.go
@@ -39,13 +39,12 @@ func newWorker(s *server, workerNum int) *worker {
 		batcher = newBatcher(s.demultiplexer.(aggregator.DemultiplexerWithAggregator))
 	}
 
-	w := &worker{
+	return &worker{
 		server:  s,
 		batcher: batcher,
 		parser:  newParser(s.config, s.sharedFloat64List, workerNum),
 		samples: make(metrics.MetricSampleBatch, 0, defaultSampleSize),
 	}
-	return w
 }
 
 func (w *worker) run() {

--- a/comp/dogstatsd/server/server_worker.go
+++ b/comp/dogstatsd/server/server_worker.go
@@ -31,7 +31,7 @@ type worker struct {
 	samples metrics.MetricSampleBatch
 }
 
-func newWorker(s *server) *worker {
+func newWorker(s *server, workerNum int) *worker {
 	var batcher *batcher
 	if s.ServerlessMode {
 		batcher = newServerlessBatcher(s.demultiplexer)
@@ -39,12 +39,13 @@ func newWorker(s *server) *worker {
 		batcher = newBatcher(s.demultiplexer.(aggregator.DemultiplexerWithAggregator))
 	}
 
-	return &worker{
+	w := &worker{
 		server:  s,
 		batcher: batcher,
-		parser:  newParser(s.config, s.sharedFloat64List),
+		parser:  newParser(s.config, s.sharedFloat64List, workerNum),
 		samples: make(metrics.MetricSampleBatch, 0, defaultSampleSize),
 	}
+	return w
 }
 
 func (w *worker) run() {


### PR DESCRIPTION
### What does this PR do?

Fixes some string interner telemetry by tagging with a unique interner ID.

### Motivation

When running with multiple workers, some of the workers step on each other while incrementing/decrementing the telemetry.
This adds clarity both for how many interners are present and what the status of each individual interner is.

### Additional Notes



### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
