### PR TITLE
[clusterchecks/common_test] Simplify test using TryLock()

### DIFF
--- a/pkg/clusteragent/clusterchecks/common_test.go
+++ b/pkg/clusteragent/clusterchecks/common_test.go
@@ -10,7 +10,6 @@ package clusterchecks
 import (
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -18,61 +17,24 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/scheduler"
 )
 
-type lockable interface {
-	Lock()
-	Unlock()
-}
-
 // requireNotLocked tries to lock a clusterStore to
 // make sure it is not left locked after an operation
 func requireNotLocked(t *testing.T, s *clusterStore) bool {
 	t.Helper()
-	if isLocked(s) {
+	if !s.TryRLock() {
 		assert.FailNow(t, "clusterStore object is locked")
 		return false
 	}
-	s.RLock()
 	defer s.RUnlock()
 
 	for node, store := range s.nodes {
-		if isLocked(store) {
+		if !store.TryLock() {
 			assert.FailNowf(t, "nodeStore %s is locked", node)
 			return false
 		}
+		store.Unlock()
 	}
 	return true
-}
-
-func isLocked(l lockable) bool {
-	ok := make(chan struct{}, 1)
-	go func() {
-		l.Lock()
-		// Ignore staticcheck SA2001.
-		// This is a valid way of checking if l is locked. We will be able to
-		// simplify all of this when we update to go 1.18, which includes
-		// RWMutex.TryLock().
-		//nolint:staticcheck
-		l.Unlock()
-		ok <- struct{}{}
-	}()
-	select {
-	case <-ok:
-		return false
-	case <-time.After(1 * time.Second):
-		return true
-	}
-}
-
-func TestNotLocked(t *testing.T) {
-	var m sync.Mutex
-	assert.False(t, isLocked(&m))
-}
-
-func TestLocked(t *testing.T) {
-	var m sync.Mutex
-	m.Lock()
-
-	assert.True(t, isLocked(&m))
 }
 
 func TestStoreNotLocked(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Simplifies some code in the test helpers defined in `pkg/clusteragent/clusterchecks/common_test.go` by using `TryLock` (introduced in Golang 1.18). It also fixes a linter issue (staticcheck SA2001).


### Describe how to test/QA your changes

Skip.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
