### PR TITLE
[DBMON-2461] Bump up go-sqllexer to support collecting procedure names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -609,7 +609,7 @@ require (
 	github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/system/socket v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-api-client-go/v2 v2.13.0 // indirect
-	github.com/DataDog/go-sqllexer v0.0.6 // indirect
+	github.com/DataDog/go-sqllexer v0.0.7 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe/go.mod h1:90sqV0j7E8wYCyqIp5d9HmYWLTFQttqPFFtNYDyAybQ=
 github.com/DataDog/go-libddwaf v1.5.0 h1:lrHP3VrEriy1M5uQuaOcKphf5GU40mBhihMAp6Ik55c=
 github.com/DataDog/go-libddwaf v1.5.0/go.mod h1:Fpnmoc2k53h6desQrH1P0/gR52CUzkLNFugE5zWwUBQ=
-github.com/DataDog/go-sqllexer v0.0.6 h1:RneAS1rOPTkdOr6ISHgu8kmLeX47VQejIXkQpXxX9rg=
-github.com/DataDog/go-sqllexer v0.0.6/go.mod h1:nB4Ea2YNsqMwtbWMc4Fm/oP98IIrSPapqwOwPioMspY=
+github.com/DataDog/go-sqllexer v0.0.7 h1:bNHPtNu1n+UYgkplPywFvyeL6A15gL+peDW+GVARnfE=
+github.com/DataDog/go-sqllexer v0.0.7/go.mod h1:nB4Ea2YNsqMwtbWMc4Fm/oP98IIrSPapqwOwPioMspY=
 github.com/DataDog/go-tuf v1.0.2-0.5.2 h1:EeZr937eKAWPxJ26IykAdWA4A0jQXJgkhUjqEI/w7+I=
 github.com/DataDog/go-tuf v1.0.2-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gopsutil v1.2.2 h1:8lmthwyyCXa1NKiYcHlrtl9AAFdfbNI2gPcioCJcBPU=

--- a/pkg/collector/python/datadog_agent.go
+++ b/pkg/collector/python/datadog_agent.go
@@ -240,6 +240,8 @@ type sqlConfig struct {
 	CollectCommands bool `json:"collect_commands"`
 	// CollectComments specifies whether the obfuscator should extract and return comments as SQL metadata when obfuscating.
 	CollectComments bool `json:"collect_comments"`
+	// CollectProcedures specifies whether the obfuscator should extract and return procedure names as SQL metadata when obfuscating.
+	CollectProcedures bool `json:"collect_procedures"`
 	// ReplaceDigits specifies whether digits in table names and identifiers should be obfuscated.
 	ReplaceDigits bool `json:"replace_digits"`
 	// KeepSQLAlias specifies whether or not to strip sql aliases while obfuscating.
@@ -252,7 +254,7 @@ type sqlConfig struct {
 	// ObfuscationMode specifies the obfuscation mode to use for go-sqllexer pkg.
 	// When specified, obfuscator will attempt to use go-sqllexer pkg to obfuscate (and normalize) SQL queries.
 	// Valid values are "obfuscate_only", "obfuscate_and_normalize"
-	ObfuscationMode obfuscate.ObfuscationMode `json:"obfuscation_mode" yaml:"obfuscation_mode"`
+	ObfuscationMode obfuscate.ObfuscationMode `json:"obfuscation_mode"`
 }
 
 // ObfuscateSQL obfuscates & normalizes the provided SQL query, writing the error into errResult if the operation
@@ -272,14 +274,15 @@ func ObfuscateSQL(rawQuery, opts *C.char, errResult **C.char) *C.char {
 	}
 	s := C.GoString(rawQuery)
 	obfuscatedQuery, err := lazyInitObfuscator().ObfuscateSQLStringWithOptions(s, &obfuscate.SQLConfig{
-		DBMS:             sqlOpts.DBMS,
-		TableNames:       sqlOpts.TableNames,
-		CollectCommands:  sqlOpts.CollectCommands,
-		CollectComments:  sqlOpts.CollectComments,
-		ReplaceDigits:    sqlOpts.ReplaceDigits,
-		KeepSQLAlias:     sqlOpts.KeepSQLAlias,
-		DollarQuotedFunc: sqlOpts.DollarQuotedFunc,
-		ObfuscationMode:  sqlOpts.ObfuscationMode,
+		DBMS:              sqlOpts.DBMS,
+		TableNames:        sqlOpts.TableNames,
+		CollectCommands:   sqlOpts.CollectCommands,
+		CollectComments:   sqlOpts.CollectComments,
+		CollectProcedures: sqlOpts.CollectProcedures,
+		ReplaceDigits:     sqlOpts.ReplaceDigits,
+		KeepSQLAlias:      sqlOpts.KeepSQLAlias,
+		DollarQuotedFunc:  sqlOpts.DollarQuotedFunc,
+		ObfuscationMode:   sqlOpts.ObfuscationMode,
 	})
 	if err != nil {
 		// memory will be freed by caller

--- a/pkg/obfuscate/go.mod
+++ b/pkg/obfuscate/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.1.1
-	github.com/DataDog/go-sqllexer v0.0.6
+	github.com/DataDog/go-sqllexer v0.0.7
 	github.com/outcaste-io/ristretto v0.2.1
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/atomic v1.10.0

--- a/pkg/obfuscate/go.sum
+++ b/pkg/obfuscate/go.sum
@@ -1,7 +1,7 @@
 github.com/DataDog/datadog-go/v5 v5.1.1 h1:JLZ6s2K1pG2h9GkvEvMdEGqMDyVLEAccdX5TltWcLMU=
 github.com/DataDog/datadog-go/v5 v5.1.1/go.mod h1:KhiYb2Badlv9/rofz+OznKoEF5XKTonWyhx5K83AP8E=
-github.com/DataDog/go-sqllexer v0.0.6 h1:RneAS1rOPTkdOr6ISHgu8kmLeX47VQejIXkQpXxX9rg=
-github.com/DataDog/go-sqllexer v0.0.6/go.mod h1:nB4Ea2YNsqMwtbWMc4Fm/oP98IIrSPapqwOwPioMspY=
+github.com/DataDog/go-sqllexer v0.0.7 h1:bNHPtNu1n+UYgkplPywFvyeL6A15gL+peDW+GVARnfE=
+github.com/DataDog/go-sqllexer v0.0.7/go.mod h1:nB4Ea2YNsqMwtbWMc4Fm/oP98IIrSPapqwOwPioMspY=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.5.1 h1:aPJp2QD7OOrhO5tQXqQoGSJc+DjDtWTGLOmNyAm6FgY=
 github.com/Microsoft/go-winio v0.5.1/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=

--- a/pkg/obfuscate/obfuscate.go
+++ b/pkg/obfuscate/obfuscate.go
@@ -127,6 +127,9 @@ type SQLConfig struct {
 	// CollectComments specifies whether the obfuscator should extract and return comments as SQL metadata when obfuscating.
 	CollectComments bool `json:"collect_comments" yaml:"collect_comments"`
 
+	// CollectProcedures specifies whether the obfuscator should extract and return procedure names as SQL metadata when obfuscating.
+	CollectProcedures bool `json:"collect_procedures" yaml:"collect_procedures"`
+
 	// ReplaceDigits specifies whether digits in table names and identifiers should be obfuscated.
 	ReplaceDigits bool `json:"replace_digits" yaml:"replace_digits"`
 
@@ -161,6 +164,8 @@ type SQLMetadata struct {
 	Commands []string `json:"commands"`
 	// Comments holds comments in an SQL statement.
 	Comments []string `json:"comments"`
+	// Procedures holds procedure names in an SQL statement.
+	Procedures []string `json:"procedures"`
 }
 
 // HTTPConfig holds the configuration settings for HTTP obfuscation.

--- a/pkg/obfuscate/sql.go
+++ b/pkg/obfuscate/sql.go
@@ -455,6 +455,7 @@ func (o *Obfuscator) ObfuscateWithSQLLexer(in string, opts *SQLConfig) (*Obfusca
 		sqllexer.WithCollectComments(opts.CollectComments),
 		sqllexer.WithCollectCommands(opts.CollectCommands),
 		sqllexer.WithCollectTables(opts.TableNames),
+		sqllexer.WithCollectProcedures(opts.CollectProcedures),
 		sqllexer.WithKeepSQLAlias(opts.KeepSQLAlias),
 	)
 	out, statementMetadata, err := sqllexer.ObfuscateAndNormalize(
@@ -469,10 +470,11 @@ func (o *Obfuscator) ObfuscateWithSQLLexer(in string, opts *SQLConfig) (*Obfusca
 	oq := &ObfuscatedQuery{
 		Query: out,
 		Metadata: SQLMetadata{
-			Size:      int64(statementMetadata.Size),
-			TablesCSV: strings.Join(statementMetadata.Tables, ","),
-			Commands:  statementMetadata.Commands,
-			Comments:  statementMetadata.Comments,
+			Size:       int64(statementMetadata.Size),
+			TablesCSV:  strings.Join(statementMetadata.Tables, ","),
+			Commands:   statementMetadata.Commands,
+			Comments:   statementMetadata.Comments,
+			Procedures: statementMetadata.Procedures,
 		},
 	}
 

--- a/pkg/obfuscate/sql_test.go
+++ b/pkg/obfuscate/sql_test.go
@@ -2123,13 +2123,14 @@ func TestSQLLexerObfuscation(t *testing.T) {
 
 func TestSQLLexerObfuscationAndNormalization(t *testing.T) {
 	tests := []struct {
-		name             string
-		query            string
-		expected         string
-		replaceDigits    bool
-		dollarQuotedFunc bool
-		keepSQLAlias     bool
-		metadata         SQLMetadata
+		name              string
+		query             string
+		expected          string
+		replaceDigits     bool
+		dollarQuotedFunc  bool
+		keepSQLAlias      bool
+		collectProcedures bool
+		metadata          SQLMetadata
 	}{
 		{
 			name:     "simple query obfuscation and normalization",
@@ -2141,7 +2142,8 @@ func TestSQLLexerObfuscationAndNormalization(t *testing.T) {
 				Commands: []string{
 					"SELECT",
 				},
-				Comments: []string{},
+				Comments:   []string{},
+				Procedures: []string{},
 			},
 		},
 		{
@@ -2155,7 +2157,8 @@ func TestSQLLexerObfuscationAndNormalization(t *testing.T) {
 				Commands: []string{
 					"SELECT",
 				},
-				Comments: []string{},
+				Comments:   []string{},
+				Procedures: []string{},
 			},
 		},
 		{
@@ -2177,6 +2180,7 @@ func TestSQLLexerObfuscationAndNormalization(t *testing.T) {
 					"-- comment",
 					"/* comment */",
 				},
+				Procedures: []string{},
 			},
 		},
 		{
@@ -2190,7 +2194,8 @@ func TestSQLLexerObfuscationAndNormalization(t *testing.T) {
 				Commands: []string{
 					"SELECT",
 				},
-				Comments: []string{},
+				Comments:   []string{},
+				Procedures: []string{},
 			},
 		},
 		{
@@ -2204,7 +2209,8 @@ func TestSQLLexerObfuscationAndNormalization(t *testing.T) {
 				Commands: []string{
 					"SELECT",
 				},
-				Comments: []string{},
+				Comments:   []string{},
+				Procedures: []string{},
 			},
 		},
 		{
@@ -2219,7 +2225,44 @@ func TestSQLLexerObfuscationAndNormalization(t *testing.T) {
 				Commands: []string{
 					"SELECT",
 				},
+				Comments:   []string{},
+				Procedures: []string{},
+			},
+		},
+		{
+			name:              "normalization with stored procedure enabled",
+			query:             "CREATE PROCEDURE TestProc AS BEGIN SELECT * FROM users WHERE id = 1 END",
+			expected:          "CREATE PROCEDURE TestProc AS BEGIN SELECT * FROM users WHERE id = ? END",
+			collectProcedures: true,
+			metadata: SQLMetadata{
+				Size:      30,
+				TablesCSV: "users",
+				Commands: []string{
+					"CREATE",
+					"BEGIN",
+					"SELECT",
+				},
 				Comments: []string{},
+				Procedures: []string{
+					"TestProc",
+				},
+			},
+		},
+		{
+			name:              "normalization with stored procedure disabled",
+			query:             "CREATE PROCEDURE TestProc AS BEGIN UPDATE users SET name = 'test' WHERE id = 1 END",
+			expected:          "CREATE PROCEDURE TestProc AS BEGIN UPDATE users SET name = ? WHERE id = ? END",
+			collectProcedures: false,
+			metadata: SQLMetadata{
+				Size:      22,
+				TablesCSV: "users",
+				Commands: []string{
+					"CREATE",
+					"BEGIN",
+					"UPDATE",
+				},
+				Comments:   []string{},
+				Procedures: []string{},
 			},
 		},
 	}
@@ -2228,13 +2271,14 @@ func TestSQLLexerObfuscationAndNormalization(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			oq, err := NewObfuscator(Config{
 				SQL: SQLConfig{
-					ObfuscationMode:  "obfuscate_and_normalize",
-					ReplaceDigits:    tt.replaceDigits,
-					DollarQuotedFunc: tt.dollarQuotedFunc,
-					KeepSQLAlias:     tt.keepSQLAlias,
-					TableNames:       true,
-					CollectCommands:  true,
-					CollectComments:  true,
+					ObfuscationMode:   "obfuscate_and_normalize",
+					ReplaceDigits:     tt.replaceDigits,
+					DollarQuotedFunc:  tt.dollarQuotedFunc,
+					KeepSQLAlias:      tt.keepSQLAlias,
+					TableNames:        true,
+					CollectCommands:   true,
+					CollectComments:   true,
+					CollectProcedures: tt.collectProcedures,
 				},
 			}).ObfuscateSQLString(tt.query)
 			require.NoError(t, err)

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -42,7 +42,7 @@ require (
 )
 
 require (
-	github.com/DataDog/go-sqllexer v0.0.6 // indirect
+	github.com/DataDog/go-sqllexer v0.0.7 // indirect
 	github.com/DataDog/go-tuf v1.0.2-0.5.2 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/containerd/cgroups/v3 v3.0.2 // indirect

--- a/pkg/trace/go.sum
+++ b/pkg/trace/go.sum
@@ -1,7 +1,7 @@
 github.com/DataDog/datadog-go/v5 v5.1.1 h1:JLZ6s2K1pG2h9GkvEvMdEGqMDyVLEAccdX5TltWcLMU=
 github.com/DataDog/datadog-go/v5 v5.1.1/go.mod h1:KhiYb2Badlv9/rofz+OznKoEF5XKTonWyhx5K83AP8E=
-github.com/DataDog/go-sqllexer v0.0.6 h1:RneAS1rOPTkdOr6ISHgu8kmLeX47VQejIXkQpXxX9rg=
-github.com/DataDog/go-sqllexer v0.0.6/go.mod h1:nB4Ea2YNsqMwtbWMc4Fm/oP98IIrSPapqwOwPioMspY=
+github.com/DataDog/go-sqllexer v0.0.7 h1:bNHPtNu1n+UYgkplPywFvyeL6A15gL+peDW+GVARnfE=
+github.com/DataDog/go-sqllexer v0.0.7/go.mod h1:nB4Ea2YNsqMwtbWMc4Fm/oP98IIrSPapqwOwPioMspY=
 github.com/DataDog/go-tuf v1.0.2-0.5.2 h1:EeZr937eKAWPxJ26IykAdWA4A0jQXJgkhUjqEI/w7+I=
 github.com/DataDog/go-tuf v1.0.2-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.8.0 h1:NNSjBdo9PlfjUKmCrjNWTxAtG7ovemO5EHT08zVpeUU=

--- a/releasenotes/notes/go-sqllexer-minor-version-bump-b81be45812e4a840.yaml
+++ b/releasenotes/notes/go-sqllexer-minor-version-bump-b81be45812e4a840.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Bump the minimum version of the `go-sqllexer` library to 0.0.7 to support collect stored procedure names.

--- a/releasenotes/notes/go-sqllexer-minor-version-bump-b81be45812e4a840.yaml
+++ b/releasenotes/notes/go-sqllexer-minor-version-bump-b81be45812e4a840.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Bump the minimum version of the `go-sqllexer` library to 0.0.7 to support collecting stored procedure names.
+    DBM: Bump the minimum version of the `go-sqllexer` library to 0.0.7 to support collecting stored procedure names.

--- a/releasenotes/notes/go-sqllexer-minor-version-bump-b81be45812e4a840.yaml
+++ b/releasenotes/notes/go-sqllexer-minor-version-bump-b81be45812e4a840.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Bump the minimum version of the `go-sqllexer` library to 0.0.7 to support collect stored procedure names.
+    Bump the minimum version of the `go-sqllexer` library to 0.0.7 to support collecting stored procedure names.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR bumps `go-sqllexer` to v0.0.7 to support collecting stored procedure names. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The stored procedure names were used to be collected in Python integrations and the logic requires (re)traverse the entire sql statement. By moving the procedure name collection to the normalization process not only reduces unnecessary rescanning of the sql statement, but also enriches the collected sql metadata.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
