### PR TITLE
On Windows, uninstalling the Agent should not fail if the Datadog Agent registry key is missing

### DIFF
--- a/releasenotes/notes/Uninstall-should-not-fail-if-registry-key-is-missing-9a48a20e8d9eebe2.yaml
+++ b/releasenotes/notes/Uninstall-should-not-fail-if-registry-key-is-missing-9a48a20e8d9eebe2.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    On Windows, uninstalling the Agent should not fail if the Datadog Agent registry key is missing.

--- a/tools/windows/DatadogAgentInstaller/CustomActions/InstallStateCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/InstallStateCustomActions.cs
@@ -222,13 +222,27 @@ namespace Datadog.CustomActions
                     return ActionResult.Success;
                 }
 
-                subkey.DeleteValue("installedDomain");
-                subkey.DeleteValue("installedUser");
+                foreach (var value in new[]
+                         {
+                             "installedDomain",
+                             "installedUser"
+                         })
+                {
+                    try
+                    {
+                        subkey.DeleteValue(value);
+                    }
+                    catch (Exception e)
+                    {
+                        // Don't print stack trace as it may be seen as a terminal error by readers of the log.
+                        _session.Log($"Warning, cannot removing registry value: {e.Message}");
+                    }
+                }
             }
             catch (Exception e)
             {
-                _session.Log($"Error removing registry properties: {e}");
-                return ActionResult.Failure;
+                _session.Log($"Warning, could not access registry key {Constants.DatadogAgentRegistryKey}: {e}");
+                // This step can fail without failing the un-installation.
             }
 
             return ActionResult.Success;


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR ensures that the uninstallation can still succeed even if the Datadog Agent registry keys are missing.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The uninstallation should always succeed.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Install the Agent, delete the Datadog Agent registry keys, and try to uninstall the Agent.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
