### PR TITLE
[CWS] fix rule engine/policy monitor data race

### DIFF
--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -201,7 +201,7 @@ func (e *RuleEngine) Start(ctx context.Context, reloadChan <-chan struct{}, wg *
 			case <-ctx.Done():
 				return
 			case <-heartbeatTicker.C:
-				ReportHeartbeatEvent(e.eventSender, e.policyMonitor.policies)
+				e.policyMonitor.ReportHeartbeatEvent(e.eventSender)
 			}
 		}
 	}()

--- a/pkg/security/rules/policy_monitor.go
+++ b/pkg/security/rules/policy_monitor.go
@@ -78,10 +78,11 @@ func (p *PolicyMonitor) SetPolicies(policies []*rules.Policy, mErrs *multierror.
 // ReportHeartbeatEvent sends HeartbeatEvents reporting the current set of policies
 func (p *PolicyMonitor) ReportHeartbeatEvent(sender events.EventSender) {
 	log.Infof("send heartbeat")
-	p.RLock()
-	defer p.RUnlock()
 
+	p.RLock()
 	rule, events := NewHeartbeatEvents(p.policies)
+	p.RUnlock()
+
 	for _, event := range events {
 		sender.SendEvent(rule, event, nil, "")
 	}

--- a/pkg/security/rules/policy_monitor.go
+++ b/pkg/security/rules/policy_monitor.go
@@ -75,6 +75,18 @@ func (p *PolicyMonitor) SetPolicies(policies []*rules.Policy, mErrs *multierror.
 	}
 }
 
+// ReportHeartbeatEvent sends HeartbeatEvents reporting the current set of policies
+func (p *PolicyMonitor) ReportHeartbeatEvent(sender events.EventSender) {
+	log.Infof("send heartbeat")
+	p.RLock()
+	defer p.RUnlock()
+
+	rule, events := NewHeartbeatEvents(p.policies)
+	for _, event := range events {
+		sender.SendEvent(rule, event, nil, "")
+	}
+}
+
 // Start the monitor
 func (p *PolicyMonitor) Start(ctx context.Context) {
 	go func() {
@@ -145,16 +157,6 @@ func ReportRuleSetLoaded(sender events.EventSender, statsdClient statsd.ClientIn
 	}
 
 	sender.SendEvent(rule, event, nil, "")
-}
-
-// ReportHeartbeatEvent periodically reports to Datadog that
-func ReportHeartbeatEvent(sender events.EventSender, policies map[string]Policy) {
-	log.Infof("send heartbeat")
-
-	rule, events := NewHeartbeatEvents(policies)
-	for _, event := range events {
-		sender.SendEvent(rule, event, nil, "")
-	}
 }
 
 // RuleState defines a loaded rule


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR fixes a data race in on the policy monitor's policies map.
The race triggers when the rule engine `LoadPolicies()` function calls the policy monitor's `SetPolicies()` and the heartbeat goroutine reads the policies map without holding the appropriate lock.


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
