### PR TITLE
[oracle] Improve obfuscator formatting (DBMON-3061)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/config/config.go
+++ b/pkg/collector/corechecks/oracle-dbm/config/config.go
@@ -148,7 +148,15 @@ Port: '%d'
 
 // GetDefaultObfuscatorOptions return default obfuscator options
 func GetDefaultObfuscatorOptions() obfuscate.SQLConfig {
-	return obfuscate.SQLConfig{DBMS: common.IntegrationName, TableNames: true, CollectCommands: true, CollectComments: true, ObfuscationMode: obfuscate.ObfuscateAndNormalize}
+	return obfuscate.SQLConfig{
+		DBMS:                          common.IntegrationName,
+		TableNames:                    true,
+		CollectCommands:               true,
+		CollectComments:               true,
+		ObfuscationMode:               obfuscate.ObfuscateAndNormalize,
+		RemoveSpaceBetweenParentheses: true,
+		KeepNull:                      true,
+	}
 }
 
 // NewCheckConfig builds a new check config.

--- a/pkg/collector/corechecks/oracle-dbm/oracle_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle_test.go
@@ -301,7 +301,15 @@ func TestObfuscator(t *testing.T) {
 	_, err := o.ObfuscateSQLString(`SELECT TRUNC(SYSDATE@!) from dual`)
 	assert.NoError(t, err, "can't obfuscate @!")
 
-	nullPlSql := "begin null; end;"
-	obfuscatedStatement, err := o.ObfuscateSQLString(nullPlSql)
-	assert.Equal(t, nullPlSql, obfuscatedStatement.Query)
+	sql := "begin null ; end"
+	obfuscatedStatement, err := o.ObfuscateSQLString(sql)
+	assert.Equal(t, sql, obfuscatedStatement.Query)
+
+	sql = "select count (*) from dual"
+	obfuscatedStatement, err = o.ObfuscateSQLString(sql)
+	assert.Equal(t, sql, obfuscatedStatement.Query)
+
+	sql = "select file# from dual"
+	obfuscatedStatement, err = o.ObfuscateSQLString(sql)
+	assert.Equal(t, sql, obfuscatedStatement.Query)
 }

--- a/releasenotes/notes/oracle-obfuscator-formatting-82605dc594edf858.yaml
+++ b/releasenotes/notes/oracle-obfuscator-formatting-82605dc594edf858.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Improve obfuscator formatting. Prevent spaces after parentheses.
+    Prevent spaces before `#` when `#` is a part of an identifier.


### PR DESCRIPTION
### What does this PR do?

- Don't obfuscate `null`
- Don't insert space after parentheses
- Don't insert space before `#`

### Motivation

Avoid unnecessary changes on the original statement.

### Describe how to test/QA your changes

Check obfuscated statements in query metrics.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
