### PR TITLE
Fix stale metrics being reported by KSM check in some cases

### DIFF
--- a/pkg/kubestatemetrics/store/store.go
+++ b/pkg/kubestatemetrics/store/store.go
@@ -156,6 +156,10 @@ func (s *MetricsStore) GetByKey(key string) (item interface{}, exists bool, err 
 // Replace will delete the contents of the store, using instead the
 // given list.
 func (s *MetricsStore) Replace(list []interface{}, _ string) error {
+	s.mutex.Lock()
+	s.metrics = map[types.UID][]DDMetricsFam{}
+	s.mutex.Unlock()
+
 	for _, o := range list {
 		err := s.Add(o)
 		if err != nil {

--- a/pkg/kubestatemetrics/store/store_test.go
+++ b/pkg/kubestatemetrics/store/store_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -442,8 +443,8 @@ func TestReplace(t *testing.T) {
 	ms.mutex.RUnlock()
 
 	// Verify that our test is setup correctly and that both metrics are in place
-	assert.Contains(t, metrics, types.UID("bec19172-8abf-11ea-8546-42010a80022c"))
-	assert.Contains(t, metrics, types.UID("8b136387-8a51-11ea-8546-42010a80022c"))
+	require.Contains(t, metrics, types.UID("bec19172-8abf-11ea-8546-42010a80022c"))
+	require.Contains(t, metrics, types.UID("8b136387-8a51-11ea-8546-42010a80022c"))
 
 	// Create a smaller set of metrics to replace the existing metrics with. We want to make sure that metrics which
 	// are not defined in the new set are removed.

--- a/pkg/kubestatemetrics/store/store_test.go
+++ b/pkg/kubestatemetrics/store/store_test.go
@@ -398,6 +398,75 @@ func TestPush(t *testing.T) {
 	}
 }
 
+func TestReplace(t *testing.T) {
+	idsToAdd := map[string]string{"bec19172-8abf-11ea-8546-42010a80022c": "gke-charly-default-pool-6948dc89-g54n", "8b136387-8a51-11ea-8546-42010a80022c": "gke-charly-default-pool-6948dc89-4r7"}
+	creationTs := int64(709655400000)
+	storeName := "*v1.Node"
+	metricName := "kube_node_created"
+
+	genFunc := func(obj interface{}) []metric.FamilyInterface {
+		o, err := meta.Accessor(obj)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		metricFamily := metric.Family{
+			Name: metricName,
+			Metrics: []*metric.Metric{
+				{
+					LabelKeys:   []string{"node"},
+					LabelValues: []string{string(o.GetUID()), o.GetName()},
+					Value:       float64(o.GetCreationTimestamp().Unix()),
+				},
+			},
+		}
+		return []metric.FamilyInterface{&metricFamily}
+	}
+
+	ms := NewMetricsStore(genFunc, storeName)
+	for uid, name := range idsToAdd {
+		s := v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				UID:               types.UID(uid),
+				CreationTimestamp: metav1.Unix(creationTs, 0),
+			},
+		}
+		err := ms.Add(&s)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	ms.mutex.RLock()
+	metrics := ms.metrics
+	ms.mutex.RUnlock()
+
+	// Verify that our test is setup correctly and that both metrics are in place
+	assert.Contains(t, metrics, types.UID("bec19172-8abf-11ea-8546-42010a80022c"))
+	assert.Contains(t, metrics, types.UID("8b136387-8a51-11ea-8546-42010a80022c"))
+
+	// Create a smaller set of metrics to replace the existing metrics with. We want to make sure that metrics which
+	// are not defined in the new set are removed.
+	s := v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "gke-charly-default-pool-6948dc89-4r7",
+			UID:               types.UID("8b136387-8a51-11ea-8546-42010a80022c"),
+			CreationTimestamp: metav1.Unix(creationTs, 0),
+		},
+	}
+	replaceList := []interface{}{&s}
+	err := ms.Replace(replaceList, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ms.mutex.RLock()
+	metrics = ms.metrics
+	ms.mutex.RUnlock()
+
+	assert.NotContains(t, metrics, types.UID("bec19172-8abf-11ea-8546-42010a80022c"))
+	assert.Contains(t, metrics, types.UID("8b136387-8a51-11ea-8546-42010a80022c"))
+}
+
 func (ms *MetricsStore) addMetrics(toAdd map[types.UID][]DDMetricsFam) {
 	ms.mutex.Lock()
 	for uid := range toAdd {

--- a/releasenotes-dca/notes/ksm-fix-stale-metrics-e677f7ed7b6256d9.yaml
+++ b/releasenotes-dca/notes/ksm-fix-stale-metrics-e677f7ed7b6256d9.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix stale metrics being reported by kubernetes_state_core check in some rare cases.


### PR DESCRIPTION
### What does this PR do?

This PR fixes the case where stale KSM metrics were being reported for objects which had been removed from the kubernetes server.

### Motivation

The change introduced here already exists in the [MetricStore implementation](https://github.com/kubernetes/kube-state-metrics/blob/main/pkg/metrics_store/metrics_store.go#L127-L140) in the upstream KSM project, and brings the function in line with what the function documentation says it is doing.

### Additional Notes

The bug in question appears to manifest when the cluster agent loses connection to the k8s API server and reconnects, and while an object was removed from the server during this disconnect window. It has been difficult to replicate locally. I have validated that the change does not break existing behavior.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

I was not able to successfully validate this change locally. Theoretically you could spin up a k8s cluster, deploy the DCA with a lower value for the `kubernetes_apiserver_client_timeout` config option (it defaults to 10 seconds, so maybe 5 seconds?), and then try and spam the API server with a bunch of resource creation and removal payloads, and then finally remove everything that you added to the cluster so it is in a slimmed down state and validate that the KSM metrics showing up in the datadog UI do not have any metrics for removed elements.

But, as mentioned above, I was not able to get this to simulate the bug on my machine, so at a minimum just make sure that the KSM metrics are not broken as a result of this change.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
