### PR TITLE
[CSPM] Do not use SECL constants in rule filters

### DIFF
--- a/docs/cloud-workload-security/agent_expressions.md
+++ b/docs/cloud-workload-security/agent_expressions.md
@@ -3120,6 +3120,14 @@ BPF program types are the supported eBPF program types.
 | `BPF_PROG_TYPE_LSM` | all |
 | `BPF_PROG_TYPE_SK_LOOKUP` | all |
 
+### `Boolean constants` {#boolean-constants}
+Boolean constants are the supported boolean constants.
+
+| Name | Architectures |
+| ---- |---------------|
+| `true` | all |
+| `false` | all |
+
 ### `DNS qclasses` {#dns-qclasses}
 DNS qclasses are the supported DNS query classes.
 
@@ -3790,14 +3798,6 @@ Ptrace constants are the supported ptrace commands for the ptrace syscall.
 | `PTRACE_SET_SYSCALL` | arm |
 | `PTRACE_PEEKMTETAGS` | arm64 |
 | `PTRACE_POKEMTETAGS` | arm64 |
-
-### `SecL constants` {#secl-constants}
-SecL constants are the supported generic SecL constants.
-
-| Name | Architectures |
-| ---- |---------------|
-| `true` | all |
-| `false` | all |
 
 ### `Signal constants` {#signal-constants}
 Signal constants are the supported signals for the kill syscall.

--- a/docs/cloud-workload-security/secl.json
+++ b/docs/cloud-workload-security/secl.json
@@ -10294,6 +10294,21 @@
       ]
     },
     {
+      "name": "Boolean constants",
+      "link": "boolean-constants",
+      "description": "Boolean constants are the supported boolean constants.",
+      "all": [
+        {
+          "name": "true",
+          "architecture": "all"
+        },
+        {
+          "name": "false",
+          "architecture": "all"
+        }
+      ]
+    },
+    {
       "name": "DNS qclasses",
       "link": "dns-qclasses",
       "description": "DNS qclasses are the supported DNS query classes.",
@@ -12736,21 +12751,6 @@
         {
           "name": "PTRACE_POKEMTETAGS",
           "architecture": "arm64"
-        }
-      ]
-    },
-    {
-      "name": "SecL constants",
-      "link": "secl-constants",
-      "description": "SecL constants are the supported generic SecL constants.",
-      "all": [
-        {
-          "name": "true",
-          "architecture": "all"
-        },
-        {
-          "name": "false",
-          "architecture": "all"
         }
       ]
     },

--- a/pkg/security/secl/model/consts_common.go
+++ b/pkg/security/secl/model/consts_common.go
@@ -540,13 +540,16 @@ var (
 		"CLASS_ANY":    255,
 	}
 
-	// seclConstants are constants supported in runtime security agent rules
-	// generate_constants:SecL constants,SecL constants are the supported generic SecL constants.
-	seclConstants = map[string]interface{}{
+	// BooleanConstants holds the evaluator for boolean constants
+	// generate_constants:Boolean constants,Boolean constants are the supported boolean constants.
+	BooleanConstants = map[string]interface{}{
 		// boolean
 		"true":  &eval.BoolEvaluator{Value: true},
 		"false": &eval.BoolEvaluator{Value: false},
 	}
+
+	// seclConstants are constants supported in runtime security agent rules
+	seclConstants = map[string]interface{}{}
 
 	// L3ProtocolConstants is the list of supported L3 protocols
 	// generate_constants:L3 protocols,L3 protocols are the supported Layer 3 protocols.
@@ -909,7 +912,14 @@ func initBPFMapNamesConstants() {
 	seclConstants["CWS_MAP_NAMES"] = &eval.StringArrayEvaluator{Values: bpfMapNames}
 }
 
+func initBoolConstants() {
+	for k, v := range BooleanConstants {
+		seclConstants[k] = v
+	}
+}
+
 func initConstants() {
+	initBoolConstants()
 	initErrorConstants()
 	initOpenConstants()
 	initFileModeConstants()

--- a/pkg/security/secl/rules/rule_filters.go
+++ b/pkg/security/secl/rules/rule_filters.go
@@ -120,7 +120,7 @@ func (r *SECLRuleFilter) IsRuleAccepted(rule *RuleDefinition) (bool, error) {
 
 	evalOpts := &eval.Opts{}
 	evalOpts.
-		WithConstants(model.SECLConstants())
+		WithConstants(model.BooleanConstants)
 
 	evaluator, err := eval.NewRuleEvaluator(astRule, r.model, evalOpts)
 	if err != nil {

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -707,7 +707,7 @@ def generate_cws_proto(ctx):
 
 
 def get_git_dirty_files():
-    dirty_stats = check_output(["git", "status", "--porcelain=v1"]).decode('utf-8')
+    dirty_stats = check_output(["git", "status", "--porcelain=v1", "untracked-files=no"]).decode('utf-8')
     paths = []
 
     # see https://git-scm.com/docs/git-status#_short_format for format documentation


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Do not use the full SECL constant set but only a very limited subset.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

When applying rule filters, we don't need SECL constants. Besides they
are now lazy initialized so that some memory is sparred.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
