### PR TITLE
[CWS] cache `hasCompleteLineage `

### DIFF
--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -455,9 +455,10 @@ var zeroProcessContext ProcessContext
 type ProcessCacheEntry struct {
 	ProcessContext
 
-	refCount  uint64                     `field:"-" json:"-"`
-	onRelease func(_ *ProcessCacheEntry) `field:"-" json:"-"`
-	releaseCb func()                     `field:"-" json:"-"`
+	hasCompleteLineage *bool
+	refCount           uint64                     `field:"-" json:"-"`
+	onRelease          func(_ *ProcessCacheEntry) `field:"-" json:"-"`
+	releaseCb          func()                     `field:"-" json:"-"`
 }
 
 // IsContainerRoot returns whether this is a top level process in the container ID

--- a/pkg/security/secl/model/process_cache_entry_unix.go
+++ b/pkg/security/secl/model/process_cache_entry_unix.go
@@ -46,14 +46,7 @@ func hasCompleteLineageInner(pc *ProcessCacheEntry) bool {
 // HasCompleteLineage returns false if, from the entry, we cannot ascend the ancestors list to PID 1
 func (pc *ProcessCacheEntry) HasCompleteLineage() bool {
 	res := hasCompleteLineageInner(pc)
-
-	for pc != nil {
-		pc.hasCompleteLineage = &res
-		if pc.Pid == 1 {
-			break
-		}
-		pc = pc.Ancestor
-	}
+	pc.hasCompleteLineage = &res
 	return res
 }
 

--- a/pkg/security/secl/model/process_cache_entry_unix.go
+++ b/pkg/security/secl/model/process_cache_entry_unix.go
@@ -23,20 +23,31 @@ func (pc *ProcessCacheEntry) SetAncestor(parent *ProcessCacheEntry) {
 		pc.Ancestor.Release()
 	}
 
+	pc.hasCompleteLineage = nil
 	pc.Ancestor = parent
 	pc.Parent = &parent.Process
 	parent.Retain()
 }
 
-// HasCompleteLineage returns false if, from the entry, we cannot ascend the ancestors list to PID 1
-func (pc *ProcessCacheEntry) HasCompleteLineage() bool {
+func hasCompleteLineageInner(pc *ProcessCacheEntry) bool {
 	for pc != nil {
+		if pc.hasCompleteLineage != nil {
+			return *pc.hasCompleteLineage
+		}
+
 		if pc.Pid == 1 {
 			return true
 		}
 		pc = pc.Ancestor
 	}
 	return false
+}
+
+// HasCompleteLineage returns false if, from the entry, we cannot ascend the ancestors list to PID 1
+func (pc *ProcessCacheEntry) HasCompleteLineage() bool {
+	res := hasCompleteLineageInner(pc)
+	pc.hasCompleteLineage = &res
+	return res
 }
 
 // HasValidLineage returns false if, from the entry, we cannot ascend the ancestors list to PID 1 or if a new is having a missing parent

--- a/pkg/security/secl/model/process_cache_entry_unix.go
+++ b/pkg/security/secl/model/process_cache_entry_unix.go
@@ -46,7 +46,14 @@ func hasCompleteLineageInner(pc *ProcessCacheEntry) bool {
 // HasCompleteLineage returns false if, from the entry, we cannot ascend the ancestors list to PID 1
 func (pc *ProcessCacheEntry) HasCompleteLineage() bool {
 	res := hasCompleteLineageInner(pc)
-	pc.hasCompleteLineage = &res
+
+	for pc != nil {
+		pc.hasCompleteLineage = &res
+		if pc.Pid == 1 {
+			break
+		}
+		pc = pc.Ancestor
+	}
 	return res
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Currently when validation the process lineage we iterate on all ancestors. This is especially an issue when we start tracing a cgroup because we do a walk on all process cache entries and validate all their lineage. This means that we will iterate on a lot of process when doing this.

This PR speeds up this process by caching the `hasCompleteLineage` status of previously validated nodes to ensure we don't spend too much time doing this validation.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This function appeared as a hotspot when profiling on container heavy workloads.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
