### PR TITLE
Update KMT kernels

### DIFF
--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -358,7 +358,7 @@ kernel_matrix_testing_run_tests_x64:
     ARCH: "x86_64"
   parallel:
     matrix:
-      - TAG: ["ubuntu_18.04", "ubuntu_20.04", "ubuntu_22.04", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_35", "fedora_36", "fedora_37", "fedora_38", "debian_10", "debian_11"]
+      - TAG: ["ubuntu_18.04", "ubuntu_20.04", "ubuntu_22.04", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_37", "fedora_38", "debian_10", "debian_11"]
 
 kernel_matrix_testing_run_tests_arm64:
   extends:
@@ -371,7 +371,7 @@ kernel_matrix_testing_run_tests_arm64:
     ARCH: "arm64"
   parallel:
     matrix:
-      - TAG: ["ubuntu_20.04", "ubuntu_22.04", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_35", "fedora_36", "fedora_37", "fedora_38"]
+      - TAG: ["ubuntu_20.04", "ubuntu_22.04", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_37", "fedora_38"]
 
 kernel_matrix_testing_cleanup:
   stage: kernel_matrix_testing

--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -371,7 +371,7 @@ kernel_matrix_testing_run_tests_arm64:
     ARCH: "arm64"
   parallel:
     matrix:
-      - TAG: ["ubuntu_20.04", "ubuntu_22.04", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_35", "fedora_36", "fedora_37", "fedora_38", "debian_10", "debian_11"]
+      - TAG: ["ubuntu_20.04", "ubuntu_22.04", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_35", "fedora_36", "fedora_37", "fedora_38"]
 
 kernel_matrix_testing_cleanup:
   stage: kernel_matrix_testing

--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -358,7 +358,7 @@ kernel_matrix_testing_run_tests_x64:
     ARCH: "x86_64"
   parallel:
     matrix:
-      - TAG: ["bionic", "focal", "jammy", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_35", "fedora_36", "fedora_37", "fedora_38"]
+      - TAG: ["ubuntu_18.04", "ubuntu_20.04", "ubuntu_22.04", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_35", "fedora_36", "fedora_37", "fedora_38", "debian_10", "debian_11"]
 
 kernel_matrix_testing_run_tests_arm64:
   extends:
@@ -371,7 +371,7 @@ kernel_matrix_testing_run_tests_arm64:
     ARCH: "arm64"
   parallel:
     matrix:
-      - TAG: ["focal", "jammy", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_35", "fedora_36", "fedora_37", "fedora_38"]
+      - TAG: ["ubuntu_20.04", "ubuntu_22.04", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_35", "fedora_36", "fedora_37", "fedora_38", "debian_10", "debian_11"]
 
 kernel_matrix_testing_cleanup:
   stage: kernel_matrix_testing

--- a/test/new-e2e/system-probe/config/vmconfig.json
+++ b/test/new-e2e/system-probe/config/vmconfig.json
@@ -122,16 +122,6 @@
                     "dir": "Fedora-Cloud-Base-38.arm64.qcow2",
                     "tag": "fedora_38",
                     "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-38.arm64.qcow2"
-                },
-                {
-                    "dir": "debian-10-generic-arm64.qcow2",
-                    "tag": "debian_10",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/debian-10-generic-arm64.qcow2"
-                },
-                {
-                    "dir": "debian-11-generic-arm64.qcow2",
-                    "tag": "debian_11",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/debian-11-generic-arm64.qcow2"
                 }
             ],
             "machine": "virt",

--- a/test/new-e2e/system-probe/config/vmconfig.json
+++ b/test/new-e2e/system-probe/config/vmconfig.json
@@ -36,16 +36,6 @@
                     "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-amd64-5.10.qcow2"
                 },
                 {
-                    "dir": "Fedora-Cloud-Base-35.amd64.qcow2",
-                    "tag": "fedora_35",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-35.amd64.qcow2"
-                },
-                {
-                    "dir": "Fedora-Cloud-Base-36.amd64.qcow2",
-                    "tag": "fedora_36",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-36.amd64.qcow2"
-                },
-                {
                     "dir": "Fedora-Cloud-Base-37.amd64.qcow2",
                     "tag": "fedora_37",
                     "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-37.amd64.qcow2"
@@ -102,16 +92,6 @@
                     "dir": "amzn2-kvm-2.0-arm64-5.10.qcow2",
                     "tag": "amzn_5.10",
                     "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-arm64-5.10.qcow2"
-                },
-                {
-                    "dir": "Fedora-Cloud-Base-35.arm64.qcow2",
-                    "tag": "fedora_35",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-35.arm64.qcow2"
-                },
-                {
-                    "dir": "Fedora-Cloud-Base-36.arm64.qcow2",
-                    "tag": "fedora_36",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-36.arm64.qcow2"
                 },
                 {
                     "dir": "Fedora-Cloud-Base-37.arm64.qcow2",

--- a/test/new-e2e/system-probe/config/vmconfig.json
+++ b/test/new-e2e/system-probe/config/vmconfig.json
@@ -38,22 +38,22 @@
                 {
                     "dir": "Fedora-Cloud-Base-35.amd64.qcow2",
                     "tag": "fedora_35",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-35.amd64.qcow2-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-35.amd64.qcow2"
                 },
                 {
                     "dir": "Fedora-Cloud-Base-36.amd64.qcow2",
                     "tag": "fedora_36",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-36.amd64.qcow2-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-36.amd64.qcow2"
                 },
                 {
                     "dir": "Fedora-Cloud-Base-37.amd64.qcow2",
                     "tag": "fedora_37",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-37.amd64.qcow2-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-37.amd64.qcow2"
                 },
                 {
                     "dir": "Fedora-Cloud-Base-38.amd64.qcow2",
                     "tag": "fedora_38",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-38.amd64.qcow2-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-38.amd64.qcow2"
                 }
 
             ],
@@ -97,22 +97,22 @@
                 {
                     "dir": "Fedora-Cloud-Base-35.arm64.qcow2",
                     "tag": "fedora_35",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-35.arm64.qcow2-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-35.arm64.qcow2"
                 },
                 {
                     "dir": "Fedora-Cloud-Base-36.arm64.qcow2",
                     "tag": "fedora_36",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-36.arm64.qcow2-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-36.arm64.qcow2"
                 },
                 {
                     "dir": "Fedora-Cloud-Base-37.arm64.qcow2",
                     "tag": "fedora_37",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-37.arm64.qcow2-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-37.arm64.qcow2"
                 },
                 {
                     "dir": "Fedora-Cloud-Base-38.arm64.qcow2",
                     "tag": "fedora_38",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-38.arm64.qcow2-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-38.arm64.qcow2"
                 }
 
             ],

--- a/test/new-e2e/system-probe/config/vmconfig.json
+++ b/test/new-e2e/system-probe/config/vmconfig.json
@@ -7,18 +7,18 @@
             "kernels": [
                 {
                     "dir": "bionic-server-cloudimg-amd64.qcow2",
-                    "tag": "bionic",
+                    "tag": "ubuntu_18.04",
                     "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bionic-server-cloudimg-amd64.qcow2"
                 },
                 {
-                    "dir": "jammy-server-cloudimg-amd64.qcow2",
-                    "tag": "jammy",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/jammy-server-cloudimg-amd64.qcow2"
+                    "dir": "focal-server-cloudimg-amd64.qcow2",
+                    "tag": "ubuntu_20.04",
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/focal-server-cloudimg-amd64.qcow2"
                 },
                 {
-                    "dir": "focal-server-cloudimg-amd64.qcow2",
-                    "tag": "focal",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/focal-server-cloudimg-amd64.qcow2"
+                    "dir": "jammy-server-cloudimg-amd64.qcow2",
+                    "tag": "ubuntu_22.04",
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/jammy-server-cloudimg-amd64.qcow2"
                 },
                 {
                     "dir": "amzn2-kvm-2.0-amd64-4.14.qcow2",
@@ -54,8 +54,17 @@
                     "dir": "Fedora-Cloud-Base-38.amd64.qcow2",
                     "tag": "fedora_38",
                     "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-38.amd64.qcow2"
+                },
+                {
+                    "dir": "debian-10-generic-amd64.qcow2",
+                    "tag": "debian_10",
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/debian-10-generic-amd64.qcow2"
+                },
+                {
+                    "dir": "debian-11-generic-amd64.qcow2",
+                    "tag": "debian_11",
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/debian-11-generic-amd64.qcow2"
                 }
-
             ],
             "vcpu": [
                 4
@@ -71,12 +80,12 @@
             "kernels": [
                 {
                     "dir": "focal-server-cloudimg-arm64.qcow2",
-                    "tag": "focal",
+                    "tag": "ubuntu_20.04",
                     "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/focal-server-cloudimg-arm64.qcow2"
                 },
                 {
                     "dir": "jammy-server-cloudimg-arm64.qcow2",
-                    "tag": "jammy",
+                    "tag": "ubuntu_22.04",
                     "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/jammy-server-cloudimg-arm64.qcow2"
                 },
                 {
@@ -113,8 +122,17 @@
                     "dir": "Fedora-Cloud-Base-38.arm64.qcow2",
                     "tag": "fedora_38",
                     "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-38.arm64.qcow2"
+                },
+                {
+                    "dir": "debian-10-generic-arm64.qcow2",
+                    "tag": "debian_10",
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/debian-10-generic-arm64.qcow2"
+                },
+                {
+                    "dir": "debian-11-generic-arm64.qcow2",
+                    "tag": "debian_11",
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/debian-11-generic-arm64.qcow2"
                 }
-
             ],
             "machine": "virt",
             "vcpu": [


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

- Add debian 10+11 for x64 (arm64 coming later).
- Remove Fedora 35 and 36
- Remove Fedora using the `-test-only` image suffix
- Rename Ubuntu kernels to `ubuntu_<release` which is easier to follow than the codenames

### Motivation

Closer matching of kitchen kernels and removing unsupported/unused kernels.

### Additional Notes

https://datadoghq.atlassian.net/browse/EBPF-285
https://datadoghq.atlassian.net/browse/EBPF-301

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
