### PR TITLE
[CWS] add ubuntu 23-10 functional tests

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -144,6 +144,7 @@ kitchen_test_security_agent_x64_ec2:
       - KITCHEN_PLATFORM: "ubuntu"
         KITCHEN_OSVERS: "ubuntu-23-10"
         KITCHEN_CWS_PLATFORM: [host, docker]
+        KITCHEN_EC2_DEVICE_NAME: "/dev/sda1"
 
 kitchen_test_security_agent_amazonlinux_x64_fentry:
   extends:

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -141,6 +141,9 @@ kitchen_test_security_agent_x64_ec2:
       - KITCHEN_PLATFORM: "centos"
         KITCHEN_OSVERS: "rocky-92"
         KITCHEN_CWS_PLATFORM: [host]
+      - KITCHEN_PLATFORM: "ubuntu"
+        KITCHEN_OSVERS: "ubuntu-23-10"
+        KITCHEN_CWS_PLATFORM: [host, docker]
 
 kitchen_test_security_agent_amazonlinux_x64_fentry:
   extends:

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -98,7 +98,8 @@
                 "ubuntu-18-04": "ami-0ee23bfc74a881de5",
                 "ubuntu-20-04": "ami-079ca844e323047c2",
                 "ubuntu-22-04": "ami-08c40ec9ead489470",
-                "ubuntu-23-04": "ami-062b1c3c00754c48b"
+                "ubuntu-23-04": "ami-062b1c3c00754c48b",
+                "ubuntu-23-10": "ami-0949b45ef274e55a1"
             },
             "arm64": {
                 "ubuntu-18-04": "ami-02ed82f3a38303e6f",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR adds CWS functional tests on ubuntu 23.10 (kernel 6.5). Those tests are currently set to be manually run
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
