### PR TITLE
[CWS] Convert filter params to a struct

### DIFF
--- a/comp/languagedetection/client/client.go
+++ b/comp/languagedetection/client/client.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	logComponent "github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
@@ -20,7 +22,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
-	"go.uber.org/fx"
 )
 
 const (
@@ -149,6 +150,7 @@ func (c *client) run() {
 			},
 			workloadmeta.SourceAll,
 			workloadmeta.EventTypeAll,
+			false,
 		),
 	)
 	defer c.store.Unsubscribe(eventCh)

--- a/comp/languagedetection/client/client.go
+++ b/comp/languagedetection/client/client.go
@@ -140,18 +140,19 @@ func (c *client) run() {
 		c.store = workloadmeta.GetGlobalStore() // TODO(components): should be replaced by components
 	}
 
+	filterParams := workloadmeta.FilterParams{
+		Kinds: []workloadmeta.Kind{
+			workloadmeta.KindKubernetesPod, // Subscribe to pod events to clean up the current batch when a pod is deleted
+			workloadmeta.KindProcess,       // Subscribe to process events to populate the current batch
+		},
+		Source:    workloadmeta.SourceAll,
+		EventType: workloadmeta.EventTypeAll,
+	}
+
 	eventCh := c.store.Subscribe(
 		subscriber,
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(
-			[]workloadmeta.Kind{
-				workloadmeta.KindKubernetesPod, // Subscribe to pod events to clean up the current batch when a pod is deleted
-				workloadmeta.KindProcess,       // Subscribe to process events to populate the current batch
-			},
-			workloadmeta.SourceAll,
-			workloadmeta.EventTypeAll,
-			false,
-		),
+		workloadmeta.NewFilter(filterParams),
 	)
 	defer c.store.Unsubscribe(eventCh)
 

--- a/comp/languagedetection/client/client.go
+++ b/comp/languagedetection/client/client.go
@@ -152,7 +152,7 @@ func (c *client) run() {
 	eventCh := c.store.Subscribe(
 		subscriber,
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(filterParams),
+		workloadmeta.NewFilter(&filterParams),
 	)
 	defer c.store.Unsubscribe(eventCh)
 

--- a/pkg/autodiscovery/listeners/container.go
+++ b/pkg/autodiscovery/listeners/container.go
@@ -43,6 +43,7 @@ func NewContainerListener(Config) (ServiceListener, error) {
 		[]workloadmeta.Kind{workloadmeta.KindContainer},
 		workloadmeta.SourceRuntime,
 		workloadmeta.EventTypeAll,
+		false,
 	)
 
 	var err error

--- a/pkg/autodiscovery/listeners/container.go
+++ b/pkg/autodiscovery/listeners/container.go
@@ -39,12 +39,12 @@ type ContainerListener struct {
 func NewContainerListener(Config) (ServiceListener, error) {
 	const name = "ad-containerlistener"
 	l := &ContainerListener{}
-	f := workloadmeta.NewFilter(
-		[]workloadmeta.Kind{workloadmeta.KindContainer},
-		workloadmeta.SourceRuntime,
-		workloadmeta.EventTypeAll,
-		false,
-	)
+	filterParams := workloadmeta.FilterParams{
+		Kinds:     []workloadmeta.Kind{workloadmeta.KindContainer},
+		Source:    workloadmeta.SourceRuntime,
+		EventType: workloadmeta.EventTypeAll,
+	}
+	f := workloadmeta.NewFilter(filterParams)
 
 	var err error
 	l.workloadmetaListener, err = newWorkloadmetaListener(name, f, l.createContainerService)

--- a/pkg/autodiscovery/listeners/container.go
+++ b/pkg/autodiscovery/listeners/container.go
@@ -44,7 +44,7 @@ func NewContainerListener(Config) (ServiceListener, error) {
 		Source:    workloadmeta.SourceRuntime,
 		EventType: workloadmeta.EventTypeAll,
 	}
-	f := workloadmeta.NewFilter(filterParams)
+	f := workloadmeta.NewFilter(&filterParams)
 
 	var err error
 	l.workloadmetaListener, err = newWorkloadmetaListener(name, f, l.createContainerService)

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -39,7 +39,7 @@ func NewKubeletListener(Config) (ServiceListener, error) {
 		Source:    workloadmeta.SourceNodeOrchestrator,
 		EventType: workloadmeta.EventTypeAll,
 	}
-	f := workloadmeta.NewFilter(filterParams)
+	f := workloadmeta.NewFilter(&filterParams)
 
 	var err error
 	l.workloadmetaListener, err = newWorkloadmetaListener(name, f, l.processPod)

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -34,12 +34,12 @@ func NewKubeletListener(Config) (ServiceListener, error) {
 	const name = "ad-kubeletlistener"
 
 	l := &KubeletListener{}
-	f := workloadmeta.NewFilter(
-		[]workloadmeta.Kind{workloadmeta.KindKubernetesPod},
-		workloadmeta.SourceNodeOrchestrator,
-		workloadmeta.EventTypeAll,
-		false,
-	)
+	filterParams := workloadmeta.FilterParams{
+		Kinds:     []workloadmeta.Kind{workloadmeta.KindKubernetesPod},
+		Source:    workloadmeta.SourceNodeOrchestrator,
+		EventType: workloadmeta.EventTypeAll,
+	}
+	f := workloadmeta.NewFilter(filterParams)
 
 	var err error
 	l.workloadmetaListener, err = newWorkloadmetaListener(name, f, l.processPod)

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -38,6 +38,7 @@ func NewKubeletListener(Config) (ServiceListener, error) {
 		[]workloadmeta.Kind{workloadmeta.KindKubernetesPod},
 		workloadmeta.SourceNodeOrchestrator,
 		workloadmeta.EventTypeAll,
+		false,
 	)
 
 	var err error

--- a/pkg/autodiscovery/providers/container.go
+++ b/pkg/autodiscovery/providers/container.go
@@ -60,6 +60,7 @@ func (k *ContainerConfigProvider) Stream(ctx context.Context) <-chan integration
 		[]workloadmeta.Kind{workloadmeta.KindKubernetesPod, workloadmeta.KindContainer},
 		workloadmeta.SourceAll,
 		workloadmeta.EventTypeAll,
+		false,
 	))
 
 	go func() {

--- a/pkg/autodiscovery/providers/container.go
+++ b/pkg/autodiscovery/providers/container.go
@@ -56,12 +56,13 @@ func (k *ContainerConfigProvider) Stream(ctx context.Context) <-chan integration
 	// need to be generated before any associated services.
 	outCh := make(chan integration.ConfigChanges)
 
-	inCh := k.workloadmetaStore.Subscribe(name, workloadmeta.ConfigProviderPriority, workloadmeta.NewFilter(
-		[]workloadmeta.Kind{workloadmeta.KindKubernetesPod, workloadmeta.KindContainer},
-		workloadmeta.SourceAll,
-		workloadmeta.EventTypeAll,
-		false,
-	))
+	filterParams := workloadmeta.FilterParams{
+		Kinds:     []workloadmeta.Kind{workloadmeta.KindKubernetesPod, workloadmeta.KindContainer},
+		Source:    workloadmeta.SourceAll,
+		EventType: workloadmeta.EventTypeAll,
+	}
+
+	inCh := k.workloadmetaStore.Subscribe(name, workloadmeta.ConfigProviderPriority, workloadmeta.NewFilter(filterParams))
 
 	go func() {
 		for {

--- a/pkg/autodiscovery/providers/container.go
+++ b/pkg/autodiscovery/providers/container.go
@@ -62,7 +62,7 @@ func (k *ContainerConfigProvider) Stream(ctx context.Context) <-chan integration
 		EventType: workloadmeta.EventTypeAll,
 	}
 
-	inCh := k.workloadmetaStore.Subscribe(name, workloadmeta.ConfigProviderPriority, workloadmeta.NewFilter(filterParams))
+	inCh := k.workloadmetaStore.Subscribe(name, workloadmeta.ConfigProviderPriority, workloadmeta.NewFilter(&filterParams))
 
 	go func() {
 		for {

--- a/pkg/cloudfoundry/containertagger/container_tagger.go
+++ b/pkg/cloudfoundry/containertagger/container_tagger.go
@@ -68,7 +68,7 @@ func (c *ContainerTagger) Start(ctx context.Context) {
 			Source:    workloadmeta.SourceClusterOrchestrator,
 			EventType: workloadmeta.EventTypeAll,
 		}
-		filter := workloadmeta.NewFilter(filterParams)
+		filter := workloadmeta.NewFilter(&filterParams)
 
 		ch := c.store.Subscribe(componentName, workloadmeta.NormalPriority, filter)
 		defer c.store.Unsubscribe(ch)

--- a/pkg/cloudfoundry/containertagger/container_tagger.go
+++ b/pkg/cloudfoundry/containertagger/container_tagger.go
@@ -63,12 +63,13 @@ func NewContainerTagger() (*ContainerTagger, error) {
 // Cancel the context to stop the container tagger.
 func (c *ContainerTagger) Start(ctx context.Context) {
 	go func() {
-		filter := workloadmeta.NewFilter(
-			[]workloadmeta.Kind{workloadmeta.KindContainer},
-			workloadmeta.SourceClusterOrchestrator,
-			workloadmeta.EventTypeAll,
-			false,
-		)
+		filterParams := workloadmeta.FilterParams{
+			Kinds:     []workloadmeta.Kind{workloadmeta.KindContainer},
+			Source:    workloadmeta.SourceClusterOrchestrator,
+			EventType: workloadmeta.EventTypeAll,
+		}
+		filter := workloadmeta.NewFilter(filterParams)
+
 		ch := c.store.Subscribe(componentName, workloadmeta.NormalPriority, filter)
 		defer c.store.Unsubscribe(ch)
 		for {

--- a/pkg/cloudfoundry/containertagger/container_tagger.go
+++ b/pkg/cloudfoundry/containertagger/container_tagger.go
@@ -63,7 +63,12 @@ func NewContainerTagger() (*ContainerTagger, error) {
 // Cancel the context to stop the container tagger.
 func (c *ContainerTagger) Start(ctx context.Context) {
 	go func() {
-		filter := workloadmeta.NewFilter([]workloadmeta.Kind{workloadmeta.KindContainer}, workloadmeta.SourceClusterOrchestrator, workloadmeta.EventTypeAll)
+		filter := workloadmeta.NewFilter(
+			[]workloadmeta.Kind{workloadmeta.KindContainer},
+			workloadmeta.SourceClusterOrchestrator,
+			workloadmeta.EventTypeAll,
+			false,
+		)
 		ch := c.store.Subscribe(componentName, workloadmeta.NormalPriority, filter)
 		defer c.store.Unsubscribe(ch)
 		for {

--- a/pkg/collector/corechecks/containerimage/check.go
+++ b/pkg/collector/corechecks/containerimage/check.go
@@ -133,15 +133,15 @@ func (c *Check) Run() error {
 	log.Infof("Starting long-running check %q", c.ID())
 	defer log.Infof("Shutting down long-running check %q", c.ID())
 
+	filterParams := workloadmeta.FilterParams{
+		Kinds:     []workloadmeta.Kind{workloadmeta.KindContainerImageMetadata},
+		Source:    workloadmeta.SourceAll,
+		EventType: workloadmeta.EventTypeSet, // We don’t care about images removal because we just have to wait for them to expire on BE side once we stopped refreshing them periodically.
+	}
 	imgEventsCh := c.workloadmetaStore.Subscribe(
 		checkName,
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(
-			[]workloadmeta.Kind{workloadmeta.KindContainerImageMetadata},
-			workloadmeta.SourceAll,
-			workloadmeta.EventTypeSet, // We don’t care about images removal because we just have to wait for them to expire on BE side once we stopped refreshing them periodically.
-			false,
-		),
+		workloadmeta.NewFilter(filterParams),
 	)
 
 	imgRefreshTicker := time.NewTicker(time.Duration(c.instance.PeriodicRefreshSeconds) * time.Second)

--- a/pkg/collector/corechecks/containerimage/check.go
+++ b/pkg/collector/corechecks/containerimage/check.go
@@ -141,7 +141,7 @@ func (c *Check) Run() error {
 	imgEventsCh := c.workloadmetaStore.Subscribe(
 		checkName,
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(filterParams),
+		workloadmeta.NewFilter(&filterParams),
 	)
 
 	imgRefreshTicker := time.NewTicker(time.Duration(c.instance.PeriodicRefreshSeconds) * time.Second)

--- a/pkg/collector/corechecks/containerimage/check.go
+++ b/pkg/collector/corechecks/containerimage/check.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"time"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
@@ -140,6 +140,7 @@ func (c *Check) Run() error {
 			[]workloadmeta.Kind{workloadmeta.KindContainerImageMetadata},
 			workloadmeta.SourceAll,
 			workloadmeta.EventTypeSet, // We don’t care about images removal because we just have to wait for them to expire on BE side once we stopped refreshing them periodically.
+			false,
 		),
 	)
 

--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -93,26 +93,26 @@ func (c *Check) Run() error {
 	log.Infof("Starting long-running check %q", c.ID())
 	defer log.Infof("Shutting down long-running check %q", c.ID())
 
+	containerFilterParams := workloadmeta.FilterParams{
+		Kinds:     []workloadmeta.Kind{workloadmeta.KindContainer},
+		Source:    workloadmeta.SourceRuntime,
+		EventType: workloadmeta.EventTypeUnset,
+	}
 	contEventsCh := c.workloadmetaStore.Subscribe(
 		checkName+"-cont",
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(
-			[]workloadmeta.Kind{workloadmeta.KindContainer},
-			workloadmeta.SourceRuntime,
-			workloadmeta.EventTypeUnset,
-			false,
-		),
+		workloadmeta.NewFilter(containerFilterParams),
 	)
 
+	podFilterParams := workloadmeta.FilterParams{
+		Kinds:     []workloadmeta.Kind{workloadmeta.KindKubernetesPod},
+		Source:    workloadmeta.SourceNodeOrchestrator,
+		EventType: workloadmeta.EventTypeUnset,
+	}
 	podEventsCh := c.workloadmetaStore.Subscribe(
 		checkName+"-pod",
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(
-			[]workloadmeta.Kind{workloadmeta.KindKubernetesPod},
-			workloadmeta.SourceNodeOrchestrator,
-			workloadmeta.EventTypeUnset,
-			false,
-		),
+		workloadmeta.NewFilter(podFilterParams),
 	)
 
 	pollInterval := time.Duration(c.instance.PollInterval) * time.Second

--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -101,7 +101,7 @@ func (c *Check) Run() error {
 	contEventsCh := c.workloadmetaStore.Subscribe(
 		checkName+"-cont",
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(containerFilterParams),
+		workloadmeta.NewFilter(&containerFilterParams),
 	)
 
 	podFilterParams := workloadmeta.FilterParams{
@@ -112,7 +112,7 @@ func (c *Check) Run() error {
 	podEventsCh := c.workloadmetaStore.Subscribe(
 		checkName+"-pod",
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(podFilterParams),
+		workloadmeta.NewFilter(&podFilterParams),
 	)
 
 	pollInterval := time.Duration(c.instance.PollInterval) * time.Second

--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"time"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
@@ -100,6 +100,7 @@ func (c *Check) Run() error {
 			[]workloadmeta.Kind{workloadmeta.KindContainer},
 			workloadmeta.SourceRuntime,
 			workloadmeta.EventTypeUnset,
+			false,
 		),
 	)
 
@@ -110,6 +111,7 @@ func (c *Check) Run() error {
 			[]workloadmeta.Kind{workloadmeta.KindKubernetesPod},
 			workloadmeta.SourceNodeOrchestrator,
 			workloadmeta.EventTypeUnset,
+			false,
 		),
 	)
 

--- a/pkg/collector/corechecks/sbom/check.go
+++ b/pkg/collector/corechecks/sbom/check.go
@@ -175,7 +175,7 @@ func (c *Check) Run() error {
 	imgEventsCh := c.workloadmetaStore.Subscribe(
 		checkName,
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(filterParams),
+		workloadmeta.NewFilter(&filterParams),
 	)
 
 	// Trigger an initial scan on host

--- a/pkg/collector/corechecks/sbom/check.go
+++ b/pkg/collector/corechecks/sbom/check.go
@@ -173,6 +173,7 @@ func (c *Check) Run() error {
 			},
 			workloadmeta.SourceAll,
 			workloadmeta.EventTypeAll,
+			false,
 		),
 	)
 

--- a/pkg/collector/corechecks/sbom/check.go
+++ b/pkg/collector/corechecks/sbom/check.go
@@ -163,18 +163,19 @@ func (c *Check) Run() error {
 	log.Infof("Starting long-running check %q", c.ID())
 	defer log.Infof("Shutting down long-running check %q", c.ID())
 
+	filterParams := workloadmeta.FilterParams{
+		Kinds: []workloadmeta.Kind{
+			workloadmeta.KindContainerImageMetadata,
+			workloadmeta.KindContainer,
+		},
+		Source:    workloadmeta.SourceAll,
+		EventType: workloadmeta.EventTypeAll,
+	}
+
 	imgEventsCh := c.workloadmetaStore.Subscribe(
 		checkName,
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(
-			[]workloadmeta.Kind{
-				workloadmeta.KindContainerImageMetadata,
-				workloadmeta.KindContainer,
-			},
-			workloadmeta.SourceAll,
-			workloadmeta.EventTypeAll,
-			false,
-		),
+		workloadmeta.NewFilter(filterParams),
 	)
 
 	// Trigger an initial scan on host

--- a/pkg/process/metadata/workloadmeta/collector/process.go
+++ b/pkg/process/metadata/workloadmeta/collector/process.go
@@ -61,7 +61,7 @@ func (c *Collector) Start(ctx context.Context, store workloadmeta.Store) error {
 		c.ddConfig.GetDuration("workloadmeta.local_process_collector.collection_interval"),
 	)
 
-	filter := workloadmeta.NewFilter([]workloadmeta.Kind{workloadmeta.KindContainer}, workloadmeta.SourceAll, workloadmeta.EventTypeAll)
+	filter := workloadmeta.NewFilter([]workloadmeta.Kind{workloadmeta.KindContainer}, workloadmeta.SourceAll, workloadmeta.EventTypeAll, false)
 	containerEvt := store.Subscribe(collectorId, workloadmeta.NormalPriority, filter)
 
 	go c.run(ctx, store, containerEvt, collectionTicker)

--- a/pkg/process/metadata/workloadmeta/collector/process.go
+++ b/pkg/process/metadata/workloadmeta/collector/process.go
@@ -61,7 +61,12 @@ func (c *Collector) Start(ctx context.Context, store workloadmeta.Store) error {
 		c.ddConfig.GetDuration("workloadmeta.local_process_collector.collection_interval"),
 	)
 
-	filter := workloadmeta.NewFilter([]workloadmeta.Kind{workloadmeta.KindContainer}, workloadmeta.SourceAll, workloadmeta.EventTypeAll, false)
+	filterParams := workloadmeta.FilterParams{
+		Kinds:     []workloadmeta.Kind{workloadmeta.KindContainer},
+		Source:    workloadmeta.SourceAll,
+		EventType: workloadmeta.EventTypeAll,
+	}
+	filter := workloadmeta.NewFilter(filterParams)
 	containerEvt := store.Subscribe(collectorId, workloadmeta.NormalPriority, filter)
 
 	go c.run(ctx, store, containerEvt, collectionTicker)

--- a/pkg/process/metadata/workloadmeta/collector/process.go
+++ b/pkg/process/metadata/workloadmeta/collector/process.go
@@ -66,7 +66,7 @@ func (c *Collector) Start(ctx context.Context, store workloadmeta.Store) error {
 		Source:    workloadmeta.SourceAll,
 		EventType: workloadmeta.EventTypeAll,
 	}
-	filter := workloadmeta.NewFilter(filterParams)
+	filter := workloadmeta.NewFilter(&filterParams)
 	containerEvt := store.Subscribe(collectorId, workloadmeta.NormalPriority, filter)
 
 	go c.run(ctx, store, containerEvt, collectionTicker)

--- a/pkg/util/proto/workloadmeta.go
+++ b/pkg/util/proto/workloadmeta.go
@@ -402,7 +402,7 @@ func WorkloadmetaFilterFromProtoFilter(protoFilter *pb.WorkloadmetaFilter) (*wor
 			Source:    workloadmeta.SourceAll,
 			EventType: workloadmeta.EventTypeAll,
 		}
-		return workloadmeta.NewFilter(filterParams), nil
+		return workloadmeta.NewFilter(&filterParams), nil
 	}
 
 	var kinds []workloadmeta.Kind
@@ -431,7 +431,7 @@ func WorkloadmetaFilterFromProtoFilter(protoFilter *pb.WorkloadmetaFilter) (*wor
 		Source:    source,
 		EventType: eventType,
 	}
-	return workloadmeta.NewFilter(filterParams), nil
+	return workloadmeta.NewFilter(&filterParams), nil
 }
 
 // WorkloadmetaEventFromProtoEvent converts the given protobuf workloadmeta event into a workloadmeta.Event

--- a/pkg/util/proto/workloadmeta.go
+++ b/pkg/util/proto/workloadmeta.go
@@ -398,7 +398,11 @@ func toProtoLaunchType(launchType workloadmeta.ECSLaunchType) (pb.ECSLaunchType,
 func WorkloadmetaFilterFromProtoFilter(protoFilter *pb.WorkloadmetaFilter) (*workloadmeta.Filter, error) {
 	if protoFilter == nil {
 		// Return filter that subscribes to everything
-		return workloadmeta.NewFilter(nil, workloadmeta.SourceAll, workloadmeta.EventTypeAll, false), nil
+		filterParams := workloadmeta.FilterParams{
+			Source:    workloadmeta.SourceAll,
+			EventType: workloadmeta.EventTypeAll,
+		}
+		return workloadmeta.NewFilter(filterParams), nil
 	}
 
 	var kinds []workloadmeta.Kind
@@ -422,7 +426,12 @@ func WorkloadmetaFilterFromProtoFilter(protoFilter *pb.WorkloadmetaFilter) (*wor
 		return nil, err
 	}
 
-	return workloadmeta.NewFilter(kinds, source, eventType, false), nil
+	filterParams := workloadmeta.FilterParams{
+		Kinds:     kinds,
+		Source:    source,
+		EventType: eventType,
+	}
+	return workloadmeta.NewFilter(filterParams), nil
 }
 
 // WorkloadmetaEventFromProtoEvent converts the given protobuf workloadmeta event into a workloadmeta.Event

--- a/pkg/util/proto/workloadmeta.go
+++ b/pkg/util/proto/workloadmeta.go
@@ -398,7 +398,7 @@ func toProtoLaunchType(launchType workloadmeta.ECSLaunchType) (pb.ECSLaunchType,
 func WorkloadmetaFilterFromProtoFilter(protoFilter *pb.WorkloadmetaFilter) (*workloadmeta.Filter, error) {
 	if protoFilter == nil {
 		// Return filter that subscribes to everything
-		return workloadmeta.NewFilter(nil, workloadmeta.SourceAll, workloadmeta.EventTypeAll), nil
+		return workloadmeta.NewFilter(nil, workloadmeta.SourceAll, workloadmeta.EventTypeAll, false), nil
 	}
 
 	var kinds []workloadmeta.Kind
@@ -422,7 +422,7 @@ func WorkloadmetaFilterFromProtoFilter(protoFilter *pb.WorkloadmetaFilter) (*wor
 		return nil, err
 	}
 
-	return workloadmeta.NewFilter(kinds, source, eventType), nil
+	return workloadmeta.NewFilter(kinds, source, eventType, false), nil
 }
 
 // WorkloadmetaEventFromProtoEvent converts the given protobuf workloadmeta event into a workloadmeta.Event

--- a/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -44,7 +44,7 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 	imgEventsCh := c.store.Subscribe(
 		"SBOM collector",
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(filterParams),
+		workloadmeta.NewFilter(&filterParams),
 	)
 	resultChan := make(chan sbom.ScanResult, 2000)
 	go func() {

--- a/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -36,15 +36,15 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 		return fmt.Errorf("error retrieving global SBOM scanner")
 	}
 
+	filterParams := workloadmeta.FilterParams{
+		Kinds:     []workloadmeta.Kind{workloadmeta.KindContainerImageMetadata},
+		Source:    workloadmeta.SourceAll,
+		EventType: workloadmeta.EventTypeSet,
+	}
 	imgEventsCh := c.store.Subscribe(
 		"SBOM collector",
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(
-			[]workloadmeta.Kind{workloadmeta.KindContainerImageMetadata},
-			workloadmeta.SourceAll,
-			workloadmeta.EventTypeSet,
-			false,
-		),
+		workloadmeta.NewFilter(filterParams),
 	)
 	resultChan := make(chan sbom.ScanResult, 2000)
 	go func() {

--- a/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	"github.com/CycloneDX/cyclonedx-go"
+
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/sbom"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors/containerd"
@@ -42,6 +43,7 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 			[]workloadmeta.Kind{workloadmeta.KindContainerImageMetadata},
 			workloadmeta.SourceAll,
 			workloadmeta.EventTypeSet,
+			false,
 		),
 	)
 	resultChan := make(chan sbom.ScanResult, 2000)

--- a/pkg/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/CycloneDX/cyclonedx-go"
+
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/sbom"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors/docker"
@@ -48,6 +49,7 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 			[]workloadmeta.Kind{workloadmeta.KindContainerImageMetadata},
 			workloadmeta.SourceAll,
 			workloadmeta.EventTypeSet,
+			false,
 		),
 	)
 

--- a/pkg/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
@@ -42,15 +42,15 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 		return fmt.Errorf("error retrieving global SBOM scanner")
 	}
 
+	filterParams := workloadmeta.FilterParams{
+		Kinds:     []workloadmeta.Kind{workloadmeta.KindContainerImageMetadata},
+		Source:    workloadmeta.SourceAll,
+		EventType: workloadmeta.EventTypeSet,
+	}
 	imgEventsCh := c.store.Subscribe(
 		"SBOM collector",
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(
-			[]workloadmeta.Kind{workloadmeta.KindContainerImageMetadata},
-			workloadmeta.SourceAll,
-			workloadmeta.EventTypeSet,
-			false,
-		),
+		workloadmeta.NewFilter(filterParams),
 	)
 
 	resultChan := make(chan sbom.ScanResult, 2000)

--- a/pkg/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
+++ b/pkg/workloadmeta/collectors/internal/docker/image_sbom_trivy.go
@@ -50,7 +50,7 @@ func (c *collector) startSBOMCollection(ctx context.Context) error {
 	imgEventsCh := c.store.Subscribe(
 		"SBOM collector",
 		workloadmeta.NormalPriority,
-		workloadmeta.NewFilter(filterParams),
+		workloadmeta.NewFilter(&filterParams),
 	)
 
 	resultChan := make(chan sbom.ScanResult, 2000)

--- a/pkg/workloadmeta/filter.go
+++ b/pkg/workloadmeta/filter.go
@@ -31,11 +31,11 @@ type FilterParams struct {
 // delivered, and the entities in the events will contain data only from that
 // source.  For example, if source is SourceRuntime, then only events from the
 // runtime will be delivered, and they will not contain any additional metadata
-// from orchestrators or cluster orchestrators.  Use SourceAll to collect data
-// from all sources.
+// from orchestrators or cluster orchestrators. Use SourceAll to collect data
+// from all sources. SourceAll is the default.
 //
 // Only events of the given type will be delivered. Use EventTypeAll to collect
-// data from all the event types.
+// data from all the event types. EventTypeAll is the default.
 func NewFilter(filterParams *FilterParams) *Filter {
 	var kindSet map[Kind]struct{}
 	kinds := filterParams.Kinds
@@ -44,6 +44,11 @@ func NewFilter(filterParams *FilterParams) *Filter {
 		for _, k := range kinds {
 			kindSet[k] = struct{}{}
 		}
+	}
+
+	// This is enforced in the matching functions, but putting here for clarity
+	if filterParams.Source == "" {
+		filterParams.Source = SourceAll
 	}
 
 	return &Filter{

--- a/pkg/workloadmeta/filter.go
+++ b/pkg/workloadmeta/filter.go
@@ -16,6 +16,7 @@ type Filter struct {
 	includePauseContainers bool
 }
 
+// FilterParams are the parameters used to create a Filter
 type FilterParams struct {
 	Kinds                  []Kind
 	Source                 Source
@@ -37,7 +38,7 @@ type FilterParams struct {
 //
 // Only events of the given type will be delivered. Use EventTypeAll to collect
 // data from all the event types.
-func NewFilter(filterParams FilterParams) *Filter {
+func NewFilter(filterParams *FilterParams) *Filter {
 	var kindSet map[Kind]struct{}
 	kinds := filterParams.Kinds
 	if len(kinds) > 0 {

--- a/pkg/workloadmeta/filter.go
+++ b/pkg/workloadmeta/filter.go
@@ -10,18 +10,16 @@ package workloadmeta
 //
 // A nil filter matches all events.
 type Filter struct {
-	kinds                  map[Kind]struct{}
-	source                 Source
-	eventType              EventType
-	includePauseContainers bool
+	kinds     map[Kind]struct{}
+	source    Source
+	eventType EventType
 }
 
 // FilterParams are the parameters used to create a Filter
 type FilterParams struct {
-	Kinds                  []Kind
-	Source                 Source
-	EventType              EventType
-	IncludePauseContainers bool
+	Kinds     []Kind
+	Source    Source
+	EventType EventType
 }
 
 // NewFilter creates a new filter for subscribing to workloadmeta events.
@@ -49,10 +47,9 @@ func NewFilter(filterParams *FilterParams) *Filter {
 	}
 
 	return &Filter{
-		kinds:                  kindSet,
-		source:                 filterParams.Source,
-		eventType:              filterParams.EventType,
-		includePauseContainers: filterParams.IncludePauseContainers,
+		kinds:     kindSet,
+		source:    filterParams.Source,
+		eventType: filterParams.EventType,
 	}
 }
 
@@ -78,16 +75,6 @@ func (f *Filter) MatchSource(source Source) bool {
 // the filter is nil, or has EventTypeAll, it always matches.
 func (f *Filter) MatchEventType(eventType EventType) bool {
 	return f.EventType() == EventTypeAll || f.EventType() == eventType
-}
-
-// MatchIncludePauseContainers returns true if the filter has the includePauseContainers param set to true. If the filter
-// is nil, it does not match.
-func (f *Filter) MatchIncludePauseContainers() bool {
-	if f.includePauseContainers == true {
-		return true
-	}
-
-	return false
 }
 
 // Source returns the source this filter is filtering by. If the filter is nil,

--- a/pkg/workloadmeta/filter.go
+++ b/pkg/workloadmeta/filter.go
@@ -10,9 +10,10 @@ package workloadmeta
 //
 // A nil filter matches all events.
 type Filter struct {
-	kinds     map[Kind]struct{}
-	source    Source
-	eventType EventType
+	kinds                  map[Kind]struct{}
+	source                 Source
+	eventType              EventType
+	includePauseContainers bool
 }
 
 // NewFilter creates a new filter for subscribing to workloadmeta events.
@@ -29,7 +30,7 @@ type Filter struct {
 //
 // Only events of the given type will be delivered. Use EventTypeAll to collect
 // data from all the event types.
-func NewFilter(kinds []Kind, source Source, eventType EventType) *Filter {
+func NewFilter(kinds []Kind, source Source, eventType EventType, includePauseContainers bool) *Filter {
 	var kindSet map[Kind]struct{}
 	if len(kinds) > 0 {
 		kindSet = make(map[Kind]struct{})
@@ -39,9 +40,10 @@ func NewFilter(kinds []Kind, source Source, eventType EventType) *Filter {
 	}
 
 	return &Filter{
-		kinds:     kindSet,
-		source:    source,
-		eventType: eventType,
+		kinds:                  kindSet,
+		source:                 source,
+		eventType:              eventType,
+		includePauseContainers: includePauseContainers,
 	}
 }
 
@@ -67,6 +69,16 @@ func (f *Filter) MatchSource(source Source) bool {
 // the filter is nil, or has EventTypeAll, it always matches.
 func (f *Filter) MatchEventType(eventType EventType) bool {
 	return f.EventType() == EventTypeAll || f.EventType() == eventType
+}
+
+// MatchIncludePauseContainers returns true if the filter has the includePauseContainers param set to true. If the filter
+// is nil, it does not match.
+func (f *Filter) MatchIncludePauseContainers() bool {
+	if f.includePauseContainers == true {
+		return true
+	}
+
+	return false
 }
 
 // Source returns the source this filter is filtering by. If the filter is nil,

--- a/pkg/workloadmeta/filter.go
+++ b/pkg/workloadmeta/filter.go
@@ -16,6 +16,13 @@ type Filter struct {
 	includePauseContainers bool
 }
 
+type FilterParams struct {
+	Kinds                  []Kind
+	Source                 Source
+	EventType              EventType
+	IncludePauseContainers bool
+}
+
 // NewFilter creates a new filter for subscribing to workloadmeta events.
 //
 // Only events for entities with one of the given kinds will be delivered.  If
@@ -30,8 +37,9 @@ type Filter struct {
 //
 // Only events of the given type will be delivered. Use EventTypeAll to collect
 // data from all the event types.
-func NewFilter(kinds []Kind, source Source, eventType EventType, includePauseContainers bool) *Filter {
+func NewFilter(filterParams FilterParams) *Filter {
 	var kindSet map[Kind]struct{}
+	kinds := filterParams.Kinds
 	if len(kinds) > 0 {
 		kindSet = make(map[Kind]struct{})
 		for _, k := range kinds {
@@ -41,9 +49,9 @@ func NewFilter(kinds []Kind, source Source, eventType EventType, includePauseCon
 
 	return &Filter{
 		kinds:                  kindSet,
-		source:                 source,
-		eventType:              eventType,
-		includePauseContainers: includePauseContainers,
+		source:                 filterParams.Source,
+		eventType:              filterParams.EventType,
+		includePauseContainers: filterParams.IncludePauseContainers,
 	}
 }
 

--- a/pkg/workloadmeta/store_example_test.go
+++ b/pkg/workloadmeta/store_example_test.go
@@ -14,7 +14,7 @@ func init() {
 }
 
 func ExampleStore_Subscribe() {
-	filter := NewFilter([]Kind{KindContainer}, SourceRuntime, EventTypeAll)
+	filter := NewFilter([]Kind{KindContainer}, SourceRuntime, EventTypeAll, false)
 	ch := GetGlobalStore().Subscribe("test", NormalPriority, filter)
 
 	go func() {

--- a/pkg/workloadmeta/store_example_test.go
+++ b/pkg/workloadmeta/store_example_test.go
@@ -19,7 +19,7 @@ func ExampleStore_Subscribe() {
 		Source:    SourceRuntime,
 		EventType: EventTypeAll,
 	}
-	filter := NewFilter(filterParams)
+	filter := NewFilter(&filterParams)
 
 	ch := GetGlobalStore().Subscribe("test", NormalPriority, filter)
 

--- a/pkg/workloadmeta/store_example_test.go
+++ b/pkg/workloadmeta/store_example_test.go
@@ -14,7 +14,13 @@ func init() {
 }
 
 func ExampleStore_Subscribe() {
-	filter := NewFilter([]Kind{KindContainer}, SourceRuntime, EventTypeAll, false)
+	filterParams := FilterParams{
+		Kinds:     []Kind{KindContainer},
+		Source:    SourceRuntime,
+		EventType: EventTypeAll,
+	}
+	filter := NewFilter(filterParams)
+
 	ch := GetGlobalStore().Subscribe("test", NormalPriority, filter)
 
 	go func() {

--- a/pkg/workloadmeta/store_test.go
+++ b/pkg/workloadmeta/store_test.go
@@ -152,7 +152,7 @@ func TestSubscribe(t *testing.T) {
 			// if the filter has type "EventTypeUnset", it does not receive
 			// events for entities that are currently in the store.
 			name: "do not receive events for entities in the store pre-subscription if filter type is EventTypeUnset",
-			filter: NewFilter(FilterParams{
+			filter: NewFilter(&FilterParams{
 				Source:    fooSource,
 				EventType: EventTypeUnset,
 			}),
@@ -173,7 +173,7 @@ func TestSubscribe(t *testing.T) {
 			// that don't match the filter at all should not
 			// generate an event.
 			name: "receive events for entities in the store pre-subscription with filter",
-			filter: NewFilter(FilterParams{
+			filter: NewFilter(&FilterParams{
 				Source:    fooSource,
 				EventType: EventTypeAll,
 			}),
@@ -340,7 +340,7 @@ func TestSubscribe(t *testing.T) {
 			// unsetting from only one (that matches the filter)
 			// correctly generates an unset event
 			name: "sets and unsets an entity with source filters",
-			filter: NewFilter(FilterParams{
+			filter: NewFilter(&FilterParams{
 				Source:    fooSource,
 				EventType: EventTypeAll,
 			}),
@@ -507,7 +507,7 @@ func TestSubscribe(t *testing.T) {
 		},
 		{
 			name: "filters by event type",
-			filter: NewFilter(FilterParams{
+			filter: NewFilter(&FilterParams{
 				Source:    SourceAll,
 				EventType: EventTypeUnset,
 			}),

--- a/pkg/workloadmeta/store_test.go
+++ b/pkg/workloadmeta/store_test.go
@@ -152,7 +152,7 @@ func TestSubscribe(t *testing.T) {
 			// if the filter has type "EventTypeUnset", it does not receive
 			// events for entities that are currently in the store.
 			name:   "do not receive events for entities in the store pre-subscription if filter type is EventTypeUnset",
-			filter: NewFilter(nil, fooSource, EventTypeUnset),
+			filter: NewFilter(nil, fooSource, EventTypeUnset, false),
 			preEvents: []CollectorEvent{
 				{
 					Type:   EventTypeSet,
@@ -170,7 +170,7 @@ func TestSubscribe(t *testing.T) {
 			// that don't match the filter at all should not
 			// generate an event.
 			name:   "receive events for entities in the store pre-subscription with filter",
-			filter: NewFilter(nil, fooSource, EventTypeAll),
+			filter: NewFilter(nil, fooSource, EventTypeAll, false),
 			preEvents: []CollectorEvent{
 				// set container with two sources, delete one source
 				{
@@ -334,7 +334,7 @@ func TestSubscribe(t *testing.T) {
 			// unsetting from only one (that matches the filter)
 			// correctly generates an unset event
 			name:   "sets and unsets an entity with source filters",
-			filter: NewFilter(nil, fooSource, EventTypeAll),
+			filter: NewFilter(nil, fooSource, EventTypeAll, false),
 			postEvents: [][]CollectorEvent{
 				{
 					{
@@ -498,7 +498,7 @@ func TestSubscribe(t *testing.T) {
 		},
 		{
 			name:   "filters by event type",
-			filter: NewFilter(nil, SourceAll, EventTypeUnset),
+			filter: NewFilter(nil, SourceAll, EventTypeUnset, false),
 			postEvents: [][]CollectorEvent{
 				{
 					{

--- a/pkg/workloadmeta/store_test.go
+++ b/pkg/workloadmeta/store_test.go
@@ -151,8 +151,11 @@ func TestSubscribe(t *testing.T) {
 		{
 			// if the filter has type "EventTypeUnset", it does not receive
 			// events for entities that are currently in the store.
-			name:   "do not receive events for entities in the store pre-subscription if filter type is EventTypeUnset",
-			filter: NewFilter(nil, fooSource, EventTypeUnset, false),
+			name: "do not receive events for entities in the store pre-subscription if filter type is EventTypeUnset",
+			filter: NewFilter(FilterParams{
+				Source:    fooSource,
+				EventType: EventTypeUnset,
+			}),
 			preEvents: []CollectorEvent{
 				{
 					Type:   EventTypeSet,
@@ -169,8 +172,11 @@ func TestSubscribe(t *testing.T) {
 			// in the store, and match a filter by source. entities
 			// that don't match the filter at all should not
 			// generate an event.
-			name:   "receive events for entities in the store pre-subscription with filter",
-			filter: NewFilter(nil, fooSource, EventTypeAll, false),
+			name: "receive events for entities in the store pre-subscription with filter",
+			filter: NewFilter(FilterParams{
+				Source:    fooSource,
+				EventType: EventTypeAll,
+			}),
 			preEvents: []CollectorEvent{
 				// set container with two sources, delete one source
 				{
@@ -333,8 +339,11 @@ func TestSubscribe(t *testing.T) {
 			// setting an entity from two different sources, but
 			// unsetting from only one (that matches the filter)
 			// correctly generates an unset event
-			name:   "sets and unsets an entity with source filters",
-			filter: NewFilter(nil, fooSource, EventTypeAll, false),
+			name: "sets and unsets an entity with source filters",
+			filter: NewFilter(FilterParams{
+				Source:    fooSource,
+				EventType: EventTypeAll,
+			}),
 			postEvents: [][]CollectorEvent{
 				{
 					{
@@ -497,8 +506,11 @@ func TestSubscribe(t *testing.T) {
 			},
 		},
 		{
-			name:   "filters by event type",
-			filter: NewFilter(nil, SourceAll, EventTypeUnset, false),
+			name: "filters by event type",
+			filter: NewFilter(FilterParams{
+				Source:    SourceAll,
+				EventType: EventTypeUnset,
+			}),
 			postEvents: [][]CollectorEvent{
 				{
 					{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
https://datadoghq.atlassian.net/browse/SEC-10906?atlOrigin=eyJpIjoiYTYzMThhYjRiOGFiNGQwZmE5M2NjYWNhNzgxMTE4ZjYiLCJwIjoiaiJ9

This is the first of a couple PRs to accomplish the goal of having Pause Container metadata available in workloadmeta store for CWS to query (but not push this data to workloadmeta subscribers). This PR converts the input params that subscribers use to create an event filter into a struct to facilitate adding additional filter params.  

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
