### PR TITLE
[oracle] Fixes for obfuscator bugs (DBMON-1535)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -136,6 +136,11 @@ Port: '%d'
 `, c.Server, c.ServiceName, c.Port)
 }
 
+// GetDefaultObfuscatorOptions return default obfuscator options
+func GetDefaultObfuscatorOptions() obfuscate.SQLConfig {
+	return obfuscate.SQLConfig{DBMS: common.IntegrationName, TableNames: true, CollectCommands: true, CollectComments: true, ObfuscationMode: obfuscate.ObfuscateAndNormalize}
+}
+
 // NewCheckConfig builds a new check config.
 func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data) (*CheckConfig, error) {
 	instance := InstanceConfig{}
@@ -145,10 +150,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	var defaultMetricCollectionInterval int64 = 60
 	instance.MetricCollectionInterval = defaultMetricCollectionInterval
 
-	instance.ObfuscatorOptions.DBMS = common.IntegrationName
-	instance.ObfuscatorOptions.TableNames = true
-	instance.ObfuscatorOptions.CollectCommands = true
-	instance.ObfuscatorOptions.CollectComments = true
+	instance.ObfuscatorOptions = GetDefaultObfuscatorOptions()
 
 	instance.QuerySamples.Enabled = true
 
@@ -156,6 +158,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	instance.QueryMetrics.CollectionInterval = defaultMetricCollectionInterval
 	instance.QueryMetrics.DBRowsLimit = 10000
 
+	instance.ExecutionPlans.Enabled = true
 	instance.ExecutionPlans.PlanCacheRetention = 15
 
 	instance.SysMetrics.Enabled = true
@@ -163,8 +166,6 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	instance.ProcessMemory.Enabled = true
 	instance.SharedMemory.Enabled = true
 	instance.InactiveSessions.Enabled = true
-
-	instance.ExecutionPlans.Enabled = true
 
 	instance.UseGlobalCustomQueries = "true"
 

--- a/pkg/collector/corechecks/oracle-dbm/oracle_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_test.go
@@ -16,11 +16,11 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/common"
+	"github.com/DataDog/datadog-agent/pkg/obfuscate"
+	_ "github.com/godror/godror"
 	"github.com/jmoiron/sqlx"
 	go_ora "github.com/sijms/go-ora/v2"
 	"github.com/stretchr/testify/assert"
-
-	_ "github.com/godror/godror"
 )
 
 func TestConnectionGoOra(t *testing.T) {
@@ -279,4 +279,25 @@ func TestSQLXIn(t *testing.T) {
 		assert.Equal(t, retValue, result, driver)
 	}
 
+}
+
+func TestObfuscator(t *testing.T) {
+	obfuscatorOptions := obfuscate.SQLConfig{}
+	obfuscatorOptions.DBMS = common.IntegrationName
+	obfuscatorOptions.TableNames = true
+	obfuscatorOptions.CollectCommands = true
+	obfuscatorOptions.CollectComments = true
+
+	o := obfuscate.NewObfuscator(obfuscate.Config{SQL: obfuscatorOptions})
+	for _, statement := range []string{
+		// needs https://datadoghq.atlassian.net/browse/DBM-2295
+		`UPDATE /* comment */ SET t n=1`,
+		`SELECT /* comment */ from dual`} {
+		obfuscatedStatement, err := o.ObfuscateSQLString(statement)
+		assert.NoError(t, err, "obfuscator error")
+		assert.NotContains(t, obfuscatedStatement.Query, "comment", "comment wasn't removed by the obfuscator")
+	}
+
+	_, err := o.ObfuscateSQLString(`SELECT TRUNC(SYSDATE@!) from dual`)
+	assert.NoError(t, err, "can't obfuscate @!")
 }

--- a/releasenotes/notes/oracle-obfuscator-1c25fa49f9f7dd0f.yaml
+++ b/releasenotes/notes/oracle-obfuscator-1c25fa49f9f7dd0f.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Switch to the new obfuscator where lots of bugs are fixed.

--- a/releasenotes/notes/oracle-obfuscator-1c25fa49f9f7dd0f.yaml
+++ b/releasenotes/notes/oracle-obfuscator-1c25fa49f9f7dd0f.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Switch to the new obfuscator where lots of bugs are fixed.
+    Switch to the new obfuscator where bugs such as getting an error when obfuscating `@!` and where comments on DMLs weren't being removed are fixed.


### PR DESCRIPTION
### What does this PR do?

Switch to the new obfuscator where lots of bugs are fixed, for example:
- error when obfuscating `@!`
- comments on DMLs weren't removed

### Describe how to test/QA your changes

Comment in the following statement is removed `update /* commendt*/ t`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
