### PR TITLE
[pkg/clusteragent][CONTINT-3411]Check if there are new languages detected compared to workloadmeta store before patching

### DIFF
--- a/pkg/clusteragent/languagedetection/patcher.go
+++ b/pkg/clusteragent/languagedetection/patcher.go
@@ -11,10 +11,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/DataDog/datadog-agent/pkg/languagedetection/util"
+	langUtil "github.com/DataDog/datadog-agent/pkg/languagedetection/util"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/client-go/dynamic"
@@ -22,11 +23,12 @@ import (
 )
 
 // OwnersLanguages maps an owner to the detected languages of each container
-type OwnersLanguages map[NamespacedOwnerReference]util.ContainersLanguages
+type OwnersLanguages map[NamespacedOwnerReference]langUtil.ContainersLanguages
 
 // LanguagePatcher defines an object that patches kubernetes resources with language annotations
 type LanguagePatcher struct {
 	k8sClient dynamic.Interface
+	store     workloadmeta.Store
 }
 
 // NewLanguagePatcher initializes and returns a new patcher with a dynamic k8s client
@@ -43,8 +45,8 @@ func NewLanguagePatcher() (*LanguagePatcher, error) {
 	}, nil
 }
 
-func (lp *LanguagePatcher) getContainersLanguagesFromPodDetail(podDetail *pbgo.PodLanguageDetails) util.ContainersLanguages {
-	containerslanguages := util.NewContainersLanguages()
+func (lp *LanguagePatcher) getContainersLanguagesFromPodDetail(podDetail *pbgo.PodLanguageDetails) langUtil.ContainersLanguages {
+	containerslanguages := langUtil.NewContainersLanguages()
 
 	for _, containerLanguageDetails := range podDetail.ContainerDetails {
 		container := containerLanguageDetails.ContainerName
@@ -84,15 +86,49 @@ func (lp *LanguagePatcher) getOwnersLanguages(requestData *pbgo.ParentLanguageAn
 	return &ownerslanguages
 }
 
+func (lp *LanguagePatcher) detectedNewLanguages(namespacedOwnerRef *NamespacedOwnerReference, detectedLanguages langUtil.ContainersLanguages) bool {
+	// Currently we only support deployment owners
+	id := fmt.Sprintf("%s/%s", namespacedOwnerRef.namespace, namespacedOwnerRef.Name)
+	owner, err := lp.store.GetKubernetesDeployment(id)
+
+	if err != nil {
+		return true
+	}
+
+	existingContainersLanguages := langUtil.NewContainersLanguages()
+
+	for container, languages := range owner.ContainerLanguages {
+		for _, language := range languages {
+			existingContainersLanguages.GetOrInitializeLanguageset(container).Add(string(language.Name))
+		}
+	}
+
+	for container, languages := range owner.InitContainerLanguages {
+		for _, language := range languages {
+			existingContainersLanguages.GetOrInitializeLanguageset(fmt.Sprintf("init.%s", container)).Add(string(language.Name))
+		}
+	}
+
+	for container, languages := range detectedLanguages {
+		for language := range languages {
+			if _, found := existingContainersLanguages.GetOrInitializeLanguageset(container)[language]; !found {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 // Updates the existing annotations based on the detected languages.
 // Currently we only add languages to the annotations.
-func (lp *LanguagePatcher) getUpdatedOwnerAnnotations(currentAnnotations map[string]string, containerslanguages util.ContainersLanguages) (map[string]string, int) {
+func (lp *LanguagePatcher) getUpdatedOwnerAnnotations(currentAnnotations map[string]string, containerslanguages langUtil.ContainersLanguages) (map[string]string, int) {
 	if currentAnnotations == nil {
 		currentAnnotations = make(map[string]string)
 	}
 
 	// Add the existing language annotations into containers languages object
-	existingContainersLanguages := util.NewContainersLanguages()
+	existingContainersLanguages := langUtil.NewContainersLanguages()
 	existingContainersLanguages.ParseAnnotations(currentAnnotations)
 
 	// Append the potentially new languages to the containers languages object
@@ -114,10 +150,15 @@ func (lp *LanguagePatcher) getUpdatedOwnerAnnotations(currentAnnotations map[str
 }
 
 // patches the owner with the corresponding language annotations
-func (lp *LanguagePatcher) patchOwner(namespacedOwnerRef *NamespacedOwnerReference, containerslanguages util.ContainersLanguages) error {
+func (lp *LanguagePatcher) patchOwner(namespacedOwnerRef *NamespacedOwnerReference, containerslanguages langUtil.ContainersLanguages) error {
 	ownerGVR, err := getGVR(namespacedOwnerRef)
 	if err != nil {
 		return err
+	}
+
+	if !lp.detectedNewLanguages(namespacedOwnerRef, containerslanguages) {
+		// No need to patch
+		return nil
 	}
 
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {

--- a/pkg/clusteragent/languagedetection/patcher_test.go
+++ b/pkg/clusteragent/languagedetection/patcher_test.go
@@ -9,25 +9,32 @@ package languagedetection
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/languagedetection/util"
+	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
+	langUtil "github.com/DataDog/datadog-agent/pkg/languagedetection/util"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 )
 
+func newMockLanguagePatcher(mockClient dynamic.Interface, mockStore *workloadmeta.MockStore) LanguagePatcher {
+	return LanguagePatcher{
+		k8sClient: mockClient,
+		store:     mockStore,
+	}
+}
+
 func TestGetContainersLanguagesFromPodDetail(t *testing.T) {
 
-	lp := &LanguagePatcher{
-		k8sClient: nil,
-	}
+	lp := newMockLanguagePatcher(nil, nil)
 
 	containerDetails := []*pbgo.ContainerLanguageDetails{
 		{
@@ -65,7 +72,7 @@ func TestGetContainersLanguagesFromPodDetail(t *testing.T) {
 
 	containerslanguages := lp.getContainersLanguagesFromPodDetail(podLanguageDetails)
 
-	expectedContainersLanguages := util.NewContainersLanguages()
+	expectedContainersLanguages := langUtil.NewContainersLanguages()
 
 	expectedContainersLanguages.GetOrInitializeLanguageset("mono-lang").Parse("java")
 	expectedContainersLanguages.GetOrInitializeLanguageset("bi-lang").Parse("java,cpp")
@@ -75,9 +82,7 @@ func TestGetContainersLanguagesFromPodDetail(t *testing.T) {
 }
 
 func TestGetOwnersLanguages(t *testing.T) {
-	lp := &LanguagePatcher{
-		k8sClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
-	}
+	lp := newMockLanguagePatcher(nil, nil)
 
 	defaultNs := "default"
 	customNs := "custom"
@@ -175,14 +180,14 @@ func TestGetOwnersLanguages(t *testing.T) {
 		},
 	}
 
-	expectedContainersLanguagesA := util.NewContainersLanguages()
+	expectedContainersLanguagesA := langUtil.NewContainersLanguages()
 
 	expectedContainersLanguagesA.GetOrInitializeLanguageset("container-1").Parse("java,cpp,go")
 	expectedContainersLanguagesA.GetOrInitializeLanguageset("container-2").Parse("java,python")
 	expectedContainersLanguagesA.GetOrInitializeLanguageset("init.container-3").Parse("java,cpp")
 	expectedContainersLanguagesA.GetOrInitializeLanguageset("init.container-4").Parse("java,python")
 
-	expectedContainersLanguagesB := util.NewContainersLanguages()
+	expectedContainersLanguagesB := langUtil.NewContainersLanguages()
 
 	expectedContainersLanguagesB.GetOrInitializeLanguageset("container-5").Parse("python,cpp,go")
 	expectedContainersLanguagesB.GetOrInitializeLanguageset("container-6").Parse("java,ruby")
@@ -200,12 +205,53 @@ func TestGetOwnersLanguages(t *testing.T) {
 
 }
 
-func TestGetUpdatedOwnerAnnotations(t *testing.T) {
-	lp := &LanguagePatcher{
-		k8sClient: nil,
-	}
+func TestDetectedNewLanguages(t *testing.T) {
+	mockStore := workloadmeta.NewMockStore()
 
-	mockContainersLanguages := util.NewContainersLanguages()
+	mockStore.SetEntity(&workloadmeta.KubernetesDeployment{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesDeployment,
+			ID:   "default/dummy",
+		},
+		ContainerLanguages: map[string][]languagemodels.Language{
+			"container-1": {
+				{
+					Name:    "go",
+					Version: "1.2",
+				},
+			},
+		},
+		InitContainerLanguages: map[string][]languagemodels.Language{
+			"container-2": {
+				{
+					Name:    "java",
+					Version: "18",
+				},
+			},
+		},
+	})
+
+	namespacedOwnerReference := NewNamespacedOwnerReference("apps/v1", "deployment", "dummy", "uid-122", "default")
+
+	lp := newMockLanguagePatcher(nil, mockStore)
+
+	detectedContainersLanguages := langUtil.NewContainersLanguages()
+
+	detectedContainersLanguages.GetOrInitializeLanguageset("container-1").Add("go")
+	detectedContainersLanguages.GetOrInitializeLanguageset("init.container-2").Add("java")
+
+	assert.False(t, lp.detectedNewLanguages(&namespacedOwnerReference, detectedContainersLanguages))
+
+	detectedContainersLanguages.GetOrInitializeLanguageset("container-1").Add("ruby")
+	detectedContainersLanguages.GetOrInitializeLanguageset("container-3").Add("cpp")
+
+	assert.True(t, lp.detectedNewLanguages(&namespacedOwnerReference, detectedContainersLanguages))
+}
+
+func TestGetUpdatedOwnerAnnotations(t *testing.T) {
+	lp := newMockLanguagePatcher(nil, nil)
+
+	mockContainersLanguages := langUtil.NewContainersLanguages()
 	mockContainersLanguages.GetOrInitializeLanguageset("container-1").Parse("cpp,java,python")
 	mockContainersLanguages.GetOrInitializeLanguageset("container-2").Parse("python,ruby")
 	mockContainersLanguages.GetOrInitializeLanguageset("container-3").Parse("cpp")
@@ -253,12 +299,8 @@ func TestGetUpdatedOwnerAnnotations(t *testing.T) {
 }
 
 func TestPatchOwner(t *testing.T) {
-
 	mockK8sClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
-
-	lp := &LanguagePatcher{
-		k8sClient: mockK8sClient,
-	}
+	lp := newMockLanguagePatcher(mockK8sClient, workloadmeta.NewMockStore())
 
 	deploymentName := "test-deployment"
 	ns := "test-namespace"
@@ -266,7 +308,7 @@ func TestPatchOwner(t *testing.T) {
 
 	namespacedOwnerReference := NewNamespacedOwnerReference("apps/v1", "deployment", deploymentName, "uid-dummy", ns)
 
-	mockContainersLanguages := util.NewContainersLanguages()
+	mockContainersLanguages := langUtil.NewContainersLanguages()
 	mockContainersLanguages.GetOrInitializeLanguageset("container-1").Parse("cpp,java,python")
 	mockContainersLanguages.GetOrInitializeLanguageset("container-2").Parse("python,ruby")
 	mockContainersLanguages.GetOrInitializeLanguageset("container-3").Parse("cpp")
@@ -317,10 +359,7 @@ func TestPatchOwner(t *testing.T) {
 
 func TestPatchAllOwners(t *testing.T) {
 	mockK8sClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
-
-	lp := &LanguagePatcher{
-		k8sClient: mockK8sClient,
-	}
+	lp := newMockLanguagePatcher(mockK8sClient, workloadmeta.NewMockStore())
 
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 
@@ -470,8 +509,6 @@ func TestPatchAllOwners(t *testing.T) {
 		"annotationkey2": "annotationvalue2",
 	}
 
-	fmt.Println(expectedAnnotationsA)
-	fmt.Println(annotations)
 	assert.True(t, reflect.DeepEqual(expectedAnnotationsA, annotations))
 
 	// Check the patch of owner B


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR modifies the language detection patcher in the cluster agent so that it checks if the request contains new languages by comparing the languages the ones already existing in workloadmeta store. If no new languages are detected, it returns without fetching the deployment from the API Server and patching the annotations.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This changes will reduce the pressure on the api server. Without this change, this is what happens:
- The handler receives a request from the language detection client containing detected languages for containers
- The handler passes these detected languages to the patcher
- The patcher first gets the owner deployment object by sending a request to the k8s api server
- The patcher reads and parses the language annotations from the obtained deployment object
- It checks if there are newly detected languages, the patcher updates the annotations and patches the deployment with the updated annotations (another request to the api server)

This means that the patcher will always make at least 1 request to the api server in order to verify if we have newly detected languages. 

By looking into workloadmeta store before hand, we reduce the number of requests to the apiserver since we no longer need to send a GET request to verify if the detected languages contain languages that don't already exist in the language annotations.

### Possible Drawbacks / Trade-offs

- In order to check if we have newly detected languages, we need to iterate over the languages stored in workloadmeta for a certain deployment entity. However, this remains acceptable knowing that the number of languages in workloadmeta for a given deployment is not expected to be very large, and this will still yield a considerable performance gain by reducing the number of GET requests to the k8s api server.

### Describe how to test/QA your changes
The testing procedure is identical to the one described in this [PR](https://github.com/DataDog/datadog-agent/pull/19636).

We can verify that the correct annotations are added to the deployment, and workloadmeta contains the correct detected languages as indicated by the language annotations.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
