### PR TITLE
[corechecks/snmp] Copy CheckConfig using mohae/deepcopy

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mohae/deepcopy"
 	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
@@ -590,58 +591,8 @@ func (c *CheckConfig) IsIPIgnored(ip net.IP) bool {
 
 // Copy makes a copy of CheckConfig
 func (c *CheckConfig) Copy() *CheckConfig {
-	newConfig := CheckConfig{}
-	newConfig.IPAddress = c.IPAddress
-	newConfig.Network = c.Network
-	newConfig.Port = c.Port
-	newConfig.CommunityString = c.CommunityString
-	newConfig.SnmpVersion = c.SnmpVersion
-	newConfig.Timeout = c.Timeout
-	newConfig.Retries = c.Retries
-	newConfig.User = c.User
-	newConfig.AuthProtocol = c.AuthProtocol
-	newConfig.AuthKey = c.AuthKey
-	newConfig.PrivProtocol = c.PrivProtocol
-	newConfig.PrivKey = c.PrivKey
-	newConfig.ContextName = c.ContextName
-	newConfig.ContextName = c.ContextName
-	newConfig.OidConfig = c.OidConfig
-	newConfig.RequestedMetrics = make([]profiledefinition.MetricsConfig, len(c.RequestedMetrics))
-	copy(newConfig.RequestedMetrics, c.RequestedMetrics)
-	newConfig.Metrics = make([]profiledefinition.MetricsConfig, len(c.Metrics))
-	copy(newConfig.Metrics, c.Metrics)
-
-	// Metadata: shallow copy is enough since metadata is not modified.
-	// However, it might be fully replaced, see CheckConfig.SetProfile
-	newConfig.Metadata = c.Metadata
-
-	newConfig.RequestedMetricTags = make([]profiledefinition.MetricTagConfig, len(c.RequestedMetricTags))
-	copy(newConfig.RequestedMetricTags, c.RequestedMetricTags)
-	newConfig.MetricTags = make([]profiledefinition.MetricTagConfig, len(c.MetricTags))
-	copy(newConfig.MetricTags, c.MetricTags)
-	newConfig.OidBatchSize = c.OidBatchSize
-	newConfig.BulkMaxRepetitions = c.BulkMaxRepetitions
-	newConfig.Profiles = c.Profiles
-	newConfig.ProfileTags = common.CopyStrings(c.ProfileTags)
-	newConfig.Profile = c.Profile
-	newConfig.ProfileDef = c.ProfileDef
-	newConfig.ExtraTags = common.CopyStrings(c.ExtraTags)
-	newConfig.InstanceTags = common.CopyStrings(c.InstanceTags)
-	newConfig.CollectDeviceMetadata = c.CollectDeviceMetadata
-	newConfig.CollectTopology = c.CollectTopology
-	newConfig.UseDeviceIDAsHostname = c.UseDeviceIDAsHostname
-	newConfig.DeviceID = c.DeviceID
-
-	newConfig.DeviceIDTags = common.CopyStrings(c.DeviceIDTags)
-	newConfig.ResolvedSubnetName = c.ResolvedSubnetName
-	newConfig.Namespace = c.Namespace
-	newConfig.AutodetectProfile = c.AutodetectProfile
-	newConfig.DetectMetricsEnabled = c.DetectMetricsEnabled
-	newConfig.DetectMetricsRefreshInterval = c.DetectMetricsRefreshInterval
-	newConfig.MinCollectionInterval = c.MinCollectionInterval
-	newConfig.InterfaceConfigs = c.InterfaceConfigs
-
-	return &newConfig
+	newCheckConfig := deepcopy.Copy(*c).(CheckConfig)
+	return &newCheckConfig
 }
 
 // CopyWithNewIP makes a copy of CheckConfig with new IP

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -2219,7 +2219,14 @@ func TestCheckConfig_Copy(t *testing.T) {
 	assert.NotSame(t, config.ProfileTags, configCopy.ProfileTags)
 	assert.NotSame(t, config.ExtraTags, configCopy.ExtraTags)
 	assert.NotSame(t, config.InstanceTags, configCopy.InstanceTags)
-	assert.NotSame(t, config.DeviceIDTags, configCopy.DeviceIDTags)
+	assert.NotSame(t, config.Profiles, configCopy.Profiles)
+
+	// Test if configCopy is modified, the original config is not changed
+	assert.Equal(t, config.Profiles, configCopy.Profiles)
+	configCopy.Profiles["new-profile"] = profile.ProfileConfig{}
+	assert.NotEqual(t, config.Profiles, configCopy.Profiles)
+	assert.Len(t, config.Profiles, 1)
+	assert.Len(t, configCopy.Profiles, 2)
 }
 
 func TestCheckConfig_CopyWithNewIP(t *testing.T) {

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -2219,6 +2219,7 @@ func TestCheckConfig_Copy(t *testing.T) {
 	assert.NotSame(t, config.ProfileTags, configCopy.ProfileTags)
 	assert.NotSame(t, config.ExtraTags, configCopy.ExtraTags)
 	assert.NotSame(t, config.InstanceTags, configCopy.InstanceTags)
+	assert.NotSame(t, config.DeviceIDTags, configCopy.DeviceIDTags)
 	assert.NotSame(t, config.Profiles, configCopy.Profiles)
 
 	// Test if configCopy is modified, the original config is not changed


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

[corechecks/snmp] Copy CheckConfig using mohae/deepcopy

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Simpler code and less maintenance.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
