### PR TITLE
Bump librdkafka and confluent-kafka to v2.3.0

### DIFF
--- a/omnibus/config/software/confluent-kafka-python.rb
+++ b/omnibus/config/software/confluent-kafka-python.rb
@@ -1,12 +1,12 @@
 # https://github.com/confluentinc/confluent-kafka-python/blob/master/INSTALL.md#install-from-source
 
 name "confluent-kafka-python"
-default_version "2.2.0"
+default_version "2.3.0"
 
 dependency "pip3"
 
 source :url => "https://github.com/confluentinc/confluent-kafka-python/archive/refs/tags/v#{version}.tar.gz",
-       :sha256 => "ee099702bd5fccd3ce4916658fed4c7ef28cb22e111defb843d27633100ff065",
+       :sha256 => "6be601e34073e7e8df883eff4540c2ed08c2f79578002774212df51c3018bd7d",
        :extract => :seven_zip
 
 relative_path "confluent-kafka-python-#{version}"

--- a/omnibus/config/software/librdkafka.rb
+++ b/omnibus/config/software/librdkafka.rb
@@ -3,12 +3,12 @@
 # https://github.com/confluentinc/confluent-kafka-python/blob/master/tools/windows-install-librdkafka.bat
 
 name "librdkafka"
-default_version "2.2.0"
+default_version "2.3.0"
 
 dependency "cyrus-sasl"
 
 source :url => "https://github.com/confluentinc/librdkafka/archive/refs/tags/v#{version}.tar.gz",
-        :sha256 => "af9a820cbecbc64115629471df7c7cecd40403b6c34bfdbb9223152677a47226",
+        :sha256 => "2d49c35c77eeb3d42fa61c43757fcbb6a206daa560247154e60642bcdcc14d12",
         :extract => :seven_zip
 
 relative_path "librdkafka-#{version}"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Update librdkafka and confluent-kafka to v2.3.0

### Motivation

~~Fix OpenSSL CVE: https://datadoghq.atlassian.net/browse/VULNOPS-1007~~ Initially this was assumed to address a CVE but based on conversations with experts this won't address the CVE on windows as we don't build librdkafka from source for windows. **2.3.0 release still includes OpenSSL 3.0.8. We'd have to build it ourselves. Or wait until they release a binary build with 3.0.11**
This will solve customer issue https://datadoghq.atlassian.net/browse/AGENT-10479 though

### Additional Notes

Integrations-core PR: https://github.com/DataDog/integrations-core/pull/16088

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
