### PR TITLE
add a precommit hook to avoid commiting to a protected branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     - id: protected-branches
       name: protected-branches
       description: checks that the commit isn't created on a protected branch
-      entry: "python3 tasks/git-hooks/protected-branches.py"
+      entry: 'python3 tasks/git-hooks/protected-branches.py'
       language: system
     - id: revive
       name: revive

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,11 @@ repos:
       args: [ "-w", "-s" ]
 - repo: local
   hooks:
+    - id: protected-branches
+      name: protected-branches
+      description: checks that the commit isn't created on a protected branch
+      entry: "python3 tasks/git-hooks/protected-branches.py"
+      language: system
     - id: revive
       name: revive
       description: revive

--- a/tasks/git-hooks/protected-branches.py
+++ b/tasks/git-hooks/protected-branches.py
@@ -8,14 +8,14 @@ import sys
 def main():
     try:
         local_branch = subprocess.check_output('git rev-parse --abbrev-ref HEAD', shell=True).decode('utf-8').strip()
-        print(local_branch)
         if local_branch == 'main':
             print("You're about to commit on main, are you sure this is what you want?")
             sys.exit(1)
         if re.fullmatch(r'^[0-9]+\.[0-9]+\.x$', local_branch):
             print("You're about to commit on a release branch, are you sure this is what you want?")
             sys.exit(1)
-    except OSError:
+    except OSError as e:
+        print(e)
         sys.exit(1)
 
 

--- a/tasks/git-hooks/protected-branches.py
+++ b/tasks/git-hooks/protected-branches.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+
+import re
+import subprocess
+import sys
+
+
+def main():
+    try:
+        local_branch = subprocess.check_output('git rev-parse --abbrev-ref HEAD', shell=True).decode('utf-8').strip()
+        print(local_branch)
+        if local_branch == 'main':
+            print("You're about to commit on main, are you sure this is what you want?")
+            sys.exit(1)
+        if re.fullmatch(r'^[0-9]+\.[0-9]+\.x$', local_branch):
+            print("You're about to commit on a release branch, are you sure this is what you want?")
+            sys.exit(1)
+    except OSError:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

It adds a pre-commit hook in order to avoid people commiting to main or release branches.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

A `git commit -av && git push` on the wrong branch happens too quickly sometimes, this will reject the creation of the commit before it's too late.
We could prevent pushing, but a pre-commit hook seems better suited since it can be ignored in cases where commiting & pushing to a protected branch is intended.
We could also prevent pushes to protected branch on github side, but this means that admins won't be able to force merge some PRs, or that they need to toggle the protection back and forth to be able to do so.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
