### PR TITLE
[AMLII-1178] [logs] gather data on usage of processing rules on unstructured data

### DIFF
--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -81,8 +81,8 @@ type LogsConfig struct {
 	SourceCategory  string
 	Tags            []string
 	ProcessingRules []*ProcessingRule `mapstructure:"log_processing_rules" json:"log_processing_rules"`
-	// See ShouldProcessRawMessage comment for information about ExperimentalProcessContentOnly.
-	ExperimentalProcessContentOnly bool `mapstructure:"experimental_process_content_only" json:"experimental_process_content_only"`
+	// ProcessRawMessage is used to process the raw message instead of only the content part of the message.
+	ProcessRawMessage *bool `mapstructure:"process_raw_message" json:"process_raw_message"`
 
 	AutoMultiLine               *bool   `mapstructure:"auto_multi_line_detection" json:"auto_multi_line_detection"`
 	AutoMultiLineSampleSize     int     `mapstructure:"auto_multi_line_sample_size" json:"auto_multi_line_sample_size"`
@@ -144,7 +144,11 @@ func (c *LogsConfig) Dump(multiline bool) string {
 	fmt.Fprintf(&b, ws("SourceCategory: %#v,"), c.SourceCategory)
 	fmt.Fprintf(&b, ws("Tags: %#v,"), c.Tags)
 	fmt.Fprintf(&b, ws("ProcessingRules: %#v,"), c.ProcessingRules)
-	fmt.Fprintf(&b, ws("ExperimentalProcessContentOnly: %#v,"), c.ExperimentalProcessContentOnly)
+	if c.ProcessRawMessage != nil {
+		fmt.Fprintf(&b, ws("ProcessRawMessage: %t,"), *c.ProcessRawMessage)
+	} else {
+		fmt.Fprint(&b, ws("ProcessRawMessage: nil,"))
+	}
 	fmt.Fprintf(&b, ws("ShouldProcessRawMessage(): %#v,"), c.ShouldProcessRawMessage())
 	if c.AutoMultiLine != nil {
 		fmt.Fprintf(&b, ws("AutoMultiLine: %t,"), *c.AutoMultiLine)
@@ -250,15 +254,14 @@ func (c *LogsConfig) AutoMultiLineEnabled(coreConfig pkgConfig.Reader) bool {
 // of only the message content.
 // This is tightly linked to how messages are transmitted through the pipeline.
 // If returning true, tailers using structured message (journald, windowsevents)
-// will fall back to previous behavior of sending the whole message (e.g. JSON
-// for journald) for post-processing. Which is the behavior of Agent <= 7.50.0.
+// will fall back to original behavior of sending the whole message (e.g. JSON
+// for journald) for post-processing.
 // Otherwise, the message content is extracted from the structured message and
 // only this part is post-processed and sent to the intake.
 func (c *LogsConfig) ShouldProcessRawMessage() bool {
-	if c.ExperimentalProcessContentOnly { //nolint:gosimple
-		return false // process only the message content
+	if c.ProcessRawMessage != nil {
+		return *c.ProcessRawMessage
 	}
-
 	return true // default behaviour when nothing's been configured
 }
 

--- a/pkg/logs/internal/processor/processor.go
+++ b/pkg/logs/internal/processor/processor.go
@@ -17,6 +17,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 )
 
+// UnstructuredProcessingMetricName collects how many rules are used on unstructured
+// content for tailers capable of processing both unstructured and structured content.
 const UnstructuredProcessingMetricName = "datadog.logs_agent.tailer.unstructured_processing"
 
 // A Processor updates messages from an inputChan and pushes

--- a/pkg/logs/internal/processor/processor.go
+++ b/pkg/logs/internal/processor/processor.go
@@ -17,6 +17,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 )
 
+const UnstructuredProcessingMetricName = "datadog.logs_agent.tailer.unstructured_processing"
+
 // A Processor updates messages from an inputChan and pushes
 // in an outputChan.
 type Processor struct {

--- a/pkg/logs/tailers/journald/tailer.go
+++ b/pkg/logs/tailers/journald/tailer.go
@@ -20,9 +20,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/framer"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/noop"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/processor"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -58,6 +60,7 @@ func NewTailer(source *sources.LogSource, outputChan chan *message.Message, jour
 		log.Warn("The processing will soon apply on the message content instead of the structured log (e.g. XML or JSON).")
 		log.Warn("A flag will make possible to use the original behavior but will have to set through configuration.")
 		log.Warn("Please reach Datadog support if you have more questions.")
+		telemetry.GetStatsTelemetryProvider().Gauge(processor.UnstructuredProcessingMetricName, float64(len(source.Config.ProcessingRules)), []string{"tailer:journald"})
 	}
 
 	return &Tailer{

--- a/pkg/logs/tailers/journald/tailer.go
+++ b/pkg/logs/tailers/journald/tailer.go
@@ -57,8 +57,8 @@ type Tailer struct {
 func NewTailer(source *sources.LogSource, outputChan chan *message.Message, journal Journal, processRawMessage bool) *Tailer {
 	if len(source.Config.ProcessingRules) > 0 {
 		log.Warn("Log processing rules with the journald collection will change in a future version of the Agent:")
-		log.Warn("The processing will soon apply on the message content instead of the structured log (e.g. XML or JSON).")
-		log.Warn("A flag will make possible to use the original behavior but will have to set through configuration.")
+		log.Warn("The processing will soon apply on the message content only instead of on the structured log (e.g. on the collected JSON).")
+		log.Warn("In order to immediately switch to this new behaviour, set 'process_raw_message' to 'false' in your logs integration config.")
 		log.Warn("Please reach Datadog support if you have more questions.")
 		telemetry.GetStatsTelemetryProvider().Gauge(processor.UnstructuredProcessingMetricName, 1, []string{"tailer:journald"})
 	}

--- a/pkg/logs/tailers/journald/tailer.go
+++ b/pkg/logs/tailers/journald/tailer.go
@@ -60,7 +60,7 @@ func NewTailer(source *sources.LogSource, outputChan chan *message.Message, jour
 		log.Warn("The processing will soon apply on the message content instead of the structured log (e.g. XML or JSON).")
 		log.Warn("A flag will make possible to use the original behavior but will have to set through configuration.")
 		log.Warn("Please reach Datadog support if you have more questions.")
-		telemetry.GetStatsTelemetryProvider().Gauge(processor.UnstructuredProcessingMetricName, float64(len(source.Config.ProcessingRules)), []string{"tailer:journald"})
+		telemetry.GetStatsTelemetryProvider().Gauge(processor.UnstructuredProcessingMetricName, 1, []string{"tailer:journald"})
 	}
 
 	return &Tailer{

--- a/pkg/logs/tailers/journald/tailer.go
+++ b/pkg/logs/tailers/journald/tailer.go
@@ -48,14 +48,13 @@ type Tailer struct {
 	stop chan struct{}
 	done chan struct{}
 	// processRawMessage indicates if we want to process and send the whole structured log message
-	// instead of on the logs content. Note that the default behavior is now to only send
-	// the logs content, as other tailers do.
+	// instead of on the logs content.
 	processRawMessage bool
 }
 
 // NewTailer returns a new tailer.
 func NewTailer(source *sources.LogSource, outputChan chan *message.Message, journal Journal, processRawMessage bool) *Tailer {
-	if len(source.Config.ProcessingRules) > 0 {
+	if len(source.Config.ProcessingRules) > 0 && processRawMessage {
 		log.Warn("Log processing rules with the journald collection will change in a future version of the Agent:")
 		log.Warn("The processing will soon apply on the message content only instead of on the structured log (e.g. on the collected JSON).")
 		log.Warn("In order to immediately switch to this new behaviour, set 'process_raw_message' to 'false' in your logs integration config.")

--- a/pkg/logs/tailers/windowsevent/tailer.go
+++ b/pkg/logs/tailers/windowsevent/tailer.go
@@ -127,7 +127,7 @@ func NewTailer(evtapi evtapi.API, source *sources.LogSource, config *Config, out
 		log.Warn("The processing will soon apply on the message content instead of the structured log (e.g. XML or JSON).")
 		log.Warn("A flag will make possible to use the original behavior but will have to set through configuration.")
 		log.Warn("Please reach Datadog support if you have more questions.")
-		telemetry.GetStatsTelemetryProvider().Gauge(processor.UnstructuredProcessingMetricName, float64(len(source.Config.ProcessingRules)), []string{"tailer:windowsevent"})
+		telemetry.GetStatsTelemetryProvider().Gauge(processor.UnstructuredProcessingMetricName, 1, []string{"tailer:windowsevent"})
 	}
 
 	return &Tailer{

--- a/pkg/logs/tailers/windowsevent/tailer.go
+++ b/pkg/logs/tailers/windowsevent/tailer.go
@@ -122,7 +122,7 @@ func NewTailer(evtapi evtapi.API, source *sources.LogSource, config *Config, out
 		evtapi = winevtapi.New()
 	}
 
-	if len(source.Config.ProcessingRules) > 0 {
+	if len(source.Config.ProcessingRules) > 0 && config.ProcessRawMessage {
 		log.Warn("Log processing rules with the Windows Events collection will change in a future version of the Agent:")
 		log.Warn("The processing will soon apply on the message content only instead of on the structured log (e.g. on the internal JSON).")
 		log.Warn("In order to immediately switch to this new behaviour, set 'process_raw_message' to 'false' in your logs integration config.")

--- a/pkg/logs/tailers/windowsevent/tailer.go
+++ b/pkg/logs/tailers/windowsevent/tailer.go
@@ -20,9 +20,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/framer"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/noop"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/processing"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/strings"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/eventlog/api"
@@ -125,6 +127,7 @@ func NewTailer(evtapi evtapi.API, source *sources.LogSource, config *Config, out
 		log.Warn("The processing will soon apply on the message content instead of the structured log (e.g. XML or JSON).")
 		log.Warn("A flag will make possible to use the original behavior but will have to set through configuration.")
 		log.Warn("Please reach Datadog support if you have more questions.")
+		telemetry.GetStatsTelemetryProvider().Gauge(processor.UnstructuredProcessingMetricName, float64(len(source.Config.ProcessingRules)), []string{"tailer:windowsevent"})
 	}
 
 	return &Tailer{

--- a/pkg/logs/tailers/windowsevent/tailer.go
+++ b/pkg/logs/tailers/windowsevent/tailer.go
@@ -124,8 +124,8 @@ func NewTailer(evtapi evtapi.API, source *sources.LogSource, config *Config, out
 
 	if len(source.Config.ProcessingRules) > 0 {
 		log.Warn("Log processing rules with the Windows Events collection will change in a future version of the Agent:")
-		log.Warn("The processing will soon apply on the message content instead of the structured log (e.g. XML or JSON).")
-		log.Warn("A flag will make possible to use the original behavior but will have to set through configuration.")
+		log.Warn("The processing will soon apply on the message content only instead of on the structured log (e.g. on the internal JSON).")
+		log.Warn("In order to immediately switch to this new behaviour, set 'process_raw_message' to 'false' in your logs integration config.")
 		log.Warn("Please reach Datadog support if you have more questions.")
 		telemetry.GetStatsTelemetryProvider().Gauge(processor.UnstructuredProcessingMetricName, 1, []string{"tailer:windowsevent"})
 	}

--- a/pkg/logs/tailers/windowsevent/tailer.go
+++ b/pkg/logs/tailers/windowsevent/tailer.go
@@ -20,7 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/decoder"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/framer"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/noop"
-	"github.com/DataDog/datadog-agent/pkg/logs/internal/processing"
+	"github.com/DataDog/datadog-agent/pkg/logs/internal/processor"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/status"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"


### PR DESCRIPTION
### What does this PR do?

Send information when processing rules are used with the `journald` or the `windowsevent` tailer.

This PR also adapts the experimental configuration flag for a better migration in future versions.

### Motivation

Better know how to switch to the new behaviour.

### Describe how to test/QA your changes

* Run an Agent with the journald tailer and configure a log processing rule.
* Confirm that a warning is logged at startup
* Confirm that `datadog.logs_agent.tailer.unstructured_processing` is emitted.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
