### PR TITLE
collect boot logs as artifacts for KMT

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,8 +168,8 @@ variables:
   DATADOG_AGENT_BTF_GEN_BUILDIMAGES: v22284534-4d24e62
   # To use images from test-infra-definitions dev branches, set the SUFFIX variable to -dev
   # and check the job creating the image to make sure you have the right SHA prefix
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: "-dev"
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES: c6983c67
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: ""
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES: d08836e5ac08
   DATADOG_AGENT_BUILDERS: v22276738-b36b132
 
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,8 +168,8 @@ variables:
   DATADOG_AGENT_BTF_GEN_BUILDIMAGES: v22284534-4d24e62
   # To use images from test-infra-definitions dev branches, set the SUFFIX variable to -dev
   # and check the job creating the image to make sure you have the right SHA prefix
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: ""
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES: 8d38c2a2a794
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: "-dev"
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES: c6983c67
   DATADOG_AGENT_BUILDERS: v22276738-b36b132
 
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded

--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -302,6 +302,11 @@ kernel_matrix_testing_setup_env:
     - inv -e system-probe.start-microvms --provision --instance-type-x86=$EC2_X86_INSTANCE_TYPE --instance-type-arm=$EC2_ARM_INSTANCE_TYPE --x86-ami-id=$X86_AMI_ID --arm-ami-id=$ARM_AMI_ID --ssh-key-name=$AWS_EC2_SSH_KEY_NAME --ssh-key-path=$AWS_EC2_SSH_KEY_FILE --infra-env=$INFRA_ENV --stack-name=kernel-matrix-testing-$CI_PIPELINE_ID
     - cat $CI_PROJECT_DIR/stack.outputs
     - pulumi logout
+    - mkdir -p $CI_PROJECT_DIR/libvirt/log/x86_64 $CI_PROJECT_DIR/libvirt/log/arm64
+    - X64_INSTANCE_IP=$(cat $CI_PROJECT_DIR/stack.outputs | grep x86_64-instance-ip | cut -d ' ' -f 2)
+    - scp -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE "ubuntu@$X64_INSTANCE_IP:/tmp/ddvm-*.log" $CI_PROJECT_DIR/libvirt/log/x86_64/
+    - ARM64_INSTANCE_IP=$(cat $CI_PROJECT_DIR/stack.outputs | grep arm64-instance-ip | cut -d ' ' -f 2)
+    - scp -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE "ubuntu@$ARM64_INSTANCE_IP:/tmp/ddvm-*.log" $CI_PROJECT_DIR/libvirt/log/arm64/
   artifacts:
     when: always
     paths:
@@ -311,6 +316,7 @@ kernel_matrix_testing_setup_env:
       - $LibvirtSSHKeyARM.pub
       - $STACK_DIR
       - $CI_PROJECT_DIR/stack.outputs
+      - $CI_PROJECT_DIR/libvirt
 
 .kernel_matrix_testing_run_tests:
   stage: kernel_matrix_testing

--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -303,9 +303,9 @@ kernel_matrix_testing_setup_env:
     - cat $CI_PROJECT_DIR/stack.outputs
     - pulumi logout
     - mkdir -p $CI_PROJECT_DIR/libvirt/log/x86_64 $CI_PROJECT_DIR/libvirt/log/arm64
-    - X64_INSTANCE_IP=$(cat $CI_PROJECT_DIR/stack.outputs | grep x86_64-instance-ip | cut -d ' ' -f 2)
+    - X64_INSTANCE_IP=$(grep x86_64-instance-ip $CI_PROJECT_DIR/stack.outputs | cut -d ' ' -f 2)
     - scp -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE "ubuntu@$X64_INSTANCE_IP:/tmp/ddvm-*.log" $CI_PROJECT_DIR/libvirt/log/x86_64/
-    - ARM64_INSTANCE_IP=$(cat $CI_PROJECT_DIR/stack.outputs | grep arm64-instance-ip | cut -d ' ' -f 2)
+    - ARM64_INSTANCE_IP=$(grep arm64-instance-ip $CI_PROJECT_DIR/stack.outputs | cut -d ' ' -f 2)
     - scp -o StrictHostKeyChecking=no -i $AWS_EC2_SSH_KEY_FILE "ubuntu@$ARM64_INSTANCE_IP:/tmp/ddvm-*.log" $CI_PROJECT_DIR/libvirt/log/arm64/
   artifacts:
     when: always

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -15,7 +15,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20231023201436-c6983c675dc1
+	github.com/DataDog/test-infra-definitions v0.0.0-20231024173211-d08836e5ac08
 	github.com/aws/aws-sdk-go-v2 v1.21.2
 	github.com/aws/aws-sdk-go-v2/config v1.18.40
 	github.com/aws/aws-sdk-go-v2/service/eks v1.29.7

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -15,7 +15,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20231020142939-8d38c2a2a794
+	github.com/DataDog/test-infra-definitions v0.0.0-20231023201436-c6983c675dc1
 	github.com/aws/aws-sdk-go-v2 v1.21.2
 	github.com/aws/aws-sdk-go-v2/config v1.18.40
 	github.com/aws/aws-sdk-go-v2/service/eks v1.29.7

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -14,8 +14,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.15.0 h1:5UVON1xs6Lul4d6R5TmLDqqSJ
 github.com/DataDog/datadog-api-client-go/v2 v2.15.0/go.mod h1:ZG8wS+y2rUmkRDJZQq7Og7EAPFPage+7vXcmuah2I9o=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20231020142939-8d38c2a2a794 h1:CcaJveKTnKl8EvQSEnNNviTffmBl8vYD+cF3YVWiuuI=
-github.com/DataDog/test-infra-definitions v0.0.0-20231020142939-8d38c2a2a794/go.mod h1:PqwpYO1dh26TxKAY1TiiMLmmSxzytx3OrXtYl086m2c=
+github.com/DataDog/test-infra-definitions v0.0.0-20231023201436-c6983c675dc1 h1:yDQGLEF8+J4TZcqVO1mFeJit5LaKf1HXpeSpL0vZN50=
+github.com/DataDog/test-infra-definitions v0.0.0-20231023201436-c6983c675dc1/go.mod h1:PqwpYO1dh26TxKAY1TiiMLmmSxzytx3OrXtYl086m2c=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -14,8 +14,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.15.0 h1:5UVON1xs6Lul4d6R5TmLDqqSJ
 github.com/DataDog/datadog-api-client-go/v2 v2.15.0/go.mod h1:ZG8wS+y2rUmkRDJZQq7Og7EAPFPage+7vXcmuah2I9o=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20231023201436-c6983c675dc1 h1:yDQGLEF8+J4TZcqVO1mFeJit5LaKf1HXpeSpL0vZN50=
-github.com/DataDog/test-infra-definitions v0.0.0-20231023201436-c6983c675dc1/go.mod h1:PqwpYO1dh26TxKAY1TiiMLmmSxzytx3OrXtYl086m2c=
+github.com/DataDog/test-infra-definitions v0.0.0-20231024173211-d08836e5ac08 h1:lY0uURrW2QGpmzBimXTJckGxvlW7PqXY9ShTL58BqcM=
+github.com/DataDog/test-infra-definitions v0.0.0-20231024173211-d08836e5ac08/go.mod h1:PqwpYO1dh26TxKAY1TiiMLmmSxzytx3OrXtYl086m2c=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/system-probe/config/vmconfig.json
+++ b/test/new-e2e/system-probe/config/vmconfig.json
@@ -4,6 +4,7 @@
             "name": "distro_x86_64",
             "recipe": "distro-x86_64",
             "arch": "x86_64",
+            "console_type": "file",
             "kernels": [
                 {
                     "dir": "bionic-server-cloudimg-amd64.qcow2",
@@ -67,6 +68,7 @@
             "name": "distro_arm64",
             "recipe": "distro-arm64",
             "arch": "arm64",
+            "console_type": "file",
             "kernels": [
                 {
                     "dir": "focal-server-cloudimg-arm64.qcow2",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Collects bool logs from micro VMs and stores them as job artifacts

### Motivation

Easier debugging in case of boot failures

### Additional Notes

https://datadoghq.atlassian.net/browse/EBPF-238

Waiting for https://github.com/DataDog/test-infra-definitions/pull/348

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
