### PR TITLE
Latest stable set to 7.49.0

### DIFF
--- a/release.json
+++ b/release.json
@@ -1,8 +1,8 @@
 {
     "base_branch": "main",
     "last_stable": {
-        "6": "6.48.1",
-        "7": "7.48.1"
+        "6": "6.49.0",
+        "7": "7.49.0"
     },
     "nightly": {
         "INTEGRATIONS_CORE_VERSION": "master",


### PR DESCRIPTION
This PR updates `latest_stable` field in `release.json` file to `7.49.0` following the recent Agent minor version release.