### PR TITLE
[CI] Clean the `test` invoke task

### DIFF
--- a/tasks/test.py
+++ b/tasks/test.py
@@ -610,10 +610,8 @@ def test(
         python_home_3=python_home_3,
         major_version=major_version,
         python_runtimes=python_runtimes,
+        race=race,
     )
-
-    if sys.platform == 'win32':
-        env['CGO_LDFLAGS'] += ' -Wl,--allow-multiple-definition'
 
     if profile:
         test_profiler = TestProfiler()
@@ -631,11 +629,6 @@ def test(
             print("\n -- Warning... disabling race test, not supported on this platform --\n")
         else:
             race_opt = "-race"
-
-        # Needed to fix an issue when using -race + gcc 10.x on Windows
-        # https://github.com/bazelbuild/rules_go/issues/2614
-        if sys.platform == 'win32':
-            ldflags += " -linkmode=external"
 
     if coverage:
         if race:

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -617,17 +617,9 @@ def test(
     test_profiler = TestProfiler() if profile else None
 
     race_opt = "-race" if race else ""
-    covermode_opt = ""
+    # atomic is quite expensive but it's the only way to run both the coverage and the race detector at the same time without getting false positives from the cover counter
+    covermode_opt = "-covermode=" + ("atomic" if race else "count") if coverage else ""
     build_cpus_opt = f"-p {cpus}" if cpus else ""
-
-    if coverage:
-        if race:
-            # atomic is quite expensive but it's the only way to run
-            # both the coverage and the race detector at the same time
-            # without getting false positives from the cover counter
-            covermode_opt = "-covermode=atomic"
-        else:
-            covermode_opt = "-covermode=count"
 
     coverprofile = f"-coverprofile={PROFILE_COV}" if coverage else ""
 

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -601,8 +601,6 @@ def test(
         for f in flavors
     }
 
-    timeout = int(timeout)
-
     ldflags, gcflags, env = get_build_flags(
         ctx,
         rtloader_root=rtloader_root,
@@ -646,7 +644,7 @@ def test(
         "covermode_opt": covermode_opt,
         "coverprofile": coverprofile,
         "test_run_arg": test_run_arg,
-        "timeout": timeout,
+        "timeout": int(timeout),
         "verbose": '-v' if verbose else '',
         "nocache": nocache,
         # Used to print failed tests at the end of the go test command

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -616,15 +616,9 @@ def test(
     # Use stdout if no profile is set
     test_profiler = TestProfiler() if profile else None
 
-    race_opt = ""
+    race_opt = "-race" if race else ""
     covermode_opt = ""
     build_cpus_opt = f"-p {cpus}" if cpus else ""
-    if race:
-        # race doesn't appear to be supported on non-x64 platforms
-        if arch == "x86":
-            print("\n -- Warning... disabling race test, not supported on this platform --\n")
-        else:
-            race_opt = "-race"
 
     if coverage:
         if race:

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -613,16 +613,12 @@ def test(
         race=race,
     )
 
-    if profile:
-        test_profiler = TestProfiler()
-    else:
-        test_profiler = None  # Use stdout
+    # Use stdout if no profile is set
+    test_profiler = TestProfiler() if profile else None
 
     race_opt = ""
     covermode_opt = ""
-    build_cpus_opt = ""
-    if cpus:
-        build_cpus_opt = f"-p {cpus}"
+    build_cpus_opt = f"-p {cpus}" if cpus else ""
     if race:
         # race doesn't appear to be supported on non-x64 platforms
         if arch == "x86":
@@ -639,9 +635,7 @@ def test(
         else:
             covermode_opt = "-covermode=count"
 
-    coverprofile = ""
-    if coverage:
-        coverprofile = f"-coverprofile={PROFILE_COV}"
+    coverprofile = f"-coverprofile={PROFILE_COV}" if coverage else ""
 
     nocache = '-count=1' if not cache else ''
 
@@ -651,9 +645,7 @@ def test(
         print(f"Removing existing '{save_result_json}' file")
         os.remove(save_result_json)
 
-    test_run_arg = ""
-    if test_run_name != "":
-        test_run_arg = f"-run {test_run_name}"
+    test_run_arg = f"-run {test_run_name}" if test_run_name else ""
 
     stdlib_build_cmd = 'go build {verbose} -mod={go_mod} -tags "{go_build_tags}" -gcflags="{gcflags}" '
     stdlib_build_cmd += '-ldflags="{ldflags}" {build_cpus} {race_opt} {nocache} std cmd'

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -137,7 +137,6 @@ def get_build_flags(
     env = {"GO111MODULE": "on"}
 
     if sys.platform == 'win32':
-        env['CGO_LDFLAGS'] += ' -Wl,--allow-multiple-definition'
         env["CGO_LDFLAGS_ALLOW"] = "-Wl,--allow-multiple-definition"
     else:
         # for pkg/ebpf/compiler on linux
@@ -180,6 +179,9 @@ def get_build_flags(
         env['DYLD_LIBRARY_PATH'] = os.environ.get('DYLD_LIBRARY_PATH', '') + f":{':'.join(rtloader_lib)}"  # OSX
         env['LD_LIBRARY_PATH'] = os.environ.get('LD_LIBRARY_PATH', '') + f":{':'.join(rtloader_lib)}"  # linux
         env['CGO_LDFLAGS'] = os.environ.get('CGO_LDFLAGS', '') + f" -L{' -L '.join(rtloader_lib)}"
+
+    if sys.platform == 'win32':
+        env['CGO_LDFLAGS'] += ' -Wl,--allow-multiple-definition'
 
     extra_cgo_flags = " -Werror -Wno-deprecated-declarations"
     if rtloader_headers:

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -181,7 +181,7 @@ def get_build_flags(
         env['CGO_LDFLAGS'] = os.environ.get('CGO_LDFLAGS', '') + f" -L{' -L '.join(rtloader_lib)}"
 
     if sys.platform == 'win32':
-        env['CGO_LDFLAGS'] += ' -Wl,--allow-multiple-definition'
+        env['CGO_LDFLAGS'] = os.environ.get('CGO_LDFLAGS', '') + ' -Wl,--allow-multiple-definition'
 
     extra_cgo_flags = " -Werror -Wno-deprecated-declarations"
     if rtloader_headers:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR refactor a bit the `test` invoke tasks. It's basically:
- Replacing several lines if by a one line ternary operator.
- Enabling the `-race` flag for every platforms. Made me realise that the go race detector has been disabled for x64 for 4 years.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This task code is really long and complex, we need to improve its readability.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
