### PR TITLE
Don't parse non array object in the fakeintake to avoid diagnose command failure

### DIFF
--- a/test/fakeintake/aggregator/checkRunAggregator.go
+++ b/test/fakeintake/aggregator/checkRunAggregator.go
@@ -48,6 +48,12 @@ func ParseCheckRunPayload(payload api.Payload) (checks []*CheckRun, err error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if len(enflated) > 0 && enflated[0] != '[' {
+		// check_run can submit non-array JSON object (diagnose command)
+		return []*CheckRun{}, nil
+	}
+
 	checks = []*CheckRun{}
 	err = json.Unmarshal(enflated, &checks)
 	if err != nil {

--- a/test/fakeintake/aggregator/checkRunAggregator_test.go
+++ b/test/fakeintake/aggregator/checkRunAggregator_test.go
@@ -18,8 +18,14 @@ import (
 var checkRunData []byte
 
 func TestCheckRun(t *testing.T) {
-	t.Run("parseCheckRunPayload should return error on invalid data", func(t *testing.T) {
+	t.Run("parseCheckRunPayload empty JSON object should be ignored", func(t *testing.T) {
 		checks, err := ParseCheckRunPayload(api.Payload{Data: []byte("{}"), Encoding: encodingEmpty})
+		assert.NoError(t, err)
+		assert.Empty(t, checks)
+	})
+
+	t.Run("parseCheckRunPayload should ignore single check run (non array object)", func(t *testing.T) {
+		checks, err := ParseCheckRunPayload(api.Payload{Data: []byte("{\"check\": \"test\", \"status\": 0}"), Encoding: encodingEmpty})
 		assert.NoError(t, err)
 		assert.Empty(t, checks)
 	})

--- a/test/fakeintake/client/fixtures/api_v1_check_run_response
+++ b/test/fakeintake/client/fixtures/api_v1_check_run_response
@@ -1,6 +1,11 @@
 {
   "payloads": [
     {
+      "timestamp": "2023-10-25T13:51:01.904425632Z",
+      "data": "eyJjaGVjayI6ICJ0ZXN0IiwgInN0YXR1cyI6IDB9",
+      "encoding": "application/json"
+    },
+    {
       "timestamp": "2023-03-03T10:50:12.265092427Z",
       "data": "eJy01M+PojAUB/D/5Z2RUAS0ve5lL7rejWlqeYtE+iO07MZM5n+f0NFMHJOxMem1hff9vEce+zeQJ5RnYOC0srkUmn8eZHAyznMtFAKDFv/1EtmvP5vdYluXu2ZL6eY3I6syL+u8yJeQge8VOi+UBUaa1WpdFTWlGTgv/OSAFRkodE50c735cdE5YHsQHWrP57Dv5SG75gaFs+JRAFlw86vvzhMuQt2KHAWt1pSQI71d2NH87QdkHWoce7kYzeRxhMN79jWSVnjRmi4PxDyc8ms79+N5VL04jJDBZuC9RHub95q7i5YvRDcFeRatp2FI1npE/q117W3Cb9AUZTQE/X8znpNilrGYwYg2qaSKlcw7w09CtwMmBdWxIGmnpJDopZ3s/HpKCyliLQqVGS9JLdEb3ZufHJN9Kf3pGof/2eEjAAD//7w2LEA=",
       "encoding": "deflate"


### PR DESCRIPTION

### What does this PR do?

Prevent the fakeintake from parsing single check run object

### Motivation

`diagnose` command sends a single check run while the fakeintake expects an array and so it returns an error which makes the `diagnose` command failing

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
