### PR TITLE
Add tls ingress metric to ksm core check

### DIFF
--- a/pkg/autodiscovery/providers/kube_services.go
+++ b/pkg/autodiscovery/providers/kube_services.go
@@ -188,6 +188,7 @@ func (k *KubeServiceConfigProvider) parseServiceAnnotations(services []*v1.Servi
 			svcConf[i].Source = "kube_services:" + serviceID
 			svcConf[i].IgnoreAutodiscoveryTags = ignoreADTags
 		}
+
 		configs = append(configs, svcConf...)
 	}
 

--- a/pkg/autodiscovery/providers/kube_services.go
+++ b/pkg/autodiscovery/providers/kube_services.go
@@ -179,10 +179,6 @@ func (k *KubeServiceConfigProvider) parseServiceAnnotations(services []*v1.Servi
 		} else {
 			delete(k.configErrors, serviceID)
 		}
-		log.Errorf("parseServiceAnnotations was called 1")
-		for _, err := range errors {
-			log.Errorf("Cannot parse service template for service %s/%s: %s", svc.Namespace, svc.Name, err)
-		}
 
 		ignoreADTags := ignoreADTagsFromAnnotations(svc.GetAnnotations(), kubeServiceAnnotationPrefix)
 

--- a/pkg/autodiscovery/providers/kube_services.go
+++ b/pkg/autodiscovery/providers/kube_services.go
@@ -179,6 +179,10 @@ func (k *KubeServiceConfigProvider) parseServiceAnnotations(services []*v1.Servi
 		} else {
 			delete(k.configErrors, serviceID)
 		}
+		log.Errorf("parseServiceAnnotations was called 1")
+		for _, err := range errors {
+			log.Errorf("Cannot parse service template for service %s/%s: %s", svc.Namespace, svc.Name, err)
+		}
 
 		ignoreADTags := ignoreADTagsFromAnnotations(svc.GetAnnotations(), kubeServiceAnnotationPrefix)
 
@@ -188,7 +192,6 @@ func (k *KubeServiceConfigProvider) parseServiceAnnotations(services []*v1.Servi
 			svcConf[i].Source = "kube_services:" + serviceID
 			svcConf[i].IgnoreAutodiscoveryTags = ignoreADTags
 		}
-
 		configs = append(configs, svcConf...)
 	}
 

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -539,12 +539,7 @@ func serviceTypeTransformer(s sender.Sender, name string, metric ksmstore.DDMetr
 // removeSecretTransformer removes the secret tag from the kube_ingress_tls metric
 func removeSecretTransformer(s sender.Sender, _ string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	if len(tags) > 0 {
-			if strings.HasPrefix(s, "secret:") {
-				tags = lo.Filter(tags, func(x string, index int) bool {
-					return x != s
-				})
-			}
-		}
+        tags = lo.Filter(tags, func(x string, _ int) bool { return !strings.HasPrefix(x, "secret:") })
 	}
 	s.Gauge(ksmMetricPrefix+"ingress.tls", metric.Val, hostname, tags)
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -538,7 +538,7 @@ func serviceTypeTransformer(s sender.Sender, name string, metric ksmstore.DDMetr
 
 // removeSecretTransformer removes the secret tag from the kube_ingress_tls metric
 func removeSecretTransformer(s sender.Sender, _ string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
-	if len(tags)>0{
+	if len(tags)>0 {
 		for i, s := range tags {
 			if strings.Contains(s, "secret:") {
 				tags[i] = ""

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -540,7 +540,7 @@ func serviceTypeTransformer(s sender.Sender, name string, metric ksmstore.DDMetr
 // removeSecretTransformer removes the secret tag from the kube_ingress_tls metric
 func removeSecretTransformer(s sender.Sender, _ string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	if len(tags) > 0 {
-        tags = lo.Filter(tags, func(x string, _ int) bool { return !strings.HasPrefix(x, "secret:") })
+		tags = lo.Filter(tags, func(x string, _ int) bool { return !strings.HasPrefix(x, "secret:") })
 	}
 	s.Gauge(ksmMetricPrefix+"ingress.tls", metric.Val, hostname, tags)
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -538,9 +538,11 @@ func serviceTypeTransformer(s sender.Sender, name string, metric ksmstore.DDMetr
 
 // removeSecretTransformer removes the secret tag from the kube_ingress_tls metric
 func removeSecretTransformer(s sender.Sender, _ string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
-	for i, s := range tags {
-		if strings.Contains(s, "secret:") {
-			tags[i] = ""
+	if len(tags)>0{
+		for i, s := range tags {
+			if strings.Contains(s, "secret:") {
+				tags[i] = ""
+			}
 		}
 	}
 	s.Gauge(ksmMetricPrefix+"ingress.tls", metric.Val, hostname, tags)

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -539,17 +539,12 @@ func serviceTypeTransformer(s sender.Sender, name string, metric ksmstore.DDMetr
 // remove secret removes the secret tag from the kube_ingress_tls metric
 func removeSecret(s sender.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	if len(tags) > 0 {
-		log.Errorf("All Tags for ingress metric are here: %+v", tags)
 		if len(tags) > 0 {
 			for i, s := range tags {
 				if strings.Contains(s, "secret:") {
 					tags[i] = ""
 				}
 			}
-		}
-		log.Errorf("New Tags for ingress metric are here: %+v", tags)
-		for _, s := range metric.Labels {
-			log.Errorf("ingress label is: %+v", s)
 		}
 	}
 	s.Gauge(ksmMetricPrefix+"ingress.tls", metric.Val, hostname, tags)

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -539,9 +539,10 @@ func serviceTypeTransformer(s sender.Sender, name string, metric ksmstore.DDMetr
 // removeSecretTransformer removes the secret tag from the kube_ingress_tls metric
 func removeSecretTransformer(s sender.Sender, _ string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	if len(tags) > 0 {
-		for i, s := range tags {
-			if strings.Contains(s, "secret:") {
-				tags[i] = ""
+			if strings.HasPrefix(s, "secret:") {
+				tags = lo.Filter(tags, func(x string, index int) bool {
+					return x != s
+				})
 			}
 		}
 	}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -538,13 +538,9 @@ func serviceTypeTransformer(s sender.Sender, name string, metric ksmstore.DDMetr
 
 // removeSecretTransformer removes the secret tag from the kube_ingress_tls metric
 func removeSecretTransformer(s sender.Sender, _ string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
-	if len(tags) > 0 {
-		if len(tags) > 0 {
-			for i, s := range tags {
-				if strings.Contains(s, "secret:") {
-					tags[i] = ""
-				}
-			}
+	for i, s := range tags {
+		if strings.Contains(s, "secret:") {
+			tags[i] = ""
 		}
 	}
 	s.Gauge(ksmMetricPrefix+"ingress.tls", metric.Val, hostname, tags)

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -537,7 +537,7 @@ func serviceTypeTransformer(s sender.Sender, name string, metric ksmstore.DDMetr
 }
 
 // removeSecretTransformer removes the secret tag from the kube_ingress_tls metric
-func removeSecretTransformer(s sender.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
+func removeSecretTransformer(s sender.Sender, _ string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	if len(tags) > 0 {
 		if len(tags) > 0 {
 			for i, s := range tags {

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -538,7 +538,7 @@ func serviceTypeTransformer(s sender.Sender, name string, metric ksmstore.DDMetr
 
 // removeSecretTransformer removes the secret tag from the kube_ingress_tls metric
 func removeSecretTransformer(s sender.Sender, _ string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
-	if len(tags)>0 {
+	if len(tags) > 0 {
 		for i, s := range tags {
 			if strings.Contains(s, "secret:") {
 				tags[i] = ""

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -17,6 +17,7 @@ import (
 	ksmstore "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store"
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/samber/lo"
 )
 
 // metricTransformerFunc is used to tweak or generate new metrics from a given KSM metric

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -113,7 +113,7 @@ func defaultMetricTransformers() map[string]metricTransformerFunc {
 		"kube_limitrange":                               limitrangeTransformer,
 		"kube_persistentvolume_status_phase":            pvPhaseTransformer,
 		"kube_service_spec_type":                        serviceTypeTransformer,
-		"kube_ingress_tls":                              removeSecret,
+		"kube_ingress_tls":                              removeSecretTransformer,
 	}
 }
 
@@ -536,8 +536,8 @@ func serviceTypeTransformer(s sender.Sender, name string, metric ksmstore.DDMetr
 	submitActiveMetric(s, ksmMetricPrefix+"service.type", metric, hostname, tags)
 }
 
-// remove secret removes the secret tag from the kube_ingress_tls metric
-func removeSecret(s sender.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
+// removeSecretTransformer removes the secret tag from the kube_ingress_tls metric
+func removeSecretTransformer(s sender.Sender, name string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
 	if len(tags) > 0 {
 		if len(tags) > 0 {
 			for i, s := range tags {

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers_test.go
@@ -2379,7 +2379,7 @@ func Test_removeSecret(t *testing.T) {
 			removeSecretTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
 				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.expected.tags)
-				s.AssertMetricNotTaggedWith(t, "Gauge", tt.expected.name, tt.expected.tags)
+				s.AssertMetricNotTaggedWith(t, "secret:foo", tt.expected.name, tt.expected.tags)
 				s.AssertNumberOfCalls(t, "Gauge", 1)
 			} else {
 				s.AssertNotCalled(t, "Gauge")

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers_test.go
@@ -2361,7 +2361,8 @@ func Test_removeSecret(t *testing.T) {
 				metric: ksmstore.DDMetric{
 					Val: 1,
 				},
-				tags: []string{"secret:foo", "tls_host:foo"},
+				tags:     []string{"secret:foo", "tls_host:foo"},
+				hostname: "foo",
 			},
 			expected: &metricsExpected{
 				name: "kubernetes_state.ingress.tls",
@@ -2375,9 +2376,10 @@ func Test_removeSecret(t *testing.T) {
 		s.SetupAcceptAll()
 		t.Run(tt.name, func(t *testing.T) {
 			currentTime := time.Now()
-			removeSecret(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
+			removeSecretTransformer(s, tt.args.name, tt.args.metric, tt.args.hostname, tt.args.tags, currentTime)
 			if tt.expected != nil {
-				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.args.tags)
+				s.AssertMetric(t, "Gauge", tt.expected.name, tt.expected.val, tt.args.hostname, tt.expected.tags)
+				s.AssertMetricNotTaggedWith(t, "Gauge", tt.expected.name, tt.expected.tags)
 				s.AssertNumberOfCalls(t, "Gauge", 1)
 			} else {
 				s.AssertNotCalled(t, "Gauge")

--- a/releasenotes/notes/adding-tls-Ingress-metric-8f3e5a19d3cbb7b0.yaml
+++ b/releasenotes/notes/adding-tls-Ingress-metric-8f3e5a19d3cbb7b0.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    The Kubernetes State Metrics Core check now collects `kubernetes_state.ingress.tld`
+    The Kubernetes State Metrics Core check now collects `kubernetes_state.ingress.tls`

--- a/releasenotes/notes/adding-tls-Ingress-metric-8f3e5a19d3cbb7b0.yaml
+++ b/releasenotes/notes/adding-tls-Ingress-metric-8f3e5a19d3cbb7b0.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    The Kubernetes State Metrics Core check now collects `kubernetes_state.ingress.tld`

--- a/releasenotes/notes/adding-tls-Ingress-metric-8f3e5a19d3cbb7b0.yaml
+++ b/releasenotes/notes/adding-tls-Ingress-metric-8f3e5a19d3cbb7b0.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    The Kubernetes State Metrics Core check now collects `kubernetes_state.ingress.tls`
+    The Kubernetes State Metrics Core check now collects `kubernetes_state.ingress.tls`.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Adds the metric `kubernetes_state.ingress.tls` to the ksm core check

<!--
-->

### Motivation
(https://datadoghq.atlassian.net/browse/CONTINT-3413)
<!--
-->

### Additional Notes

<!--

-->

### Describe how to test/QA your changes
Add ingress to deployment and confirm metric comes in. Ensure the metric does not have the `secret` tag associated with it.
```apiVersion: networking.k8s.io/v1
kind: Ingress 
metadata:  
  name: web-server-ingress
  namespace: web
spec:
  ingressClassName: nginx
  rules:
  - host: web.example.com
    http:
      paths:  
      - path: /
        pathType: Prefix
        backend:
          service:
            name: web-server-service
            port:
              number: 5000
  tls:
    - hosts:
      - demo.mlopshub.com
      secretName: hello-app-tls
    
```
<!--
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
