### PR TITLE
Update log regression test cases

### DIFF
--- a/test/regression/cases/file_to_blackhole/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole/lading/lading.yaml
@@ -14,3 +14,7 @@ blackhole:
       binding_addr: "127.0.0.1:9091"
   - http:
       binding_addr: "127.0.0.1:9092"
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:5000/telemetry"

--- a/test/regression/cases/file_to_blackhole/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole/lading/lading.yaml
@@ -3,10 +3,10 @@ generator:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
       path_template: "/tmp/file-gen-%NNN%.log"
-      duplicates: 4
+      duplicates: 4 ## this multiplies bytes_per_second by 4
       variant: "ascii"
-      bytes_per_second: "100Mb"
-      maximum_bytes_per_file: "200Mb"
+      bytes_per_second: "10Mb"
+      maximum_bytes_per_file: "20Mb"
       maximum_prebuild_cache_size_bytes: "400Mb"
 
 blackhole:

--- a/test/regression/cases/tcp_dd_logs_filter_exclude/lading/lading.yaml
+++ b/test/regression/cases/tcp_dd_logs_filter_exclude/lading/lading.yaml
@@ -4,12 +4,16 @@ generator:
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
       addr: "127.0.0.1:10000"
       variant: "datadog_log"
-      bytes_per_second: "500 Mb"
+      bytes_per_second: "50 Mb"
       block_sizes: ["8Kb", "4Kb", "2Kb", "1Kb", "512b", "256b", "128b"]
-      maximum_prebuild_cache_size_bytes: "256 Mb"
+      maximum_prebuild_cache_size_bytes: "400 Mb"
 
 blackhole:
   - tcp:
       binding_addr: "127.0.0.1:9091"
   - http:
       binding_addr: "127.0.0.1:9092"
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:5000/telemetry"

--- a/test/regression/cases/tcp_syslog_to_blackhole/lading/lading.yaml
+++ b/test/regression/cases/tcp_syslog_to_blackhole/lading/lading.yaml
@@ -4,7 +4,7 @@ generator:
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
       addr: "127.0.0.1:10000"
       variant: "syslog5424"
-      bytes_per_second: "500 Mb"
+      bytes_per_second: "50 Mb"
       block_sizes: ["1Mb", "0.5Mb", "0.25Mb", "0.125Mb", "128Kb"]
       maximum_prebuild_cache_size_bytes: "256 Mb"
 

--- a/test/regression/cases/tcp_syslog_to_blackhole/lading/lading.yaml
+++ b/test/regression/cases/tcp_syslog_to_blackhole/lading/lading.yaml
@@ -11,3 +11,7 @@ generator:
 blackhole:
   - http:
       binding_addr: "127.0.0.1:9092"
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:5000/telemetry"


### PR DESCRIPTION
### What does this PR do?
Updates logs regression detector experiments to scrape target metrics from the Agent and reduces load to be more realistic with current hardware.


### Motivation
Pairing session with @GeorgeHahn 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
