### PR TITLE
[RC-1313] Add integration allow list

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -302,7 +302,7 @@ func InitConfig(config Config) {
 	// Remote config products
 	config.BindEnvAndSetDefault("remote_configuration.apm_sampling.enabled", true)
 	config.BindEnvAndSetDefault("remote_configuration.agent_integrations.enabled", false)
-	config.BindEnvAndSetDefault("remote_configuration.agent_integrations.allow_list", []string{})
+	config.BindEnvAndSetDefault("remote_configuration.agent_integrations.allow_list", defaultAllowedRCIntegrations)
 	config.BindEnvAndSetDefault("remote_configuration.agent_integrations.block_list", []string{})
 
 	// Auto exit configuration
@@ -2038,10 +2038,6 @@ func IsRemoteConfigEnabled(cfg Reader) bool {
 // with remote-config
 func GetRemoteConfigurationAllowedIntegrations(cfg Reader) map[string]bool {
 	allowList := cfg.GetStringSlice("remote_configuration.agent_integrations.allow_list")
-	if len(allowList) == 0 {
-		allowList = defaultAllowedRCIntegrations
-	}
-
 	allowMap := map[string]bool{}
 	for _, integration := range allowList {
 		allowMap[strings.ToLower(integration)] = true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -302,6 +302,8 @@ func InitConfig(config Config) {
 	// Remote config products
 	config.BindEnvAndSetDefault("remote_configuration.apm_sampling.enabled", true)
 	config.BindEnvAndSetDefault("remote_configuration.agent_integrations.enabled", false)
+	config.BindEnvAndSetDefault("remote_configuration.agent_integrations.allow_list", []string{})
+	config.BindEnvAndSetDefault("remote_configuration.agent_integrations.block_list", []string{})
 
 	// Auto exit configuration
 	config.BindEnvAndSetDefault("auto_exit.validation_period", 60)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -130,6 +130,9 @@ var (
 	DefaultSecurityProfilesDir = filepath.Join(defaultRunPath, "runtime-security", "profiles")
 )
 
+// List of integrations allowed to be configured by RC by default
+var defaultAllowedRCIntegrations = []string{}
+
 // PrometheusScrapeChecksTransformer unmarshals a prometheus check.
 func PrometheusScrapeChecksTransformer(in string) interface{} {
 	var promChecks []*types.PrometheusCheck
@@ -2027,4 +2030,25 @@ func IsRemoteConfigEnabled(cfg Reader) bool {
 		return false
 	}
 	return cfg.GetBool("remote_configuration.enabled")
+}
+
+// GetRemoteConfigurationAllowedIntegrations returns the list of integrations that can be scheduled
+// with remote-config
+func GetRemoteConfigurationAllowedIntegrations(cfg Reader) map[string]bool {
+	allowList := cfg.GetStringSlice("remote_configuration.agent_integrations.allow_list")
+	if len(allowList) == 0 {
+		allowList = defaultAllowedRCIntegrations
+	}
+
+	allowMap := map[string]bool{}
+	for _, integration := range allowList {
+		allowMap[strings.ToLower(integration)] = true
+	}
+
+	blockList := cfg.GetStringSlice("remote_configuration.agent_integrations.block_list")
+	for _, blockedIntegration := range blockList {
+		allowMap[strings.ToLower(blockedIntegration)] = false
+	}
+
+	return allowMap
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -911,6 +911,26 @@ func TestIsRemoteConfigEnabled(t *testing.T) {
 	require.False(t, IsRemoteConfigEnabled(testConfig))
 }
 
+func TestGetRemoteConfigurationAllowedIntegrations(t *testing.T) {
+	// EMPTY configuration
+	testConfig := SetupConfFromYAML("")
+	require.Equal(t, map[string]bool{}, GetRemoteConfigurationAllowedIntegrations(testConfig))
+
+	t.Setenv("DD_REMOTE_CONFIGURATION_AGENT_INTEGRATIONS_ALLOW_LIST", "[\"POSTgres\", \"redisDB\"]")
+	testConfig = SetupConfFromYAML("")
+	require.Equal(t,
+		map[string]bool{"postgres": true, "redisdb": true},
+		GetRemoteConfigurationAllowedIntegrations(testConfig),
+	)
+
+	t.Setenv("DD_REMOTE_CONFIGURATION_AGENT_INTEGRATIONS_BLOCK_LIST", "[\"mySQL\", \"redisDB\"]")
+	testConfig = SetupConfFromYAML("")
+	require.Equal(t,
+		map[string]bool{"postgres": true, "redisdb": false, "mysql": false},
+		GetRemoteConfigurationAllowedIntegrations(testConfig),
+	)
+}
+
 func TestLanguageDetectionSettings(t *testing.T) {
 	testConfig := SetupConfFromYAML("")
 	require.False(t, testConfig.GetBool("language_detection.enabled"))


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR introduces an explicit allow list of integrations that can be scheduled with remote-config in the agent.

This change introduces 2 new configuration options:
```
remote_configuration:
    agent_integrations:
        allow_list: ["postgres", "mysql"]
        block_list: ["redisdb", "mysql"]
```

The behavior is the following:
* If `allow_list` is empty, it is set to the default allow list value (currently empty as well)
* If an integration is both in `allow_list` and `block_list`, `block_list` takes precedence
* If an integration is `allowed`, it can be scheduled with remote-config
* If an integration is `blocked` or not `allowed`, it explicitly can't be scheduled with remote-config

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
