### PR TITLE
[oracle] Fix broken tests (DBMON-3044)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/custom_queries_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/custom_queries_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
 )
 
 var chk Check
@@ -63,7 +64,6 @@ func TestCustomQueries(t *testing.T) {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 	}
 	defer db.Close()
-	chk.dbCustomQueries = sqlx.NewDb(db, "sqlmock")
 
 	dbMock.ExpectExec("alter.*").WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -79,15 +79,17 @@ func TestCustomQueries(t *testing.T) {
 		Query:        "SELECT c1, c2 FROM t",
 		Columns:      columns,
 	}
-
-	initAndStartAgentDemultiplexer(t)
+	
+	senderManager := mocksender.CreateDefaultDemultiplexer()
+	chk, err := initCheck(t, senderManager, "localhost", 1523, "a", "a", "a")
 	chk.Run()
 
-	sender := mocksender.NewMockSender(chk.ID())
+	sender := mocksender.NewMockSenderWithSenderManager(chk.ID(), senderManager)
 	sender.SetupAcceptAll()
 	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 
 	chk.config.InstanceConfig.CustomQueries = []config.CustomQuery{q}
+	chk.dbCustomQueries = sqlx.NewDb(db, "sqlmock")
 
 	err = chk.CustomQueries()
 	assert.NoError(t, err, "failed to execute custom query")

--- a/pkg/collector/corechecks/oracle-dbm/custom_queries_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/custom_queries_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-
 )
 
 var chk Check

--- a/pkg/collector/corechecks/oracle-dbm/oracle_dictionary_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_dictionary_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestGetFullSqlText(t *testing.T) {
-	initAndStartAgentDemultiplexer(t)
 	for _, tnsAlias := range []string{"", TNS_ALIAS} {
 		chk.db = nil
 

--- a/pkg/collector/corechecks/oracle-dbm/oracle_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_test.go
@@ -112,7 +112,6 @@ func getTemporaryLobs(db *sqlx.DB) (int, error) {
 }
 
 func TestChkRun(t *testing.T) {
-	initAndStartAgentDemultiplexer(t)
 	chk.dbmEnabled = true
 	chk.config.InstanceConfig.InstantClient = false
 

--- a/pkg/collector/corechecks/oracle-dbm/statements_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 func TestQueryMetrics(t *testing.T) {
-	initAndStartAgentDemultiplexer(t)
 	chk.dbmEnabled = true
 	chk.statementsLastRun = time.Now().Add(-48 * time.Hour)
 	count, err := chk.StatementMetrics()
@@ -28,7 +27,6 @@ func TestQueryMetrics(t *testing.T) {
 }
 
 func TestUInt64Binding(t *testing.T) {
-	initAndStartAgentDemultiplexer(t)
 
 	chk.dbmEnabled = true
 	chk.config.QueryMetrics.Enabled = true

--- a/pkg/collector/corechecks/oracle-dbm/testutil.go
+++ b/pkg/collector/corechecks/oracle-dbm/testutil.go
@@ -13,9 +13,10 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/stretchr/testify/require"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 )
 
-func initCheck(t *testing.T, senderManager sender.senderManager, server string, port int, user string, password string, serviceName string) (Check, error) {
+func initCheck(t *testing.T, senderManager sender.SenderManager, server string, port int, user string, password string, serviceName string) (Check, error) {
 	c := Check{}
 	rawInstanceConfig := []byte(fmt.Sprintf(`
 server: %s
@@ -26,7 +27,6 @@ service_name: %s
 `, server, port, user, password, serviceName))
 	err := c.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(``), "oracle_test")
 	require.NoError(t, err)
-	initAndStartAgentDemultiplexer(t)
 
 	return c, err
 }


### PR DESCRIPTION
### What does this PR do?

Fixing broken tests.

### Motivation

Changes in the agent test API broke the tests.

### Describe how to test/QA your changes

Run the tests.

```
go clean -testcache                                                     
gotestsum --jsonfile module_test_output.json --format pkgname --packages=./pkg/collector/corechecks/oracle-dbm/... -- -mod=mod -vet=off --tags=oracle_test,oracle,test
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
