### PR TITLE
Fix debian 10 system-probe kitchen test failures

### DIFF
--- a/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
+++ b/test/kitchen/site-cookbooks/dd-system-probe-check/recipes/linux.rb
@@ -42,8 +42,22 @@ package 'java' do
   case node[:platform]
   when 'redhat', 'centos', 'fedora', 'amazon'
     package_name 'java'
-  when 'ubuntu', 'debian'
+  when 'ubuntu'
     package_name 'default-jre'
+  when 'debian'
+    package_name 'default-jre'
+    # ignore failure because of error about /etc/ssl/certs/java/cacerts
+    ignore_failure true
+  end
+end
+
+# do install a second time to fix debian error
+package 'ca-certificates-java' do
+  case node[:platform]
+  when 'debian'
+    action :install
+  else
+    action :nothing
   end
 end
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

ignore failure and install `ca-certificates-java` a second time

### Motivation

failing jobs because of failure to install `ca-certificates-java` package:
```
head: cannot open '/etc/ssl/certs/java/cacerts' for reading: No such file or directory
       Exception in thread "main" java.lang.InternalError: Error loading java.security file
```

### Additional Notes

I tried many ways around it, but it seems the best route is to ignore the first failure and try installing again. Then it successfully does the post-install hook, since java has been installed.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
