### PR TITLE
[windows] Fix http truncation miscounting

### DIFF
--- a/cmd/system-probe/config/adjust_usm.go
+++ b/cmd/system-probe/config/adjust_usm.go
@@ -38,7 +38,6 @@ func adjustUSM(cfg config.Config) {
 	applyDefault(cfg, smNS("http_idle_connection_ttl_in_s"), 30)
 	deprecateInt64(cfg, netNS("http_notification_threshold"), smNS("http_notification_threshold"))
 	applyDefault(cfg, smNS("http_notification_threshold"), 512)
-	// http_max_request_fragment
 	deprecateInt64(cfg, netNS("http_max_request_fragment"), smNS("http_max_request_fragment"))
 	// set the default to be the max allowed by the driver.  So now the config will allow us to
 	// shorten the allowed path, but not lengthen it.

--- a/cmd/system-probe/config/adjust_usm.go
+++ b/cmd/system-probe/config/adjust_usm.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	maxHTTPFrag = 160
+	maxHTTPFrag = 512 // matches hard limit currently imposed in NPM driver
 )
 
 func adjustUSM(cfg config.Config) {
@@ -38,8 +38,9 @@ func adjustUSM(cfg config.Config) {
 	applyDefault(cfg, smNS("http_idle_connection_ttl_in_s"), 30)
 	deprecateInt64(cfg, netNS("http_notification_threshold"), smNS("http_notification_threshold"))
 	applyDefault(cfg, smNS("http_notification_threshold"), 512)
+	// http_max_request_fragment
 	deprecateInt64(cfg, netNS("http_max_request_fragment"), smNS("http_max_request_fragment"))
-	applyDefault(cfg, smNS("http_max_request_fragment"), 160)
+	applyDefault(cfg, smNS("http_max_request_fragment"), 208)
 	applyDefault(cfg, smNS("max_concurrent_requests"), cfg.GetInt(spNS("max_tracked_connections")))
 
 	if cfg.GetBool(dsmNS("enabled")) {

--- a/cmd/system-probe/config/adjust_usm.go
+++ b/cmd/system-probe/config/adjust_usm.go
@@ -40,7 +40,9 @@ func adjustUSM(cfg config.Config) {
 	applyDefault(cfg, smNS("http_notification_threshold"), 512)
 	// http_max_request_fragment
 	deprecateInt64(cfg, netNS("http_max_request_fragment"), smNS("http_max_request_fragment"))
-	applyDefault(cfg, smNS("http_max_request_fragment"), 208)
+	// set the default to be the max allowed by the driver.  So now the config will allow us to
+	// shorten the allowed path, but not lengthen it.
+	applyDefault(cfg, smNS("http_max_request_fragment"), maxHTTPFrag)
 	applyDefault(cfg, smNS("max_concurrent_requests"), cfg.GetInt(spNS("max_tracked_connections")))
 
 	if cfg.GetBool(dsmNS("enabled")) {

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -250,7 +250,7 @@ func InitSystemProbeConfig(cfg Config) {
 	// Default value (512) is set in `adjustUSM`, to avoid having "deprecation warning", due to the default value.
 	cfg.BindEnv(join(netNS, "http_notification_threshold"))
 	cfg.BindEnv(join(smNS, "http_notification_threshold"))
-	// Default value (160) is set in `adjustUSM`, to avoid having "deprecation warning", due to the default value.
+	// Default value (512) is set in `adjustUSM`, to avoid having "deprecation warning", due to the default value.
 	cfg.BindEnv(join(netNS, "http_max_request_fragment"))
 	cfg.BindEnv(join(smNS, "http_max_request_fragment"))
 

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -783,7 +783,7 @@ func TestHTTPNotificationThreshold(t *testing.T) {
 
 	t.Run("via YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, makeYamlConfigString("network_config", "http_notification_threshold", validNotificationThreshold))
+		cfg := configurationFromYAML(t, makeYamlConfigString("service_monitoring_config", "http_notification_threshold", validNotificationThreshold))
 		require.Equal(t, cfg.HTTPNotificationThreshold, int64(validNotificationThreshold))
 	})
 

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -972,7 +972,7 @@ service_monitoring_config:
 		aconfig.ResetSystemProbeConfig(t)
 		cfg := New()
 		// Default value.
-		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(160))
+		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(208))
 	})
 }
 
@@ -982,72 +982,72 @@ func TestHTTPMaxRequestFragmentLimit(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		cfg := configurationFromYAML(t, `
 network_config:
-  http_max_request_fragment: 175
+  http_max_request_fragment: 600
 `)
-		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(160))
+		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(512))
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		t.Setenv("DD_NETWORK_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", "175")
+		t.Setenv("DD_NETWORK_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", "600")
 
 		cfg := New()
 
-		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(160))
+		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(512))
 	})
 
 	t.Run("via YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		cfg := configurationFromYAML(t, `
 service_monitoring_config:
-  http_max_request_fragment: 175
+  http_max_request_fragment: 600
 `)
-		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(160))
+		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(512))
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", "175")
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", "600")
 
 		cfg := New()
 
-		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(160))
+		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(512))
 	})
 
 	t.Run("Deprecated is enabled, new is disabled", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		t.Setenv("DD_NETWORK_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", "175")
+		t.Setenv("DD_NETWORK_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", "600")
 
 		cfg := New()
 
-		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(160))
+		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(512))
 	})
 
 	t.Run("Deprecated is disabled, new is enabled", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", "175")
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", "600")
 
 		cfg := New()
 
-		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(160))
+		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(512))
 	})
 
 	t.Run("Both enabled", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		// Setting a different value
-		t.Setenv("DD_NETWORK_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", "176")
-		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", "175")
+		t.Setenv("DD_NETWORK_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", "600")
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", "601")
 
 		cfg := New()
 
-		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(160))
+		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(512))
 	})
 
 	t.Run("Not enabled", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		cfg := New()
 		// Default value.
-		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(160))
+		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(208))
 	})
 }
 

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -28,7 +28,7 @@ const (
 	driverMaxFragmentLimit             = 512
 	validNotificationThreshold         = 100
 	invalidNotificationThreshold       = 1200
-	invalidHttpRequestFragment         = 600
+	invalidHTTPRequestFragment         = 600
 )
 
 func makeYamlConfigString(section, entry string, val int) string {
@@ -982,14 +982,14 @@ service_monitoring_config:
 func TestHTTPMaxRequestFragmentLimit(t *testing.T) {
 	t.Run("via deprecated YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, makeYamlConfigString("network_config", "http_max_request_fragment", invalidHttpRequestFragment))
+		cfg := configurationFromYAML(t, makeYamlConfigString("network_config", "http_max_request_fragment", invalidHTTPRequestFragment))
 
 		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(driverMaxFragmentLimit))
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		t.Setenv("DD_NETWORK_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", strconv.Itoa(invalidHttpRequestFragment))
+		t.Setenv("DD_NETWORK_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", strconv.Itoa(invalidHTTPRequestFragment))
 
 		cfg := New()
 
@@ -998,14 +998,14 @@ func TestHTTPMaxRequestFragmentLimit(t *testing.T) {
 
 	t.Run("via YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		cfg := configurationFromYAML(t, makeYamlConfigString("service_monitoring_config", "http_max_request_fragment", invalidHttpRequestFragment))
+		cfg := configurationFromYAML(t, makeYamlConfigString("service_monitoring_config", "http_max_request_fragment", invalidHTTPRequestFragment))
 
 		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(driverMaxFragmentLimit))
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", strconv.Itoa(invalidHttpRequestFragment))
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", strconv.Itoa(invalidHTTPRequestFragment))
 
 		cfg := New()
 
@@ -1014,7 +1014,7 @@ func TestHTTPMaxRequestFragmentLimit(t *testing.T) {
 
 	t.Run("Deprecated is enabled, new is disabled", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		t.Setenv("DD_NETWORK_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", strconv.Itoa(invalidHttpRequestFragment))
+		t.Setenv("DD_NETWORK_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", strconv.Itoa(invalidHTTPRequestFragment))
 
 		cfg := New()
 
@@ -1023,7 +1023,7 @@ func TestHTTPMaxRequestFragmentLimit(t *testing.T) {
 
 	t.Run("Deprecated is disabled, new is enabled", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
-		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", strconv.Itoa(invalidHttpRequestFragment))
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", strconv.Itoa(invalidHTTPRequestFragment))
 
 		cfg := New()
 
@@ -1033,8 +1033,8 @@ func TestHTTPMaxRequestFragmentLimit(t *testing.T) {
 	t.Run("Both enabled", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		// Setting a different value
-		t.Setenv("DD_NETWORK_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", strconv.Itoa(invalidHttpRequestFragment))
-		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", strconv.Itoa(invalidHttpRequestFragment+1))
+		t.Setenv("DD_NETWORK_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", strconv.Itoa(invalidHTTPRequestFragment))
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_HTTP_MAX_REQUEST_FRAGMENT", strconv.Itoa(invalidHTTPRequestFragment+1))
 
 		cfg := New()
 

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -22,6 +22,12 @@ import (
 	aconfig "github.com/DataDog/datadog-agent/pkg/config"
 )
 
+// variables for testing config options
+const (
+	driverDefaultNotificationThreshold = 512
+	driverMaxFragmentLimit = 512
+)
+
 func TestDisablingDNSInspection(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
@@ -823,7 +829,7 @@ service_monitoring_config:
 		aconfig.ResetSystemProbeConfig(t)
 		cfg := New()
 		// Default value.
-		require.Equal(t, cfg.HTTPNotificationThreshold, int64(512))
+		require.Equal(t, cfg.HTTPNotificationThreshold, int64(driverDefaultNotificationThreshold))
 	})
 }
 
@@ -835,7 +841,7 @@ func TestHTTPNotificationThresholdOverLimit(t *testing.T) {
 network_config:
   http_notification_threshold: 1025
 `)
-		require.Equal(t, cfg.HTTPNotificationThreshold, int64(512))
+		require.Equal(t, cfg.HTTPNotificationThreshold, int64(driverDefaultNotificationThreshold))
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
@@ -844,7 +850,7 @@ network_config:
 
 		cfg := New()
 
-		require.Equal(t, cfg.HTTPNotificationThreshold, int64(512))
+		require.Equal(t, cfg.HTTPNotificationThreshold, int64(driverDefaultNotificationThreshold))
 	})
 
 	t.Run("via YAML", func(t *testing.T) {
@@ -853,7 +859,7 @@ network_config:
 service_monitoring_config:
   http_notification_threshold: 1025
 `)
-		require.Equal(t, cfg.HTTPNotificationThreshold, int64(512))
+		require.Equal(t, cfg.HTTPNotificationThreshold, int64(driverDefaultNotificationThreshold))
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
@@ -862,7 +868,7 @@ service_monitoring_config:
 
 		cfg := New()
 
-		require.Equal(t, cfg.HTTPNotificationThreshold, int64(512))
+		require.Equal(t, cfg.HTTPNotificationThreshold, int64(driverDefaultNotificationThreshold))
 	})
 
 	t.Run("Deprecated is enabled, new is disabled", func(t *testing.T) {
@@ -871,7 +877,7 @@ service_monitoring_config:
 
 		cfg := New()
 
-		require.Equal(t, cfg.HTTPNotificationThreshold, int64(512))
+		require.Equal(t, cfg.HTTPNotificationThreshold, int64(driverDefaultNotificationThreshold))
 	})
 
 	t.Run("Deprecated is disabled, new is enabled", func(t *testing.T) {
@@ -880,7 +886,7 @@ service_monitoring_config:
 
 		cfg := New()
 
-		require.Equal(t, cfg.HTTPNotificationThreshold, int64(512))
+		require.Equal(t, cfg.HTTPNotificationThreshold, int64(driverDefaultNotificationThreshold))
 	})
 
 	t.Run("Both enabled", func(t *testing.T) {
@@ -891,14 +897,14 @@ service_monitoring_config:
 
 		cfg := New()
 
-		require.Equal(t, cfg.HTTPNotificationThreshold, int64(512))
+		require.Equal(t, cfg.HTTPNotificationThreshold, int64(driverDefaultNotificationThreshold))
 	})
 
 	t.Run("Not enabled", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		cfg := New()
 		// Default value.
-		require.Equal(t, cfg.HTTPNotificationThreshold, int64(512))
+		require.Equal(t, cfg.HTTPNotificationThreshold, int64(driverDefaultNotificationThreshold))
 	})
 }
 
@@ -972,7 +978,7 @@ service_monitoring_config:
 		aconfig.ResetSystemProbeConfig(t)
 		cfg := New()
 		// Default value.
-		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(512))
+		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(driverMaxFragmentLimit))
 	})
 }
 
@@ -984,7 +990,7 @@ func TestHTTPMaxRequestFragmentLimit(t *testing.T) {
 network_config:
   http_max_request_fragment: 600
 `)
-		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(512))
+		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(driverMaxFragmentLimit))
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
@@ -993,7 +999,7 @@ network_config:
 
 		cfg := New()
 
-		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(512))
+		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(driverMaxFragmentLimit))
 	})
 
 	t.Run("via YAML", func(t *testing.T) {
@@ -1002,7 +1008,7 @@ network_config:
 service_monitoring_config:
   http_max_request_fragment: 600
 `)
-		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(512))
+		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(driverMaxFragmentLimit))
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
@@ -1011,7 +1017,7 @@ service_monitoring_config:
 
 		cfg := New()
 
-		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(512))
+		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(driverMaxFragmentLimit))
 	})
 
 	t.Run("Deprecated is enabled, new is disabled", func(t *testing.T) {
@@ -1029,7 +1035,7 @@ service_monitoring_config:
 
 		cfg := New()
 
-		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(512))
+		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(driverMaxFragmentLimit))
 	})
 
 	t.Run("Both enabled", func(t *testing.T) {
@@ -1040,14 +1046,14 @@ service_monitoring_config:
 
 		cfg := New()
 
-		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(512))
+		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(driverMaxFragmentLimit))
 	})
 
 	t.Run("Not enabled", func(t *testing.T) {
 		aconfig.ResetSystemProbeConfig(t)
 		cfg := New()
 		// Default value.
-		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(512))
+		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(driverMaxFragmentLimit))
 	})
 }
 

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -972,7 +972,7 @@ service_monitoring_config:
 		aconfig.ResetSystemProbeConfig(t)
 		cfg := New()
 		// Default value.
-		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(208))
+		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(512))
 	})
 }
 
@@ -1047,7 +1047,7 @@ service_monitoring_config:
 		aconfig.ResetSystemProbeConfig(t)
 		cfg := New()
 		// Default value.
-		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(208))
+		require.Equal(t, cfg.HTTPMaxRequestFragment, int64(512))
 	})
 }
 

--- a/pkg/network/protocols/http/model_windows.go
+++ b/pkg/network/protocols/http/model_windows.go
@@ -124,7 +124,7 @@ func (tx *WinHttpTransaction) Incomplete() bool {
 }
 
 func (tx *WinHttpTransaction) Path(buffer []byte) ([]byte, bool) {
-	bLen := bytes.IndexByte(tx.RequestFragment, 0)
+	bLen := bytes.IndexByte(tx.RequestFragment[:], 0)
 	if bLen == -1 {
 		bLen = len(tx.RequestFragment)
 	}
@@ -145,7 +145,7 @@ func (tx *WinHttpTransaction) Path(buffer []byte) ([]byte, bool) {
 	}
 	n := copy(buffer, b[:j])
 	// indicate if we knowingly captured the entire path
-	fullPath := n <= len(b)
+	fullPath := n < len(b)
 	return buffer[:n], fullPath
 
 }

--- a/pkg/network/protocols/http/model_windows.go
+++ b/pkg/network/protocols/http/model_windows.go
@@ -124,7 +124,7 @@ func (tx *WinHttpTransaction) Incomplete() bool {
 }
 
 func (tx *WinHttpTransaction) Path(buffer []byte) ([]byte, bool) {
-	bLen := bytes.IndexByte(tx.RequestFragment[:], 0)
+	bLen := bytes.IndexByte(tx.RequestFragment, 0)
 	if bLen == -1 {
 		bLen = len(tx.RequestFragment)
 	}

--- a/pkg/network/protocols/http/model_windows_test.go
+++ b/pkg/network/protocols/http/model_windows_test.go
@@ -8,8 +8,6 @@
 package http
 
 import (
-	//"runtime"
-	//"strings"
 	"strings"
 	"testing"
 

--- a/pkg/network/protocols/http/model_windows_test.go
+++ b/pkg/network/protocols/http/model_windows_test.go
@@ -1,0 +1,103 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package http
+
+import (
+	//"runtime"
+	//"strings"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/network/driver"
+	"github.com/stretchr/testify/assert"
+)
+
+func requestFragment(fragment []byte, buffsize int) []byte {
+	b := make([]byte, buffsize)
+
+	copy(b[:], fragment)
+	return b
+}
+
+func TestPath(t *testing.T) {
+	cfg := config.New()
+	BufferSize := int(cfg.HTTPMaxRequestFragment)
+	tx := WinHttpTransaction{
+		RequestFragment: requestFragment([]byte("GET /foo/bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0"), BufferSize),
+	}
+	b := make([]byte, cfg.HTTPMaxRequestFragment)
+	path, fullPath := tx.Path(b)
+	assert.Equal(t, "/foo/bar", string(path))
+	assert.True(t, fullPath)
+}
+
+func TestMaximumLengthPath(t *testing.T) {
+	cfg := config.New()
+	BufferSize := int(cfg.HTTPMaxRequestFragment)
+	rep := strings.Repeat("a", BufferSize-6)
+	str := "GET /" + rep
+	str += "bc"
+	tx := WinHttpTransaction{
+		RequestFragment: requestFragment([]byte(str), BufferSize),
+	}
+	b := make([]byte, BufferSize)
+	path, fullPath := tx.Path(b)
+	expected := "/" + rep
+	expected = expected + "b"
+	assert.Equal(t, expected, string(path))
+	assert.False(t, fullPath)
+
+}
+
+func TestFullPath(t *testing.T) {
+	cfg := config.New()
+	BufferSize := int(cfg.HTTPMaxRequestFragment)
+
+	prefix := "GET /"
+	rep := strings.Repeat("a", BufferSize-len(prefix)-1)
+	str := prefix + rep + " "
+	tx := WinHttpTransaction{
+		RequestFragment: requestFragment([]byte(str), BufferSize),
+	}
+	b := make([]byte, BufferSize)
+	path, fullPath := tx.Path(b)
+	expected := "/" + rep
+	assert.Equal(t, expected, string(path))
+	assert.True(t, fullPath)
+}
+
+func TestPathHandlesNullTerminator(t *testing.T) {
+	cfg := config.New()
+	BufferSize := int(cfg.HTTPMaxRequestFragment)
+
+	tx := WinHttpTransaction{
+		// This probably isn't a valid HTTP request
+		// (since it's missing a version before the end),
+		// but if the null byte isn't handled
+		// then the path becomes "/foo/\x00bar"
+
+		RequestFragment: requestFragment([]byte("GET /foo/\x00bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0"), BufferSize),
+	}
+	b := make([]byte, BufferSize)
+	path, fullPath := tx.Path(b)
+	assert.Equal(t, "/foo/", string(path))
+	assert.False(t, fullPath)
+}
+
+func TestLatency(t *testing.T) {
+	tx := WinHttpTransaction{
+		Txn: driver.HttpTransactionType{
+			ResponseLastSeen: 2e6,
+			RequestStarted:   1e6,
+		},
+	}
+
+	// quantization brings it down
+	assert.Equal(t, 999424.0, tx.RequestLatency())
+}

--- a/pkg/network/protocols/http/model_windows_test.go
+++ b/pkg/network/protocols/http/model_windows_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build windows
+//go:build windows && npm
 
 package http
 

--- a/releasenotes/notes/fixconnectiontruncation-a7fa7b4e5351b17e.yaml
+++ b/releasenotes/notes/fixconnectiontruncation-a7fa7b4e5351b17e.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    For USM on Windows, fixes the problem where paths were being erroneously
+    reported as truncated


### PR DESCRIPTION
- Fixes problem wherein http paths were being reported as truncated when they in fact are not

- Updates the http buffer size to 512, which is the current max the driver allows

- Sets the upper bound on the windows collection size to 512 bytes.

- Therefore, the default is the max; the only configurable is to set the buffer size lower

- enables testing of windows path parsing


### Describe how to test/QA your changes

Tests now included

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
