### PR TITLE
[cmd/cluster-agent] disabled language detection handler if language detection feature is disabled

### DIFF
--- a/cmd/cluster-agent/api/v1/language_detection.go
+++ b/cmd/cluster-agent/api/v1/language_detection.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/api"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/languagedetection"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
 
 	"github.com/gorilla/mux"
@@ -25,6 +26,12 @@ func InstallLanguageDetectionEndpoints(r *mux.Router) {
 }
 
 func postDetectedLanguages(w http.ResponseWriter, r *http.Request) {
+	if !config.Datadog.GetBool("language_detecion.enabled") {
+		languagedetection.ErrorResponses.Inc()
+		http.Error(w, "Language detection feature is disabled on the cluster agent", http.StatusInternalServerError)
+		return
+	}
+
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Failed to read request body", http.StatusBadRequest)

--- a/cmd/cluster-agent/api/v1/language_detection.go
+++ b/cmd/cluster-agent/api/v1/language_detection.go
@@ -28,7 +28,7 @@ func InstallLanguageDetectionEndpoints(r *mux.Router) {
 func postDetectedLanguages(w http.ResponseWriter, r *http.Request) {
 	if !config.Datadog.GetBool("language_detecion.enabled") {
 		languagedetection.ErrorResponses.Inc()
-		http.Error(w, "Language detection feature is disabled on the cluster agent", http.StatusInternalServerError)
+		http.Error(w, "Language detection feature is disabled on the cluster agent", http.StatusServiceUnavailable)
 		return
 	}
 

--- a/cmd/cluster-agent/api/v1/language_detection.go
+++ b/cmd/cluster-agent/api/v1/language_detection.go
@@ -26,7 +26,7 @@ func InstallLanguageDetectionEndpoints(r *mux.Router) {
 }
 
 func postDetectedLanguages(w http.ResponseWriter, r *http.Request) {
-	if !config.Datadog.GetBool("language_detecion.enabled") {
+	if !config.Datadog.GetBool("language_detection.enabled") {
 		languagedetection.ErrorResponses.Inc()
 		http.Error(w, "Language detection feature is disabled on the cluster agent", http.StatusServiceUnavailable)
 		return


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR modifies the language detection dca handler so that it returns an error in case if it receives a request while the language detection feature is disabled. (i.e `language_detection.enabled: false`)

### Motivation

In the normal case, the client should not be sending requests to the language detection handler in case language detection is disabled as a feature. 

However, in the case of rollout of the agent deployment, if the previous state has the language detection enabled and the new state (after rollout) has the language detection feature disabled, the old versions of the agent pods will still be sending patching requests to the language detection handler until the rollout is fully finished. 

Knowing that the cluster agent rollout is usually faster (less pods to update) than that of the agent deployment, it would be useful to stop the handler as early as possible from patching deployments in response to requests received from the node.


### Possible Drawbacks / Trade-offs

- This will potentially increase `fail_response` reported via telemetry when a rollout disables language detection after it had been previously enabled. However, this should be okay, as we still have other telemetry metrics that indicate more specific information about what went wrong when handling a patching request fails.

### Describe how to test/QA your changes

- Deploy the cluster agent on a kubernetes cluster (e.g using `kind` or `minikube`). 
- Ensure `language_detection.enabled` is set to `false` (this should be the case by default)
- Start a shell interface on one of the node agents and try to send an empty request using the following commad: `curl -k -X POST -H "Authorization: Bearer $DD_CLUSTER_AGENT_AUTH_TOKEN" https://datadog-agent-cluster-agent:5005/api/v1/languagedetection` 
- The response should look similar to the following: **Language detection feature is disabled on the cluster agent**

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
