### PR TITLE
[USM] make protocols init aware of build mode

### DIFF
--- a/pkg/network/protocols/protocols.go
+++ b/pkg/network/protocols/protocols.go
@@ -74,6 +74,7 @@ type ProtocolStats struct {
 type ProtocolFactory func(*config.Config) (Protocol, error)
 type ProtocolSpec struct {
 	Factory   ProtocolFactory
+	Instance  Protocol
 	Maps      []*manager.Map
 	Probes    []*manager.Probe
 	TailCalls []manager.TailCallRoute

--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -183,19 +183,7 @@ func (e *ebpfProgram) Init() error {
 		}
 	}()
 
-	var undefinedProbes []manager.ProbeIdentificationPair
-	for _, tc := range e.tailCallRouter {
-		undefinedProbes = append(undefinedProbes, tc.ProbeIdentificationPair)
-	}
-
-	for _, s := range e.probesResolvers {
-		undefinedProbes = append(undefinedProbes, s.GetAllUndefinedProbes()...)
-	}
-
 	e.DumpHandler = e.dumpMapsHandler
-	e.InstructionPatcher = func(m *manager.Manager) error {
-		return errtelemetry.PatchEBPFTelemetry(m, true, undefinedProbes)
-	}
 	for _, s := range e.subprograms {
 		s.ConfigureManager(e.Manager)
 	}
@@ -326,6 +314,43 @@ func (e *ebpfProgram) initPrebuilt() error {
 	return e.init(bc, manager.Options{ConstantEditors: offsets})
 }
 
+// getProtocolsForBuildMode returns 2 lists - supported and not-supported protocol lists.
+// 1. Supported - enabled protocols which are supported by the current build mode (`e.buildMode`)
+// 2. Not Supported - disabled protocols, and enabled protocols which are not supported by the current build mode.
+func (e *ebpfProgram) getProtocolsForBuildMode() ([]*protocols.ProtocolSpec, []*protocols.ProtocolSpec) {
+	supported := make([]*protocols.ProtocolSpec, 0)
+	notSupported := make([]*protocols.ProtocolSpec, 0, len(e.disabledProtocols))
+	notSupported = append(notSupported, e.disabledProtocols...)
+
+	for _, p := range e.enabledProtocols {
+		if p.Instance.IsBuildModeSupported(e.buildMode) {
+			supported = append(supported, p)
+		} else {
+			notSupported = append(notSupported, p)
+		}
+	}
+
+	return supported, notSupported
+}
+
+// configureManagerWithSupportedProtocols given a protocol list, we're adding for each protocol its Maps, Probes and
+// TailCalls to the program's lists. Also, we're providing a cleanup method (the return value) which allows removal
+// of the elements we added in case of a failure in the initialization.
+func (e *ebpfProgram) configureManagerWithSupportedProtocols(protocols []*protocols.ProtocolSpec) func() {
+	for _, spec := range protocols {
+		e.Maps = append(e.Maps, spec.Maps...)
+		e.Probes = append(e.Probes, spec.Probes...)
+		e.tailCallRouter = append(e.tailCallRouter, spec.TailCalls...)
+	}
+	return func() {
+		for _, spec := range protocols {
+			e.Maps = e.Maps[:len(e.Maps)-len(spec.Maps)]
+			e.Probes = e.Probes[:len(e.Probes)-len(spec.Probes)]
+			e.tailCallRouter = e.tailCallRouter[:len(e.tailCallRouter)-len(spec.TailCalls)]
+		}
+	}
+}
+
 func (e *ebpfProgram) init(buf bytecode.AssetReader, options manager.Options) error {
 	kprobeAttachMethod := manager.AttachKprobeWithPerfEventOpen
 	if e.cfg.AttachKprobesWithKprobeEventsABI {
@@ -360,7 +385,6 @@ func (e *ebpfProgram) init(buf bytecode.AssetReader, options manager.Options) er
 		manager.ConstantEditor{Name: "ephemeral_range_begin", Value: uint64(begin)},
 		manager.ConstantEditor{Name: "ephemeral_range_end", Value: uint64(end)})
 
-	options.TailCallRouter = e.tailCallRouter
 	options.ActivatedProbes = []manager.ProbesSelector{
 		&manager.ProbeSelector{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
@@ -393,12 +417,15 @@ func (e *ebpfProgram) init(buf bytecode.AssetReader, options manager.Options) er
 		s.ConfigureOptions(&options)
 	}
 
-	for _, p := range e.enabledProtocols {
+	supported, notSupported := e.getProtocolsForBuildMode()
+	cleanup := e.configureManagerWithSupportedProtocols(supported)
+	options.TailCallRouter = e.tailCallRouter
+	for _, p := range supported {
 		p.Instance.ConfigureOptions(e.Manager.Manager, &options)
 	}
 
 	// Add excluded functions from disabled protocols
-	for _, p := range e.disabledProtocols {
+	for _, p := range notSupported {
 		for _, m := range p.Maps {
 			// Unused maps still need to have a non-zero size
 			options.MapSpecEditors[m.Name] = manager.MapSpecEditor{
@@ -418,7 +445,24 @@ func (e *ebpfProgram) init(buf bytecode.AssetReader, options manager.Options) er
 		}
 	}
 
-	return e.InitWithOptions(buf, options)
+	var undefinedProbes []manager.ProbeIdentificationPair
+	for _, tc := range e.tailCallRouter {
+		undefinedProbes = append(undefinedProbes, tc.ProbeIdentificationPair)
+	}
+
+	for _, s := range e.probesResolvers {
+		undefinedProbes = append(undefinedProbes, s.GetAllUndefinedProbes()...)
+	}
+
+	e.InstructionPatcher = func(m *manager.Manager) error {
+		return errtelemetry.PatchEBPFTelemetry(m, true, undefinedProbes)
+	}
+
+	err := e.InitWithOptions(buf, options)
+	if err != nil {
+		cleanup()
+	}
+	return err
 }
 
 const connProtoTTL = 3 * time.Minute
@@ -532,11 +576,6 @@ func (e *ebpfProgram) initProtocols(c *config.Config) error {
 		}
 
 		if protocol != nil {
-			// Configure the manager
-			e.Maps = append(e.Maps, spec.Maps...)
-			e.Probes = append(e.Probes, spec.Probes...)
-			e.tailCallRouter = append(e.tailCallRouter, spec.TailCalls...)
-
 			spec.Instance = protocol
 			e.enabledProtocols = append(e.enabledProtocols, spec)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR make the initialization of protocols aware of the build mode and allows to safely remove unsupported (but enabled) protocols from the initialization.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The 3rd stage on our journey to migrate go-tls into the protocol format.
Now after we have `IsBuildModeSupported` and we move the protocols into `ebpf_main.go`, we can connect the two, and make the initialization of protocols aware of the build mode, and to exclude unsupported (but enabled) protocols from the initialization.

That way we can "safely" fallback into prebuilt mechanism is there issue with CO-RE and runtime compilation.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Please review commit by commit (+ read the commit messages) for a better understanding of the changes.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
