### PR TITLE
remove copy/paste code

### DIFF
--- a/cmd/system-probe/config/adjust_usm.go
+++ b/cmd/system-probe/config/adjust_usm.go
@@ -38,6 +38,7 @@ func adjustUSM(cfg config.Config) {
 	applyDefault(cfg, smNS("http_idle_connection_ttl_in_s"), 30)
 	deprecateInt64(cfg, netNS("http_notification_threshold"), smNS("http_notification_threshold"))
 	applyDefault(cfg, smNS("http_notification_threshold"), 512)
+	// http_max_request_fragment
 	deprecateInt64(cfg, netNS("http_max_request_fragment"), smNS("http_max_request_fragment"))
 	// set the default to be the max allowed by the driver.  So now the config will allow us to
 	// shorten the allowed path, but not lengthen it.

--- a/cmd/system-probe/config/adjust_usm.go
+++ b/cmd/system-probe/config/adjust_usm.go
@@ -38,7 +38,6 @@ func adjustUSM(cfg config.Config) {
 	applyDefault(cfg, smNS("http_idle_connection_ttl_in_s"), 30)
 	deprecateInt64(cfg, netNS("http_notification_threshold"), smNS("http_notification_threshold"))
 	applyDefault(cfg, smNS("http_notification_threshold"), 512)
-	// http_max_request_fragment
 	deprecateInt64(cfg, netNS("http_max_request_fragment"), smNS("http_max_request_fragment"))
 	// set the default to be the max allowed by the driver.  So now the config will allow us to
 	// shorten the allowed path, but not lengthen it.

--- a/pkg/network/protocols/http/model.go
+++ b/pkg/network/protocols/http/model.go
@@ -8,6 +8,8 @@
 package http
 
 import (
+	"bytes"
+
 	"github.com/DataDog/datadog-agent/pkg/network/types"
 )
 
@@ -26,4 +28,33 @@ type Transaction interface {
 	ResponseLastSeen() uint64
 	SetResponseLastSeen(ls uint64)
 	RequestStarted() uint64
+}
+
+func computePath(targetBuffer, requestBuffer []byte) ([]byte, bool) {
+	bLen := bytes.IndexByte(requestBuffer, 0)
+	if bLen == -1 {
+		bLen = len(requestBuffer)
+	}
+	// trim null byte + after
+	b := requestBuffer[:bLen]
+	// find first space after request method
+	i := bytes.IndexByte(b, ' ')
+	i++
+	// ensure we found a space, it isn't at the end, and the next chars are '/' or '*'
+	if i == 0 || i == len(b) || (b[i] != '/' && b[i] != '*') {
+		return nil, false
+	}
+	// trim to start of path
+	b = b[i:]
+	// capture until we find the slice end, a space, or a question mark (we ignore the query parameters)
+	var j int
+	for j = 0; j < len(b) && b[j] != ' ' && b[j] != '?'; j++ { //nolint:revive
+		// revive complains about the empty block.  However, the empty block is what
+		// we want.  We're just searching for the index of the last place of interest
+		// of the string.  the resulting `j` is what's interesting
+	}
+	n := copy(targetBuffer, b[:j])
+	// indicate if we knowingly captured the entire path
+	fullPath := n < len(b)
+	return targetBuffer[:n], fullPath
 }

--- a/pkg/network/protocols/http/model_linux.go
+++ b/pkg/network/protocols/http/model_linux.go
@@ -8,7 +8,6 @@
 package http
 
 import (
-	"bytes"
 	"encoding/hex"
 	"strconv"
 	"strings"
@@ -23,29 +22,7 @@ import (
 // Example:
 // For a request fragment "GET /foo?var=bar HTTP/1.1", this method will return "/foo"
 func (e *EbpfEvent) Path(buffer []byte) ([]byte, bool) {
-	bLen := bytes.IndexByte(e.Http.Request_fragment[:], 0)
-	if bLen == -1 {
-		bLen = len(e.Http.Request_fragment)
-	}
-	// trim null byte + after
-	b := e.Http.Request_fragment[:bLen]
-	// find first space after request method
-	i := bytes.IndexByte(b, ' ')
-	i++
-	// ensure we found a space, it isn't at the end, and the next chars are '/' or '*'
-	if i == 0 || i == len(b) || (b[i] != '/' && b[i] != '*') {
-		return nil, false
-	}
-	// trim to start of path
-	b = b[i:]
-	// capture until we find the slice end, a space, or a question mark (we ignore the query parameters)
-	var j int
-	for j = 0; j < len(b) && b[j] != ' ' && b[j] != '?'; j++ {
-	}
-	n := copy(buffer, b[:j])
-	// indicate if we knowingly captured the entire path
-	fullPath := n < len(b)
-	return buffer[:n], fullPath
+	return computePath(buffer, e.Http.Request_fragment[:])
 }
 
 // RequestLatency returns the latency of the request in nanoseconds

--- a/pkg/network/protocols/http/model_linux_test.go
+++ b/pkg/network/protocols/http/model_linux_test.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package http
+
+func getBufferSize() int {
+	return BufferSize
+}
+func makeTxnFromRequestString(s string) EbpfEvent {
+	return EbpfEvent{
+		Http: EbpfTx{
+			Request_fragment: requestFragment([]byte(s)),
+		},
+	}
+}
+
+func makeTxnFromLatency(lastSeen, started uint64) EbpfEvent {
+	return EbpfEvent{
+		Http: EbpfTx{
+			Response_last_seen: lastSeen,
+			Request_started:    started,
+		},
+	}
+}

--- a/pkg/network/protocols/http/model_test.go
+++ b/pkg/network/protocols/http/model_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux_bpf
+//go:build linux_bpf || windows
 
 package http
 
@@ -16,32 +16,23 @@ import (
 )
 
 func TestPath(t *testing.T) {
-	tx := EbpfEvent{
-		Http: EbpfTx{
-			Request_fragment: requestFragment(
-				[]byte("GET /foo/bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0"),
-			),
-		},
-	}
-
-	b := make([]byte, BufferSize)
+	tx := makeTxnFromRequestString("GET /foo/bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0")
+	b := make([]byte, getBufferSize())
 	path, fullPath := tx.Path(b)
 	assert.Equal(t, "/foo/bar", string(path))
 	assert.True(t, fullPath)
 }
 
 func TestMaximumLengthPath(t *testing.T) {
-	rep := strings.Repeat("a", BufferSize-6)
+	bs := getBufferSize()
+
+	rep := strings.Repeat("a", bs-6)
 	str := "GET /" + rep
 	str += "bc"
-	tx := EbpfEvent{
-		Http: EbpfTx{
-			Request_fragment: requestFragment(
-				[]byte(str),
-			),
-		},
-	}
-	b := make([]byte, BufferSize)
+
+	tx := makeTxnFromRequestString(str)
+
+	b := make([]byte, bs)
 	path, fullPath := tx.Path(b)
 	expected := "/" + rep
 	expected = expected + "b"
@@ -50,17 +41,12 @@ func TestMaximumLengthPath(t *testing.T) {
 }
 
 func TestFullPath(t *testing.T) {
+	bs := getBufferSize()
 	prefix := "GET /"
-	rep := strings.Repeat("a", BufferSize-len(prefix)-1)
+	rep := strings.Repeat("a", bs-len(prefix)-1)
 	str := prefix + rep + " "
-	tx := EbpfEvent{
-		Http: EbpfTx{
-			Request_fragment: requestFragment(
-				[]byte(str),
-			),
-		},
-	}
-	b := make([]byte, BufferSize)
+	tx := makeTxnFromRequestString(str)
+	b := make([]byte, bs)
 	path, fullPath := tx.Path(b)
 	expected := "/" + rep
 	assert.Equal(t, expected, string(path))
@@ -68,47 +54,33 @@ func TestFullPath(t *testing.T) {
 }
 
 func TestPathHandlesNullTerminator(t *testing.T) {
-	tx := EbpfEvent{
-		Http: EbpfTx{
-			Request_fragment: requestFragment(
-				// This probably isn't a valid HTTP request
-				// (since it's missing a version before the end),
-				// but if the null byte isn't handled
-				// then the path becomes "/foo/\x00bar"
-				[]byte("GET /foo/\x00bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0"),
-			),
-		},
-	}
+	bs := getBufferSize()
 
-	b := make([]byte, BufferSize)
+	// This probably isn't a valid HTTP request
+	// (since it's missing a version before the end),
+	// but if the null byte isn't handled
+	// then the path becomes "/foo/\x00bar"
+	tx := makeTxnFromRequestString("GET /foo/\x00bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0")
+
+	b := make([]byte, bs)
 	path, fullPath := tx.Path(b)
 	assert.Equal(t, "/foo/", string(path))
 	assert.False(t, fullPath)
 }
 
 func TestLatency(t *testing.T) {
-	tx := EbpfEvent{
-		Http: EbpfTx{
-			Response_last_seen: 2e6,
-			Request_started:    1e6,
-		},
-	}
+	tx := makeTxnFromLatency(2e6, 1e6)
 	// quantization brings it down
 	assert.Equal(t, 999424.0, tx.RequestLatency())
 }
 
 func BenchmarkPath(b *testing.B) {
-	tx := EbpfEvent{
-		Http: EbpfTx{
-			Request_fragment: requestFragment(
-				[]byte("GET /foo/bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0"),
-			),
-		},
-	}
+	bs := getBufferSize()
+	tx := makeTxnFromRequestString("GET /foo/bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0")
 
 	b.ReportAllocs()
 	b.ResetTimer()
-	buf := make([]byte, BufferSize)
+	buf := make([]byte, bs)
 	for i := 0; i < b.N; i++ {
 		_, _ = tx.Path(buf)
 	}

--- a/pkg/network/protocols/http/model_test.go
+++ b/pkg/network/protocols/http/model_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux_bpf || windows
+//go:build linux_bpf || (windows && npm)
 
 package http
 

--- a/pkg/network/protocols/http/model_windows.go
+++ b/pkg/network/protocols/http/model_windows.go
@@ -8,7 +8,6 @@
 package http
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 	"strconv"
@@ -124,30 +123,7 @@ func (tx *WinHttpTransaction) Incomplete() bool {
 }
 
 func (tx *WinHttpTransaction) Path(buffer []byte) ([]byte, bool) {
-	bLen := bytes.IndexByte(tx.RequestFragment, 0)
-	if bLen == -1 {
-		bLen = len(tx.RequestFragment)
-	}
-	// trim null byte + after
-	b := tx.RequestFragment[:bLen]
-	// find first space after request method
-	i := bytes.IndexByte(b, ' ')
-	i++
-	// ensure we found a space, it isn't at the end, and the next chars are '/' or '*'
-	if i == 0 || i == len(b) || (b[i] != '/' && b[i] != '*') {
-		return nil, false
-	}
-	// trim to start of path
-	b = b[i:]
-	// capture until we find the slice end, a space, or a question mark (we ignore the query parameters)
-	var j int
-	for j = 0; j < len(b) && b[j] != ' ' && b[j] != '?'; j++ {
-	}
-	n := copy(buffer, b[:j])
-	// indicate if we knowingly captured the entire path
-	fullPath := n < len(b)
-	return buffer[:n], fullPath
-
+	return computePath(buffer, tx.RequestFragment)
 }
 func (tx *WinHttpTransaction) SetStatusCode(code uint16) {
 	tx.Txn.ResponseStatusCode = code


### PR DESCRIPTION
Follow on to #20560

Remove copy/paste code.

By adding some simple helpers, combine the linux test and the
windows test into single test code that's the same for both
for easier maintenance.

Also combine the `Path` function, since the platform specific
versions were exact duplicates of each other.

Also enables unit tests on windows; previously was running only on linux.
Result is that bug fixed in #20560 would have been caught by tests, and in fact wouldn't have existed if using shared code rather than copy/pasted.

### Additional Notes


### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes


### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
