### PR TITLE
usm: tests: Fixed protocol classification flakiness

### DIFF
--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -1713,6 +1713,7 @@ func testEdgeCasesProtocolClassification(t *testing.T, tr *Tracer, clientHost, t
 
 					r := bufio.NewReader(c)
 					for {
+						// The server reads up to a marker, in our case `$`.
 						input, err := r.ReadBytes(byte('$'))
 						if err != nil {
 							return

--- a/pkg/network/tracer/tracer_classification_test.go
+++ b/pkg/network/tracer/tracer_classification_test.go
@@ -1449,7 +1449,8 @@ func testHTTPProtocolClassification(t *testing.T, tr *Tracer, clientHost, target
 					ReadTimeout:  time.Second,
 					WriteTimeout: time.Second,
 				}
-				srv.SetKeepAlivesEnabled(false)
+				// Temporary change, without it the protocol classification is flaky.
+				srv.SetKeepAlivesEnabled(true)
 				go func() {
 					_ = srv.Serve(ln)
 				}()
@@ -1711,8 +1712,11 @@ func testEdgeCasesProtocolClassification(t *testing.T, tr *Tracer, clientHost, t
 					defer c.Close()
 
 					r := bufio.NewReader(c)
-					input, err := r.ReadBytes(byte('\n'))
-					if err == nil {
+					for {
+						input, err := r.ReadBytes(byte('$'))
+						if err != nil {
+							return
+						}
 						c.Write(input)
 					}
 				})
@@ -1725,11 +1729,20 @@ func testEdgeCasesProtocolClassification(t *testing.T, tr *Tracer, clientHost, t
 				c, err := defaultDialer.DialContext(timedContext, "tcp", ctx.targetAddress)
 				require.NoError(t, err)
 				defer c.Close()
-				c.Write([]byte("GET /200/foobar HTTP/1.1\n"))
-				io.Copy(io.Discard, c)
-				// http2 prefix.
-				c.Write([]byte("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"))
-				io.Copy(io.Discard, c)
+				// The server reads up to a marker, in our case `$`.
+				httpInput := []byte("GET /200/foobar HTTP/1.1\n$")
+				http2Input := []byte("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n$")
+				for _, input := range [][]byte{httpInput, http2Input} {
+					// Calling write multiple times to increase chances for classification.
+					_, err = c.Write(input)
+					require.NoError(t, err)
+
+					// This is an echo server, we expect to get the same buffer as we sent, so the output buffer
+					// has the same length of the input.
+					input = input[:0]
+					_, err = c.Read(input)
+					require.NoError(t, err)
+				}
 			},
 			teardown:   teardown,
 			validation: validateProtocolConnection(&protocols.Stack{Application: protocols.HTTP}),


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

* Uses a server with keep-alive enabled to avoid a race in the protocol classification cleanup.
* Fixes the mixed tests, which didn't send and verify the http2 input.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fixing test flakiness

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
