### PR TITLE
[usm] create range to fix flaky tests in HTTP/2 and gRPC

### DIFF
--- a/pkg/network/protocols/grpc/monitor_test.go
+++ b/pkg/network/protocols/grpc/monitor_test.go
@@ -77,6 +77,11 @@ func getClientsIndex(index, totalCount int) int {
 	return index % totalCount
 }
 
+type captureRange struct {
+	lower int
+	upper int
+}
+
 func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 	t := s.T()
 	cfg := config.New()
@@ -93,7 +98,7 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 	tests := []struct {
 		name              string
 		runClients        func(t *testing.T, clientsCount int)
-		expectedEndpoints map[http.Key]int
+		expectedEndpoints map[http.Key]captureRange
 		expectedError     bool
 	}{
 		{
@@ -106,11 +111,14 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 					require.NoError(t, client.HandleUnary(defaultCtx, "first"))
 				}
 			},
-			expectedEndpoints: map[http.Key]int{
+			expectedEndpoints: map[http.Key]captureRange{
 				{
 					Path:   http.Path{Content: http.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
-				}: 1000,
+				}: {
+					lower: 999,
+					upper: 1001,
+				},
 			},
 		},
 		{
@@ -122,15 +130,21 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 				require.NoError(t, clients[getClientsIndex(1, clientsCount)].GetFeature(defaultCtx, -746143763, 407838351))
 				require.NoError(t, clients[getClientsIndex(2, clientsCount)].HandleUnary(defaultCtx, "first"))
 			},
-			expectedEndpoints: map[http.Key]int{
+			expectedEndpoints: map[http.Key]captureRange{
 				{
 					Path:   http.Path{Content: http.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
-				}: 2,
+				}: {
+					lower: 2,
+					upper: 2,
+				},
 				{
 					Path:   http.Path{Content: http.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
 					Method: http.MethodPost,
-				}: 1,
+				}: {
+					lower: 1,
+					upper: 1,
+				},
 			},
 		},
 		{
@@ -143,15 +157,21 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 				require.NoError(t, clients[getClientsIndex(2, clientsCount)].HandleUnary(defaultCtx, "third"))
 				require.NoError(t, clients[getClientsIndex(3, clientsCount)].GetFeature(defaultCtx, -743999179, 408122808))
 			},
-			expectedEndpoints: map[http.Key]int{
+			expectedEndpoints: map[http.Key]captureRange{
 				{
 					Path:   http.Path{Content: http.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
-				}: 2,
+				}: {
+					lower: 2,
+					upper: 2,
+				},
 				{
 					Path:   http.Path{Content: http.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
 					Method: http.MethodPost,
-				}: 2,
+				}: {
+					lower: 2,
+					upper: 2,
+				},
 			},
 		},
 		{
@@ -164,15 +184,21 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 				require.NoError(t, clients[getClientsIndex(2, clientsCount)].GetFeature(defaultCtx, -743999179, 408122808))
 				require.NoError(t, clients[getClientsIndex(3, clientsCount)].HandleUnary(defaultCtx, "third"))
 			},
-			expectedEndpoints: map[http.Key]int{
+			expectedEndpoints: map[http.Key]captureRange{
 				{
 					Path:   http.Path{Content: http.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
-				}: 2,
+				}: {
+					lower: 2,
+					upper: 2,
+				},
 				{
 					Path:   http.Path{Content: http.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
 					Method: http.MethodPost,
-				}: 2,
+				}: {
+					lower: 2,
+					upper: 2,
+				},
 			},
 		},
 		{
@@ -185,11 +211,14 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 					require.NoError(t, client.HandleStream(defaultCtx, 10))
 				}
 			},
-			expectedEndpoints: map[http.Key]int{
+			expectedEndpoints: map[http.Key]captureRange{
 				{
 					Path:   http.Path{Content: http.Interner.GetString("/protobuf.Math/Max")},
 					Method: http.MethodPost,
-				}: 25,
+				}: {
+					lower: 25,
+					upper: 25,
+				},
 			},
 		},
 		{
@@ -202,15 +231,21 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 				require.NoError(t, clients[getClientsIndex(2, clientsCount)].HandleStream(defaultCtx, 10))
 				require.NoError(t, clients[getClientsIndex(3, clientsCount)].HandleUnary(defaultCtx, "second"))
 			},
-			expectedEndpoints: map[http.Key]int{
+			expectedEndpoints: map[http.Key]captureRange{
 				{
 					Path:   http.Path{Content: http.Interner.GetString("/protobuf.Math/Max")},
 					Method: http.MethodPost,
-				}: 2,
+				}: {
+					lower: 2,
+					upper: 2,
+				},
 				{
 					Path:   http.Path{Content: http.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
-				}: 2,
+				}: {
+					lower: 2,
+					upper: 2,
+				},
 			},
 		},
 		{
@@ -232,15 +267,21 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 				require.NoError(t, clients[getClientsIndex(2, clientsCount)].HandleUnary(ctxWithHeaders, string(longName)))
 				require.NoError(t, clients[getClientsIndex(3, clientsCount)].GetFeature(ctxWithoutHeaders, -743999179, 408122808))
 			},
-			expectedEndpoints: map[http.Key]int{
+			expectedEndpoints: map[http.Key]captureRange{
 				{
 					Path:   http.Path{Content: http.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
 					Method: http.MethodPost,
-				}: 2,
+				}: {
+					lower: 2,
+					upper: 2,
+				},
 				{
 					Path:   http.Path{Content: http.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
-				}: 2,
+				}: {
+					lower: 2,
+					upper: 2,
+				},
 			},
 			expectedError: true,
 		},
@@ -263,15 +304,21 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 				require.NoError(t, clients[getClientsIndex(0, clientsCount)].HandleUnary(ctxWithHeaders, string(longName)))
 				require.NoError(t, clients[getClientsIndex(0, clientsCount)].GetFeature(ctxWithoutHeaders, -743999179, 408122808))
 			},
-			expectedEndpoints: map[http.Key]int{
+			expectedEndpoints: map[http.Key]captureRange{
 				{
 					Path:   http.Path{Content: http.Interner.GetString("/routeguide.RouteGuide/GetFeature")},
 					Method: http.MethodPost,
-				}: 2,
+				}: {
+					lower: 2,
+					upper: 2,
+				},
 				{
 					Path:   http.Path{Content: http.Interner.GetString("/helloworld.Greeter/SayHello")},
 					Method: http.MethodPost,
-				}: 2,
+				}: {
+					lower: 2,
+					upper: 2,
+				},
 			},
 			expectedError: true,
 		},
@@ -335,11 +382,6 @@ func (s *USMgRPCSuite) TestSimpleGRPCScenarios() {
 			})
 		}
 	}
-}
-
-type captureRange struct {
-	lower int
-	upper int
 }
 
 func (s *USMgRPCSuite) TestLargeBodiesGRPCScenarios() {

--- a/pkg/network/usm/monitor_test.go
+++ b/pkg/network/usm/monitor_test.go
@@ -568,8 +568,8 @@ func (s *USMHTTP2Suite) TestSimpleHTTP2() {
 					Path:   http.Path{Content: http.Interner.GetString("/")},
 					Method: http.MethodPost,
 				}: {
-					lower: 1000,
-					upper: 1000,
+					lower: 999,
+					upper: 1001,
 				},
 			},
 		},
@@ -590,8 +590,8 @@ func (s *USMHTTP2Suite) TestSimpleHTTP2() {
 					Path:   http.Path{Content: http.Interner.GetString("/index.html")},
 					Method: http.MethodPost,
 				}: {
-					lower: 1000,
-					upper: 1000,
+					lower: 999,
+					upper: 1001,
 				},
 			},
 		},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fix gRPC and HTTP/2 UT's  by creating range for expected hits

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
