### PR TITLE
usm: http: Bump path limit to 208 characters

### DIFF
--- a/pkg/network/ebpf/c/protocols/http/types.h
+++ b/pkg/network/ebpf/c/protocols/http/types.h
@@ -4,9 +4,9 @@
 #include "conn_tuple.h"
 
 // This determines the size of the payload fragment that is captured for each HTTP request
-#define HTTP_BUFFER_SIZE (8 * 20)
+#define HTTP_BUFFER_SIZE (8 * 26)
 // This controls the number of HTTP transactions read from userspace at a time
-#define HTTP_BATCH_SIZE 15
+#define HTTP_BATCH_SIZE 14
 
 // HTTP/1.1 XXX
 // _________^
@@ -16,7 +16,7 @@
 // For more information see `http_seen_before`
 #define HTTP_TERMINATING 0xFFFFFFFF
 
-// This is needed to reduce code size on multiple copy opitmizations that were made in
+// This is needed to reduce code size on multiple copy optimizations that were made in
 // the http eBPF program.
 _Static_assert((HTTP_BUFFER_SIZE % 8) == 0, "HTTP_BUFFER_SIZE must be a multiple of 8.");
 

--- a/pkg/network/protocols/http/types_linux.go
+++ b/pkg/network/protocols/http/types_linux.go
@@ -36,11 +36,11 @@ type EbpfTx struct {
 	Response_status_code uint16
 	Request_method       uint8
 	Pad_cgo_0            [1]byte
-	Request_fragment     [160]byte
+	Request_fragment     [208]byte
 }
 
 const (
-	BufferSize = 0xa0
+	BufferSize = 0xd0
 )
 
 type ConnTag = uint64


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Allows capturing HTTP endpoints up to 200-204 characters instead of 152-156 previously (depends on the method).
Bumping the internal kernel buffer to 208 characters. The buffer contains the method (GET is the shortest, OPTIONS in the longest), a space, and the endpoint, thus our effective limit is 200-204 characters of the endpoint

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Feature requests.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
