### PR TITLE
[dogstatsd] better use of the counter and gauges in the string interner

### DIFF
--- a/comp/dogstatsd/server/intern_test.go
+++ b/comp/dogstatsd/server/intern_test.go
@@ -6,10 +6,29 @@
 package server
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func BenchmarkLoadOrStoreReset(b *testing.B) {
+	sInterner := newStringInterner(4, 1)
+
+	// benchmark with the internal telemetry enabled
+	sInterner.telemetry.enabled = true
+	sInterner.prepareTelemetry()
+
+	list := []string{}
+	for i := 0; i < 512; i++ {
+		list = append(list, fmt.Sprintf("testing.metric%d", i))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sInterner.LoadOrStore([]byte(list[i%len(list)]))
+	}
+}
 
 func TestInternLoadOrStoreValue(t *testing.T) {
 	assert := assert.New(t)


### PR DESCRIPTION
### What does this PR do?

Improves how #20308 is using the internal telemetry to improve performances. We remarked a performance hit in that area with our nightly benchmarks. 

### Additional Notes

Added a basic micro-benchmark to validate performance improvements.

Before:
```
BenchmarkLoadOrStoreReset-10             1335985               900.7 ns/op
```
After:
```
BenchmarkLoadOrStoreReset-10            12263616               93.39 ns/op
```

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
