### PR TITLE
Make dependabot update google.golang.org/grpc

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,8 +13,6 @@ updates:
       # They are ignored since bumping them would have no effect on the build.
       # To update them automatically, it is necessary to remove the `replace` directive.
       - dependency-name: k8s.io/*
-      - dependency-name: github.com/grpc-ecosystem/grpc-gateway
-      - dependency-name: google.golang.org/grpc
       - dependency-name: github.com/cihub/seelog
       - dependency-name: github.com/containerd/cgroups
       - dependency-name: github.com/containerd/containerd


### PR DESCRIPTION
### What does this PR do?

Make dependabot :dependabot: update
* `google.golang.org/grpc` and
* `github.com/grpc-ecosystem/grpc-gateway`

### Motivation

Those two modules where explicitly ignored in the dependabot config file.
The comment explained that it was because of some `replace` directives:
https://github.com/DataDog/datadog-agent/blob/ccd8099a92389204c0152054d1fd2c357becb621/.github/dependabot.yaml#L11-L17

But the corresponding `replace` directives have been removed by #12455: https://github.com/DataDog/datadog-agent/pull/12455/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6

So, now that the exceptions are not needed any more, I’d like dependabot :dependabot: to be able to open a fix PR for DataDog/image-vuln-scans#1205.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
