### PR TITLE
Lee.avital/refactor dns

### DIFF
--- a/pkg/network/dns/null.go
+++ b/pkg/network/dns/null.go
@@ -19,7 +19,7 @@ func NewNullReverseDNS() ReverseDNS {
 type nullReverseDNS struct{}
 
 func (d nullReverseDNS) WaitDomain(domain string) error {
-	panic("implement me")
+	return nil
 }
 
 func (nullReverseDNS) Resolve(_ map[util.Address]struct{}) map[util.Address][]Hostname {

--- a/pkg/network/dns/null.go
+++ b/pkg/network/dns/null.go
@@ -18,6 +18,10 @@ func NewNullReverseDNS() ReverseDNS {
 
 type nullReverseDNS struct{}
 
+func (d nullReverseDNS) WaitDomain(domain string) error {
+	panic("implement me")
+}
+
 func (nullReverseDNS) Resolve(_ map[util.Address]struct{}) map[util.Address][]Hostname {
 	return nil
 }

--- a/pkg/network/dns/snooper.go
+++ b/pkg/network/dns/snooper.go
@@ -129,7 +129,6 @@ func (s *socketFilterSnooper) GetDNSStats() StatsByKeyByNameByType {
 }
 
 func (s *socketFilterSnooper) WaitDomain(domain string) error {
-	fmt.Println("wait domain", domain)
 	timeout := time.After(s.statKeeper.expirationPeriod)
 	tick := time.NewTicker(time.Millisecond * 10)
 	defer tick.Stop()
@@ -140,16 +139,14 @@ func (s *socketFilterSnooper) WaitDomain(domain string) error {
 		case <-tick.C:
 			s.statKeeper.mux.Lock()
 			for _, byDomain := range s.statKeeper.stats {
-				for d, _ := range byDomain {
+				for d := range byDomain {
 					if d.Get() == domain {
-						fmt.Println("got it!")
 						s.statKeeper.mux.Unlock()
 						return nil
 					}
 				}
 			}
 			s.statKeeper.mux.Unlock()
-			fmt.Println("here")
 		}
 
 	}

--- a/pkg/network/dns/types.go
+++ b/pkg/network/dns/types.go
@@ -69,6 +69,10 @@ type ReverseDNS interface {
 	GetDNSStats() StatsByKeyByNameByType
 	Start() error
 	Close()
+
+	// WaitDomain is only used for testing. It waits until the ReverseDNS has an entry for the given domain.
+	// This is used to synchronize a particular domain in tests.
+	WaitDomain(domain string) error
 }
 
 // Key is an identifier for a set of DNS connections

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1347,7 +1347,7 @@ func (s *TracerSuite) TestDNSStatsWithNAT() {
 	cfg.CollectDNSStats = true
 	cfg.DNSTimeout = 1 * time.Second
 	tr := setupTracer(t, cfg)
-	testDNSStats(t, tr, "golang.org", 1, 0, 0, "2.2.2.2")
+	testDNSStats(t, tr, "golang.org", "success", "2.2.2.2")
 }
 
 func iptablesWrapper(t *testing.T, f func()) {

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1071,13 +1071,15 @@ func testDNSStats(t *testing.T, tr *Tracer, domain, outcome string, serverIP str
 
 		failedResponses := total - successfulResponses
 
+		assert.Equal(t, queryMsg.Len(), int(conn.Last.SentBytes))
+
 		switch outcome {
 		case "success":
-			assert.NotZero(t, uint32(1), successfulResponses, "expected a successful response")
+			assert.Equal(t, uint32(1), successfulResponses, "expected a successful response")
 		case "failure":
-			assert.NotZero(t, uint32(1), failedResponses, "expected a failed response")
+			assert.Equal(t, uint32(1), failedResponses, "expected a failed response")
 		case "timeout":
-			assert.NotZero(t, uint32(1), timeouts, "expected a timeout")
+			assert.Equal(t, uint32(1), timeouts, "expected a timeout")
 		}
 	}, 3*time.Second, 100*time.Millisecond)
 }

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1044,11 +1044,8 @@ func testDNSStats(t *testing.T, tr *Tracer, domain, outcome string, serverIP str
 		connections := getConnections(t, tr)
 		conn, ok := findConnection(dnsClientAddr, dnsServerAddr, connections)
 		if !assert.True(t, ok) {
-			fmt.Println("no conn")
 			return
 		}
-
-		fmt.Println("checking ", conn)
 
 		dnsKey, _ := network.DNSKey(conn)
 		assert.Equal(t, os.Getpid(), int(conn.Pid))
@@ -1056,7 +1053,6 @@ func testDNSStats(t *testing.T, tr *Tracer, domain, outcome string, serverIP str
 
 		dnsStats, ok := connections.DNSStats[dnsKey]
 		if !assert.True(t, ok) {
-			fmt.Println("no DNS stats")
 			return
 		}
 
@@ -1075,7 +1071,6 @@ func testDNSStats(t *testing.T, tr *Tracer, domain, outcome string, serverIP str
 
 		failedResponses := total - successfulResponses
 
-		fmt.Println(total, successfulResponses, failedResponses)
 		switch outcome {
 		case "success":
 			assert.NotZero(t, uint32(1), successfulResponses, "expected a successful response")


### PR DESCRIPTION
All the tests which use 8.8.8.8 went through a function called
testDnsStats. Which would look for a single timeout, failure, or
success.

In the cases that it was looking for a success or failure (NXDOMAIN), it was
possible for it to flake in one of two ways:
* 8.8.8.8 would not respond due to packet loss or slow responses
* 8.8.8.8 would respond, but the response would not be seen in time by
  the snooper before the test called getConnections(tracer).

This updates the test in two ways to avoid these flakes:
1. it wraps the test in a loop which retries the request to DNS and
   asserts that the correct error code
2. It adds a test only method to dns_snooper called WaitDomain() wich
   waits for a domain to make its way to the DNS stat keeper. The tests
   will:
    * clear the tracer state
    * run the DNS request
    * call waitDomain()
    * call getConnections(tracer)
  Using this order means getConnections() will have a fully processed
  DNS request.
