### PR TITLE
[oracle] Limit query metrics execution time (DBMON-2948)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -41,6 +41,7 @@ type QueryMetricsConfig struct {
 	DisableLastActive  bool                        `yaml:"disable_last_active"`
 	Lookback           int64                       `yaml:"lookback"`
 	Trackers           []queryMetricsTrackerConfig `yaml:"trackers"`
+	MaxRunTime         int64                       `yaml:"max_run_time"`
 }
 
 type SysMetricsConfig struct {
@@ -167,6 +168,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	instance.QueryMetrics.Enabled = true
 	instance.QueryMetrics.CollectionInterval = defaultMetricCollectionInterval
 	instance.QueryMetrics.DBRowsLimit = 10000
+	instance.QueryMetrics.MaxRunTime = 20
 
 	instance.ExecutionPlans.Enabled = true
 	instance.ExecutionPlans.PlanCacheRetention = 15

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -401,7 +401,7 @@ func (c *Check) StatementMetrics() (int, error) {
 		defer o.Stop()
 		var diff OracleRowMonotonicCount
 		planErrors = 0
-		sendFqtAndPlan := true
+		sendPlan := true
 		for i, statementMetricRow := range statementMetricsAll {
 			var trace bool
 			for _, t := range c.config.QueryMetrics.Trackers {
@@ -576,9 +576,9 @@ func (c *Check) StatementMetrics() (int, error) {
 				c.fqtEmitted = getFqtEmittedCache()
 			}
 
-			if sendFqtAndPlan {
+			if sendPlan {
 				if (i+1)%10 == 0 && time.Since(start).Seconds() >= float64(c.config.QueryMetrics.MaxRunTime) {
-					sendFqtAndPlan = false
+					sendPlan = false
 				}
 				if _, found := c.fqtEmitted.Get(queryRow.QuerySignature); !found {
 					FQTDBMetadata := FQTDBMetadata{Tables: queryRow.Tables, Commands: queryRow.Commands}

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -578,7 +578,7 @@ func (c *Check) StatementMetrics() (int, error) {
 
 			if sendFqtAndPlan {
 				if (i+1)%10 == 0 && time.Since(start).Seconds() >= float64(c.config.QueryMetrics.MaxRunTime) {
-					sendFqtAndPlan = true
+					sendFqtAndPlan = false
 				}
 				if _, found := c.fqtEmitted.Get(queryRow.QuerySignature); !found {
 					FQTDBMetadata := FQTDBMetadata{Tables: queryRow.Tables, Commands: queryRow.Commands}

--- a/pkg/collector/corechecks/oracle-dbm/statements.go
+++ b/pkg/collector/corechecks/oracle-dbm/statements.go
@@ -402,7 +402,8 @@ func (c *Check) StatementMetrics() (int, error) {
 		defer o.Stop()
 		var diff OracleRowMonotonicCount
 		planErrors = 0
-		for _, statementMetricRow := range statementMetricsAll {
+		sendFqtAndPlan := true
+		for i, statementMetricRow := range statementMetricsAll {
 
 			var trace bool
 			for _, t := range c.config.QueryMetrics.Trackers {
@@ -578,204 +579,209 @@ func (c *Check) StatementMetrics() (int, error) {
 				c.fqtEmitted = getFqtEmittedCache()
 			}
 
-			if _, found := c.fqtEmitted.Get(queryRow.QuerySignature); !found {
-				FQTDBMetadata := FQTDBMetadata{Tables: queryRow.Tables, Commands: queryRow.Commands}
-				FQTDB := FQTDB{Instance: c.cdbName, QuerySignature: queryRow.QuerySignature, Statement: SQLStatement, FQTDBMetadata: FQTDBMetadata}
-				FQTDBOracle := FQTDBOracle{
-					CDBName: c.cdbName,
+			if sendFqtAndPlan {
+				if (i+1)%10 == 0 && time.Since(start).Seconds() >= float64(c.config.QueryMetrics.MaxRunTime) {
+					sendFqtAndPlan = true
 				}
-				FQTPayload := FQTPayload{
-					Timestamp:    float64(time.Now().UnixMilli()),
-					Host:         c.dbHostname,
-					AgentVersion: c.agentVersion,
-					Source:       common.IntegrationName,
-					Tags:         c.tagsString,
-					DBMType:      "fqt",
-					FQTDB:        FQTDB,
-					FQTDBOracle:  FQTDBOracle,
-				}
-				FQTPayloadBytes, err := json.Marshal(FQTPayload)
-				if err != nil {
-					log.Errorf("%s Error marshalling fqt payload: %s", c.logPrompt, err)
-				}
-				log.Debugf("%s Query metrics fqt payload %s", c.logPrompt, string(FQTPayloadBytes))
-				sender.EventPlatformEvent(FQTPayloadBytes, "dbm-samples")
-				c.fqtEmitted.Set(queryRow.QuerySignature, "1", cache.DefaultExpiration)
-			}
-
-			if c.config.ExecutionPlans.Enabled {
-				planCacheKey := strconv.FormatUint(statementMetricRow.PlanHashValue, 10)
-				if c.planEmitted == nil {
-					c.planEmitted = getPlanEmittedCache(c)
-				}
-				_, found := c.planEmitted.Get(planCacheKey)
-				if c.config.ExecutionPlans.PlanCacheRetention == 0 || !found {
-					var planStepsPayload []PlanDefinition
-					var planStepsDB []PlanRows
-					var oraclePlan OraclePlan
-
-					var planQuery string
-					if isDbVersionGreaterOrEqualThan(c, minMultitenantVersion) {
-						planQuery = planQuery12
-						err = selectWrapper(c, &planStepsDB, planQuery, statementMetricRow.SQLID, statementMetricRow.PlanHashValue, statementMetricRow.ConID)
-					} else {
-						planQuery = planQuery11
-						err = selectWrapper(c, &planStepsDB, planQuery, statementMetricRow.SQLID, statementMetricRow.PlanHashValue)
+				if _, found := c.fqtEmitted.Get(queryRow.QuerySignature); !found {
+					FQTDBMetadata := FQTDBMetadata{Tables: queryRow.Tables, Commands: queryRow.Commands}
+					FQTDB := FQTDB{Instance: c.cdbName, QuerySignature: queryRow.QuerySignature, Statement: SQLStatement, FQTDBMetadata: FQTDBMetadata}
+					FQTDBOracle := FQTDBOracle{
+						CDBName: c.cdbName,
 					}
+					FQTPayload := FQTPayload{
+						Timestamp:    float64(time.Now().UnixMilli()),
+						Host:         c.dbHostname,
+						AgentVersion: c.agentVersion,
+						Source:       common.IntegrationName,
+						Tags:         c.tagsString,
+						DBMType:      "fqt",
+						FQTDB:        FQTDB,
+						FQTDBOracle:  FQTDBOracle,
+					}
+					FQTPayloadBytes, err := json.Marshal(FQTPayload)
+					if err != nil {
+						log.Errorf("%s Error marshalling fqt payload: %s", c.logPrompt, err)
+					}
+					log.Debugf("%s Query metrics fqt payload %s", c.logPrompt, string(FQTPayloadBytes))
+					sender.EventPlatformEvent(FQTPayloadBytes, "dbm-samples")
+					c.fqtEmitted.Set(queryRow.QuerySignature, "1", cache.DefaultExpiration)
+				}
 
-					if err == nil {
-						if len(planStepsDB) > 0 {
-							for _, stepRow := range planStepsDB {
-								var stepPayload PlanDefinition
-								if stepRow.Operation.Valid {
-									stepPayload.Operation = stepRow.Operation.String
-								}
-								if stepRow.Options.Valid {
-									stepPayload.Options = stepRow.Options.String
-								}
-								if stepRow.ObjectOwner.Valid {
-									stepPayload.ObjectOwner = stepRow.ObjectOwner.String
-								}
-								if stepRow.ObjectName.Valid {
-									stepPayload.ObjectName = stepRow.ObjectName.String
-								}
-								if stepRow.ObjectAlias.Valid {
-									stepPayload.ObjectAlias = stepRow.ObjectAlias.String
-								}
-								if stepRow.ObjectType.Valid {
-									stepPayload.ObjectType = stepRow.ObjectType.String
-								}
-								if stepRow.PlanStepId.Valid {
-									stepPayload.PlanStepId = stepRow.PlanStepId.Int64
-								}
-								if stepRow.ParentId.Valid {
-									stepPayload.ParentId = stepRow.ParentId.Int64
-								}
-								if stepRow.Depth.Valid {
-									stepPayload.Depth = stepRow.Depth.Int64
-								}
-								if stepRow.Position.Valid {
-									stepPayload.Position = stepRow.Position.Int64
-								}
-								if stepRow.SearchColumns.Valid {
-									stepPayload.SearchColumns = stepRow.SearchColumns.Int64
-								}
-								if stepRow.Cost.Valid {
-									stepPayload.Cost = stepRow.Cost.Float64
-								}
-								if stepRow.Cardinality.Valid {
-									stepPayload.Cardinality = stepRow.Cardinality.Float64
-								}
-								if stepRow.Bytes.Valid {
-									stepPayload.Bytes = stepRow.Bytes.Float64
-								}
-								if stepRow.PartitionStart.Valid {
-									stepPayload.PartitionStart = stepRow.PartitionStart.String
-								}
-								if stepRow.PartitionStop.Valid {
-									stepPayload.PartitionStop = stepRow.PartitionStop.String
-								}
-								if stepRow.CPUCost.Valid {
-									stepPayload.CPUCost = stepRow.CPUCost.Float64
-								}
-								if stepRow.IOCost.Valid {
-									stepPayload.IOCost = stepRow.IOCost.Float64
-								}
-								if stepRow.TempSpace.Valid {
-									stepPayload.TempSpace = stepRow.TempSpace.Float64
-								}
-								handlePredicate("access", stepRow.AccessPredicates, &stepPayload.AccessPredicates, statementMetricRow, c, o)
-								handlePredicate("filter", stepRow.FilterPredicates, &stepPayload.FilterPredicates, statementMetricRow, c, o)
-								if stepRow.Projection.Valid {
-									stepPayload.Projection = stepRow.Projection.String
-								}
-								if stepRow.LastStarts != nil {
-									stepPayload.LastStarts = *stepRow.LastStarts
-								}
-								if stepRow.LastOutputRows != nil {
-									stepPayload.LastOutputRows = *stepRow.LastOutputRows
-								}
-								if stepRow.LastCRBufferGets != nil {
-									stepPayload.LastCRBufferGets = *stepRow.LastCRBufferGets
-								}
-								if stepRow.LastDiskReads != nil {
-									stepPayload.LastDiskReads = *stepRow.LastDiskReads
-								}
-								if stepRow.LastDiskWrites != nil {
-									stepPayload.LastDiskWrites = *stepRow.LastDiskWrites
-								}
-								if stepRow.LastElapsedTime != nil {
-									stepPayload.LastElapsedTime = *stepRow.LastElapsedTime
-								}
-								if stepRow.LastMemoryUsed != nil {
-									stepPayload.LastMemoryUsed = *stepRow.LastMemoryUsed
-								}
-								if stepRow.LastDegree != nil {
-									stepPayload.LastDegree = *stepRow.LastDegree
-								}
-								if stepRow.LastTempsegSize != nil {
-									stepPayload.LastTempsegSize = *stepRow.LastTempsegSize
-								}
-								if stepRow.PlanCreated.Valid && stepRow.PlanCreated.String != "" {
-									oraclePlan.Timestamp = stepRow.PlanCreated.String
-								}
-								if stepRow.OptimizerMode.Valid && stepRow.OptimizerMode.String != "" {
-									oraclePlan.OptimizerMode = stepRow.OptimizerMode.String
-								}
-								if stepRow.Other.Valid && stepRow.Other.String != "" {
-									oraclePlan.Other = stepRow.Other.String
-								}
+				if c.config.ExecutionPlans.Enabled {
+					planCacheKey := strconv.FormatUint(statementMetricRow.PlanHashValue, 10)
+					if c.planEmitted == nil {
+						c.planEmitted = getPlanEmittedCache(c)
+					}
+					_, found := c.planEmitted.Get(planCacheKey)
+					if c.config.ExecutionPlans.PlanCacheRetention == 0 || !found {
+						var planStepsPayload []PlanDefinition
+						var planStepsDB []PlanRows
+						var oraclePlan OraclePlan
 
-								oraclePlan.PDBName = statementMetricRow.PDBName
-								oraclePlan.SQLID = statementMetricRow.SQLID
-								oraclePlan.ForceMatchingSignature = statementMetricRow.ForceMatchingSignature
-								oraclePlan.Executions = statementMetricRow.Executions
-								oraclePlan.ElapsedTime = statementMetricRow.ElapsedTime
-
-								planStepsPayload = append(planStepsPayload, stepPayload)
-							}
-							oraclePlan.PlanHashValue = statementMetricRow.PlanHashValue
-							planStatementMetadata := PlanStatementMetadata{
-								Tables:   queryRow.Tables,
-								Commands: queryRow.Commands,
-							}
-							planPlanDB := PlanPlanDB{
-								Definition: planStepsPayload,
-								Signature:  strconv.FormatUint(statementMetricRow.PlanHashValue, 10),
-							}
-							planDB := PlanDB{
-								Instance:       c.cdbName,
-								Plan:           planPlanDB,
-								QuerySignature: queryRow.QuerySignature,
-								Statement:      SQLStatement,
-								Metadata:       planStatementMetadata,
-							}
-							tags := strings.Join(append(c.tags, fmt.Sprintf("pdb:%s", statementMetricRow.PDBName)), ",")
-
-							planPayload := PlanPayload{
-								Timestamp:    float64(time.Now().UnixMilli()),
-								Host:         c.dbHostname,
-								AgentVersion: c.agentVersion,
-								Source:       common.IntegrationName,
-								Tags:         tags,
-								DBMType:      "plan",
-								PlanDB:       planDB,
-								OraclePlan:   oraclePlan,
-							}
-							planPayloadBytes, err := json.Marshal(planPayload)
-							if err != nil {
-								log.Errorf("%s Error marshalling plan payload: %s", c.logPrompt, err)
-							}
-
-							sender.EventPlatformEvent(planPayloadBytes, "dbm-samples")
-							log.Debugf("%s Plan payload %+v", c.logPrompt, string(planPayloadBytes))
-							c.planEmitted.Set(planCacheKey, "1", cache.DefaultExpiration)
+						var planQuery string
+						if isDbVersionGreaterOrEqualThan(c, minMultitenantVersion) {
+							planQuery = planQuery12
+							err = selectWrapper(c, &planStepsDB, planQuery, statementMetricRow.SQLID, statementMetricRow.PlanHashValue, statementMetricRow.ConID)
 						} else {
-							log.Infof("%s Plan for SQL_ID %s and plan_hash_value: %d not found", c.logPrompt, statementMetricRow.SQLID, statementMetricRow.PlanHashValue)
+							planQuery = planQuery11
+							err = selectWrapper(c, &planStepsDB, planQuery, statementMetricRow.SQLID, statementMetricRow.PlanHashValue)
 						}
-					} else {
-						planErrors++
-						log.Errorf("%s failed getting execution plan %s for SQL_ID: %s, plan_hash_value: %d", c.logPrompt, err, statementMetricRow.SQLID, statementMetricRow.PlanHashValue)
+
+						if err == nil {
+							if len(planStepsDB) > 0 {
+								for _, stepRow := range planStepsDB {
+									var stepPayload PlanDefinition
+									if stepRow.Operation.Valid {
+										stepPayload.Operation = stepRow.Operation.String
+									}
+									if stepRow.Options.Valid {
+										stepPayload.Options = stepRow.Options.String
+									}
+									if stepRow.ObjectOwner.Valid {
+										stepPayload.ObjectOwner = stepRow.ObjectOwner.String
+									}
+									if stepRow.ObjectName.Valid {
+										stepPayload.ObjectName = stepRow.ObjectName.String
+									}
+									if stepRow.ObjectAlias.Valid {
+										stepPayload.ObjectAlias = stepRow.ObjectAlias.String
+									}
+									if stepRow.ObjectType.Valid {
+										stepPayload.ObjectType = stepRow.ObjectType.String
+									}
+									if stepRow.PlanStepId.Valid {
+										stepPayload.PlanStepId = stepRow.PlanStepId.Int64
+									}
+									if stepRow.ParentId.Valid {
+										stepPayload.ParentId = stepRow.ParentId.Int64
+									}
+									if stepRow.Depth.Valid {
+										stepPayload.Depth = stepRow.Depth.Int64
+									}
+									if stepRow.Position.Valid {
+										stepPayload.Position = stepRow.Position.Int64
+									}
+									if stepRow.SearchColumns.Valid {
+										stepPayload.SearchColumns = stepRow.SearchColumns.Int64
+									}
+									if stepRow.Cost.Valid {
+										stepPayload.Cost = stepRow.Cost.Float64
+									}
+									if stepRow.Cardinality.Valid {
+										stepPayload.Cardinality = stepRow.Cardinality.Float64
+									}
+									if stepRow.Bytes.Valid {
+										stepPayload.Bytes = stepRow.Bytes.Float64
+									}
+									if stepRow.PartitionStart.Valid {
+										stepPayload.PartitionStart = stepRow.PartitionStart.String
+									}
+									if stepRow.PartitionStop.Valid {
+										stepPayload.PartitionStop = stepRow.PartitionStop.String
+									}
+									if stepRow.CPUCost.Valid {
+										stepPayload.CPUCost = stepRow.CPUCost.Float64
+									}
+									if stepRow.IOCost.Valid {
+										stepPayload.IOCost = stepRow.IOCost.Float64
+									}
+									if stepRow.TempSpace.Valid {
+										stepPayload.TempSpace = stepRow.TempSpace.Float64
+									}
+									handlePredicate("access", stepRow.AccessPredicates, &stepPayload.AccessPredicates, statementMetricRow, c, o)
+									handlePredicate("filter", stepRow.FilterPredicates, &stepPayload.FilterPredicates, statementMetricRow, c, o)
+									if stepRow.Projection.Valid {
+										stepPayload.Projection = stepRow.Projection.String
+									}
+									if stepRow.LastStarts != nil {
+										stepPayload.LastStarts = *stepRow.LastStarts
+									}
+									if stepRow.LastOutputRows != nil {
+										stepPayload.LastOutputRows = *stepRow.LastOutputRows
+									}
+									if stepRow.LastCRBufferGets != nil {
+										stepPayload.LastCRBufferGets = *stepRow.LastCRBufferGets
+									}
+									if stepRow.LastDiskReads != nil {
+										stepPayload.LastDiskReads = *stepRow.LastDiskReads
+									}
+									if stepRow.LastDiskWrites != nil {
+										stepPayload.LastDiskWrites = *stepRow.LastDiskWrites
+									}
+									if stepRow.LastElapsedTime != nil {
+										stepPayload.LastElapsedTime = *stepRow.LastElapsedTime
+									}
+									if stepRow.LastMemoryUsed != nil {
+										stepPayload.LastMemoryUsed = *stepRow.LastMemoryUsed
+									}
+									if stepRow.LastDegree != nil {
+										stepPayload.LastDegree = *stepRow.LastDegree
+									}
+									if stepRow.LastTempsegSize != nil {
+										stepPayload.LastTempsegSize = *stepRow.LastTempsegSize
+									}
+									if stepRow.PlanCreated.Valid && stepRow.PlanCreated.String != "" {
+										oraclePlan.Timestamp = stepRow.PlanCreated.String
+									}
+									if stepRow.OptimizerMode.Valid && stepRow.OptimizerMode.String != "" {
+										oraclePlan.OptimizerMode = stepRow.OptimizerMode.String
+									}
+									if stepRow.Other.Valid && stepRow.Other.String != "" {
+										oraclePlan.Other = stepRow.Other.String
+									}
+
+									oraclePlan.PDBName = statementMetricRow.PDBName
+									oraclePlan.SQLID = statementMetricRow.SQLID
+									oraclePlan.ForceMatchingSignature = statementMetricRow.ForceMatchingSignature
+									oraclePlan.Executions = statementMetricRow.Executions
+									oraclePlan.ElapsedTime = statementMetricRow.ElapsedTime
+
+									planStepsPayload = append(planStepsPayload, stepPayload)
+								}
+								oraclePlan.PlanHashValue = statementMetricRow.PlanHashValue
+								planStatementMetadata := PlanStatementMetadata{
+									Tables:   queryRow.Tables,
+									Commands: queryRow.Commands,
+								}
+								planPlanDB := PlanPlanDB{
+									Definition: planStepsPayload,
+									Signature:  strconv.FormatUint(statementMetricRow.PlanHashValue, 10),
+								}
+								planDB := PlanDB{
+									Instance:       c.cdbName,
+									Plan:           planPlanDB,
+									QuerySignature: queryRow.QuerySignature,
+									Statement:      SQLStatement,
+									Metadata:       planStatementMetadata,
+								}
+								tags := strings.Join(append(c.tags, fmt.Sprintf("pdb:%s", statementMetricRow.PDBName)), ",")
+
+								planPayload := PlanPayload{
+									Timestamp:    float64(time.Now().UnixMilli()),
+									Host:         c.dbHostname,
+									AgentVersion: c.agentVersion,
+									Source:       common.IntegrationName,
+									Tags:         tags,
+									DBMType:      "plan",
+									PlanDB:       planDB,
+									OraclePlan:   oraclePlan,
+								}
+								planPayloadBytes, err := json.Marshal(planPayload)
+								if err != nil {
+									log.Errorf("%s Error marshalling plan payload: %s", c.logPrompt, err)
+								}
+
+								sender.EventPlatformEvent(planPayloadBytes, "dbm-samples")
+								log.Debugf("%s Plan payload %+v", c.logPrompt, string(planPayloadBytes))
+								c.planEmitted.Set(planCacheKey, "1", cache.DefaultExpiration)
+							} else {
+								log.Infof("%s Plan for SQL_ID %s and plan_hash_value: %d not found", c.logPrompt, statementMetricRow.SQLID, statementMetricRow.PlanHashValue)
+							}
+						} else {
+							planErrors++
+							log.Errorf("%s failed getting execution plan %s for SQL_ID: %s, plan_hash_value: %d", c.logPrompt, err, statementMetricRow.SQLID, statementMetricRow.PlanHashValue)
+						}
 					}
 				}
 			}

--- a/releasenotes/notes/oracle-query-metrics-time-limit-0e7fe39d80ba885d.yaml
+++ b/releasenotes/notes/oracle-query-metrics-time-limit-0e7fe39d80ba885d.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Impose the time limit on query metrics processing. After exceeding the default limit of 20s, the agent stops emitting execution plans and fqt events.

--- a/releasenotes/notes/oracle-query-metrics-time-limit-0e7fe39d80ba885d.yaml
+++ b/releasenotes/notes/oracle-query-metrics-time-limit-0e7fe39d80ba885d.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Impose the time limit on query metrics processing. After exceeding the default limit of 20s, the agent stops emitting execution plans and fqt events.
+    Impose a time limit on query metrics processing. After exceeding the default limit of 20s, the Agent stops emitting execution plans and fqt events.


### PR DESCRIPTION
### What does this PR do?

Limit query metrics execution time. After reaching the limit, FQT and plan events aren't being emitted anymore.

### Motivation

After starting the agent, FQT and plan TTL caches are empty, which can lead to longer execution times until the caches are filled. To avoid this situation, we are introducing the time limit (default 20s) for running the check.

### Possible Drawbacks / Trade-offs

We can miss some events.

### Describe how to test/QA your changes

Just check that FQT and plan events are being emitted.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
