### PR TITLE
[oracle] Add resource manager monitoring (DBMON-2959)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -89,6 +89,10 @@ type CustomQuery struct {
 	Tags         []string             `yaml:"tags"`
 }
 
+type resourceManagerConfig struct {
+	Enabled bool `yaml:"enabled"`
+}
+
 // InstanceConfig is used to deserialize integration instance config.
 type InstanceConfig struct {
 	Server                             string                 `yaml:"server"`
@@ -119,6 +123,7 @@ type InstanceConfig struct {
 	CustomQueries                      []CustomQuery          `yaml:"custom_queries"`
 	MetricCollectionInterval           int64                  `yaml:"metric_collection_interval"`
 	DatabaseInstanceCollectionInterval uint64                 `yaml:"database_instance_collection_interval"`
+	ResourceManager                    resourceManagerConfig  `yaml:"resource_manager"`
 }
 
 // CheckConfig holds the config needed for an integration instance to run.
@@ -166,6 +171,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	instance.ProcessMemory.Enabled = true
 	instance.SharedMemory.Enabled = true
 	instance.InactiveSessions.Enabled = true
+	instance.ResourceManager.Enabled = true
 
 	instance.UseGlobalCustomQueries = "true"
 

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -224,6 +224,14 @@ func (c *Check) Run() error {
 				}
 			}
 		}
+		if metricIntervalExpired {
+			if c.config.ResourceManager.Enabled {
+				err := c.resourceManager()
+				if err != nil {
+					return fmt.Errorf("%s %w", c.logPrompt, err)
+				}
+			}
+		}
 	}
 
 	if c.config.AgentSQLTrace.Enabled {

--- a/pkg/collector/corechecks/oracle-dbm/resource_manager.go
+++ b/pkg/collector/corechecks/oracle-dbm/resource_manager.go
@@ -22,8 +22,8 @@ type resourceManagerRow struct {
 	PdbName           sql.NullString `db:"NAME"`
 	ConsumerGroupName string         `db:"CONSUMER_GROUP_NAME"`
 	PlanName          string         `db:"PLAN_NAME"`
-	CpuConsumedTime   float64        `db:"CPU_CONSUMED_TIME"`
-	CpuWaitTime       float64        `db:"CPU_WAIT_TIME"`
+	CPUConsumedTime   float64        `db:"CPU_CONSUMED_TIME"`
+	CPUWaitTime       float64        `db:"CPU_WAIT_TIME"`
 }
 
 func (c *Check) resourceManager() error {
@@ -40,8 +40,8 @@ func (c *Check) resourceManager() error {
 		tags := appendPDBTag(c.tags, r.PdbName)
 		tags = append(tags, "consumer_group_name:"+r.ConsumerGroupName)
 		tags = append(tags, "plan_name:"+r.ConsumerGroupName)
-		sender.Gauge(fmt.Sprintf("%s.resource_manager.cpu_consumed_time", common.IntegrationName), r.CpuConsumedTime, "", tags)
-		sender.Gauge(fmt.Sprintf("%s.resource_manager.cpu_wait_time", common.IntegrationName), r.CpuWaitTime, "", tags)
+		sender.Gauge(fmt.Sprintf("%s.resource_manager.cpu_consumed_time", common.IntegrationName), r.CPUConsumedTime, "", tags)
+		sender.Gauge(fmt.Sprintf("%s.resource_manager.cpu_wait_time", common.IntegrationName), r.CPUWaitTime, "", tags)
 	}
 	sender.Commit()
 	return nil

--- a/pkg/collector/corechecks/oracle-dbm/resource_manager.go
+++ b/pkg/collector/corechecks/oracle-dbm/resource_manager.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle
+
+package oracle
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/common"
+)
+
+const resourceManagerQuery = `SELECT c.name name, consumer_group_name, plan_name, cpu_consumed_time, cpu_wait_time 
+FROM v$rsrcmgrmetric r, v$containers c
+WHERE c.con_id(+) = r.con_id`
+
+type resourceManagerRow struct {
+	PdbName           sql.NullString `db:"NAME"`
+	ConsumerGroupName string         `db:"CONSUMER_GROUP_NAME"`
+	PlanName          string         `db:"PLAN_NAME"`
+	CpuConsumedTime   float64        `db:"CPU_CONSUMED_TIME"`
+	CpuWaitTime       float64        `db:"CPU_WAIT_TIME"`
+}
+
+func (c *Check) resourceManager() error {
+	rows := []resourceManagerRow{}
+	err := selectWrapper(c, &rows, resourceManagerQuery)
+	if err != nil {
+		return fmt.Errorf("failed to collect resource manager statistics: %w", err)
+	}
+	sender, err := c.GetSender()
+	if err != nil {
+		return fmt.Errorf("failed to initialize sender: %w", err)
+	}
+	for _, r := range rows {
+		tags := appendPDBTag(c.tags, r.PdbName)
+		tags = append(tags, "consumer_group_name:"+r.ConsumerGroupName)
+		tags = append(tags, "plan_name:"+r.ConsumerGroupName)
+		sender.Gauge(fmt.Sprintf("%s.resource_manager.cpu_consumed_time", common.IntegrationName), r.CpuConsumedTime, "", tags)
+		sender.Gauge(fmt.Sprintf("%s.resource_manager.cpu_wait_time", common.IntegrationName), r.CpuWaitTime, "", tags)
+	}
+	sender.Commit()
+	return nil
+}

--- a/releasenotes/notes/oracle-resource-manager-e8e204fd8516aa1e.yaml
+++ b/releasenotes/notes/oracle-resource-manager-e8e204fd8516aa1e.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add metrics for monitoring Oracle resource manager.


### PR DESCRIPTION
### What does this PR do?

Adding resource manager monitoring to Oracle.

### Motivation

It was requested by Bosch.

### Describe how to test/QA your changes

Check if `oracle.resource_manager*` metrics are being transmitted

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
