### PR TITLE
Make the containers new-e2e tests send datadog events to help debugging

### DIFF
--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/google/uuid v1.3.1
 	github.com/kr/pretty v0.3.1
 	github.com/pkg/sftp v1.13.6
+	gopkg.in/zorkian/go-datadog-api.v2 v2.30.0
 	k8s.io/api v0.28.3
 	k8s.io/apimachinery v0.28.3
 	k8s.io/cli-runtime v0.28.3
@@ -188,6 +189,7 @@ require (
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	github.com/zclconf/go-cty v1.13.2 // indirect
+	github.com/zorkian/go-datadog-api v2.30.0+incompatible // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20230725093048-515e97ebf090 // indirect
@@ -205,7 +207,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.0 // indirect
 	k8s.io/component-base v0.28.3 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -548,6 +548,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.13.2 h1:4GvrUxe/QUDYuJKAav4EYqdM47/kZa672LwmXFmEKT0=
 github.com/zclconf/go-cty v1.13.2/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
+github.com/zorkian/go-datadog-api v2.30.0+incompatible h1:R4ryGocppDqZZbnNc5EDR8xGWF/z/MxzWnqTUijDQes=
+github.com/zorkian/go-datadog-api v2.30.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.starlark.net v0.0.0-20230525235612-a134d8f9ddca h1:VdD38733bfYv5tUZwEIskMM93VanwNIi5bIKnDrJdEY=
 go.starlark.net v0.0.0-20230525235612-a134d8f9ddca/go.mod h1:jxU+3+j+71eXOW14274+SmmuW82qJzl6iZSeqEtTGds=
@@ -776,6 +778,8 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/zorkian/go-datadog-api.v2 v2.30.0 h1:umQdVO0Ytx+kYadhuJNjFtDgIsIEBnKrOTvNuu8ClKI=
+gopkg.in/zorkian/go-datadog-api.v2 v2.30.0/go.mod h1:kx0CSMRpzEZfx/nFH62GLU4stZjparh/BRpM89t4XCQ=
 gotest.tools/v3 v3.5.0 h1:Ljk6PdHdOhAb5aDMWXjDLMMhph+BpztA4v1QdqEW2eY=
 gotest.tools/v3 v3.5.0/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/test/new-e2e/tests/containers/base_test.go
+++ b/test/new-e2e/tests/containers/base_test.go
@@ -6,6 +6,7 @@
 package containers
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -14,21 +15,34 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"gopkg.in/yaml.v3"
+	"gopkg.in/zorkian/go-datadog-api.v2"
 
 	"github.com/DataDog/agent-payload/v5/gogen"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
 )
 
 type baseSuite struct {
 	suite.Suite
 
-	startTime  time.Time
-	endTime    time.Time
-	Fakeintake *fakeintake.Client
+	startTime     time.Time
+	endTime       time.Time
+	datadogClient *datadog.Client
+	Fakeintake    *fakeintake.Client
+	clusterName   string
 }
 
 func (suite *baseSuite) SetupSuite() {
+	apiKey, err := runner.GetProfile().SecretStore().Get(parameters.APIKey)
+	suite.Require().NoError(err)
+	appKey, err := runner.GetProfile().SecretStore().Get(parameters.APPKey)
+	suite.Require().NoError(err)
+	suite.datadogClient = datadog.NewClient(apiKey, appKey)
+
 	suite.startTime = time.Now()
 }
 
@@ -37,68 +51,139 @@ func (suite *baseSuite) TearDownSuite() {
 }
 
 type testMetricArgs struct {
-	filter testMetricFilterArgs
-	expect testMetricExpectArgs
+	Filter testMetricFilterArgs
+	Expect testMetricExpectArgs
 }
 
 type testMetricFilterArgs struct {
-	name string
-	tags []string
+	Name string
+	Tags []string
 }
 
 type testMetricExpectArgs struct {
-	tags  *[]string
-	value *testMetricExpectValueArgs
+	Tags  *[]string
+	Value *testMetricExpectValueArgs
 }
 
 type testMetricExpectValueArgs struct {
-	min float64
-	max float64
+	Min float64
+	Max float64
+}
+
+// myCollectT does nothing more than "github.com/stretchr/testify/assert".CollectT
+// It’s used only to get access to `errors` field which is otherwise private.
+type myCollectT struct {
+	*assert.CollectT
+
+	errors []error
+}
+
+func (mc *myCollectT) Errorf(format string, args ...interface{}) {
+	mc.errors = append(mc.errors, fmt.Errorf(format, args...))
+	mc.CollectT.Errorf(format, args...)
 }
 
 func (suite *baseSuite) testMetric(args *testMetricArgs) {
-	suite.Run(fmt.Sprintf("%s{%s}", args.filter.name, strings.Join(args.filter.tags, ",")), func() {
+	suite.Run(fmt.Sprintf("%s{%s}", args.Filter.Name, strings.Join(args.Filter.Tags, ",")), func() {
 		var expectedTags []*regexp.Regexp
-		if args.expect.tags != nil {
-			expectedTags = lo.Map(*args.expect.tags, func(tag string, _ int) *regexp.Regexp { return regexp.MustCompile(tag) })
+		if args.Expect.Tags != nil {
+			expectedTags = lo.Map(*args.Expect.Tags, func(tag string, _ int) *regexp.Regexp { return regexp.MustCompile(tag) })
 		}
 
+		sendEvent := func(alertType, text string) {
+			formattedArgs, err := yaml.Marshal(args)
+			suite.Require().NoError(err)
+
+			tags := lo.Map(args.Filter.Tags, func(tag string, _ int) string {
+				return "filter_tag_" + tag
+			})
+
+			if _, err := suite.datadogClient.PostEvent(&datadog.Event{
+				Title: pointer.Ptr(fmt.Sprintf("testMetric %s{%s}", args.Filter.Name, strings.Join(args.Filter.Tags, ","))),
+				Text: pointer.Ptr(fmt.Sprintf(`%%%%%%
+### Result
+
+`+"```"+`
+%s
+`+"```"+`
+
+### Query
+
+`+"```"+`
+%s
+`+"```"+`
+ %%%%%%`, text, formattedArgs)),
+				AlertType: &alertType,
+				Tags: append([]string{
+					"app:agent-new-e2e-tests-containers",
+					"cluster_name:" + suite.clusterName,
+					"metric:" + args.Filter.Name,
+					"test:" + suite.T().Name(),
+				}, tags...),
+			}); err != nil {
+				suite.T().Logf("Failed to post event: %s", err)
+			}
+		}
+
+		defer func() {
+			if suite.T().Failed() {
+				sendEvent("error", fmt.Sprintf("Failed finding %s{%s} with proper tags", args.Filter.Name, strings.Join(args.Filter.Tags, ",")))
+			} else {
+				sendEvent("success", "All good!")
+			}
+		}()
+
 		suite.EventuallyWithTf(func(collect *assert.CollectT) {
+			myCollect := &myCollectT{
+				CollectT: collect,
+				errors:   []error{},
+			}
+			// To enforce the use of myCollect instead
+			collect = nil //nolint:ineffassign
+
+			defer func() {
+				if len(myCollect.errors) == 0 {
+					sendEvent("success", "All good!")
+				} else {
+					sendEvent("warning", errors.Join(myCollect.errors...).Error())
+				}
+			}()
+
 			metrics, err := suite.Fakeintake.FilterMetrics(
-				args.filter.name,
-				fakeintake.WithTags[*aggregator.MetricSeries](args.filter.tags),
+				args.Filter.Name,
+				fakeintake.WithTags[*aggregator.MetricSeries](args.Filter.Tags),
 			)
 			if err != nil {
-				collect.Errorf("%w", err)
+				myCollect.Errorf("%w", err)
 				return
 			}
 			if len(metrics) == 0 {
-				collect.Errorf("No `%s{%s}` metrics yet", args.filter.name, strings.Join(args.filter.tags, ","))
+				myCollect.Errorf("No `%s{%s}` metrics yet", args.Filter.Name, strings.Join(args.Filter.Tags, ","))
 				return
 			}
 
 			// Check tags
 			if expectedTags != nil {
 				if err := assertTags(metrics[len(metrics)-1].GetTags(), expectedTags); err != nil {
-					collect.Errorf("Tags mismatch on `%s`: %w", args.filter.name, err)
+					myCollect.Errorf("Tags mismatch on `%s`: %w", args.Filter.Name, err)
 				}
 			}
 
 			// Check value
-			if args.expect.value != nil {
+			if args.Expect.Value != nil {
 				if lo.CountBy(metrics[len(metrics)-1].GetPoints(), func(v *gogen.MetricPayload_MetricPoint) bool {
-					return v.GetValue() >= args.expect.value.min &&
-						v.GetValue() <= args.expect.value.max
+					return v.GetValue() >= args.Expect.Value.Min &&
+						v.GetValue() <= args.Expect.Value.Max
 				}) == 0 {
-					collect.Errorf(
+					myCollect.Errorf(
 						"No value of `%s{%s}` is in the range [%f;%f]",
-						args.filter.name,
-						strings.Join(args.filter.tags, ","),
-						args.expect.value.min,
-						args.expect.value.max,
+						args.Filter.Name,
+						strings.Join(args.Filter.Tags, ","),
+						args.Expect.Value.Min,
+						args.Expect.Value.Max,
 					)
 				}
 			}
-		}, 2*time.Minute, 10*time.Second, "Failed finding %s{%s} with proper tags", args.filter.name, strings.Join(args.filter.tags, ","))
+		}, 2*time.Minute, 10*time.Second, "Failed finding %s{%s} with proper tags", args.Filter.Name, strings.Join(args.Filter.Tags, ","))
 	})
 }

--- a/test/new-e2e/tests/containers/ecs_test.go
+++ b/test/new-e2e/tests/containers/ecs_test.go
@@ -56,6 +56,7 @@ func (suite *ecsSuite) SetupSuite() {
 	fakeintakeHost := stackOutput.Outputs["fakeintake-host"].Value.(string)
 	suite.Fakeintake = fakeintake.NewClient(fmt.Sprintf("http://%s", fakeintakeHost))
 	suite.ecsClusterName = stackOutput.Outputs["ecs-cluster-name"].Value.(string)
+	suite.clusterName = suite.ecsClusterName
 
 	suite.baseSuite.SetupSuite()
 }
@@ -179,11 +180,11 @@ func (suite *ecsSuite) TestNginx() {
 	// `nginx` check is configured via docker labels
 	// Test it is properly scheduled
 	suite.testMetric(&testMetricArgs{
-		filter: testMetricFilterArgs{
-			name: "nginx.net.request_per_s",
+		Filter: testMetricFilterArgs{
+			Name: "nginx.net.request_per_s",
 		},
-		expect: testMetricExpectArgs{
-			tags: &[]string{
+		Expect: testMetricExpectArgs{
+			Tags: &[]string{
 				`^cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`,
 				`^container_id:`,
 				`^container_name:ecs-.*-nginx-ec2-`,
@@ -210,11 +211,11 @@ func (suite *ecsSuite) TestRedis() {
 	// `redis` check is auto-configured due to image name
 	// Test it is properly scheduled
 	suite.testMetric(&testMetricArgs{
-		filter: testMetricFilterArgs{
-			name: "redis.net.instantaneous_ops_per_sec",
+		Filter: testMetricFilterArgs{
+			Name: "redis.net.instantaneous_ops_per_sec",
 		},
-		expect: testMetricExpectArgs{
-			tags: &[]string{
+		Expect: testMetricExpectArgs{
+			Tags: &[]string{
 				`^cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`,
 				`^container_id:`,
 				`^container_name:ecs-.*-redis-ec2-`,
@@ -240,11 +241,11 @@ func (suite *ecsSuite) TestRedis() {
 func (suite *ecsSuite) TestDogstatsd() {
 	// Test dogstatsd origin detection with UDS
 	suite.testMetric(&testMetricArgs{
-		filter: testMetricFilterArgs{
-			name: "custom.metric",
+		Filter: testMetricFilterArgs{
+			Name: "custom.metric",
 		},
-		expect: testMetricExpectArgs{
-			tags: &[]string{
+		Expect: testMetricExpectArgs{
+			Tags: &[]string{
 				`^cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`,
 				`^container_id:`,
 				`^container_name:ecs-.*-dogstatsd-uds-ec2-`,
@@ -270,11 +271,11 @@ func (suite *ecsSuite) TestDogstatsd() {
 func (suite *ecsSuite) TestPrometheus() {
 	// Test Prometheus check
 	suite.testMetric(&testMetricArgs{
-		filter: testMetricFilterArgs{
-			name: "prometheus.prom_gauge",
+		Filter: testMetricFilterArgs{
+			Name: "prometheus.prom_gauge",
 		},
-		expect: testMetricExpectArgs{
-			tags: &[]string{
+		Expect: testMetricExpectArgs{
+			Tags: &[]string{
 				`^cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`,
 				`^container_id:`,
 				`^container_name:ecs-.*-prometheus-ec2-`,


### PR DESCRIPTION
### What does this PR do?

Emit a datadog event each time a metric is asserted in the new-e2e test framework.

### Motivation

Knowing that the agent is broken because an e2e test is failing is nice.
But knowing what it broken and why because e2e test failures are giving a maximum of information regarding the failure is better.

In that context, the `containers` e2e tests are already providing, at the end of their execution, a link to a [dashboard](https://dddev.datadoghq.com/dashboard/qcp-brm-ysc/e2e-tests-containers-k8s) containing all the metrics that are produced and asserted by the tests.

This PR adds an event overlay on top of those graph so that we can visually see *when* the assertion ran.

It is useful to visualize when a metric eventually show up after the retry loop ended, or when we do too many useless retries, etc.

### Additional Notes

Here is what the dashboard looks like: 
![image](https://github.com/DataDog/datadog-agent/assets/1437785/4e1d4b3b-975c-4913-8c80-f42f65adc6d4)

The events contain information about what was looked for and what was missing:
![image](https://github.com/DataDog/datadog-agent/assets/1437785/cf116032-a204-42ad-9590-a1c0429e7455)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
