### PR TITLE
[Serverless] Use Extractor to determine trace context [SVLS-3935]

### DIFF
--- a/pkg/serverless/daemon/routes.go
+++ b/pkg/serverless/daemon/routes.go
@@ -58,15 +58,10 @@ func (s *StartInvocation) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Could not read StartInvocation request body", 400)
 		return
 	}
-	lambdaInvokeContext := invocationlifecycle.LambdaInvokeEventHeaders{
-		TraceID:          r.Header.Get(invocationlifecycle.TraceIDHeader),
-		ParentID:         r.Header.Get(invocationlifecycle.ParentIDHeader),
-		SamplingPriority: r.Header.Get(invocationlifecycle.SamplingPriorityHeader),
-	}
 	startDetails := &invocationlifecycle.InvocationStartDetails{
 		StartTime:             startTime,
 		InvokeEventRawPayload: reqBody,
-		InvokeEventHeaders:    lambdaInvokeContext,
+		InvokeEventHeaders:    r.Header,
 		InvokedFunctionARN:    s.daemon.ExecutionContext.GetCurrentState().ARN,
 	}
 

--- a/pkg/serverless/daemon/routes_test.go
+++ b/pkg/serverless/daemon/routes_test.go
@@ -209,12 +209,35 @@ func TestStartEndInvocationSpanParenting(t *testing.T) {
 			expParentID: 7431398482019833808,
 		},
 		{
+			name:        "sqs-batch",
+			payload:     getEventFromFile("sqs-batch.json"),
+			expSpans:    2,
+			expTraceID:  2684756524522091840,
+			expParentID: 7431398482019833808,
+		},
+		{
+			name:        "sqs_no_dd_context",
+			payload:     getEventFromFile("sqs_no_dd_context.json"),
+			expSpans:    2,
+			expTraceID:  0,
+			expParentID: 0,
+		},
+		{
+			// NOTE: sns trace extraction not implemented yet
+			name:        "sns",
+			payload:     getEventFromFile("sns.json"),
+			expSpans:    2,
+			expTraceID:  0,
+			expParentID: 0,
+		},
+		{
 			name:        "sns-sqs",
 			payload:     getEventFromFile("snssqs.json"),
 			expSpans:    3,
 			expTraceID:  1728904347387697031,
 			expParentID: 353722510835624345,
 		},
+		// TODO: test inferred spans disabled
 	}
 
 	for _, tc := range testcases {

--- a/pkg/serverless/daemon/routes_test.go
+++ b/pkg/serverless/daemon/routes_test.go
@@ -223,7 +223,7 @@ func TestStartEndInvocationSpanParenting(t *testing.T) {
 			expParentID: 0,
 		},
 		{
-			// NOTE: sns trace extraction not implemented yet
+			// NOTE: sns trace extraction not yet implemented
 			name:        "sns",
 			payload:     getEventFromFile("sns.json"),
 			expInfSpans: 1,

--- a/pkg/serverless/daemon/routes_test.go
+++ b/pkg/serverless/daemon/routes_test.go
@@ -166,9 +166,7 @@ func TestStartEndInvocationSpanParenting(t *testing.T) {
 	processTrace := func(p *api.Payload) {
 		for _, c := range p.TracerPayload.Chunks {
 			priorities = append(priorities, c.Priority)
-			for _, span := range c.Spans {
-				spans = append(spans, span)
-			}
+			spans = append(spans, c.Spans...)
 		}
 	}
 

--- a/pkg/serverless/daemon/routes_test.go
+++ b/pkg/serverless/daemon/routes_test.go
@@ -132,7 +132,7 @@ func TestTraceContext(t *testing.T) {
 		DetectLambdaLibrary: func() bool { return false },
 	}
 	client := &http.Client{}
-	body := bytes.NewBuffer([]byte(`{"toto": "tutu","Headers": {"x-datadog-trace-id": "2222"}}`))
+	body := bytes.NewBuffer([]byte(`{"toto": "tutu","Headers": {"x-datadog-trace-id": "2222","x-datadog-parent-id":"3333"}}`))
 	request, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://127.0.0.1:%d/lambda/start-invocation", port), body)
 	assert.Nil(err)
 	response, err := client.Do(request)

--- a/pkg/serverless/invocationlifecycle/invocation_details.go
+++ b/pkg/serverless/invocationlifecycle/invocation_details.go
@@ -6,6 +6,7 @@
 package invocationlifecycle
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace/inferredspan"
@@ -16,18 +17,9 @@ import (
 type InvocationStartDetails struct {
 	StartTime             time.Time
 	InvokeEventRawPayload []byte
-	InvokeEventHeaders    LambdaInvokeEventHeaders
+	InvokeEventHeaders    http.Header
 	InvokedFunctionARN    string
 	InferredSpan          inferredspan.InferredSpan
-}
-
-// LambdaInvokeEventHeaders stores the headers with information needed for trace propagation
-// from a direct lambda invocation.
-// This structure is passed to the onInvokeStart method of the invocationProcessor interface
-type LambdaInvokeEventHeaders struct {
-	TraceID          string
-	ParentID         string
-	SamplingPriority string
 }
 
 // InvocationEndDetails stores information about the end of an invocation.

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -19,6 +19,7 @@ import (
 	serverlessLog "github.com/DataDog/datadog-agent/pkg/serverless/logs"
 	serverlessMetrics "github.com/DataDog/datadog-agent/pkg/serverless/metrics"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trace/inferredspan"
+	"github.com/DataDog/datadog-agent/pkg/serverless/trace/propagation"
 	"github.com/DataDog/datadog-agent/pkg/serverless/trigger"
 	"github.com/DataDog/datadog-agent/pkg/trace/api"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
@@ -33,6 +34,7 @@ type LifecycleProcessor struct {
 	DetectLambdaLibrary  func() bool
 	InferredSpansEnabled bool
 	SubProcessor         InvocationSubProcessor
+	Extractor            propagation.Extractor
 
 	requestHandler *RequestHandler
 	serviceName    string
@@ -106,6 +108,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 		log.Debugf("[lifecycle] Error parsing ARN: %v", err)
 	}
 
+	var ev interface{}
 	switch eventType {
 	case trigger.APIGatewayEvent:
 		var event events.APIGatewayProxyRequest
@@ -113,6 +116,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 			log.Debugf("Failed to unmarshal %s event: %s", apiGateway, err)
 			break
 		}
+		ev = event
 		lp.initFromAPIGatewayEvent(event, region)
 	case trigger.APIGatewayV2Event:
 		var event events.APIGatewayV2HTTPRequest
@@ -120,6 +124,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 			log.Debugf("Failed to unmarshal %s event: %s", apiGateway, err)
 			break
 		}
+		ev = event
 		lp.initFromAPIGatewayV2Event(event, region)
 	case trigger.APIGatewayWebsocketEvent:
 		var event events.APIGatewayWebsocketProxyRequest
@@ -127,6 +132,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 			log.Debugf("Failed to unmarshal %s event: %s", apiGateway, err)
 			break
 		}
+		ev = event
 		lp.initFromAPIGatewayWebsocketEvent(event, region)
 	case trigger.APIGatewayLambdaAuthorizerTokenEvent:
 		var event events.APIGatewayCustomAuthorizerRequest
@@ -134,6 +140,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 			log.Debugf("Failed to unmarshal %s event: %s", apiGateway, err)
 			break
 		}
+		ev = event
 		lp.initFromAPIGatewayLambdaAuthorizerTokenEvent(event)
 	case trigger.APIGatewayLambdaAuthorizerRequestParametersEvent:
 		var event events.APIGatewayCustomAuthorizerRequestTypeRequest
@@ -141,6 +148,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 			log.Debugf("Failed to unmarshal %s event: %s", apiGateway, err)
 			break
 		}
+		ev = event
 		lp.initFromAPIGatewayLambdaAuthorizerRequestParametersEvent(event)
 	case trigger.ALBEvent:
 		var event events.ALBTargetGroupRequest
@@ -148,6 +156,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 			log.Debugf("Failed to unmarshal %s event: %s", applicationLoadBalancer, err)
 			break
 		}
+		ev = event
 		lp.initFromALBEvent(event)
 	case trigger.CloudWatchEvent:
 		var event events.CloudWatchEvent
@@ -155,6 +164,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 			log.Debugf("Failed to unmarshal %s event: %s", cloudwatchEvents, err)
 			break
 		}
+		ev = event
 		lp.initFromCloudWatchEvent(event)
 	case trigger.CloudWatchLogsEvent:
 		var event events.CloudwatchLogsEvent
@@ -162,6 +172,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 			log.Debugf("Failed to unmarshal %s event: %s", cloudwatchLogs, err)
 			break
 		}
+		ev = event
 		lp.initFromCloudWatchLogsEvent(event, region, account)
 	case trigger.DynamoDBStreamEvent:
 		var event events.DynamoDBEvent
@@ -169,6 +180,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 			log.Debugf("Failed to unmarshal %s event: %s", dynamoDB, err)
 			break
 		}
+		ev = event
 		lp.initFromDynamoDBStreamEvent(event)
 	case trigger.KinesisStreamEvent:
 		var event events.KinesisEvent
@@ -176,6 +188,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 			log.Debugf("Failed to unmarshal %s event: %s", kinesis, err)
 			break
 		}
+		ev = event
 		lp.initFromKinesisStreamEvent(event)
 	case trigger.EventBridgeEvent:
 		var event inferredspan.EventBridgeEvent
@@ -183,6 +196,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 			log.Debugf("Failed to unmarshal %s event: %s", eventBridge, err)
 			break
 		}
+		ev = event
 		lp.initFromEventBridgeEvent(event)
 	case trigger.S3Event:
 		var event events.S3Event
@@ -190,6 +204,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 			log.Debugf("Failed to unmarshal %s event: %s", s3, err)
 			break
 		}
+		ev = event
 		lp.initFromS3Event(event)
 	case trigger.SNSEvent:
 		var event events.SNSEvent
@@ -197,6 +212,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 			log.Debugf("Failed to unmarshal %s event: %s", sns, err)
 			break
 		}
+		ev = event
 		lp.initFromSNSEvent(event)
 	case trigger.SQSEvent:
 		var event events.SQSEvent
@@ -204,6 +220,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 			log.Debugf("Failed to unmarshal %s event: %s", sqs, err)
 			break
 		}
+		ev = event
 		lp.initFromSQSEvent(event)
 	case trigger.LambdaFunctionURLEvent:
 		var event events.LambdaFunctionURLRequest
@@ -211,6 +228,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 			log.Debugf("Failed to unmarshal %s event: %s", functionURL, err)
 			break
 		}
+		ev = event
 		lp.initFromLambdaFunctionURLEvent(event, region, account, resource)
 	default:
 		log.Debug("Skipping adding trigger types and inferred spans as a non-supported payload was received.")
@@ -221,7 +239,7 @@ func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails
 	}
 
 	if !lp.DetectLambdaLibrary() {
-		lp.startExecutionSpan(payloadBytes, startDetails)
+		lp.startExecutionSpan(ev, payloadBytes, startDetails)
 	}
 }
 

--- a/pkg/serverless/invocationlifecycle/trace.go
+++ b/pkg/serverless/invocationlifecycle/trace.go
@@ -56,10 +56,11 @@ func (lp *LifecycleProcessor) startExecutionSpan(event interface{}, rawPayload [
 		executionContext.TraceID = traceContext.TraceID
 		executionContext.parentID = traceContext.ParentID
 		executionContext.SamplingPriority = traceContext.SamplingPriority
-		if lp.InferredSpansEnabled {
-			inferredSpan := lp.GetInferredSpan()
+		inferredSpan := lp.GetInferredSpan()
+		if lp.InferredSpansEnabled && inferredSpan.Span.Start != 0 {
 			inferredSpan.Span.TraceID = traceContext.TraceID
 			inferredSpan.Span.ParentID = traceContext.ParentID
+			executionContext.parentID = inferredSpan.Span.SpanID
 		}
 	} else {
 		executionContext.TraceID = 0

--- a/pkg/serverless/invocationlifecycle/trace.go
+++ b/pkg/serverless/invocationlifecycle/trace.go
@@ -40,10 +40,6 @@ type ExecutionStartInfo struct {
 	SamplingPriority sampler.SamplingPriority
 }
 
-type invocationPayload struct {
-	Headers map[string]string `json:"headers"`
-}
-
 // startExecutionSpan records information from the start of the invocation.
 // It should be called at the start of the invocation.
 func (lp *LifecycleProcessor) startExecutionSpan(event interface{}, rawPayload []byte, startDetails *InvocationStartDetails) {
@@ -199,14 +195,6 @@ func convertStrToUnit64(s string) (uint64, error) {
 		log.Debugf("Error while converting %s, failing with : %s", s, err)
 	}
 	return num, err
-}
-
-func getSamplingPriority(directInvokeHeader string) sampler.SamplingPriority {
-	samplingPriority := sampler.PriorityNone
-	if v, err := strconv.ParseInt(directInvokeHeader, 10, 8); err == nil {
-		samplingPriority = sampler.SamplingPriority(v)
-	}
-	return samplingPriority
 }
 
 // InjectContext injects the context

--- a/pkg/serverless/invocationlifecycle/trace.go
+++ b/pkg/serverless/invocationlifecycle/trace.go
@@ -43,10 +43,10 @@ type ExecutionStartInfo struct {
 // startExecutionSpan records information from the start of the invocation.
 // It should be called at the start of the invocation.
 func (lp *LifecycleProcessor) startExecutionSpan(event interface{}, rawPayload []byte, startDetails *InvocationStartDetails) {
+	inferredSpan := lp.GetInferredSpan()
 	executionContext := lp.GetExecutionInfo()
 	executionContext.requestPayload = rawPayload
 	executionContext.startTime = startDetails.StartTime
-	inferredSpan := lp.GetInferredSpan()
 
 	traceContext, err := lp.Extractor.Extract(event, rawPayload)
 	if err != nil {

--- a/pkg/serverless/invocationlifecycle/trace.go
+++ b/pkg/serverless/invocationlifecycle/trace.go
@@ -46,6 +46,7 @@ func (lp *LifecycleProcessor) startExecutionSpan(event interface{}, rawPayload [
 	executionContext := lp.GetExecutionInfo()
 	executionContext.requestPayload = rawPayload
 	executionContext.startTime = startDetails.StartTime
+	inferredSpan := lp.GetInferredSpan()
 
 	traceContext, err := lp.Extractor.Extract(event, rawPayload)
 	if err != nil {
@@ -56,16 +57,17 @@ func (lp *LifecycleProcessor) startExecutionSpan(event interface{}, rawPayload [
 		executionContext.TraceID = traceContext.TraceID
 		executionContext.parentID = traceContext.ParentID
 		executionContext.SamplingPriority = traceContext.SamplingPriority
-		inferredSpan := lp.GetInferredSpan()
 		if lp.InferredSpansEnabled && inferredSpan.Span.Start != 0 {
 			inferredSpan.Span.TraceID = traceContext.TraceID
 			inferredSpan.Span.ParentID = traceContext.ParentID
-			executionContext.parentID = inferredSpan.Span.SpanID
 		}
 	} else {
 		executionContext.TraceID = 0
 		executionContext.parentID = 0
 		executionContext.SamplingPriority = sampler.PriorityNone
+	}
+	if lp.InferredSpansEnabled && inferredSpan.Span.Start != 0 {
+		executionContext.parentID = inferredSpan.Span.SpanID
 	}
 }
 

--- a/pkg/serverless/invocationlifecycle/trace_test.go
+++ b/pkg/serverless/invocationlifecycle/trace_test.go
@@ -40,14 +40,6 @@ func TestConvertStrToUnit64Success(t *testing.T) {
 	assert.Equal(t, uint64(1234), value)
 }
 
-func TestGetSamplingPriority(t *testing.T) {
-	assert.Equal(t, sampler.PriorityNone, getSamplingPriority("yyy"))
-	assert.Equal(t, sampler.PriorityUserDrop, getSamplingPriority("-1"))
-	assert.Equal(t, sampler.PriorityAutoDrop, getSamplingPriority("0"))
-	assert.Equal(t, sampler.PriorityAutoKeep, getSamplingPriority("1"))
-	assert.Equal(t, sampler.PriorityUserKeep, getSamplingPriority("2"))
-}
-
 func TestInjectContextNoContext(t *testing.T) {
 	currentExecutionInfo := newExecutionContextWithTime()
 	InjectContext(currentExecutionInfo, nil)

--- a/pkg/serverless/invocationlifecycle/trace_test.go
+++ b/pkg/serverless/invocationlifecycle/trace_test.go
@@ -91,10 +91,10 @@ func TestStartExecutionSpanWithoutPayload(t *testing.T) {
 	}
 	startDetails := &InvocationStartDetails{
 		StartTime:          timeNow(),
-		InvokeEventHeaders: LambdaInvokeEventHeaders{},
+		InvokeEventHeaders: http.Header{},
 	}
 	lp.startExecutionSpan(nil, []byte(""), startDetails)
-	assert.Equal(t, currentExecutionInfo.startTime, currentExecutionInfo.startTime)
+	assert.Equal(t, startDetails.StartTime, currentExecutionInfo.startTime)
 	assert.Equal(t, uint64(0), currentExecutionInfo.TraceID)
 	assert.Equal(t, uint64(0), currentExecutionInfo.SpanID)
 	assert.Equal(t, sampler.PriorityNone, currentExecutionInfo.SamplingPriority)
@@ -111,7 +111,7 @@ func TestStartExecutionSpanWithPayload(t *testing.T) {
 	}
 	startDetails := &InvocationStartDetails{
 		StartTime:          startTime,
-		InvokeEventHeaders: LambdaInvokeEventHeaders{},
+		InvokeEventHeaders: http.Header{},
 	}
 	lp.startExecutionSpan(nil, []byte(testString), startDetails)
 	assert.Equal(t, startTime, currentExecutionInfo.startTime)
@@ -129,12 +129,11 @@ func TestStartExecutionSpanWithPayloadAndLambdaContextHeaders(t *testing.T) {
 		},
 	}
 	testString := `{"resource":"/users/create","path":"/users/create","httpMethod":"GET"}`
-	lambdaInvokeContext := LambdaInvokeEventHeaders{
-		TraceID:          "5736943178450432258",
-		ParentID:         "1480558859903409531",
-		SamplingPriority: "1",
-	}
 
+	lambdaInvokeContext := http.Header{}
+	lambdaInvokeContext.Set(TraceIDHeader, "5736943178450432258")
+	lambdaInvokeContext.Set(ParentIDHeader, "1480558859903409531")
+	lambdaInvokeContext.Set(SamplingPriorityHeader, "1")
 	startTime := timeNow()
 	startDetails := &InvocationStartDetails{
 		StartTime:          startTime,
@@ -159,7 +158,7 @@ func TestStartExecutionSpanWithPayloadAndInvalidIDs(t *testing.T) {
 	startTime := timeNow()
 	startDetails := &InvocationStartDetails{
 		StartTime:          startTime,
-		InvokeEventHeaders: LambdaInvokeEventHeaders{},
+		InvokeEventHeaders: http.Header{},
 	}
 	lp.startExecutionSpan(nil, []byte(invalidTestString), startDetails)
 	assert.Equal(t, startTime, currentExecutionInfo.startTime)
@@ -176,7 +175,7 @@ func TestStartExecutionSpanWithHeadersAndInferredSpan(t *testing.T) {
 	startTime := timeNow()
 	startDetails := &InvocationStartDetails{
 		StartTime:          startTime,
-		InvokeEventHeaders: LambdaInvokeEventHeaders{},
+		InvokeEventHeaders: http.Header{},
 	}
 	inferredSpan := &inferredspan.InferredSpan{}
 	inferredSpan.Span = &pb.Span{
@@ -218,7 +217,7 @@ func TestEndExecutionSpanWithEmptyObjectRequestResponse(t *testing.T) {
 	}
 	startDetails := &InvocationStartDetails{
 		StartTime:          startTime,
-		InvokeEventHeaders: LambdaInvokeEventHeaders{},
+		InvokeEventHeaders: http.Header{},
 	}
 
 	lp.startExecutionSpan(nil, []byte("[]"), startDetails)
@@ -273,7 +272,7 @@ func TestEndExecutionSpanWithNullRequestResponse(t *testing.T) {
 	}
 	startDetails := &InvocationStartDetails{
 		StartTime:          startTime,
-		InvokeEventHeaders: LambdaInvokeEventHeaders{},
+		InvokeEventHeaders: http.Header{},
 	}
 
 	lp.startExecutionSpan(nil, nil, startDetails)
@@ -330,7 +329,7 @@ func TestEndExecutionSpanWithNoError(t *testing.T) {
 
 	startDetails := &InvocationStartDetails{
 		StartTime:          startTime,
-		InvokeEventHeaders: LambdaInvokeEventHeaders{},
+		InvokeEventHeaders: http.Header{},
 	}
 	lp.startExecutionSpan(nil, []byte(testString), startDetails)
 
@@ -393,7 +392,7 @@ func TestEndExecutionSpanProactInit(t *testing.T) {
 
 	startDetails := &InvocationStartDetails{
 		StartTime:          startTime,
-		InvokeEventHeaders: LambdaInvokeEventHeaders{},
+		InvokeEventHeaders: http.Header{},
 	}
 	lp.startExecutionSpan(nil, []byte(testString), startDetails)
 
@@ -454,7 +453,7 @@ func TestEndExecutionSpanWithInvalidCaptureLambdaPayloadValue(t *testing.T) {
 	}
 	startDetails := &InvocationStartDetails{
 		StartTime:          startTime,
-		InvokeEventHeaders: LambdaInvokeEventHeaders{},
+		InvokeEventHeaders: http.Header{},
 	}
 	lp.startExecutionSpan(nil, []byte(testString), startDetails)
 
@@ -500,7 +499,7 @@ func TestEndExecutionSpanWithError(t *testing.T) {
 	startTime := time.Now()
 	startDetails := &InvocationStartDetails{
 		StartTime:          startTime,
-		InvokeEventHeaders: LambdaInvokeEventHeaders{},
+		InvokeEventHeaders: http.Header{},
 	}
 	lp.startExecutionSpan(nil, []byte(testString), startDetails)
 
@@ -560,7 +559,7 @@ func TestLanguageTag(t *testing.T) {
 		startTime := time.Now()
 		startDetails := &InvocationStartDetails{
 			StartTime:          startTime,
-			InvokeEventHeaders: LambdaInvokeEventHeaders{},
+			InvokeEventHeaders: http.Header{},
 		}
 		lp.startExecutionSpan(nil, []byte(testString), startDetails)
 

--- a/pkg/serverless/invocationlifecycle/trace_test.go
+++ b/pkg/serverless/invocationlifecycle/trace_test.go
@@ -312,7 +312,7 @@ func TestStartExecutionSpan(t *testing.T) {
 			propStyle:      "datadog",
 			expectCtx: &ExecutionStartInfo{
 				TraceID:          1,
-				parentID:         1,
+				parentID:         123, // parent is inferred span
 				SamplingPriority: sampler.SamplingPriority(1),
 			},
 		},
@@ -324,7 +324,10 @@ func TestStartExecutionSpan(t *testing.T) {
 			startTime := time.Now()
 			actualCtx := &ExecutionStartInfo{}
 			inferredSpan := &inferredspan.InferredSpan{
-				Span: &pb.Span{},
+				Span: &pb.Span{
+					SpanID: 123,
+					Start:  startTime.UnixNano() - 10,
+				},
 			}
 			lp := &LifecycleProcessor{
 				InferredSpansEnabled: tc.infSpanEnabled,
@@ -351,7 +354,7 @@ func TestStartExecutionSpan(t *testing.T) {
 
 			if tc.infSpanEnabled {
 				assert.Equal(tc.expectCtx.TraceID, inferredSpan.Span.TraceID)
-				assert.Equal(tc.expectCtx.parentID, inferredSpan.Span.ParentID)
+				assert.Equal(tc.expectCtx.TraceID, inferredSpan.Span.ParentID)
 			} else {
 				assert.Equal(uint64(0), inferredSpan.Span.TraceID)
 				assert.Equal(uint64(0), inferredSpan.Span.ParentID)

--- a/pkg/serverless/trace/inferredspan/span_enrichment.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment.go
@@ -275,18 +275,6 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithSQSEvent(eventPayload ev
 		receiptHandle:  eventRecord.ReceiptHandle,
 		senderID:       eventRecord.Attributes["SenderId"],
 	}
-
-	traceContext := extractTraceContext(eventRecord)
-	if traceContext == nil {
-		log.Debug("No trace context found")
-		return
-	}
-	if traceContext.TraceID != nil {
-		inferredSpan.Span.TraceID = *traceContext.TraceID
-	}
-	if traceContext.ParentID != nil {
-		inferredSpan.Span.ParentID = *traceContext.ParentID
-	}
 }
 
 // EnrichInferredSpanWithEventBridgeEvent uses the parsed event

--- a/pkg/serverless/trace/inferredspan/span_enrichment_test.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment_test.go
@@ -727,9 +727,9 @@ func TestEnrichInferredSpanWithSQSEvent(t *testing.T) {
 	inferredSpan := mockInferredSpan()
 	inferredSpan.EnrichInferredSpanWithSQSEvent(sqsRequest)
 	span := inferredSpan.Span
-	assert.Equal(t, uint64(2684756524522091840), span.TraceID)
+	assert.Equal(t, uint64(7353030974370088224), span.TraceID)
 	assert.Equal(t, uint64(8048964810003407541), span.SpanID)
-	assert.Equal(t, uint64(7431398482019833808), span.ParentID)
+	assert.Equal(t, uint64(0), span.ParentID)
 	assert.Equal(t, int64(1634662094538000000), span.Start)
 	assert.Equal(t, "sqs", span.Service)
 	assert.Equal(t, "aws.sqs", span.Name)

--- a/pkg/serverless/trace/propagation/carriers.go
+++ b/pkg/serverless/trace/propagation/carriers.go
@@ -3,7 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022-present Datadog, Inc.
 
+<<<<<<< HEAD
 // Package propagation manages propagation of trace context headers.
+=======
+>>>>>>> a4f45507ed (Add copyright headers to new files.)
 package propagation
 
 import (

--- a/pkg/serverless/trace/propagation/carriers.go
+++ b/pkg/serverless/trace/propagation/carriers.go
@@ -3,10 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022-present Datadog, Inc.
 
-<<<<<<< HEAD
 // Package propagation manages propagation of trace context headers.
-=======
->>>>>>> a4f45507ed (Add copyright headers to new files.)
 package propagation
 
 import (

--- a/pkg/serverless/trace/testdata/event_samples/sqs-aws-header.json
+++ b/pkg/serverless/trace/testdata/event_samples/sqs-aws-header.json
@@ -1,0 +1,23 @@
+{
+    "Records": [
+        {
+            "messageId": "2fcbad66-372a-4b1c-87da-26b2cea13936",
+            "receiptHandle": "AQEBnxFcyzQZhkrLV/TrSpn0VBszuq4a5/u66uyGRdUKuvXMurd6RRV952L+arORbE4MlGqWLUxurzYH9mKvc/A3MYjmGwQvvhp6uK5c7gXxg6tvHVAlsEFmTB0p35dxfGCmtrJbzdPjVtmcucPEpRx7z51tQokgGWuJbqx3Z9MVRD+6dyO3o6Zu6G3oWUgiUZ0dxhNoIIeT6xr/tEsoWhGK9ZUPRJ7e0BM/UZKfkecX1CVgVZ8J/t8fHRklJd34S6pN99SPNBKx+1lOZCelm2MihbQR6zax8bkhwL3glxYP83MxexvfOELA3G/6jx96oQ4mQdJASsKFUzvcs2NUxX+0bBVX9toS7MW/Udv+3CiQwSjjkc18A385QHtNrJDRbH33OUxFCqN5CcUMiGvEFed5EQ==",
+            "body": "Asynchronously invoking a Lambda function with SQS.",
+            "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "1634662094538",
+                "SenderId": "AROAYYB64AB3LSVUYFP5T:harv-inferred-spans-dev-initSender",
+                "ApproximateFirstReceiveTimestamp": "1634662094544",
+                "AWSTraceHeader": "Root=1-00000000-00000000aaaaaaaaaaaaaaaa;Parent=bbbbbbbbbbbbbbbb;Sampled=1"
+            },
+            "messageAttributes": {
+            },
+            "md5OfMessageAttributes": "14b3b4a81d5ddeb96af62963d703c528",
+            "md5OfBody": "24933a8beabe72088d7576cab1a59142",
+            "eventSource": "aws:sqs",
+            "eventSourceARN": "arn:aws:sqs:sa-east-1:425362996713:InferredSpansQueueNode",
+            "awsRegion": "sa-east-1"
+        }
+    ]
+}

--- a/pkg/serverless/trace/testdata/event_samples/sqs-batch.json
+++ b/pkg/serverless/trace/testdata/event_samples/sqs-batch.json
@@ -36,7 +36,7 @@
             },
             "messageAttributes": {
                 "_datadog": {
-                    "stringValue": "{\"x-datadog-trace-id\":\"2684756524522091840\",\"x-datadog-parent-id\":\"7431398482019833808\",\"x-datadog-sampled\":\"1\",\"x-datadog-sampling-priority\":\"1\"}",
+                    "stringValue": "{\"x-datadog-trace-id\":\"2684756524522091841\",\"x-datadog-parent-id\":\"7431398482019833809\",\"x-datadog-sampled\":\"1\",\"x-datadog-sampling-priority\":\"1\"}",
                     "stringListValues": [],
                     "binaryListValues": [],
                     "dataType": "String"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This pull request uses the `propagation.Extractor` type created in https://github.com/DataDog/datadog-agent/pull/20363 to extract trace-id, parent-id, and sampling priority from the event/context. It then deletes a bunch of now dead code.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The `propagation.Extractor` type is designed to be used in a central location to handle all trace context extraction logic. Now, if we wish to add support for propagating trace context from a new event type, there is just one spot of code that needs to be updated.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Previously, there were two places in the code where we extracted trace context. SQS/SNS context was extracted in `pkg/serverless/trace/inferredspan/span_enrichment.go:EnrichInferredSpanWithSQSEvent` from the inbound lambda event. Then, in `pkg/serverless/invocationlifecycle/trace.go:LifecycleProcessor.startExecutionSpan`, we use the grab the trace and parent ids from the inferred span. These are potentially overwritten by trace context found in the inbound lambda event under the `Headers` field. If none are found there, then we'd lastly look for context in the request headers sent from the layer.

Now, all of this extraction is done in a single location. First, using the `propagation.Extractor` to find context in the inbound lambda event and if not found, look in the request headers. You will notice, this greatly simplifies the code.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

There are a few subtle ways that I have changed some of the log in `startExecutionSpan`.

| before | after |
|-----|-----|
| `startExecutionSpan` first looks for trace and parent ids in the inferred span; SQS/SNS are the only inferred spans that could have trace context at this point; if trace context is found in the both the SQS event and the request headers the context from the request headers is used | Trace context is no longer extracted from the inferred span; if trace context is found in both the SQS event and the requeset headers the context from the SQS event is used |
| If only one of trace id or parent id are found in the inbound request headers, the partial context is used | If only one of trace id or parent id are found in the inbound request headers, the entire context is ignored |
| If the inbound lambda event has a `Headers` field, it is the sole location trace context is searched | If the inbound lambda event has a `Headers` field, we will fall back to looking for trace context in the inbound request headers |
| Only some parts of the found trace context are applied to the inferred span | All parts of the trace context (trace id, parent id) are applied to the inferred span |

These changes should be listed in our release notes in case functionality is changed for a customer.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Test that propagation of `tracecontext` headers works for a lambda caller which executes a lambda function via HTTP call.

Test that propagation of `tracecontext` headers works for a lambda producer which sends an SQS message consumed by another lambda function.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
