### PR TITLE
omnibus: rename os helper to <os>_target

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -19,7 +19,7 @@ third_party_licenses "../LICENSE-3rdparty.csv"
 
 homepage 'http://www.datadoghq.com'
 
-if windows?
+if windows_target?
   # Note: this is the path used by Omnibus to build the agent, the final install
   # dir will be determined by the Windows installer. This path must not contain
   # spaces because Omnibus doesn't quote the Git commands it launches.
@@ -32,12 +32,12 @@ end
 
 install_dir INSTALL_DIR
 
-if windows?
+if windows_target?
   python_2_embedded PYTHON_2_EMBEDDED_DIR
   python_3_embedded PYTHON_3_EMBEDDED_DIR
   maintainer 'Datadog Inc.' # Windows doesn't want our e-mail address :(
 else
-  if redhat? || suse?
+  if redhat_target? || suse_target?
     maintainer 'Datadog, Inc <package@datadoghq.com>'
 
     # NOTE: with script dependencies, we only care about preinst/postinst/posttrans,
@@ -51,7 +51,7 @@ else
     runtime_script_dependency :pre, "coreutils"
     runtime_script_dependency :pre, "findutils"
     runtime_script_dependency :pre, "grep"
-    if redhat?
+    if redhat_target?
       runtime_script_dependency :pre, "glibc-common"
       runtime_script_dependency :pre, "shadow-utils"
     else
@@ -62,11 +62,11 @@ else
     maintainer 'Datadog Packages <package@datadoghq.com>'
   end
 
-  if debian?
+  if debian_target?
     runtime_recommended_dependency 'datadog-signing-keys (>= 1:1.3.1)'
   end
 
-  if osx?
+  if osx_target?
     unless ENV['SKIP_SIGN_MAC'] == 'true'
       code_signing_identity 'Developer ID Application: Datadog, Inc. (JKFCB4CN7C)'
     end
@@ -289,11 +289,11 @@ dependency 'agent-dependencies'
 dependency 'datadog-agent'
 
 # System-probe
-if linux? && !heroku?
+if linux_target? && !heroku_target?
   dependency 'system-probe'
 end
 
-if osx?
+if osx_target?
   dependency 'datadog-agent-mac-app'
 end
 
@@ -306,7 +306,7 @@ if with_python_runtime? "3"
   dependency 'datadog-agent-integrations-py3'
 end
 
-if linux?
+if linux_target?
   dependency 'datadog-security-agent-policies'
 end
 
@@ -323,7 +323,7 @@ dependency 'datadog-agent-finalize'
 dependency 'datadog-cf-finalize'
 
 # Additional software
-if windows?
+if windows_target?
   if ENV['WINDOWS_DDNPM_DRIVER'] and not ENV['WINDOWS_DDNPM_DRIVER'].empty?
     dependency 'datadog-windows-filter-driver'
   end
@@ -335,14 +335,14 @@ if windows?
   end
 end
 
-if linux?
+if linux_target?
   extra_package_file '/etc/init/datadog-agent.conf'
   extra_package_file '/etc/init/datadog-agent-process.conf'
   extra_package_file '/etc/init/datadog-agent-sysprobe.conf'
   extra_package_file '/etc/init/datadog-agent-trace.conf'
   extra_package_file '/etc/init/datadog-agent-security.conf'
   systemd_directory = "/usr/lib/systemd/system"
-  if debian?
+  if debian_target?
     systemd_directory = "/lib/systemd/system"
 
     extra_package_file "/etc/init.d/datadog-agent"
@@ -361,13 +361,13 @@ if linux?
 end
 
 # all flavors use the same package scripts
-if linux?
-  if debian?
+if linux_target?
+  if debian_target?
     package_scripts_path "#{Omnibus::Config.project_root}/package-scripts/agent-deb"
   else
     package_scripts_path "#{Omnibus::Config.project_root}/package-scripts/agent-rpm"
   end
-elsif osx?
+elsif osx_target?
     package_scripts_path "#{Omnibus::Config.project_root}/package-scripts/agent-dmg"
 end
 
@@ -376,7 +376,7 @@ resources_path "#{Omnibus::Config.project_root}/resources/agent"
 exclude '\.git*'
 exclude 'bundler\/git'
 
-if windows?
+if windows_target?
   FORBIDDEN_SYMBOLS = [
     "github.com/golang/glog"
   ]
@@ -412,7 +412,7 @@ if windows?
 
 end
 
-if linux? or windows?
+if linux_target? or windows_target?
   # the stripper will drop the symbols in a `.debug` folder in the installdir
   # we want to make sure that directory is not in the main build, while present
   # in the debug package.

--- a/omnibus/config/projects/dogstatsd.rb
+++ b/omnibus/config/projects/dogstatsd.rb
@@ -19,7 +19,7 @@ if ohai['platform'] == "windows"
   maintainer 'Datadog Inc.' # Windows doesn't want our e-mail address :(
 else
   install_dir '/opt/datadog-dogstatsd'
-  if redhat? || suse?
+  if redhat_target? || suse_target?
     maintainer 'Datadog, Inc <package@datadoghq.com>'
 
     # NOTE: with script dependencies, we only care about preinst/postinst/posttrans,
@@ -32,7 +32,7 @@ else
     # have to list them, because they'll already be there because of preinst
     runtime_script_dependency :pre, "coreutils"
     runtime_script_dependency :pre, "grep"
-    if redhat?
+    if redhat_target?
       runtime_script_dependency :pre, "glibc-common"
       runtime_script_dependency :pre, "shadow-utils"
     else
@@ -43,7 +43,7 @@ else
     maintainer 'Datadog Packages <package@datadoghq.com>'
   end
 
-  if debian?
+  if debian_target?
     runtime_recommended_dependency 'datadog-signing-keys (>= 1:1.3.1)'
   end
 end
@@ -169,15 +169,15 @@ dependency 'datadog-dogstatsd'
 dependency 'datadog-dogstatsd-finalize'
 
 # package scripts
-if linux?
-  if debian?
+if linux_target?
+  if debian_target?
     package_scripts_path "#{Omnibus::Config.project_root}/package-scripts/dogstatsd-deb"
   else
     package_scripts_path "#{Omnibus::Config.project_root}/package-scripts/dogstatsd-rpm"
   end
 end
 
-if linux?
+if linux_target?
   extra_package_file '/etc/init/datadog-dogstatsd.conf'
   extra_package_file '/lib/systemd/system/datadog-dogstatsd.service'
   extra_package_file '/etc/datadog-dogstatsd/'

--- a/omnibus/config/projects/iot-agent.rb
+++ b/omnibus/config/projects/iot-agent.rb
@@ -21,7 +21,7 @@ if ohai['platform'] == "windows"
   maintainer 'Datadog Inc.' # Windows doesn't want our e-mail address :(
 else
   install_dir '/opt/datadog-agent'
-  if redhat? || suse?
+  if redhat_target? || suse_target?
     maintainer 'Datadog, Inc <package@datadoghq.com>'
 
     # NOTE: with script dependencies, we only care about preinst/postinst/posttrans,
@@ -34,7 +34,7 @@ else
     # have to list them, because they'll already be there because of preinst
     runtime_script_dependency :pre, "coreutils"
     runtime_script_dependency :pre, "grep"
-    if redhat?
+    if redhat_target?
       runtime_script_dependency :pre, "glibc-common"
       runtime_script_dependency :pre, "shadow-utils"
     else
@@ -45,10 +45,10 @@ else
     maintainer 'Datadog Packages <package@datadoghq.com>'
   end
 
-  if debian?
+  if debian_target?
     runtime_recommended_dependency 'datadog-signing-keys (>= 1:1.3.1)'
   end
-  unless osx?
+  unless osx_target?
     conflict 'datadog-agent'
   end
 end
@@ -109,14 +109,14 @@ end
 # ------------------------------------
 
 # Linux
-if linux?
+if linux_target?
   # Upstart
-  if debian? || redhat? || suse?
+  if debian_target? || redhat_target? || suse_target?
     extra_package_file '/etc/init/datadog-agent.conf'
   end
 
   # Systemd
-  if debian?
+  if debian_target?
     extra_package_file '/lib/systemd/system/datadog-agent.service'
   else
     extra_package_file '/usr/lib/systemd/system/datadog-agent.service'
@@ -186,7 +186,7 @@ dependency 'preparation'
 # Datadog agent
 dependency 'datadog-iot-agent'
 
-if windows?
+if windows_target?
   dependency 'datadog-agent-finalize'
 end
 
@@ -194,8 +194,8 @@ end
 dependency 'version-manifest'
 
 # package scripts
-if linux?
-  if debian?
+if linux_target?
+  if debian_target?
     package_scripts_path "#{Omnibus::Config.project_root}/package-scripts/iot-agent-deb"
   else
     package_scripts_path "#{Omnibus::Config.project_root}/package-scripts/iot-agent-rpm"

--- a/omnibus/config/software/agent-dependencies.rb
+++ b/omnibus/config/software/agent-dependencies.rb
@@ -1,7 +1,7 @@
 name 'agent-dependencies'
 
 # Linux-specific dependencies
-if linux?
+if linux_target?
   dependency 'procps-ng'
   dependency 'curl'
 end

--- a/omnibus/config/software/confluent-kafka-python.rb
+++ b/omnibus/config/software/confluent-kafka-python.rb
@@ -15,7 +15,7 @@ build do
   license "Apache-2.0"
   license_file "./LICENSE.txt"
 
-  if windows?
+  if windows_target?
     pip = "#{windows_safe_path(python_3_embedded)}\\Scripts\\pip.exe"
     command "#{pip} install confluent-kafka"
   else
@@ -28,6 +28,6 @@ build do
     command "#{pip} install --no-binary confluent-kafka .", :env => build_env
   end
 
-  
+
 
 end

--- a/omnibus/config/software/cyrus-sasl.rb
+++ b/omnibus/config/software/cyrus-sasl.rb
@@ -21,7 +21,7 @@ build do
 
   configure_opts = ["--with-dblib=lmdb"]
 
-  if osx?
+  if osx_target?
     # https://github.com/Homebrew/homebrew-core/blob/e2071268473bcddaf72f8e3f7aa4153a18d1ccfa/Formula/cyrus-sasl.rb
     configure_opts = configure_opts.append("--disable-macos-framework")
   end

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -20,7 +20,7 @@ build do
     # TODO too many things done here, should be split
     block do
         # Conf files
-        if windows?
+        if windows_target?
             conf_dir_root = "#{Omnibus::Config.source_dir()}/etc/datadog-agent"
             conf_dir = "#{conf_dir_root}/extra_package_files/EXAMPLECONFSLOCATION"
             mkdir conf_dir
@@ -64,7 +64,7 @@ build do
 
         end
 
-        if linux? || osx?
+        if linux_target? || osx_target?
             # Setup script aliases, e.g. `/opt/datadog-agent/embedded/bin/pip` will
             # default to `pip2` if the default Python runtime is Python 2.
             if with_python_runtime? "2"
@@ -96,10 +96,10 @@ build do
             delete "#{install_dir}/embedded/lib/*.la"
         end
 
-        if linux?
+        if linux_target?
             # Fix pip after building on extended toolchain in CentOS builder
             if redhat? && ohai["platform_version"].to_i == 6
-              unless arm?
+              unless arm_target?
                 rhel_toolchain_root = "/opt/rh/devtoolset-1.1/root"
                 # lets be cautious - we first search for the expected toolchain path, if its not there, bail out
                 command "find #{install_dir} -type f -iname '*_sysconfigdata*.py' -exec grep -inH '#{rhel_toolchain_root}' {} \\; |  egrep '.*'"
@@ -116,7 +116,7 @@ build do
             move "#{install_dir}/scripts/datadog-agent-sysprobe.conf", "/etc/init"
             move "#{install_dir}/scripts/datadog-agent-security.conf", "/etc/init"
             systemd_directory = "/usr/lib/systemd/system"
-            if debian?
+            if debian_target?
                 # debian recommends using a different directory for systemd unit files
                 systemd_directory = "/lib/systemd/system"
 
@@ -145,7 +145,7 @@ build do
             move "#{install_dir}/etc/datadog-agent/compliance.d", "/etc/datadog-agent"
 
             # Move SELinux policy
-            if debian? || redhat?
+            if debian_target? || redhat_target?
               move "#{install_dir}/etc/datadog-agent/selinux", "/etc/datadog-agent/selinux"
             end
 
@@ -213,7 +213,7 @@ build do
             delete "#{install_dir}/embedded/bin/pg_config"
         end
 
-        if osx?
+        if osx_target?
             # Remove linux specific configs
             delete "#{install_dir}/etc/conf.d/file_handle.d"
 

--- a/omnibus/config/software/datadog-agent-integrations-py2-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2-dependencies.rb
@@ -2,7 +2,7 @@ name 'datadog-agent-integrations-py2-dependencies'
 
 dependency 'pip2'
 
-if arm?
+if arm_target?
   # same with libffi to build the cffi wheel
   dependency 'libffi'
   # same with libxml2 and libxslt to build the lxml wheel
@@ -10,12 +10,12 @@ if arm?
   dependency 'libxslt'
 end
 
-if osx?
+if osx_target?
   dependency 'postgresql'
   dependency 'unixodbc'
 end
 
-if linux?
+if linux_target?
   # * Psycopg2 doesn't come with pre-built wheel on the arm architecture.
   #   to compile from source, it requires the `pg_config` executable present on the $PATH
   # * We also need it to build psycopg[c] Python dependency
@@ -34,7 +34,7 @@ if linux?
   dependency 'gstatus'
 end
 
-if linux?
+if linux_target?
   # We need to use cython<3.0.0 to build pyyaml for py2
   dependency 'pyyaml-py2'
   dependency 'kubernetes-py2'

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -37,13 +37,13 @@ excluded_folders = [
 excluded_packages = Array.new
 
 
-if suse?
+if suse_target?
   # Temporarily exclude Aerospike until builder supports new dependency
   excluded_packages.push(/^aerospike==/)
   excluded_folders.push('aerospike')
 end
 
-if osx?
+if osx_target?
   # exclude aerospike, new version 3.10 is not supported on MacOS yet
   excluded_folders.push('aerospike')
 
@@ -52,7 +52,7 @@ if osx?
   excluded_folders.push('aerospike')
 end
 
-if arm?
+if arm_target?
   # Temporarily exclude Aerospike until builder supports new dependency
   excluded_folders.push('aerospike')
   excluded_packages.push(/^aerospike==/)
@@ -62,11 +62,11 @@ if arm?
   excluded_packages.push(/^pymqi==/)
 end
 
-if arm? || !_64_bit?
+if arm_target? || !_64_bit?
   excluded_packages.push(/^orjson==/)
 end
 
-if linux?
+if linux_target?
   excluded_packages.push(/^pyyaml==/)
   excluded_packages.push(/^kubernetes==/)
 end
@@ -81,7 +81,7 @@ build do
   license_file "./LICENSE"
 
   # The dir for confs
-  if osx?
+  if osx_target?
     conf_dir = "#{install_dir}/etc/conf.d"
   else
     conf_dir = "#{install_dir}/etc/datadog-agent/conf.d"
@@ -89,7 +89,7 @@ build do
   mkdir conf_dir
 
   # aliases for pip
-  if windows?
+  if windows_target?
     pip = "#{windows_safe_path(python_2_embedded)}\\Scripts\\pip.exe"
     python = "#{windows_safe_path(python_2_embedded)}\\python.exe"
   else
@@ -106,7 +106,7 @@ build do
 
   # Install the checks along with their dependencies
   block do
-    if windows?
+    if windows_target?
       wheel_build_dir = "#{windows_safe_path(project_dir)}\\.wheels"
       build_deps_dir = "#{windows_safe_path(project_dir)}\\.build_deps"
     else
@@ -154,7 +154,7 @@ build do
     # don't have precompiled MacOS wheels. When building C extensions, the CFLAGS variable is added to
     # the command-line parameters, even when compiling C++ code, where -std=c99 is invalid.
     # See: https://github.com/python/cpython/blob/v2.7.18/Lib/distutils/sysconfig.py#L222
-    if linux? || windows?
+    if linux_target? || windows_target?
       nix_build_env["CFLAGS"] += " -std=c99"
     end
 
@@ -164,7 +164,7 @@ build do
     # We don't use the .in file provided by the base check directly because we
     # want to filter out things before installing.
     #
-    if windows?
+    if windows_target?
       static_reqs_in_file = "#{windows_safe_path(project_dir)}\\datadog_checks_base\\datadog_checks\\base\\data\\#{agent_requirements_in}"
       static_reqs_out_folder = "#{windows_safe_path(project_dir)}\\"
       static_reqs_out_file = static_reqs_out_folder + filtered_agent_requirements_in
@@ -182,12 +182,12 @@ build do
     # Creating a hash containing the requirements and requirements file path associated to every lib
     requirements_custom = Hash.new()
 
-    specific_build_env = windows? ? win_specific_build_env : nix_specific_build_env
-    build_env = windows? ? win_build_env : nix_build_env
-    cwd = windows? ? "#{windows_safe_path(project_dir)}\\datadog_checks_base" : "#{project_dir}/datadog_checks_base"
+    specific_build_env = windows_target? ? win_specific_build_env : nix_specific_build_env
+    build_env = windows_target? ? win_build_env : nix_build_env
+    cwd = windows_target? ? "#{windows_safe_path(project_dir)}\\datadog_checks_base" : "#{project_dir}/datadog_checks_base"
 
     specific_build_env.each do |lib, env|
-      lib_compiled_req_file_path = (windows? ? "#{windows_safe_path(install_dir)}\\" : "#{install_dir}/") + "agent_#{lib}_requirements-py2.txt"
+      lib_compiled_req_file_path = (windows_target? ? "#{windows_safe_path(install_dir)}\\" : "#{install_dir}/") + "agent_#{lib}_requirements-py2.txt"
       requirements_custom[lib] = {
         "req_lines" => Array.new,
         "req_file_path" => static_reqs_out_folder + lib + "-py2.in",
@@ -198,7 +198,7 @@ build do
     File.open("#{static_reqs_in_file}", 'r+').readlines().each do |line|
       next if excluded_packages.any? { |package_regex| line.match(package_regex) }
 
-      if line.start_with?('psycopg[binary]') && !windows?
+      if line.start_with?('psycopg[binary]') && !windows_target?
           line.sub! 'psycopg[binary]', 'psycopg[c]'
       end
       # Keeping the custom env requirements lines apart to install them with a specific env
@@ -269,7 +269,7 @@ build do
     # This is then used as a constraint file by the integration command to avoid messing with the agent's python environment
     command "#{pip} freeze > #{install_dir}/#{final_constraints_file}"
 
-    if windows?
+    if windows_target?
         cached_wheels_dir = "#{windows_safe_path(wheel_build_dir)}\\.cached"
     else
         cached_wheels_dir = "#{wheel_build_dir}/.cached"
@@ -319,7 +319,7 @@ build do
     cache_bucket = ENV.fetch('INTEGRATION_WHEELS_CACHE_BUCKET', '')
     cache_branch = `cd .. && inv release.get-release-json-value base_branch`.strip
     # On windows, `aws` actually executes Ruby's AWS SDK, but we want the Python one
-    awscli = if windows? then '"c:\Program files\python39\scripts\aws"' else 'aws' end
+    awscli = if windows_target? then '"c:\Program files\python39\scripts\aws"' else 'aws' end
     if cache_bucket != ''
       mkdir cached_wheels_dir
       command "inv -e agent.get-integrations-from-cache " \
@@ -332,7 +332,7 @@ build do
         :cwd => tasks_dir_in
 
       # install all wheels from cache in one pip invocation to speed things up
-      if windows?
+      if windows_target?
         command "#{python} -m pip install --no-deps --no-index " \
           "--find-links #{windows_safe_path(cached_wheels_dir)} -r #{windows_safe_path(cached_wheels_dir)}\\found.txt"
       else
@@ -348,7 +348,7 @@ build do
       # get list of integration wheels already installed from cache
       installed_list = Array.new
       if cache_bucket != ''
-        if windows?
+        if windows_target?
           installed_out = `#{python} -m pip list --format json`
         else
           installed_out = `#{pip} list --format json`
@@ -417,7 +417,7 @@ build do
           next
         end
 
-        if windows?
+        if windows_target?
           command "#{python} -m pip wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => win_build_env, :cwd => "#{windows_safe_path(project_dir)}\\#{check}"
           command "#{python} -m pip install datadog-#{check} --no-deps --no-index --find-links=#{wheel_build_dir}"
         else
@@ -438,7 +438,7 @@ build do
 
       # From now on we don't need piptools anymore, uninstall its deps so we don't include them in the final artifact
       uninstall_buildtime_deps.each do |dep|
-        if windows?
+        if windows_target?
           command "#{python} -m pip uninstall -y #{dep}"
         else
           command "#{pip} uninstall -y #{dep}"
@@ -451,7 +451,7 @@ build do
       # from the last block
 
       # Patch applies to only one file: set it explicitly as a target, no need for -p
-      if windows?
+      if windows_target?
         patch :source => "create-regex-at-runtime.patch", :target => "#{python_2_embedded}/Lib/site-packages/yaml/reader.py"
         patch :source => "remove-maxfile-maxpath-psutil.patch", :target => "#{python_2_embedded}/Lib/site-packages/psutil/__init__.py"
       else
@@ -460,7 +460,7 @@ build do
       end
 
       # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
-      if windows?
+      if windows_target?
         command "#{python} -m pip check"
       else
         command "#{pip} check"
@@ -469,7 +469,7 @@ build do
 
     block do
       # Removing tests that don't need to be shipped in the embedded folder
-      if windows?
+      if windows_target?
         delete "#{python_2_embedded}/Lib/site-packages/Cryptodome/SelfTest/"
       else
         delete "#{install_dir}/embedded/lib/python2.7/site-packages/Cryptodome/SelfTest/"

--- a/omnibus/config/software/datadog-agent-integrations-py3-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3-dependencies.rb
@@ -6,7 +6,7 @@ dependency 'setuptools3'
 dependency 'snowflake-connector-python-py3'
 dependency 'confluent-kafka-python'
 
-if arm?
+if arm_target?
   # same with libffi to build the cffi wheel
   dependency 'libffi'
   # same with libxml2 and libxslt to build the lxml wheel
@@ -14,12 +14,12 @@ if arm?
   dependency 'libxslt'
 end
 
-if osx?
+if osx_target?
   dependency 'postgresql'
   dependency 'unixodbc'
 end
 
-if linux?
+if linux_target?
   # * Psycopg2 doesn't come with pre-built wheel on the arm architecture.
   #   to compile from source, it requires the `pg_config` executable present on the $PATH
   # * We also need it to build psycopg[c] Python dependency
@@ -38,11 +38,11 @@ if linux?
   dependency 'gstatus'
 end
 
-if redhat? && !arm?
+if redhat_target? && !arm_target?
   dependency 'pydantic-core-py3'
 end
 
-if linux?
+if linux_target?
   # We need to use cython<3.0.0 to build oracledb
   dependency 'oracledb-py3'
 end

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -45,38 +45,38 @@ excluded_packages = Array.new
 excluded_packages.push(/^snowflake-connector-python==/)
 excluded_packages.push(/^confluent-kafka==/)
 
-if suse?
+if suse_target?
   # Temporarily exclude Aerospike until builder supports new dependency
   excluded_packages.push(/^aerospike==/)
   excluded_folders.push('aerospike')
 end
 
-if osx?
+if osx_target?
   # Temporarily exclude Aerospike until builder supports new dependency
   excluded_packages.push(/^aerospike==/)
   excluded_folders.push('aerospike')
   excluded_folders.push('teradata')
 end
 
-if arm?
+if arm_target?
   # This doesn't build on ARM
   excluded_folders.push('ibm_ace')
   excluded_folders.push('ibm_mq')
   excluded_packages.push(/^pymqi==/)
 end
 
-if redhat? && !arm?
+if redhat? && !arm_target?
   excluded_packages.push(/^pydantic-core==/)
 end
 
 # _64_bit checks the kernel arch.  On windows, the builder is 64 bit
 # even when doing a 32 bit build.  Do a specific check for the 32 bit
 # build
-if arm? || !_64_bit? || (windows? && windows_arch_i386?)
+if arm_target? || !_64_bit? || (windows_target? && windows_arch_i386?)
   excluded_packages.push(/^orjson==/)
 end
 
-if linux?
+if linux_target?
   excluded_packages.push(/^oracledb==/)
 end
 
@@ -90,7 +90,7 @@ build do
   license_file "./LICENSE"
 
   # The dir for confs
-  if osx?
+  if osx_target?
     conf_dir = "#{install_dir}/etc/conf.d"
   else
     conf_dir = "#{install_dir}/etc/datadog-agent/conf.d"
@@ -98,7 +98,7 @@ build do
   mkdir conf_dir
 
   # aliases for pip
-  if windows?
+  if windows_target?
     python = "#{windows_safe_path(python_3_embedded)}\\python.exe"
   else
     python = "#{install_dir}/embedded/bin/python3"
@@ -112,7 +112,7 @@ build do
 
   # Install the checks along with their dependencies
   block do
-    if windows?
+    if windows_target?
       wheel_build_dir = "#{windows_safe_path(project_dir)}\\.wheels"
       build_deps_dir = "#{windows_safe_path(project_dir)}\\.build_deps"
     else
@@ -154,12 +154,12 @@ build do
     # don't have precompiled MacOS wheels. When building C extensions, the CFLAGS variable is added to
     # the command-line parameters, even when compiling C++ code, where -std=c99 is invalid.
     # See: https://github.com/python/cpython/blob/v3.8.8/Lib/distutils/sysconfig.py#L227
-    if linux? || windows?
+    if linux_target? || windows_target?
       nix_build_env["CFLAGS"] += " -std=c99"
     end
 
     # We only have gcc 10.4.0 on linux for now
-    if linux?
+    if linux_target?
       nix_build_env["CC"] = "/opt/gcc-#{gcc_version}/bin/gcc"
       nix_build_env["CXX"] = "/opt/gcc-#{gcc_version}/bin/g++"
     end
@@ -175,7 +175,7 @@ build do
 
     # We need to explicitly specify RUSTFLAGS for libssl and libcrypto
     # See https://github.com/pyca/cryptography/issues/8614#issuecomment-1489366475
-    if redhat? && !arm?
+    if redhat? && !arm_target?
         nix_specific_build_env["cryptography"] = nix_build_env.merge(
             {
                 "RUSTFLAGS" => "-C link-arg=-Wl,-rpath,#{install_dir}/embedded/lib",
@@ -194,7 +194,7 @@ build do
     # We don't use the .in file provided by the base check directly because we
     # want to filter out things before installing.
     #
-    if windows?
+    if windows_target?
       static_reqs_in_file = "#{windows_safe_path(project_dir)}\\datadog_checks_base\\datadog_checks\\base\\data\\#{agent_requirements_in}"
       static_reqs_out_folder = "#{windows_safe_path(project_dir)}\\"
       static_reqs_out_file = static_reqs_out_folder + filtered_agent_requirements_in
@@ -212,13 +212,13 @@ build do
     # Creating a hash containing the requirements and requirements file path associated to every lib
     requirements_custom = Hash.new()
 
-    specific_build_env = windows? ? win_specific_build_env : nix_specific_build_env
-    build_env = windows? ? win_build_env : nix_build_env
-    cwd_base = windows? ? "#{windows_safe_path(project_dir)}\\datadog_checks_base" : "#{project_dir}/datadog_checks_base"
-    cwd_downloader = windows? ? "#{windows_safe_path(project_dir)}\\datadog_checks_downloader" : "#{project_dir}/datadog_checks_downloader"
+    specific_build_env = windows_target? ? win_specific_build_env : nix_specific_build_env
+    build_env = windows_target? ? win_build_env : nix_build_env
+    cwd_base = windows_target? ? "#{windows_safe_path(project_dir)}\\datadog_checks_base" : "#{project_dir}/datadog_checks_base"
+    cwd_downloader = windows_target? ? "#{windows_safe_path(project_dir)}\\datadog_checks_downloader" : "#{project_dir}/datadog_checks_downloader"
 
     specific_build_env.each do |lib, env|
-      lib_compiled_req_file_path = (windows? ? "#{windows_safe_path(install_dir)}\\" : "#{install_dir}/") + "agent_#{lib}_requirements-py3.txt"
+      lib_compiled_req_file_path = (windows_target? ? "#{windows_safe_path(install_dir)}\\" : "#{install_dir}/") + "agent_#{lib}_requirements-py3.txt"
       requirements_custom[lib] = {
         "req_lines" => Array.new,
         "req_file_path" => static_reqs_out_folder + lib + "-py3.in",
@@ -230,7 +230,7 @@ build do
       next if excluded_packages.any? { |package_regex| line.match(package_regex) }
 
       # on non windows OS, we use the c version of the psycopg installation
-      if line.start_with?('psycopg[binary]') && !windows?
+      if line.start_with?('psycopg[binary]') && !windows_target?
         line.sub! 'psycopg[binary]', 'psycopg[c]'
       end
       # Keeping the custom env requirements lines apart to install them with a specific env
@@ -302,7 +302,7 @@ build do
     # This is then used as a constraint file by the integration command to avoid messing with the agent's python environment
     command "#{python} -m pip freeze > #{install_dir}/#{final_constraints_file}"
 
-    if windows?
+    if windows_target?
         cached_wheels_dir = "#{windows_safe_path(wheel_build_dir)}\\.cached"
     else
         cached_wheels_dir = "#{wheel_build_dir}/.cached"
@@ -352,7 +352,7 @@ build do
     cache_bucket = ENV.fetch('INTEGRATION_WHEELS_CACHE_BUCKET', '')
     cache_branch = `cd .. && inv release.get-release-json-value base_branch`.strip
     # On windows, `aws` actually executes Ruby's AWS SDK, but we want the Python one
-    awscli = if windows? then '"c:\Program files\python39\scripts\aws"' else 'aws' end
+    awscli = if windows_target? then '"c:\Program files\python39\scripts\aws"' else 'aws' end
     if cache_bucket != ''
       mkdir cached_wheels_dir
       command "inv -e agent.get-integrations-from-cache " \
@@ -365,7 +365,7 @@ build do
         :cwd => tasks_dir_in
 
       # install all wheels from cache in one pip invocation to speed things up
-      if windows?
+      if windows_target?
         command "#{python} -m pip install --no-deps --no-index " \
           " --find-links #{windows_safe_path(cached_wheels_dir)} -r #{windows_safe_path(cached_wheels_dir)}\\found.txt"
       else
@@ -446,7 +446,7 @@ build do
           next
         end
 
-        if windows?
+        if windows_target?
           command "#{python} -m pip wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => win_build_env, :cwd => "#{windows_safe_path(project_dir)}\\#{check}"
         else
           command "#{python} -m pip wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => nix_build_env, :cwd => "#{project_dir}/#{check}"
@@ -475,7 +475,7 @@ build do
       # from the last block
 
       # Patch applies to only one file: set it explicitly as a target, no need for -p
-      if windows?
+      if windows_target?
         patch :source => "remove-maxfile-maxpath-psutil.patch", :target => "#{python_3_embedded}/Lib/site-packages/psutil/__init__.py"
       else
         patch :source => "remove-maxfile-maxpath-psutil.patch", :target => "#{install_dir}/embedded/lib/python3.9/site-packages/psutil/__init__.py"
@@ -487,7 +487,7 @@ build do
 
     block do
       # Removing tests that don't need to be shipped in the embedded folder
-      if windows?
+      if windows_target?
         delete "#{python_3_embedded}/Lib/site-packages/Cryptodome/SelfTest/"
       else
         delete "#{install_dir}/embedded/lib/python3.9/site-packages/Cryptodome/SelfTest/"

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -65,6 +65,9 @@ if arm_target?
   excluded_packages.push(/^pymqi==/)
 end
 
+# We explicitly check for redhat builder, not target
+# Our centos/redhat builder uses glibc 2.12 while pydantic
+# requires glibc 2.17
 if redhat? && !arm_target?
   excluded_packages.push(/^pydantic-core==/)
 end
@@ -175,7 +178,7 @@ build do
 
     # We need to explicitly specify RUSTFLAGS for libssl and libcrypto
     # See https://github.com/pyca/cryptography/issues/8614#issuecomment-1489366475
-    if redhat? && !arm_target?
+    if redhat_target? && !arm_target?
         nix_specific_build_env["cryptography"] = nix_build_env.merge(
             {
                 "RUSTFLAGS" => "-C link-arg=-Wl,-rpath,#{install_dir}/embedded/lib",

--- a/omnibus/config/software/datadog-agent-prepare.rb
+++ b/omnibus/config/software/datadog-agent-prepare.rb
@@ -31,7 +31,7 @@ build do
   end
 end
 
-if windows?
+if windows_target?
   build do
     block do
       FileUtils.mkdir_p(File.expand_path(File.join(Omnibus::Config.source_dir(), "datadog-agent", "src", "github.com", "DataDog", "datadog-agent", "bin", "agent")))

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -11,10 +11,10 @@ name 'datadog-agent'
 dependency "python2" if with_python_runtime? "2"
 dependency "python3" if with_python_runtime? "3"
 
-dependency "libarchive" if windows?
-dependency "yaml-cpp" if windows?
+dependency "libarchive" if windows_target?
+dependency "yaml-cpp" if windows_target?
 
-dependency "openscap" if linux? and !arm7l? and !heroku? # Security-agent dependency, not needed for Heroku
+dependency "openscap" if linux_target? and !arm7l_target? and !heroku_target? # Security-agent dependency, not needed for Heroku
 
 dependency 'datadog-agent-dependencies'
 
@@ -27,7 +27,7 @@ build do
   # set GOPATH on the omnibus source dir for this software
   gopath = Pathname.new(project_dir) + '../../../..'
   etc_dir = "/etc/datadog-agent"
-  if windows?
+  if windows_target?
     env = {
         'GOPATH' => gopath.to_path,
         'PATH' => "#{gopath.to_path}/bin:#{ENV['PATH']}",
@@ -62,7 +62,7 @@ build do
   env = with_embedded_path(env)
 
   # we assume the go deps are already installed before running omnibus
-  if windows?
+  if windows_target?
     platform = windows_arch_i386? ? "x86" : "x64"
     do_windows_sysprobe = ""
     if not windows_arch_i386? and ENV['WINDOWS_DDNPM_DRIVER'] and not ENV['WINDOWS_DDNPM_DRIVER'].empty?
@@ -80,20 +80,20 @@ build do
     command "inv -e agent.build --exclude-rtloader --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg} --rebuild --no-development --embedded-path=#{install_dir}/embedded --python-home-2=#{install_dir}/embedded --python-home-3=#{install_dir}/embedded --flavor #{flavor_arg}", env: env
   end
 
-  if osx?
+  if osx_target?
     conf_dir = "#{install_dir}/etc"
   else
     conf_dir = "#{install_dir}/etc/datadog-agent"
   end
   mkdir conf_dir
   mkdir "#{install_dir}/bin"
-  unless windows?
+  unless windows_target?
     mkdir "#{install_dir}/run/"
     mkdir "#{install_dir}/scripts/"
   end
 
   ## build the custom action library required for the install
-  if windows?
+  if windows_target?
     platform = windows_arch_i386? ? "x86" : "x64"
     debug_customaction = ""
     if ENV['DEBUG_CUSTOMACTION'] and not ENV['DEBUG_CUSTOMACTION'].empty?
@@ -104,12 +104,12 @@ build do
 
   # move around bin and config files
   move 'bin/agent/dist/datadog.yaml', "#{conf_dir}/datadog.yaml.example"
-  if linux? or (windows? and not windows_arch_i386? and ENV['WINDOWS_DDNPM_DRIVER'] and not ENV['WINDOWS_DDNPM_DRIVER'].empty?)
+  if linux_target? or (windows_target? and not windows_arch_i386? and ENV['WINDOWS_DDNPM_DRIVER'] and not ENV['WINDOWS_DDNPM_DRIVER'].empty?)
       move 'bin/agent/dist/system-probe.yaml', "#{conf_dir}/system-probe.yaml.example"
   end
   move 'bin/agent/dist/conf.d', "#{conf_dir}/"
 
-  unless windows?
+  unless windows_target?
     copy 'bin/agent', "#{install_dir}/bin/"
   else
     copy 'bin/agent/ddtray.exe', "#{install_dir}/bin/agent"
@@ -124,7 +124,7 @@ build do
     platform = windows_arch_i386? ? "x86" : "x64"
     command "invoke trace-agent.build --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg} --arch #{platform} --flavor #{flavor_arg}", :env => env
 
-    if windows?
+    if windows_target?
       copy 'bin/trace-agent/trace-agent.exe', "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent"
     else
       copy 'bin/trace-agent/trace-agent', "#{install_dir}/embedded/bin"
@@ -132,7 +132,7 @@ build do
   end
 
   # Process agent
-  if windows?
+  if windows_target?
     platform = windows_arch_i386? ? "x86" : "x64"
     # Build the process-agent with the correct go version for windows
     command "invoke -e process-agent.build --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg} --arch #{platform} --flavor #{flavor_arg}", :env => env
@@ -144,7 +144,7 @@ build do
   end
 
   # System-probe
-  if windows?
+  if windows_target?
     unless windows_arch_i386?
       if ENV['WINDOWS_DDNPM_DRIVER'] and not ENV['WINDOWS_DDNPM_DRIVER'].empty?
         ## don't bother with system probe build on x86.
@@ -152,24 +152,24 @@ build do
         copy 'bin/system-probe/system-probe.exe', "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent"
       end
     end
-  elsif linux?
+  elsif linux_target?
     command "invoke -e system-probe.build-sysprobe-binary"
     copy "bin/system-probe/system-probe", "#{install_dir}/embedded/bin"
   end
 
   # Add SELinux policy for system-probe
-  if debian? || redhat?
+  if debian_target? || redhat_target?
     mkdir "#{conf_dir}/selinux"
     command "inv -e selinux.compile-system-probe-policy-file --output-directory #{conf_dir}/selinux", env: env
   end
 
   # Security agent
-  unless heroku?
-    if not windows? or (ENV['WINDOWS_DDPROCMON_DRIVER'] and not ENV['WINDOWS_DDPROCMON_DRIVER'].empty?)
+  unless heroku_target?
+    if not windows_target? or (ENV['WINDOWS_DDPROCMON_DRIVER'] and not ENV['WINDOWS_DDPROCMON_DRIVER'].empty?)
       command "invoke -e security-agent.build --major-version #{major_version_arg}", :env => env
-      if windows?
+      if windows_target?
         copy 'bin/security-agent/security-agent.exe', "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent"
-      else 
+      else
         copy 'bin/security-agent/security-agent', "#{install_dir}/embedded/bin"
       end
       move 'bin/agent/dist/security-agent.yaml', "#{conf_dir}/security-agent.yaml.example"
@@ -177,15 +177,15 @@ build do
   end
 
   # APM Injection agent
-  if windows?
+  if windows_target?
     if ENV['WINDOWS_APMINJECT_MODULE'] and not ENV['WINDOWS_APMINJECT_MODULE'].empty?
       command "inv generate-config --build-type apm-injection --output-file ./bin/agent/dist/apm-inject.yaml", :env => env
      #move 'bin/agent/dist/system-probe.yaml', "#{conf_dir}/system-probe.yaml.example"
       move 'bin/agent/dist/apm-inject.yaml', "#{conf_dir}/apm-inject.yaml.example"
     end
   end
-  if linux?
-    if debian?
+  if linux_target?
+    if debian_target?
       erb source: "upstart_debian.conf.erb",
           dest: "#{install_dir}/scripts/datadog-agent.conf",
           mode: 0644,
@@ -222,7 +222,7 @@ build do
           dest: "#{install_dir}/scripts/datadog-agent-security",
           mode: 0755,
           vars: { install_dir: install_dir, etc_dir: etc_dir }
-    elsif redhat? || suse?
+    elsif redhat_target? || suse_target?
       # Ship a different upstart job definition on RHEL to accommodate the old
       # version of upstart (0.6.5) that RHEL 6 provides.
       erb source: "upstart_redhat.conf.erb",
@@ -269,7 +269,7 @@ build do
         vars: { install_dir: install_dir, etc_dir: etc_dir }
   end
 
-  if osx?
+  if osx_target?
     # Launchd service definition
     erb source: "launchd.plist.example.erb",
         dest: "#{conf_dir}/com.datadoghq.agent.plist.example",
@@ -290,7 +290,7 @@ build do
   # The file below is touched by software builds that don't put anything in the installation
   # directory (libgcc right now) so that the git_cache gets updated let's remove it from the
   # final package
-  unless windows?
+  unless windows_target?
     delete "#{install_dir}/uselessfile"
   end
 end

--- a/omnibus/config/software/datadog-buildpack-finalize.rb
+++ b/omnibus/config/software/datadog-buildpack-finalize.rb
@@ -20,7 +20,7 @@ build do
     # TODO too many things done here, should be split
     block do
         # Conf files
-        if windows?
+        if windows_target?
             ## this section creates the parallel `bin` directory structure for the Windows
             ## CF build pack.  None of the files created here will end up in the binary
             ## (MSI) distribution.

--- a/omnibus/config/software/datadog-cf-finalize.rb
+++ b/omnibus/config/software/datadog-cf-finalize.rb
@@ -20,7 +20,7 @@ build do
     # TODO too many things done here, should be split
     block do
         # Conf files
-        if windows?
+        if windows_target?
             ## this section creates the parallel `bin` directory structure for the Windows
             ## CF build pack.  None of the files created here will end up in the binary
             ## (MSI) distribution.

--- a/omnibus/config/software/datadog-dogstatsd-finalize.rb
+++ b/omnibus/config/software/datadog-dogstatsd-finalize.rb
@@ -17,7 +17,7 @@ skip_transitive_dependency_licensing true
 build do
     license :project_license
 
-    if windows?
+    if windows_target?
         conf_dir_root = "#{Omnibus::Config.source_dir()}/etc/datadog-dogstatsd"
         conf_dir = "#{conf_dir_root}/extra_package_files/EXAMPLECONFSLOCATION"
         mkdir conf_dir
@@ -35,7 +35,7 @@ build do
         mkdir "/var/log/datadog"
 
         # cleanup clutter
-        delete "#{install_dir}/etc" if !osx?
+        delete "#{install_dir}/etc" if !osx_target?
         delete "#{install_dir}/bin/dogstatsd/dist"
     end
 end

--- a/omnibus/config/software/datadog-dogstatsd.rb
+++ b/omnibus/config/software/datadog-dogstatsd.rb
@@ -26,7 +26,7 @@ build do
     env["GOMODCACHE"] = gomodcache.to_path
   end
 
-  if windows?
+  if windows_target?
     major_version_arg = "%MAJOR_VERSION%"
   else
     major_version_arg = "$MAJOR_VERSION"
@@ -36,13 +36,13 @@ build do
   command "invoke dogstatsd.build --rebuild --major-version #{major_version_arg}", env: env
 
   mkdir "#{install_dir}/etc/datadog-dogstatsd"
-  unless windows?
+  unless windows_target?
     mkdir "#{install_dir}/run/"
     mkdir "#{install_dir}/scripts/"
   end
 
   # move around bin and config files
-  if windows?
+  if windows_target?
     mkdir "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent"
     copy 'bin/dogstatsd/dogstatsd.exe', "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent"
   else
@@ -50,15 +50,15 @@ build do
   end
   move 'bin/dogstatsd/dist/dogstatsd.yaml', "#{install_dir}/etc/datadog-dogstatsd/dogstatsd.yaml.example"
 
-  if linux?
-    if debian?
+  if linux_target?
+    if debian_target?
       erb source: "upstart_debian.conf.erb",
           dest: "#{install_dir}/scripts/datadog-dogstatsd.conf",
           mode: 0644,
           vars: { install_dir: install_dir }
     # Ship a different upstart job definition on RHEL to accommodate the old
     # version of upstart (0.6.5) that RHEL 6 provides.
-    elsif redhat? || suse?
+    elsif redhat_target? || suse_target?
       erb source: "upstart_redhat.conf.erb",
           dest: "#{install_dir}/scripts/datadog-dogstatsd.conf",
           mode: 0644,

--- a/omnibus/config/software/datadog-iot-agent.rb
+++ b/omnibus/config/software/datadog-iot-agent.rb
@@ -31,7 +31,7 @@ build do
   # include embedded path (mostly for `pkg-config` binary)
   env = with_embedded_path(env)
 
-  if windows?
+  if windows_target?
     major_version_arg = "%MAJOR_VERSION%"
     py_runtimes_arg = "%PY_RUNTIMES%"
   else
@@ -39,7 +39,7 @@ build do
     py_runtimes_arg = "$PY_RUNTIMES"
   end
 
-  if linux?
+  if linux_target?
     command "invoke agent.build --flavor iot --rebuild --no-development --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg}", env: env
     mkdir "#{install_dir}/bin"
     mkdir "#{install_dir}/run/"
@@ -55,12 +55,12 @@ build do
     copy 'bin/agent', "#{install_dir}/bin/"
 
     # Upstart
-    if debian?
+    if debian_target?
       erb source: "upstart_debian.conf.erb",
           dest: "/etc/init/datadog-agent.conf",
           mode: 0644,
           vars: { install_dir: install_dir, etc_dir: etc_dir }
-    elsif redhat? || suse?
+    elsif redhat_target? || suse_target?
       # Ship a different upstart job definition on RHEL to accommodate the old
       # version of upstart (0.6.5) that RHEL 6 provides.
       erb source: "upstart_redhat.conf.erb",
@@ -70,7 +70,7 @@ build do
     end
 
     # Systemd
-    if debian?
+    if debian_target?
       erb source: "systemd.service.erb",
           dest: "/lib/systemd/system/datadog-agent.service",
           mode: 0644,
@@ -84,7 +84,7 @@ build do
     end
 
   end
-  if windows?
+  if windows_target?
     platform = windows_arch_i386? ? "x86" : "x64"
 
     conf_dir = "#{install_dir}/etc/datadog-agent"
@@ -109,7 +109,7 @@ build do
 
   end
   block do
-    if windows?
+    if windows_target?
       # defer compilation step in a block to allow getting the project's build version, which is populated
       # only once the software that the project takes its version from (i.e. `datadog-agent`) has finished building
       platform = windows_arch_i386? ? "x86" : "x64"

--- a/omnibus/config/software/jmxfetch.rb
+++ b/omnibus/config/software/jmxfetch.rb
@@ -37,7 +37,7 @@ build do
 
   mkdir jar_dir
 
-  if osx? && code_signing_identity
+  if osx_target? && code_signing_identity
     # Also sign binaries and libraries inside the .jar, because they're detected by the Apple notarization service.
     command "unzip jmxfetch.jar -d ."
     delete "jmxfetch.jar"

--- a/omnibus/config/software/libxcrypt.rb
+++ b/omnibus/config/software/libxcrypt.rb
@@ -23,7 +23,7 @@ build do
 
     env = with_standard_compiler_flags
 
-    if redhat? && !arm? && ohai['platform_version'].to_i == 6
+    if redhat? && !arm_target? && ohai['platform_version'].to_i == 6
         # On the CentOS 6 builder, use gcc 4.9.2 in the devtoolset-3 env,
         # and ignore sign conversion warnings.
         env["CC"] = "/opt/rh/devtoolset-3/root/usr/bin/gcc"

--- a/omnibus/config/software/pydantic-core-py3.rb
+++ b/omnibus/config/software/pydantic-core-py3.rb
@@ -19,7 +19,7 @@ build do
 
   patch :source => "pydantic-core-build-for-manylinux1.patch"
 
-  if windows?
+  if windows_target?
     pip = "#{windows_safe_path(python_3_embedded)}\\Scripts\\pip.exe"
   else
     pip = "#{install_dir}/embedded/bin/pip3"

--- a/omnibus/config/software/pylint2.rb
+++ b/omnibus/config/software/pylint2.rb
@@ -9,7 +9,7 @@ build do
   license "GPL-2.0"
 
   # aliases for the pips
-  if windows?
+  if windows_target?
     pip2 = "#{windows_safe_path(python_2_embedded)}\\Scripts\\pip.exe"
     python2 = "#{windows_safe_path(python_2_embedded)}\\python.exe"
   else
@@ -27,7 +27,7 @@ build do
   # pin 2 dependencies of pylint:
   # - configparser: later versions (up to v3.7.1) are broken
   # - lazy-object-proxy 1.7.0 broken on python 2 https://github.com/ionelmc/python-lazy-object-proxy/issues/61
-  if windows?
+  if windows_target?
     command "#{python2} -m pip install configparser==3.5.0 lazy-object-proxy==1.6.0", :env => build_env
     command "#{python2} -m pip install pylint==#{version}", :env => build_env
   else

--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -45,7 +45,7 @@ if ohai["platform"] != "windows"
                           "--enable-shared",
                           "--without-gcc",
                           "CC=clang")
-  elsif linux?
+  elsif linux_target?
     python_configure_options.push("--enable-unicode=ucs4",
                           "--enable-shared")
   end
@@ -54,13 +54,13 @@ if ohai["platform"] != "windows"
     # 2.0 is the license version here, not the python version
     license "Python-2.0"
 
-    patch :source => "avoid-allocating-thunks-in-ctypes.patch" if linux?
-    patch :source => "fix-platform-ubuntu.diff" if linux?
+    patch :source => "avoid-allocating-thunks-in-ctypes.patch" if linux_target?
+    patch :source => "fix-platform-ubuntu.diff" if linux_target?
     # security patches backported by the debian community
     # see: http://deb.debian.org/debian/pool/main/p/python2.7/python2.7_2.7.18-6.diff.gz
-    patch :source => "python2.7_2.7.18-cve-2019-20907.diff" unless windows?
-    patch :source => "python2.7_2.7.18-cve-2020-8492.diff" unless windows?
-    patch :source => "python2.7_2.7.18-cve-2021-3177.diff" unless windows?
+    patch :source => "python2.7_2.7.18-cve-2019-20907.diff" unless windows_target?
+    patch :source => "python2.7_2.7.18-cve-2020-8492.diff" unless windows_target?
+    patch :source => "python2.7_2.7.18-cve-2021-3177.diff" unless windows_target?
 
     configure(*python_configure_options, :env => env)
     command "make -j #{workers}", :env => env

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -27,7 +27,7 @@ if ohai["platform"] != "windows"
     python_configure_options.push("--enable-ipv6",
                           "--with-universal-archs=intel",
                           "--enable-shared")
-  elsif linux?
+  elsif linux_target?
     python_configure_options.push("--enable-shared",
                           "--enable-ipv6")
   elsif aix?

--- a/omnibus/config/software/snmp-traps.rb
+++ b/omnibus/config/software/snmp-traps.rb
@@ -8,7 +8,7 @@ source :url => "https://s3.amazonaws.com/dd-agent-omnibus/snmp_traps_db/dd_traps
 
 build do
   # The dir for confs
-  if osx?
+  if osx_target?
     traps_db_dir = "#{install_dir}/etc/conf.d/snmp.d/traps_db"
   else
     traps_db_dir = "#{install_dir}/etc/datadog-agent/conf.d/snmp.d/traps_db"

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -23,7 +23,7 @@ build do
   # This introduces a pyarrow dependency that is not needed for the agent and fails to build on the CentOS 6 builder.
   delete "pyproject.toml"
 
-  if windows?
+  if windows_target?
     pip = "#{windows_safe_path(python_3_embedded)}\\Scripts\\pip.exe"
     build_env = {}
   else

--- a/omnibus/lib/ostools.rb
+++ b/omnibus/lib/ostools.rb
@@ -1,39 +1,39 @@
 # ------------------------------------
 # OS-detection helper functions
 # ------------------------------------
-def linux?()
+def linux_target?()
     return %w(rhel debian fedora suse gentoo slackware arch exherbo).include? ohai['platform_family']
 end
 
-def redhat?()
+def redhat_target?()
     return %w(rhel fedora).include? ohai['platform_family']
 end
 
-def suse?()
+def suse_target?()
     return %w(suse).include? ohai['platform_family']
 end
 
-def debian?()
+def debian_target?()
     return ohai['platform_family'] == 'debian'
 end
 
-def osx?()
+def osx_target?()
     return ohai['platform_family'] == 'mac_os_x'
 end
 
-def windows?()
+def windows_target?()
     return ohai['platform_family'] == 'windows'
 end
 
-def arm?()
+def arm_target?()
     return ohai["kernel"]["machine"].start_with?("aarch", "arm")
 end
 
-def arm7l?()
+def arm7l_target?()
     return ohai["kernel"]["machine"] == 'armv7l'
 end
 
-def heroku?()
+def heroku_target?()
     return ENV['AGENT_FLAVOR'] == 'heroku'
 end
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR renames our arch/distribution accessors

### Motivation

There are 2 main reasons to do so:
- These accessors conflict with some provided by cher-sugar
- We want to be able to differentiate building *for* and *on*. This is currently the same as we don't cross compile, but should we start doing so, we will need to stop assuming the host machine is the same as the builder.

This also allows us to build for suse on a redhat image or similar scenarios

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

This is cherry-picked from https://github.com/DataDog/datadog-agent/pull/20001 which we don't want to merge right now, however this commit is likely to accumulate conflicts, I'd rather merge it sooner

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
