### PR TITLE
[CONTINT-3346] Enable container lifecycle events collection

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1108,7 +1108,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("orchestrator_explorer.run_on_node_agent", false)
 
 	// Container lifecycle configuration
-	config.BindEnvAndSetDefault("container_lifecycle.enabled", false)
+	config.BindEnvAndSetDefault("container_lifecycle.enabled", true)
 	bindEnvAndSetLogsConfigKeys(config, "container_lifecycle.")
 
 	// Container image configuration

--- a/releasenotes/notes/enable_contlcycle-9f736e8798e0d90d.yaml
+++ b/releasenotes/notes/enable_contlcycle-9f736e8798e0d90d.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Enable container lifecycle events collection by default.
+    This feature helps stopped containers to be cleaned from the Datadog app faster.

--- a/releasenotes/notes/enable_contlcycle-9f736e8798e0d90d.yaml
+++ b/releasenotes/notes/enable_contlcycle-9f736e8798e0d90d.yaml
@@ -9,4 +9,4 @@
 features:
   - |
     Enable container lifecycle events collection by default.
-    This feature helps stopped containers to be cleaned from the Datadog app faster.
+    This feature helps stopped containers to be cleaned from Datadog faster.


### PR DESCRIPTION
### What does this PR do?

Enable container lifecycle events collection by default.

### Motivation

Container lifecycle events allows the agent to notify the datadog backends when containers stopped so that they can be cleaned from the UI faster.

### Additional Notes

This feature has been enabled on our internal clusters for more than a year now.
It has been enabled in the Helm chart with DataDog/helm-charts#1214.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the agent and check that the `container-lifecycle` check is running.

```
agent status
```
```
[…]
==========
Aggregator
==========
[…]
  container-lifecycle: 25
[…]
```

or

```
agent checkconfig
```
```
[…]
=== container_lifecycle check ===
Configuration provider: file
Configuration source: file:/etc/datadog-agent/conf.d/container_lifecycle.d/conf.yaml.default
Config for instance ID: container_lifecycle:b628cf9ded5c9324
{}
~
Auto-discovery IDs:
* _container_lifecycle
===
[…]
```

Note that since DataDog/helm-charts#1214, this feature is enabled by the public Helm chart `3.41.0` or newer.
So, in order to test that the feature is now properly enabled by default in the agent itself, we need:
* either to use a public Helm chart `3.40.4` or older;
* or deploy the agent with something else than the Helm chart;
* or manually remove the setting of the `DD_CONTAINER_LIFECYCLE_ENABLED` environment variable in the agent pod manifest.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
