### PR TITLE
pkg/trace/api: consider Datadog-Client-Computed-Stats header on OTLP endpoint

### DIFF
--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -252,8 +252,9 @@ func (o *OTLPReceiver) ReceiveResourceSpans(ctx context.Context, rspans ptrace.R
 	metrics.Count("datadog.trace_agent.otlp.spans", spancount, tags, 1)
 	metrics.Count("datadog.trace_agent.otlp.traces", int64(len(tracesByID)), tags, 1)
 	p := Payload{
-		Source:              tagstats,
-		ClientComputedStats: rattr[keyStatsComputed] != "",
+		Source:                 tagstats,
+		ClientComputedStats:    rattr[keyStatsComputed] != "" || httpHeader.Get(header.ComputedStats) != "",
+		ClientComputedTopLevel: httpHeader.Get(header.ComputedTopLevel) != "",
 	}
 	if env == "" {
 		env = o.conf.DefaultEnv


### PR DESCRIPTION
This change adds support for the Datadog-Client-Computed-Stats header to the OTLP API along with tests. This allows API callers to disable APM Stats computation of ingested spans.

*QA Instructions*:
1. Send spans to the OTLP Ingest and confirm that APM Stats are computed.
2. Send spans to the OTLP Ingest with the `Datadog-Client-Computed-Stats: true` header and confirm that stats aren't computed.