### PR TITLE
[e2e] fix race condition workspace

### DIFF
--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -218,7 +218,7 @@ def _get_existing_stacks(ctx: Context) -> List[Stack]:
     e2e_stacks: List[Stack] = []
     for workspace_dir in workspace_dirs:
         with ctx.cd(workspace_dir):
-            output = ctx.run("PULUMI_SKIP_UPDATE_CHECK=true pulumi stack ls --all", pty=True)
+            output = ctx.run("PULUMI_SKIP_UPDATE_CHECK=true pulumi stack ls", pty=True)
             if output is None or not output:
                 return []
             lines = output.stdout.splitlines()

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -2,12 +2,12 @@
 Running E2E Tests with infra based on Pulumi
 """
 
-from collections import namedtuple
 import json
 import os
 import os.path
 import shutil
 import tempfile
+from collections import namedtuple
 from pathlib import Path
 from typing import List
 

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -2,6 +2,7 @@
 Running E2E Tests with infra based on Pulumi
 """
 
+from collections import namedtuple
 import json
 import os
 import os.path
@@ -187,6 +188,9 @@ def _clean_locks():
             print(f"🗑️ Deleted lock: {subdir}")
 
 
+Stack = namedtuple('Stack', ['name', 'workspaceDirectory'])
+
+
 def _clean_stacks(ctx: Context):
     print("🧹 Clean up stack")
     stacks = _get_existing_stacks(ctx)
@@ -201,47 +205,55 @@ def _clean_stacks(ctx: Context):
         _remove_stack(ctx, stack)
 
 
-def _get_existing_stacks(ctx: Context) -> List[str]:
-    # running in temp dir as this is where datadog-agent test
-    # stacks are stored
-    with ctx.cd(tempfile.gettempdir()):
-        output = ctx.run("PULUMI_SKIP_UPDATE_CHECK=true pulumi stack ls --all", pty=True)
-        if output is None or not output:
-            return []
-        lines = output.stdout.splitlines()
-        lines = lines[1:]  # skip headers
-        e2e_stacks: List[str] = []
-        for line in lines:
-            stack_name = line.split(" ")[0]
-            print(f"Adding stack {stack_name}")
-            e2e_stacks.append(stack_name)
-        return e2e_stacks
+def _get_existing_stacks(ctx: Context) -> List[Stack]:
+    # running in temp dir and `pulumi-workspace` subfolder as this is where datadog-agent test
+    # stacks are stored.
+    workspace_dirs = [tempfile.gettempdir()]
+    workspace_subdirs_root = os.path.join(tempfile.gettempdir(), "pulumi-workspace")
+    if os.path.isdir(workspace_subdirs_root):
+        for entry in os.listdir(Path(workspace_subdirs_root)):
+            subdir = os.path.join(workspace_subdirs_root, entry)
+            if os.path.isdir(subdir):
+                workspace_dirs.append(subdir)
+    e2e_stacks: List[Stack] = []
+    for workspace_dir in workspace_dirs:
+        with ctx.cd(workspace_dir):
+            output = ctx.run("PULUMI_SKIP_UPDATE_CHECK=true pulumi stack ls --all", pty=True)
+            if output is None or not output:
+                return []
+            lines = output.stdout.splitlines()
+            lines = lines[1:]  # skip headers
+            for line in lines:
+                stack_name = line.split(" ")[0]
+                print(f"Adding stack {stack_name}")
+                e2e_stacks.append(Stack(stack_name, workspace_dir))
+            return e2e_stacks
 
 
-def _destroy_stack(ctx: Context, stack_name: str):
+def _destroy_stack(ctx: Context, stack: Stack):
     # running in temp dir as this is where datadog-agent test
     # stacks are stored. It is expected to fail on stacks existing locally
     # with resources removed by agent-sandbox clean up job
-    with ctx.cd(tempfile.gettempdir()):
+    with ctx.cd(stack.workspaceDirectory):
         ret = ctx.run(
-            f"PULUMI_SKIP_UPDATE_CHECK=true pulumi destroy --stack {stack_name} --yes --remove --skip-preview",
+            f"PULUMI_SKIP_UPDATE_CHECK=true pulumi destroy --stack {stack.name} --yes --remove --skip-preview",
             pty=True,
             warn=True,
         )
         if ret is not None and ret.exited != 0:
             # run with refresh on first destroy attempt failure
             ctx.run(
-                f"PULUMI_SKIP_UPDATE_CHECK=true pulumi destroy --stack {stack_name} -r --yes --remove --skip-preview",
+                f"PULUMI_SKIP_UPDATE_CHECK=true pulumi destroy --stack {stack.name} -r --yes --remove --skip-preview",
                 pty=True,
                 warn=True,
             )
 
 
-def _remove_stack(ctx: Context, stack_name: str):
+def _remove_stack(ctx: Context, stack: Stack):
     # running in temp dir as this is where datadog-agent test
     # stacks are stored
-    with ctx.cd(tempfile.gettempdir()):
-        ctx.run(f"PULUMI_SKIP_UPDATE_CHECK=true pulumi stack rm --force --yes --stack {stack_name}", pty=True)
+    with ctx.cd(stack.workspaceDirectory):
+        ctx.run(f"PULUMI_SKIP_UPDATE_CHECK=true pulumi stack rm --force --yes --stack {stack.name}", pty=True)
 
 
 def _get_pulumi_about(ctx: Context) -> dict:

--- a/test/new-e2e/pkg/runner/ci_profile.go
+++ b/test/new-e2e/pkg/runner/ci_profile.go
@@ -8,7 +8,6 @@ package runner
 import (
 	"fmt"
 	"os"
-	"path"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
@@ -68,13 +67,6 @@ func NewCIProfile() (Profile, error) {
 		baseProfile: newProfile("e2eci", ciEnvironments, store, &secretStore),
 		ciUniqueID:  "ci-" + pipelineID + "-" + projectID,
 	}, nil
-}
-
-// GetWorkspacePath returns the directory for CI Pulumi workspace.
-// Since one Workspace supports one single program and we have one program per stack,
-// the path should be unique for each stack.
-func (p ciProfile) GetWorkspacePath(stackName string) string {
-	return path.Join(workspaceRootFolder, stackName)
 }
 
 // NamePrefix returns a prefix to name objects based on a CI unique ID

--- a/test/new-e2e/pkg/runner/ci_profile.go
+++ b/test/new-e2e/pkg/runner/ci_profile.go
@@ -8,6 +8,7 @@ package runner
 import (
 	"fmt"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
@@ -26,10 +27,6 @@ type ciProfile struct {
 
 // NewCIProfile creates a new CI profile
 func NewCIProfile() (Profile, error) {
-	// Create workspace directory
-	if err := os.MkdirAll(workspaceFolder, 0o700); err != nil {
-		return nil, fmt.Errorf("unable to create temporary folder at: %s, err: %w", workspaceFolder, err)
-	}
 	ciSecretPrefix := os.Getenv("CI_SECRET_PREFIX")
 	if len(ciSecretPrefix) == 0 {
 		ciSecretPrefix = defaultCISecretPrefix
@@ -73,9 +70,11 @@ func NewCIProfile() (Profile, error) {
 	}, nil
 }
 
-// RootWorkspacePath returns the root directory for CI Pulumi workspace
-func (p ciProfile) RootWorkspacePath() string {
-	return workspaceFolder
+// GetWorkspacePath returns the directory for CI Pulumi workspace.
+// Since one Workspace supports one single program and we have one program per stack,
+// the path should be unique for each stack.
+func (p ciProfile) GetWorkspacePath(stackName string) string {
+	return path.Join(workspaceRootFolder, stackName)
 }
 
 // NamePrefix returns a prefix to name objects based on a CI unique ID

--- a/test/new-e2e/pkg/runner/local_profile.go
+++ b/test/new-e2e/pkg/runner/local_profile.go
@@ -21,9 +21,6 @@ const (
 
 // NewLocalProfile creates a new local profile
 func NewLocalProfile() (Profile, error) {
-	if err := os.MkdirAll(workspaceFolder, 0o700); err != nil {
-		return nil, fmt.Errorf("unable to create temporary folder at: %s, err: %w", workspaceFolder, err)
-	}
 	envValueStore := parameters.NewEnvStore(EnvPrefix)
 
 	configPath, err := getConfigFilePath()
@@ -69,9 +66,11 @@ type localProfile struct {
 	baseProfile
 }
 
-// RootWorkspacePath returns the root directory for local Pulumi workspace
-func (p localProfile) RootWorkspacePath() string {
-	return workspaceFolder
+// GetWorkspacePath returns the directory for local Pulumi workspace.
+// Since one Workspace supports one single program and we have one program per stack,
+// the path should be unique for each stack.
+func (p localProfile) GetWorkspacePath(stackName string) string {
+	return path.Join(workspaceRootFolder, stackName)
 }
 
 // NamePrefix returns a prefix to name objects based on local username

--- a/test/new-e2e/pkg/runner/local_profile.go
+++ b/test/new-e2e/pkg/runner/local_profile.go
@@ -66,13 +66,6 @@ type localProfile struct {
 	baseProfile
 }
 
-// GetWorkspacePath returns the directory for local Pulumi workspace.
-// Since one Workspace supports one single program and we have one program per stack,
-// the path should be unique for each stack.
-func (p localProfile) GetWorkspacePath(stackName string) string {
-	return path.Join(workspaceRootFolder, stackName)
-}
-
 // NamePrefix returns a prefix to name objects based on local username
 func (p localProfile) NamePrefix() string {
 	// Stack names may only contain alphanumeric characters, hyphens, underscores, or periods.

--- a/test/new-e2e/pkg/runner/mock_profile.go
+++ b/test/new-e2e/pkg/runner/mock_profile.go
@@ -8,8 +8,6 @@
 package runner
 
 import (
-	"fmt"
-
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
 )
 
@@ -17,16 +15,13 @@ var _ Profile = &mockProfile{}
 
 func newMockProfile(storeMap map[parameters.StoreKey]string) Profile {
 	store := parameters.NewMockStore(storeMap)
-	return mockProfile{baseProfile: newProfile("totoro", []string{}, store, nil)}
+	mp := mockProfile{baseProfile: newProfile("totoro", []string{}, store, nil)}
+	mp.baseProfile.workspaceRootFolder = "mock"
+	return mp
 }
 
 type mockProfile struct {
 	baseProfile
-}
-
-// GetWorkspacePath returns the root directory for local Pulumi workspace
-func (mp mockProfile) GetWorkspacePath(stackName string) string {
-	return fmt.Sprintf("mock-%s", stackName)
 }
 
 // NamePrefix returns a prefix to name objects

--- a/test/new-e2e/pkg/runner/mock_profile.go
+++ b/test/new-e2e/pkg/runner/mock_profile.go
@@ -7,7 +7,11 @@
 
 package runner
 
-import "github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
+)
 
 var _ Profile = &mockProfile{}
 
@@ -20,9 +24,9 @@ type mockProfile struct {
 	baseProfile
 }
 
-// RootWorkspacePath returns the root directory for local Pulumi workspace
-func (mp mockProfile) RootWorkspacePath() string {
-	return "mock"
+// GetWorkspacePath returns the root directory for local Pulumi workspace
+func (mp mockProfile) GetWorkspacePath(stackName string) string {
+	return fmt.Sprintf("mock-%s", stackName)
 }
 
 // NamePrefix returns a prefix to name objects

--- a/test/new-e2e/pkg/runner/profile.go
+++ b/test/new-e2e/pkg/runner/profile.go
@@ -7,6 +7,7 @@ package runner
 
 import (
 	"os"
+	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -31,7 +32,7 @@ const (
 )
 
 var (
-	workspaceRootFolder = os.TempDir()
+	workspaceRootFolder = path.Join(os.TempDir(), "pulumi-workspace")
 	runProfile          Profile
 	initProfile         sync.Once
 )

--- a/test/new-e2e/pkg/runner/profile.go
+++ b/test/new-e2e/pkg/runner/profile.go
@@ -31,9 +31,9 @@ const (
 )
 
 var (
-	workspaceFolder = os.TempDir()
-	runProfile      Profile
-	initProfile     sync.Once
+	workspaceRootFolder = os.TempDir()
+	runProfile          Profile
+	initProfile         sync.Once
 )
 
 // Profile interface defines functions required by a profile
@@ -42,8 +42,10 @@ type Profile interface {
 	EnvironmentNames() string
 	// ProjectName used by Pulumi
 	ProjectName() string
-	// RootWorkspacePath returns the root directory for local Pulumi workspace
-	RootWorkspacePath() string
+	// GetWorkspacePath returns the directory for local Pulumi workspace.
+	// Since one Workspace supports one single program and we have one program per stack,
+	// the path should be unique for each stack.
+	GetWorkspacePath(stackName string) string
 	// ParamStore() returns the normal parameter store
 	ParamStore() parameters.Store
 	// SecretStore returns the secure parameter store

--- a/test/new-e2e/pkg/runner/profile.go
+++ b/test/new-e2e/pkg/runner/profile.go
@@ -6,6 +6,9 @@
 package runner
 
 import (
+	"fmt"
+	"hash/fnv"
+	"io"
 	"os"
 	"path"
 	"strconv"
@@ -32,9 +35,9 @@ const (
 )
 
 var (
-	workspaceRootFolder = path.Join(os.TempDir(), "pulumi-workspace")
-	runProfile          Profile
-	initProfile         sync.Once
+	defaultWorkspaceRootFolder = path.Join(os.TempDir(), "pulumi-workspace")
+	runProfile                 Profile
+	initProfile                sync.Once
 )
 
 // Profile interface defines functions required by a profile
@@ -59,17 +62,19 @@ type Profile interface {
 
 // Shared implementations for common profiles methods
 type baseProfile struct {
-	projectName  string
-	environments []string
-	store        parameters.Store
-	secretStore  parameters.Store
+	projectName         string
+	environments        []string
+	store               parameters.Store
+	secretStore         parameters.Store
+	workspaceRootFolder string
 }
 
 func newProfile(projectName string, environments []string, store parameters.Store, secretStore *parameters.Store) baseProfile {
 	p := baseProfile{
-		projectName:  projectName,
-		environments: environments,
-		store:        store,
+		projectName:         projectName,
+		environments:        environments,
+		store:               store,
+		workspaceRootFolder: defaultWorkspaceRootFolder,
 	}
 
 	if secretStore == nil {
@@ -99,6 +104,19 @@ func (p baseProfile) ParamStore() parameters.Store {
 // SecretStore returns the secret parameters store
 func (p baseProfile) SecretStore() parameters.Store {
 	return p.secretStore
+}
+
+// GetWorkspacePath returns the directory for CI Pulumi workspace.
+// Since one Workspace supports one single program and we have one program per stack,
+// the path should be unique for each stack.
+func (p baseProfile) GetWorkspacePath(stackName string) string {
+	return path.Join(p.workspaceRootFolder, hashString(stackName))
+}
+
+func hashString(s string) string {
+	hasher := fnv.New64a()
+	_, _ = io.WriteString(hasher, s)
+	return fmt.Sprintf("%016x", hasher.Sum64())
 }
 
 // GetProfile return a profile initialising it at first call

--- a/test/new-e2e/pkg/runner/profile_test.go
+++ b/test/new-e2e/pkg/runner/profile_test.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package runner
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
+)
+
+func TestGetWorkspacePath(t *testing.T) {
+	type args struct {
+		stackName string
+	}
+	mp := newMockProfile(map[parameters.StoreKey]string{})
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "default",
+			args: args{stackName: "test"},
+			want: "mock/f9e6e6ef197c2b25",
+		},
+		{
+			name: "emojis and special characters",
+			args: args{stackName: "😎🚚/\\//    *"},
+			want: "mock/36353ef968c3b874",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mp.GetWorkspacePath(tt.args.stackName); got != tt.want {
+				t.Errorf("baseProfile.GetWorkspacePath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/new-e2e/pkg/utils/infra/stack_manager.go
+++ b/test/new-e2e/pkg/utils/infra/stack_manager.go
@@ -260,7 +260,13 @@ func buildWorkspace(ctx context.Context, profile runner.Profile, stackName strin
 		},
 	}
 
-	return auto.NewLocalWorkspace(ctx, auto.Project(project), auto.Program(runFunc), auto.WorkDir(profile.RootWorkspacePath()))
+	// create workspace directory
+	workspaceStackDir := profile.GetWorkspacePath(stackName)
+	if err := os.MkdirAll(workspaceStackDir, 0o700); err != nil {
+		return nil, fmt.Errorf("unable to create temporary folder at: %s, err: %w", workspaceStackDir, err)
+	}
+
+	return auto.NewLocalWorkspace(ctx, auto.Project(project), auto.Program(runFunc), auto.WorkDir(workspaceStackDir))
 }
 
 func buildStackName(namePrefix, stackName string) string {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Create one workspace per stack, to avoid race conditions on common `Pulumi.yaml`. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We currently use one common Pulumi workspace for all tests. Each test defines one Pulumi stack, and each Pulumi stack has its own Pulumi program, aka the run function.

The problem is a Pulumi workspace supports multiple stacks, but one single program across all stacks

> To enable a broad range of runtime customization the API defines a Workspace interface. A Workspace is the execution context containing a single Pulumi project, a program, and multiple stacks. Workspaces are used to manage the execution environment, providing various utilities such as plugin installation, environment configuration ($PULUMI_HOME), and creation, deletion, and listing of Stacks.

Source: https://www.pulumi.com/docs/using-pulumi/automation-api/concepts-terminology/#workspace

We recently changed the lock logic around stacks, allowing running multiple stacks in parallel. This has the advantage of using the same runner to run multiple e2e tests in parallel. But it also raised flakiness on some e2e tests jobs, running multiple stacks in parallel.

Here is an example of failing job: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/361860810#L503

The error is reported when accessing `/tmp/Pulumi.yaml`. While each stack has its own `Pulumi.<stack>.yaml`, there is one single `/tmp/Pulumi.yaml` per workspace. If multiple stacks access this file, they break code execution causing a race condition in accessing and modifying the workspace file.

For this reason, we now have one workspace per stack. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

This change has the disadvantage of requiring one extra step to list all existing stacks on a host. The cleanup task was updated and tested to support cleaning both legacy and new implementation.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
