### PR TITLE
[oracle] Fix wrong query metric values (DBMON-2962)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/custom_queries_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/custom_queries_test.go
@@ -23,14 +23,6 @@ import (
 
 var chk Check
 
-var HOST = "localhost"
-var PORT = 1521
-var USER = "c##datadog"
-var PASSWORD = "datadog"
-var SERVICE_NAME = "XE"
-var TNS_ALIAS = "XE"
-var TNS_ADMIN = "/Users/nenad.noveljic/go/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/testutil/etc/netadmin"
-
 func TestBasic(t *testing.T) {
 	chk = Check{}
 
@@ -78,7 +70,7 @@ func TestCustomQueries(t *testing.T) {
 		Query:        "SELECT c1, c2 FROM t",
 		Columns:      columns,
 	}
-	
+
 	senderManager := mocksender.CreateDefaultDemultiplexer()
 	chk, err := initCheck(t, senderManager, "localhost", 1523, "a", "a", "a")
 	chk.Run()

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -87,6 +87,7 @@ type Check struct {
 	logPrompt                               string
 	initialized                             bool
 	multitenant                             bool
+	lastOracleRows                          []OracleRow // added for tests
 }
 
 func handleServiceCheck(c *Check, err error) {

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -74,7 +74,7 @@ type StatementMetricsDB struct {
 	StatementMetricsKeyDB
 	SQLText       string `db:"SQL_TEXT"`
 	SQLTextLength int16  `db:"SQL_TEXT_LENGTH"`
-	SQLID         string `db:"SQL_ID"`
+	//SQLID         string `db:"SQL_ID"`
 	StatementMetricsMonotonicCountDB
 	StatementMetricsGaugeDB
 }
@@ -570,7 +570,6 @@ func (c *Check) StatementMetrics() (int, error) {
 			oracleRows = append(oracleRows, oracleRow)
 			if trace {
 				log.Infof("%s qm_tracker payload: %+v", c.logPrompt, oracleRow)
-				fmt.Printf("%s qm_tracker payload: %+v \n\n", c.logPrompt, oracleRow)
 			}
 
 			if c.fqtEmitted == nil {

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -403,7 +403,6 @@ func (c *Check) StatementMetrics() (int, error) {
 		var diff OracleRowMonotonicCount
 		planErrors = 0
 		for _, statementMetricRow := range statementMetricsAll {
-
 			var trace bool
 			for _, t := range c.config.QueryMetrics.Trackers {
 				if len(t.ContainsText) > 0 {
@@ -420,16 +419,15 @@ func (c *Check) StatementMetrics() (int, error) {
 					}
 				}
 			}
-
 			if trace {
-				log.Infof("%s queried: %+v", c.logPrompt, statementMetricRow)
+				log.Errorf("%s qm_tracker queried: %+v", c.logPrompt, statementMetricRow)
 			}
 
 			newCache[statementMetricRow.StatementMetricsKeyDB] = statementMetricRow.StatementMetricsMonotonicCountDB
 			previousMonotonic, exists := c.statementMetricsMonotonicCountsPrevious[statementMetricRow.StatementMetricsKeyDB]
 			if exists {
 				if trace {
-					log.Infof("%s previous: %+v %+v", c.logPrompt, statementMetricRow.StatementMetricsKeyDB, previousMonotonic)
+					log.Errorf("%s qm_tracker previous: %+v %+v", c.logPrompt, statementMetricRow.StatementMetricsKeyDB, previousMonotonic)
 				}
 				diff = OracleRowMonotonicCount{}
 				if diff.ParseCalls = statementMetricRow.ParseCalls - previousMonotonic.ParseCalls; diff.ParseCalls < 0 {
@@ -571,7 +569,7 @@ func (c *Check) StatementMetrics() (int, error) {
 
 			oracleRows = append(oracleRows, oracleRow)
 			if trace {
-				log.Infof("%s payload: %+v", c.logPrompt, oracleRow)
+				log.Errorf("%s qm_tracker payload: %+v", c.logPrompt, oracleRow)
 			}
 
 			if c.fqtEmitted == nil {
@@ -805,6 +803,8 @@ func (c *Check) StatementMetrics() (int, error) {
 		OracleRows:            oracleRows,
 		OracleVersion:         c.dbVersion,
 	}
+
+	c.lastOracleRows = oracleRows
 
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -74,7 +74,6 @@ type StatementMetricsDB struct {
 	StatementMetricsKeyDB
 	SQLText       string `db:"SQL_TEXT"`
 	SQLTextLength int16  `db:"SQL_TEXT_LENGTH"`
-	//SQLID         string `db:"SQL_ID"`
 	StatementMetricsMonotonicCountDB
 	StatementMetricsGaugeDB
 }

--- a/pkg/collector/corechecks/oracle-dbm/testutil.go
+++ b/pkg/collector/corechecks/oracle-dbm/testutil.go
@@ -11,15 +11,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/stretchr/testify/require"
-	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 )
 
 func initCheck(t *testing.T, senderManager sender.SenderManager, server string, port int, user string, password string, serviceName string) (Check, error) {
 	c := Check{}
-	rawInstanceConfig := []byte(fmt.Sprintf(`
-server: %s
+	rawInstanceConfig := []byte(fmt.Sprintf(`server: %s
 port: %d
 username: %s
 password: %s
@@ -30,3 +29,11 @@ service_name: %s
 
 	return c, err
 }
+
+var HOST = "localhost"
+var PORT = 1521
+var USER = "c##datadog"
+var PASSWORD = "datadog"
+var SERVICE_NAME = "XE"
+var TNS_ALIAS = "XE"
+var TNS_ADMIN = "/Users/nenad.noveljic/go/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/testutil/etc/netadmin"

--- a/releasenotes/notes/oracle-query-metric-wrong-data-169df53af1888788.yaml
+++ b/releasenotes/notes/oracle-query-metric-wrong-data-169df53af1888788.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fixing wrong values in Oracle query metrics data. Extreme cases were inflated statistics and missing statements. Affected were pure DML and PL/SQL statements.
+    Fixes wrong values in Oracle query metrics data. Extreme cases had inflated statistics and missing statements. The affected were pure DML and PL/SQL statements.

--- a/releasenotes/notes/oracle-query-metric-wrong-data-169df53af1888788.yaml
+++ b/releasenotes/notes/oracle-query-metric-wrong-data-169df53af1888788.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixing wrong values in Oracle query metrics data. Extreme cases were inflated statistics and missing statements. Affected were pure DML and PL/SQL statements.


### PR DESCRIPTION
### What does this PR do?

Fixing wrong query metrics. Extreme cases were inflated statistics or missing statements. Affected statements were those with `force_matching_signature = 0`, i.e. some DML and PL/SQL statements. 

New test cases were added. 

### Details

`SQLID` was redundantly defined; once in `StatementMetricsKeyDB` , and then in `StatementMetricsDB` . As `StatementMetricsDB` aggregates `StatementMetricsKeyDB` , `SQLID` in `StatementMetricsKeyDB` was empty, so all statements having `force_matching_signature = 0` were aggregated together.

### Describe how to test/QA your changes

Check if this appears in query metrics: 

```
begin
  loop
    null;
  end loop;
end;
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
