### PR TITLE
[pkg/util/kubernetes][CONTINT-477] add rate_limit_queries_remaining_min telemetry in cluster agent external metrics server

### DIFF
--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -65,7 +65,12 @@ const (
 	queryEndpoint = "/api/v1/query"
 )
 
-<<<<<<< HEAD
+var (
+	refreshPeriod  = config.Datadog.GetInt("external_metrics_provider.refresh_period")
+	expiryDuration = 2 * refreshPeriod
+	mrr            = newMinRemainingRequests(time.Duration(time.Duration(expiryDuration) * time.Second))
+)
+
 // isRateLimitError is a helper function that checks if the received error is a rate limit error
 func isRateLimitError(err error) bool {
 	if err == nil {
@@ -73,13 +78,6 @@ func isRateLimitError(err error) bool {
 	}
 	return strings.Contains(err.Error(), "429 Too Many Requests")
 }
-=======
-var (
-	refreshPeriod  = config.Datadog.GetInt("external_metrics_provider.refresh_period")
-	expiryDuration = 2 * refreshPeriod
-	mrr            = newMinRemainingRequests(time.Duration(expiryDuration))
-)
->>>>>>> 9005f6e178 (add rate_limit_queries_remaining_min telemetry in cluster agent external metrics server)
 
 // queryDatadogExternal converts the metric name and labels from the Ref format into a Datadog metric.
 // It returns the last value for a bucket of 5 minutes,

--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/zorkian/go-datadog-api.v2"
 	utilserror "k8s.io/apimachinery/pkg/util/errors"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	le "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -35,6 +36,9 @@ var (
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 	rateLimitsRemaining = telemetry.NewGaugeWithOpts("", "rate_limit_queries_remaining",
 		[]string{"endpoint", le.JoinLeaderLabel}, "number of queries remaining before next reset",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+	rateLimitsRemainingMin = telemetry.NewGaugeWithOpts("", "rate_limit_queries_remaining_min",
+		[]string{"endpoint", le.JoinLeaderLabel}, "minimum number of queries remaining before next reset observed during an expiration interval of 2*refresh period",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 	rateLimitsReset = telemetry.NewGaugeWithOpts("", "rate_limit_queries_reset",
 		[]string{"endpoint", le.JoinLeaderLabel}, "number of seconds before next reset",
@@ -61,6 +65,7 @@ const (
 	queryEndpoint = "/api/v1/query"
 )
 
+<<<<<<< HEAD
 // isRateLimitError is a helper function that checks if the received error is a rate limit error
 func isRateLimitError(err error) bool {
 	if err == nil {
@@ -68,6 +73,13 @@ func isRateLimitError(err error) bool {
 	}
 	return strings.Contains(err.Error(), "429 Too Many Requests")
 }
+=======
+var (
+	refreshPeriod  = config.Datadog.GetInt("external_metrics_provider.refresh_period")
+	expiryDuration = 2 * refreshPeriod
+	mrr            = newMinRemainingRequests(time.Duration(expiryDuration))
+)
+>>>>>>> 9005f6e178 (add rate_limit_queries_remaining_min telemetry in cluster agent external metrics server)
 
 // queryDatadogExternal converts the metric name and labels from the Ref format into a Datadog metric.
 // It returns the last value for a bucket of 5 minutes,
@@ -170,6 +182,11 @@ func (p *Processor) queryDatadogExternal(ddQueries []string, timeWindow time.Dur
 			}
 		}
 	}
+
+	// Update rateLimitsRemainingMin metric
+	updateMap := p.datadogClient.GetRateLimitStats()
+	queryLimits := updateMap[queryEndpoint]
+	mrr.update(queryLimits.Remaining)
 
 	return processedMetrics, nil
 }

--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -197,7 +197,7 @@ func (p *Processor) queryDatadogExternal(ddQueries []string, timeWindow time.Dur
 	newVal, err := strconv.Atoi(queryLimits.Remaining)
 	if err == nil {
 		getMinRemainingRequestsTracker().update(newVal)
-		rateLimitsRemainingMin.Set(float64(minRemainingRequestsTracker.val), queryEndpoint, le.JoinLeaderLabel)
+		rateLimitsRemainingMin.Set(float64(minRemainingRequestsTracker.get()), queryEndpoint, le.JoinLeaderLabel)
 	}
 
 	return processedMetrics, nil

--- a/pkg/util/kubernetes/autoscalers/datadogexternal_util.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal_util.go
@@ -41,5 +41,7 @@ func (mt *minTracker) update(newVal int) {
 }
 
 func (mt *minTracker) get() int {
+	mt.Lock()
+	defer mt.Unlock()
 	return mt.val
 }

--- a/pkg/util/kubernetes/autoscalers/datadogexternal_util.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal_util.go
@@ -39,3 +39,7 @@ func (mt *minTracker) update(newVal int) {
 		mt.timestamp = time.Now()
 	}
 }
+
+func (mt *minTracker) get() int {
+	return mt.val
+}

--- a/pkg/util/kubernetes/autoscalers/datadogexternal_util.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal_util.go
@@ -9,12 +9,14 @@ package autoscalers
 
 import (
 	"strconv"
+	"sync"
 	"time"
 
 	le "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
 )
 
 type minRemainingRequests struct {
+	sync.Mutex
 	val            int
 	timestamp      time.Time
 	expiryDuration time.Duration
@@ -29,6 +31,9 @@ func newMinRemainingRequests(expiryDuration time.Duration) minRemainingRequests 
 }
 
 func (mrr *minRemainingRequests) update(newVal string) {
+	mrr.Lock()
+	defer mrr.Unlock()
+
 	newValFloat, err := strconv.Atoi(newVal)
 
 	if err != nil {

--- a/pkg/util/kubernetes/autoscalers/datadogexternal_util.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal_util.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoscalers
+
+import (
+	"strconv"
+	"time"
+
+	le "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
+)
+
+type minRemainingRequests struct {
+	val            int
+	timestamp      time.Time
+	expiryDuration time.Duration
+}
+
+func newMinRemainingRequests(expiryDuration time.Duration) minRemainingRequests {
+	return minRemainingRequests{
+		val:            -1,
+		timestamp:      time.Now(),
+		expiryDuration: expiryDuration,
+	}
+}
+
+func (mrr *minRemainingRequests) update(newVal string) {
+	newValFloat, err := strconv.Atoi(newVal)
+
+	if err != nil {
+		return
+	}
+
+	isSet := mrr.val >= 0
+	hasExpired := time.Since(mrr.timestamp) > mrr.expiryDuration
+
+	if mrr.val >= newValFloat || !isSet || hasExpired {
+		mrr.val = newValFloat
+		mrr.timestamp = time.Now()
+		rateLimitsRemainingMin.Set(float64(mrr.val), queryEndpoint, le.JoinLeaderValue)
+	}
+}

--- a/pkg/util/kubernetes/autoscalers/datadogexternal_util_test.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal_util_test.go
@@ -14,34 +14,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUpdateMinimumRemainingRequests(t *testing.T) {
+func TestUpdateMinTracker(t *testing.T) {
 	expiryDuration := 60 * time.Second
 
-	mrr := newMinTracker(expiryDuration)
+	mt := newMinTracker(expiryDuration)
 
 	// Should update
-	mrr.update(10)
-	assert.Equal(t, mrr.val, 10)
+	mt.update(10)
+	assert.Equal(t, mt.get(), 10)
 
 	// Should not update, since value didn't expire yet
-	mrr.update(11)
-	assert.Equal(t, mrr.val, 10)
+	mt.update(11)
+	assert.Equal(t, mt.get(), 10)
 
 	// simulate waiting half the expirationDuration
-	mrr.timestamp = time.Now().Add(-expiryDuration / 2)
+	mt.timestamp = time.Now().Add(-expiryDuration / 2)
 
 	// Should not update
-	mrr.update(199)
-	assert.Equal(t, mrr.val, 10)
+	mt.update(199)
+	assert.Equal(t, mt.get(), 10)
 
 	// Shoud update, even if value didn't expire because new value is lower
-	mrr.update(5)
-	assert.Equal(t, mrr.val, 5)
+	mt.update(5)
+	assert.Equal(t, mt.get(), 5)
 
 	// Change timestamp to simulate expiration
-	mrr.timestamp = time.Now().Add(-2 * expiryDuration)
+	mt.timestamp = time.Now().Add(-2 * expiryDuration)
 
 	// Shoud update because current value has expired
-	mrr.update(100)
-	assert.Equal(t, mrr.val, 100)
+	mt.update(100)
+	assert.Equal(t, mt.get(), 100)
 }

--- a/pkg/util/kubernetes/autoscalers/datadogexternal_util_test.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal_util_test.go
@@ -14,26 +14,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsSet(t *testing.T) {
+func TestUpdateMinimumRemainingRequests(t *testing.T) {
 	expiryDuration := 60 * time.Second
-	mrr := newMinRemainingRequests(expiryDuration)
+
+	mrr := newMinTracker(expiryDuration)
 
 	// Should update
-	mrr.update("10")
+	mrr.update(10)
 	assert.Equal(t, mrr.val, 10)
 
 	// Should not update, since value didn't expire yet
-	mrr.update("11")
+	mrr.update(11)
+	assert.Equal(t, mrr.val, 10)
+
+	// simulate waiting half the expirationDuration
+	mrr.timestamp = time.Now().Add(-expiryDuration / 2)
+
+	// Should not update
+	mrr.update(199)
 	assert.Equal(t, mrr.val, 10)
 
 	// Shoud update, even if value didn't expire because new value is lower
-	mrr.update("5")
+	mrr.update(5)
 	assert.Equal(t, mrr.val, 5)
 
-	// Change timestamp to simulate expiratio
+	// Change timestamp to simulate expiration
 	mrr.timestamp = time.Now().Add(-2 * expiryDuration)
 
 	// Shoud update because current value has expired
-	mrr.update("100")
+	mrr.update(100)
 	assert.Equal(t, mrr.val, 100)
 }

--- a/pkg/util/kubernetes/autoscalers/datadogexternal_util_test.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal_util_test.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoscalers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSet(t *testing.T) {
+	expiryDuration := 60 * time.Second
+	mrr := newMinRemainingRequests(expiryDuration)
+
+	// Should update
+	mrr.update("10")
+	assert.Equal(t, mrr.val, 10)
+
+	// Should not update, since value didn't expire yet
+	mrr.update("11")
+	assert.Equal(t, mrr.val, 10)
+
+	// Shoud update, even if value didn't expire because new value is lower
+	mrr.update("5")
+	assert.Equal(t, mrr.val, 5)
+
+	// Change timestamp to simulate expiratio
+	mrr.timestamp = time.Now().Add(-2 * expiryDuration)
+
+	// Shoud update because current value has expired
+	mrr.update("100")
+	assert.Equal(t, mrr.val, 100)
+}

--- a/releasenotes-dca/notes/add-rate_limit_queries_remaining_min_telemetry-233fcfdbc0fe3822.yaml
+++ b/releasenotes-dca/notes/add-rate_limit_queries_remaining_min_telemetry-233fcfdbc0fe3822.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Report `rate_limit_queries_remaining_min` telemetry from `external-metrics` server.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR adds `rate_limit_queries_remaining_min` telemetry in cluster agent external metrics server. This metric represents the minimum of number of remaining requests over the last 2*refresh_period that the datadog client can send to the backend. 

`rate_limit_queries_remaining_min` is updated in 2 cases:
- The new received rate limit remaining queries is less than the existing value of `rate_limit_queries_remaining_min`
- `rate_limit_queries_remaining_min` has not been updated for more than 2 * refresh_period

The refresh period is set to 30 seconds by default.

### Motivation

As Datadog Cluster-Agent user, I would like to monitor the state of the external-metrics server to better react in case of Datadog API query Rate-limit errors, since it can impact my applications autoscaling. 

The official datadog-cluster-agent integration already provide some metrics to see the current rate limit state by API key. It works fine when the Rate Limit quota is set for a period of 1h hour. 
For example a customer can send 20k queries per hour. So the metric (generated every 15sec) can decrease during the 1 hour period. and create a monitor if the metrics return only 10% of the quota.

But with new rate limit configuration for large customer, this metric become useless since the Rate-Limit period is now 10sec. For example 200 queries every 10sec. Which make the value flaky and inaccurate when this metric is generated every 15sec.

Having a metric that indicates the minimum value of `rate_limit_queries_remaining` over some period of time will be useful to stabilise the metric to better react to rate limit errors in advance.


### Additional Notes
- The cluster agent sends 0-N queries to the backend every refresh period
- Currently, `rate_limit_queries_remaining` is updated only after the response of the last (N-th) query is received. 
- This makes the metric flaky, especially when the Rate-Limit period becomes small.
- With this new metric, the minimum value of `rate_limit_queries_remaining` is conserved during at least `2*refresh_period`, and is investigated after every single query sent to the backend, which makes the metric less flaky and more useful to create monitors to be alerted before rate limit error occurs.

### Possible Drawbacks / Trade-offs
In order for `rate_limit_queries_remaining` and `rate_limit_queries_remaining_min` to show significant difference, the cluster agents need to a lot of queries (so we need to have several HPA/WPA) to the backend. 

### Describe how to test/QA your changes

- Start the cluster agent on a cluster that has several HPA/WPA, collecting external metrics via complex queries. 
- Run the following command several times on the leader cluster agent: `datadog-cluster-agent telemetry | grep rate_limit_queries_remaining`
- The result will show you both `rate_limit_queries_remaining` and `rate_limit_queries_remaining_min`. 
- You should find that `rate_limit_queries_remaining_min` is always less than `rate_limit_queries_remaining` and that it takes at 2*refresh_period (by default 60 seconds) to increase.

Doing this test produced the following consecutive outputs:

```
# HELP rate_limit_queries_remaining number of queries remaining before next reset
# TYPE rate_limit_queries_remaining gauge
rate_limit_queries_remaining{endpoint="/api/v1/query",join_leader="true"} 353
# HELP rate_limit_queries_remaining_min minimum number of queries remaining before next reset observed during an expiration interval of 2*refresh period
# TYPE rate_limit_queries_remaining_min gauge
rate_limit_queries_remaining_min{endpoint="/api/v1/query",join_leader="true"} 197
adelhajhassan@COMP-Y0K2MF67D1 ~ % kubectl exec datadog-cluster-agent-6cdb6df59b-sktds   -n datadog-agent -- datadog-cluster-agent telemetry | grep rate_limit_queries_remaining
# HELP rate_limit_queries_remaining number of queries remaining before next reset
# TYPE rate_limit_queries_remaining gauge
rate_limit_queries_remaining{endpoint="/api/v1/query",join_leader="true"} 294
# HELP rate_limit_queries_remaining_min minimum number of queries remaining before next reset observed during an expiration interval of 2*refresh period
# TYPE rate_limit_queries_remaining_min gauge
rate_limit_queries_remaining_min{endpoint="/api/v1/query",join_leader="true"} 197
adelhajhassan@COMP-Y0K2MF67D1 ~ % kubectl exec datadog-cluster-agent-6cdb6df59b-sktds   -n datadog-agent -- datadog-cluster-agent telemetry | grep rate_limit_queries_remaining
# HELP rate_limit_queries_remaining number of queries remaining before next reset
# TYPE rate_limit_queries_remaining gauge
rate_limit_queries_remaining{endpoint="/api/v1/query",join_leader="true"} 386
# HELP rate_limit_queries_remaining_min minimum number of queries remaining before next reset observed during an expiration interval of 2*refresh period
# TYPE rate_limit_queries_remaining_min gauge
rate_limit_queries_remaining_min{endpoint="/api/v1/query",join_leader="true"} 197
adelhajhassan@COMP-Y0K2MF67D1 ~ % kubectl exec datadog-cluster-agent-6cdb6df59b-sktds   -n datadog-agent -- datadog-cluster-agent telemetry | grep rate_limit_queries_remaining
# HELP rate_limit_queries_remaining number of queries remaining before next reset
# TYPE rate_limit_queries_remaining gauge
rate_limit_queries_remaining{endpoint="/api/v1/query",join_leader="true"} 354
# HELP rate_limit_queries_remaining_min minimum number of queries remaining before next reset observed during an expiration interval of 2*refresh period
# TYPE rate_limit_queries_remaining_min gauge
rate_limit_queries_remaining_min{endpoint="/api/v1/query",join_leader="true"} 197
adelhajhassan@COMP-Y0K2MF67D1 ~ % kubectl exec datadog-cluster-agent-6cdb6df59b-sktds   -n datadog-agent -- datadog-cluster-agent telemetry | grep rate_limit_queries_remaining
# HELP rate_limit_queries_remaining number of queries remaining before next reset
# TYPE rate_limit_queries_remaining gauge
rate_limit_queries_remaining{endpoint="/api/v1/query",join_leader="true"} 376
# HELP rate_limit_queries_remaining_min minimum number of queries remaining before next reset observed during an expiration interval of 2*refresh period
# TYPE rate_limit_queries_remaining_min gauge
rate_limit_queries_remaining_min{endpoint="/api/v1/query",join_leader="true"} 220
adelhajhassan@COMP-Y0K2MF67D1 ~ % kubectl exec datadog-cluster-agent-6cdb6df59b-sktds   -n datadog-agent -- datadog-cluster-agent telemetry | grep rate_limit_queries_remaining
# HELP rate_limit_queries_remaining number of queries remaining before next reset
# TYPE rate_limit_queries_remaining gauge
rate_limit_queries_remaining{endpoint="/api/v1/query",join_leader="true"} 332
# HELP rate_limit_queries_remaining_min minimum number of queries remaining before next reset observed during an expiration interval of 2*refresh period
# TYPE rate_limit_queries_remaining_min gauge
rate_limit_queries_remaining_min{endpoint="/api/v1/query",join_leader="true"} 248
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
