### PR TITLE
Support multiple tags generated from same label

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
@@ -62,6 +62,9 @@ func (h *PodHandlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resourc
 	}
 
 	m.Tags = append(m.Tags, taggerTags...)
+	for _, tag := range taggerTags {
+		log.Infof("BeforeCacheCheck: add tag ", tag)
+	}
 
 	// additional tags
 	m.Tags = append(m.Tags, fmt.Sprintf("pod_status:%s", strings.ToLower(m.Status)))

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
@@ -62,9 +62,6 @@ func (h *PodHandlers) BeforeCacheCheck(ctx *processors.ProcessorContext, resourc
 	}
 
 	m.Tags = append(m.Tags, taggerTags...)
-	for _, tag := range taggerTags {
-		log.Infof("BeforeCacheCheck: add tag ", tag)
-	}
 
 	// additional tags
 	m.Tags = append(m.Tags, fmt.Sprintf("pod_status:%s", strings.ToLower(m.Status)))

--- a/pkg/tagger/utils/k8s_metadata.go
+++ b/pkg/tagger/utils/k8s_metadata.go
@@ -38,7 +38,7 @@ func InitMetadataAsTags(metadataAsTags map[string]string) (map[string]string, ma
 
 // AddMetadataAsTags converts name and value into tags based on the metadata as tags configuration and patterns
 func AddMetadataAsTags(name, value string, metadataAsTags map[string]string, glob map[string]glob.Glob, tags *TagList) {
-	for pattern, tmpl := range metadataAsTags {
+	for pattern, tmplStr := range metadataAsTags {
 		n := strings.ToLower(name)
 		if g, ok := glob[pattern]; ok {
 			if !g.Match(n) {
@@ -47,8 +47,20 @@ func AddMetadataAsTags(name, value string, metadataAsTags map[string]string, glo
 		} else if pattern != n {
 			continue
 		}
-		tags.AddAuto(resolveTag(tmpl, name), value)
+		tagTmplList := splitTags(tmplStr)
+		for _, tmpl := range tagTmplList {
+			tags.AddAuto(resolveTag(tmpl, name), value)
+		}
 	}
+}
+
+// splitTags splits tmplStr into tag slice using "," as delimiter. This can generate multiple tags from a label
+func splitTags(tmplStr string) []string {
+	tagTmpList := strings.Split(tmplStr, ",")
+	for i := range tagTmpList {
+		tagTmpList[i] = strings.TrimSpace(tagTmpList[i])
+	}
+	return tagTmpList
 }
 
 var templateVariables = map[string]struct{}{

--- a/pkg/tagger/utils/k8s_metadata_test.go
+++ b/pkg/tagger/utils/k8s_metadata_test.go
@@ -97,6 +97,27 @@ func TestMetadataAsTags(t *testing.T) {
 			metadataAsTags: map[string]string{"*": "%%env%%"},
 			want:           []string{"foo:bar"},
 		},
+		{
+			name:           "nominal split case",
+			k:              "foo",
+			v:              "bar",
+			metadataAsTags: map[string]string{"foo": "foo, app_foo"},
+			want:           []string{"foo:bar", "app_foo:bar"},
+		},
+		{
+			name:           "label tpl var with normal label",
+			k:              "foo",
+			v:              "bar",
+			metadataAsTags: map[string]string{"foo": "%%label%% , app_foo"},
+			want:           []string{"foo:bar", "app_foo:bar"},
+		},
+		{
+			name:           "normal label and annotation tpl var with suffix",
+			k:              "foo",
+			v:              "bar",
+			metadataAsTags: map[string]string{"foo": "app_foo,%%annotation%%_suffix"},
+			want:           []string{"app_foo:bar", "foo_suffix:bar"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/releasenotes/notes/support-multi-tag-from-one-label-395654c3192ea4aa.yaml
+++ b/releasenotes/notes/support-multi-tag-from-one-label-395654c3192ea4aa.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add logic to support multiple tags created by a single label/annotaion. 
+    For example, add to config with 
+      podLabelsAsTags: 
+        chart_name: chart_name, app_chart_name 
+    Two tags should be extracted: chart_name and app_chart_name
+    Note: the format must be a comma separated list of tags

--- a/releasenotes/notes/support-multi-tag-from-one-label-395654c3192ea4aa.yaml
+++ b/releasenotes/notes/support-multi-tag-from-one-label-395654c3192ea4aa.yaml
@@ -9,8 +9,7 @@
 enhancements:
   - |
     Add logic to support multiple tags created by a single label/annotaion. 
-    For example, add to config with 
+    For example, add the following config to extract tags for chart_name and app_chart_name. 
       podLabelsAsTags: 
         chart_name: chart_name, app_chart_name 
-    Two tags should be extracted: chart_name and app_chart_name
-    Note: the format must be a comma separated list of tags
+    Note: the format must be a comma-separated list of tags.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
As part of [CONTINT-3327](https://datadoghq.atlassian.net/browse/CONTINT-3327), we will start to support multiple tags generated from same label/annotations



<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Currently a given label can only create one tag. In order to [fix chart name in internal cluster](https://datadoghq.atlassian.net/browse/CONTINT-3327), we need a code change in the agent to allow a given resource label to be used for two datadog tags.

### Additional Notes
Tags are separated by comma

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
Existing labels that contain "," will be broken. 

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
```
datadog:
  podLabelsAsTags:
    chart_name: pod_chart_name, chart_name, app_chart_name
  nodeLabelsAsTags:
    chart_name: node_chart_name, host_chart_name
```

And add chart_name to pod and node in k8s, there should be five new tags created



<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.


[CONTINT-3327]: https://datadoghq.atlassian.net/browse/CONTINT-3327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ