### PR TITLE
Adds instructions to readme about JMXFetch and clarifies detailed dev docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ The file `bin/agent/dist/datadog.yaml` is copied from `dev/dist/datadog.yaml` by
 
 ### Run a JMX check
 In order to run a JMX based check locally, you must have:
-1) A copy of a JMXFetch `jar` copied to `dev/dist/jmx/jmxfetch.jar`
-2) `java` available on your `$PATH`
+1. A copy of a JMXFetch `jar` copied to `dev/dist/jmx/jmxfetch.jar`
+2. `java` available on your `$PATH`
 
-For detailed instructions, check [here](./docs/dev/checks/jmxfetch.md)
+For detailed instructions, see [JMX checks](./docs/dev/checks/jmxfetch.md)
 
 ## Contributing code
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ You can run the agent with:
 
 The file `bin/agent/dist/datadog.yaml` is copied from `dev/dist/datadog.yaml` by `invoke agent.build` and must contain a valid api key.
 
-### Running a JMX check
+### Run a JMX check
 In order to run a JMX based check locally, you must have:
 1) A copy of a JMXFetch `jar` copied to `dev/dist/jmx/jmxfetch.jar`
 2) `java` available on your `$PATH`

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ You can run the agent with:
 
 The file `bin/agent/dist/datadog.yaml` is copied from `dev/dist/datadog.yaml` by `invoke agent.build` and must contain a valid api key.
 
+### Running a JMX check
+In order to run a JMX based check locally, you must have:
+1) A copy of a JMXFetch `jar` copied to `dev/dist/jmx/jmxfetch.jar`
+2) `java` available on your `$PATH`
+
+For detailed instructions, check [here](./docs/dev/checks/jmxfetch.md)
+
 ## Contributing code
 
 You'll find information and help on how to contribute code to this project under

--- a/docs/dev/checks/jmxfetch.md
+++ b/docs/dev/checks/jmxfetch.md
@@ -6,8 +6,8 @@ integrations locally. In other words, you've made changes to how JMXFetch
 works and you'd like to run JMXFetch via the Agent to validate your changes.
 
 ## Stable JMXFetch
-If your goal is just to run an JMX-based check and you don't need a custom
-version of JMXFetch, follow these instructions.
+If your goal is to run a JMX-based check and you don't need a custom
+version of JMXFetch, follow the instructions below:
 
 1. Download the `-jar-with-dependencies.jar` build of the latest version of JMXFetch from
    [`maven`](https://repo1.maven.org/maven2/com/datadoghq/jmxfetch/)

--- a/docs/dev/checks/jmxfetch.md
+++ b/docs/dev/checks/jmxfetch.md
@@ -5,6 +5,20 @@ These docs are intended to help you test changes to either JMXFetch or JMX-based
 integrations locally. In other words, you've made changes to how JMXFetch
 works and you'd like to run JMXFetch via the Agent to validate your changes.
 
+## Stable JMXFetch
+If your goal is just to run an JMX-based check and you don't need a custom
+version of JMXFetch, follow these instructions.
+
+1. Download the `-jar-with-dependencies.jar` build of the latest version of JMXFetch from
+   [`maven`](https://repo1.maven.org/maven2/com/datadoghq/jmxfetch/)
+2. Copy it to `$GOPATH/src/github.com/DataDog/datadog-agent/dev/dist/jmx/jmxfetch.jar`.
+3. Run `inv agent.run`.
+4. Validate that the JMXFetch section appears in `agent status`.
+
+If you have a JMX-based integration configured to run, it should automatically
+be run in your local JMXFetch instance.
+
+
 ## Custom Build of JMXFetch
 1. [Build JMXFetch](https://github.com/DataDog/jmxfetch/#building-from-source).
 2. Copy the resulting jar into `$GOPATH/src/github.com/DataDog/datadog-agent/dev/dist/jmx/jmxfetch.jar`.

--- a/docs/dev/checks/jmxfetch.md
+++ b/docs/dev/checks/jmxfetch.md
@@ -11,7 +11,7 @@ version of JMXFetch, follow the instructions below:
 
 1. Download the `-jar-with-dependencies.jar` build of the latest version of JMXFetch from
    [`maven`](https://repo1.maven.org/maven2/com/datadoghq/jmxfetch/)
-2. Copy it to `$GOPATH/src/github.com/DataDog/datadog-agent/dev/dist/jmx/jmxfetch.jar`.
+2. Copy the jar file and rename it to `$GOPATH/src/github.com/DataDog/datadog-agent/dev/dist/jmx/jmxfetch.jar`.
 3. Run `inv agent.run`.
 4. Validate that the JMXFetch section appears in `agent status`.
 

--- a/docs/dev/checks/jmxfetch.md
+++ b/docs/dev/checks/jmxfetch.md
@@ -15,8 +15,8 @@ version of JMXFetch, follow the instructions below:
 3. Run `inv agent.run`.
 4. Validate that the JMXFetch section appears in `agent status`.
 
-If you have a JMX-based integration configured to run, it should automatically
-be run in your local JMXFetch instance.
+If you have a JMX-based integration configured to run, it automatically
+runs in your local JMXFetch instance.
 
 
 ## Custom Build of JMXFetch


### PR DESCRIPTION
### What does this PR do?
Adds instructions for developers looking to run JMX based checks to the readme and clarifies the detailed documentation


### Motivation

Make it easier for devs to run JMXFetch locally

### Additional Notes



### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
