### PR TITLE
Use XZ compressed images in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -169,7 +169,7 @@ variables:
   # To use images from test-infra-definitions dev branches, set the SUFFIX variable to -dev
   # and check the job creating the image to make sure you have the right SHA prefix
   TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX: ""
-  TEST_INFRA_DEFINITIONS_BUILDIMAGES: d08836e5ac08
+  TEST_INFRA_DEFINITIONS_BUILDIMAGES: 8158a5b2c60e
   DATADOG_AGENT_BUILDERS: v22276738-b36b132
 
   DATADOG_AGENT_EMBEDDED_PATH: /opt/datadog-agent/embedded

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.48.1
 	github.com/DataDog/datadog-api-client-go v1.16.0
 	github.com/DataDog/datadog-api-client-go/v2 v2.15.0
+	github.com/DataDog/test-infra-definitions v0.0.0-20231027103941-793f85ac8e4d
 	github.com/docker/cli v24.0.6+incompatible
 	github.com/docker/docker v24.0.6+incompatible
 	github.com/google/uuid v1.3.1

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.48.1
 	github.com/DataDog/datadog-api-client-go v1.16.0
 	github.com/DataDog/datadog-api-client-go/v2 v2.15.0
-	github.com/DataDog/test-infra-definitions v0.0.0-20231027103941-793f85ac8e4d
+	github.com/DataDog/test-infra-definitions v0.0.0-20231027164033-8158a5b2c60e
 	github.com/docker/cli v24.0.6+incompatible
 	github.com/docker/docker v24.0.6+incompatible
 	github.com/google/uuid v1.3.1

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -15,7 +15,6 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20231024173211-d08836e5ac08
 	github.com/aws/aws-sdk-go-v2 v1.21.2
 	github.com/aws/aws-sdk-go-v2/config v1.18.40
 	github.com/aws/aws-sdk-go-v2/service/eks v1.29.7

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -14,8 +14,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.15.0 h1:5UVON1xs6Lul4d6R5TmLDqqSJ
 github.com/DataDog/datadog-api-client-go/v2 v2.15.0/go.mod h1:ZG8wS+y2rUmkRDJZQq7Og7EAPFPage+7vXcmuah2I9o=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20231027103941-793f85ac8e4d h1:Sf+BUJuQl9SDL7cNUjut3JgAr/jpPfcKkYHw88Q1pZk=
-github.com/DataDog/test-infra-definitions v0.0.0-20231027103941-793f85ac8e4d/go.mod h1:PqwpYO1dh26TxKAY1TiiMLmmSxzytx3OrXtYl086m2c=
+github.com/DataDog/test-infra-definitions v0.0.0-20231027164033-8158a5b2c60e h1:BtKaW1sKpfvEHo6qdYPZ+kb28QC6YDlZS7ISGAmi4GQ=
+github.com/DataDog/test-infra-definitions v0.0.0-20231027164033-8158a5b2c60e/go.mod h1:PqwpYO1dh26TxKAY1TiiMLmmSxzytx3OrXtYl086m2c=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -14,8 +14,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.15.0 h1:5UVON1xs6Lul4d6R5TmLDqqSJ
 github.com/DataDog/datadog-api-client-go/v2 v2.15.0/go.mod h1:ZG8wS+y2rUmkRDJZQq7Og7EAPFPage+7vXcmuah2I9o=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20231024173211-d08836e5ac08 h1:lY0uURrW2QGpmzBimXTJckGxvlW7PqXY9ShTL58BqcM=
-github.com/DataDog/test-infra-definitions v0.0.0-20231024173211-d08836e5ac08/go.mod h1:PqwpYO1dh26TxKAY1TiiMLmmSxzytx3OrXtYl086m2c=
+github.com/DataDog/test-infra-definitions v0.0.0-20231027103941-793f85ac8e4d h1:Sf+BUJuQl9SDL7cNUjut3JgAr/jpPfcKkYHw88Q1pZk=
+github.com/DataDog/test-infra-definitions v0.0.0-20231027103941-793f85ac8e4d/go.mod h1:PqwpYO1dh26TxKAY1TiiMLmmSxzytx3OrXtYl086m2c=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/system-probe/config/vmconfig.json
+++ b/test/new-e2e/system-probe/config/vmconfig.json
@@ -9,52 +9,52 @@
                 {
                     "dir": "bionic-server-cloudimg-amd64.qcow2",
                     "tag": "ubuntu_18.04",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bionic-server-cloudimg-amd64.qcow2"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bionic-server-cloudimg-amd64.qcow2.xz-test-only"
                 },
                 {
                     "dir": "focal-server-cloudimg-amd64.qcow2",
                     "tag": "ubuntu_20.04",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/focal-server-cloudimg-amd64.qcow2"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/focal-server-cloudimg-amd64.qcow2.xz-test-only"
                 },
                 {
                     "dir": "jammy-server-cloudimg-amd64.qcow2",
                     "tag": "ubuntu_22.04",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/jammy-server-cloudimg-amd64.qcow2"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/jammy-server-cloudimg-amd64.qcow2.xz-test-only"
                 },
                 {
                     "dir": "amzn2-kvm-2.0-amd64-4.14.qcow2",
                     "tag": "amzn_4.14",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-amd64-4.14.qcow2"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-amd64-4.14.qcow2.xz-test-only"
                 },
                 {
                     "dir": "amzn2-kvm-2.0-amd64-5.4.qcow2",
                     "tag": "amzn_5.4",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-amd64-5.4.qcow2"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-amd64-5.4.qcow2.xz-test-only"
                 },
                 {
                     "dir": "amzn2-kvm-2.0-amd64-5.10.qcow2",
                     "tag": "amzn_5.10",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-amd64-5.10.qcow2"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-amd64-5.10.qcow2.xz-test-only"
                 },
                 {
                     "dir": "Fedora-Cloud-Base-37.amd64.qcow2",
                     "tag": "fedora_37",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-37.amd64.qcow2"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-37.amd64.qcow2.xz-test-only"
                 },
                 {
                     "dir": "Fedora-Cloud-Base-38.amd64.qcow2",
                     "tag": "fedora_38",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-38.amd64.qcow2"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-38.amd64.qcow2.xz-test-only"
                 },
                 {
                     "dir": "debian-10-generic-amd64.qcow2",
                     "tag": "debian_10",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/debian-10-generic-amd64.qcow2"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/debian-10-generic-amd64.qcow2.xz-test-only"
                 },
                 {
                     "dir": "debian-11-generic-amd64.qcow2",
                     "tag": "debian_11",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/debian-11-generic-amd64.qcow2"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/debian-11-generic-amd64.qcow2.xz-test-only"
                 }
             ],
             "vcpu": [
@@ -81,37 +81,37 @@
                 {
                     "dir": "focal-server-cloudimg-arm64.qcow2",
                     "tag": "ubuntu_20.04",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/focal-server-cloudimg-arm64.qcow2"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/focal-server-cloudimg-arm64.qcow2.xz-test-only"
                 },
                 {
                     "dir": "jammy-server-cloudimg-arm64.qcow2",
                     "tag": "ubuntu_22.04",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/jammy-server-cloudimg-arm64.qcow2"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/jammy-server-cloudimg-arm64.qcow2.xz-test-only"
                 },
                 {
                     "dir": "amzn2-kvm-2.0-arm64-4.14.qcow2",
                     "tag": "amzn_4.14",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-arm64-4.14.qcow2"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-arm64-4.14.qcow2.xz-test-only"
                 },
                 {
                     "dir": "amzn2-kvm-2.0-arm64-5.4.qcow2",
                     "tag": "amzn_5.4",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-arm64-5.4.qcow2"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-arm64-5.4.qcow2.xz-test-only"
                 },
                 {
                     "dir": "amzn2-kvm-2.0-arm64-5.10.qcow2",
                     "tag": "amzn_5.10",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-arm64-5.10.qcow2"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-arm64-5.10.qcow2.xz-test-only"
                 },
                 {
                     "dir": "Fedora-Cloud-Base-37.arm64.qcow2",
                     "tag": "fedora_37",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-37.arm64.qcow2"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-37.arm64.qcow2.xz-test-only"
                 },
                 {
                     "dir": "Fedora-Cloud-Base-38.arm64.qcow2",
                     "tag": "fedora_38",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-38.arm64.qcow2"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-38.arm64.qcow2.xz-test-only"
                 }
             ],
             "machine": "virt",

--- a/test/new-e2e/system-probe/config/vmconfig.json
+++ b/test/new-e2e/system-probe/config/vmconfig.json
@@ -9,52 +9,52 @@
                 {
                     "dir": "bionic-server-cloudimg-amd64.qcow2",
                     "tag": "ubuntu_18.04",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bionic-server-cloudimg-amd64.qcow2.xz-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bionic-server-cloudimg-amd64.qcow2.xz"
                 },
                 {
                     "dir": "focal-server-cloudimg-amd64.qcow2",
                     "tag": "ubuntu_20.04",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/focal-server-cloudimg-amd64.qcow2.xz-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/focal-server-cloudimg-amd64.qcow2.xz"
                 },
                 {
                     "dir": "jammy-server-cloudimg-amd64.qcow2",
                     "tag": "ubuntu_22.04",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/jammy-server-cloudimg-amd64.qcow2.xz-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/jammy-server-cloudimg-amd64.qcow2.xz"
                 },
                 {
                     "dir": "amzn2-kvm-2.0-amd64-4.14.qcow2",
                     "tag": "amzn_4.14",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-amd64-4.14.qcow2.xz-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-amd64-4.14.qcow2.xz"
                 },
                 {
                     "dir": "amzn2-kvm-2.0-amd64-5.4.qcow2",
                     "tag": "amzn_5.4",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-amd64-5.4.qcow2.xz-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-amd64-5.4.qcow2.xz"
                 },
                 {
                     "dir": "amzn2-kvm-2.0-amd64-5.10.qcow2",
                     "tag": "amzn_5.10",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-amd64-5.10.qcow2.xz-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-amd64-5.10.qcow2.xz"
                 },
                 {
                     "dir": "Fedora-Cloud-Base-37.amd64.qcow2",
                     "tag": "fedora_37",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-37.amd64.qcow2.xz-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-37.amd64.qcow2.xz"
                 },
                 {
                     "dir": "Fedora-Cloud-Base-38.amd64.qcow2",
                     "tag": "fedora_38",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-38.amd64.qcow2.xz-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-38.amd64.qcow2.xz"
                 },
                 {
                     "dir": "debian-10-generic-amd64.qcow2",
                     "tag": "debian_10",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/debian-10-generic-amd64.qcow2.xz-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/debian-10-generic-amd64.qcow2.xz"
                 },
                 {
                     "dir": "debian-11-generic-amd64.qcow2",
                     "tag": "debian_11",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/debian-11-generic-amd64.qcow2.xz-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/debian-11-generic-amd64.qcow2.xz"
                 }
             ],
             "vcpu": [
@@ -81,37 +81,37 @@
                 {
                     "dir": "focal-server-cloudimg-arm64.qcow2",
                     "tag": "ubuntu_20.04",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/focal-server-cloudimg-arm64.qcow2.xz-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/focal-server-cloudimg-arm64.qcow2.xz"
                 },
                 {
                     "dir": "jammy-server-cloudimg-arm64.qcow2",
                     "tag": "ubuntu_22.04",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/jammy-server-cloudimg-arm64.qcow2.xz-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/jammy-server-cloudimg-arm64.qcow2.xz"
                 },
                 {
                     "dir": "amzn2-kvm-2.0-arm64-4.14.qcow2",
                     "tag": "amzn_4.14",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-arm64-4.14.qcow2.xz-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-arm64-4.14.qcow2.xz"
                 },
                 {
                     "dir": "amzn2-kvm-2.0-arm64-5.4.qcow2",
                     "tag": "amzn_5.4",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-arm64-5.4.qcow2.xz-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-arm64-5.4.qcow2.xz"
                 },
                 {
                     "dir": "amzn2-kvm-2.0-arm64-5.10.qcow2",
                     "tag": "amzn_5.10",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-arm64-5.10.qcow2.xz-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-arm64-5.10.qcow2.xz"
                 },
                 {
                     "dir": "Fedora-Cloud-Base-37.arm64.qcow2",
                     "tag": "fedora_37",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-37.arm64.qcow2.xz-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-37.arm64.qcow2.xz"
                 },
                 {
                     "dir": "Fedora-Cloud-Base-38.arm64.qcow2",
                     "tag": "fedora_38",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-38.arm64.qcow2.xz-test-only"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-38.arm64.qcow2.xz"
                 }
             ],
             "machine": "virt",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Use xz compressed VM images in CI.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
The `test-only` suffix will be removed once the associated [PR](https://github.com/DataDog/ami-builder/pull/122) in ami-builder is merged.
The test-infra-definitions buildimage will be updated once the associated [PR](https://github.com/DataDog/test-infra-definitions/pull/415) is merged.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
