### PR TITLE
[USM] http2 frame split

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -40,6 +40,8 @@
 
 #define HTTP2_CONTENT_TYPE_IDX 31
 
+#define MAX_FRAME_SIZE 16384
+
 // Huffman-encoded strings for paths "/" and "/index.html". Needed for HTTP2
 // decoding, as these two paths are in the static table, we need to add the
 // encoded string ourselves instead of reading them from the Header.
@@ -120,5 +122,11 @@ typedef struct {
     __u8 frames_count;
     http2_frame_with_offset frames_array[HTTP2_MAX_FRAMES_ITERATIONS] __attribute__((aligned(8)));
 } http2_tail_call_state_t;
+
+typedef struct {
+    __u32 remainder;
+    __u32 header_length;
+    char buf[HTTP2_FRAME_HEADER_SIZE];
+} frame_header_remainder_t;
 
 #endif

--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -8,7 +8,7 @@
 // Maximum number of frames to be processed in a single TCP packet. That's also the number of tail calls we'll have.
 // NOTE: we may need to revisit this const if we need to capture more connections.
 #define HTTP2_MAX_FRAMES_ITERATIONS 10
-#define HTTP2_MAX_FRAMES_TO_FILTER  500
+#define HTTP2_MAX_FRAMES_TO_FILTER  100
 
 // A limit of max headers which we process in the request/response.
 #define HTTP2_MAX_HEADERS_COUNT_FOR_FILTERING 20

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -51,7 +51,7 @@ static __always_inline bool read_var_int_with_given_current_char(struct __sk_buf
         return true;
     }
 
-    if (skb_info->data_off <= skb->len) {
+    if (skb_info->data_off <= skb_info->data_end) {
         __u8 next_char = 0;
         bpf_skb_load_bytes(skb, skb_info->data_off, &next_char, sizeof(next_char));
         if ((next_char & 128) == 0) {
@@ -72,7 +72,7 @@ static __always_inline bool read_var_int_with_given_current_char(struct __sk_buf
 //
 // The returned remain buffer is either a smaller suffix of p, or err != nil.
 static __always_inline bool read_var_int(struct __sk_buff *skb, skb_info_t *skb_info, __u8 max_number_for_bits, __u8 *out) {
-    if (skb_info->data_off > skb->len) {
+    if (skb_info->data_off > skb_info->data_end) {
         return false;
     }
     __u8 current_char_as_number = 0;
@@ -148,7 +148,7 @@ static __always_inline bool parse_field_literal(struct __sk_buff *skb, skb_info_
     }
 
     __u32 final_size = str_len < HTTP2_MAX_PATH_LEN ? str_len : HTTP2_MAX_PATH_LEN;
-    if (skb_info->data_off + final_size > skb->len) {
+    if (skb_info->data_off + final_size > skb_info->data_end) {
         goto end;
     }
 
@@ -168,7 +168,7 @@ static __always_inline __u8 filter_relevant_headers(struct __sk_buff *skb, skb_i
     __u8 interesting_headers = 0;
     http2_header_t *current_header;
     const __u32 frame_end = skb_info->data_off + frame_length;
-    const __u32 end = frame_end < skb->len + 1 ? frame_end : skb->len + 1;
+    const __u32 end = frame_end < skb_info->data_end + 1 ? frame_end : skb_info->data_end + 1;
     bool is_literal = false;
     bool is_indexed = false;
     __u8 max_bits = 0;
@@ -350,7 +350,7 @@ static __always_inline bool format_http2_frame_header(struct http2_frame *out) {
 }
 
 static __always_inline void skip_preface(struct __sk_buff *skb, skb_info_t *skb_info) {
-    if (skb_info->data_off + HTTP2_MARKER_SIZE <= skb->len) {
+    if (skb_info->data_off + HTTP2_MARKER_SIZE <= skb_info->data_end) {
         char preface[HTTP2_MARKER_SIZE];
         bpf_memset((char *)preface, 0, HTTP2_MARKER_SIZE);
         bpf_skb_load_bytes(skb, skb_info->data_off, preface, HTTP2_MARKER_SIZE);
@@ -371,7 +371,7 @@ static __always_inline __u8 find_relevant_headers(struct __sk_buff *skb, skb_inf
 #pragma unroll(HTTP2_MAX_FRAMES_TO_FILTER)
     for (__u32 iteration = 0; iteration < HTTP2_MAX_FRAMES_TO_FILTER; ++iteration) {
         // Checking we can read HTTP2_FRAME_HEADER_SIZE from the skb.
-        if (skb_info->data_off + HTTP2_FRAME_HEADER_SIZE > skb->len) {
+        if (skb_info->data_off + HTTP2_FRAME_HEADER_SIZE > skb_info->data_end) {
             break;
         }
         if (interesting_frame_index >= HTTP2_MAX_FRAMES_ITERATIONS) {
@@ -488,7 +488,7 @@ int socket__http2_frames_parser(struct __sk_buff *skb) {
     local_skb_info.data_off = current_frame.offset;
 
     parse_frame(skb, &local_skb_info, &dispatcher_args_copy.tup, http2_ctx, &current_frame.frame);
-    if (local_skb_info.data_off >= skb->len) {
+    if (local_skb_info.data_off >= local_skb_info.data_end) {
         goto delete_iteration;
     }
 

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -360,8 +360,12 @@ static __always_inline void skip_preface(struct __sk_buff *skb, skb_info_t *skb_
     }
 }
 
+// The function is trying to read the remaining of a split frame header. We have the first part in
+// `frame_state->buf` (from the previous packet), and now we're trying to read the remaining (`frame_state->remainder`
+// bytes from the current packet).
 static __always_inline void fix_header_frame(struct __sk_buff *skb, skb_info_t *skb_info, char *out, frame_header_remainder_t *frame_state) {
     bpf_memcpy(out, frame_state->buf, HTTP2_FRAME_HEADER_SIZE);
+    // Verifier is unhappy with a single call to `bpf_skb_load_bytes` with a variable length (although checking boundaries)
     switch (frame_state->remainder) {
     case 1:
         bpf_skb_load_bytes(skb, skb_info->data_off, out + HTTP2_FRAME_HEADER_SIZE - 1, 1);

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -360,7 +360,7 @@ static __always_inline void skip_preface(struct __sk_buff *skb, skb_info_t *skb_
     }
 }
 
-static __always_inline __u8 find_relevant_headers(struct __sk_buff *skb, skb_info_t *skb_info, http2_frame_with_offset *frames_array) {
+static __always_inline __u8 find_relevant_headers(struct __sk_buff *skb, skb_info_t *skb_info, http2_frame_with_offset *frames_array, frame_header_reminder_t *reminder) {
     bool is_headers_frame, is_data_end_of_stream;
     __u8 interesting_frame_index = 0;
     struct http2_frame current_frame = {};
@@ -431,8 +431,34 @@ int socket__http2_filter(struct __sk_buff *skb) {
     // in a map, we cannot allow it to be modified. Thus, having a local copy of skb_info.
     skb_info_t local_skb_info = dispatcher_args_copy.skb_info;
 
+    frame_header_reminder_t *frame_state = bpf_map_lookup_elem(&http2_reminder, &dispatcher_args_copy.tup);
     // filter frames
-    iteration_value.frames_count = find_relevant_headers(skb, &local_skb_info, iteration_value.frames_array);
+    iteration_value.frames_count = find_relevant_headers(skb, &local_skb_info, iteration_value.frames_array, frame_state);
+
+    // if we have a state and we consumed it, then delete it.
+    if (frame_state != NULL && frame_state->reminder == 0) {
+        bpf_map_delete_elem(&http2_reminder, &dispatcher_args_copy.tup);
+    }
+
+    frame_header_reminder_t new_frame_state = {0};
+    // We have a reminder
+    if (local_skb_info.data_off > local_skb_info.data_end) {
+        new_frame_state.reminder = local_skb_info.data_off - local_skb_info.data_end;
+        bpf_map_update_elem(&http2_reminder, &dispatcher_args_copy.tup, &new_frame_state, BPF_ANY);
+    }
+
+    // Frame header reminder
+    if (local_skb_info.data_off < local_skb_info.data_end && local_skb_info.data_off + HTTP2_FRAME_HEADER_SIZE > local_skb_info.data_end) {
+        new_frame_state.reminder = HTTP2_FRAME_HEADER_SIZE - (local_skb_info.data_end - local_skb_info.data_off);
+
+    #pragma unroll(HTTP2_FRAME_HEADER_SIZE)
+        for (__u32 iteration = 0; iteration < HTTP2_FRAME_HEADER_SIZE && new_frame_state.reminder + iteration < HTTP2_FRAME_HEADER_SIZE; ++iteration) {
+            bpf_skb_load_bytes(skb, local_skb_info.data_off + iteration, new_frame_state.buf + iteration, 1);
+        }
+
+        bpf_map_update_elem(&http2_reminder, &dispatcher_args_copy.tup, &new_frame_state, BPF_ANY);
+    }
+
     if (iteration_value.frames_count == 0) {
         return 0;
     }

--- a/pkg/network/ebpf/c/protocols/http2/maps-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/maps-defs.h
@@ -1,6 +1,17 @@
 #ifndef __HTTP2_MAPS_DEFS_H
 #define __HTTP2_MAPS_DEFS_H
 
+// http2_packet_context maps a connection tuple to the reminder from the previous packet.
+// It is possible for frames to be split to multiple tcp packets, so we need to associate the reminder from the previous
+// packet, to the current one.
+typedef struct {
+    __u32 reminder;
+    __u32 header_length;
+    char buf[HTTP2_FRAME_HEADER_SIZE];
+} frame_header_reminder_t;
+
+BPF_HASH_MAP(http2_reminder, conn_tuple_t, frame_header_reminder_t, 2048)
+
 // http2_static_table is the map that holding the supported static values by index and its static value.
 BPF_HASH_MAP(http2_static_table, u8, static_table_value_t, 20)
 

--- a/pkg/network/ebpf/c/protocols/http2/maps-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/maps-defs.h
@@ -1,16 +1,10 @@
 #ifndef __HTTP2_MAPS_DEFS_H
 #define __HTTP2_MAPS_DEFS_H
 
-// http2_packet_context maps a connection tuple to the reminder from the previous packet.
-// It is possible for frames to be split to multiple tcp packets, so we need to associate the reminder from the previous
+// http2_remainder maps a connection tuple to the remainder from the previous packet.
+// It is possible for frames to be split to multiple tcp packets, so we need to associate the remainder from the previous
 // packet, to the current one.
-typedef struct {
-    __u32 reminder;
-    __u32 header_length;
-    char buf[HTTP2_FRAME_HEADER_SIZE];
-} frame_header_reminder_t;
-
-BPF_HASH_MAP(http2_reminder, conn_tuple_t, frame_header_reminder_t, 2048)
+BPF_HASH_MAP(http2_remainder, conn_tuple_t, frame_header_remainder_t, 2048)
 
 // http2_static_table is the map that holding the supported static values by index and its static value.
 BPF_HASH_MAP(http2_static_table, u8, static_table_value_t, 20)

--- a/pkg/network/protocols/grpc/monitor_test.go
+++ b/pkg/network/protocols/grpc/monitor_test.go
@@ -48,7 +48,6 @@ type USMgRPCSuite struct {
 }
 
 func TestGRPCScenarios(t *testing.T) {
-	t.Skip("tests are broken after upgrading go-grpc to 1.58")
 	currKernelVersion, err := kernel.HostVersion()
 	require.NoError(t, err)
 	if currKernelVersion < http2.MinimumKernelVersion {

--- a/pkg/network/usm/monitor_test.go
+++ b/pkg/network/usm/monitor_test.go
@@ -520,8 +520,6 @@ type captureRange struct {
 }
 
 func TestHTTP2(t *testing.T) {
-	t.Skip("tests are broken after upgrading go-grpc to 1.58")
-
 	currKernelVersion, err := kernel.HostVersion()
 	require.NoError(t, err)
 	if currKernelVersion < usmhttp2.MinimumKernelVersion {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

The PR handles HTTP/2 frame split over TCP packets.

Large payloads can be split over TCP packets, so we have to consider a "reminder" over TCP packets.
The reminder exists if the next offset to read from is bigger than the packet's end, or if we're missing less than 9 bytes to read the next frame header.

For the next packet we are doing the following:
 1. Check if we have a frame-header reminder - if so, we must try and read the rest of the frame header.
    In case of a failure, we abort.
 2. If we don't have a frame-header reminder, then we're trying to read a valid frame.
    HTTP2 can send valid frames (like SETTINGS and PING) during a split DATA frames. If such a frame exists,
    then we won't have a the rest of the split frame in the same packet.
 3. If we reached here, and we have a reminder, then we're consuming the reminder and checking we can read the
    next frame header.
 4. We failed reading any frame. Aborting

The PR introduces:
* A more sophisticated frame validator (type is valid, length does not exceeds 16KB, stream id is 0 or odd)
* Instead of using `skb->len` that can contain padding, we're using `skb_info.data_end` introduced in #18951 
* Support for frame header split over TCP packets
* Support for frame payload split over TCP packets

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

For a while our gRPC and HTTP2 tests were flaky on the CI, but we couldn't reproduce the issue. Recently, the upgrade of `go-grpc` to version `1.58` allowed us to reproduce the issue locally, and we were able to see the scenario of split frames over multiple TCP packets.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
The PR changes the max number of frames to filter in a single packet from 500 to 100, since we added more branches to the eBPF code, and it exceeds the 1M branches limits of the verifier.
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
