### PR TITLE
[NDM] Cleanup Netflow V9/IPFIX pipeline

### DIFF
--- a/comp/netflow/common/constants.go
+++ b/comp/netflow/common/constants.go
@@ -26,4 +26,7 @@ const (
 
 	// DefaultPrometheusListenerAddress is the default goflow prometheus listener address
 	DefaultPrometheusListenerAddress = "localhost:9090"
+
+	// MetricPrefix is the common metric prefix for Netflow telemetry
+	MetricPrefix = "datadog.netflow."
 )

--- a/comp/netflow/common/flow.go
+++ b/comp/netflow/common/flow.go
@@ -9,6 +9,7 @@ package common
 import (
 	"bytes"
 	"encoding/binary"
+	flowmessage "github.com/netsampler/goflow2/pb"
 	"hash/fnv"
 )
 
@@ -66,7 +67,32 @@ type Flow struct {
 	Tos uint32 // FLOW KEY
 
 	NextHop []byte // FLOW KEY
+
+	// Configured fields
+	AdditionalFields AdditionalFields
 }
+
+type AdditionalFields = map[string]any
+
+type FlowMessageWithAdditionalFields struct {
+	FlowMessage      *flowmessage.FlowMessage
+	AdditionalFields AdditionalFields
+}
+
+type EndianType string
+
+var (
+	BigEndian    EndianType = "big"
+	LittleEndian EndianType = "little"
+)
+
+type FieldType string
+
+var (
+	String FieldType = "string"
+	Varint FieldType = "varint"
+	Bytes  FieldType = "bytes"
+)
 
 // AggregationHash return a hash used as aggregation key
 func (f *Flow) AggregationHash() uint64 {

--- a/comp/netflow/common/flow.go
+++ b/comp/netflow/common/flow.go
@@ -72,26 +72,35 @@ type Flow struct {
 	AdditionalFields AdditionalFields
 }
 
+// AdditionalFields holds additional fields collected
 type AdditionalFields = map[string]any
 
+// FlowMessageWithAdditionalFields contains a goflow flowmessage and additional fields
 type FlowMessageWithAdditionalFields struct {
 	FlowMessage      *flowmessage.FlowMessage
 	AdditionalFields AdditionalFields
 }
 
+// EndianType is used to configure additional fields endianness
 type EndianType string
 
 var (
-	BigEndian    EndianType = "big"
+	// BigEndian is used to configure a big endian additional field
+	BigEndian EndianType = "big"
+	// LittleEndian is used to configure a little endian additional field
 	LittleEndian EndianType = "little"
 )
 
+// FieldType is used to configure additional fields data type
 type FieldType string
 
 var (
+	// String type is used to configure a textual additional field
 	String FieldType = "string"
+	// Varint type is used to configure an integer additional field
 	Varint FieldType = "varint"
-	Bytes  FieldType = "bytes"
+	// Bytes type is used to configure a hex additional field
+	Bytes FieldType = "bytes"
 )
 
 // AggregationHash return a hash used as aggregation key

--- a/comp/netflow/config/config.go
+++ b/comp/netflow/config/config.go
@@ -41,6 +41,14 @@ type ListenerConfig struct {
 	BindHost  string          `mapstructure:"bind_host"`
 	Workers   int             `mapstructure:"workers"`
 	Namespace string          `mapstructure:"namespace"`
+	Mapping   []Mapping       `mapstructure:"mapping"`
+}
+
+type Mapping struct {
+	Field       uint16            `mapstructure:"field"`
+	Destination string            `mapstructure:"destination"`
+	Endian      common.EndianType `mapstructure:"endianness"`
+	Type        common.FieldType  `mapstructure:"type"`
 }
 
 // ReadConfig builds and returns configuration from Agent configuration.

--- a/comp/netflow/config/config.go
+++ b/comp/netflow/config/config.go
@@ -44,6 +44,7 @@ type ListenerConfig struct {
 	Mapping   []Mapping       `mapstructure:"mapping"`
 }
 
+// Mapping contains configuration for a Netflow/IPFIX field mapping
 type Mapping struct {
 	Field       uint16            `mapstructure:"field"`
 	Destination string            `mapstructure:"destination"`

--- a/comp/netflow/flowaggregator/aggregator.go
+++ b/comp/netflow/flowaggregator/aggregator.go
@@ -137,7 +137,7 @@ func (agg *FlowAggregator) run() {
 func (agg *FlowAggregator) sendFlows(flows []*common.Flow, flushTime time.Time) {
 	for _, flow := range flows {
 		flowPayload := buildPayload(flow, agg.hostname, flushTime)
-		payloadBytes, err := json.Marshal(flowPayload)
+		payloadBytes, err := flowPayload.MarshalJSON()
 		if err != nil {
 			agg.logger.Errorf("Error marshalling device metadata: %s", err)
 			continue

--- a/comp/netflow/flowaggregator/aggregator.go
+++ b/comp/netflow/flowaggregator/aggregator.go
@@ -31,7 +31,6 @@ import (
 )
 
 const flushFlowsToSendInterval = 10 * time.Second
-const metricPrefix = "datadog.netflow."
 
 // FlowAggregator is used for space and time aggregation of NetFlow flows
 type FlowAggregator struct {
@@ -354,9 +353,9 @@ func (agg *FlowAggregator) submitCollectorMetrics() error {
 			}
 			switch metricType {
 			case metrics.GaugeType:
-				agg.sender.Gauge(metricPrefix+name, value, "", tags)
+				agg.sender.Gauge(common.MetricPrefix+name, value, "", tags)
 			case metrics.MonotonicCountType:
-				agg.sender.MonotonicCount(metricPrefix+name, value, "", tags)
+				agg.sender.MonotonicCount(common.MetricPrefix+name, value, "", tags)
 			default:
 				agg.logger.Debugf("cannot submit unsupported type %s", metricType.String())
 			}

--- a/comp/netflow/flowaggregator/aggregator_test.go
+++ b/comp/netflow/flowaggregator/aggregator_test.go
@@ -90,53 +90,53 @@ func TestAggregator(t *testing.T) {
 	// language=json
 	event := []byte(`
 {
-  "flush_timestamp": 1550505606000,
-  "type": "netflow9",
-  "sampling_rate": 0,
-  "direction": "ingress",
-  "start": 1234568,
-  "end": 1234569,
   "bytes": 20,
-  "packets": 4,
-  "ether_type": "IPv4",
-  "ip_protocol": "TCP",
-  "device": {
-    "namespace": "my-ns"
-  },
-  "exporter": {
-    "ip": "127.0.0.1"
-  },
-  "source": {
-    "ip": "10.10.10.10",
-    "port": "2000",
-    "mac": "00:00:00:00:00:00",
-    "mask": "0.0.0.0/0"
-  },
   "destination": {
     "ip": "10.10.10.20",
     "port": "80",
     "mac": "00:00:00:00:00:00",
     "mask": "0.0.0.0/0"
   },
-  "ingress": {
-    "interface": {
-      "index": 0
-    }
+  "device": {
+    "namespace": "my-ns"
   },
+  "direction": "ingress",
   "egress": {
     "interface": {
       "index": 0
     }
   },
+  "end": 1234569,
+  "ether_type": "IPv4",
+  "exporter": {
+    "ip": "127.0.0.1"
+  },
+  "flush_timestamp": 1550505606000,
   "host": "my-hostname",
+  "ingress": {
+    "interface": {
+      "index": 0
+    }
+  },
+  "ip_protocol": "TCP",
+  "next_hop": {
+    "ip": ""
+  },
+  "packets": 4,
+  "sampling_rate": 0,
+  "source": {
+    "ip": "10.10.10.10",
+    "port": "2000",
+    "mac": "00:00:00:00:00:00",
+    "mask": "0.0.0.0/0"
+  },
+  "start": 1234568,
   "tcp_flags": [
     "FIN",
     "SYN",
     "ACK"
   ],
-  "next_hop": {
-    "ip": ""
-  }
+  "type": "netflow9"
 }
 `)
 	compactEvent := new(bytes.Buffer)

--- a/comp/netflow/flowaggregator/aggregator_test.go
+++ b/comp/netflow/flowaggregator/aggregator_test.go
@@ -287,7 +287,7 @@ func TestAggregator_withMockPayload(t *testing.T) {
 	listenerErr := atomic.NewString("")
 	listenerFlowCount := atomic.NewInt64(0)
 
-	flowState, err := goflowlib.StartFlowRoutine(common.TypeNetFlow5, "127.0.0.1", port, 1, "default", nil, aggregator.GetFlowInChan(), logger, listenerErr, listenerFlowCount)
+	flowState, err := goflowlib.StartFlowRoutine(common.TypeNetFlow5, "127.0.0.1", port, 1, "default", nil, aggregator.GetFlowInChan(), logger, sender, listenerErr, listenerFlowCount)
 	assert.NoError(t, err)
 
 	time.Sleep(100 * time.Millisecond) // wait to make sure goflow listener is started before sending

--- a/comp/netflow/flowaggregator/aggregator_test.go
+++ b/comp/netflow/flowaggregator/aggregator_test.go
@@ -287,7 +287,7 @@ func TestAggregator_withMockPayload(t *testing.T) {
 	listenerErr := atomic.NewString("")
 	listenerFlowCount := atomic.NewInt64(0)
 
-	flowState, err := goflowlib.StartFlowRoutine(common.TypeNetFlow5, "127.0.0.1", port, 1, "default", aggregator.GetFlowInChan(), logger, listenerErr, listenerFlowCount)
+	flowState, err := goflowlib.StartFlowRoutine(common.TypeNetFlow5, "127.0.0.1", port, 1, "default", nil, aggregator.GetFlowInChan(), logger, listenerErr, listenerFlowCount)
 	assert.NoError(t, err)
 
 	time.Sleep(100 * time.Millisecond) // wait to make sure goflow listener is started before sending

--- a/comp/netflow/flowaggregator/buildpayload.go
+++ b/comp/netflow/flowaggregator/buildpayload.go
@@ -59,5 +59,6 @@ func buildPayload(aggFlow *common.Flow, hostname string, flushTime time.Time) pa
 		NextHop: payload.NextHop{
 			IP: format.IPAddr(aggFlow.NextHop),
 		},
+		AdditionalFields: aggFlow.AdditionalFields,
 	}
 }

--- a/comp/netflow/flowaggregator/buildpayload_test.go
+++ b/comp/netflow/flowaggregator/buildpayload_test.go
@@ -49,6 +49,9 @@ func Test_buildPayload(t *testing.T) {
 				Tos:             3,
 				NextHop:         []byte{10, 10, 10, 30},
 				TCPFlags:        uint32(19), // 19 = SYN,ACK,FIN
+				AdditionalFields: map[string]any{
+					"custom_field": "test",
+				},
 			},
 			expectedPayload: payload.FlowPayload{
 				FlushTimestamp: curTime.UnixMilli(),
@@ -84,6 +87,9 @@ func Test_buildPayload(t *testing.T) {
 				TCPFlags: []string{"FIN", "SYN", "ACK"},
 				NextHop: payload.NextHop{
 					IP: "10.10.10.30",
+				},
+				AdditionalFields: map[string]any{
+					"custom_field": "test",
 				},
 			},
 		},

--- a/comp/netflow/flowaggregator/flowaccumulator.go
+++ b/comp/netflow/flowaggregator/flowaccumulator.go
@@ -138,6 +138,19 @@ func (f *flowAccumulator) add(flowToAdd *common.Flow) {
 		aggFlow.flow.EndTimestamp = common.Max(aggFlow.flow.EndTimestamp, flowToAdd.EndTimestamp)
 		aggFlow.flow.SequenceNum = common.Max(aggFlow.flow.SequenceNum, flowToAdd.SequenceNum)
 		aggFlow.flow.TCPFlags |= flowToAdd.TCPFlags
+
+		// keep first non-null value for custom fields
+		if flowToAdd.AdditionalFields != nil {
+			if aggFlow.flow.AdditionalFields == nil {
+				aggFlow.flow.AdditionalFields = flowToAdd.AdditionalFields
+			} else {
+				for field, value := range flowToAdd.AdditionalFields {
+					if _, ok := aggFlow.flow.AdditionalFields[field]; !ok {
+						aggFlow.flow.AdditionalFields[field] = value
+					}
+				}
+			}
+		}
 	}
 	f.flows[aggHash] = aggFlow
 }

--- a/comp/netflow/flowaggregator/flowaccumulator_test.go
+++ b/comp/netflow/flowaggregator/flowaccumulator_test.go
@@ -51,6 +51,9 @@ func Test_flowAccumulator_add(t *testing.T) {
 		SrcPort:        2000,
 		DstPort:        80,
 		TCPFlags:       synFlag,
+		AdditionalFields: map[string]any{
+			"custom_field": "test",
+		},
 	}
 	flowA2 := &common.Flow{
 		FlowType:       common.TypeNetFlow9,
@@ -65,6 +68,10 @@ func Test_flowAccumulator_add(t *testing.T) {
 		SrcPort:        2000,
 		DstPort:        80,
 		TCPFlags:       ackFlag,
+		AdditionalFields: map[string]any{
+			"custom_field":   "another_test",
+			"custom_field_2": "second_flow_field",
+		},
 	}
 	flowB1 := &common.Flow{
 		FlowType:       common.TypeNetFlow9,
@@ -98,6 +105,7 @@ func Test_flowAccumulator_add(t *testing.T) {
 	assert.Equal(t, uint64(1234568), wrappedFlowA.flow.StartTimestamp)
 	assert.Equal(t, uint64(1234579), wrappedFlowA.flow.EndTimestamp)
 	assert.Equal(t, synAckFlag, wrappedFlowA.flow.TCPFlags)
+	assert.Equal(t, map[string]any{"custom_field": "test", "custom_field_2": "second_flow_field"}, wrappedFlowA.flow.AdditionalFields) // Keeping first value seen for key `custom_field`
 
 	wrappedFlowB := acc.flows[flowB1.AggregationHash()]
 	assert.Equal(t, []byte{10, 10, 10, 10}, wrappedFlowB.flow.SrcAddr)

--- a/comp/netflow/goflowlib/additionalfields/netflow.go
+++ b/comp/netflow/goflowlib/additionalfields/netflow.go
@@ -74,7 +74,7 @@ func searchNetFlowDataSetsRecords(dataRecords []netflow.DataRecord, fieldsConfig
 }
 
 func searchNetFlowDataSets(dataFlowSet []netflow.DataFlowSet, fieldsConfig map[uint16]config.Mapping) []common.AdditionalFields {
-	var flowsAdditonalFields []map[string]any
+	var flowsAdditonalFields []common.AdditionalFields
 	for _, dataFlowSetItem := range dataFlowSet {
 		setsAdditionalFields := searchNetFlowDataSetsRecords(dataFlowSetItem.Records, fieldsConfig)
 		if setsAdditionalFields != nil {
@@ -90,7 +90,7 @@ func ProcessMessageNetFlowAdditionalFields(msgDec interface{}, fieldsConfig map[
 		return nil, nil
 	}
 
-	var flowsAdditonalFields []map[string]any
+	var flowsAdditonalFields []common.AdditionalFields
 
 	switch msgDecConv := msgDec.(type) {
 	case netflow.NFv9Packet:

--- a/comp/netflow/goflowlib/additionalfields/netflow.go
+++ b/comp/netflow/goflowlib/additionalfields/netflow.go
@@ -3,9 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
-// Package customfields provides a producer collecting
+// Package additionalfields provides a producer collecting
 // additional fields from Netflow/IPFIX packets.
-package customfields
+package additionalfields
 
 import (
 	"bytes"
@@ -24,7 +24,7 @@ func decodeUNumberWithEndianness(b []byte, out *uint64, endianness common.Endian
 	return producer.DecodeUNumber(b, out)
 }
 
-func mapCustomField(additionalFields common.AdditionalFields, v []byte, cfg config.Mapping) {
+func mapAdditionalField(additionalFields common.AdditionalFields, v []byte, cfg config.Mapping) {
 	// TODO : Add more types (IP address, timestamp, ...)
 	if cfg.Type == common.Varint {
 		var dstVar uint64
@@ -56,7 +56,7 @@ func convertNetFlowDataSet(record []netflow.DataField, fieldsConfig map[uint16]c
 			continue
 		}
 
-		mapCustomField(additionalFields, v, mappingConfig)
+		mapAdditionalField(additionalFields, v, mappingConfig)
 	}
 
 	return additionalFields
@@ -84,8 +84,8 @@ func searchNetFlowDataSets(dataFlowSet []netflow.DataFlowSet, fieldsConfig map[u
 	return flowsAdditonalFields
 }
 
-// ProcessMessageNetFlowCustomFields collects additional fields from netflow packet using the given config
-func ProcessMessageNetFlowCustomFields(msgDec interface{}, fieldsConfig map[uint16]config.Mapping) ([]common.AdditionalFields, error) {
+// ProcessMessageNetFlowAdditionalFields collects additional fields from netflow packet using the given config
+func ProcessMessageNetFlowAdditionalFields(msgDec interface{}, fieldsConfig map[uint16]config.Mapping) ([]common.AdditionalFields, error) {
 	if len(fieldsConfig) == 0 {
 		return nil, nil
 	}

--- a/comp/netflow/goflowlib/additionalfields/netflow_test.go
+++ b/comp/netflow/goflowlib/additionalfields/netflow_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
-package customfields
+package additionalfields
 
 import (
 	"github.com/DataDog/datadog-agent/comp/netflow/common"
@@ -38,7 +38,7 @@ func makeSampleNetflowPacket(fields []netflow.DataField) netflow.NFv9Packet {
 	}
 }
 
-func Test_ProcessMessageNetFlowCustomFields(t *testing.T) {
+func Test_ProcessMessageNetFlowAdditionalFields(t *testing.T) {
 	tests := []struct {
 		name                    string
 		fields                  []netflow.DataField
@@ -159,7 +159,7 @@ func Test_ProcessMessageNetFlowCustomFields(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			packet := makeSampleNetflowPacket(tt.fields)
-			expectedFields, err := ProcessMessageNetFlowCustomFields(packet, tt.config)
+			expectedFields, err := ProcessMessageNetFlowAdditionalFields(packet, tt.config)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedCollectedFields, expectedFields)
 		})

--- a/comp/netflow/goflowlib/convert.go
+++ b/comp/netflow/goflowlib/convert.go
@@ -134,11 +134,11 @@ func applyCustomField(flow *common.Flow, destination string, fieldValue any) boo
 	return true
 }
 
-type FlowFieldsTypes interface {
+type flowFieldsTypes interface {
 	uint64 | uint32 | []byte
 }
 
-func setValue[T FlowFieldsTypes](field *T, value any) {
+func setValue[T flowFieldsTypes](field *T, value any) {
 	if v, ok := value.(T); ok {
 		*field = v
 	}

--- a/comp/netflow/goflowlib/convert.go
+++ b/comp/netflow/goflowlib/convert.go
@@ -44,10 +44,10 @@ func ConvertFlow(srcFlow *flowpb.FlowMessage, namespace string) *common.Flow {
 	}
 }
 
-// ConvertFlowWithCustomFields convert goflow flow structure and additional fields to internal flow structure
-func ConvertFlowWithCustomFields(srcFlow *common.FlowMessageWithAdditionalFields, namespace string) *common.Flow {
+// ConvertFlowWithAdditionalFields convert goflow flow structure and additional fields to internal flow structure
+func ConvertFlowWithAdditionalFields(srcFlow *common.FlowMessageWithAdditionalFields, namespace string) *common.Flow {
 	flow := ConvertFlow(srcFlow.FlowMessage, namespace)
-	applyCustomFields(flow, srcFlow.AdditionalFields)
+	applyAdditionalFields(flow, srcFlow.AdditionalFields)
 	return flow
 }
 
@@ -68,9 +68,9 @@ func convertFlowType(flowType flowpb.FlowMessage_FlowType) common.FlowType {
 	return flowTypeStr
 }
 
-func applyCustomFields(flow *common.Flow, additionalFields common.AdditionalFields) {
+func applyAdditionalFields(flow *common.Flow, additionalFields common.AdditionalFields) {
 	for destination, fieldValue := range additionalFields {
-		applied := applyCustomField(flow, destination, fieldValue)
+		applied := applyAdditionalField(flow, destination, fieldValue)
 		if applied {
 			// We replaced a field of common.Flow with an additional field, no need to keep it in the map
 			delete(additionalFields, destination)
@@ -79,7 +79,7 @@ func applyCustomFields(flow *common.Flow, additionalFields common.AdditionalFiel
 	flow.AdditionalFields = additionalFields
 }
 
-func applyCustomField(flow *common.Flow, destination string, fieldValue any) bool {
+func applyAdditionalField(flow *common.Flow, destination string, fieldValue any) bool {
 	// Make sure FlowFieldsTypes includes the type of the following fields
 	switch destination {
 	case "direction":

--- a/comp/netflow/goflowlib/convert.go
+++ b/comp/netflow/goflowlib/convert.go
@@ -44,6 +44,13 @@ func ConvertFlow(srcFlow *flowpb.FlowMessage, namespace string) *common.Flow {
 	}
 }
 
+// ConvertFlowWithCustomFields convert goflow flow structure and additional fields to internal flow structure
+func ConvertFlowWithCustomFields(srcFlow *common.FlowMessageWithAdditionalFields, namespace string) *common.Flow {
+	flow := ConvertFlow(srcFlow.FlowMessage, namespace)
+	applyCustomFields(flow, srcFlow.AdditionalFields)
+	return flow
+}
+
 func convertFlowType(flowType flowpb.FlowMessage_FlowType) common.FlowType {
 	var flowTypeStr common.FlowType
 	switch flowType {
@@ -59,4 +66,80 @@ func convertFlowType(flowType flowpb.FlowMessage_FlowType) common.FlowType {
 		flowTypeStr = common.TypeUnknown
 	}
 	return flowTypeStr
+}
+
+func applyCustomFields(flow *common.Flow, additionalFields common.AdditionalFields) {
+	for destination, fieldValue := range additionalFields {
+		applied := applyCustomField(flow, destination, fieldValue)
+		if applied {
+			// We replaced a field of common.Flow with an additional field, no need to keep it in the map
+			delete(additionalFields, destination)
+		}
+	}
+	flow.AdditionalFields = additionalFields
+}
+
+func applyCustomField(flow *common.Flow, destination string, fieldValue any) bool {
+	// Make sure FlowFieldsTypes includes the type of the following fields
+	switch destination {
+	case "direction":
+		setValue(&flow.Direction, fieldValue)
+	case "start":
+		setValue(&flow.StartTimestamp, fieldValue)
+	case "end":
+		setValue(&flow.EndTimestamp, fieldValue)
+	case "bytes":
+		setValue(&flow.Bytes, fieldValue)
+	case "packets":
+		setValue(&flow.Packets, fieldValue)
+	case "ether_type":
+		setValue(&flow.EtherType, fieldValue)
+	case "ip_protocol":
+		setValue(&flow.IPProtocol, fieldValue)
+	case "exporter.ip":
+		setValue(&flow.ExporterAddr, fieldValue)
+	case "source.ip":
+		setValue(&flow.SrcAddr, fieldValue)
+	case "source.port":
+		var port uint64
+		setValue(&port, fieldValue)
+		flow.SrcPort = int32(port)
+	case "source.mac":
+		setValue(&flow.SrcMac, fieldValue)
+	case "source.mask":
+		setValue(&flow.SrcMask, fieldValue)
+	case "destination.ip":
+		setValue(&flow.DstAddr, fieldValue)
+	case "destination.port":
+		var port uint64
+		setValue(&port, fieldValue)
+		flow.DstPort = int32(port)
+	case "destination.mac":
+		setValue(&flow.DstMac, fieldValue)
+	case "destination.mask":
+		setValue(&flow.DstMask, fieldValue)
+	case "ingress.interface":
+		setValue(&flow.InputInterface, fieldValue)
+	case "egress.interface":
+		setValue(&flow.OutputInterface, fieldValue)
+	case "tcp_flags":
+		setValue(&flow.TCPFlags, fieldValue)
+	case "next_hop.ip":
+		setValue(&flow.NextHop, fieldValue)
+	case "tos":
+		setValue(&flow.Tos, fieldValue)
+	default:
+		return false
+	}
+	return true
+}
+
+type FlowFieldsTypes interface {
+	uint64 | uint32 | []byte
+}
+
+func setValue[T FlowFieldsTypes](field *T, value any) {
+	if v, ok := value.(T); ok {
+		*field = v
+	}
 }

--- a/comp/netflow/goflowlib/convert_test.go
+++ b/comp/netflow/goflowlib/convert_test.go
@@ -103,3 +103,66 @@ func TestConvertFlow(t *testing.T) {
 	actualFlow := ConvertFlow(&srcFlow, "my-ns")
 	assert.Equal(t, expectedFlow, *actualFlow)
 }
+
+func TestConvertFlowWithCustomFields(t *testing.T) {
+	srcFlow := common.FlowMessageWithAdditionalFields{FlowMessage: &flowpb.FlowMessage{
+		Type:           flowpb.FlowMessage_NETFLOW_V9,
+		TimeReceived:   1234567,
+		SequenceNum:    20,
+		SamplingRate:   10,
+		FlowDirection:  1,
+		SamplerAddress: []byte{127, 0, 0, 1},
+		TimeFlowStart:  1234568,
+		TimeFlowEnd:    1234569,
+		Bytes:          10,
+		Packets:        2,
+		SrcAddr:        []byte{10, 10, 10, 10},
+		DstAddr:        []byte{10, 10, 10, 20},
+		SrcMac:         uint64(10),
+		DstMac:         uint64(20),
+		SrcNet:         uint32(10),
+		DstNet:         uint32(20),
+		Etype:          uint32(1),
+		Proto:          uint32(6),
+		SrcPort:        uint32(2000),
+		DstPort:        uint32(80),
+		InIf:           10,
+		OutIf:          20,
+		IpTos:          3,
+		NextHop:        []byte{10, 10, 10, 30},
+	},
+		AdditionalFields: map[string]any{
+			"bytes":        uint64(1000),
+			"custom_field": "test",
+		},
+	}
+	expectedFlow := common.Flow{
+		Namespace:        "my-ns",
+		FlowType:         common.TypeNetFlow9,
+		SequenceNum:      20,
+		SamplingRate:     10,
+		Direction:        1,
+		ExporterAddr:     []byte{127, 0, 0, 1},
+		StartTimestamp:   1234568,
+		EndTimestamp:     1234569,
+		Bytes:            1000, // Bytes were replaced by AdditionalFields.bytes
+		Packets:          2,
+		SrcAddr:          []byte{10, 10, 10, 10},
+		DstAddr:          []byte{10, 10, 10, 20},
+		SrcMac:           uint64(10),
+		DstMac:           uint64(20),
+		SrcMask:          uint32(10),
+		DstMask:          uint32(20),
+		EtherType:        uint32(1),
+		IPProtocol:       uint32(6),
+		SrcPort:          2000,
+		DstPort:          80,
+		InputInterface:   10,
+		OutputInterface:  20,
+		Tos:              3,
+		NextHop:          []byte{10, 10, 10, 30},
+		AdditionalFields: map[string]any{"custom_field": "test"},
+	}
+	actualFlow := ConvertFlowWithCustomFields(&srcFlow, "my-ns")
+	assert.Equal(t, expectedFlow, *actualFlow)
+}

--- a/comp/netflow/goflowlib/convert_test.go
+++ b/comp/netflow/goflowlib/convert_test.go
@@ -104,7 +104,7 @@ func TestConvertFlow(t *testing.T) {
 	assert.Equal(t, expectedFlow, *actualFlow)
 }
 
-func TestConvertFlowWithCustomFields(t *testing.T) {
+func TestConvertFlowWithAdditionalFields(t *testing.T) {
 	srcFlow := common.FlowMessageWithAdditionalFields{FlowMessage: &flowpb.FlowMessage{
 		Type:           flowpb.FlowMessage_NETFLOW_V9,
 		TimeReceived:   1234567,
@@ -163,6 +163,6 @@ func TestConvertFlowWithCustomFields(t *testing.T) {
 		NextHop:          []byte{10, 10, 10, 30},
 		AdditionalFields: map[string]any{"custom_field": "test"},
 	}
-	actualFlow := ConvertFlowWithCustomFields(&srcFlow, "my-ns")
+	actualFlow := ConvertFlowWithAdditionalFields(&srcFlow, "my-ns")
 	assert.Equal(t, expectedFlow, *actualFlow)
 }

--- a/comp/netflow/goflowlib/customfields/netflow.go
+++ b/comp/netflow/goflowlib/customfields/netflow.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
+// Package customfields provides a producer collecting
+// additional fields from Netflow/IPFIX packets.
 package customfields
 
 import (
@@ -18,9 +20,8 @@ import (
 func decodeUNumberWithEndianness(b []byte, out *uint64, endianness common.EndianType) error {
 	if endianness == common.LittleEndian {
 		return producer.DecodeUNumberLE(b, out)
-	} else {
-		return producer.DecodeUNumber(b, out)
 	}
+	return producer.DecodeUNumber(b, out)
 }
 
 func mapCustomField(additionalFields common.AdditionalFields, v []byte, cfg config.Mapping) {

--- a/comp/netflow/goflowlib/customfields/netflow.go
+++ b/comp/netflow/goflowlib/customfields/netflow.go
@@ -1,0 +1,97 @@
+package customfields
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"github.com/DataDog/datadog-agent/comp/netflow/common"
+	"github.com/DataDog/datadog-agent/comp/netflow/config"
+	"github.com/netsampler/goflow2/decoders/netflow"
+	"github.com/netsampler/goflow2/producer"
+)
+
+func DecodeUNumberWithEndianness(b []byte, out *uint64, endianness common.EndianType) {
+	if endianness == common.LittleEndian {
+		producer.DecodeUNumberLE(b, out)
+	} else {
+		producer.DecodeUNumber(b, out)
+	}
+}
+
+func MapCustomField(additionalFields common.AdditionalFields, v []byte, cfg config.Mapping) {
+	// TODO : Add more types (IP address, timestamp, ...)
+	if cfg.Type == common.Varint {
+		var dstVar uint64
+		DecodeUNumberWithEndianness(v, &dstVar, cfg.Endian)
+		additionalFields[cfg.Destination] = dstVar
+	} else if cfg.Type == common.String {
+		additionalFields[cfg.Destination] = string(bytes.Trim(v, "\x00")) // Removing trailing null chars
+	} else {
+		additionalFields[cfg.Destination] = hex.EncodeToString(v)
+	}
+}
+
+func ConvertNetFlowDataSet(record []netflow.DataField, fieldsConfig map[uint16]config.Mapping) common.AdditionalFields {
+	additionalFields := make(common.AdditionalFields)
+
+	for i := range record {
+		df := record[i]
+
+		v, ok := df.Value.([]byte)
+		if !ok {
+			continue
+		}
+
+		mappingConfig, ok := fieldsConfig[df.Type]
+		if !ok {
+			continue
+		}
+
+		MapCustomField(additionalFields, v, mappingConfig)
+	}
+
+	return additionalFields
+}
+
+func SearchNetFlowDataSetsRecords(dataRecords []netflow.DataRecord, fieldsConfig map[uint16]config.Mapping) []common.AdditionalFields {
+	var setsAdditionalFields []common.AdditionalFields
+	for _, record := range dataRecords {
+		additionalFields := ConvertNetFlowDataSet(record.Values, fieldsConfig)
+		if additionalFields != nil {
+			setsAdditionalFields = append(setsAdditionalFields, additionalFields)
+		}
+	}
+	return setsAdditionalFields
+}
+
+func SearchNetFlowDataSets(dataFlowSet []netflow.DataFlowSet, fieldsConfig map[uint16]config.Mapping) []common.AdditionalFields {
+	var flowsAdditonalFields []map[string]any
+	for _, dataFlowSetItem := range dataFlowSet {
+		setsAdditionalFields := SearchNetFlowDataSetsRecords(dataFlowSetItem.Records, fieldsConfig)
+		if setsAdditionalFields != nil {
+			flowsAdditonalFields = append(flowsAdditonalFields, setsAdditionalFields...)
+		}
+	}
+	return flowsAdditonalFields
+}
+
+func ProcessMessageNetFlowCustomFields(msgDec interface{}, fieldsConfig map[uint16]config.Mapping) ([]common.AdditionalFields, error) {
+	if len(fieldsConfig) == 0 {
+		return nil, nil
+	}
+
+	var flowsAdditonalFields []map[string]any
+
+	switch msgDecConv := msgDec.(type) {
+	case netflow.NFv9Packet:
+		dataFlowSet, _, _, _ := producer.SplitNetFlowSets(msgDecConv)
+		flowsAdditonalFields = SearchNetFlowDataSets(dataFlowSet, fieldsConfig)
+	case netflow.IPFIXPacket:
+		dataFlowSet, _, _, _ := producer.SplitIPFIXSets(msgDecConv)
+		flowsAdditonalFields = SearchNetFlowDataSets(dataFlowSet, fieldsConfig)
+	default:
+		return flowsAdditonalFields, errors.New("Bad NetFlow/IPFIX version")
+	}
+
+	return flowsAdditonalFields, nil
+}

--- a/comp/netflow/goflowlib/customfields/netflow.go
+++ b/comp/netflow/goflowlib/customfields/netflow.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
 package customfields
 
 import (
@@ -10,19 +15,22 @@ import (
 	"github.com/netsampler/goflow2/producer"
 )
 
-func DecodeUNumberWithEndianness(b []byte, out *uint64, endianness common.EndianType) {
+func decodeUNumberWithEndianness(b []byte, out *uint64, endianness common.EndianType) error {
 	if endianness == common.LittleEndian {
-		producer.DecodeUNumberLE(b, out)
+		return producer.DecodeUNumberLE(b, out)
 	} else {
-		producer.DecodeUNumber(b, out)
+		return producer.DecodeUNumber(b, out)
 	}
 }
 
-func MapCustomField(additionalFields common.AdditionalFields, v []byte, cfg config.Mapping) {
+func mapCustomField(additionalFields common.AdditionalFields, v []byte, cfg config.Mapping) {
 	// TODO : Add more types (IP address, timestamp, ...)
 	if cfg.Type == common.Varint {
 		var dstVar uint64
-		DecodeUNumberWithEndianness(v, &dstVar, cfg.Endian)
+		err := decodeUNumberWithEndianness(v, &dstVar, cfg.Endian)
+		if err != nil {
+			return
+		}
 		additionalFields[cfg.Destination] = dstVar
 	} else if cfg.Type == common.String {
 		additionalFields[cfg.Destination] = string(bytes.Trim(v, "\x00")) // Removing trailing null chars
@@ -31,7 +39,7 @@ func MapCustomField(additionalFields common.AdditionalFields, v []byte, cfg conf
 	}
 }
 
-func ConvertNetFlowDataSet(record []netflow.DataField, fieldsConfig map[uint16]config.Mapping) common.AdditionalFields {
+func convertNetFlowDataSet(record []netflow.DataField, fieldsConfig map[uint16]config.Mapping) common.AdditionalFields {
 	additionalFields := make(common.AdditionalFields)
 
 	for i := range record {
@@ -47,16 +55,16 @@ func ConvertNetFlowDataSet(record []netflow.DataField, fieldsConfig map[uint16]c
 			continue
 		}
 
-		MapCustomField(additionalFields, v, mappingConfig)
+		mapCustomField(additionalFields, v, mappingConfig)
 	}
 
 	return additionalFields
 }
 
-func SearchNetFlowDataSetsRecords(dataRecords []netflow.DataRecord, fieldsConfig map[uint16]config.Mapping) []common.AdditionalFields {
+func searchNetFlowDataSetsRecords(dataRecords []netflow.DataRecord, fieldsConfig map[uint16]config.Mapping) []common.AdditionalFields {
 	var setsAdditionalFields []common.AdditionalFields
 	for _, record := range dataRecords {
-		additionalFields := ConvertNetFlowDataSet(record.Values, fieldsConfig)
+		additionalFields := convertNetFlowDataSet(record.Values, fieldsConfig)
 		if additionalFields != nil {
 			setsAdditionalFields = append(setsAdditionalFields, additionalFields)
 		}
@@ -64,10 +72,10 @@ func SearchNetFlowDataSetsRecords(dataRecords []netflow.DataRecord, fieldsConfig
 	return setsAdditionalFields
 }
 
-func SearchNetFlowDataSets(dataFlowSet []netflow.DataFlowSet, fieldsConfig map[uint16]config.Mapping) []common.AdditionalFields {
+func searchNetFlowDataSets(dataFlowSet []netflow.DataFlowSet, fieldsConfig map[uint16]config.Mapping) []common.AdditionalFields {
 	var flowsAdditonalFields []map[string]any
 	for _, dataFlowSetItem := range dataFlowSet {
-		setsAdditionalFields := SearchNetFlowDataSetsRecords(dataFlowSetItem.Records, fieldsConfig)
+		setsAdditionalFields := searchNetFlowDataSetsRecords(dataFlowSetItem.Records, fieldsConfig)
 		if setsAdditionalFields != nil {
 			flowsAdditonalFields = append(flowsAdditonalFields, setsAdditionalFields...)
 		}
@@ -75,6 +83,7 @@ func SearchNetFlowDataSets(dataFlowSet []netflow.DataFlowSet, fieldsConfig map[u
 	return flowsAdditonalFields
 }
 
+// ProcessMessageNetFlowCustomFields collects additional fields from netflow packet using the given config
 func ProcessMessageNetFlowCustomFields(msgDec interface{}, fieldsConfig map[uint16]config.Mapping) ([]common.AdditionalFields, error) {
 	if len(fieldsConfig) == 0 {
 		return nil, nil
@@ -85,10 +94,10 @@ func ProcessMessageNetFlowCustomFields(msgDec interface{}, fieldsConfig map[uint
 	switch msgDecConv := msgDec.(type) {
 	case netflow.NFv9Packet:
 		dataFlowSet, _, _, _ := producer.SplitNetFlowSets(msgDecConv)
-		flowsAdditonalFields = SearchNetFlowDataSets(dataFlowSet, fieldsConfig)
+		flowsAdditonalFields = searchNetFlowDataSets(dataFlowSet, fieldsConfig)
 	case netflow.IPFIXPacket:
 		dataFlowSet, _, _, _ := producer.SplitIPFIXSets(msgDecConv)
-		flowsAdditonalFields = SearchNetFlowDataSets(dataFlowSet, fieldsConfig)
+		flowsAdditonalFields = searchNetFlowDataSets(dataFlowSet, fieldsConfig)
 	default:
 		return flowsAdditonalFields, errors.New("Bad NetFlow/IPFIX version")
 	}

--- a/comp/netflow/goflowlib/customfields/netflow_test.go
+++ b/comp/netflow/goflowlib/customfields/netflow_test.go
@@ -1,0 +1,197 @@
+package customfields
+
+import (
+	"github.com/DataDog/datadog-agent/comp/netflow/common"
+	"github.com/DataDog/datadog-agent/comp/netflow/config"
+	"github.com/netsampler/goflow2/decoders/netflow"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func makeSampleNetflowPacket(fields []netflow.DataField) netflow.NFv9Packet {
+	flowSet := netflow.DataFlowSet{
+		FlowSetHeader: netflow.FlowSetHeader{
+			Id:     1,
+			Length: 10,
+		},
+		Records: []netflow.DataRecord{
+			{Values: fields},
+		},
+	}
+
+	anyFlowSets := make([]interface{}, 1)
+	anyFlowSets[0] = flowSet
+
+	return netflow.NFv9Packet{
+		Version:        9,
+		Count:          1,
+		SystemUptime:   10,
+		UnixSeconds:    10,
+		SequenceNumber: 1,
+		SourceId:       2,
+		FlowSets:       anyFlowSets,
+	}
+}
+
+func Test_ProcessMessageNetFlowCustomFields(t *testing.T) {
+	tests := []struct {
+		name                    string
+		fields                  []netflow.DataField
+		config                  map[uint16]config.Mapping
+		expectedCollectedFields []common.AdditionalFields
+	}{
+		{
+			name: "Custom field int",
+			fields: []netflow.DataField{{
+				Type:  123,
+				Value: []byte{45},
+			}},
+			config: map[uint16]config.Mapping{
+				123: {
+					Field:       123,
+					Destination: "test_field",
+					Type:        common.Varint,
+				},
+			},
+			expectedCollectedFields: []common.AdditionalFields{{
+				"test_field": uint64(45),
+			}},
+		},
+		{
+			name: "Custom field string",
+			fields: []netflow.DataField{{
+				Type:  123,
+				Value: []byte("test"),
+			}},
+			config: map[uint16]config.Mapping{
+				123: {
+					Field:       123,
+					Destination: "test_field",
+					Type:        common.String,
+				},
+			},
+			expectedCollectedFields: []common.AdditionalFields{{
+				"test_field": "test",
+			}},
+		},
+		{
+			name: "Custom field hex",
+			fields: []netflow.DataField{{
+				Type:  123,
+				Value: []byte{45, 12},
+			}},
+			config: map[uint16]config.Mapping{
+				123: {
+					Field:       123,
+					Destination: "test_field",
+				},
+			},
+			expectedCollectedFields: []common.AdditionalFields{{
+				"test_field": "2d0c",
+			}},
+		},
+		{
+			name: "Custom field mixed types",
+			fields: []netflow.DataField{{
+				Type:  123,
+				Value: []byte{45},
+			}, {
+				Type:  124,
+				Value: []byte("hello"),
+			}},
+			config: map[uint16]config.Mapping{
+				123: {
+					Field:       123,
+					Destination: "test_field",
+					Type:        common.Varint,
+				},
+				124: {
+					Field:       124,
+					Destination: "second_field",
+					Type:        common.String,
+				},
+			},
+			expectedCollectedFields: []common.AdditionalFields{{
+				"test_field":   uint64(45),
+				"second_field": "hello",
+			}},
+		},
+		{
+			name: "Custom field missing field in packet",
+			fields: []netflow.DataField{{
+				Type:  123,
+				Value: []byte{45},
+			}, {
+				Type:  124,
+				Value: []byte("hello"),
+			}},
+			config: map[uint16]config.Mapping{
+				123: {
+					Field:       123,
+					Destination: "test_field",
+					Type:        common.Varint,
+				},
+				126: {
+					Field:       126,
+					Destination: "missing_field",
+					Type:        common.Varint,
+				},
+			},
+			expectedCollectedFields: []common.AdditionalFields{{
+				"test_field": uint64(45),
+			}},
+		},
+		{
+			name: "Custom field empty configuration",
+			fields: []netflow.DataField{{
+				Type:  123,
+				Value: []byte{45, 12},
+			}},
+			config:                  map[uint16]config.Mapping{},
+			expectedCollectedFields: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			packet := makeSampleNetflowPacket(tt.fields)
+			expectedFields, err := ProcessMessageNetFlowCustomFields(packet, tt.config)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedCollectedFields, expectedFields)
+		})
+	}
+}
+
+func Test_DecodeUNumberWithEndianness(t *testing.T) {
+	tests := []struct {
+		name       string
+		bytes      []byte
+		endianness common.EndianType
+		expected   uint64
+	}{
+		{
+			name:       "Little endian",
+			bytes:      []byte{45, 12, 34},
+			endianness: common.LittleEndian,
+			expected:   uint64(2231341),
+		},
+		{
+			name:       "Big endian",
+			bytes:      []byte{45, 12, 34},
+			endianness: common.BigEndian,
+			expected:   uint64(2952226),
+		},
+		{
+			name:       "Big endian by default",
+			bytes:      []byte{45, 12, 34},
+			endianness: "",
+			expected:   uint64(2952226),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out uint64
+			DecodeUNumberWithEndianness(tt.bytes, &out, tt.endianness)
+			assert.Equal(t, tt.expected, out)
+		})
+	}
+}

--- a/comp/netflow/goflowlib/customfields/netflow_test.go
+++ b/comp/netflow/goflowlib/customfields/netflow_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
 package customfields
 
 import (
@@ -190,7 +195,8 @@ func Test_DecodeUNumberWithEndianness(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var out uint64
-			DecodeUNumberWithEndianness(tt.bytes, &out, tt.endianness)
+			err := decodeUNumberWithEndianness(tt.bytes, &out, tt.endianness)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, out)
 		})
 	}

--- a/comp/netflow/goflowlib/flowstate.go
+++ b/comp/netflow/goflowlib/flowstate.go
@@ -8,6 +8,8 @@ package goflowlib
 import (
 	"context"
 	"fmt"
+	"github.com/DataDog/datadog-agent/comp/netflow/config"
+	"github.com/DataDog/datadog-agent/comp/netflow/goflowlib/netflowstate"
 
 	"github.com/netsampler/goflow2/decoders/netflow/templates"
 	"go.uber.org/atomic"
@@ -47,6 +49,7 @@ func StartFlowRoutine(
 	port uint16,
 	workers int,
 	namespace string,
+	fieldMappings []config.Mapping,
 	flowInChan chan *common.Flow,
 	logger log.Component,
 	atomicErr *atomic.String,
@@ -65,7 +68,7 @@ func StartFlowRoutine(
 		}
 		defer templateSystem.Close(ctx)
 
-		state := utils.NewStateNetFlow()
+		state := netflowstate.NewStateNetFlow(fieldMappings)
 		state.Format = formatDriver
 		state.Logger = logrusLogger
 		state.TemplateSystem = templateSystem

--- a/comp/netflow/goflowlib/flowstate.go
+++ b/comp/netflow/goflowlib/flowstate.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"github.com/DataDog/datadog-agent/comp/netflow/config"
 	"github.com/DataDog/datadog-agent/comp/netflow/goflowlib/netflowstate"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 
 	"github.com/netsampler/goflow2/decoders/netflow/templates"
 	"go.uber.org/atomic"
@@ -52,6 +53,7 @@ func StartFlowRoutine(
 	fieldMappings []config.Mapping,
 	flowInChan chan *common.Flow,
 	logger log.Component,
+	sender sender.Sender,
 	atomicErr *atomic.String,
 	listenerFlowCount *atomic.Int64) (*FlowStateWrapper, error) {
 	var flowState FlowRunnableState
@@ -68,7 +70,7 @@ func StartFlowRoutine(
 		}
 		defer templateSystem.Close(ctx)
 
-		state := netflowstate.NewStateNetFlow(fieldMappings)
+		state := netflowstate.NewStateNetFlow(fieldMappings, sender)
 		state.Format = formatDriver
 		state.Logger = logrusLogger
 		state.TemplateSystem = templateSystem

--- a/comp/netflow/goflowlib/flowstate_test.go
+++ b/comp/netflow/goflowlib/flowstate_test.go
@@ -6,6 +6,7 @@
 package goflowlib
 
 import (
+	"github.com/DataDog/datadog-agent/comp/netflow/config"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,7 +22,7 @@ func TestStartFlowRoutine_invalidType(t *testing.T) {
 	listenerErr := atomic.NewString("")
 	listenerFlowCount := atomic.NewInt64(0)
 
-	state, err := StartFlowRoutine("invalid", "my-hostname", 1234, 1, "my-ns", make(chan *common.Flow), logger, listenerErr, listenerFlowCount)
+	state, err := StartFlowRoutine("invalid", "my-hostname", 1234, 1, "my-ns", []config.Mapping{}, make(chan *common.Flow), logger, listenerErr, listenerFlowCount)
 
 	assert.EqualError(t, err, "unknown flow type: invalid")
 	assert.Nil(t, state)

--- a/comp/netflow/goflowlib/flowstate_test.go
+++ b/comp/netflow/goflowlib/flowstate_test.go
@@ -22,7 +22,7 @@ func TestStartFlowRoutine_invalidType(t *testing.T) {
 	listenerErr := atomic.NewString("")
 	listenerFlowCount := atomic.NewInt64(0)
 
-	state, err := StartFlowRoutine("invalid", "my-hostname", 1234, 1, "my-ns", []config.Mapping{}, make(chan *common.Flow), logger, listenerErr, listenerFlowCount)
+	state, err := StartFlowRoutine("invalid", "my-hostname", 1234, 1, "my-ns", []config.Mapping{}, make(chan *common.Flow), logger, nil, listenerErr, listenerFlowCount)
 
 	assert.EqualError(t, err, "unknown flow type: invalid")
 	assert.Nil(t, state)

--- a/comp/netflow/goflowlib/formatdriver.go
+++ b/comp/netflow/goflowlib/formatdriver.go
@@ -48,7 +48,7 @@ func (d *AggregatorFormatDriver) Format(data interface{}) ([]byte, []byte, error
 		d.flowAggIn <- ConvertFlow(flow, d.namespace)
 	case *common.FlowMessageWithAdditionalFields:
 		d.listenerFlowCount.Add(1)
-		d.flowAggIn <- ConvertFlowWithCustomFields(flow, d.namespace)
+		d.flowAggIn <- ConvertFlowWithAdditionalFields(flow, d.namespace)
 	default:
 		return nil, nil, fmt.Errorf("message is not flowpb.FlowMessage or common.FlowMessageWithAdditionalFields")
 	}

--- a/comp/netflow/goflowlib/formatdriver.go
+++ b/comp/netflow/goflowlib/formatdriver.go
@@ -50,7 +50,7 @@ func (d *AggregatorFormatDriver) Format(data interface{}) ([]byte, []byte, error
 		d.listenerFlowCount.Add(1)
 		d.flowAggIn <- ConvertFlowWithCustomFields(flow, d.namespace)
 	default:
-		return nil, nil, fmt.Errorf("message is not flowpb.FlowMessage")
+		return nil, nil, fmt.Errorf("message is not flowpb.FlowMessage or common.FlowMessageWithAdditionalFields")
 	}
 
 	return nil, nil, nil

--- a/comp/netflow/goflowlib/formatdriver.go
+++ b/comp/netflow/goflowlib/formatdriver.go
@@ -42,11 +42,16 @@ func (d *AggregatorFormatDriver) Init(context.Context) error {
 
 // Format desc
 func (d *AggregatorFormatDriver) Format(data interface{}) ([]byte, []byte, error) {
-	flow, ok := data.(*flowpb.FlowMessage)
-	if !ok {
+	switch flow := data.(type) {
+	case *flowpb.FlowMessage:
+		d.listenerFlowCount.Add(1)
+		d.flowAggIn <- ConvertFlow(flow, d.namespace)
+	case *common.FlowMessageWithAdditionalFields:
+		d.listenerFlowCount.Add(1)
+		d.flowAggIn <- ConvertFlowWithCustomFields(flow, d.namespace)
+	default:
 		return nil, nil, fmt.Errorf("message is not flowpb.FlowMessage")
 	}
-	d.listenerFlowCount.Add(1)
-	d.flowAggIn <- ConvertFlow(flow, d.namespace)
+
 	return nil, nil, nil
 }

--- a/comp/netflow/goflowlib/netflowstate/netflow.go
+++ b/comp/netflow/goflowlib/netflowstate/netflow.go
@@ -1,0 +1,366 @@
+package netflowstate
+
+import (
+	"bytes"
+	"context"
+	"github.com/DataDog/datadog-agent/comp/netflow/common"
+	"github.com/DataDog/datadog-agent/comp/netflow/config"
+	"github.com/DataDog/datadog-agent/comp/netflow/goflowlib/customfields"
+	"github.com/netsampler/goflow2/utils"
+	"sync"
+	"time"
+
+	"github.com/netsampler/goflow2/decoders/netflow"
+	"github.com/netsampler/goflow2/decoders/netflow/templates"
+	"github.com/netsampler/goflow2/format"
+	flowmessage "github.com/netsampler/goflow2/pb"
+	"github.com/netsampler/goflow2/producer"
+	"github.com/netsampler/goflow2/transport"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type StateNetFlow struct {
+	stopper
+
+	Format    format.FormatInterface
+	Transport transport.TransportInterface
+	Logger    utils.Logger
+
+	samplinglock *sync.RWMutex
+	sampling     map[string]producer.SamplingRateSystem
+
+	Config       *producer.ProducerConfig
+	configMapped *producer.ProducerConfigMapped
+
+	TemplateSystem templates.TemplateInterface
+
+	ctx context.Context
+
+	mappedFieldsConfig map[uint16]config.Mapping
+}
+
+func NewStateNetFlow(mappingConfs []config.Mapping) *StateNetFlow {
+	return &StateNetFlow{
+		ctx:                context.Background(),
+		samplinglock:       &sync.RWMutex{},
+		sampling:           make(map[string]producer.SamplingRateSystem),
+		mappedFieldsConfig: mapFieldsConfig(mappingConfs),
+	}
+}
+
+func (s *StateNetFlow) DecodeFlow(msg interface{}) error {
+	pkt := msg.(utils.BaseMessage)
+	buf := bytes.NewBuffer(pkt.Payload)
+
+	key := pkt.Src.String()
+	samplerAddress := pkt.Src
+	if samplerAddress.To4() != nil {
+		samplerAddress = samplerAddress.To4()
+	}
+
+	s.samplinglock.RLock()
+	sampling, ok := s.sampling[key]
+	s.samplinglock.RUnlock()
+	if !ok {
+		sampling = producer.CreateSamplingSystem()
+		s.samplinglock.Lock()
+		s.sampling[key] = sampling
+		s.samplinglock.Unlock()
+	}
+
+	ts := uint64(time.Now().UTC().Unix())
+	if pkt.SetTime {
+		ts = uint64(pkt.RecvTime.UTC().Unix())
+	}
+
+	timeTrackStart := time.Now()
+	msgDec, err := netflow.DecodeMessageContext(s.ctx, buf, key, netflow.TemplateWrapper{s.ctx, key, s.TemplateSystem})
+	if err != nil {
+		switch err.(type) {
+		case *netflow.ErrorTemplateNotFound:
+			utils.NetFlowErrors.With(
+				prometheus.Labels{
+					"router": key,
+					"error":  "template_not_found",
+				}).
+				Inc()
+		default:
+			utils.NetFlowErrors.With(
+				prometheus.Labels{
+					"router": key,
+					"error":  "error_decoding",
+				}).
+				Inc()
+		}
+		return err
+	}
+
+	var flows []*common.FlowMessageWithAdditionalFields
+	var flowMessageSet []*flowmessage.FlowMessage
+	var additionalFields []common.AdditionalFields
+
+	switch msgDecConv := msgDec.(type) {
+	case netflow.NFv9Packet:
+		utils.NetFlowStats.With(
+			prometheus.Labels{
+				"router":  key,
+				"version": "9",
+			}).
+			Inc()
+
+		for _, fs := range msgDecConv.FlowSets {
+			switch fsConv := fs.(type) {
+			case netflow.TemplateFlowSet:
+				utils.NetFlowSetStatsSum.With(
+					prometheus.Labels{
+						"router":  key,
+						"version": "9",
+						"type":    "TemplateFlowSet",
+					}).
+					Inc()
+
+				utils.NetFlowSetRecordsStatsSum.With(
+					prometheus.Labels{
+						"router":  key,
+						"version": "9",
+						"type":    "TemplateFlowSet",
+					}).
+					Add(float64(len(fsConv.Records)))
+
+			case netflow.NFv9OptionsTemplateFlowSet:
+				utils.NetFlowSetStatsSum.With(
+					prometheus.Labels{
+						"router":  key,
+						"version": "9",
+						"type":    "OptionsTemplateFlowSet",
+					}).
+					Inc()
+
+				utils.NetFlowSetRecordsStatsSum.With(
+					prometheus.Labels{
+						"router":  key,
+						"version": "9",
+						"type":    "OptionsTemplateFlowSet",
+					}).
+					Add(float64(len(fsConv.Records)))
+
+			case netflow.OptionsDataFlowSet:
+				utils.NetFlowSetStatsSum.With(
+					prometheus.Labels{
+						"router":  key,
+						"version": "9",
+						"type":    "OptionsDataFlowSet",
+					}).
+					Inc()
+
+				utils.NetFlowSetRecordsStatsSum.With(
+					prometheus.Labels{
+						"router":  key,
+						"version": "9",
+						"type":    "OptionsDataFlowSet",
+					}).
+					Add(float64(len(fsConv.Records)))
+			case netflow.DataFlowSet:
+				utils.NetFlowSetStatsSum.With(
+					prometheus.Labels{
+						"router":  key,
+						"version": "9",
+						"type":    "DataFlowSet",
+					}).
+					Inc()
+
+				utils.NetFlowSetRecordsStatsSum.With(
+					prometheus.Labels{
+						"router":  key,
+						"version": "9",
+						"type":    "DataFlowSet",
+					}).
+					Add(float64(len(fsConv.Records)))
+			}
+		}
+		flowMessageSet, err = producer.ProcessMessageNetFlowConfig(msgDecConv, sampling, s.configMapped)
+
+		additionalFields, err = customfields.ProcessMessageNetFlowCustomFields(msgDecConv, s.mappedFieldsConfig)
+		if err != nil {
+			s.Logger.Errorf("failed to process additional fields %s", err)
+		}
+
+		for i, fmsg := range flowMessageSet {
+			fmsg.TimeReceived = ts
+			fmsg.SamplerAddress = samplerAddress
+			timeDiff := fmsg.TimeReceived - fmsg.TimeFlowEnd
+
+			message := common.FlowMessageWithAdditionalFields{
+				FlowMessage: fmsg,
+			}
+
+			if additionalFields != nil {
+				message.AdditionalFields = additionalFields[i]
+			}
+
+			flows = append(flows, &message)
+
+			utils.NetFlowTimeStatsSum.With(
+				prometheus.Labels{
+					"router":  key,
+					"version": "9",
+				}).
+				Observe(float64(timeDiff))
+		}
+
+	case netflow.IPFIXPacket:
+		utils.NetFlowStats.With(
+			prometheus.Labels{
+				"router":  key,
+				"version": "10",
+			}).
+			Inc()
+
+		for _, fs := range msgDecConv.FlowSets {
+			switch fsConv := fs.(type) {
+			case netflow.TemplateFlowSet:
+				utils.NetFlowSetStatsSum.With(
+					prometheus.Labels{
+						"router":  key,
+						"version": "10",
+						"type":    "TemplateFlowSet",
+					}).
+					Inc()
+
+				utils.NetFlowSetRecordsStatsSum.With(
+					prometheus.Labels{
+						"router":  key,
+						"version": "10",
+						"type":    "TemplateFlowSet",
+					}).
+					Add(float64(len(fsConv.Records)))
+
+			case netflow.IPFIXOptionsTemplateFlowSet:
+				utils.NetFlowSetStatsSum.With(
+					prometheus.Labels{
+						"router":  key,
+						"version": "10",
+						"type":    "OptionsTemplateFlowSet",
+					}).
+					Inc()
+
+				utils.NetFlowSetRecordsStatsSum.With(
+					prometheus.Labels{
+						"router":  key,
+						"version": "10",
+						"type":    "OptionsTemplateFlowSet",
+					}).
+					Add(float64(len(fsConv.Records)))
+
+			case netflow.OptionsDataFlowSet:
+
+				utils.NetFlowSetStatsSum.With(
+					prometheus.Labels{
+						"router":  key,
+						"version": "10",
+						"type":    "OptionsDataFlowSet",
+					}).
+					Inc()
+
+				utils.NetFlowSetRecordsStatsSum.With(
+					prometheus.Labels{
+						"router":  key,
+						"version": "10",
+						"type":    "OptionsDataFlowSet",
+					}).
+					Add(float64(len(fsConv.Records)))
+
+			case netflow.DataFlowSet:
+				utils.NetFlowSetStatsSum.With(
+					prometheus.Labels{
+						"router":  key,
+						"version": "10",
+						"type":    "DataFlowSet",
+					}).
+					Inc()
+
+				utils.NetFlowSetRecordsStatsSum.With(
+					prometheus.Labels{
+						"router":  key,
+						"version": "10",
+						"type":    "DataFlowSet",
+					}).
+					Add(float64(len(fsConv.Records)))
+			}
+		}
+		flowMessageSet, err = producer.ProcessMessageNetFlowConfig(msgDecConv, sampling, s.configMapped)
+
+		additionalFields, err = customfields.ProcessMessageNetFlowCustomFields(msgDecConv, s.mappedFieldsConfig)
+		if err != nil {
+			s.Logger.Errorf("failed to process additional fields %s", err)
+		}
+
+		for i, fmsg := range flowMessageSet {
+			fmsg.TimeReceived = ts
+			fmsg.SamplerAddress = samplerAddress
+			timeDiff := fmsg.TimeReceived - fmsg.TimeFlowEnd
+
+			message := common.FlowMessageWithAdditionalFields{
+				FlowMessage: fmsg,
+			}
+
+			if additionalFields != nil {
+				message.AdditionalFields = additionalFields[i]
+			}
+
+			flows = append(flows, &message)
+
+			utils.NetFlowTimeStatsSum.With(
+				prometheus.Labels{
+					"router":  key,
+					"version": "10",
+				}).
+				Observe(float64(timeDiff))
+		}
+	}
+
+	timeTrackStop := time.Now()
+	utils.DecoderTime.With(
+		prometheus.Labels{
+			"name": "NetFlow",
+		}).
+		Observe(float64((timeTrackStop.Sub(timeTrackStart)).Nanoseconds()) / 1000)
+
+	for _, flow := range flows {
+		if s.Format != nil {
+			key, data, err := s.Format.Format(flow)
+
+			if err != nil && s.Logger != nil {
+				s.Logger.Error(err)
+			}
+			if err == nil && s.Transport != nil {
+				err = s.Transport.Send(key, data)
+				if err != nil {
+					s.Logger.Error(err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *StateNetFlow) initConfig() {
+	s.configMapped = producer.NewProducerConfigMapped(s.Config)
+}
+
+func mapFieldsConfig(mappingConfs []config.Mapping) map[uint16]config.Mapping {
+	mappedFieldsConfig := make(map[uint16]config.Mapping)
+	for _, conf := range mappingConfs {
+		mappedFieldsConfig[conf.Field] = conf
+	}
+	return mappedFieldsConfig
+}
+
+func (s *StateNetFlow) FlowRoutine(workers int, addr string, port int, reuseport bool) error {
+	if err := s.start(); err != nil {
+		return err
+	}
+	s.initConfig()
+	return utils.UDPStoppableRoutine(s.stopCh, "NetFlow", s.DecodeFlow, workers, addr, port, reuseport, s.Logger)
+}

--- a/comp/netflow/goflowlib/netflowstate/netflow.go
+++ b/comp/netflow/goflowlib/netflowstate/netflow.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"github.com/DataDog/datadog-agent/comp/netflow/common"
 	"github.com/DataDog/datadog-agent/comp/netflow/config"
-	"github.com/DataDog/datadog-agent/comp/netflow/goflowlib/customfields"
+	"github.com/DataDog/datadog-agent/comp/netflow/goflowlib/additionalfields"
 	"github.com/netsampler/goflow2/utils"
 	"sync"
 	"time"
@@ -193,7 +193,7 @@ func (s *StateNetFlow) DecodeFlow(msg interface{}) error {
 			s.Logger.Errorf("failed to process netflow packet %s", err)
 		}
 
-		additionalFields, err = customfields.ProcessMessageNetFlowCustomFields(msgDecConv, s.mappedFieldsConfig)
+		additionalFields, err = additionalfields.ProcessMessageNetFlowAdditionalFields(msgDecConv, s.mappedFieldsConfig)
 		if err != nil {
 			s.Logger.Errorf("failed to process additional fields %s", err)
 		}
@@ -306,7 +306,7 @@ func (s *StateNetFlow) DecodeFlow(msg interface{}) error {
 			s.Logger.Errorf("failed to process netflow packet %s", err)
 		}
 
-		additionalFields, err = customfields.ProcessMessageNetFlowCustomFields(msgDecConv, s.mappedFieldsConfig)
+		additionalFields, err = additionalfields.ProcessMessageNetFlowAdditionalFields(msgDecConv, s.mappedFieldsConfig)
 		if err != nil {
 			s.Logger.Errorf("failed to process additional fields %s", err)
 		}

--- a/comp/netflow/goflowlib/netflowstate/netflow.go
+++ b/comp/netflow/goflowlib/netflowstate/netflow.go
@@ -88,9 +88,9 @@ func (s *StateNetFlow) DecodeFlow(msg interface{}) error {
 	if err != nil {
 		switch err.(type) {
 		case *netflow.ErrorTemplateNotFound:
-			s.sender.Count(common.MetricPrefix+"processor.errors", 1, "", []string{"exporter_ip:" + key, "error:template_not_found"})
+			s.sender.Count(common.MetricPrefix+"processor.errors", 1, "", []string{"exporter_ip:" + key, "error:template_not_found", "flow_protocol:netflow"})
 		default:
-			s.sender.Count(common.MetricPrefix+"processor.errors", 1, "", []string{"exporter_ip:" + key, "error:error_decoding"})
+			s.sender.Count(common.MetricPrefix+"processor.errors", 1, "", []string{"exporter_ip:" + key, "error:error_decoding", "flow_protocol:netflow"})
 		}
 		return err
 	}
@@ -153,12 +153,12 @@ func (s *StateNetFlow) FlowRoutine(workers int, addr string, port int, reuseport
 func (s *StateNetFlow) sendTelemetryMetrics(msg any, exporterIP string) {
 	switch msgDec := msg.(type) {
 	case netflow.NFv9Packet:
-		s.sender.Count(common.MetricPrefix+"processor.processed", 1, "", []string{"exporter_ip:" + exporterIP, "version:9"})
+		s.sender.Count(common.MetricPrefix+"processor.processed", 1, "", []string{"exporter_ip:" + exporterIP, "version:9", "flow_protocol:netflow"})
 		for _, fs := range msgDec.FlowSets {
 			s.sendFlowSetMetrics(fs, exporterIP, "9")
 		}
 	case netflow.IPFIXPacket:
-		s.sender.Count(common.MetricPrefix+"processor.processed", 1, "", []string{"exporter_ip:" + exporterIP, "version:10"})
+		s.sender.Count(common.MetricPrefix+"processor.processed", 1, "", []string{"exporter_ip:" + exporterIP, "version:10", "flow_protocol:netflow"})
 		for _, fs := range msgDec.FlowSets {
 			s.sendFlowSetMetrics(fs, exporterIP, "10")
 		}
@@ -168,12 +168,12 @@ func (s *StateNetFlow) sendTelemetryMetrics(msg any, exporterIP string) {
 func (s *StateNetFlow) sendFlowSetMetrics(fs any, exporterIP string, version string) {
 	switch fs.(type) {
 	case netflow.TemplateFlowSet:
-		s.sender.Count(common.MetricPrefix+"processor.flowsets", 1, "", []string{"exporter_ip:" + exporterIP, "version:" + version, "type:template_flow_set"})
+		s.sender.Count(common.MetricPrefix+"processor.flowsets", 1, "", []string{"exporter_ip:" + exporterIP, "version:" + version, "type:template_flow_set", "flow_protocol:netflow"})
 	case netflow.NFv9OptionsTemplateFlowSet:
-		s.sender.Count(common.MetricPrefix+"processor.flowsets", 1, "", []string{"exporter_ip:" + exporterIP, "version:" + version, "type:options_template_flow_set"})
+		s.sender.Count(common.MetricPrefix+"processor.flowsets", 1, "", []string{"exporter_ip:" + exporterIP, "version:" + version, "type:options_template_flow_set", "flow_protocol:netflow"})
 	case netflow.OptionsDataFlowSet:
-		s.sender.Count(common.MetricPrefix+"processor.flowsets", 1, "", []string{"exporter_ip:" + exporterIP, "version:" + version, "type:options_data_flow_set"})
+		s.sender.Count(common.MetricPrefix+"processor.flowsets", 1, "", []string{"exporter_ip:" + exporterIP, "version:" + version, "type:options_data_flow_set", "flow_protocol:netflow"})
 	case netflow.DataFlowSet:
-		s.sender.Count(common.MetricPrefix+"processor.flowsets", 1, "", []string{"exporter_ip:" + exporterIP, "version:" + version, "type:data_flow_set"})
+		s.sender.Count(common.MetricPrefix+"processor.flowsets", 1, "", []string{"exporter_ip:" + exporterIP, "version:" + version, "type:data_flow_set", "flow_protocol:netflow"})
 	}
 }

--- a/comp/netflow/goflowlib/netflowstate/netflow.go
+++ b/comp/netflow/goflowlib/netflowstate/netflow.go
@@ -88,9 +88,9 @@ func (s *StateNetFlow) DecodeFlow(msg interface{}) error {
 	if err != nil {
 		switch err.(type) {
 		case *netflow.ErrorTemplateNotFound:
-			s.sender.Count("datadog.netflow.processor.errors", 1, "", []string{"exporter_ip:" + key, "error:template_not_found"})
+			s.sender.Count(common.MetricPrefix+"processor.errors", 1, "", []string{"exporter_ip:" + key, "error:template_not_found"})
 		default:
-			s.sender.Count("datadog.netflow.processor.errors", 1, "", []string{"exporter_ip:" + key, "error:error_decoding"})
+			s.sender.Count(common.MetricPrefix+"processor.errors", 1, "", []string{"exporter_ip:" + key, "error:error_decoding"})
 		}
 		return err
 	}
@@ -153,12 +153,12 @@ func (s *StateNetFlow) FlowRoutine(workers int, addr string, port int, reuseport
 func (s *StateNetFlow) sendTelemetryMetrics(msg any, exporterIP string) {
 	switch msgDec := msg.(type) {
 	case netflow.NFv9Packet:
-		s.sender.Count("datadog.netflow.processor.processed", 1, "", []string{"exporter_ip:" + exporterIP, "version:9"})
+		s.sender.Count(common.MetricPrefix+"processor.processed", 1, "", []string{"exporter_ip:" + exporterIP, "version:9"})
 		for _, fs := range msgDec.FlowSets {
 			s.sendFlowSetMetrics(fs, exporterIP, "9")
 		}
 	case netflow.IPFIXPacket:
-		s.sender.Count("datadog.netflow.processor.processed", 1, "", []string{"exporter_ip:" + exporterIP, "version:10"})
+		s.sender.Count(common.MetricPrefix+"processor.processed", 1, "", []string{"exporter_ip:" + exporterIP, "version:10"})
 		for _, fs := range msgDec.FlowSets {
 			s.sendFlowSetMetrics(fs, exporterIP, "10")
 		}
@@ -168,12 +168,12 @@ func (s *StateNetFlow) sendTelemetryMetrics(msg any, exporterIP string) {
 func (s *StateNetFlow) sendFlowSetMetrics(fs any, exporterIP string, version string) {
 	switch fs.(type) {
 	case netflow.TemplateFlowSet:
-		s.sender.Count("datadog.netflow.processor.flowsets", 1, "", []string{"exporter_ip:" + exporterIP, "version:" + version, "type:template_flow_set"})
+		s.sender.Count(common.MetricPrefix+"processor.flowsets", 1, "", []string{"exporter_ip:" + exporterIP, "version:" + version, "type:template_flow_set"})
 	case netflow.NFv9OptionsTemplateFlowSet:
-		s.sender.Count("datadog.netflow.processor.flowsets", 1, "", []string{"exporter_ip:" + exporterIP, "version:" + version, "type:options_template_flow_set"})
+		s.sender.Count(common.MetricPrefix+"processor.flowsets", 1, "", []string{"exporter_ip:" + exporterIP, "version:" + version, "type:options_template_flow_set"})
 	case netflow.OptionsDataFlowSet:
-		s.sender.Count("datadog.netflow.processor.flowsets", 1, "", []string{"exporter_ip:" + exporterIP, "version:" + version, "type:options_data_flow_set"})
+		s.sender.Count(common.MetricPrefix+"processor.flowsets", 1, "", []string{"exporter_ip:" + exporterIP, "version:" + version, "type:options_data_flow_set"})
 	case netflow.DataFlowSet:
-		s.sender.Count("datadog.netflow.processor.flowsets", 1, "", []string{"exporter_ip:" + exporterIP, "version:" + version, "type:data_flow_set"})
+		s.sender.Count(common.MetricPrefix+"processor.flowsets", 1, "", []string{"exporter_ip:" + exporterIP, "version:" + version, "type:data_flow_set"})
 	}
 }

--- a/comp/netflow/goflowlib/netflowstate/netflow.go
+++ b/comp/netflow/goflowlib/netflowstate/netflow.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
+// Package netflowstate provides a Netflow state manager
+// on top of goflow default producer, to allow additional fields collection.
 package netflowstate
 
 import (

--- a/comp/netflow/goflowlib/netflowstate/netflow.go
+++ b/comp/netflow/goflowlib/netflowstate/netflow.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
 package netflowstate
 
 import (
@@ -19,6 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// StateNetFlow holds a NetflowV9/IPFIX producer
 type StateNetFlow struct {
 	stopper
 
@@ -39,6 +45,7 @@ type StateNetFlow struct {
 	mappedFieldsConfig map[uint16]config.Mapping
 }
 
+// NewStateNetFlow initializes a new Netflow/IPFIX producer, with the goflow default producer and the additional fields producer
 func NewStateNetFlow(mappingConfs []config.Mapping) *StateNetFlow {
 	return &StateNetFlow{
 		ctx:                context.Background(),
@@ -48,6 +55,7 @@ func NewStateNetFlow(mappingConfs []config.Mapping) *StateNetFlow {
 	}
 }
 
+// DecodeFlow decodes a flow into common.FlowMessageWithAdditionalFields
 func (s *StateNetFlow) DecodeFlow(msg interface{}) error {
 	pkt := msg.(utils.BaseMessage)
 	buf := bytes.NewBuffer(pkt.Payload)
@@ -74,7 +82,7 @@ func (s *StateNetFlow) DecodeFlow(msg interface{}) error {
 	}
 
 	timeTrackStart := time.Now()
-	msgDec, err := netflow.DecodeMessageContext(s.ctx, buf, key, netflow.TemplateWrapper{s.ctx, key, s.TemplateSystem})
+	msgDec, err := netflow.DecodeMessageContext(s.ctx, buf, key, netflow.TemplateWrapper{Ctx: s.ctx, Key: key, Inner: s.TemplateSystem})
 	if err != nil {
 		switch err.(type) {
 		case *netflow.ErrorTemplateNotFound:
@@ -179,6 +187,9 @@ func (s *StateNetFlow) DecodeFlow(msg interface{}) error {
 			}
 		}
 		flowMessageSet, err = producer.ProcessMessageNetFlowConfig(msgDecConv, sampling, s.configMapped)
+		if err != nil {
+			s.Logger.Errorf("failed to process netflow packet %s", err)
+		}
 
 		additionalFields, err = customfields.ProcessMessageNetFlowCustomFields(msgDecConv, s.mappedFieldsConfig)
 		if err != nil {
@@ -289,6 +300,9 @@ func (s *StateNetFlow) DecodeFlow(msg interface{}) error {
 			}
 		}
 		flowMessageSet, err = producer.ProcessMessageNetFlowConfig(msgDecConv, sampling, s.configMapped)
+		if err != nil {
+			s.Logger.Errorf("failed to process netflow packet %s", err)
+		}
 
 		additionalFields, err = customfields.ProcessMessageNetFlowCustomFields(msgDecConv, s.mappedFieldsConfig)
 		if err != nil {
@@ -357,6 +371,7 @@ func mapFieldsConfig(mappingConfs []config.Mapping) map[uint16]config.Mapping {
 	return mappedFieldsConfig
 }
 
+// FlowRoutine starts a goflow flow routine
 func (s *StateNetFlow) FlowRoutine(workers int, addr string, port int, reuseport bool) error {
 	if err := s.start(); err != nil {
 		return err

--- a/comp/netflow/goflowlib/netflowstate/netflow_test.go
+++ b/comp/netflow/goflowlib/netflowstate/netflow_test.go
@@ -1,0 +1,58 @@
+package netflowstate
+
+import (
+	"context"
+	"github.com/DataDog/datadog-agent/comp/netflow/testutil"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/netsampler/goflow2/decoders/netflow/templates"
+	// install the in-memory template manager
+	_ "github.com/netsampler/goflow2/decoders/netflow/templates/memory"
+	"github.com/netsampler/goflow2/utils"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"net"
+	"testing"
+	"time"
+)
+
+type mockedFormatDriver struct{}
+
+func (m *mockedFormatDriver) Format(data interface{}) ([]byte, []byte, error) {
+	return nil, nil, nil
+}
+
+func TestNetflowState_TelemetryMetrics(t *testing.T) {
+	sender := mocksender.NewMockSender("")
+	sender.On("Count", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+
+	logrusLogger := logrus.StandardLogger()
+	ctx := context.Background()
+
+	templateSystem, err := templates.FindTemplateSystem(ctx, "memory")
+	require.NoError(t, err, "error with template")
+	defer templateSystem.Close(ctx)
+
+	state := NewStateNetFlow(nil, sender)
+	state.Format = &mockedFormatDriver{}
+	state.Logger = logrusLogger
+	state.TemplateSystem = templateSystem
+
+	flowData, err := testutil.GetNetFlow9Packet()
+	require.NoError(t, err, "error getting netflow9 packet data")
+
+	flowPacket := utils.BaseMessage{
+		Src:      net.ParseIP("127.0.0.1"),
+		Port:     3000,
+		Payload:  flowData,
+		SetTime:  false,
+		RecvTime: time.Now(),
+	}
+
+	err = state.DecodeFlow(flowPacket)
+	require.NoError(t, err, "error handling flow packet")
+
+	sender.AssertMetric(t, "Count", "datadog.netflow.processor.processed", 1, "", []string{"exporter_ip:127.0.0.1", "version:9", "flow_protocol:netflow"})
+	sender.AssertMetric(t, "Count", "datadog.netflow.processor.flowsets", 1, "", []string{"exporter_ip:127.0.0.1", "type:template_flow_set", "version:9", "flow_protocol:netflow"})
+	sender.AssertMetric(t, "Count", "datadog.netflow.processor.flowsets", 1, "", []string{"exporter_ip:127.0.0.1", "type:data_flow_set", "version:9", "flow_protocol:netflow"})
+}

--- a/comp/netflow/goflowlib/netflowstate/netflow_test.go
+++ b/comp/netflow/goflowlib/netflowstate/netflow_test.go
@@ -18,7 +18,7 @@ import (
 
 type mockedFormatDriver struct{}
 
-func (m *mockedFormatDriver) Format(data interface{}) ([]byte, []byte, error) {
+func (m *mockedFormatDriver) Format(_ interface{}) ([]byte, []byte, error) {
 	return nil, nil, nil
 }
 

--- a/comp/netflow/goflowlib/netflowstate/netflow_test.go
+++ b/comp/netflow/goflowlib/netflowstate/netflow_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
 package netflowstate
 
 import (

--- a/comp/netflow/goflowlib/netflowstate/stopper.go
+++ b/comp/netflow/goflowlib/netflowstate/stopper.go
@@ -1,0 +1,33 @@
+package netflowstate
+
+import (
+	"errors"
+)
+
+// ErrAlreadyStarted error happens when you try to start twice a flow routine
+var ErrAlreadyStarted = errors.New("the routine is already started")
+
+// stopper mechanism, common for all the flow routines
+type stopper struct {
+	stopCh chan struct{}
+}
+
+func (s *stopper) start() error {
+	if s.stopCh != nil {
+		return ErrAlreadyStarted
+	}
+	s.stopCh = make(chan struct{})
+	return nil
+}
+
+func (s *stopper) Shutdown() {
+	if s.stopCh != nil {
+		select {
+		case <-s.stopCh:
+		default:
+			close(s.stopCh)
+		}
+
+		s.stopCh = nil
+	}
+}

--- a/comp/netflow/goflowlib/netflowstate/stopper.go
+++ b/comp/netflow/goflowlib/netflowstate/stopper.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
 package netflowstate
 
 import (

--- a/comp/netflow/payload/payload.go
+++ b/comp/netflow/payload/payload.go
@@ -39,25 +39,29 @@ type ObservationPoint struct {
 	Interface Interface `json:"interface"`
 }
 
+// AdditionalFields contains additional configured fields
+type AdditionalFields = map[string]any
+
 // FlowPayload contains network devices flows
 type FlowPayload struct {
-	FlushTimestamp int64            `json:"flush_timestamp"`
-	FlowType       string           `json:"type"`
-	SamplingRate   uint64           `json:"sampling_rate"`
-	Direction      string           `json:"direction"`
-	Start          uint64           `json:"start"` // in seconds
-	End            uint64           `json:"end"`   // in seconds
-	Bytes          uint64           `json:"bytes"`
-	Packets        uint64           `json:"packets"`
-	EtherType      string           `json:"ether_type,omitempty"`
-	IPProtocol     string           `json:"ip_protocol"`
-	Device         Device           `json:"device"`
-	Exporter       Exporter         `json:"exporter"`
-	Source         Endpoint         `json:"source"`
-	Destination    Endpoint         `json:"destination"`
-	Ingress        ObservationPoint `json:"ingress"`
-	Egress         ObservationPoint `json:"egress"`
-	Host           string           `json:"host"`
-	TCPFlags       []string         `json:"tcp_flags,omitempty"`
-	NextHop        NextHop          `json:"next_hop,omitempty"`
+	FlushTimestamp   int64            `json:"flush_timestamp"`
+	FlowType         string           `json:"type"`
+	SamplingRate     uint64           `json:"sampling_rate"`
+	Direction        string           `json:"direction"`
+	Start            uint64           `json:"start"` // in seconds
+	End              uint64           `json:"end"`   // in seconds
+	Bytes            uint64           `json:"bytes"`
+	Packets          uint64           `json:"packets"`
+	EtherType        string           `json:"ether_type,omitempty"`
+	IPProtocol       string           `json:"ip_protocol"`
+	Device           Device           `json:"device"`
+	Exporter         Exporter         `json:"exporter"`
+	Source           Endpoint         `json:"source"`
+	Destination      Endpoint         `json:"destination"`
+	Ingress          ObservationPoint `json:"ingress"`
+	Egress           ObservationPoint `json:"egress"`
+	Host             string           `json:"host"`
+	TCPFlags         []string         `json:"tcp_flags,omitempty"`
+	NextHop          NextHop          `json:"next_hop,omitempty"`
+	AdditionalFields AdditionalFields `json:"additional_fields,omitempty"`
 }

--- a/comp/netflow/server/integration_test.go
+++ b/comp/netflow/server/integration_test.go
@@ -142,7 +142,7 @@ func TestNetFlow_IntegrationTest_SFlow5(t *testing.T) {
 	assertFlowEventsCount(t, port, srv, packetData, 7)
 }
 
-func TestNetFlow_IntegrationTest_CustomFields(t *testing.T) {
+func TestNetFlow_IntegrationTest_AdditionalFields(t *testing.T) {
 	port, err := ndmtestutils.GetFreePort()
 	require.NoError(t, err)
 	var epForwarder forwarder.MockComponent
@@ -184,13 +184,13 @@ func TestNetFlow_IntegrationTest_CustomFields(t *testing.T) {
 	require.NoError(t, err, "error getting packet")
 
 	// Set expectations
-	testutil.ExpectPayloadWithCustomFields(t, epForwarder)
+	testutil.ExpectPayloadWithAdditionalFields(t, epForwarder)
 	epForwarder.EXPECT().SendEventPlatformEventBlocking(gomock.Any(), "network-devices-metadata").Return(nil).Times(1)
 
 	assertFlowEventsCount(t, port, srv, flowData, 29)
 }
 
-func BenchmarkNetflowCustomFields(b *testing.B) {
+func BenchmarkNetflowAdditionalFields(b *testing.B) {
 	flowChan := make(chan *common.Flow, 10)
 	listenerFlowCount := atomic.NewInt64(0)
 

--- a/comp/netflow/server/integration_test.go
+++ b/comp/netflow/server/integration_test.go
@@ -8,6 +8,14 @@
 package server
 
 import (
+	"context"
+	"github.com/DataDog/datadog-agent/comp/netflow/goflowlib"
+	"github.com/DataDog/datadog-agent/comp/netflow/goflowlib/netflowstate"
+	"github.com/netsampler/goflow2/decoders/netflow/templates"
+	"github.com/netsampler/goflow2/utils"
+	"github.com/sirupsen/logrus"
+	"go.uber.org/atomic"
+	"net"
 	"testing"
 	"time"
 
@@ -132,4 +140,138 @@ func TestNetFlow_IntegrationTest_SFlow5(t *testing.T) {
 	require.NoError(t, err, "error getting sflow data")
 
 	assertFlowEventsCount(t, port, srv, packetData, 7)
+}
+
+func TestNetFlow_IntegrationTest_CustomFields(t *testing.T) {
+	port, err := ndmtestutils.GetFreePort()
+	require.NoError(t, err)
+	var epForwarder forwarder.MockComponent
+	srv := fxutil.Test[Component](t, fx.Options(
+		testOptions,
+		fx.Populate(&epForwarder),
+		fx.Replace(
+			&nfconfig.NetflowConfig{
+				Enabled:                 true,
+				AggregatorFlushInterval: 1,
+				Listeners: []nfconfig.ListenerConfig{{
+					FlowType: common.TypeNetFlow9,
+					BindHost: "127.0.0.1",
+					Port:     port,
+					Mapping: []nfconfig.Mapping{
+						{
+							Field:       11,
+							Destination: "source.port", // Inverting source and destination port to test
+							Type:        common.Varint,
+						},
+						{
+							Field:       7,
+							Destination: "destination.port",
+							Type:        common.Varint,
+						},
+						{
+							Field:       32,
+							Destination: "icmp_type",
+							Type:        common.Bytes,
+						},
+					},
+				}},
+			},
+		),
+		setTimeNow,
+	)).(*Server)
+
+	flowData, err := testutil.GetNetFlow9Packet()
+	require.NoError(t, err, "error getting packet")
+
+	// Set expectations
+	testutil.ExpectPayloadWithCustomFields(t, epForwarder)
+	epForwarder.EXPECT().SendEventPlatformEventBlocking(gomock.Any(), "network-devices-metadata").Return(nil).Times(1)
+
+	assertFlowEventsCount(t, port, srv, flowData, 29)
+}
+
+func BenchmarkNetflowCustomFields(b *testing.B) {
+	flowChan := make(chan *common.Flow, 10)
+	listenerFlowCount := atomic.NewInt64(0)
+
+	go func() {
+		for {
+			// Consume chan while benchmarking
+			<-flowChan
+		}
+	}()
+
+	formatDriver := goflowlib.NewAggregatorFormatDriver(flowChan, "bench", listenerFlowCount)
+	logrusLogger := logrus.StandardLogger()
+	ctx := context.Background()
+
+	templateSystem, err := templates.FindTemplateSystem(ctx, "memory")
+	if err != nil {
+		require.NoError(b, err, "error with template")
+	}
+	defer templateSystem.Close(ctx)
+
+	goflowState := utils.NewStateNetFlow()
+	goflowState.Format = formatDriver
+	goflowState.Logger = logrusLogger
+	goflowState.TemplateSystem = templateSystem
+
+	customStateWithoutFields := netflowstate.NewStateNetFlow(nil)
+	customStateWithoutFields.Format = formatDriver
+	customStateWithoutFields.Logger = logrusLogger
+	customStateWithoutFields.TemplateSystem = templateSystem
+
+	customState := netflowstate.NewStateNetFlow([]nfconfig.Mapping{
+		{
+			Field:       11,
+			Destination: "source.port",
+			Type:        common.Varint,
+		},
+		{
+			Field:       7,
+			Destination: "destination.port",
+			Type:        common.Varint,
+		},
+		{
+			Field:       32,
+			Destination: "icmp_type",
+			Type:        common.Bytes,
+		},
+	})
+
+	customState.Format = formatDriver
+	customState.Logger = logrusLogger
+	customState.TemplateSystem = templateSystem
+
+	flowData, err := testutil.GetNetFlow9Packet()
+	require.NoError(b, err, "error getting cflow flow data")
+
+	flowPacket := utils.BaseMessage{
+		Src:      net.ParseIP("127.0.0.1"),
+		Port:     3000,
+		Payload:  flowData,
+		SetTime:  false,
+		RecvTime: time.Now(),
+	}
+
+	b.Run("goflow2 default", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			err = goflowState.DecodeFlow(flowPacket)
+			require.NoError(b, err, "error processing packet")
+		}
+	})
+
+	b.Run("goflow2 netflow custom state without custom fields", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			err = customStateWithoutFields.DecodeFlow(flowPacket)
+			require.NoError(b, err, "error processing packet")
+		}
+	})
+
+	b.Run("goflow2 netflow custom state with custom fields", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			err = customState.DecodeFlow(flowPacket)
+			require.NoError(b, err, "error processing packet")
+		}
+	})
 }

--- a/comp/netflow/server/integration_test.go
+++ b/comp/netflow/server/integration_test.go
@@ -244,7 +244,7 @@ func BenchmarkNetflowAdditionalFields(b *testing.B) {
 	customState.TemplateSystem = templateSystem
 
 	flowData, err := testutil.GetNetFlow9Packet()
-	require.NoError(b, err, "error getting cflow flow data")
+	require.NoError(b, err, "error getting netflow9 packet data")
 
 	flowPacket := utils.BaseMessage{
 		Src:      net.ParseIP("127.0.0.1"),

--- a/comp/netflow/server/listener.go
+++ b/comp/netflow/server/listener.go
@@ -13,6 +13,8 @@ import (
 	"go.uber.org/atomic"
 )
 
+// netflowListener contains state of goflow listener and the related netflow config
+// flowState can be of type *utils.StateNetFlow/StateSFlow/StateNFLegacy
 type netflowListener struct {
 	flowState *goflowlib.FlowStateWrapper
 	config    config.ListenerConfig
@@ -30,6 +32,7 @@ func startFlowListener(listenerConfig config.ListenerConfig, flowAgg *flowaggreg
 		listenerConfig.Port,
 		listenerConfig.Workers,
 		listenerConfig.Namespace,
+		listenerConfig.Mapping,
 		flowAgg.GetFlowInChan(),
 		logger,
 		listenerAtomicErr,

--- a/comp/netflow/server/listener.go
+++ b/comp/netflow/server/listener.go
@@ -10,6 +10,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/netflow/config"
 	"github.com/DataDog/datadog-agent/comp/netflow/flowaggregator"
 	"github.com/DataDog/datadog-agent/comp/netflow/goflowlib"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"go.uber.org/atomic"
 )
 
@@ -22,7 +23,7 @@ type netflowListener struct {
 	flowCount *atomic.Int64
 }
 
-func startFlowListener(listenerConfig config.ListenerConfig, flowAgg *flowaggregator.FlowAggregator, logger log.Component) (*netflowListener, error) {
+func startFlowListener(listenerConfig config.ListenerConfig, flowAgg *flowaggregator.FlowAggregator, logger log.Component, sender sender.Sender) (*netflowListener, error) {
 	listenerAtomicErr := atomic.NewString("")
 	listenerFlowCount := atomic.NewInt64(0)
 
@@ -35,6 +36,7 @@ func startFlowListener(listenerConfig config.ListenerConfig, flowAgg *flowaggreg
 		listenerConfig.Mapping,
 		flowAgg.GetFlowInChan(),
 		logger,
+		sender,
 		listenerAtomicErr,
 		listenerFlowCount)
 

--- a/comp/netflow/testutil/testutil.go
+++ b/comp/netflow/testutil/testutil.go
@@ -168,51 +168,49 @@ func ExpectPayloadWithCustomFields(t *testing.T, mockEpForwarder forwarder.MockC
 	events := [][]byte{
 		[]byte(`
 {
-  "flush_timestamp": 1550505606000,
-  "type": "netflow9",
-  "sampling_rate": 0,
-  "direction": "ingress",
-  "start": 1675736722,
-  "end": 1675258375,
-  "bytes": 1139872000,
-  "packets": 35006208,
-  "ether_type": "IPv4",
-  "ip_protocol": "WB-MON",
+  "bytes": 114702,
+  "destination": {
+    "ip": "53.0.97.192",
+    "port": "5915",
+    "mac": "00:00:00:00:00:00",
+    "mask": "0.0.0.0/0"
+  },
   "device": {
     "namespace": "default"
   },
+  "direction": "ingress",
+  "egress": {
+    "interface": {
+      "index": 4352
+    }
+  },
+  "end": 1675541179,
+  "ether_type": "IPv4",
   "exporter": {
     "ip": "127.0.0.1"
   },
-  "source": {
-    "ip": "1.76.41.19",
-    "port": "35824",
-    "mac": "00:00:00:00:00:00",
-    "mask": "0.0.0.0/0"
-  },
-  "destination": {
-    "ip": "31.27.0.0",
-    "port": "78",
-    "mac": "00:00:00:00:00:00",
-    "mask": "0.0.0.0/0"
-  },
+  "flush_timestamp": 1550505606000,
+  "host": "my-hostname",
+  "icmp_type": "1200",
   "ingress": {
     "interface": {
-      "index": 13568
+      "index": 27505
     }
   },
-  "egress": {
-    "interface": {
-      "index": 48576
-    }
-  },
-  "host": "my-hostname",
+  "ip_protocol": "ICMP",
   "next_hop": {
     "ip": ""
   },
-  "additional_fields": {
-    "icmp_type": "0000"
-  }
+  "packets": 840155153,
+  "sampling_rate": 0,
+  "source": {
+    "ip": "2.10.65.0",
+    "port": "0",
+    "mac": "00:00:00:00:00:00",
+    "mask": "0.0.0.0/0"
+  },
+  "start": 1675307019,
+  "type": "netflow9"
 }
 `),
 	}

--- a/comp/netflow/testutil/testutil.go
+++ b/comp/netflow/testutil/testutil.go
@@ -162,9 +162,9 @@ func ExpectNetflow5Payloads(t *testing.T, mockEpForwarder forwarder.MockComponen
 	}
 }
 
-// ExpectPayloadWithCustomFields expects the payloads that should result from our
+// ExpectPayloadWithAdditionalFields expects the payloads that should result from our
 // recorded Netflow9 pcap file with inverted source and destination ports and icmp_type custom field.
-func ExpectPayloadWithCustomFields(t *testing.T, mockEpForwarder forwarder.MockComponent) {
+func ExpectPayloadWithAdditionalFields(t *testing.T, mockEpForwarder forwarder.MockComponent) {
 	events := [][]byte{
 		[]byte(`
 {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR cleans up Netflow V9 / IPFIX state code.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Before this change :
```
BenchmarkNetflowAdditionalFields/goflow2_default
BenchmarkNetflowAdditionalFields/goflow2_default-10         	   30405	     39570 ns/op
BenchmarkNetflowAdditionalFields/goflow2_netflow_custom_state_without_custom_fields
BenchmarkNetflowAdditionalFields/goflow2_netflow_custom_state_without_custom_fields-10         	   29553	     40791 ns/op
BenchmarkNetflowAdditionalFields/goflow2_netflow_custom_state_with_custom_fields
BenchmarkNetflowAdditionalFields/goflow2_netflow_custom_state_with_custom_fields-10            	   21940	     54895 ns/op
```

After :
```
BenchmarkNetflowAdditionalFields/goflow2_default
BenchmarkNetflowAdditionalFields/goflow2_default-10         	   29782	     40976 ns/op
BenchmarkNetflowAdditionalFields/goflow2_netflow_custom_state_without_custom_fields
BenchmarkNetflowAdditionalFields/goflow2_netflow_custom_state_without_custom_fields-10         	   32721	     37218 ns/op
BenchmarkNetflowAdditionalFields/goflow2_netflow_custom_state_with_custom_fields
BenchmarkNetflowAdditionalFields/goflow2_netflow_custom_state_with_custom_fields-10            	   22956	     52122 ns/op
```


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
