### PR TITLE
Fix flakey test - TestDnsStats

### DIFF
--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1072,7 +1072,6 @@ func (s *TracerSuite) TestDNSStats() {
 	t := s.T()
 	cfg := testConfig()
 	cfg.CollectDNSStats = true
-	cfg.DNSTimeout = 5 * time.Second
 	tr := setupTracer(t, cfg)
 	t.Run("valid domain", func(t *testing.T) {
 		testDNSStats(t, tr, "golang.org", 1, 0, 0, validDNSServer)
@@ -1086,7 +1085,7 @@ func (s *TracerSuite) TestDNSStatsWithTimeout() {
 	t := s.T()
 	cfg := testConfig()
 	cfg.CollectDNSStats = true
-	cfg.DNSTimeout = 1 * time.Second
+	cfg.DNSTimeout = 250 * time.Millisecond
 	tr := setupTracer(t, cfg)
 	t.Run("timeout", func(t *testing.T) {
 		testDNSStats(t, tr, "golang.org", 0, 0, 1, "1.2.3.4")

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1017,17 +1017,15 @@ func testDNSStats(t *testing.T, tr *Tracer, domain string, success, failure, tim
 	queryMsg.RecursionDesired = true
 
 	dnsClient := new(dns.Client)
-	dnsConn, err := dnsClient.Dial(dnsServerAddr.String())
-	require.NoError(t, err)
-	defer dnsConn.Close()
-	dnsClientAddr := dnsConn.LocalAddr().(*net.UDPAddr)
+	var dnsClientAddr *net.UDPAddr
 	require.Eventually(t, func() bool {
+		dnsConn, err := dnsClient.Dial(dnsServerAddr.String())
+		require.NoError(t, err)
+		dnsClientAddr = dnsConn.LocalAddr().(*net.UDPAddr)
 		_, _, err = dnsClient.ExchangeWithConn(queryMsg, dnsConn)
+		_ = dnsConn.Close()
 		return err == nil || timeout != 0
 	}, 3*time.Second, 100*time.Millisecond, "Failed to get dns response")
-
-	// Allow the DNS reply to be processed in the snooper
-	time.Sleep(time.Millisecond * 500)
 
 	// Iterate through active connections until we find connection created above, and confirm send + recv counts
 	connections := getConnections(t, tr)

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1003,7 +1003,8 @@ func getConnections(t require.TestingT, tr *Tracer) *network.Connections {
 }
 
 const (
-	validDNSServer = "8.8.8.8"
+	validDNSServer   = "8.8.8.8"
+	invalidDNSServer = "1.2.3.4" // queries to this IP will always time out
 )
 
 func testDNSStats(t *testing.T, tr *Tracer, domain string, success, failure, timeout int, serverIP string) {
@@ -1026,8 +1027,8 @@ func testDNSStats(t *testing.T, tr *Tracer, domain string, success, failure, tim
 		dnsClientAddr = dnsConn.LocalAddr().(*net.UDPAddr)
 		_, _, err = dnsClient.ExchangeWithConn(queryMsg, dnsConn)
 		_ = dnsConn.Close()
-		assert.True(c, err == nil || timeout != 0, "Expected no DNS error")
-	}, 3*time.Second, 100*time.Millisecond, "Failed to get dns response")
+		assert.True(c, err == nil || timeout != 0, "expected no DNS error")
+	}, 6*time.Second, 100*time.Millisecond, "failed to get dns response")
 
 	// Allow the DNS reply to be processed in the snooper
 	time.Sleep(time.Millisecond * 500)
@@ -1088,7 +1089,7 @@ func (s *TracerSuite) TestDNSStatsWithTimeout() {
 	cfg.DNSTimeout = 250 * time.Millisecond
 	tr := setupTracer(t, cfg)
 	t.Run("timeout", func(t *testing.T) {
-		testDNSStats(t, tr, "golang.org", 0, 0, 1, "1.2.3.4")
+		testDNSStats(t, tr, "golang.org", 0, 0, 1, invalidDNSServer)
 	})
 }
 

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1018,13 +1018,13 @@ func testDNSStats(t *testing.T, tr *Tracer, domain string, success, failure, tim
 
 	dnsClient := new(dns.Client)
 	var dnsClientAddr *net.UDPAddr
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		dnsConn, err := dnsClient.Dial(dnsServerAddr.String())
-		require.NoError(t, err)
+		assert.Nil(c, err)
 		dnsClientAddr = dnsConn.LocalAddr().(*net.UDPAddr)
 		_, _, err = dnsClient.ExchangeWithConn(queryMsg, dnsConn)
 		_ = dnsConn.Close()
-		return err == nil || timeout != 0
+		assert.True(c, err == nil || timeout != 0, "Expected no DNS error")
 	}, 3*time.Second, 100*time.Millisecond, "Failed to get dns response")
 
 	// Allow the DNS reply to be processed in the snooper

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1027,6 +1027,9 @@ func testDNSStats(t *testing.T, tr *Tracer, domain string, success, failure, tim
 		return err == nil || timeout != 0
 	}, 3*time.Second, 100*time.Millisecond, "Failed to get dns response")
 
+	// Allow the DNS reply to be processed in the snooper
+	time.Sleep(time.Millisecond * 500)
+
 	// Iterate through active connections until we find connection created above, and confirm send + recv counts
 	connections := getConnections(t, tr)
 	conn, ok := findConnection(dnsClientAddr, dnsServerAddr, connections)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Creates a new DNS connection in each retry of the require.Eventually

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

https://datadoghq.atlassian.net/browse/NPM-3012

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
