### PR TITLE
[CONTINT-3311] New-e2e: check that all ECS tasks are running

### DIFF
--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -35,6 +35,7 @@ require (
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.73
+	github.com/DataDog/datadog-agent/pkg/util/pointer v0.48.1
 	github.com/DataDog/datadog-api-client-go v1.16.0
 	github.com/DataDog/datadog-api-client-go/v2 v2.15.0
 	github.com/docker/cli v24.0.4+incompatible
@@ -70,7 +71,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.43 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.37 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.42 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ecs v1.29.6 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ecs v1.29.6
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.35 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.14.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.16.0 // indirect

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -6,6 +6,8 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/agent-payload/v5 v5.0.73 h1:fnCnAR+nWY+q//fBZSab4cDFFng0scPEfmLdl9ngmQY=
 github.com/DataDog/agent-payload/v5 v5.0.73/go.mod h1:oQZi1VZp1e3QvlSUX4iphZCpJaFepUxWq0hNXxihKBM=
+github.com/DataDog/datadog-agent/pkg/util/pointer v0.48.1 h1:xFZ6rpOv00L/20e7Y8rGVOW4wr4y+rHlBydOH9rdKeI=
+github.com/DataDog/datadog-agent/pkg/util/pointer v0.48.1/go.mod h1:eTXti9mx7qhkoi+Qg3mMmvVY5McghUUgsf4Hrk9zY8k=
 github.com/DataDog/datadog-api-client-go v1.16.0 h1:5jOZv1m98criCvYTa3qpW8Hzv301nbZX3K9yJtwGyWY=
 github.com/DataDog/datadog-api-client-go v1.16.0/go.mod h1:PgrP2ABuJWL3Auw2iEkemAJ/r72ghG4DQQmb5sgnKW4=
 github.com/DataDog/datadog-api-client-go/v2 v2.15.0 h1:5UVON1xs6Lul4d6R5TmLDqqSJxOkunkm/UdM/fjm+zc=

--- a/test/new-e2e/tests/containers/ecs_test.go
+++ b/test/new-e2e/tests/containers/ecs_test.go
@@ -12,13 +12,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/infra"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ecs"
 
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	awsecs "github.com/aws/aws-sdk-go-v2/service/ecs"
+	awsecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/fatih/color"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -71,6 +76,93 @@ type ecsSuite struct {
 	baseSuite
 
 	ecsClusterName string
+}
+
+func (suite *ecsSuite) TestAgent() {
+	ctx := context.Background()
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	suite.Require().NoErrorf(err, "Failed to load AWS config")
+
+	client := awsecs.NewFromConfig(cfg)
+
+	suite.Run("ECS tasks are ready", func() {
+		suite.EventuallyWithTf(func(collect *assert.CollectT) {
+			var initToken string
+			for nextToken := &initToken; nextToken != nil; {
+				if nextToken == &initToken {
+					nextToken = nil
+				}
+
+				servicesList, err := client.ListServices(ctx, &awsecs.ListServicesInput{
+					Cluster:    &suite.ecsClusterName,
+					MaxResults: pointer.Ptr(int32(10)), // Because `DescribeServices` takes at most 10 services in input
+					NextToken:  nextToken,
+				})
+				if err != nil {
+					collect.Errorf("Failed to list ECS services: %w", err)
+					return
+				}
+
+				nextToken = servicesList.NextToken
+
+				servicesDescription, err := client.DescribeServices(ctx, &awsecs.DescribeServicesInput{
+					Cluster:  &suite.ecsClusterName,
+					Services: servicesList.ServiceArns,
+				})
+				if err != nil {
+					collect.Errorf("Failed to describe ECS services %v: %w", servicesList.ServiceArns, err)
+					continue
+				}
+
+				for _, serviceDescription := range servicesDescription.Services {
+					if serviceDescription.DesiredCount == 0 {
+						collect.Errorf("ECS service %s has no task.", *serviceDescription.ServiceName)
+					}
+
+					for nextToken := &initToken; nextToken != nil; {
+						if nextToken == &initToken {
+							nextToken = nil
+						}
+
+						tasksList, err := client.ListTasks(ctx, &awsecs.ListTasksInput{
+							Cluster:       &suite.ecsClusterName,
+							ServiceName:   serviceDescription.ServiceName,
+							DesiredStatus: awsecstypes.DesiredStatusRunning,
+							MaxResults:    pointer.Ptr(int32(100)), // Because `DescribeTasks` takes at most 100 tasks in input
+							NextToken:     nextToken,
+						})
+						if err != nil {
+							collect.Errorf("Failed to list ECS tasks for service %s: %w", *serviceDescription.ServiceName, err)
+							break
+						}
+
+						nextToken = tasksList.NextToken
+
+						tasksDescription, err := client.DescribeTasks(ctx, &awsecs.DescribeTasksInput{
+							Cluster: &suite.ecsClusterName,
+							Tasks:   tasksList.TaskArns,
+						})
+						if err != nil {
+							collect.Errorf("Failed to describe ECS tasks %v: %w", tasksList.TaskArns, err)
+							continue
+						}
+
+						for _, taskDescription := range tasksDescription.Tasks {
+							if *taskDescription.LastStatus != string(awsecstypes.DesiredStatusRunning) ||
+								taskDescription.HealthStatus == awsecstypes.HealthStatusUnhealthy {
+								collect.Errorf("Task %s of service %s is %s %s.",
+									*taskDescription.TaskArn,
+									*serviceDescription.ServiceName,
+									*taskDescription.LastStatus,
+									taskDescription.HealthStatus)
+							}
+						}
+					}
+				}
+			}
+		}, 5*time.Minute, 10*time.Second, "Not all tasks became ready in time.")
+	})
 }
 
 func (suite *ecsSuite) TestNginx() {

--- a/test/new-e2e/tests/containers/ecs_test.go
+++ b/test/new-e2e/tests/containers/ecs_test.go
@@ -78,7 +78,21 @@ type ecsSuite struct {
 	ecsClusterName string
 }
 
-func (suite *ecsSuite) TestAgent() {
+// Once pulumi has finished to create a stack, it can still take some time for the images to be pulled,
+// for the containers to be started, for the agent collectors to collect workload information
+// and to feed workload meta and the tagger.
+//
+// We could increase the timeout of all tests to cope with the agent tagger warmup time.
+// But in case of a single bug making a single tag missing from every metric,
+// all the tests would time out and that would be a waste of time.
+//
+// It’s better to have the first test having a long timeout to wait for the agent to warmup,
+// and to have the following tests with a smaller timeout.
+//
+// Inside a testify test suite, tests are executed in alphabetical order.
+// The 00 in Test00UpAndRunning is here to guarantee that this test, waiting for all tasks to be ready
+// is run first.
+func (suite *ecsSuite) Test00UpAndRunning() {
 	ctx := context.Background()
 
 	cfg, err := awsconfig.LoadDefaultConfig(ctx)

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -118,7 +118,7 @@ func (suite *k8sSuite) TestAgent() {
 					}
 				}
 			}
-		}, 2*time.Minute, 10*time.Second, "Not all agents eventually became ready in time.")
+		}, 5*time.Minute, 10*time.Second, "Not all agents eventually became ready in time.")
 	})
 
 	versionExtractor := regexp.MustCompile(`Commit: ([[:xdigit:]]+)`)

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -39,7 +39,21 @@ type k8sSuite struct {
 	K8sClient *kubernetes.Clientset
 }
 
-func (suite *k8sSuite) TestAgent() {
+// Once pulumi has finished to create a stack, it can still take some time for the images to be pulled,
+// for the containers to be started, for the agent collectors to collect workload information
+// and to feed workload meta and the tagger.
+//
+// We could increase the timeout of all tests to cope with the agent tagger warmup time.
+// But in case of a single bug making a single tag missing from every metric,
+// all the tests would time out and that would be a waste of time.
+//
+// It’s better to have the first test having a long timeout to wait for the agent to warmup,
+// and to have the following tests with a smaller timeout.
+//
+// Inside a testify test suite, tests are executed in alphabetical order.
+// The 00 in Test00UpAndRunning is here to guarantee that this test, waiting for the agent pods to be ready
+// is run first.
+func (suite *k8sSuite) Test00UpAndRunning() {
 	ctx := context.Background()
 
 	suite.Run("agent pods are ready and not restarting", func() {


### PR DESCRIPTION
### What does this PR do?

Check that all ECS tasks are running before continuing the tests.

### Motivation

ECS tests are randomly failing with always the same type of error: ECS specific tags are missing.
[Ex.](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/354548669):
```
=== FAIL: tests/containers TestECSSuite/TestPrometheus/prometheus.prom_gauge{} (120.01s)
    base_test.go:29: Tags mismatch on `prometheus.prom_gauge`: missing tags: ^cluster_name:ci-22199720-4670-ecs-cluster-ecs$, ^task_version:[[:digit:]]+$, ^task_name:.*-prometheus-ec2$, ^task_family:.*-prometheus-ec2$, ^ecs_cluster_name:ci-22199720-4670-ecs-cluster-ecs$, ^ecs_container_name:prometheus$, ^task_arn:
    base_test.go:29: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/base_test.go:29
        	            				/go/pkg/mod/github.com/stretchr/testify@v1.8.5-0.20231013065317-89920137cdfa/suite/suite.go:112
        	Error:      	Condition never satisfied
        	Test:       	TestECSSuite/TestPrometheus/prometheus.prom_gauge{}
        	Messages:   	Failed finding prometheus.prom_gauge{} with proper tags
        --- FAIL: TestECSSuite/TestPrometheus/prometheus.prom_gauge{} (120.01s)
```

This error happens randomly, each time on a different metric, but it’s always the same tags that are missing.
This is the sign that we didn’t let enough time for the ECS collector to feed workload meta and the tagger.

Rather than increasing the time-out of the all retry loops of all the tests, let’s wait for all the ECS tasks to become ready before moving on similarly to what we do for Kubernetes tests (#20302).

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Check ECS new-e2e tests.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
