### PR TITLE
[oracle] Bug fix for RDS non-multitenant (DBMON-3071)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/init.go
+++ b/pkg/collector/corechecks/oracle-dbm/init.go
@@ -100,8 +100,7 @@ func (c *Check) init() error {
 	// determine hosting type
 	ht := selfManaged
 
-	if isMultitenant {
-		// is RDS?
+	if isDbVersionGreaterOrEqualThan(c, "19") {
 		if ht == selfManaged {
 			// Is RDS?
 			if c.filePath == "" {
@@ -117,7 +116,7 @@ func (c *Check) init() error {
 		}
 
 		// is OCI?
-		if ht == selfManaged {
+		if ht == selfManaged && isMultitenant {
 			var cloudRows int
 			if c.connectedToPdb {
 				err = getWrapper(c, &cloudRows, "select 1 from v$pdbs where cloud_identity like '%oraclecloud%' and rownum = 1")

--- a/releasenotes/notes/oracle-rds-non-cdb-e989b38c310f8efa.yaml
+++ b/releasenotes/notes/oracle-rds-non-cdb-e989b38c310f8efa.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix the bug that prevented Oracle DBM working properly on AWS RDS non-multitenant instances.


### PR DESCRIPTION
### What does this PR do?

Bug fix for check failing on RDS non-multitenant instances.

### Describe how to test/QA your changes

Configure the agent for an RDS non-multitenant instance and check for `ORA-` messages in `agent.log` and metrics in frontend.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
