### PR TITLE
Cleanup e2e stacks even when the tests failed

### DIFF
--- a/test/new-e2e/tests/containers/main_test.go
+++ b/test/new-e2e/tests/containers/main_test.go
@@ -20,15 +20,13 @@ var keepStacks = flag.Bool("keep-stacks", false, "Do not destroy the Pulumi stac
 
 func TestMain(m *testing.M) {
 	code := m.Run()
-	if code == 0 {
-		if runner.GetProfile().AllowDevMode() && *keepStacks {
-			fmt.Fprintln(os.Stderr, "Keeping stacks")
-		} else {
-			fmt.Fprintln(os.Stderr, "Cleaning up stacks")
-			errs := infra.GetStackManager().Cleanup(context.Background())
-			for _, err := range errs {
-				fmt.Fprint(os.Stderr, err.Error())
-			}
+	if runner.GetProfile().AllowDevMode() && *keepStacks {
+		fmt.Fprintln(os.Stderr, "Keeping stacks")
+	} else {
+		fmt.Fprintln(os.Stderr, "Cleaning up stacks")
+		errs := infra.GetStackManager().Cleanup(context.Background())
+		for _, err := range errs {
+			fmt.Fprint(os.Stderr, err.Error())
 		}
 	}
 	os.Exit(code)


### PR DESCRIPTION
### What does this PR do?

Delete the Pulumi stacks at the end of the e2e tests, even in case of failure.

### Motivation

The framework initially planned to delete Pulumi stacks at the end of successful tests but to keep them for investigation in case of failure.
The issue is that e2e tests are failing so often that we leak a lot of Pulumi stacks and this is exhausting the LoadBalancer quota.

### Additional Notes

Ex. of tests that are failing:
* https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/359697501
* https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/359697502
* https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/359998380
* https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/359998381

The error is always the same:
```
        	            	  aws:lb:LoadBalancer (aws-nginx-lb):
        	            	    error: 1 error occurred:
        	            	    	* creating ELBv2 application Load Balancer (ci-22514388-4670-ecs-cl-ngin-7cc): TooManyLoadBalancers: The maximum number of load balancers has been reached
        	            	    	status code: 400, request id: 312493e8-b550-4467-9fba-bb5e518a521b
```

And the AWS console confirms that we are leaking too many resources:
![image](https://github.com/DataDog/datadog-agent/assets/1437785/df9dca7f-c832-4422-a0f6-19ef1622ca0f)

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
