### PR TITLE
[CWS] make kernel version and os release fetching a bit more resilient

### DIFF
--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -130,7 +130,11 @@ func DefaultRuleFilter(r *Rule) bool {
 		return false
 	}
 	if len(r.Filters) > 0 {
-		ruleFilterModel := rules.NewRuleFilterModel()
+		ruleFilterModel, err := rules.NewRuleFilterModel()
+		if err != nil {
+			log.Errorf("failed to apply rule filters: %v", err)
+			return false
+		}
 		seclRuleFilter := secl.NewSECLRuleFilter(ruleFilterModel)
 		accepted, err := seclRuleFilter.IsRuleAccepted(&secl.RuleDefinition{
 			Filters: r.Filters,
@@ -372,7 +376,12 @@ func (a *Agent) runKubernetesConfigurationsExport(ctx context.Context) {
 }
 
 func (a *Agent) runAptConfigurationExport(ctx context.Context) {
-	ruleFilterModel := rules.NewRuleFilterModel()
+	ruleFilterModel, err := rules.NewRuleFilterModel()
+	if err != nil {
+		log.Errorf("failed to run apt configuration export: %v", err)
+		return
+	}
+
 	seclRuleFilter := secl.NewSECLRuleFilter(ruleFilterModel)
 	accepted, err := seclRuleFilter.IsRuleAccepted(&secl.RuleDefinition{
 		Filters: []string{aptconfig.SeclFilter},

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -116,7 +116,10 @@ func (e *RuleEngine) Start(ctx context.Context, reloadChan <-chan struct{}, wg *
 		ruleFilters = append(ruleFilters, agentVersionFilter)
 	}
 
-	ruleFilterModel := NewRuleFilterModel()
+	ruleFilterModel, err := NewRuleFilterModel()
+	if err != nil {
+		return fmt.Errorf("failed to create rule filter: %w", err)
+	}
 	seclRuleFilter := rules.NewSECLRuleFilter(ruleFilterModel)
 	macroFilters = append(macroFilters, seclRuleFilter)
 	ruleFilters = append(ruleFilters, seclRuleFilter)
@@ -127,7 +130,7 @@ func (e *RuleEngine) Start(ctx context.Context, reloadChan <-chan struct{}, wg *
 	}
 
 	if err := e.LoadPolicies(e.policyProviders, true); err != nil {
-		return fmt.Errorf("failed to load policies: %s", err)
+		return fmt.Errorf("failed to load policies: %w", err)
 	}
 
 	wg.Add(1)

--- a/pkg/security/rules/rule_filters_model_linux.go
+++ b/pkg/security/rules/rule_filters_model_linux.go
@@ -26,11 +26,14 @@ type RuleFilterModel struct {
 }
 
 // NewRuleFilterModel returns a new rule filter model
-func NewRuleFilterModel() *RuleFilterModel {
-	kv, _ := kernel.NewKernelVersion()
+func NewRuleFilterModel() (*RuleFilterModel, error) {
+	kv, err := kernel.NewKernelVersion()
+	if err != nil {
+		return nil, err
+	}
 	return &RuleFilterModel{
 		Version: kv,
-	}
+	}, nil
 }
 
 // NewEvent returns a new event

--- a/pkg/security/rules/rule_filters_model_other.go
+++ b/pkg/security/rules/rule_filters_model_other.go
@@ -23,8 +23,8 @@ type RuleFilterModel struct {
 }
 
 // NewRuleFilterModel returns a new rule filtering model
-func NewRuleFilterModel() *RuleFilterModel {
-	return &RuleFilterModel{}
+func NewRuleFilterModel() (*RuleFilterModel, error) {
+	return &RuleFilterModel{}, nil
 }
 
 // NewEvent returns a new rule filtering event

--- a/pkg/security/tests/rule_filters_test.go
+++ b/pkg/security/tests/rule_filters_test.go
@@ -27,7 +27,8 @@ func TestSECLRuleFilter(t *testing.T) {
 		Code:         kernel.Kernel5_9,
 	}
 
-	m := rulesmodule.NewRuleFilterModel()
+	m, err := rulesmodule.NewRuleFilterModel()
+	assert.NoError(t, err)
 	m.Version = kv
 	seclRuleFilter := rules.NewSECLRuleFilter(m)
 


### PR DESCRIPTION
### What does this PR do?

This PR adds error handling when we fail to build a `kernel.Version` object. This was silently ignored before leading to nil ptr exceptions.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

The QA for this PR should be ensuring the security agent and system probe are not crashing on different installation methods related to the kernel version collection

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
