### PR TITLE
omnibus: use existing configure command

### DIFF
--- a/omnibus/config/software/attr.rb
+++ b/omnibus/config/software/attr.rb
@@ -31,13 +31,7 @@ relative_path "#{name}-#{version}"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  configure_command = [
-    "./configure",
-    "--disable-static",
-    "--prefix=#{install_dir}/embedded",
-  ]
-
-  command configure_command.join(" "), env: env
+  configure env: env
 
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env

--- a/omnibus/config/software/dbus.rb
+++ b/omnibus/config/software/dbus.rb
@@ -24,7 +24,6 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   configure_options = [
-    "--prefix=#{install_dir}/embedded",
     "--disable-static",
     "--disable-doxygen-docs",
     "--disable-ducktype-docs",

--- a/omnibus/config/software/elfutils.rb
+++ b/omnibus/config/software/elfutils.rb
@@ -38,7 +38,6 @@ build do
     env = with_standard_compiler_flags(with_embedded_path)
 
     configure_options = [
-      "--prefix=#{install_dir}/embedded",
       "--disable-debuginfod",
       "--disable-libdebuginfod",
       "--disable-nls",

--- a/omnibus/config/software/libgcrypt.rb
+++ b/omnibus/config/software/libgcrypt.rb
@@ -33,11 +33,10 @@ relative_path "libgcrypt-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  
+
   env["CFLAGS"] = "-I#{install_dir}/embedded/include -O1 -D_FORTIFY_SOURCE=1 -fPIC"
 
   configure_options = [
-    "--prefix=#{install_dir}/embedded",
     "--enable-maintainer-mode",
   ]
 

--- a/omnibus/config/software/libgpg-error.rb
+++ b/omnibus/config/software/libgpg-error.rb
@@ -35,8 +35,10 @@ build do
   env["CFLAGS"] << " -fPIC"
 
   configure_options = [
-    "--prefix=#{install_dir}/embedded",
     "--enable-maintainer-mode",
+    "--disable-tests",
+    "--disable-doc",
+    "--disable-languages",
   ]
 
   configure(*configure_options, env: env)

--- a/omnibus/config/software/popt.rb
+++ b/omnibus/config/software/popt.rb
@@ -38,7 +38,6 @@ build do
   update_config_guess
 
   configure_options = [
-    "--prefix=#{install_dir}/embedded",
     "--disable-static",
     "--disable-nls",
   ]

--- a/omnibus/config/software/xmlsec.rb
+++ b/omnibus/config/software/xmlsec.rb
@@ -42,12 +42,11 @@ build do
   env["CFLAGS"] << " -std=c99"
 
   update_config_guess
-
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded" \
-          " --enable-docs" \
-          " --disable-static", env: env
-
+  configure_options = [
+    " --enable-docs",
+    " --disable-static"
+  ]
+  configure(*configure_options, env: env)
   make "-j #{workers}", env: env
   make "install", env: env
 end


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR switches to the omnibus provided `configure` command.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This will help tweak our build configurations by having a single place to modify for all autotools based software dependencies we have, and removes a bit of boilerplate code

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
