### PR TITLE
[kubelet client] Ignore rootCA failure if kubelet_tls_verify=false

### DIFF
--- a/pkg/util/kubernetes/kubelet/kubelet_client.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_client.go
@@ -68,7 +68,12 @@ func newForConfig(config kubeletClientConfig, timeout time.Duration) (*kubeletCl
 	if config.caPath != "" {
 		tlsConfig.RootCAs, err = kubernetes.GetCertificateAuthority(config.caPath)
 		if err != nil {
-			return nil, err
+			// Ignore failure in retrieving root CA as kubelet_tls_verify=false make the RootCAs parameter un-used.
+			if tlsConfig.InsecureSkipVerify {
+				log.Debugf("Failed to retrieve root certificate authority from path %s: %s. Ignoring error as kubelet_tls_verify=false", config.caPath, err)
+			} else {
+				return nil, err
+			}
 		}
 	}
 

--- a/releasenotes/notes/kubelet-tls-verify-precedence-373a7ece8830d6e4.yaml
+++ b/releasenotes/notes/kubelet-tls-verify-precedence-373a7ece8830d6e4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    [kubelet] The Kubelet client no longer fails to initialize when the parameter ``kubelet_tls_verify`` is set to ``false`` with a misconfigured root certificate authority.


### PR DESCRIPTION
### What does this PR do?

* Allows the kubelet client to initialize when `kubelet_tls_verify=false` despite an error when retrieving the root CAs from the configuration

### Motivation

* Self-testing on OpenShift, I encountered a situation where the root CA cert would not be mounted inside the security agent and despite using `kubelet_tls_verify=false`, the security agent was still unable to connect to the kubelet

### Additional Notes

A considered alternative would be to not even attempt to retrieve the root CA cert when the setting is present : 
```
	// Retrieving root certificate authorities unless TLS verification is skipped
	if config.caPath != "" && !tlsConfig.InsecureSkipVerify {
		tlsConfig.RootCAs, err = kubernetes.GetCertificateAuthority(config.caPath)
		if err != nil {
			return nil, err
		}
	}
```
However, this becomes "silent" for the user.

### Possible Drawbacks / Trade-offs

* A failure to init the kubelet previously in this situation will now be "resolved" and the kubelet connection will work despite a wrong user configuration / setting

### Describe how to test/QA your changes

* Start a kind cluster
* With the Helm chart, provide a fake path for `agentCAPath` without setting `hostCAPath` while using `tlsVerify` and ensure the Agent is able to connect to the kubelet -> e.g. review the kubelet check in `agent status` or use `agent diagnose` : 
```
datadog:
  kubelet:
    tlsVerify: false
    agentCAPath: /var/run/host-kubelet-ca.crt
  logLevel: debug
```
* Assess the presence of the debug log : `CORE | DEBUG | (pkg/util/kubernetes/kubelet/kubelet_client.go:73 in newForConfig) | Failed to retrieve root certificate authority from path /var/run/host-kubelet-ca.crt: open /var/run/host-kubelet-ca.crt: no such file or directory. Ignoring error as kubelet_tls_verify=false`

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
