### PR TITLE
usm: http2: Bump max interesting frames limit to 30

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -7,7 +7,7 @@
 
 // Maximum number of frames to be processed in a single TCP packet. That's also the number of tail calls we'll have.
 // NOTE: we may need to revisit this const if we need to capture more connections.
-#define HTTP2_MAX_FRAMES_ITERATIONS 10
+#define HTTP2_MAX_FRAMES_ITERATIONS 30
 #define HTTP2_MAX_FRAMES_TO_FILTER  100
 
 // A limit of max headers which we process in the request/response.

--- a/pkg/network/ebpf/c/protocols/http2/maps-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/maps-defs.h
@@ -29,6 +29,9 @@ BPF_LRU_MAP(http2_iterations, dispatcher_arguments_t, http2_tail_call_state_t, 0
 /* Allocating an array of headers, to hold all interesting headers from the frame. */
 BPF_PERCPU_ARRAY_MAP(http2_headers_to_process, __u32, http2_header_t[HTTP2_MAX_HEADERS_COUNT_FOR_PROCESSING], 1)
 
+/* Allocating an array of frame, to hold all interesting frames from the packet. */
+BPF_PERCPU_ARRAY_MAP(http2_frames_to_process, __u32, http2_tail_call_state_t, 1)
+
 /* Allocating a stream on the heap, the stream is used to save the current stream info. */
 BPF_PERCPU_ARRAY_MAP(http2_stream_heap, __u32, http2_stream_t, 1)
 

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -69,6 +69,9 @@ var Spec = &protocols.ProtocolSpec{
 			Name: "http2_headers_to_process",
 		},
 		{
+			Name: "http2_frames_to_process",
+		},
+		{
 			Name: "http2_stream_heap",
 		},
 		{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Trying to increase the current limit ends with a verification error of hitting the 1m instruction limit. Thus, we had to look for conditions to simplify and remove to cut the number of branches the verifier has to go through.

We can remove the if-clause in `skip_preface` which checks the boundaries before the call as in case of exceeding the packet limits, `bpf_skb_load_bytes` will fail, and the buffer will be empty, or at least, won't match the HTTP2 magic we're comparing to.

Removing the condition allows us to bump the limit up to 22 max interesting frames, without having any other compilation or verification issues. Trying to bump the limit to 23, returns a compilation error caused by exceeding the stack limitation (as we're creating `http2_tail_call_state_t` on the stack).

To fix that, we're introducing a per-cpu array `http2_frames_to_process` which acts as a heap. With that change we're able to bump the limit to 30. We're now limited by the max number of nested tail calls allowed. The nubmer is 32 (the actual limit is 33, but some JITs don't have the update), and we already have `socket__protocol_dispatcher` and `socket__http2_filter`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Handling cases where a single packet holds more than 10 interesting frames.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Performance:

CPU - negligible diff

![image](https://github.com/DataDog/datadog-agent/assets/17148247/e370b8de-713d-40a9-aa6b-e2392ca28b0a)

RSS - negligible diff (2%)
![image](https://github.com/DataDog/datadog-agent/assets/17148247/9b61071c-a59a-4194-a300-f5ee6585a8c2)

Accuracy - 100%

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
