### PR TITLE
[oracle] Emit query metrics with zero executions (DBMON-2963)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/oracle_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/common"
-	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 	"github.com/jmoiron/sqlx"
 	go_ora "github.com/sijms/go-ora/v2"
 	"github.com/stretchr/testify/assert"
@@ -279,25 +278,5 @@ func TestSQLXIn(t *testing.T) {
 		}
 		assert.Equal(t, retValue, result, driver)
 	}
-}
 
-func TestObfuscator(t *testing.T) {
-	obfuscatorOptions := obfuscate.SQLConfig{}
-	obfuscatorOptions.DBMS = common.IntegrationName
-	obfuscatorOptions.TableNames = true
-	obfuscatorOptions.CollectCommands = true
-	obfuscatorOptions.CollectComments = true
-
-	o := obfuscate.NewObfuscator(obfuscate.Config{SQL: obfuscatorOptions})
-	for _, statement := range []string{
-		// needs https://datadoghq.atlassian.net/browse/DBM-2295
-		`UPDATE /* comment */ SET t n=1`,
-		`SELECT /* comment */ from dual`} {
-		obfuscatedStatement, err := o.ObfuscateSQLString(statement)
-		assert.NoError(t, err, "obfuscator error")
-		assert.NotContains(t, obfuscatedStatement.Query, "comment", "comment wasn't removed by the obfuscator")
-	}
-
-	_, err := o.ObfuscateSQLString(`SELECT TRUNC(SYSDATE@!) from dual`)
-	assert.NoError(t, err, "can't obfuscate @!")
 }

--- a/pkg/collector/corechecks/oracle-dbm/oracle_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/common"
+	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 	"github.com/jmoiron/sqlx"
 	go_ora "github.com/sijms/go-ora/v2"
 	"github.com/stretchr/testify/assert"
@@ -278,5 +279,25 @@ func TestSQLXIn(t *testing.T) {
 		}
 		assert.Equal(t, retValue, result, driver)
 	}
+}
 
+func TestObfuscator(t *testing.T) {
+	obfuscatorOptions := obfuscate.SQLConfig{}
+	obfuscatorOptions.DBMS = common.IntegrationName
+	obfuscatorOptions.TableNames = true
+	obfuscatorOptions.CollectCommands = true
+	obfuscatorOptions.CollectComments = true
+
+	o := obfuscate.NewObfuscator(obfuscate.Config{SQL: obfuscatorOptions})
+	for _, statement := range []string{
+		// needs https://datadoghq.atlassian.net/browse/DBM-2295
+		`UPDATE /* comment */ SET t n=1`,
+		`SELECT /* comment */ from dual`} {
+		obfuscatedStatement, err := o.ObfuscateSQLString(statement)
+		assert.NoError(t, err, "obfuscator error")
+		assert.NotContains(t, obfuscatedStatement.Query, "comment", "comment wasn't removed by the obfuscator")
+	}
+
+	_, err := o.ObfuscateSQLString(`SELECT TRUNC(SYSDATE@!) from dual`)
+	assert.NoError(t, err, "can't obfuscate @!")
 }

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -456,7 +456,7 @@ func (c *Check) StatementMetrics() (int, error) {
 				if diff.Fetches = statementMetricRow.Fetches - previousMonotonic.Fetches; diff.Fetches < 0 {
 					continue
 				}
-				if diff.Executions = statementMetricRow.Executions - previousMonotonic.Executions; diff.Executions <= 0 {
+				if diff.Executions = statementMetricRow.Executions - previousMonotonic.Executions; diff.Executions < 0 {
 					continue
 				}
 				if diff.EndOfFetchCount = statementMetricRow.EndOfFetchCount - previousMonotonic.EndOfFetchCount; diff.EndOfFetchCount < 0 {

--- a/releasenotes/notes/oracle-qmetrics-zero-executions-33b2cfcc887ad181.yaml
+++ b/releasenotes/notes/oracle-qmetrics-zero-executions-33b2cfcc887ad181.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Emit query metrics with zero executions to capture long runners spanning over several sampling periods.


### PR DESCRIPTION
### What does this PR do?

We start emitting query metrics for the queries for which the executions hasn't increased between two sampling intervals.

### Motivation

With this change we will capture queries which are executing over multiple sampling intervals, as the `executions` statistic is updated only after the execution is finished. We weren't emitting such queries because until recently we weren't handling `executions=0` case in backend and frontend. 

### Describe how to test/QA your changes

Check if the long runner is appearing in query metrics GUI.

![image](https://github.com/DataDog/datadog-agent/assets/18366081/3d2be2a3-db7e-4bc6-9e77-062d520fdaa8)

```
{"query_signature":"98bcafed0e72e0fe","dd_tables":["dba_extents"],"dd_commands":["SELECT"],"sql_fulltext":"select e.* from dba_extents e, dba_extents","query_hash":"5344853624903649526","plan_hash":"1338825147","pdb_name":"xe.CDB$ROOT","disk_reads":6107,"direct_reads":3366,"buffer_gets":24409,"cpu_time":2024235,"elapsed_time":2023212,"user_io_wait_time":240629,"io_interconnect_bytes":50028544,"physical_read_requests":2956,"physical_read_bytes":50028544,"version_count":1,"sharable_mem":2369616}
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
