### PR TITLE
Reduce allocation pressure in process_linux

### DIFF
--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -514,7 +514,15 @@ func (p *probe) parseStatusLine(line []byte, sInfo *statusInfo) {
 	}
 }
 
-// parseStatusKV takes tokens parsed from each line in "status" file and populates statusInfo object
+// parseStatusKV takes tokens parsed from each line in "status" file and
+// populates statusInfo object.
+//
+// Notes on Performance:
+// Passed key, value are byte slices and we attempt to avoid coercion
+// to string in this function: string allocation is expensive and this function
+// is called often in the operation of the process-agent. There are still some
+// functions in the call-stack here that allocate. It's possible that this
+// function could be made zero-copy with some more effort, should the need arise.
 func (p *probe) parseStatusKV(key, value []byte, sInfo *statusInfo) {
 	switch {
 	case bytes.Equal(key, keyName):

--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -20,6 +20,7 @@ import (
 	"syscall"
 	"time"
 	"unicode"
+	"unsafe"
 
 	"go.uber.org/atomic"
 
@@ -40,12 +41,23 @@ const (
 
 var (
 	// PageSize is the system's memory page size
-	PageSize = uint64(os.Getpagesize())
+	PageSize                    = uint64(os.Getpagesize())
+	keyName                     = []byte("Name")
+	keyState                    = []byte("State")
+	keyUid                      = []byte("Uid")
+	keyGid                      = []byte("Gid")
+	keyNSpid                    = []byte("NSpid")
+	keyThreads                  = []byte("Threads")
+	keyVoluntaryCtxtSwitches    = []byte("voluntary_ctxt_switches")
+	keyNonvoluntaryCtxtSwitches = []byte("nonvoluntary_ctxt_switches")
+	keyVmRSS                    = []byte("VmRSS")
+	keyVmSize                   = []byte("VmSize")
+	keyVmSwap                   = []byte("VmSwap")
 )
 
 type statusInfo struct {
-	name        string
-	status      string
+	name        []byte
+	status      []byte
 	uids        []int32
 	gids        []int32
 	nspid       int32
@@ -187,14 +199,14 @@ func (p *probe) StatsForPIDs(pids []int32, now time.Time) (map[int32]*Stats, err
 		memInfoEx := p.parseStatm(pathForPID)
 
 		stats := &Stats{
-			CreateTime:  statInfo.createTime,    // /proc/[pid]/stat
-			Status:      statusInfo.status,      // /proc/[pid]/status
-			Nice:        statInfo.nice,          // /proc/[pid]/stat
-			CPUTime:     statInfo.cpuStat,       // /proc/[pid]/stat
-			MemInfo:     statusInfo.memInfo,     // /proc/[pid]/status
-			MemInfoEx:   memInfoEx,              // /proc/[pid]/statm
-			CtxSwitches: statusInfo.ctxSwitches, // /proc/[pid]/status
-			NumThreads:  statusInfo.numThreads,  // /proc/[pid]/status
+			CreateTime:  statInfo.createTime,       // /proc/[pid]/stat
+			Status:      string(statusInfo.status), // /proc/[pid]/status
+			Nice:        statInfo.nice,             // /proc/[pid]/stat
+			CPUTime:     statInfo.cpuStat,          // /proc/[pid]/stat
+			MemInfo:     statusInfo.memInfo,        // /proc/[pid]/status
+			MemInfoEx:   memInfoEx,                 // /proc/[pid]/statm
+			CtxSwitches: statusInfo.ctxSwitches,    // /proc/[pid]/status
+			NumThreads:  statusInfo.numThreads,     // /proc/[pid]/status
 		}
 		if p.elevatedPermissions {
 			stats.OpenFdCount = p.getFDCount(pathForPID) // /proc/[pid]/fd, requires permission checks
@@ -258,21 +270,21 @@ func (p *probe) ProcessesByPID(now time.Time, collectStats bool) (map[int32]*Pro
 			Ppid:    statInfo.ppid,                             // /proc/[pid]/stat
 			Cmdline: cmdline,                                   // /proc/[pid]/cmdline
 			Comm:    comm,                                      // /proc/[pid]/comm
-			Name:    statusInfo.name,                           // /proc/[pid]/status
+			Name:    string(statusInfo.name),                   // /proc/[pid]/status
 			Uids:    statusInfo.uids,                           // /proc/[pid]/status
 			Gids:    statusInfo.gids,                           // /proc/[pid]/status
 			Cwd:     p.getLinkWithAuthCheck(pathForPID, "cwd"), // /proc/[pid]/cwd, requires permission checks
 			Exe:     p.getLinkWithAuthCheck(pathForPID, "exe"), // /proc/[pid]/exe, requires permission checks
 			NsPid:   statusInfo.nspid,                          // /proc/[pid]/status
 			Stats: &Stats{
-				CreateTime:  statInfo.createTime,    // /proc/[pid]/stat
-				Status:      statusInfo.status,      // /proc/[pid]/status
-				Nice:        statInfo.nice,          // /proc/[pid]/stat
-				CPUTime:     statInfo.cpuStat,       // /proc/[pid]/stat
-				MemInfo:     statusInfo.memInfo,     // /proc/[pid]/status
-				MemInfoEx:   memInfoEx,              // /proc/[pid]/statm
-				CtxSwitches: statusInfo.ctxSwitches, // /proc/[pid]/status
-				NumThreads:  statusInfo.numThreads,  // /proc/[pid]/status
+				CreateTime:  statInfo.createTime,       // /proc/[pid]/stat
+				Status:      string(statusInfo.status), // /proc/[pid]/status
+				Nice:        statInfo.nice,             // /proc/[pid]/stat
+				CPUTime:     statInfo.cpuStat,          // /proc/[pid]/stat
+				MemInfo:     statusInfo.memInfo,        // /proc/[pid]/status
+				MemInfoEx:   memInfoEx,                 // /proc/[pid]/statm
+				CtxSwitches: statusInfo.ctxSwitches,    // /proc/[pid]/status
+				NumThreads:  statusInfo.numThreads,     // /proc/[pid]/status
 			},
 		}
 		if p.elevatedPermissions {
@@ -496,77 +508,77 @@ func (p *probe) parseStatusLine(line []byte, sInfo *statusInfo) {
 		if i+2 < len(line) && line[i] == ':' && unicode.IsSpace(rune(line[i+1])) {
 			key := line[0:i]
 			value := line[i+2:]
-			p.parseStatusKV(string(key), string(value), sInfo)
+			p.parseStatusKV(key, value, sInfo)
 			break
 		}
 	}
 }
 
 // parseStatusKV takes tokens parsed from each line in "status" file and populates statusInfo object
-func (p *probe) parseStatusKV(key, value string, sInfo *statusInfo) {
-	switch key {
-	case "Name":
-		sInfo.name = strings.Trim(value, " \t")
-	case "State":
-		sInfo.status = value[0:1]
-	case "Uid":
-		sInfo.uids = make([]int32, 0, 4)
-		for _, i := range strings.Split(value, "\t") {
-			v, err := strconv.ParseInt(i, 10, 32)
-			if err == nil {
-				sInfo.uids = append(sInfo.uids, int32(v))
+func (p *probe) parseStatusKV(key, value []byte, sInfo *statusInfo) {
+	switch {
+	case bytes.Equal(key, keyName):
+		sInfo.name = bytes.Trim(value, " \t")
+	case bytes.Equal(key, keyState):
+		sInfo.status = value[:1]
+	case bytes.Equal(key, keyUid), bytes.Equal(key, keyGid):
+		values := bytes.Fields(value)
+		ints := make([]int32, 0, len(values))
+		for _, v := range values {
+			if i, err := parseBytesToInt(v, 10, 32); err == nil {
+				ints = append(ints, int32(i))
 			}
 		}
-	case "Gid":
-		sInfo.gids = make([]int32, 0, 4)
-		for _, i := range strings.Split(value, "\t") {
-			v, err := strconv.ParseInt(i, 10, 32)
-			if err == nil {
-				sInfo.gids = append(sInfo.gids, int32(v))
-			}
+		if key[0] == 'U' {
+			sInfo.uids = ints
+		} else {
+			sInfo.gids = ints
 		}
-	case "NSpid":
-		values := strings.Split(value, "\t")
+	case bytes.Equal(key, keyNSpid):
+		values := bytes.Split(value, []byte("\t"))
 		// only report process namespaced PID
-		v, err := strconv.ParseInt(values[len(values)-1], 10, 32)
-		if err == nil {
+		if v, err := parseBytesToInt(values[len(values)-1], 10, 32); err == nil {
 			sInfo.nspid = int32(v)
 		}
-	case "Threads":
-		v, err := strconv.ParseInt(value, 10, 32)
-		if err == nil {
+	case bytes.Equal(key, keyThreads):
+		if v, err := parseBytesToInt(value, 10, 32); err == nil {
 			sInfo.numThreads = int32(v)
 		}
-	case "voluntary_ctxt_switches":
-		v, err := strconv.ParseInt(value, 10, 64)
-		if err == nil {
-			sInfo.ctxSwitches.Voluntary = v
+	case bytes.Equal(key, keyVoluntaryCtxtSwitches), bytes.Equal(key, keyNonvoluntaryCtxtSwitches):
+		if v, err := parseBytesToInt(value, 10, 64); err == nil {
+			if key[0] == 'v' {
+				sInfo.ctxSwitches.Voluntary = v
+			} else {
+				sInfo.ctxSwitches.Involuntary = v
+			}
 		}
-	case "nonvoluntary_ctxt_switches":
-		v, err := strconv.ParseInt(value, 10, 64)
-		if err == nil {
-			sInfo.ctxSwitches.Involuntary = v
-		}
-	case "VmRSS":
-		value := strings.TrimSuffix(value, "kB") // trim spaces and suffix "kB"
-		value = strings.Trim(value, " ")
-		v, err := strconv.ParseUint(value, 10, 64)
-		if err == nil {
-			sInfo.memInfo.RSS = v * 1024
-		}
-	case "VmSize":
-		value := strings.TrimSuffix(value, "kB") // trim spaces and suffix "kB"
-		value = strings.Trim(value, " ")
-		v, err := strconv.ParseUint(value, 10, 64)
-		if err == nil {
-			sInfo.memInfo.VMS = v * 1024
-		}
-	case "VmSwap":
-		value := strings.TrimSuffix(value, "kB") // trim spaces and suffix "kB"
-		value = strings.Trim(value, " ")
-		v, err := strconv.ParseUint(value, 10, 64)
-		if err == nil {
-			sInfo.memInfo.Swap = v * 1024
+	case bytes.Equal(key, keyVmRSS), bytes.Equal(key, keyVmSize), bytes.Equal(key, keyVmSwap):
+		parseMemInfo(value, key, sInfo.memInfo)
+	}
+}
+
+func parseBytesToInt(buf []byte, base int, bitSize int) (int64, error) {
+	// Safety: We are not modifying the contents of the byte slice.
+	return strconv.ParseInt(*(*string)(unsafe.Pointer(&buf)), base, bitSize)
+}
+
+func parseBytesToUint(buf []byte, base int, bitSize int) (uint64, error) {
+	// Safety: We are not modifying the contents of the byte slice.
+	return strconv.ParseUint(*(*string)(unsafe.Pointer(&buf)), base, bitSize)
+}
+
+func parseMemInfo(value, key []byte, memInfo *MemoryInfoStat) {
+	value = bytes.TrimSuffix(value, []byte("kB"))
+	value = bytes.TrimSpace(value)
+	if v, err := parseBytesToUint(value, 10, 64); err == nil {
+		v *= 1024
+		switch key[3] { // Using the fourth byte to differentiate between RSS, Size, and Swap
+		case 'S': // VmRSS
+			memInfo.RSS = v
+		case 'i': // VmSize
+			memInfo.VMS = v
+		case 'w': // VmSwap
+			memInfo.Swap = v
 		}
 	}
 }

--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -44,15 +44,15 @@ var (
 	PageSize                    = uint64(os.Getpagesize())
 	keyName                     = []byte("Name")
 	keyState                    = []byte("State")
-	keyUid                      = []byte("Uid")
+	keyUID                      = []byte("Uid")
 	keyGid                      = []byte("Gid")
 	keyNSpid                    = []byte("NSpid")
 	keyThreads                  = []byte("Threads")
 	keyVoluntaryCtxtSwitches    = []byte("voluntary_ctxt_switches")
 	keyNonvoluntaryCtxtSwitches = []byte("nonvoluntary_ctxt_switches")
-	keyVmRSS                    = []byte("VmRSS")
-	keyVmSize                   = []byte("VmSize")
-	keyVmSwap                   = []byte("VmSwap")
+	keyVMRSS                    = []byte("VmRSS")
+	keyVMSize                   = []byte("VmSize")
+	keyVMSwap                   = []byte("VmSwap")
 )
 
 type statusInfo struct {
@@ -521,7 +521,7 @@ func (p *probe) parseStatusKV(key, value []byte, sInfo *statusInfo) {
 		sInfo.name = bytes.Trim(value, " \t")
 	case bytes.Equal(key, keyState):
 		sInfo.status = value[:1]
-	case bytes.Equal(key, keyUid), bytes.Equal(key, keyGid):
+	case bytes.Equal(key, keyUID), bytes.Equal(key, keyGid):
 		values := bytes.Fields(value)
 		ints := make([]int32, 0, len(values))
 		for _, v := range values {
@@ -552,7 +552,7 @@ func (p *probe) parseStatusKV(key, value []byte, sInfo *statusInfo) {
 				sInfo.ctxSwitches.Involuntary = v
 			}
 		}
-	case bytes.Equal(key, keyVmRSS), bytes.Equal(key, keyVmSize), bytes.Equal(key, keyVmSwap):
+	case bytes.Equal(key, keyVMRSS), bytes.Equal(key, keyVMSize), bytes.Equal(key, keyVMSwap):
 		parseMemInfo(value, key, sInfo.memInfo)
 	}
 }

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -350,7 +350,7 @@ func TestParseStatusLine(t *testing.T) {
 		{
 			line: []byte("Name:\tpostgres"),
 			expected: &statusInfo{
-				name:        "postgres",
+				name:        []byte("postgres"),
 				memInfo:     &MemoryInfoStat{},
 				ctxSwitches: &NumCtxSwitchesStat{},
 			},
@@ -358,7 +358,7 @@ func TestParseStatusLine(t *testing.T) {
 		{
 			line: []byte("Name:\t\t  \t\t\t  postgres"),
 			expected: &statusInfo{
-				name:        "postgres",
+				name:        []byte("postgres"),
 				memInfo:     &MemoryInfoStat{},
 				ctxSwitches: &NumCtxSwitchesStat{},
 			},
@@ -366,7 +366,7 @@ func TestParseStatusLine(t *testing.T) {
 		{
 			line: []byte("State:\tS (sleeping)"),
 			expected: &statusInfo{
-				status:      "S",
+				status:      []byte("S"),
 				memInfo:     &MemoryInfoStat{},
 				ctxSwitches: &NumCtxSwitchesStat{},
 			},
@@ -374,7 +374,7 @@ func TestParseStatusLine(t *testing.T) {
 		{
 			line: []byte("State:\tR (running)"),
 			expected: &statusInfo{
-				status:      "R",
+				status:      []byte("R"),
 				memInfo:     &MemoryInfoStat{},
 				ctxSwitches: &NumCtxSwitchesStat{},
 			},
@@ -476,6 +476,149 @@ func TestParseStatusLine(t *testing.T) {
 		result := &statusInfo{memInfo: &MemoryInfoStat{}, ctxSwitches: &NumCtxSwitchesStat{}}
 		probe.parseStatusLine(tc.line, result)
 		assert.EqualValues(t, tc.expected, result)
+	}
+}
+
+func BenchmarkParseStatusLine(b *testing.B) {
+	probe := getProbeWithPermission()
+	defer probe.Close()
+
+	testCases := []struct {
+		line     []byte
+		expected *statusInfo
+	}{
+		{
+			line: []byte("Name:\tpostgres"),
+			expected: &statusInfo{
+				name:        []byte("postgres"),
+				memInfo:     &MemoryInfoStat{},
+				ctxSwitches: &NumCtxSwitchesStat{},
+			},
+		},
+		{
+			line: []byte("Name:\t\t  \t\t\t  postgres"),
+			expected: &statusInfo{
+				name:        []byte("postgres"),
+				memInfo:     &MemoryInfoStat{},
+				ctxSwitches: &NumCtxSwitchesStat{},
+			},
+		},
+		{
+			line: []byte("State:\tS (sleeping)"),
+			expected: &statusInfo{
+				status:      []byte("S"),
+				memInfo:     &MemoryInfoStat{},
+				ctxSwitches: &NumCtxSwitchesStat{},
+			},
+		},
+		{
+			line: []byte("State:\tR (running)"),
+			expected: &statusInfo{
+				status:      []byte("R"),
+				memInfo:     &MemoryInfoStat{},
+				ctxSwitches: &NumCtxSwitchesStat{},
+			},
+		},
+		{
+			line: []byte("Uid:\t112\t112\t112\t112"),
+			expected: &statusInfo{
+				uids:        []int32{112, 112, 112, 112},
+				memInfo:     &MemoryInfoStat{},
+				ctxSwitches: &NumCtxSwitchesStat{},
+			},
+		},
+		{
+			line: []byte("Gid:\t1000\t1000\t1000\t1000"),
+			expected: &statusInfo{
+				gids:        []int32{1000, 1000, 1000, 1000},
+				memInfo:     &MemoryInfoStat{},
+				ctxSwitches: &NumCtxSwitchesStat{},
+			},
+		},
+		{
+			line: []byte("NSpid:\t123"),
+			expected: &statusInfo{
+				nspid:       123,
+				memInfo:     &MemoryInfoStat{},
+				ctxSwitches: &NumCtxSwitchesStat{},
+			},
+		},
+		{
+			line: []byte("NSpid:\t123\t456"),
+			expected: &statusInfo{
+				nspid:       456,
+				memInfo:     &MemoryInfoStat{},
+				ctxSwitches: &NumCtxSwitchesStat{},
+			},
+		},
+		{
+			line: []byte("Threads:\t1"),
+			expected: &statusInfo{
+				numThreads:  1,
+				memInfo:     &MemoryInfoStat{},
+				ctxSwitches: &NumCtxSwitchesStat{},
+			},
+		},
+		{
+			line: []byte("voluntary_ctxt_switches:\t3"),
+			expected: &statusInfo{
+				memInfo: &MemoryInfoStat{},
+				ctxSwitches: &NumCtxSwitchesStat{
+					Voluntary: 3,
+				},
+			},
+		},
+		{
+			line: []byte("nonvoluntary_ctxt_switches:\t411"),
+			expected: &statusInfo{
+				memInfo: &MemoryInfoStat{},
+				ctxSwitches: &NumCtxSwitchesStat{
+					Involuntary: 411,
+				},
+			},
+		},
+		{
+			line: []byte("bad status line"), // bad status
+			expected: &statusInfo{
+				memInfo:     &MemoryInfoStat{},
+				ctxSwitches: &NumCtxSwitchesStat{},
+			},
+		},
+		{
+			line: []byte("Name:\t"), // edge case for parsing failure
+			expected: &statusInfo{
+				memInfo:     &MemoryInfoStat{},
+				ctxSwitches: &NumCtxSwitchesStat{},
+			},
+		},
+		{
+			line: []byte("VmRSS:\t712 kB"),
+			expected: &statusInfo{
+				memInfo:     &MemoryInfoStat{RSS: 712 * 1024},
+				ctxSwitches: &NumCtxSwitchesStat{},
+			},
+		},
+		{
+			line: []byte("VmSize:\t14652 kB"),
+			expected: &statusInfo{
+				memInfo:     &MemoryInfoStat{VMS: 14652 * 1024},
+				ctxSwitches: &NumCtxSwitchesStat{},
+			},
+		},
+		{
+			line: []byte("VmSwap:\t3 kB"),
+			expected: &statusInfo{
+				memInfo:     &MemoryInfoStat{Swap: 3 * 1024},
+				ctxSwitches: &NumCtxSwitchesStat{},
+			},
+		},
+	}
+
+	for i := 0; i < b.N; i++ {
+		for _, tc := range testCases {
+			result := &statusInfo{memInfo: &MemoryInfoStat{}, ctxSwitches: &NumCtxSwitchesStat{}}
+			probe.parseStatusLine(tc.line, result)
+		}
 	}
 }
 

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -659,8 +659,8 @@ func testParseStatus(t *testing.T, probeOptions ...Option) {
 		expCtxSwitches, err := expProc.NumCtxSwitches()
 		assert.NoError(t, err)
 
-		assert.Equal(t, expName, actual.name)
-		assert.Equal(t, expStatus, actual.status)
+		assert.Equal(t, expName, string(actual.name))
+		assert.Equal(t, expStatus, string(actual.status))
 		assert.EqualValues(t, expUIDs, actual.uids)
 		assert.EqualValues(t, expGIDs, actual.gids)
 		assert.Equal(t, expThreads, actual.numThreads)


### PR DESCRIPTION
### What does this PR do?

This commit attempts to reduce allocation pressure in process_linux, following on from #20502. That PR indicates that ParseStatusLine is an allocation hotspot. We attempt to avoid that hotspot by not converting the key, value arguments to parseStatusKV -- a child function -- into strings but pass them as `[]byte`. This allows us to elide conversion of the key into a string in all case and the value in a few. If we have a `ParseInt` routine in the code base that works directly on byte slices this result can be improved.

### Motivation

Desire to improve on the finding of #20502 that there was an allocation hotspot present here. Overall goal, less allocation pressure in the process-agent. 

### Additional Notes

I have introduced a new benchmark function, patterned on the existing test function.

Previous:

```
BenchmarkParseStatusLine-16     421380	  2657 ns/op    984 B/op    50 allocs/op
```

Current:
```
BenchmarkParseStatusLine-16     734079    1446 ns/op    296 B/op    6 allocs/op
````

REF SMPTNG-74


