### PR TITLE
[DBMON-3067] Add SQL obfuscation options to give customer more control over how SQ…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -613,7 +613,7 @@ require (
 	github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/system/socket v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-api-client-go/v2 v2.13.0 // indirect
-	github.com/DataDog/go-sqllexer v0.0.7 // indirect
+	github.com/DataDog/go-sqllexer v0.0.8 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe/go.mod h1:90sqV0j7E8wYCyqIp5d9HmYWLTFQttqPFFtNYDyAybQ=
 github.com/DataDog/go-libddwaf v1.5.0 h1:lrHP3VrEriy1M5uQuaOcKphf5GU40mBhihMAp6Ik55c=
 github.com/DataDog/go-libddwaf v1.5.0/go.mod h1:Fpnmoc2k53h6desQrH1P0/gR52CUzkLNFugE5zWwUBQ=
-github.com/DataDog/go-sqllexer v0.0.7 h1:bNHPtNu1n+UYgkplPywFvyeL6A15gL+peDW+GVARnfE=
-github.com/DataDog/go-sqllexer v0.0.7/go.mod h1:nB4Ea2YNsqMwtbWMc4Fm/oP98IIrSPapqwOwPioMspY=
+github.com/DataDog/go-sqllexer v0.0.8 h1:vfC8R9PhmJfeOKcFYAX9UOd890A3wu3KrjU9Kr7nM0E=
+github.com/DataDog/go-sqllexer v0.0.8/go.mod h1:nB4Ea2YNsqMwtbWMc4Fm/oP98IIrSPapqwOwPioMspY=
 github.com/DataDog/go-tuf v1.0.2-0.5.2 h1:EeZr937eKAWPxJ26IykAdWA4A0jQXJgkhUjqEI/w7+I=
 github.com/DataDog/go-tuf v1.0.2-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gopsutil v1.2.2 h1:8lmthwyyCXa1NKiYcHlrtl9AAFdfbNI2gPcioCJcBPU=

--- a/pkg/collector/python/datadog_agent.go
+++ b/pkg/collector/python/datadog_agent.go
@@ -255,6 +255,19 @@ type sqlConfig struct {
 	// When specified, obfuscator will attempt to use go-sqllexer pkg to obfuscate (and normalize) SQL queries.
 	// Valid values are "obfuscate_only", "obfuscate_and_normalize"
 	ObfuscationMode obfuscate.ObfuscationMode `json:"obfuscation_mode"`
+
+	// RemoveSpaceBetweenParentheses specifies whether to remove spaces between parentheses.
+	// By default, spaces are inserted between parentheses during normalization.
+	RemoveSpaceBetweenParentheses bool `json:"remove_space_between_parentheses"`
+
+	// KeepNull specifies whether to disable obfuscate NULL value with ?.
+	KeepNull bool `json:"keep_null"`
+
+	// KeepBoolean specifies whether to disable obfuscate boolean value with ?.
+	KeepBoolean bool `json:"keep_boolean"`
+
+	// KeepPositionalParameter specifies whether to disable obfuscate positional parameter with ?.
+	KeepPositionalParameter bool `json:"keep_positional_parameter"`
 }
 
 // ObfuscateSQL obfuscates & normalizes the provided SQL query, writing the error into errResult if the operation
@@ -274,15 +287,19 @@ func ObfuscateSQL(rawQuery, opts *C.char, errResult **C.char) *C.char {
 	}
 	s := C.GoString(rawQuery)
 	obfuscatedQuery, err := lazyInitObfuscator().ObfuscateSQLStringWithOptions(s, &obfuscate.SQLConfig{
-		DBMS:              sqlOpts.DBMS,
-		TableNames:        sqlOpts.TableNames,
-		CollectCommands:   sqlOpts.CollectCommands,
-		CollectComments:   sqlOpts.CollectComments,
-		CollectProcedures: sqlOpts.CollectProcedures,
-		ReplaceDigits:     sqlOpts.ReplaceDigits,
-		KeepSQLAlias:      sqlOpts.KeepSQLAlias,
-		DollarQuotedFunc:  sqlOpts.DollarQuotedFunc,
-		ObfuscationMode:   sqlOpts.ObfuscationMode,
+		DBMS:                          sqlOpts.DBMS,
+		TableNames:                    sqlOpts.TableNames,
+		CollectCommands:               sqlOpts.CollectCommands,
+		CollectComments:               sqlOpts.CollectComments,
+		CollectProcedures:             sqlOpts.CollectProcedures,
+		ReplaceDigits:                 sqlOpts.ReplaceDigits,
+		KeepSQLAlias:                  sqlOpts.KeepSQLAlias,
+		DollarQuotedFunc:              sqlOpts.DollarQuotedFunc,
+		ObfuscationMode:               sqlOpts.ObfuscationMode,
+		RemoveSpaceBetweenParentheses: sqlOpts.RemoveSpaceBetweenParentheses,
+		KeepNull:                      sqlOpts.KeepNull,
+		KeepBoolean:                   sqlOpts.KeepBoolean,
+		KeepPositionalParameter:       sqlOpts.KeepPositionalParameter,
 	})
 	if err != nil {
 		// memory will be freed by caller

--- a/pkg/collector/python/datadog_agent.go
+++ b/pkg/collector/python/datadog_agent.go
@@ -258,15 +258,19 @@ type sqlConfig struct {
 
 	// RemoveSpaceBetweenParentheses specifies whether to remove spaces between parentheses.
 	// By default, spaces are inserted between parentheses during normalization.
+	// This option is only valid when ObfuscationMode is "obfuscate_and_normalize".
 	RemoveSpaceBetweenParentheses bool `json:"remove_space_between_parentheses"`
 
 	// KeepNull specifies whether to disable obfuscate NULL value with ?.
+	// This option is only valid when ObfuscationMode is "obfuscate_only" or "obfuscate_and_normalize".
 	KeepNull bool `json:"keep_null"`
 
 	// KeepBoolean specifies whether to disable obfuscate boolean value with ?.
+	// This option is only valid when ObfuscationMode is "obfuscate_only" or "obfuscate_and_normalize".
 	KeepBoolean bool `json:"keep_boolean"`
 
 	// KeepPositionalParameter specifies whether to disable obfuscate positional parameter with ?.
+	// This option is only valid when ObfuscationMode is "obfuscate_only" or "obfuscate_and_normalize".
 	KeepPositionalParameter bool `json:"keep_positional_parameter"`
 }
 

--- a/pkg/obfuscate/go.mod
+++ b/pkg/obfuscate/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.1.1
-	github.com/DataDog/go-sqllexer v0.0.7
+	github.com/DataDog/go-sqllexer v0.0.8
 	github.com/outcaste-io/ristretto v0.2.1
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/atomic v1.10.0

--- a/pkg/obfuscate/go.sum
+++ b/pkg/obfuscate/go.sum
@@ -1,7 +1,7 @@
 github.com/DataDog/datadog-go/v5 v5.1.1 h1:JLZ6s2K1pG2h9GkvEvMdEGqMDyVLEAccdX5TltWcLMU=
 github.com/DataDog/datadog-go/v5 v5.1.1/go.mod h1:KhiYb2Badlv9/rofz+OznKoEF5XKTonWyhx5K83AP8E=
-github.com/DataDog/go-sqllexer v0.0.7 h1:bNHPtNu1n+UYgkplPywFvyeL6A15gL+peDW+GVARnfE=
-github.com/DataDog/go-sqllexer v0.0.7/go.mod h1:nB4Ea2YNsqMwtbWMc4Fm/oP98IIrSPapqwOwPioMspY=
+github.com/DataDog/go-sqllexer v0.0.8 h1:vfC8R9PhmJfeOKcFYAX9UOd890A3wu3KrjU9Kr7nM0E=
+github.com/DataDog/go-sqllexer v0.0.8/go.mod h1:nB4Ea2YNsqMwtbWMc4Fm/oP98IIrSPapqwOwPioMspY=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.5.1 h1:aPJp2QD7OOrhO5tQXqQoGSJc+DjDtWTGLOmNyAm6FgY=
 github.com/Microsoft/go-winio v0.5.1/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=

--- a/pkg/obfuscate/obfuscate.go
+++ b/pkg/obfuscate/obfuscate.go
@@ -150,15 +150,19 @@ type SQLConfig struct {
 
 	// RemoveSpaceBetweenParentheses specifies whether to remove spaces between parentheses.
 	// By default, spaces are inserted between parentheses during normalization.
+	// This option is only valid when ObfuscationMode is "obfuscate_and_normalize".
 	RemoveSpaceBetweenParentheses bool `json:"remove_space_between_parentheses" yaml:"remove_space_between_parentheses"`
 
 	// KeepNull specifies whether to disable obfuscate NULL value with ?.
+	// This option is only valid when ObfuscationMode is "obfuscate_only" or "obfuscate_and_normalize".
 	KeepNull bool `json:"keep_null" yaml:"keep_null"`
 
 	// KeepBoolean specifies whether to disable obfuscate boolean value with ?.
+	// This option is only valid when ObfuscationMode is "obfuscate_only" or "obfuscate_and_normalize".
 	KeepBoolean bool `json:"keep_boolean" yaml:"keep_boolean"`
 
 	// KeepPositionalParameter specifies whether to disable obfuscate positional parameter with ?.
+	// This option is only valid when ObfuscationMode is "obfuscate_only" or "obfuscate_and_normalize".
 	KeepPositionalParameter bool `json:"keep_positional_parameter" yaml:"keep_positional_parameter"`
 
 	// Cache reports whether the obfuscator should use a LRU look-up cache for SQL obfuscations.

--- a/pkg/obfuscate/obfuscate.go
+++ b/pkg/obfuscate/obfuscate.go
@@ -148,6 +148,19 @@ type SQLConfig struct {
 	// Valid values are "obfuscate_only", "obfuscate_and_normalize"
 	ObfuscationMode ObfuscationMode `json:"obfuscation_mode" yaml:"obfuscation_mode"`
 
+	// RemoveSpaceBetweenParentheses specifies whether to remove spaces between parentheses.
+	// By default, spaces are inserted between parentheses during normalization.
+	RemoveSpaceBetweenParentheses bool `json:"remove_space_between_parentheses" yaml:"remove_space_between_parentheses"`
+
+	// KeepNull specifies whether to disable obfuscate NULL value with ?.
+	KeepNull bool `json:"keep_null" yaml:"keep_null"`
+
+	// KeepBoolean specifies whether to disable obfuscate boolean value with ?.
+	KeepBoolean bool `json:"keep_boolean" yaml:"keep_boolean"`
+
+	// KeepPositionalParameter specifies whether to disable obfuscate positional parameter with ?.
+	KeepPositionalParameter bool `json:"keep_positional_parameter" yaml:"keep_positional_parameter"`
+
 	// Cache reports whether the obfuscator should use a LRU look-up cache for SQL obfuscations.
 	Cache bool
 }

--- a/pkg/obfuscate/sql.go
+++ b/pkg/obfuscate/sql.go
@@ -433,9 +433,9 @@ func (o *Obfuscator) ObfuscateWithSQLLexer(in string, opts *SQLConfig) (*Obfusca
 	obfuscator := sqllexer.NewObfuscator(
 		sqllexer.WithReplaceDigits(opts.ReplaceDigits),
 		sqllexer.WithDollarQuotedFunc(opts.DollarQuotedFunc),
-		sqllexer.WithReplacePositionalParameter(true),
-		sqllexer.WithReplaceBoolean(true),
-		sqllexer.WithReplaceNull(true),
+		sqllexer.WithReplacePositionalParameter(!opts.KeepPositionalParameter),
+		sqllexer.WithReplaceBoolean(!opts.KeepBoolean),
+		sqllexer.WithReplaceNull(!opts.KeepNull),
 	)
 	if opts.ObfuscationMode == ObfuscateOnly {
 		// Obfuscate the query without normalizing it.
@@ -457,6 +457,7 @@ func (o *Obfuscator) ObfuscateWithSQLLexer(in string, opts *SQLConfig) (*Obfusca
 		sqllexer.WithCollectTables(opts.TableNames),
 		sqllexer.WithCollectProcedures(opts.CollectProcedures),
 		sqllexer.WithKeepSQLAlias(opts.KeepSQLAlias),
+		sqllexer.WithRemoveSpaceBetweenParentheses(opts.RemoveSpaceBetweenParentheses),
 	)
 	out, statementMetadata, err := sqllexer.ObfuscateAndNormalize(
 		in,

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -42,7 +42,7 @@ require (
 )
 
 require (
-	github.com/DataDog/go-sqllexer v0.0.7 // indirect
+	github.com/DataDog/go-sqllexer v0.0.8 // indirect
 	github.com/DataDog/go-tuf v1.0.2-0.5.2 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/containerd/cgroups/v3 v3.0.2 // indirect

--- a/pkg/trace/go.sum
+++ b/pkg/trace/go.sum
@@ -1,7 +1,7 @@
 github.com/DataDog/datadog-go/v5 v5.1.1 h1:JLZ6s2K1pG2h9GkvEvMdEGqMDyVLEAccdX5TltWcLMU=
 github.com/DataDog/datadog-go/v5 v5.1.1/go.mod h1:KhiYb2Badlv9/rofz+OznKoEF5XKTonWyhx5K83AP8E=
-github.com/DataDog/go-sqllexer v0.0.7 h1:bNHPtNu1n+UYgkplPywFvyeL6A15gL+peDW+GVARnfE=
-github.com/DataDog/go-sqllexer v0.0.7/go.mod h1:nB4Ea2YNsqMwtbWMc4Fm/oP98IIrSPapqwOwPioMspY=
+github.com/DataDog/go-sqllexer v0.0.8 h1:vfC8R9PhmJfeOKcFYAX9UOd890A3wu3KrjU9Kr7nM0E=
+github.com/DataDog/go-sqllexer v0.0.8/go.mod h1:nB4Ea2YNsqMwtbWMc4Fm/oP98IIrSPapqwOwPioMspY=
 github.com/DataDog/go-tuf v1.0.2-0.5.2 h1:EeZr937eKAWPxJ26IykAdWA4A0jQXJgkhUjqEI/w7+I=
 github.com/DataDog/go-tuf v1.0.2-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.8.0 h1:NNSjBdo9PlfjUKmCrjNWTxAtG7ovemO5EHT08zVpeUU=

--- a/releasenotes/notes/sql-obfuscation-config-options-d9dfbc9ca568c63f.yaml
+++ b/releasenotes/notes/sql-obfuscation-config-options-d9dfbc9ca568c63f.yaml
@@ -9,7 +9,7 @@
 enhancements:
   - |
     dbm: add SQL obfuscation options to give customer more control over how SQL is obfuscated and normalized.
-    - `RemoveSpaceBetweenParentheses` - remove spaces between parentheses. This option is only valid when ObfuscationMode is "obfuscate_and_normalize".
-    - `KeepNull` - disable obfuscating null values with ?. This option is only valid when ObfuscationMode is "obfuscate_only" or "obfuscate_and_normalize".
-    - `KeepBoolean` - disable obfuscating boolean values with ?. This option is only valid when ObfuscationMode is "obfuscate_only" or "obfuscate_and_normalize".
-    - `KeepPositionalParameter` - disable obfuscating positional parameters with ?. This option is only valid when ObfuscationMode is "obfuscate_only" or "obfuscate_and_normalize".
+    - ``RemoveSpaceBetweenParentheses`` - remove spaces between parentheses. This option is only valid when ``ObfuscationMode`` is ``obfuscate_and_normalize``.
+    - ``KeepNull` - disable obfuscating null values with ?. This option is only valid when ``ObfuscationMode`` is "obfuscate_only" or ``obfuscate_and_normalize``.
+    - ``KeepBoolean`` - disable obfuscating boolean values with ?. This option is only valid when ``ObfuscationMode`` is ``obfuscate_only`` or ``obfuscate_and_normalize``.
+    - ``KeepPositionalParameter`` - disable obfuscating positional parameters with ?. This option is only valid when ``ObfuscationMode`` is ``obfuscate_only`` or ``obfuscate_and_normalize``.

--- a/releasenotes/notes/sql-obfuscation-config-options-d9dfbc9ca568c63f.yaml
+++ b/releasenotes/notes/sql-obfuscation-config-options-d9dfbc9ca568c63f.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    dbm: add SQL obfuscation options to give customer more control over how SQL is obfuscated and normalized.
+    - `RemoveSpaceBetweenParentheses` - remove spaces between parentheses
+    - `KeepNull` - disable obfuscating null values with ?
+    - `KeepBoolean` - disable obfuscating boolean values with ?
+    - `KeepPositionalParameter` - disable obfuscating positional parameters with ?

--- a/releasenotes/notes/sql-obfuscation-config-options-d9dfbc9ca568c63f.yaml
+++ b/releasenotes/notes/sql-obfuscation-config-options-d9dfbc9ca568c63f.yaml
@@ -9,7 +9,7 @@
 enhancements:
   - |
     dbm: add SQL obfuscation options to give customer more control over how SQL is obfuscated and normalized.
-    - `RemoveSpaceBetweenParentheses` - remove spaces between parentheses
-    - `KeepNull` - disable obfuscating null values with ?
-    - `KeepBoolean` - disable obfuscating boolean values with ?
-    - `KeepPositionalParameter` - disable obfuscating positional parameters with ?
+    - `RemoveSpaceBetweenParentheses` - remove spaces between parentheses. This option is only valid when ObfuscationMode is "obfuscate_and_normalize".
+    - `KeepNull` - disable obfuscating null values with ?. This option is only valid when ObfuscationMode is "obfuscate_only" or "obfuscate_and_normalize".
+    - `KeepBoolean` - disable obfuscating boolean values with ?. This option is only valid when ObfuscationMode is "obfuscate_only" or "obfuscate_and_normalize".
+    - `KeepPositionalParameter` - disable obfuscating positional parameters with ?. This option is only valid when ObfuscationMode is "obfuscate_only" or "obfuscate_and_normalize".


### PR DESCRIPTION
…L is obfuscated and normalized

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR adds additional SQL obfuscation options to give customer more control over how SQL is obfuscated and normalized.
- `RemoveSpaceBetweenParentheses` - remove spaces between parentheses
- `KeepNull` - disable obfuscating null values with ?
- `KeepBoolean` - disable obfuscating boolean values with ?
- `KeepPositionalParameter` - disable obfuscating positional parameters with ?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The motivation behind this PR is
- gives more obfuscation flexibility to customers on what to obfuscate
- be ready for Oracle DBM

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
