### PR TITLE
[NPM-3047] Fix negative tests and test handling in flaky TestReadInitialUDPState test

### DIFF
--- a/pkg/network/port_test.go
+++ b/pkg/network/port_test.go
@@ -154,19 +154,16 @@ func TestReadInitialUDPState(t *testing.T) {
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		initialPorts, err := ReadInitialState("/proc", UDP, true)
-		require.NoError(t, err)
+		require.NoError(c, err)
 		for _, p := range ports[:2] {
-			assert.Contains(t, initialPorts, PortMapping{testRootNs, p}, fmt.Sprintf("PortMapping (testRootNs, p) returned false for port %d", p))
+			assert.Contains(c, initialPorts, PortMapping{testRootNs, p}, fmt.Sprintf("PortMapping (testRootNs, p) returned false for port %d", p))
 		}
 		for _, p := range ports[2:] {
-			assert.Contains(t, initialPorts, PortMapping{nsIno, p}, fmt.Sprintf("PortMapping(nsIno, p) returned false for port %d", p))
+			assert.Contains(c, initialPorts, PortMapping{nsIno, p}, fmt.Sprintf("PortMapping(nsIno, p) returned false for port %d", p))
 		}
-		if isUnusedUDPPort(t, 999) {
-			_, ok := initialPorts[PortMapping{testRootNs, 999}]
-			assert.False(t, ok, "expected IsListening(testRootNs, 999) to return false, but returned true")
-
-			_, ok = initialPorts[PortMapping{nsIno, 999}]
-			assert.False(t, ok, "expected IsListening(nsIno, 999) to return false, but returned true")
+		if isUnusedUDPPort(t, 53) {
+			assert.NotContains(c, initialPorts, PortMapping{testRootNs, 53}, "expected IsListening(testRootNs, 999) to return false, but returned true")
+			assert.NotContains(c, initialPorts, PortMapping{nsIno, 53}, "expected IsListening(nsIno, 999) to return false, but returned true")
 		}
 	}, 3*time.Second, time.Second, "udp/udp6 ports are listening")
 }

--- a/pkg/network/port_test.go
+++ b/pkg/network/port_test.go
@@ -161,9 +161,9 @@ func TestReadInitialUDPState(t *testing.T) {
 		for _, p := range ports[2:] {
 			assert.Contains(c, initialPorts, PortMapping{nsIno, p}, fmt.Sprintf("PortMapping(nsIno, p) returned false for port %d", p))
 		}
-		if isUnusedUDPPort(t, 53) {
-			assert.NotContains(c, initialPorts, PortMapping{testRootNs, 53}, "expected IsListening(testRootNs, 999) to return false, but returned true")
-			assert.NotContains(c, initialPorts, PortMapping{nsIno, 53}, "expected IsListening(nsIno, 999) to return false, but returned true")
+		if isUnusedUDPPort(t, 999) {
+			assert.NotContains(c, initialPorts, PortMapping{testRootNs, 999}, "expected IsListening(testRootNs, 999) to return false, but returned true")
+			assert.NotContains(c, initialPorts, PortMapping{nsIno, 999}, "expected IsListening(nsIno, 999) to return false, but returned true")
 		}
 	}, 3*time.Second, time.Second, "udp/udp6 ports are listening")
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR fixes the flaky behavior from https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/360112683 by using `require.EventuallyWithT` with assertions instead of `t.Errorf` and checking a hardcoded port is unused (not being listened on) before running negative tests on it. 

### Motivation

https://datadoghq.atlassian.net/browse/NPM-3047


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
