### PR TITLE
Use m5dn.metal machines for x86_64 VMs

### DIFF
--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -111,7 +111,7 @@ upload_dependencies_x64:
   variables:
     ARCHIVE_NAME: dependencies-x86_64.tar.gz
     ARCH: amd64
-    INSTANCE_TYPE: m5d.metal
+    INSTANCE_TYPE: m5dn.metal
 
 upload_dependencies_arm64:
   extends:
@@ -195,7 +195,7 @@ upload_system_probe_tests_x64:
   variables:
     ARCHIVE_NAME: tests-x86_64.tar.gz
     ARCH: x86_64
-    INSTANCE_TYPE: m5d.metal
+    INSTANCE_TYPE: m5dn.metal
 
 upload_system_probe_tests_arm64:
   extends:
@@ -248,7 +248,7 @@ upload_minimized_btfs_x64:
   variables:
     ARCHIVE_NAME: btfs-x86_64.tar.gz
     ARCH: x86_64
-    INSTANCE_TYPE: m5d.metal
+    INSTANCE_TYPE: m5dn.metal
 
 upload_minimized_btfs_arm64:
   extends:
@@ -276,7 +276,7 @@ kernel_matrix_testing_setup_env:
   needs: ["go_deps", "go_tools_deps"]
   tags: ["arch:amd64"]
   variables:
-    EC2_X86_INSTANCE_TYPE: "m5d.metal"
+    EC2_X86_INSTANCE_TYPE: "m5dn.metal"
     EC2_ARM_INSTANCE_TYPE: "m6gd.metal"
     X86_AMI_ID: $KERNEL_MATRIX_TESTING_X86_AMI_ID
     ARM_AMI_ID: $KERNEL_MATRIX_TESTING_ARM_AMI_ID

--- a/tasks/kernel_matrix_testing/stacks.py
+++ b/tasks/kernel_matrix_testing/stacks.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     libvirt = None
 
-X86_INSTANCE_TYPE = "m5d.metal"
+X86_INSTANCE_TYPE = "m5dn.metal"
 ARM_INSTANCE_TYPE = "m6gd.metal"
 
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
The m5dn.metal instances have a network bandwidth of 100Gigabytes vs 25 Gigabytes for the old m5d.metal instance.
The higher network bandwidth would allow faster downloading of VM images which is the main bottleneck in the KMT pipeline.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
https://datadoghq.atlassian.net/browse/EBPF-327

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
