### PR TITLE
Fix metric aggregation in serverless-init

### DIFF
--- a/cmd/serverless-init/initcontainer/initcontainer.go
+++ b/cmd/serverless-init/initcontainer/initcontainer.go
@@ -11,7 +11,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/DataDog/datadog-agent/cmd/serverless-init/metric"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -19,6 +18,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/metric"
 
 	"go.uber.org/atomic"
 

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -113,7 +113,9 @@ func setupTraceAgent(traceAgent *trace.ServerlessTraceAgent, tags map[string]str
 
 func setupMetricAgent(tags map[string]string) *metrics.ServerlessMetricAgent {
 	config.Datadog.Set("use_v2_api.series", false)
-	metricAgent := &metrics.ServerlessMetricAgent{}
+	metricAgent := &metrics.ServerlessMetricAgent{
+		SketchesBucketOffset: time.Second * 0,
+	}
 	// we don't want to add the container_id tag to metrics for cardinality reasons
 	tags = tag.WithoutContainerID(tags)
 	tagArray := tag.GetBaseTagsArrayWithMetadataTags(tags)

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -199,7 +199,9 @@ func runAgent(stopCh chan struct{}) (serverlessDaemon *daemon.Daemon, err error)
 	lambdaSpanChan := make(chan *pb.Span)
 	lambdaInitMetricChan := make(chan *serverlessLogs.LambdaInitMetric)
 	coldStartSpanId := random.Random.Uint64()
-	metricAgent := &metrics.ServerlessMetricAgent{}
+	metricAgent := &metrics.ServerlessMetricAgent{
+		SketchesBucketOffset: time.Second * 10,
+	}
 	metricAgent.Start(daemon.FlushTimeout, &metrics.MetricConfig{}, &metrics.MetricDogStatsD{})
 	serverlessDaemon.SetStatsdServer(metricAgent)
 	serverlessDaemon.SetupLogCollectionHandler(logsAPICollectionRoute, logChannel, config.Datadog.GetBool("serverless.logs_enabled"), config.Datadog.GetBool("enhanced_metrics"), lambdaInitMetricChan)

--- a/comp/dogstatsd/server/component.go
+++ b/comp/dogstatsd/server/component.go
@@ -7,6 +7,8 @@
 package server
 
 import (
+	"time"
+
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"go.uber.org/fx"
@@ -30,7 +32,7 @@ type Component interface {
 	UdsListenerRunning() bool
 
 	// ServerlessFlush flushes all the data to the aggregator to them send it to the Datadog intake.
-	ServerlessFlush()
+	ServerlessFlush(time.Duration)
 
 	// SetExtraTags sets extra tags. All metrics sent to the DogstatsD will be tagged with them.
 	SetExtraTags(tags []string)

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -519,7 +519,7 @@ func (s *server) forwarder(fcon net.Conn) {
 }
 
 // ServerlessFlush flushes all the data to the aggregator to them send it to the Datadog intake.
-func (s *server) ServerlessFlush() {
+func (s *server) ServerlessFlush(sketchesBucketDelay time.Duration) {
 	s.log.Debug("Received a Flush trigger")
 
 	// make all workers flush their aggregated data (in the batchers) into the time samplers
@@ -528,7 +528,7 @@ func (s *server) ServerlessFlush() {
 	start := time.Now()
 	// flush the aggregator to have the serializer/forwarder send data to the backend.
 	// We add 10 seconds to the interval to ensure that we're getting the whole sketches bucket
-	s.demultiplexer.ForceFlushToSerializer(start.Add(time.Second*10), true)
+	s.demultiplexer.ForceFlushToSerializer(start.Add(sketchesBucketDelay), true)
 }
 
 // dropCR drops a terminal \r from the data.

--- a/comp/dogstatsd/server/server_mock.go
+++ b/comp/dogstatsd/server/server_mock.go
@@ -44,6 +44,6 @@ func (s *serverMock) UDPLocalAddr() string {
 	return ""
 }
 
-func (s *serverMock) ServerlessFlush() {}
+func (s *serverMock) ServerlessFlush(time.Duration) {}
 
 func (s *serverMock) SetExtraTags(tags []string) {}

--- a/pkg/serverless/metrics/metric.go
+++ b/pkg/serverless/metrics/metric.go
@@ -23,6 +23,8 @@ type ServerlessMetricAgent struct {
 	dogStatsDServer dogstatsdServer.Component
 	tags            []string
 	Demux           aggregator.Demultiplexer
+
+	SketchesBucketOffset time.Duration
 }
 
 // MetricConfig abstacts the config package
@@ -96,7 +98,7 @@ func (c *ServerlessMetricAgent) IsReady() bool {
 // Flush triggers a DogStatsD flush
 func (c *ServerlessMetricAgent) Flush() {
 	if c.IsReady() {
-		c.dogStatsDServer.ServerlessFlush()
+		c.dogStatsDServer.ServerlessFlush(c.SketchesBucketOffset)
 	}
 }
 

--- a/pkg/serverless/metrics/metric_test.go
+++ b/pkg/serverless/metrics/metric_test.go
@@ -36,7 +36,9 @@ func TestMain(m *testing.M) {
 
 func TestStartDoesNotBlock(t *testing.T) {
 	config.Load()
-	metricAgent := &ServerlessMetricAgent{}
+	metricAgent := &ServerlessMetricAgent{
+		SketchesBucketOffset: time.Second * 10,
+	}
 	defer metricAgent.Stop()
 	metricAgent.Start(10*time.Second, &MetricConfig{}, &MetricDogStatsD{})
 	assert.NotNil(t, metricAgent.Demux)
@@ -56,7 +58,9 @@ func (m *InvalidMetricConfigMocked) GetMultipleEndpoints() (map[string][]string,
 }
 
 func TestStartInvalidConfig(t *testing.T) {
-	metricAgent := &ServerlessMetricAgent{}
+	metricAgent := &ServerlessMetricAgent{
+		SketchesBucketOffset: time.Second * 10,
+	}
 	defer metricAgent.Stop()
 	metricAgent.Start(1*time.Second, &InvalidMetricConfigMocked{}, &MetricDogStatsD{})
 	assert.False(t, metricAgent.IsReady())
@@ -69,7 +73,9 @@ func (m *MetricDogStatsDMocked) NewServer(demux aggregator.Demultiplexer) (dogst
 }
 
 func TestStartInvalidDogStatsD(t *testing.T) {
-	metricAgent := &ServerlessMetricAgent{}
+	metricAgent := &ServerlessMetricAgent{
+		SketchesBucketOffset: time.Second * 10,
+	}
 	defer metricAgent.Stop()
 	metricAgent.Start(1*time.Second, &MetricConfig{}, &MetricDogStatsDMocked{})
 	assert.False(t, metricAgent.IsReady())
@@ -82,7 +88,9 @@ func TestStartWithProxy(t *testing.T) {
 
 	t.Setenv(proxyEnabledEnvVar, "true")
 
-	metricAgent := &ServerlessMetricAgent{}
+	metricAgent := &ServerlessMetricAgent{
+		SketchesBucketOffset: time.Second * 10,
+	}
 	defer metricAgent.Stop()
 	metricAgent.Start(10*time.Second, &MetricConfig{}, &MetricDogStatsD{})
 
@@ -96,7 +104,9 @@ func TestStartWithProxy(t *testing.T) {
 }
 
 func TestRaceFlushVersusAddSample(t *testing.T) {
-	metricAgent := &ServerlessMetricAgent{}
+	metricAgent := &ServerlessMetricAgent{
+		SketchesBucketOffset: time.Second * 10,
+	}
 	defer metricAgent.Stop()
 	metricAgent.Start(10*time.Second, &ValidMetricConfigMocked{}, &MetricDogStatsD{})
 
@@ -215,7 +225,7 @@ func TestRaceFlushVersusParsePacket(t *testing.T) {
 
 	go func(wg *sync.WaitGroup) {
 		for i := 0; i < 1000; i++ {
-			s.ServerlessFlush()
+			s.ServerlessFlush(time.Second * 10)
 		}
 		finish.Done()
 	}(finish)

--- a/pkg/serverless/otlp/otlp_test.go
+++ b/pkg/serverless/otlp/otlp_test.go
@@ -68,7 +68,9 @@ func TestServerlessOTLPAgentReceivesTraces(t *testing.T) {
 	})
 
 	// setup metric agent
-	metricAgent := &metrics.ServerlessMetricAgent{}
+	metricAgent := &metrics.ServerlessMetricAgent{
+		SketchesBucketOffset: time.Second * 10,
+	}
 	metricAgent.Start(5*time.Second, &metrics.MetricConfig{}, &metrics.MetricDogStatsD{})
 	defer metricAgent.Stop()
 	assert.NotNil(metricAgent.Demux)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR fixes an issue with incorrect metrics aggregation in serverless-init. Adding 10s to the sketches bucket is only required in Lambda, but since serverless-init was using the same codepath, it also added the 10s delay.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
