### PR TITLE
[SEC-11328] inventory: add `feature_csm_vm_containers_enabled` and `feature_csm_vm_hosts_enabled`

### DIFF
--- a/comp/metadata/inventoryagent/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagent.go
@@ -163,7 +163,7 @@ func (ia *inventoryagent) initData() {
 	ia.data["feature_dynamic_instrumentation_enabled"] = pkgconfig.SystemProbe.GetBool("dynamic_instrumentation.enabled")
 	ia.data["feature_remote_configuration_enabled"] = ia.conf.GetBool("remote_configuration.enabled")
 
-	ia.data["feature_container_image_enabled"] = ia.conf.GetBool("container_image.enabled")
+	ia.data["feature_container_images_enabled"] = ia.conf.GetBool("container_image.enabled")
 
 	ia.data["feature_cws_enabled"] = pkgconfig.SystemProbe.GetBool("runtime_security_config.enabled")
 	ia.data["feature_cws_network_enabled"] = pkgconfig.SystemProbe.GetBool("event_monitoring_config.network.enabled")

--- a/comp/metadata/inventoryagent/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagent.go
@@ -168,8 +168,8 @@ func (ia *inventoryagent) initData() {
 	ia.data["feature_cws_security_profiles_enabled"] = pkgconfig.SystemProbe.GetBool("runtime_security_config.activity_dump.enabled")
 	ia.data["feature_cws_remote_config_enabled"] = pkgconfig.SystemProbe.GetBool("runtime_security_config.remote_configuration.enabled")
 
-	ia.data["feature_csm_vm_containers_enabled"] = ia.conf.GetBool("container_image.enabled") && ia.conf.GetBool("sbom.container_image.enabled")
-	ia.data["feature_csm_vm_hosts_enabled"] = ia.conf.GetBool("sbom.host.enabled")
+	ia.data["feature_csm_vm_containers_enabled"] = ia.conf.GetBool("sbom.enabled") && ia.conf.GetBool("container_image.enabled") && ia.conf.GetBool("sbom.container_image.enabled")
+	ia.data["feature_csm_vm_hosts_enabled"] = ia.conf.GetBool("sbom.enabled") && ia.conf.GetBool("sbom.host.enabled")
 
 	ia.data["feature_process_enabled"] = ia.conf.GetBool("process_config.process_collection.enabled")
 	ia.data["feature_process_language_detection_enabled"] = ia.conf.GetBool("language_detection.enabled")

--- a/comp/metadata/inventoryagent/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagent.go
@@ -163,6 +163,8 @@ func (ia *inventoryagent) initData() {
 	ia.data["feature_dynamic_instrumentation_enabled"] = pkgconfig.SystemProbe.GetBool("dynamic_instrumentation.enabled")
 	ia.data["feature_remote_configuration_enabled"] = ia.conf.GetBool("remote_configuration.enabled")
 
+	ia.data["feature_container_image_enabled"] = ia.conf.GetBool("container_image.enabled")
+
 	ia.data["feature_cws_enabled"] = pkgconfig.SystemProbe.GetBool("runtime_security_config.enabled")
 	ia.data["feature_cws_network_enabled"] = pkgconfig.SystemProbe.GetBool("event_monitoring_config.network.enabled")
 	ia.data["feature_cws_security_profiles_enabled"] = pkgconfig.SystemProbe.GetBool("runtime_security_config.activity_dump.enabled")

--- a/comp/metadata/inventoryagent/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagent.go
@@ -168,7 +168,7 @@ func (ia *inventoryagent) initData() {
 	ia.data["feature_cws_security_profiles_enabled"] = pkgconfig.SystemProbe.GetBool("runtime_security_config.activity_dump.enabled")
 	ia.data["feature_cws_remote_config_enabled"] = pkgconfig.SystemProbe.GetBool("runtime_security_config.remote_configuration.enabled")
 
-	ia.data["feature_csm_vm_containers_enabled"] = ia.conf.GetBool("sbom.container_image.enabled")
+	ia.data["feature_csm_vm_containers_enabled"] = ia.conf.GetBool("container_image.enabled") && ia.conf.GetBool("sbom.container_image.enabled")
 	ia.data["feature_csm_vm_hosts_enabled"] = ia.conf.GetBool("sbom.host.enabled")
 
 	ia.data["feature_process_enabled"] = ia.conf.GetBool("process_config.process_collection.enabled")

--- a/comp/metadata/inventoryagent/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagent.go
@@ -168,6 +168,9 @@ func (ia *inventoryagent) initData() {
 	ia.data["feature_cws_security_profiles_enabled"] = pkgconfig.SystemProbe.GetBool("runtime_security_config.activity_dump.enabled")
 	ia.data["feature_cws_remote_config_enabled"] = pkgconfig.SystemProbe.GetBool("runtime_security_config.remote_configuration.enabled")
 
+	ia.data["feature_csm_vm_containers_enabled"] = ia.conf.GetBool("sbom.container_image.enabled")
+	ia.data["feature_csm_vm_hosts_enabled"] = ia.conf.GetBool("sbom.host.enabled")
+
 	ia.data["feature_process_enabled"] = ia.conf.GetBool("process_config.process_collection.enabled")
 	ia.data["feature_process_language_detection_enabled"] = ia.conf.GetBool("language_detection.enabled")
 	ia.data["feature_processes_container_enabled"] = ia.conf.GetBool("process_config.container_collection.enabled")

--- a/comp/metadata/inventoryagent/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagent_test.go
@@ -141,6 +141,8 @@ func TestInitData(t *testing.T) {
 		"process_config.container_collection.enabled": true,
 		"remote_configuration.enabled":                true,
 		"process_config.process_collection.enabled":   true,
+		"container_image.enabled":                     true,
+		"sbom.enabled":                                true,
 		"sbom.container_image.enabled":                true,
 		"sbom.host.enabled":                           true,
 	}
@@ -167,6 +169,7 @@ func TestInitData(t *testing.T) {
 		"feature_processes_container_enabled":        true,
 		"feature_remote_configuration_enabled":       true,
 		"feature_process_enabled":                    true,
+		"feature_container_image_enabled":            true,
 
 		"feature_dynamic_instrumentation_enabled":      true,
 		"feature_cws_enabled":                          true,

--- a/comp/metadata/inventoryagent/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagent_test.go
@@ -141,6 +141,8 @@ func TestInitData(t *testing.T) {
 		"process_config.container_collection.enabled": true,
 		"remote_configuration.enabled":                true,
 		"process_config.process_collection.enabled":   true,
+		"sbom.container_image.enabled":                true,
+		"sbom.host.enabled":                           true,
 	}
 	ia := getTestInventoryPayload(t, overrides)
 
@@ -171,6 +173,8 @@ func TestInitData(t *testing.T) {
 		"feature_cws_network_enabled":                  true,
 		"feature_cws_security_profiles_enabled":        true,
 		"feature_cws_remote_config_enabled":            true,
+		"feature_csm_vm_containers_enabled":            true,
+		"feature_csm_vm_hosts_enabled":                 true,
 		"feature_networks_enabled":                     true,
 		"feature_networks_http_enabled":                true,
 		"feature_networks_https_enabled":               true,

--- a/comp/metadata/inventoryagent/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagent_test.go
@@ -169,7 +169,7 @@ func TestInitData(t *testing.T) {
 		"feature_processes_container_enabled":        true,
 		"feature_remote_configuration_enabled":       true,
 		"feature_process_enabled":                    true,
-		"feature_container_image_enabled":            true,
+		"feature_container_images_enabled":           true,
 
 		"feature_dynamic_instrumentation_enabled":      true,
 		"feature_cws_enabled":                          true,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

The PR adds 2 new entries to the inventory metadata payload to report the enabled status of infra VM containers and hosts. This will be used for onboarding from the UI.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

To QA this PR you need to ensure that the value reported in REDAPL is the expected one (on multiple configurations of the config)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
