### PR TITLE
support template variable in tagger

### DIFF
--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/tmplvar"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
@@ -732,10 +733,10 @@ func parseJSONValue(value string, tags *utils.TagList) error {
 	for key, value := range result {
 		switch v := value.(type) {
 		case string:
-			tags.AddAuto(key, v)
+			tags.AddAuto(key, tmplvar.ParseTemplateEnvString(v))
 		case []interface{}:
 			for _, tag := range v {
-				tags.AddAuto(key, fmt.Sprint(tag))
+				tags.AddAuto(key, tmplvar.ParseTemplateEnvString(fmt.Sprint(tag)))
 			}
 		default:
 			log.Debugf("Tag value %s is not valid, must be a string or an array, skipping", v)
@@ -758,7 +759,7 @@ func parseContainerADTagsLabels(tags *utils.TagList, labelValue string) {
 			log.Debugf("Tag '%s' is not in k:v format", tag)
 			continue
 		}
-		tags.AddHigh(tagParts[0], tagParts[1])
+		tags.AddHigh(tagParts[0], tmplvar.ParseTemplateEnvString(tagParts[1]))
 	}
 }
 

--- a/pkg/tagger/collectors/workloadmeta_test.go
+++ b/pkg/tagger/collectors/workloadmeta_test.go
@@ -7,6 +7,7 @@ package collectors
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"testing"
 
@@ -1316,16 +1317,28 @@ func TestParseJSONValue(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:  "strings only",
-			value: `{"key1": "val1", "key2": "val2"}`,
+			name:  "strings with template var",
+			value: `{"key1": "val1", "key2": "val2", "key3": "%%env_TEAM_NAME%%_app"}`,
 			want: []string{
 				"key1:val1",
 				"key2:val2",
+				"key3:containers_app",
+			},
+			wantErr: false,
+		},
+		{
+			name:  "arrays with template var",
+			value: `{"key1": ["val1", "val11"], "key2": ["val2", "%%env_TEAM_NAME%%_app"]}`,
+			want: []string{
+				"key1:val1",
+				"key1:val11",
+				"key2:val2",
+				"key2:containers_app",
 			},
 			wantErr: false,
 		},
 	}
-
+	os.Setenv("TEAM_NAME", "containers")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tags := utils.NewTagList()

--- a/pkg/util/tmplvar/parse_test.go
+++ b/pkg/util/tmplvar/parse_test.go
@@ -7,6 +7,7 @@ package tmplvar
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,6 +49,46 @@ func TestParseTemplateVar(t *testing.T) {
 			name, key := parseTemplateVar([]byte(testCase.tmpl))
 			assert.Equal(t, testCase.name, string(name))
 			assert.Equal(t, testCase.key, string(key))
+		})
+	}
+}
+
+func TestParseTemplateEnvString(t *testing.T) {
+	testCases := []struct {
+		tmpl, expected_value string
+	}{
+		{
+			"app",
+			"app",
+		},
+		{
+			"app",
+			"app",
+		},
+		{
+			"%%env_APP%%",
+			"testapp", //found
+		},
+		{
+			"%%env_app%%",
+			"%%env_app%%", //not found, return original string
+		},
+		{
+			"%%env_TEAM_NAME%%",
+			"containers",
+		},
+		{
+			"team_%%env_TEAM_NAME%%_%%env_APP%%_prod",
+			"team_containers_testapp_prod",
+		},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
+			os.Setenv("APP", "testapp")
+			os.Setenv("TEAM_NAME", "containers")
+			value := ParseTemplateEnvString(testCase.tmpl)
+			assert.Equal(t, testCase.expected_value, value)
 		})
 	}
 }

--- a/pkg/util/tmplvar/parse_test.go
+++ b/pkg/util/tmplvar/parse_test.go
@@ -55,7 +55,7 @@ func TestParseTemplateVar(t *testing.T) {
 
 func TestParseTemplateEnvString(t *testing.T) {
 	testCases := []struct {
-		tmpl, expected_value string
+		tmpl, expectedValue string
 	}{
 		{
 			"app",
@@ -88,7 +88,7 @@ func TestParseTemplateEnvString(t *testing.T) {
 			os.Setenv("APP", "testapp")
 			os.Setenv("TEAM_NAME", "containers")
 			value := ParseTemplateEnvString(testCase.tmpl)
-			assert.Equal(t, testCase.expected_value, value)
+			assert.Equal(t, testCase.expectedValue, value)
 		})
 	}
 }

--- a/releasenotes/notes/support-template_variable-in-tag-annotation-ac13282c439589f3.yaml
+++ b/releasenotes/notes/support-template_variable-in-tag-annotation-ac13282c439589f3.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+enhancements:
+  - |
+    Add tagger parse to support envirable varible in format of "%%env_XXXXX%%". 
+    For example, add the following template variable to ad.datadoghq.com/tags or com.datadoghq.ad.tags
+      "available_zone": "%%env_AVAILABILITY_ZONE%%"
+    %%env_AVAILABILITY_ZONE%% will be replaced by the env var in the tagger

--- a/releasenotes/notes/support-template_variable-in-tag-annotation-ac13282c439589f3.yaml
+++ b/releasenotes/notes/support-template_variable-in-tag-annotation-ac13282c439589f3.yaml
@@ -7,7 +7,7 @@
 # Each section note must be formatted as reStructuredText.
 enhancements:
   - |
-    Add tagger parse to support envirable varible in format of "%%env_XXXXX%%". 
+    Add tagger parsing to support environment variables in "%%env_XXXXX%%" format. 
     For example, add the following template variable to ad.datadoghq.com/tags or com.datadoghq.ad.tags
       "available_zone": "%%env_AVAILABILITY_ZONE%%"
     %%env_AVAILABILITY_ZONE%% will be replaced by the env var in the tagger


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
[CONTINT-687](https://datadoghq.atlassian.net/browse/CONTINT-687)
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Support template variable (envvar) with placeholder like` %%env_***%%` in ad.datadoghq.com/tags and com.datadoghq.ad.tags

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
For example, set in ad.datadoghq.com/tags annotations
```
        ad.datadoghq.com/tags: 
        {
            "fabric-az": "%%env_AVAILABILITY_ZONE%%"
         }
```
and set AVAILABILITY_ZONE in env
```
> kesd  -n datadog-agent exec -it datadog-agent-h67bm-zxn85 -- env | grep ZONE
Defaulted container "agent" out of: agent, trace-agent, security-agent, system-probe, process-agent, init-volume (init), init-config (init), seccomp-setup (init)
AVAILABILITY_ZONE=us-east-1b 
```
%%env_AVAILABILITY_ZONE%% will be replaced by us-east-1b in the tag



<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.


[CONTINT-687]: https://datadoghq.atlassian.net/browse/CONTINT-687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ