### PR TITLE
[serverless] basic fix for function url events

### DIFF
--- a/pkg/serverless/invocationlifecycle/init.go
+++ b/pkg/serverless/invocationlifecycle/init.go
@@ -183,6 +183,9 @@ func (lp *LifecycleProcessor) initFromSQSEvent(event events.SQSEvent) {
 
 func (lp *LifecycleProcessor) initFromLambdaFunctionURLEvent(event events.LambdaFunctionURLRequest, region string, accountID string, functionName string) {
 	lp.requestHandler.event = event
+	if !lp.DetectLambdaLibrary() && lp.InferredSpansEnabled {
+		lp.GetInferredSpan().EnrichInferredSpanWithLambdaFunctionURLEvent(event)
+	}
 	lp.addTag(tagFunctionTriggerEventSource, functionURL)
 	lp.addTag(tagFunctionTriggerEventSourceArn, fmt.Sprintf("arn:aws:lambda:%v:%v:url:%v", region, accountID, functionName))
 	lp.addTags(trigger.GetTagsFromLambdaFunctionURLRequest(event))

--- a/pkg/serverless/trace/inferredspan/span_enrichment.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment.go
@@ -129,7 +129,7 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayHTTPEvent(even
 
 // EnrichInferredSpanWithLambdaFunctionURLEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
-// specific set of data to the span expected from a Lambda Funciton URL event.
+// specific set of data to the span expected from a Lambda Function URL event.
 func (inferredSpan *InferredSpan) EnrichInferredSpanWithLambdaFunctionURLEvent(eventPayload events.LambdaFunctionURLRequest) {
 	log.Debug("Enriching an inferred span for a Lambda Function URL")
 	requestContext := eventPayload.RequestContext
@@ -139,8 +139,8 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithLambdaFunctionURLEvent(e
 	domainName := requestContext.DomainName
 	httpurl := fmt.Sprintf("%s%s", domainName, path)
 	startTime := calculateStartTime(requestContext.TimeEpoch)
-	apiId := requestContext.APIID
-	serviceName := DetermineServiceName(serviceMapping, apiId, "lambda_url", domainName)
+	apiID := requestContext.APIID
+	serviceName := DetermineServiceName(serviceMapping, apiID, "lambda_url", domainName)
 	inferredSpan.Span.Name = "aws.lambda.url"
 	inferredSpan.Span.Service = serviceName
 	inferredSpan.Span.Resource = resource

--- a/pkg/serverless/trace/inferredspan/span_enrichment.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment.go
@@ -127,6 +127,40 @@ func (inferredSpan *InferredSpan) EnrichInferredSpanWithAPIGatewayHTTPEvent(even
 	inferredSpan.IsAsync = eventPayload.Headers[invocationType] == "Event"
 }
 
+// EnrichInferredSpanWithLambdaFunctionURLEvent uses the parsed event
+// payload to enrich the current inferred span. It applies a
+// specific set of data to the span expected from a Lambda Funciton URL event.
+func (inferredSpan *InferredSpan) EnrichInferredSpanWithLambdaFunctionURLEvent(eventPayload events.LambdaFunctionURLRequest) {
+	log.Debug("Enriching an inferred span for a Lambda Function URL")
+	requestContext := eventPayload.RequestContext
+	http := requestContext.HTTP
+	path := eventPayload.RequestContext.HTTP.Path
+	resource := fmt.Sprintf("%s %s", http.Method, path)
+	domainName := requestContext.DomainName
+	httpurl := fmt.Sprintf("%s%s", domainName, path)
+	startTime := calculateStartTime(requestContext.TimeEpoch)
+	apiId := requestContext.APIID
+	serviceName := DetermineServiceName(serviceMapping, apiId, "lambda_url", domainName)
+	inferredSpan.Span.Name = "aws.lambda.url"
+	inferredSpan.Span.Service = serviceName
+	inferredSpan.Span.Resource = resource
+	inferredSpan.Span.Type = "http"
+	inferredSpan.Span.Start = startTime
+	inferredSpan.Span.Meta = map[string]string{
+		endpoint:      path,
+		httpURL:       httpurl,
+		httpMethod:    http.Method,
+		httpProtocol:  http.Protocol,
+		httpSourceIP:  http.SourceIP,
+		httpUserAgent: http.UserAgent,
+		operationName: "aws.lambda.url",
+		requestID:     requestContext.RequestID,
+		resourceNames: resource,
+	}
+
+	inferredSpan.IsAsync = eventPayload.Headers[invocationType] == "Event"
+}
+
 // EnrichInferredSpanWithAPIGatewayWebsocketEvent uses the parsed event
 // payload to enrich the current inferred span. It applies a
 // specific set of data to the span expected from a Websocket event.

--- a/pkg/serverless/trace/inferredspan/span_enrichment_test.go
+++ b/pkg/serverless/trace/inferredspan/span_enrichment_test.go
@@ -257,6 +257,30 @@ func TestEnrichInferredSpanWithAPIGatewayHTTPEvent(t *testing.T) {
 	assert.Equal(t, "GET /httpapi/get", span.Meta[resourceNames])
 }
 
+func TestEnrichInferredSpanWithLambdaFunctionURLEventt(t *testing.T) {
+	var apiGatewayHTTPEvent events.LambdaFunctionURLRequest
+	_ = json.Unmarshal(getEventFromFile("http-api.json"), &apiGatewayHTTPEvent)
+	inferredSpan := mockInferredSpan()
+	inferredSpan.EnrichInferredSpanWithLambdaFunctionURLEvent(apiGatewayHTTPEvent)
+
+	span := inferredSpan.Span
+	assert.Equal(t, uint64(7353030974370088224), span.TraceID)
+	assert.Equal(t, uint64(8048964810003407541), span.SpanID)
+	assert.Equal(t, int64(1631212283738000000), span.Start)
+	assert.Equal(t, "x02yirxc7a.execute-api.sa-east-1.amazonaws.com", span.Service)
+	assert.Equal(t, "aws.lambda.url", span.Name)
+	assert.Equal(t, "GET /httpapi/get", span.Resource)
+	assert.Equal(t, "http", span.Type)
+	assert.Equal(t, "GET", span.Meta[httpMethod])
+	assert.Equal(t, "HTTP/1.1", span.Meta[httpProtocol])
+	assert.Equal(t, "38.122.226.210", span.Meta[httpSourceIP])
+	assert.Equal(t, "x02yirxc7a.execute-api.sa-east-1.amazonaws.com/httpapi/get", span.Meta[httpURL])
+	assert.Equal(t, "curl/7.64.1", span.Meta[httpUserAgent])
+	assert.Equal(t, "aws.lambda.url", span.Meta[operationName])
+	assert.Equal(t, "FaHnXjKCGjQEJ7A=", span.Meta[requestID])
+	assert.Equal(t, "GET /httpapi/get", span.Meta[resourceNames])
+}
+
 func TestRemapsSpecificInferredSpanServiceNamesFromAPIGatewayHTTPAPIEvent(t *testing.T) {
 	// Load the original event
 	var apiGatewayHTTPAPIEvent events.APIGatewayV2HTTPRequest


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fix the inferred span for function url event
This PR only added very basic fix and it has ugly repeated code. `EnrichInferredSpanWithLambdaFunctionURLEvent` is basically a copy of `EnrichInferredSpanWithAPIGatewayHTTPEvent` above, except the *Name* and *OperationName* are "aws.lambda.url" instead.
I'll refactor all the `EnrichInferredSpanWith<EventType>Event` methods in a separate PR. 


### Motivation
Currently the inferred span in the function url case is broken:
<img width="1142" alt="Screenshot 2023-10-30 at 12 53 36 PM" src="https://github.com/DataDog/datadog-agent/assets/5253430/041759d0-b44f-4bca-b466-e008ee6f3d7d">
With this PR's fix, it will look like this:
<img width="1120" alt="Screenshot 2023-10-30 at 12 53 10 PM" src="https://github.com/DataDog/datadog-agent/assets/5253430/a4d214bc-c9c3-4b2d-86d5-7875d5e97d3b">

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
