### PR TITLE
[Serverless] Refactor methods to LifecycleProcessor [SVLS-3934]

### DIFF
--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -264,17 +264,18 @@ func (lp *LifecycleProcessor) OnInvokeEnd(endDetails *InvocationEndDetails) {
 			log.Debug("[lifecycle] Attempting to complete the inferred span")
 			log.Debugf("[lifecycle] Inferred span context: %+v", lp.GetInferredSpan().Span)
 			if lp.GetInferredSpan().Span.Start != 0 {
-				if lp.requestHandler.inferredSpans[1] != nil {
+				span0, span1 := lp.requestHandler.inferredSpans[0], lp.requestHandler.inferredSpans[1]
+				if span1 != nil {
 					log.Debug("[lifecycle] Completing a secondary inferred span")
 					lp.setParentIDForMultipleInferredSpans()
-					lp.requestHandler.inferredSpans[1].AddTagToInferredSpan("http.status_code", statusCode)
-					lp.requestHandler.inferredSpans[1].AddTagToInferredSpan("peer.service", lp.GetServiceName())
-					lp.requestHandler.inferredSpans[1].CompleteInferredSpan(lp.ProcessTrace, lp.getInferredSpanStart(), endDetails.IsError, lp.GetExecutionInfo().TraceID, lp.GetExecutionInfo().SamplingPriority)
+					span1.AddTagToInferredSpan("http.status_code", statusCode)
+					span1.AddTagToInferredSpan("peer.service", lp.GetServiceName())
+					lp.completeInferredSpan(span1, lp.getInferredSpanStart(), endDetails.IsError)
 					log.Debug("[lifecycle] The secondary inferred span attributes are %v", lp.requestHandler.inferredSpans[1])
 				}
-				lp.GetInferredSpan().AddTagToInferredSpan("http.status_code", statusCode)
-				lp.GetInferredSpan().AddTagToInferredSpan("peer.service", lp.GetServiceName())
-				lp.GetInferredSpan().CompleteInferredSpan(lp.ProcessTrace, endDetails.EndTime, endDetails.IsError, lp.GetExecutionInfo().TraceID, lp.GetExecutionInfo().SamplingPriority)
+				span0.AddTagToInferredSpan("http.status_code", statusCode)
+				span0.AddTagToInferredSpan("peer.service", lp.GetServiceName())
+				lp.completeInferredSpan(span0, endDetails.EndTime, endDetails.IsError)
 				log.Debugf("[lifecycle] The inferred span attributes are: %v", lp.GetInferredSpan())
 			} else {
 				log.Debug("[lifecyle] Failed to complete inferred span due to a missing start time. Please check that the event payload was received with the appropriate data")

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -258,7 +258,7 @@ func (lp *LifecycleProcessor) OnInvokeEnd(endDetails *InvocationEndDetails) {
 			endDetails.IsError = true
 		}
 
-		endExecutionSpan(lp.GetExecutionInfo(), lp.requestHandler.triggerTags, lp.requestHandler.triggerMetrics, lp.ProcessTrace, endDetails)
+		lp.endExecutionSpan(endDetails)
 
 		if lp.InferredSpansEnabled {
 			log.Debug("[lifecycle] Attempting to complete the inferred span")

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -221,7 +221,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 	}
 
 	if !lp.DetectLambdaLibrary() {
-		startExecutionSpan(lp.GetExecutionInfo(), lp.GetInferredSpan(), payloadBytes, startDetails, lp.InferredSpansEnabled)
+		lp.startExecutionSpan(payloadBytes, startDetails)
 	}
 }
 

--- a/pkg/serverless/invocationlifecycle/trace_test.go
+++ b/pkg/serverless/invocationlifecycle/trace_test.go
@@ -239,9 +239,14 @@ func TestEndExecutionSpanWithEmptyObjectRequestResponse(t *testing.T) {
 	t.Setenv(functionNameEnvVar, "TestFunction")
 	t.Setenv("DD_CAPTURE_LAMBDA_PAYLOAD", "true")
 	startTime := time.Now()
+	var tracePayload *api.Payload
 	lp := &LifecycleProcessor{
 		requestHandler: &RequestHandler{
 			executionInfo: currentExecutionInfo,
+			triggerTags:   make(map[string]string),
+		},
+		ProcessTrace: func(payload *api.Payload) {
+			tracePayload = payload
 		},
 	}
 	startDetails := &InvocationStartDetails{
@@ -253,10 +258,6 @@ func TestEndExecutionSpanWithEmptyObjectRequestResponse(t *testing.T) {
 
 	duration := 1 * time.Second
 	endTime := startTime.Add(duration)
-	var tracePayload *api.Payload
-	mockProcessTrace := func(payload *api.Payload) {
-		tracePayload = payload
-	}
 
 	endDetails := &InvocationEndDetails{
 		EndTime:            endTime,
@@ -268,7 +269,7 @@ func TestEndExecutionSpanWithEmptyObjectRequestResponse(t *testing.T) {
 		Runtime:            "dotnet6",
 	}
 
-	endExecutionSpan(currentExecutionInfo, make(map[string]string), nil, mockProcessTrace, endDetails)
+	lp.endExecutionSpan(endDetails)
 	executionSpan := tracePayload.TracerPayload.Chunks[0].Spans[0]
 	expectingResultMetaMap := map[string]string{
 		"request_id":        "test-request-id",
@@ -293,9 +294,14 @@ func TestEndExecutionSpanWithNullRequestResponse(t *testing.T) {
 	t.Setenv(functionNameEnvVar, "TestFunction")
 	t.Setenv("DD_CAPTURE_LAMBDA_PAYLOAD", "true")
 	startTime := time.Now()
+	var tracePayload *api.Payload
 	lp := &LifecycleProcessor{
 		requestHandler: &RequestHandler{
 			executionInfo: currentExecutionInfo,
+			triggerTags:   make(map[string]string),
+		},
+		ProcessTrace: func(payload *api.Payload) {
+			tracePayload = payload
 		},
 	}
 	startDetails := &InvocationStartDetails{
@@ -307,10 +313,6 @@ func TestEndExecutionSpanWithNullRequestResponse(t *testing.T) {
 
 	duration := 1 * time.Second
 	endTime := startTime.Add(duration)
-	var tracePayload *api.Payload
-	mockProcessTrace := func(payload *api.Payload) {
-		tracePayload = payload
-	}
 
 	endDetails := &InvocationEndDetails{
 		EndTime:            endTime,
@@ -322,7 +324,7 @@ func TestEndExecutionSpanWithNullRequestResponse(t *testing.T) {
 		Runtime:            "dotnet6",
 	}
 
-	endExecutionSpan(currentExecutionInfo, make(map[string]string), nil, mockProcessTrace, endDetails)
+	lp.endExecutionSpan(endDetails)
 	executionSpan := tracePayload.TracerPayload.Chunks[0].Spans[0]
 	expectingResultMetaMap := map[string]string{
 		"request_id":        "test-request-id",
@@ -344,9 +346,14 @@ func TestEndExecutionSpanWithNullRequestResponse(t *testing.T) {
 
 func TestEndExecutionSpanWithNoError(t *testing.T) {
 	currentExecutionInfo := &ExecutionStartInfo{}
+	var tracePayload *api.Payload
 	lp := &LifecycleProcessor{
 		requestHandler: &RequestHandler{
 			executionInfo: currentExecutionInfo,
+			triggerTags:   make(map[string]string),
+		},
+		ProcessTrace: func(payload *api.Payload) {
+			tracePayload = payload
 		},
 	}
 	t.Setenv(functionNameEnvVar, "TestFunction")
@@ -362,10 +369,6 @@ func TestEndExecutionSpanWithNoError(t *testing.T) {
 
 	duration := 1 * time.Second
 	endTime := startTime.Add(duration)
-	var tracePayload *api.Payload
-	mockProcessTrace := func(payload *api.Payload) {
-		tracePayload = payload
-	}
 
 	endDetails := &InvocationEndDetails{
 		EndTime:            endTime,
@@ -377,7 +380,7 @@ func TestEndExecutionSpanWithNoError(t *testing.T) {
 		Runtime:            "dotnet6",
 	}
 
-	endExecutionSpan(currentExecutionInfo, make(map[string]string), nil, mockProcessTrace, endDetails)
+	lp.endExecutionSpan(endDetails)
 	executionSpan := tracePayload.TracerPayload.Chunks[0].Spans[0]
 	expectingResultMetaMap := map[string]string{
 		"request_id":                "test-request-id",
@@ -406,9 +409,14 @@ func TestEndExecutionSpanWithNoError(t *testing.T) {
 
 func TestEndExecutionSpanProactInit(t *testing.T) {
 	currentExecutionInfo := &ExecutionStartInfo{}
+	var tracePayload *api.Payload
 	lp := &LifecycleProcessor{
 		requestHandler: &RequestHandler{
 			executionInfo: currentExecutionInfo,
+			triggerTags:   make(map[string]string),
+		},
+		ProcessTrace: func(payload *api.Payload) {
+			tracePayload = payload
 		},
 	}
 	t.Setenv(functionNameEnvVar, "TestFunction")
@@ -424,10 +432,6 @@ func TestEndExecutionSpanProactInit(t *testing.T) {
 
 	duration := 1 * time.Second
 	endTime := startTime.Add(duration)
-	var tracePayload *api.Payload
-	mockProcessTrace := func(payload *api.Payload) {
-		tracePayload = payload
-	}
 
 	endDetails := &InvocationEndDetails{
 		EndTime:            endTime,
@@ -438,7 +442,7 @@ func TestEndExecutionSpanProactInit(t *testing.T) {
 		ProactiveInit:      true,
 	}
 
-	endExecutionSpan(currentExecutionInfo, make(map[string]string), nil, mockProcessTrace, endDetails)
+	lp.endExecutionSpan(endDetails)
 	executionSpan := tracePayload.TracerPayload.Chunks[0].Spans[0]
 	expectingResultMetaMap := map[string]string{
 		"request_id":                                           "test-request-id",
@@ -471,9 +475,14 @@ func TestEndExecutionSpanWithInvalidCaptureLambdaPayloadValue(t *testing.T) {
 	testString := `{"resource":"/users/create","path":"/users/create","httpMethod":"GET","headers":{"Accept":"*/*","Accept-Encoding":"gzip","x-datadog-parent-id":"1480558859903409531","x-datadog-sampling-priority":"1","x-datadog-trace-id":"5736943178450432258"}}`
 	startTime := time.Now()
 	currentExecutionInfo := &ExecutionStartInfo{}
+	var tracePayload *api.Payload
 	lp := &LifecycleProcessor{
 		requestHandler: &RequestHandler{
 			executionInfo: currentExecutionInfo,
+			triggerTags:   make(map[string]string),
+		},
+		ProcessTrace: func(payload *api.Payload) {
+			tracePayload = payload
 		},
 	}
 	startDetails := &InvocationStartDetails{
@@ -485,11 +494,6 @@ func TestEndExecutionSpanWithInvalidCaptureLambdaPayloadValue(t *testing.T) {
 	duration := 1 * time.Second
 	endTime := startTime.Add(duration)
 
-	var tracePayload *api.Payload
-	mockProcessTrace := func(payload *api.Payload) {
-		tracePayload = payload
-	}
-
 	endDetails := &InvocationEndDetails{
 		EndTime:            endTime,
 		IsError:            false,
@@ -497,7 +501,7 @@ func TestEndExecutionSpanWithInvalidCaptureLambdaPayloadValue(t *testing.T) {
 		ResponseRawPayload: []byte(`{"response":"test response payload"}`),
 	}
 
-	endExecutionSpan(currentExecutionInfo, make(map[string]string), nil, mockProcessTrace, endDetails)
+	lp.endExecutionSpan(endDetails)
 	executionSpan := tracePayload.TracerPayload.Chunks[0].Spans[0]
 	assert.Equal(t, "aws.lambda", executionSpan.Name)
 	assert.Equal(t, "aws.lambda", executionSpan.Service)
@@ -514,9 +518,14 @@ func TestEndExecutionSpanWithInvalidCaptureLambdaPayloadValue(t *testing.T) {
 
 func TestEndExecutionSpanWithError(t *testing.T) {
 	currentExecutionInfo := &ExecutionStartInfo{}
+	var tracePayload *api.Payload
 	lp := &LifecycleProcessor{
 		requestHandler: &RequestHandler{
 			executionInfo: currentExecutionInfo,
+			triggerTags:   make(map[string]string),
+		},
+		ProcessTrace: func(payload *api.Payload) {
+			tracePayload = payload
 		},
 	}
 	t.Setenv(functionNameEnvVar, "TestFunction")
@@ -530,10 +539,6 @@ func TestEndExecutionSpanWithError(t *testing.T) {
 
 	duration := 1 * time.Second
 	endTime := startTime.Add(duration)
-	var tracePayload *api.Payload
-	mockProcessTrace := func(payload *api.Payload) {
-		tracePayload = payload
-	}
 
 	endDetails := &InvocationEndDetails{
 		EndTime:            endTime,
@@ -541,7 +546,7 @@ func TestEndExecutionSpanWithError(t *testing.T) {
 		RequestID:          "test-request-id",
 		ResponseRawPayload: []byte(`{}`),
 	}
-	endExecutionSpan(currentExecutionInfo, make(map[string]string), nil, mockProcessTrace, endDetails)
+	lp.endExecutionSpan(endDetails)
 	executionSpan := tracePayload.TracerPayload.Chunks[0].Spans[0]
 	assert.Equal(t, executionSpan.Error, int32(1))
 }
@@ -595,9 +600,14 @@ func TestLanguageTag(t *testing.T) {
 
 	for _, tc := range testCases {
 		currentExecutionInfo := &ExecutionStartInfo{}
+		var tracePayload *api.Payload
 		lp := &LifecycleProcessor{
 			requestHandler: &RequestHandler{
 				executionInfo: currentExecutionInfo,
+				triggerTags:   make(map[string]string),
+			},
+			ProcessTrace: func(payload *api.Payload) {
+				tracePayload = payload
 			},
 		}
 		t.Setenv(functionNameEnvVar, "TestFunction")
@@ -612,10 +622,6 @@ func TestLanguageTag(t *testing.T) {
 
 		duration := 1 * time.Second
 		endTime := startTime.Add(duration)
-		var tracePayload *api.Payload
-		mockProcessTrace := func(payload *api.Payload) {
-			tracePayload = payload
-		}
 
 		endDetails := &InvocationEndDetails{
 			EndTime:            endTime,
@@ -627,7 +633,7 @@ func TestLanguageTag(t *testing.T) {
 			Runtime:            tc.runtime, // add runtime
 		}
 
-		endExecutionSpan(currentExecutionInfo, make(map[string]string), nil, mockProcessTrace, endDetails)
+		lp.endExecutionSpan(endDetails)
 		executionSpan := tracePayload.TracerPayload.Chunks[0].Spans[0]
 		assert.Equal(t, "aws.lambda", executionSpan.Name)
 		assert.Equal(t, "aws.lambda", executionSpan.Service)

--- a/pkg/serverless/trace/inferredspan/inferred_span.go
+++ b/pkg/serverless/trace/inferredspan/inferred_span.go
@@ -18,9 +18,6 @@ import (
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/serverless/random"
 	"github.com/DataDog/datadog-agent/pkg/serverless/tags"
-	"github.com/DataDog/datadog-agent/pkg/trace/api"
-	"github.com/DataDog/datadog-agent/pkg/trace/info"
-	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -98,46 +95,6 @@ func FilterFunctionTags(input map[string]string) map[string]string {
 	return output
 }
 
-// CompleteInferredSpan finishes the inferred span and passes it
-// as an API payload to be processed by the trace agent
-func (inferredSpan *InferredSpan) CompleteInferredSpan(
-	processTrace func(p *api.Payload),
-	endTime time.Time,
-	isError bool,
-	traceID uint64,
-	samplingPriority sampler.SamplingPriority) {
-
-	durationIsSet := inferredSpan.Span.Duration != 0
-	if inferredSpan.IsAsync {
-		// SNSSQS span duration is set in invocationlifecycle/init.go
-		if !durationIsSet {
-			inferredSpan.Span.Duration = inferredSpan.CurrentInvocationStartTime.UnixNano() - inferredSpan.Span.Start
-		}
-	} else {
-		inferredSpan.Span.Duration = endTime.UnixNano() - inferredSpan.Span.Start
-	}
-	if isError {
-		inferredSpan.Span.Error = 1
-	}
-
-	inferredSpan.Span.TraceID = traceID
-
-	traceChunk := &pb.TraceChunk{
-		Origin:   "lambda",
-		Spans:    []*pb.Span{inferredSpan.Span},
-		Priority: int32(samplingPriority),
-	}
-
-	tracerPayload := &pb.TracerPayload{
-		Chunks: []*pb.TraceChunk{traceChunk},
-	}
-
-	processTrace(&api.Payload{
-		Source:        info.NewReceiverStats().GetTagStats(info.Tags{}),
-		TracerPayload: tracerPayload,
-	})
-}
-
 // GenerateSpanId creates a secure random span id in specific scenarios, otherwise return a pseudo random id
 func GenerateSpanId() uint64 {
 	isSnapStart := os.Getenv(tags.InitType) == tags.SnapStartValue
@@ -152,9 +109,9 @@ func GenerateSpanId() uint64 {
 	return random.Random.Uint64()
 }
 
-// generateInferredSpan declares and initializes a new inferred span
-// with the SpanID and TraceID
-func (inferredSpan *InferredSpan) generateInferredSpan(startTime time.Time) {
+// GenerateInferredSpan declares and initializes a new inferred span with a
+// SpanID
+func (inferredSpan *InferredSpan) GenerateInferredSpan(startTime time.Time) {
 
 	inferredSpan.CurrentInvocationStartTime = startTime
 	inferredSpan.Span = &pb.Span{

--- a/pkg/serverless/trace/inferredspan/inferred_span_test.go
+++ b/pkg/serverless/trace/inferredspan/inferred_span_test.go
@@ -7,14 +7,11 @@ package inferredspan
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
-	"github.com/DataDog/datadog-agent/pkg/trace/api"
-	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 )
 
 func TestInferredSpanCheck(t *testing.T) {
@@ -89,118 +86,6 @@ func TestFilterFunctionTags(t *testing.T) {
 	assert.Equal(t, filteredTags["region"], "test")
 	assert.Equal(t, filteredTags["account_id"], "test")
 	assert.Equal(t, filteredTags["aws_account"], "test")
-}
-
-func TestCompleteInferredSpanWithNoError(t *testing.T) {
-	var inferredSpan InferredSpan
-	startTime := time.Now()
-
-	inferredSpan.generateInferredSpan(time.Now())
-	inferredSpan.Span.TraceID = 2350923428932752492
-	inferredSpan.Span.SpanID = 1304592378509342580
-	inferredSpan.Span.Start = startTime.UnixNano()
-	inferredSpan.Span.Name = "aws.mock"
-	inferredSpan.Span.Service = "aws.mock"
-	inferredSpan.Span.Resource = "test-function"
-	inferredSpan.Span.Type = "http"
-	inferredSpan.Span.Meta = map[string]string{
-		stage: "dev",
-	}
-
-	duration := 1 * time.Second
-	endTime := startTime.Add(duration)
-	isError := false
-	var tracePayload *api.Payload
-	mockProcessTrace := func(payload *api.Payload) {
-		tracePayload = payload
-	}
-
-	inferredSpan.CompleteInferredSpan(mockProcessTrace, endTime, isError, 1234, sampler.PriorityAutoKeep)
-	span := tracePayload.TracerPayload.Chunks[0].Spans[0]
-	assert.Equal(t, "aws.mock", span.Name)
-	assert.Equal(t, "aws.mock", span.Service)
-	assert.Equal(t, "test-function", span.Resource)
-	assert.Equal(t, "http", span.Type)
-	assert.Equal(t, "dev", span.Meta["stage"])
-	assert.Equal(t, uint64(1234), span.TraceID)
-	assert.Equal(t, inferredSpan.Span.SpanID, span.SpanID)
-	assert.Equal(t, duration.Nanoseconds(), span.Duration)
-	assert.Equal(t, int32(0), inferredSpan.Span.Error)
-}
-
-func TestCompleteInferredSpanWithError(t *testing.T) {
-	var inferredSpan InferredSpan
-	startTime := time.Now()
-
-	inferredSpan.generateInferredSpan(time.Now())
-	inferredSpan.Span.TraceID = 2350923428932752492
-	inferredSpan.Span.SpanID = 1304592378509342580
-	inferredSpan.Span.Start = startTime.UnixNano()
-	inferredSpan.Span.Name = "aws.mock"
-	inferredSpan.Span.Service = "aws.mock"
-	inferredSpan.Span.Resource = "test-function"
-	inferredSpan.Span.Type = "http"
-	inferredSpan.Span.Meta = map[string]string{
-		stage: "dev",
-	}
-
-	duration := 1 * time.Second
-	endTime := startTime.Add(duration)
-	isError := true
-	var tracePayload *api.Payload
-	mockProcessTrace := func(payload *api.Payload) {
-		tracePayload = payload
-	}
-
-	inferredSpan.CompleteInferredSpan(mockProcessTrace, endTime, isError, 1234, sampler.PriorityAutoKeep)
-	span := tracePayload.TracerPayload.Chunks[0].Spans[0]
-	assert.Equal(t, "aws.mock", span.Name)
-	assert.Equal(t, "aws.mock", span.Service)
-	assert.Equal(t, "test-function", span.Resource)
-	assert.Equal(t, "http", span.Type)
-	assert.Equal(t, "dev", span.Meta["stage"])
-	assert.Equal(t, uint64(1234), span.TraceID)
-	assert.Equal(t, inferredSpan.Span.SpanID, span.SpanID)
-	assert.Equal(t, duration.Nanoseconds(), span.Duration)
-	assert.Equal(t, int32(1), inferredSpan.Span.Error)
-}
-
-func TestCompleteInferredSpanWithAsync(t *testing.T) {
-	var inferredSpan InferredSpan
-	// Start of inferred span
-	startTime := time.Now()
-	duration := 2 * time.Second
-	// mock invocation end time
-	lambdaInvocationStartTime := startTime.Add(duration)
-	inferredSpan.generateInferredSpan(lambdaInvocationStartTime)
-	inferredSpan.IsAsync = true
-	inferredSpan.Span.TraceID = 2350923428932752492
-	inferredSpan.Span.SpanID = 1304592378509342580
-	inferredSpan.Span.Start = startTime.UnixNano()
-	inferredSpan.Span.Name = "aws.mock"
-	inferredSpan.Span.Service = "aws.mock"
-	inferredSpan.Span.Resource = "test-function"
-	inferredSpan.Span.Type = "http"
-	inferredSpan.Span.Meta = map[string]string{
-		stage: "dev",
-	}
-	isError := false
-	var tracePayload *api.Payload
-	mockProcessTrace := func(payload *api.Payload) {
-		tracePayload = payload
-	}
-
-	inferredSpan.CompleteInferredSpan(mockProcessTrace, time.Now(), isError, 1234, sampler.PriorityAutoKeep)
-	span := tracePayload.TracerPayload.Chunks[0].Spans[0]
-	assert.Equal(t, "aws.mock", span.Name)
-	assert.Equal(t, "aws.mock", span.Service)
-	assert.Equal(t, "test-function", span.Resource)
-	assert.Equal(t, "http", span.Type)
-	assert.Equal(t, "dev", span.Meta["stage"])
-	assert.Equal(t, uint64(1234), span.TraceID)
-	assert.Equal(t, inferredSpan.Span.SpanID, span.SpanID)
-	assert.Equal(t, duration.Nanoseconds(), span.Duration)
-	assert.Equal(t, int32(0), inferredSpan.Span.Error)
 }
 
 func TestIsInferredSpansEnabledWhileTrue(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Moves three functions to be methods on the `LifecycleProcessor`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

These three methods have incredibly long signatures. For my work to add W3C trace context support to the extension, I will need to touch the signatures to these methods. Before doing that work, this PR will mean a smaller diff later as well as more easy to read code.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.

[SVLS-3934]

[SVLS-3934]: https://datadoghq.atlassian.net/browse/SVLS-3934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ