### PR TITLE
Add fake intake for process discovery payloads

### DIFF
--- a/test/fakeintake/aggregator/processDiscoveryAggregator.go
+++ b/test/fakeintake/aggregator/processDiscoveryAggregator.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package aggregator
+
+import (
+	"fmt"
+	"time"
+
+	agentmodel "github.com/DataDog/agent-payload/v5/process"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/api"
+)
+
+// ProcessDiscoveryPayload is a payload type for the process_discovery check
+type ProcessDiscoveryPayload struct {
+	agentmodel.CollectorProcDiscovery
+	collectedTime time.Time
+}
+
+func (p ProcessDiscoveryPayload) name() string {
+	return p.HostName
+}
+
+// GetTags is not implemented for process_discovery payloads
+func (p ProcessDiscoveryPayload) GetTags() []string {
+	return nil
+}
+
+// GetCollectedTime returns the time that the payload was received by the fake intake
+func (p ProcessDiscoveryPayload) GetCollectedTime() time.Time {
+	return p.collectedTime
+}
+
+// ParseProcessDiscoveryPayload parses an api.Payload into a list of ProcessDiscoveryPayload
+func ParseProcessDiscoveryPayload(payload api.Payload) ([]*ProcessDiscoveryPayload, error) {
+	msg, err := agentmodel.DecodeMessage(payload.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	switch m := msg.Body.(type) {
+	case *agentmodel.CollectorProcDiscovery:
+		return []*ProcessDiscoveryPayload{
+			{CollectorProcDiscovery: *m, collectedTime: payload.Timestamp},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unexpected type %s", msg.Header.Type)
+	}
+}
+
+// ProcessDiscoveryAggregator is an Aggregator for ProcessDiscoveryPayload
+type ProcessDiscoveryAggregator struct {
+	Aggregator[*ProcessDiscoveryPayload]
+}
+
+// NewProcessDiscoveryAggregator returns a new ProcessDiscoveryAggregator
+func NewProcessDiscoveryAggregator() ProcessDiscoveryAggregator {
+	return ProcessDiscoveryAggregator{
+		Aggregator: newAggregator(ParseProcessDiscoveryPayload),
+	}
+}

--- a/test/fakeintake/aggregator/processDiscoveryAggregator_test.go
+++ b/test/fakeintake/aggregator/processDiscoveryAggregator_test.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package aggregator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/api"
+	"github.com/DataDog/datadog-agent/test/fakeintake/fixtures"
+)
+
+func TestProcessDiscoveryAggregator(t *testing.T) {
+	payload := fixtures.CollectorProcDiscoveryPayload(t)
+
+	t.Run("empty payload", func(t *testing.T) {
+		payloads, err := ParseProcessDiscoveryPayload(api.Payload{Data: []byte("")})
+		assert.Error(t, err)
+		assert.Nil(t, payloads)
+	})
+
+	t.Run("malformed payload", func(t *testing.T) {
+		payloads, err := ParseProcessDiscoveryPayload(api.Payload{Data: []byte("not a payload")})
+		assert.Error(t, err)
+		assert.Nil(t, payloads)
+	})
+
+	t.Run("valid payload", func(t *testing.T) {
+		payloads, err := ParseProcessDiscoveryPayload(api.Payload{Data: payload})
+		require.NoError(t, err)
+		require.Len(t, payloads, 1)
+
+		payload := payloads[0]
+		assert.Equal(t, "i-078e212", payload.HostName)
+		assert.Len(t, payload.ProcessDiscoveries, 6)
+	})
+}

--- a/test/fakeintake/client/client_test.go
+++ b/test/fakeintake/client/client_test.go
@@ -287,4 +287,29 @@ func TestClient(t *testing.T) {
 		assert.True(t, client.containerAggregator.ContainsPayloadName("i-078e212"))
 		assert.False(t, client.containerAggregator.ContainsPayloadName("totoro"))
 	})
+
+	t.Run("getProcessDiscoveries", func(t *testing.T) {
+		payload := fixtures.CollectorProcDiscoveryPayload(t)
+		response := fmt.Sprintf(
+			`{
+				"payloads": [
+					{
+						"timestamp": "2023-07-12T11:05:20.847091908Z",
+						"data": "%s",
+						"encoding": "protobuf"
+					}
+				]
+			}`, base64.StdEncoding.EncodeToString(payload))
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(response))
+		}))
+		defer ts.Close()
+
+		client := NewClient(ts.URL)
+		err := client.getProcessDiscoveries()
+		require.NoError(t, err)
+		assert.True(t, client.processDiscoveryAggregator.ContainsPayloadName("i-078e212"))
+		assert.False(t, client.processDiscoveryAggregator.ContainsPayloadName("totoro"))
+	})
 }

--- a/test/fakeintake/fixtures/process.go
+++ b/test/fakeintake/fixtures/process.go
@@ -551,3 +551,98 @@ func CollectorContainerPayload(t *testing.T) []byte {
 
 	return encode(t, agentmodel.TypeCollectorContainer, &body)
 }
+
+// CollectorProcDiscoveryPayload serializes an agentmodel.CollectorProcDiscovery into a []byte
+// payload.
+// It should use the same serialization steps as the process-agent's EncodePayload function.
+func CollectorProcDiscoveryPayload(t *testing.T) []byte {
+	body := agentmodel.CollectorProcDiscovery{
+		HostName:  "i-078e212",
+		GroupId:   21052302,
+		GroupSize: 1,
+		ProcessDiscoveries: []*agentmodel.ProcessDiscovery{
+			{
+				Pid:   446,
+				NsPid: 446,
+				Command: &agentmodel.Command{
+					Args: []string{"/usr/bin/python3", "/usr/bin/networkd-dispatcher", "--run-startup-triggers"},
+					Ppid: 1,
+				},
+				User: &agentmodel.ProcessUser{
+					Name: "root",
+				},
+				CreateTime: 1696620615000,
+			},
+			{
+				Pid:   494,
+				NsPid: 494,
+				Command: &agentmodel.Command{
+					Args: []string{"/usr/sbin/chronyd", "-F", "1"},
+					Ppid: 485,
+				},
+				User: &agentmodel.ProcessUser{
+					Name: "_chrony",
+					Uid:  114,
+					Gid:  121,
+				},
+				CreateTime: 1696620615000,
+			},
+			{
+				Pid:   2636,
+				NsPid: 2636,
+				Command: &agentmodel.Command{
+					Args: []string{"/opt/datadog-agent/embedded/bin/process-agent", "--cfgpath=/etc/datadog-agent/datadog.yaml", "--sysprobe-config=/etc/datadog-agent/system-probe.yaml", "--pid=/opt/datadog-agent/run/process-agent.pid"},
+					Cwd:  "/",
+					Ppid: 1,
+					Exe:  "/opt/datadog-agent/embedded/bin/process-agent",
+				},
+				User: &agentmodel.ProcessUser{
+					Name: "dd-agent",
+					Uid:  115,
+					Gid:  122,
+				},
+				CreateTime: 1696620744000,
+			},
+			{
+				Pid:   712,
+				NsPid: 712,
+				Command: &agentmodel.Command{
+					Args: []string{"(sd-pam)"},
+					Ppid: 711,
+				},
+				User: &agentmodel.ProcessUser{
+					Name: "ubuntu",
+					Uid:  1000,
+					Gid:  1000,
+				},
+				CreateTime: 1696620618000,
+			},
+			{
+				Pid:   1767,
+				NsPid: 1767,
+				Command: &agentmodel.Command{
+					Args: []string{"/usr/libexec/packagekitd"},
+					Ppid: 1,
+				},
+				User: &agentmodel.ProcessUser{
+					Name: "root",
+				},
+				CreateTime: 1696620635000,
+			},
+			{
+				Pid:   520,
+				NsPid: 520,
+				Command: &agentmodel.Command{
+					Args: []string{"/sbin/agetty", "-o", "-p -- \\u", "--noclear", "tty1", "linux"},
+					Ppid: 1,
+				},
+				User: &agentmodel.ProcessUser{
+					Name: "root",
+				},
+				CreateTime: 1696620616000,
+			},
+		},
+	}
+
+	return encode(t, agentmodel.TypeCollectorProcDiscovery, &body)
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Add handling to fake intake for payloads from the process_discovery check.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

https://datadoghq.atlassian.net/browse/PROCS-3371

Prereq for creating E2E tests for the process_discovery check.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
