### PR TITLE
[corechecks/snmp] Make mergeProfiles return a deepcopy

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/profile/utils.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/utils.go
@@ -5,13 +5,17 @@
 
 package profile
 
+import "github.com/mohae/deepcopy"
+
+// mergeProfiles merges two profiles config map
+// we use deepcopy to lower risk of modifying original profiles
 func mergeProfiles(profilesA ProfileConfigMap, profilesB ProfileConfigMap) ProfileConfigMap {
 	profiles := make(ProfileConfigMap)
 	for k, v := range profilesA {
-		profiles[k] = v
+		profiles[k] = deepcopy.Copy(v).(ProfileConfig)
 	}
 	for k, v := range profilesB {
-		profiles[k] = v
+		profiles[k] = deepcopy.Copy(v).(ProfileConfig)
 	}
 	return profiles
 }

--- a/pkg/collector/corechecks/snmp/internal/profile/utils_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/utils_test.go
@@ -1,0 +1,124 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package profile
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
+	"github.com/mohae/deepcopy"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_mergeProfiles(t *testing.T) {
+	profilesA := ProfileConfigMap{
+		"profile-p1": ProfileConfig{
+			Definition: profiledefinition.ProfileDefinition{
+				Name:        "profile-p1",
+				Description: "profile-p1 from A",
+			},
+		},
+		"profile-p2": ProfileConfig{
+			Definition: profiledefinition.ProfileDefinition{
+				Metadata: profiledefinition.MetadataConfig{
+					"device": profiledefinition.MetadataResourceConfig{
+						Fields: map[string]profiledefinition.MetadataField{
+							"name": {
+								Value: "foo",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	profilesACopy := deepcopy.Copy(profilesA).(ProfileConfigMap)
+	profilesB := ProfileConfigMap{
+		"profile-p1": ProfileConfig{
+			Definition: profiledefinition.ProfileDefinition{
+				Name:        "profile-p1",
+				Description: "profile-p1 from B",
+			},
+		},
+		"profile-p3": ProfileConfig{
+			Definition: profiledefinition.ProfileDefinition{
+				Metadata: profiledefinition.MetadataConfig{
+					"device": profiledefinition.MetadataResourceConfig{
+						Fields: map[string]profiledefinition.MetadataField{
+							"name": {
+								Value: "bar",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	profilesBCopy := deepcopy.Copy(profilesB).(ProfileConfigMap)
+
+	actualMergedProfiles := mergeProfiles(profilesA, profilesB)
+
+	p2 := actualMergedProfiles["profile-p2"]
+	p2.Definition.Description = "abc"
+	p2.Definition.Metadata["device"] = profiledefinition.MetadataResourceConfig{
+		Fields: map[string]profiledefinition.MetadataField{
+			"name": {
+				Value: "foo2",
+			},
+		},
+	}
+	actualMergedProfiles["profile-p2"] = p2
+
+	p3 := actualMergedProfiles["profile-p3"]
+	p3.Definition.Description = "abc"
+	p3.Definition.Metadata["device"] = profiledefinition.MetadataResourceConfig{
+		Fields: map[string]profiledefinition.MetadataField{
+			"name": {
+				Value: "bar2",
+			},
+		},
+	}
+	actualMergedProfiles["profile-p3"] = p3
+
+	expectedMergedProfiles := ProfileConfigMap{
+		"profile-p1": ProfileConfig{
+			Definition: profiledefinition.ProfileDefinition{
+				Name:        "profile-p1",
+				Description: "profile-p1 from B",
+			},
+		},
+		"profile-p2": ProfileConfig{
+			Definition: profiledefinition.ProfileDefinition{
+				Description: "abc",
+				Metadata: profiledefinition.MetadataConfig{
+					"device": profiledefinition.MetadataResourceConfig{
+						Fields: map[string]profiledefinition.MetadataField{
+							"name": {
+								Value: "foo2",
+							},
+						},
+					},
+				},
+			},
+		},
+		"profile-p3": ProfileConfig{
+			Definition: profiledefinition.ProfileDefinition{
+				Description: "abc",
+				Metadata: profiledefinition.MetadataConfig{
+					"device": profiledefinition.MetadataResourceConfig{
+						Fields: map[string]profiledefinition.MetadataField{
+							"name": {
+								Value: "bar2",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	assert.Equal(t, expectedMergedProfiles, actualMergedProfiles)
+	assert.Equal(t, profilesACopy, profilesA)
+	assert.Equal(t, profilesBCopy, profilesB)
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
[corechecks/snmp] Copy during mergeProfiles

Shouldn't lead to perf issues since profiles mergeProfiles is only called during profile loading time that is not in the critical path of the integration.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Avoid accidental modification

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
