### PR TITLE
Use require.EventuallyWithT to avoid asserting when fakeintake is not ready

### DIFF
--- a/test/new-e2e/tests/agent-subcommands/flare/flare_test.go
+++ b/test/new-e2e/tests/agent-subcommands/flare/flare_test.go
@@ -32,7 +32,7 @@ func requestAgentFlareAndFetchFromFakeIntake(v *commandFlareSuite, flareArgs ...
 	// Wait for the fakeintake to be ready to avoid 503 when sending the flare
 	require.EventuallyWithT(v.T(), func(c *assert.CollectT) {
 		assert.NoError(c, v.Env().Fakeintake.Client.GetServerHealth())
-	}, 5*time.Minute, 20*time.Second)
+	}, 5*time.Minute, 20*time.Second, "expected fakeintake server to be ready; not ready in 5min")
 
 	_ = v.Env().Agent.Flare(flareArgs...)
 

--- a/test/new-e2e/tests/agent-subcommands/flare/flare_test.go
+++ b/test/new-e2e/tests/agent-subcommands/flare/flare_test.go
@@ -30,7 +30,7 @@ func TestFlareSuite(t *testing.T) {
 
 func requestAgentFlareAndFetchFromFakeIntake(v *commandFlareSuite, flareArgs ...client.AgentArgsOption) flare.Flare {
 	// Wait for the fakeintake to be ready to avoid 503 when sending the flare
-	v.EventuallyWithT(func(c *assert.CollectT) {
+	require.EventuallyWithT(v.T(), func(c *assert.CollectT) {
 		assert.NoError(c, v.Env().Fakeintake.Client.GetServerHealth())
 	}, 5*time.Minute, 20*time.Second)
 


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

The flare e2e test flaked in CI : https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/355539502#L2972

```
Error:      	Condition never satisfied
...
Error:      	Received unexpected error:
        	            	Asking the agent to build the flare archive.
        	            	/tmp/datadog-agent-2023-10-24T10-05-17Z-info.zip is going to be uploaded to Datadog
        	            	
        	            	Error: Could not determine flare URL via redirects: 503 Service Temporarily Unavailable
...
```
We should use require.EventuallyWithT instead of assert.EventuallyWithT to avoid this similar to the [dns failover test](https://github.com/DataDog/datadog-agent/pull/20167/files#diff-72dfa07faf6bffa9ea4df4b2d3f4780e083592bfa9c7e0aaf6808fcf9e2ccee8R102)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
