### PR TITLE
Decouple how the status component get information from expvar 

### DIFF
--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -150,24 +150,22 @@ func init() {
 	expvarcollector.RegisterExpvarReport("dogstatsdStats", func() (interface{}, error) {
 		dogstatsdStats := make(map[string]interface{})
 
-		if expvar.Get("dogstatsd") != nil {
-			dogstatsdStatsJSON := []byte(expvar.Get("dogstatsd").String())
-			dogstatsdUdsStatsJSON := []byte(expvar.Get("dogstatsd-uds").String())
-			dogstatsdUDPStatsJSON := []byte(expvar.Get("dogstatsd-udp").String())
-			json.Unmarshal(dogstatsdStatsJSON, &dogstatsdStats) //nolint:errcheck
-			dogstatsdUdsStats := make(map[string]interface{})
-			json.Unmarshal(dogstatsdUdsStatsJSON, &dogstatsdUdsStats) //nolint:errcheck
-			for name, value := range dogstatsdUdsStats {
-				dogstatsdStats["Uds"+name] = value
-			}
-			dogstatsdUDPStats := make(map[string]interface{})
-			json.Unmarshal(dogstatsdUDPStatsJSON, &dogstatsdUDPStats) //nolint:errcheck
-			for name, value := range dogstatsdUDPStats {
-				dogstatsdStats["Udp"+name] = value
-			}
-			return dogstatsdStats, nil
+		dogstatsdStatsJSON := []byte(dogstatsdExpvars.String())
+		dogstatsdUdsStatsJSON := []byte(expvar.Get("dogstatsd-uds").String())
+		dogstatsdUDPStatsJSON := []byte(expvar.Get("dogstatsd-udp").String())
+		json.Unmarshal(dogstatsdStatsJSON, &dogstatsdStats) //nolint:errcheck
+		dogstatsdUdsStats := make(map[string]interface{})
+		json.Unmarshal(dogstatsdUdsStatsJSON, &dogstatsdUdsStats) //nolint:errcheck
+		for name, value := range dogstatsdUdsStats {
+			dogstatsdStats["Uds"+name] = value
+		}
+		dogstatsdUDPStats := make(map[string]interface{})
+		json.Unmarshal(dogstatsdUDPStatsJSON, &dogstatsdUDPStats) //nolint:errcheck
+		for name, value := range dogstatsdUDPStats {
+			dogstatsdStats["Udp"+name] = value
 		}
 		return dogstatsdStats, nil
+
 	})
 }
 

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -147,7 +147,7 @@ type server struct {
 }
 
 func init() {
-	expvarcollector.RegisterExpvarReport("dogstatsdStats", func() (interface{}, error) {
+	expvarcollector.RegisterExpvarCallback("dogstatsdStats", func() (interface{}, error) {
 		dogstatsdStats := make(map[string]interface{})
 
 		dogstatsdStatsJSON := []byte(dogstatsdExpvars.String())

--- a/comp/forwarder/defaultforwarder/transaction/transaction.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction.go
@@ -162,7 +162,7 @@ func init() {
 	TransactionsExpvars.Set("HTTPErrors", &transactionsHTTPErrors)
 	TransactionsExpvars.Set("HTTPErrorsByCode", &transactionsHTTPErrorsByCode)
 
-	expvarcollector.RegisterExpvarReport("forwarderStats", func() (interface{}, error) {
+	expvarcollector.RegisterExpvarCallback("forwarderStats", func() (interface{}, error) {
 		forwarderStatsJSON := []byte(ForwarderExpvars.String())
 		forwarderStats := make(map[string]interface{})
 		json.Unmarshal(forwarderStatsJSON, &forwarderStats) //nolint:errcheck

--- a/comp/forwarder/defaultforwarder/transaction/transaction.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction.go
@@ -163,7 +163,7 @@ func init() {
 	TransactionsExpvars.Set("HTTPErrorsByCode", &transactionsHTTPErrorsByCode)
 
 	expvarcollector.RegisterExpvarReport("forwarderStats", func() (interface{}, error) {
-		forwarderStatsJSON := []byte(expvar.Get("forwarder").String())
+		forwarderStatsJSON := []byte(ForwarderExpvars.String())
 		forwarderStats := make(map[string]interface{})
 		json.Unmarshal(forwarderStatsJSON, &forwarderStats) //nolint:errcheck
 		return forwarderStats, nil

--- a/comp/forwarder/defaultforwarder/transaction/transaction.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"expvar"
 	"fmt"
 	"io"
@@ -21,6 +22,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
+	"github.com/DataDog/datadog-agent/pkg/status/expvarcollector"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 )
@@ -159,6 +161,13 @@ func init() {
 	transactionsErrorsByType.Set("SentRequestErrors", &transactionsSentRequestErrors)
 	TransactionsExpvars.Set("HTTPErrors", &transactionsHTTPErrors)
 	TransactionsExpvars.Set("HTTPErrorsByCode", &transactionsHTTPErrorsByCode)
+
+	expvarcollector.RegisterExpvarReport("forwarderStats", func() (interface{}, error) {
+		forwarderStatsJSON := []byte(expvar.Get("forwarder").String())
+		forwarderStats := make(map[string]interface{})
+		json.Unmarshal(forwarderStatsJSON, &forwarderStats) //nolint:errcheck
+		return forwarderStats, nil
+	})
 }
 
 // Priority defines the priority of a transaction

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -199,7 +199,7 @@ func init() {
 
 	aggregatorExpvars.Set("MetricTags", expvar.Func(expMetricTags))
 
-	expvarcollector.RegisterExpvarReport("aggregator", func() (interface{}, error) {
+	expvarcollector.RegisterExpvarCallback("aggregator", func() (interface{}, error) {
 		aggregatorStatsJSON := []byte(aggregatorExpvars.String())
 		aggregatorStats := make(map[string]interface{})
 		json.Unmarshal(aggregatorStatsJSON, &aggregatorStats) //nolint:errcheck

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -200,7 +200,7 @@ func init() {
 	aggregatorExpvars.Set("MetricTags", expvar.Func(expMetricTags))
 
 	expvarcollector.RegisterExpvarReport("aggregator", func() (interface{}, error) {
-		aggregatorStatsJSON := []byte(expvar.Get("aggregator").String())
+		aggregatorStatsJSON := []byte(aggregatorExpvars.String())
 		aggregatorStats := make(map[string]interface{})
 		json.Unmarshal(aggregatorStatsJSON, &aggregatorStats) //nolint:errcheck
 		s, err := checkstats.TranslateEventPlatformEventTypes(aggregatorStats)

--- a/pkg/autodiscovery/stats.go
+++ b/pkg/autodiscovery/stats.go
@@ -27,7 +27,7 @@ func init() {
 		return errorStats.getResolveWarnings()
 	}))
 
-	expvarcollector.RegisterExpvarReport("autoConfigStats", func() (interface{}, error) {
+	expvarcollector.RegisterExpvarCallback("autoConfigStats", func() (interface{}, error) {
 		autoConfigStatsJSON := []byte(acErrors.String())
 		autoConfigStats := make(map[string]interface{})
 		json.Unmarshal(autoConfigStatsJSON, &autoConfigStats) //nolint:errcheck

--- a/pkg/autodiscovery/stats.go
+++ b/pkg/autodiscovery/stats.go
@@ -6,8 +6,11 @@
 package autodiscovery
 
 import (
+	"encoding/json"
 	"expvar"
 	"sync"
+
+	"github.com/DataDog/datadog-agent/pkg/status/expvarcollector"
 )
 
 var (
@@ -23,6 +26,13 @@ func init() {
 	acErrors.Set("ResolveWarnings", expvar.Func(func() interface{} {
 		return errorStats.getResolveWarnings()
 	}))
+
+	expvarcollector.RegisterExpvarReport("autoConfigStats", func() (interface{}, error) {
+		autoConfigStatsJSON := []byte(expvar.Get("autoconfig").String())
+		autoConfigStats := make(map[string]interface{})
+		json.Unmarshal(autoConfigStatsJSON, &autoConfigStats) //nolint:errcheck
+		return autoConfigStats, nil
+	})
 }
 
 // loaderErrorStats holds the error objects

--- a/pkg/autodiscovery/stats.go
+++ b/pkg/autodiscovery/stats.go
@@ -28,7 +28,7 @@ func init() {
 	}))
 
 	expvarcollector.RegisterExpvarReport("autoConfigStats", func() (interface{}, error) {
-		autoConfigStatsJSON := []byte(expvar.Get("autoconfig").String())
+		autoConfigStatsJSON := []byte(acErrors.String())
 		autoConfigStats := make(map[string]interface{})
 		json.Unmarshal(autoConfigStatsJSON, &autoConfigStats) //nolint:errcheck
 		return autoConfigStats, nil

--- a/pkg/collector/corechecks/net/ntp.go
+++ b/pkg/collector/corechecks/net/ntp.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/beevik/ntp"
@@ -21,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
+	"github.com/DataDog/datadog-agent/pkg/status/expvarcollector"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -248,4 +250,13 @@ func ntpFactory() check.Check {
 
 func init() {
 	core.RegisterCheck(ntpCheckName, ntpFactory)
+
+	expvarcollector.RegisterExpvarReport("ntpOffset", func() (interface{}, error) {
+		ntpOffset := expvar.Get("ntpOffset")
+		if ntpOffset != nil && ntpOffset.String() != "" {
+			result, err := strconv.ParseFloat(ntpOffset.String(), 64)
+			return result, err
+		}
+		return nil, nil
+	})
 }

--- a/pkg/collector/corechecks/net/ntp.go
+++ b/pkg/collector/corechecks/net/ntp.go
@@ -42,6 +42,18 @@ var (
 		nil, "Ntp offset")
 )
 
+func init() {
+	core.RegisterCheck(ntpCheckName, ntpFactory)
+
+	expvarcollector.RegisterExpvarReport("ntpOffset", func() (interface{}, error) {
+		if ntpExpVar.String() != "" {
+			result, err := strconv.ParseFloat(ntpExpVar.String(), 64)
+			return result, err
+		}
+		return nil, nil
+	})
+}
+
 // NTPCheck only has sender and config
 type NTPCheck struct {
 	core.CheckBase
@@ -246,17 +258,4 @@ func ntpFactory() check.Check {
 	return &NTPCheck{
 		CheckBase: core.NewCheckBaseWithInterval(ntpCheckName, time.Duration(defaultMinCollectionInterval)*time.Second),
 	}
-}
-
-func init() {
-	core.RegisterCheck(ntpCheckName, ntpFactory)
-
-	expvarcollector.RegisterExpvarReport("ntpOffset", func() (interface{}, error) {
-		ntpOffset := expvar.Get("ntpOffset")
-		if ntpOffset != nil && ntpOffset.String() != "" {
-			result, err := strconv.ParseFloat(ntpOffset.String(), 64)
-			return result, err
-		}
-		return nil, nil
-	})
 }

--- a/pkg/collector/corechecks/net/ntp.go
+++ b/pkg/collector/corechecks/net/ntp.go
@@ -45,7 +45,7 @@ var (
 func init() {
 	core.RegisterCheck(ntpCheckName, ntpFactory)
 
-	expvarcollector.RegisterExpvarReport("ntpOffset", func() (interface{}, error) {
+	expvarcollector.RegisterExpvarCallback("ntpOffset", func() (interface{}, error) {
 		if ntpExpVar.String() != "" {
 			result, err := strconv.ParseFloat(ntpExpVar.String(), 64)
 			return result, err

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -224,12 +224,11 @@ func init() {
 	expvarPyInit.Set("Errors", expvar.Func(expvarPythonInitErrors))
 
 	expvarcollector.RegisterExpvarReport("pythonInit", func() (interface{}, error) {
-		pythonInitData := expvar.Get("pythonInit")
 		pythonInit := make(map[string]interface{})
-		if pythonInitData != nil {
-			pythonInitJSON := []byte(pythonInitData.String())
-			json.Unmarshal(pythonInitJSON, &pythonInit) //nolint:errcheck
-		}
+
+		pythonInitJSON := []byte(expvarPyInit.String())
+		json.Unmarshal(pythonInitJSON, &pythonInit) //nolint:errcheck
+
 		return pythonInit, nil
 	})
 }

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -223,7 +223,7 @@ func init() {
 	expvarPyInit = expvar.NewMap("pythonInit")
 	expvarPyInit.Set("Errors", expvar.Func(expvarPythonInitErrors))
 
-	expvarcollector.RegisterExpvarReport("pythonInit", func() (interface{}, error) {
+	expvarcollector.RegisterExpvarCallback("pythonInit", func() (interface{}, error) {
 		pythonInit := make(map[string]interface{})
 
 		pythonInitJSON := []byte(expvarPyInit.String())

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -8,6 +8,7 @@
 package python
 
 import (
+	"encoding/json"
 	"expvar"
 	"fmt"
 	"os"
@@ -21,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/status/expvarcollector"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
@@ -220,6 +222,16 @@ func init() {
 
 	expvarPyInit = expvar.NewMap("pythonInit")
 	expvarPyInit.Set("Errors", expvar.Func(expvarPythonInitErrors))
+
+	expvarcollector.RegisterExpvarReport("pythonInit", func() (interface{}, error) {
+		pythonInitData := expvar.Get("pythonInit")
+		pythonInit := make(map[string]interface{})
+		if pythonInitData != nil {
+			pythonInitJSON := []byte(pythonInitData.String())
+			json.Unmarshal(pythonInitJSON, &pythonInit) //nolint:errcheck
+		}
+		return pythonInit, nil
+	})
 }
 
 func expvarPythonInitErrors() interface{} {

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -80,7 +80,7 @@ func init() {
 		}
 	}
 
-	expvarcollector.RegisterExpvarReport("pyLoaderStats", func() (interface{}, error) {
+	expvarcollector.RegisterExpvarCallback("pyLoaderStats", func() (interface{}, error) {
 		stats := make(map[string]interface{})
 		pyLoaderStatsJSON := []byte(pyLoaderStats.String())
 		json.Unmarshal(pyLoaderStatsJSON, &stats) //nolint:errcheck

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -8,6 +8,7 @@
 package python
 
 import (
+	"encoding/json"
 	"errors"
 	"expvar"
 	"fmt"
@@ -23,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	agentConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/status/expvarcollector"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
@@ -77,6 +79,17 @@ func init() {
 			fmt.Sprintf("agent_version_patch:%d", agentVersion.Patch),
 		}
 	}
+
+	expvarcollector.RegisterExpvarReport("pyLoaderStats", func() (interface{}, error) {
+		pyLoaderData := expvar.Get("pyLoader")
+		pyLoaderStats := make(map[string]interface{})
+		if pyLoaderData != nil {
+			pyLoaderStatsJSON := []byte(pyLoaderData.String())
+			json.Unmarshal(pyLoaderStatsJSON, &pyLoaderStats) //nolint:errcheck
+
+		}
+		return pyLoaderStats, nil
+	})
 }
 
 // PythonCheckLoader is a specific loader for checks living in Python modules

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -81,14 +81,10 @@ func init() {
 	}
 
 	expvarcollector.RegisterExpvarReport("pyLoaderStats", func() (interface{}, error) {
-		pyLoaderData := expvar.Get("pyLoader")
-		pyLoaderStats := make(map[string]interface{})
-		if pyLoaderData != nil {
-			pyLoaderStatsJSON := []byte(pyLoaderData.String())
-			json.Unmarshal(pyLoaderStatsJSON, &pyLoaderStats) //nolint:errcheck
-
-		}
-		return pyLoaderStats, nil
+		stats := make(map[string]interface{})
+		pyLoaderStatsJSON := []byte(pyLoaderStats.String())
+		json.Unmarshal(pyLoaderStatsJSON, &stats) //nolint:errcheck
+		return stats, nil
 	})
 }
 

--- a/pkg/collector/runner/expvars/expvars.go
+++ b/pkg/collector/runner/expvars/expvars.go
@@ -6,6 +6,7 @@
 package expvars
 
 import (
+	"encoding/json"
 	"expvar"
 	"sync"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	checkstats "github.com/DataDog/datadog-agent/pkg/collector/check/stats"
+	"github.com/DataDog/datadog-agent/pkg/status/expvarcollector"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -53,6 +55,13 @@ func init() {
 	checkStats = &expCheckStats{
 		stats: make(map[string]map[checkid.ID]*checkstats.Stats),
 	}
+
+	expvarcollector.RegisterExpvarReport("runnerStats", func() (interface{}, error) {
+		runnerStatsJSON := []byte(expvar.Get(runnerExpvarKey).String())
+		runnerStats := make(map[string]interface{})
+		json.Unmarshal(runnerStatsJSON, &runnerStats) //nolint:errcheck
+		return runnerStats, nil
+	})
 }
 
 // Helpers

--- a/pkg/collector/runner/expvars/expvars.go
+++ b/pkg/collector/runner/expvars/expvars.go
@@ -56,7 +56,7 @@ func init() {
 		stats: make(map[string]map[checkid.ID]*checkstats.Stats),
 	}
 
-	expvarcollector.RegisterExpvarReport("runnerStats", func() (interface{}, error) {
+	expvarcollector.RegisterExpvarCallback("runnerStats", func() (interface{}, error) {
 		runnerStatsJSON := []byte(runnerStats.String())
 		stats := make(map[string]interface{})
 		json.Unmarshal(runnerStatsJSON, &stats) //nolint:errcheck

--- a/pkg/collector/runner/expvars/expvars.go
+++ b/pkg/collector/runner/expvars/expvars.go
@@ -57,10 +57,10 @@ func init() {
 	}
 
 	expvarcollector.RegisterExpvarReport("runnerStats", func() (interface{}, error) {
-		runnerStatsJSON := []byte(expvar.Get(runnerExpvarKey).String())
-		runnerStats := make(map[string]interface{})
-		json.Unmarshal(runnerStatsJSON, &runnerStats) //nolint:errcheck
-		return runnerStats, nil
+		runnerStatsJSON := []byte(runnerStats.String())
+		stats := make(map[string]interface{})
+		json.Unmarshal(runnerStatsJSON, &stats) //nolint:errcheck
+		return stats, nil
 	})
 }
 

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -50,7 +50,7 @@ func init() {
 		return errorStats.getRunErrors()
 	}))
 
-	expvarcollector.RegisterExpvarReport("checkSchedulerStats", func() (interface{}, error) {
+	expvarcollector.RegisterExpvarCallback("checkSchedulerStats", func() (interface{}, error) {
 		checkSchedulerStatsJSON := []byte(schedulerErrs.String())
 		checkSchedulerStats := make(map[string]interface{})
 		json.Unmarshal(checkSchedulerStatsJSON, &checkSchedulerStats) //nolint:errcheck

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -51,7 +51,7 @@ func init() {
 	}))
 
 	expvarcollector.RegisterExpvarReport("checkSchedulerStats", func() (interface{}, error) {
-		checkSchedulerStatsJSON := []byte(expvar.Get("CheckScheduler").String())
+		checkSchedulerStatsJSON := []byte(schedulerErrs.String())
 		checkSchedulerStats := make(map[string]interface{})
 		json.Unmarshal(checkSchedulerStatsJSON, &checkSchedulerStats) //nolint:errcheck
 		return checkSchedulerStats, nil

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -6,6 +6,7 @@
 package collector
 
 import (
+	"encoding/json"
 	"expvar"
 	"fmt"
 	"strings"
@@ -19,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	"github.com/DataDog/datadog-agent/pkg/collector/loaders"
+	"github.com/DataDog/datadog-agent/pkg/status/expvarcollector"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -47,6 +49,13 @@ func init() {
 	schedulerErrs.Set("RunErrors", expvar.Func(func() interface{} {
 		return errorStats.getRunErrors()
 	}))
+
+	expvarcollector.RegisterExpvarReport("checkSchedulerStats", func() (interface{}, error) {
+		checkSchedulerStatsJSON := []byte(expvar.Get("CheckScheduler").String())
+		checkSchedulerStats := make(map[string]interface{})
+		json.Unmarshal(checkSchedulerStatsJSON, &checkSchedulerStats) //nolint:errcheck
+		return checkSchedulerStats, nil
+	})
 }
 
 // CheckScheduler is the check scheduler

--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -53,7 +53,7 @@ const (
 )
 
 func init() {
-	expvarcollector.RegisterExpvarReport("complianceChecks", func() (interface{}, error) {
+	expvarcollector.RegisterExpvarCallback("complianceChecks", func() (interface{}, error) {
 		complianceStatusJSON := []byte(status.String())
 		complianceStatus := make(map[string]interface{})
 		json.Unmarshal(complianceStatusJSON, &complianceStatus) //nolint:errcheck

--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -54,13 +54,10 @@ const (
 
 func init() {
 	expvarcollector.RegisterExpvarReport("complianceChecks", func() (interface{}, error) {
-		if status != nil {
-			complianceStatusJSON := []byte(status.String())
-			complianceStatus := make(map[string]interface{})
-			json.Unmarshal(complianceStatusJSON, &complianceStatus) //nolint:errcheck
-			return complianceStatus, nil
-		}
-		return nil, nil
+		complianceStatusJSON := []byte(status.String())
+		complianceStatus := make(map[string]interface{})
+		json.Unmarshal(complianceStatusJSON, &complianceStatus) //nolint:errcheck
+		return complianceStatus, nil
 	})
 }
 

--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -11,6 +11,7 @@ package compliance
 import (
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"expvar"
 	"fmt"
 	"hash/fnv"
@@ -26,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 	secl "github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/status/expvarcollector"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
@@ -49,6 +51,18 @@ const (
 	// configurations which tend to be constant.
 	defaultCheckIntervalLowPriority = 3 * time.Hour
 )
+
+func init() {
+	expvarcollector.RegisterExpvarReport("complianceChecks", func() (interface{}, error) {
+		if status != nil {
+			complianceStatusJSON := []byte(status.String())
+			complianceStatus := make(map[string]interface{})
+			json.Unmarshal(complianceStatusJSON, &complianceStatus) //nolint:errcheck
+			return complianceStatus, nil
+		}
+		return nil, nil
+	})
+}
 
 // AgentOptions holds the different options to configure the compliance agent.
 type AgentOptions struct {

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -135,8 +135,8 @@ func init() {
 	expvarcollector.RegisterExpvarReport("remoteConfiguration", func() (interface{}, error) {
 		status := make(map[string]interface{})
 
-		if config.IsRemoteConfigEnabled(config.Datadog) && expvar.Get("remoteConfigStatus") != nil {
-			remoteConfigStatusJSON := expvar.Get("remoteConfigStatus").String()
+		if config.IsRemoteConfigEnabled(config.Datadog) {
+			remoteConfigStatusJSON := exportedMapStatus.String()
 			json.Unmarshal([]byte(remoteConfigStatusJSON), &status) //nolint:errcheck
 		} else {
 			if !config.Datadog.GetBool("remote_configuration.enabled") {

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -132,7 +132,7 @@ func init() {
 	exportedMapStatus.Set("apiKeyScoped", &exportedStatusKeyAuthorized)
 	exportedMapStatus.Set("lastError", &exportedLastUpdateErr)
 
-	expvarcollector.RegisterExpvarReport("remoteConfiguration", func() (interface{}, error) {
+	expvarcollector.RegisterExpvarCallback("remoteConfiguration", func() (interface{}, error) {
 		status := make(map[string]interface{})
 
 		if config.IsRemoteConfigEnabled(config.Datadog) {

--- a/pkg/metadata/inventories_collector.go
+++ b/pkg/metadata/inventories_collector.go
@@ -22,7 +22,7 @@ import (
 )
 
 func init() {
-	expvarcollector.RegisterExpvarReport("inventories", func() (interface{}, error) {
+	expvarcollector.RegisterExpvarCallback("inventories", func() (interface{}, error) {
 		inventories := expvar.Get("inventories")
 		var inventoriesStats map[string]interface{}
 		if inventories != nil {

--- a/pkg/snmp/traps/server.go
+++ b/pkg/snmp/traps/server.go
@@ -139,8 +139,3 @@ func (s *TrapServer) Stop() {
 func IsEnabled(conf config.Component) bool {
 	return conf.GetBool("network_devices.snmp_traps.enabled")
 }
-
-// GetStatus returns key-value data for use in status reporting of the traps server.
-func GetStatus() map[string]interface{} {
-	return status.GetStatus()
-}

--- a/pkg/snmp/traps/status/status.go
+++ b/pkg/snmp/traps/status/status.go
@@ -24,7 +24,7 @@ func init() {
 	trapsExpvars.Set("Packets", &trapsPackets)
 	trapsExpvars.Set("PacketsAuthErrors", &trapsPacketsAuthErrors)
 
-	expvarcollector.RegisterExpvarReport("snmpTrapsStats", func() (interface{}, error) {
+	expvarcollector.RegisterExpvarCallback("snmpTrapsStats", func() (interface{}, error) {
 		status := make(map[string]interface{})
 
 		metricsJSON := []byte(trapsExpvars.String())

--- a/pkg/snmp/traps/status/status.go
+++ b/pkg/snmp/traps/status/status.go
@@ -27,7 +27,7 @@ func init() {
 	expvarcollector.RegisterExpvarReport("snmpTrapsStats", func() (interface{}, error) {
 		status := make(map[string]interface{})
 
-		metricsJSON := []byte(expvar.Get("snmp_traps").String())
+		metricsJSON := []byte(trapsExpvars.String())
 		metrics := make(map[string]interface{})
 		json.Unmarshal(metricsJSON, &metrics) //nolint:errcheck
 		if dropped := getDroppedPackets(); dropped > 0 {

--- a/pkg/status/expvarcollector/expvarcollector.go
+++ b/pkg/status/expvarcollector/expvarcollector.go
@@ -27,3 +27,8 @@ func Report(stats map[string]interface{}) (map[string]interface{}, []error) {
 	}
 	return stats, errors
 }
+
+// ResetExpvarRegistry reset expvarRegistry. Use for testing
+func ResetExpvarRegistry() {
+	expvarRegistry = map[string]func() (interface{}, error){}
+}

--- a/pkg/status/expvarcollector/expvarcollector.go
+++ b/pkg/status/expvarcollector/expvarcollector.go
@@ -3,14 +3,18 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package expvarcollector allows external pacjages to register the expvar that wants to report on for agent status command.
 package expvarcollector
 
 var expvarRegistry = map[string]func() (interface{}, error){}
 
+// RegisterExpvarReport allow components to register the function to collect
+// expvar variables.
 func RegisterExpvarReport(key string, report func() (interface{}, error)) {
 	expvarRegistry[key] = report
 }
 
+// Report iterates over the registered collect function and append the result into the stats map
 func Report(stats map[string]interface{}) (map[string]interface{}, []error) {
 	errors := []error{}
 	for key, report := range expvarRegistry {

--- a/pkg/status/expvarcollector/expvarcollector.go
+++ b/pkg/status/expvarcollector/expvarcollector.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package expvarcollector
+
+var expvarRegistry = map[string]func() (interface{}, error){}
+
+func RegisterExpvarReport(key string, report func() (interface{}, error)) {
+	expvarRegistry[key] = report
+}
+
+func Report(stats map[string]interface{}) (map[string]interface{}, []error) {
+	errors := []error{}
+	for key, report := range expvarRegistry {
+		result, err := report()
+		if err != nil {
+			errors = append(errors, err)
+		} else {
+			stats[key] = result
+		}
+	}
+	return stats, errors
+}

--- a/pkg/status/expvarcollector/expvarcollector.go
+++ b/pkg/status/expvarcollector/expvarcollector.go
@@ -8,14 +8,14 @@ package expvarcollector
 
 var expvarRegistry = map[string]func() (interface{}, error){}
 
-// RegisterExpvarReport allow components to register the function to collect
+// RegisterExpvarCallback allow components to register the function to collect
 // expvar variables.
-func RegisterExpvarReport(key string, report func() (interface{}, error)) {
+func RegisterExpvarCallback(key string, report func() (interface{}, error)) {
 	expvarRegistry[key] = report
 }
 
 // Report iterates over the registered collect function and append the result into the stats map
-func Report(stats map[string]interface{}) (map[string]interface{}, []error) {
+func Collect(stats map[string]interface{}) (map[string]interface{}, []error) {
 	errors := []error{}
 	for key, report := range expvarRegistry {
 		result, err := report()

--- a/pkg/status/expvarcollector/expvarcollector_test.go
+++ b/pkg/status/expvarcollector/expvarcollector_test.go
@@ -10,17 +10,17 @@ import (
 	"testing"
 )
 
-func TestReport(t *testing.T) {
-	RegisterExpvarReport("testing_no_error", func() (interface{}, error) {
+func TestCollect(t *testing.T) {
+	RegisterExpvarCallback("testing_no_error", func() (interface{}, error) {
 		return "foo", nil
 	})
 
-	RegisterExpvarReport("testing_with_error", func() (interface{}, error) {
+	RegisterExpvarCallback("testing_with_error", func() (interface{}, error) {
 		return nil, fmt.Errorf("testin the error case")
 	})
 
 	stats := make(map[string]interface{})
-	stats, errors := Report(stats)
+	stats, errors := Collect(stats)
 
 	if len(errors) != 1 {
 		t.Errorf("Expected to have one error got %d", len(errors))

--- a/pkg/status/expvarcollector/expvarcollector_test.go
+++ b/pkg/status/expvarcollector/expvarcollector_test.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package expvarcollector
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestReport(t *testing.T) {
+	RegisterExpvarReport("testing_no_error", func() (interface{}, error) {
+		return "foo", nil
+	})
+
+	RegisterExpvarReport("testing_with_error", func() (interface{}, error) {
+		return nil, fmt.Errorf("testin the error case")
+	})
+
+	stats := make(map[string]interface{})
+	stats, errors := Report(stats)
+
+	if len(errors) != 1 {
+		t.Errorf("Expected to have one error got %d", len(errors))
+	}
+	_, ok := stats["testing_with_error"]
+	if ok {
+		t.Error("Reports with errors do not add an entry into the stats map.")
+	}
+
+	val, ok := stats["testing_no_error"]
+	if !ok {
+		t.Error("Reports without errors must add an entry into the stats map.")
+	}
+
+	stringVal := val.(string)
+	if stringVal != "foo" {
+		t.Errorf("Invaid report result expected 'foo' got: %s", stringVal)
+	}
+
+	ResetExpvarRegistry()
+
+	stats = make(map[string]interface{})
+	stats, errors = Report(stats)
+
+	if len(errors) != 0 {
+		t.Errorf("Expected to have zero errors got %d", len(errors))
+	}
+
+	_, ok = stats["testing_no_error"]
+	if ok {
+		t.Error("After calling ResetExpvarRegistry we should not populate stats with any report information")
+	}
+}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -309,7 +309,7 @@ func getEndpointsInfos() (map[string]interface{}, error) {
 // It gets the status elements common to all Agent flavors.
 func getCommonStatus() (map[string]interface{}, error) {
 	stats := make(map[string]interface{})
-	stats, errors := expvarcollector.Report(stats)
+	stats, errors := expvarcollector.Collect(stats)
 
 	if len(errors) > 0 {
 		log.Errorf("Error Getting ExpVar Stats: %v", errors)

--- a/pkg/util/hostname/providers.go
+++ b/pkg/util/hostname/providers.go
@@ -9,9 +9,11 @@ package hostname
 
 import (
 	"context"
+	"encoding/json"
 	"expvar"
 	"fmt"
 
+	"github.com/DataDog/datadog-agent/pkg/status/expvarcollector"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -31,6 +33,14 @@ func init() {
 	hostnameErrors.Init()
 	hostnameExpvars.Set("provider", &hostnameProvider)
 	hostnameExpvars.Set("errors", &hostnameErrors)
+
+	expvarcollector.RegisterExpvarReport("hostnameStats", func() (interface{}, error) {
+		hostnameStatsJSON := []byte(expvar.Get("hostname").String())
+		hostnameStats := make(map[string]interface{})
+		json.Unmarshal(hostnameStatsJSON, &hostnameStats) //nolint:errcheck
+
+		return hostnameStats, nil
+	})
 }
 
 // providerCb is a generic function to grab the hostname and return it. currentHostname represents the hostname detected

--- a/pkg/util/hostname/providers.go
+++ b/pkg/util/hostname/providers.go
@@ -34,7 +34,7 @@ func init() {
 	hostnameExpvars.Set("provider", &hostnameProvider)
 	hostnameExpvars.Set("errors", &hostnameErrors)
 
-	expvarcollector.RegisterExpvarReport("hostnameStats", func() (interface{}, error) {
+	expvarcollector.RegisterExpvarCallback("hostnameStats", func() (interface{}, error) {
 		hostnameStatsJSON := []byte(expvar.Get("hostname").String())
 		hostnameStats := make(map[string]interface{})
 		json.Unmarshal(hostnameStatsJSON, &hostnameStats) //nolint:errcheck


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

We introduce a new way for packages to register functions that return information from expvar variables. The status page later would iterate over those functions and populate the stats map.

This has the added benefit that status no longer needs to know the name of the expvar that other packages define. 

The work we are doing now might have to get reviewed once we can make the status package into a pure component. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The idea is that pkg/status could gather the expvar information in a less couple way.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
