### PR TITLE
[process-agent] Minor fixes to comments, logging and fx bundle boundaries

### DIFF
--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -121,10 +121,13 @@ func runApp(ctx context.Context, globalParams *command.GlobalParams) error {
 				LogParams:    command.DaemonLogParams,
 			},
 		),
-		// Populate dependencies required for initialization in this function.
+		// Populate dependencies required for initialization in this function
 		fx.Populate(&appInitDeps),
 
-		// Provide process agent bundle so fx knows where to find components.
+		// Provide core components
+		core.Bundle,
+
+		// Provide process agent bundle so fx knows where to find components
 		process.Bundle,
 
 		// Provide remote config client module

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -75,7 +75,7 @@ func runAgent(ctx context.Context, globalParams *command.GlobalParams) error {
 	if globalParams.PidFilePath != "" {
 		err := pidfile.WritePID(globalParams.PidFilePath)
 		if err != nil {
-			_ = log.Errorf("Error while writing PID file, exiting: %v", err)
+			log.Errorf("Error while writing PID file, exiting: %v", err)
 			return err
 		}
 
@@ -167,7 +167,7 @@ func runApp(ctx context.Context, globalParams *command.GlobalParams) error {
 		if appInitDeps.Logger == nil {
 			fmt.Println("Failed to initialize the process agent: ", fxutil.UnwrapIfErrArgumentsFailed(err))
 		} else {
-			_ = appInitDeps.Logger.Critical("Failed to initialize the process agent: ", fxutil.UnwrapIfErrArgumentsFailed(err))
+			appInitDeps.Logger.Critical("Failed to initialize the process agent: ", fxutil.UnwrapIfErrArgumentsFailed(err))
 		}
 		return err
 	}
@@ -229,12 +229,12 @@ type miscDeps struct {
 // Todo: move metadata/workloadmeta/collector to workloadmeta
 func initMisc(deps miscDeps) error {
 	if err := statsd.Configure(ddconfig.GetBindHost(), deps.Config.GetInt("dogstatsd_port"), false); err != nil {
-		_ = log.Criticalf("Error configuring statsd: %s", err)
+		log.Criticalf("Error configuring statsd: %s", err)
 		return err
 	}
 
 	if err := ddutil.SetupCoreDump(deps.Config); err != nil {
-		_ = log.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
+		log.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
 	}
 
 	// Setup workloadmeta
@@ -251,7 +251,7 @@ func initMisc(deps miscDeps) error {
 	if deps.Config.GetBool("process_config.remote_tagger") {
 		options, err := remote.NodeAgentOptions()
 		if err != nil {
-			_ = log.Errorf("unable to deps.Configure the remote tagger: %s", err)
+			log.Errorf("unable to deps.Configure the remote tagger: %s", err)
 		} else {
 			t = remote.NewTagger(options)
 		}
@@ -270,12 +270,12 @@ func initMisc(deps miscDeps) error {
 
 			err := tagger.Init(startCtx)
 			if err != nil {
-				_ = log.Errorf("failed to start the tagger: %s", err)
+				log.Errorf("failed to start the tagger: %s", err)
 			}
 
 			err = manager.ConfigureAutoExit(startCtx, deps.Config)
 			if err != nil {
-				_ = log.Criticalf("Unable to configure auto-exit, err: %w", err)
+				log.Criticalf("Unable to configure auto-exit, err: %w", err)
 				return err
 			}
 

--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/process-agent/command"
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
@@ -88,6 +89,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 
 			return fxutil.OneShot(runCheckCmd,
 				fx.Supply(cliParams, bundleParams),
+				core.Bundle,
 				processComponent.Bundle,
 			)
 		},

--- a/cmd/process-agent/subcommands/config/config.go
+++ b/cmd/process-agent/subcommands/config/config.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/cmd/process-agent/command"
+	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/process"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
@@ -38,7 +39,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(showRuntimeConfiguration,
 				fx.Supply(globalParams, command.GetCoreBundleParamsForOneShot(globalParams)),
-
+				core.Bundle,
 				process.Bundle,
 			)
 		},
@@ -52,7 +53,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			RunE: func(cmd *cobra.Command, args []string) error {
 				return fxutil.OneShot(listRuntimeConfigurableValue,
 					fx.Supply(globalParams, command.GetCoreBundleParamsForOneShot(globalParams)),
-
+					core.Bundle,
 					process.Bundle,
 				)
 			},
@@ -67,7 +68,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			RunE: func(cmd *cobra.Command, args []string) error {
 				return fxutil.OneShot(setConfigValue,
 					fx.Supply(globalParams, args, command.GetCoreBundleParamsForOneShot(globalParams)),
-
+					core.Bundle,
 					process.Bundle,
 				)
 			},
@@ -81,7 +82,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			RunE: func(cmd *cobra.Command, args []string) error {
 				return fxutil.OneShot(getConfigValue,
 					fx.Supply(globalParams, args, command.GetCoreBundleParamsForOneShot(globalParams)),
-
+					core.Bundle,
 					process.Bundle,
 				)
 			},

--- a/cmd/process-agent/subcommands/events/events.go
+++ b/cmd/process-agent/subcommands/events/events.go
@@ -18,6 +18,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/cmd/process-agent/command"
+	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
@@ -71,7 +72,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(runEventListener,
 				fx.Supply(cliParams, command.GetCoreBundleParamsForOneShot(globalParams)),
-
+				core.Bundle,
 				process.Bundle,
 			)
 		},
@@ -85,7 +86,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(runEventStore,
 				fx.Supply(cliParams, command.GetCoreBundleParamsForOneShot(globalParams)),
-
+				core.Bundle,
 				process.Bundle,
 			)
 		},

--- a/cmd/process-agent/subcommands/status/status.go
+++ b/cmd/process-agent/subcommands/status/status.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/cmd/process-agent/command"
+	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/log"
 	"github.com/DataDog/datadog-agent/comp/process"
@@ -75,7 +76,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fxutil.OneShot(runStatus,
 				fx.Supply(cliParams, command.GetCoreBundleParamsForOneShot(globalParams)),
-
+				core.Bundle,
 				process.Bundle,
 			)
 		},

--- a/comp/process/bundle.go
+++ b/comp/process/bundle.go
@@ -12,7 +12,6 @@
 package process
 
 import (
-	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/process/apiserver"
 	"github.com/DataDog/datadog-agent/comp/process/connectionscheck/connectionscheckimpl"
 	"github.com/DataDog/datadog-agent/comp/process/containercheck/containercheckimpl"
@@ -51,6 +50,4 @@ var Bundle = fxutil.Bundle(
 	expvarsimpl.Module,
 	apiserver.Module,
 	forwarders.Module,
-
-	core.Bundle,
 )

--- a/comp/process/bundle_test.go
+++ b/comp/process/bundle_test.go
@@ -28,6 +28,7 @@ func TestBundleDependencies(t *testing.T) {
 	fxutil.TestBundle(t, Bundle,
 		fx.Supply(mockCoreBundleParams),
 		fx.Provide(func() types.CheckComponent { return nil }),
+		core.MockBundle,
 	)
 }
 
@@ -58,6 +59,7 @@ func TestBundleOneShot(t *testing.T) {
 
 			mockCoreBundleParams,
 		),
+		core.MockBundle,
 		Bundle,
 	)
 	require.NoError(t, err)

--- a/pkg/process/metadata/workloadmeta/collector/process.go
+++ b/pkg/process/metadata/workloadmeta/collector/process.go
@@ -97,9 +97,6 @@ func (c *Collector) run(ctx context.Context, store workloadmeta.Store, container
 	}
 }
 
-// Pull is unused at the moment used due to the short frequency in which it is called.
-// In the future, we should use it to poll for processes that have been collected and store them in workload-meta.
-
 func (c *Collector) handleContainerEvent(evt workloadmeta.EventBundle) {
 	defer close(evt.Ch)
 


### PR DESCRIPTION
### What does this PR do?

- remove dangling comment
  - the function was removed in: https://github.com/DataDog/datadog-agent/pull/18270#discussion_r1281927573
- move core bundle out of the process bundle as it does not own it
  - From FX best practice: [Don't provide what you don't own](https://uber-go.github.io/fx/modules.html#don-t-provide-what-you-don-t-own)
- remove the explicit ignore of log errors 

### Motivation
🧹 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
