### PR TITLE
Add tests for Cloud Foundry `workloadmeta` collectors

### DIFF
--- a/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_container/cloudfoundry_container.go
+++ b/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_container/cloudfoundry_container.go
@@ -2,8 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
-
-package cloudfoundry_container
+package container
 
 import (
 	"context"

--- a/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_container/cloudfoundry_container_test.go
+++ b/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_container/cloudfoundry_container_test.go
@@ -21,8 +21,7 @@ func (store *fakeWorkloadmetaStore) Notify(events []workloadmeta.CollectorEvent)
 	store.notifiedEvents = append(store.notifiedEvents, events...)
 }
 
-func TestStart(t *testing.T) {
-
+func TestStartError(t *testing.T) {
 	workloadmetaStore := fakeWorkloadmetaStore{}
 	c := collector{
 		store: &workloadmetaStore,

--- a/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_container/cloudfoundry_container_test.go
+++ b/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_container/cloudfoundry_container_test.go
@@ -1,4 +1,8 @@
-package cloudfoundry_container
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+package container
 
 import (
 	"context"

--- a/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_container/cloudfoundry_container_test.go
+++ b/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_container/cloudfoundry_container_test.go
@@ -1,0 +1,52 @@
+package cloudfoundry_container
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeWorkloadmetaStore struct {
+	workloadmeta.Store
+	notifiedEvents []workloadmeta.CollectorEvent
+}
+
+func (store *fakeWorkloadmetaStore) Notify(events []workloadmeta.CollectorEvent) {
+	store.notifiedEvents = append(store.notifiedEvents, events...)
+}
+
+func TestStart(t *testing.T) {
+
+	workloadmetaStore := fakeWorkloadmetaStore{}
+	c := collector{
+		store: &workloadmetaStore,
+	}
+
+	err := c.Start(context.TODO(), &workloadmetaStore)
+	assert.Error(t, err)
+}
+
+func TestPull(t *testing.T) {
+	workloadmetaStore := fakeWorkloadmetaStore{}
+	fakeNodeName := "fake-hostname"
+
+	c := collector{
+		store:    &workloadmetaStore,
+		nodeName: fakeNodeName,
+	}
+
+	err := c.Pull(context.TODO())
+	assert.NoError(t, err)
+	assert.NotEmpty(t, workloadmetaStore.notifiedEvents)
+
+	event0 := workloadmetaStore.notifiedEvents[0]
+
+	assert.Equal(t, event0.Type, workloadmeta.EventTypeSet)
+	assert.Equal(t, event0.Source, workloadmeta.SourceClusterOrchestrator)
+
+	containerEntity, ok := event0.Entity.(*workloadmeta.Container)
+	assert.True(t, ok)
+	assert.Equal(t, containerEntity.ID, fakeNodeName)
+}

--- a/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_vm/cloudfoundry_vm.go
+++ b/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_vm/cloudfoundry_vm.go
@@ -2,8 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
-
-package cloudfoundry_vm
+package vm
 
 import (
 	"context"

--- a/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_vm/cloudfoundry_vm_test.go
+++ b/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_vm/cloudfoundry_vm_test.go
@@ -245,6 +245,7 @@ func TestPullActiveContainer(t *testing.T) {
 	assert.True(t, ok)
 
 	assert.Equal(t, containerEntity.Kind, workloadmeta.KindContainer)
+	assert.Equal(t, containerEntity.Runtime, workloadmeta.ContainerRuntimeGarden)
 	assert.Equal(t, containerEntity.ID, activeContainer.Handle())
 	assert.Equal(t, containerEntity.State.Status, workloadmeta.ContainerStatusRunning)
 	assert.True(t, containerEntity.State.Running)
@@ -281,6 +282,7 @@ func TestPullStoppedContainer(t *testing.T) {
 	assert.True(t, ok)
 
 	assert.Equal(t, containerEntity.Kind, workloadmeta.KindContainer)
+	assert.Equal(t, containerEntity.Runtime, workloadmeta.ContainerRuntimeGarden)
 	assert.Equal(t, containerEntity.ID, stoppedContainer.Handle())
 	assert.Equal(t, containerEntity.State.Status, workloadmeta.ContainerStatusStopped)
 	assert.False(t, containerEntity.State.Running)

--- a/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_vm/cloudfoundry_vm_test.go
+++ b/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_vm/cloudfoundry_vm_test.go
@@ -193,7 +193,7 @@ func (f *FakeDCAClient) PostLanguageMetadata(_ context.Context, _ *pbgo.ParentLa
 	panic("implement me")
 }
 
-func TestStart(t *testing.T) {
+func TestStartError(t *testing.T) {
 	fakeGardenUtil := FakeGardenUtil{}
 
 	workloadmetaStore := fakeWorkloadmetaStore{}

--- a/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_vm/cloudfoundry_vm_test.go
+++ b/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_vm/cloudfoundry_vm_test.go
@@ -196,10 +196,7 @@ func TestStart(t *testing.T) {
 }
 
 func TestPullNoContainers(t *testing.T) {
-	containers := []garden.Container{}
-	fakeGardenUtil := FakeGardenUtil{
-		containers: containers,
-	}
+	fakeGardenUtil := FakeGardenUtil{containers: nil}
 	fakeDCAClient := FakeDCAClient{}
 	workloadmetaStore := fakeWorkloadmetaStore{}
 

--- a/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_vm/cloudfoundry_vm_test.go
+++ b/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_vm/cloudfoundry_vm_test.go
@@ -1,4 +1,8 @@
-package cloudfoundry_vm
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+package vm
 
 import (
 	"context"
@@ -13,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/exp/slices"
 )
 
 var activeContainer = gardenfakes.FakeContainer{
@@ -67,6 +72,9 @@ func (f *FakeGardenUtil) GetContainersInfo(handles []string) (map[string]garden.
 	containersInfo := make(map[string]garden.ContainerInfoEntry)
 	for _, container := range f.containers {
 		handle := container.Handle()
+		if !slices.Contains(handles, handle) {
+			continue
+		}
 		info, err := container.Info()
 		entry := garden.ContainerInfoEntry{
 			Info: info,
@@ -79,7 +87,7 @@ func (f *FakeGardenUtil) GetContainersInfo(handles []string) (map[string]garden.
 	return containersInfo, nil
 }
 
-func (f *FakeGardenUtil) GetContainersMetrics(handles []string) (map[string]garden.ContainerMetricsEntry, error) {
+func (f *FakeGardenUtil) GetContainersMetrics(_ []string) (map[string]garden.ContainerMetricsEntry, error) {
 	return map[string]garden.ContainerMetricsEntry{}, nil
 
 }
@@ -138,35 +146,35 @@ func (f *FakeDCAClient) GetVersion() (version.Version, error) {
 	panic("implement me")
 }
 
-func (f *FakeDCAClient) GetNodeLabels(nodeName string) (map[string]string, error) {
+func (f *FakeDCAClient) GetNodeLabels(_ string) (map[string]string, error) {
 	panic("implement me")
 }
 
-func (f *FakeDCAClient) GetNodeAnnotations(nodeName string) (map[string]string, error) {
+func (f *FakeDCAClient) GetNodeAnnotations(_ string) (map[string]string, error) {
 	panic("implement me")
 }
 
-func (f *FakeDCAClient) GetNamespaceLabels(nsName string) (map[string]string, error) {
+func (f *FakeDCAClient) GetNamespaceLabels(_ string) (map[string]string, error) {
 	panic("implement me")
 }
 
-func (f *FakeDCAClient) GetPodsMetadataForNode(nodeName string) (apiv1.NamespacesPodsStringsSet, error) {
+func (f *FakeDCAClient) GetPodsMetadataForNode(_ string) (apiv1.NamespacesPodsStringsSet, error) {
 	panic("implement me")
 }
 
-func (f *FakeDCAClient) GetKubernetesMetadataNames(nodeName, ns, podName string) ([]string, error) {
+func (f *FakeDCAClient) GetKubernetesMetadataNames(_, _, _ string) ([]string, error) {
 	panic("implement me")
 }
 
-func (f *FakeDCAClient) PostClusterCheckStatus(ctx context.Context, identifier string, status types.NodeStatus) (types.StatusResponse, error) {
+func (f *FakeDCAClient) PostClusterCheckStatus(_ context.Context, _ string, _ types.NodeStatus) (types.StatusResponse, error) {
 	panic("implement me")
 }
 
-func (f *FakeDCAClient) GetClusterCheckConfigs(ctx context.Context, identifier string) (types.ConfigResponse, error) {
+func (f *FakeDCAClient) GetClusterCheckConfigs(_ context.Context, _ string) (types.ConfigResponse, error) {
 	panic("implement me")
 }
 
-func (f *FakeDCAClient) GetEndpointsCheckConfigs(ctx context.Context, nodeName string) (types.ConfigResponse, error) {
+func (f *FakeDCAClient) GetEndpointsCheckConfigs(_ context.Context, _ string) (types.ConfigResponse, error) {
 	panic("implement me")
 }
 
@@ -174,7 +182,7 @@ func (f *FakeDCAClient) GetKubernetesClusterID() (string, error) {
 	panic("implement me")
 }
 
-func (f *FakeDCAClient) GetCFAppsMetadataForNode(nodename string) (map[string][]string, error) {
+func (f *FakeDCAClient) GetCFAppsMetadataForNode(_ string) (map[string][]string, error) {
 	return map[string][]string{
 		activeContainer.Handle():  {"container_name:active-container-app"},
 		stoppedContainer.Handle(): {"container_name:stopped-container-app"},

--- a/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_vm/cloudfoundry_vm_test.go
+++ b/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_vm/cloudfoundry_vm_test.go
@@ -1,0 +1,111 @@
+package cloudfoundry_vm
+
+import (
+	"context"
+
+	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+// type collector struct {
+// 	store workloadmeta.Store
+// 	seen  map[workloadmeta.EntityID]struct{}
+
+// 	gardenUtil cloudfoundry.GardenUtilInterface
+// 	nodeName   string
+
+// 	dcaClient  clusteragent.DCAClientInterface
+// 	dcaEnabled bool
+// }
+
+type FakeDCAClient struct {
+	LocalVersion                 version.Version
+	LocalClusterAgentAPIEndpoint string
+
+	VersionErr error
+
+	NodeLabels    map[string]string
+	NodeLabelsErr error
+
+	NodeAnnotations    map[string]string
+	NodeAnnotationsErr error
+
+	NamespaceLabels    map[string]string
+	NamespaceLabelsErr error
+
+	PodMetadataForNode    apiv1.NamespacesPodsStringsSet
+	PodMetadataForNodeErr error
+
+	KubernetesMetadataNames    []string
+	KubernetesMetadataNamesErr error
+
+	ClusterCheckStatus    types.StatusResponse
+	ClusterCheckStatusErr error
+
+	ClusterCheckConfigs    types.ConfigResponse
+	ClusterCheckConfigsErr error
+
+	EndpointsCheckConfigs    types.ConfigResponse
+	EndpointsCheckConfigsErr error
+
+	ClusterID    string
+	ClusterIDErr error
+}
+
+func (f *FakeDCAClient) Version() version.Version {
+	panic("implement me")
+}
+
+func (f *FakeDCAClient) ClusterAgentAPIEndpoint() string {
+	panic("implement me")
+}
+
+func (f *FakeDCAClient) GetVersion() (version.Version, error) {
+	panic("implement me")
+}
+
+func (f *FakeDCAClient) GetNodeLabels(nodeName string) (map[string]string, error) {
+	panic("implement me")
+}
+
+func (f *FakeDCAClient) GetNodeAnnotations(nodeName string) (map[string]string, error) {
+	panic("implement me")
+}
+
+func (f *FakeDCAClient) GetNamespaceLabels(nsName string) (map[string]string, error) {
+	panic("implement me")
+}
+
+func (f *FakeDCAClient) GetPodsMetadataForNode(nodeName string) (apiv1.NamespacesPodsStringsSet, error) {
+	panic("implement me")
+}
+
+func (f *FakeDCAClient) GetKubernetesMetadataNames(nodeName, ns, podName string) ([]string, error) {
+	panic("implement me")
+}
+
+func (f *FakeDCAClient) PostClusterCheckStatus(ctx context.Context, identifier string, status types.NodeStatus) (types.StatusResponse, error) {
+	panic("implement me")
+}
+
+func (f *FakeDCAClient) GetClusterCheckConfigs(ctx context.Context, identifier string) (types.ConfigResponse, error) {
+	panic("implement me")
+}
+
+func (f *FakeDCAClient) GetEndpointsCheckConfigs(ctx context.Context, nodeName string) (types.ConfigResponse, error) {
+	panic("implement me")
+}
+
+func (f *FakeDCAClient) GetKubernetesClusterID() (string, error) {
+	panic("implement me")
+}
+
+func (f *FakeDCAClient) GetCFAppsMetadataForNode(_ string) (map[string][]string, error) {
+	panic("implement me")
+}
+
+func (f *FakeDCAClient) PostLanguageMetadata(_ context.Context, _ *pbgo.ParentLanguageAnnotationRequest) error {
+	panic("implement me")
+}

--- a/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_vm/cloudfoundry_vm_test.go
+++ b/pkg/workloadmeta/collectors/internal/cloudfoundry/cf_vm/cloudfoundry_vm_test.go
@@ -176,8 +176,8 @@ func (f *FakeDCAClient) GetKubernetesClusterID() (string, error) {
 
 func (f *FakeDCAClient) GetCFAppsMetadataForNode(nodename string) (map[string][]string, error) {
 	return map[string][]string{
-		activeContainer.Handle():  []string{"container_name:active-container-app"},
-		stoppedContainer.Handle(): []string{"container_name:stopped-container-app"},
+		activeContainer.Handle():  {"container_name:active-container-app"},
+		stoppedContainer.Handle(): {"container_name:stopped-container-app"},
 	}, nil
 }
 
@@ -355,18 +355,8 @@ func TestPullAppNameWithDCA(t *testing.T) {
 	assert.NotEmpty(t, workloadmetaStore.notifiedEvents)
 
 	event0 := workloadmetaStore.notifiedEvents[0]
-
-	assert.Equal(t, event0.Type, workloadmeta.EventTypeSet)
-	assert.Equal(t, event0.Source, workloadmeta.SourceClusterOrchestrator)
-
 	containerEntity, ok := event0.Entity.(*workloadmeta.Container)
 	assert.True(t, ok)
-
-	assert.Equal(t, containerEntity.Kind, workloadmeta.KindContainer)
-	assert.Equal(t, containerEntity.ID, activeContainer.Handle())
-	assert.Equal(t, containerEntity.State.Status, workloadmeta.ContainerStatusRunning)
-	assert.True(t, containerEntity.State.Running)
-	assert.NotEmpty(t, containerEntity.CollectorTags)
 	assert.Contains(t, containerEntity.CollectorTags, "container_name:active-container-app")
 }
 
@@ -392,17 +382,7 @@ func TestPullAppNameWitoutDCA(t *testing.T) {
 	assert.NotEmpty(t, workloadmetaStore.notifiedEvents)
 
 	event0 := workloadmetaStore.notifiedEvents[0]
-
-	assert.Equal(t, event0.Type, workloadmeta.EventTypeSet)
-	assert.Equal(t, event0.Source, workloadmeta.SourceClusterOrchestrator)
-
 	containerEntity, ok := event0.Entity.(*workloadmeta.Container)
 	assert.True(t, ok)
-
-	assert.Equal(t, containerEntity.Kind, workloadmeta.KindContainer)
-	assert.Equal(t, containerEntity.ID, activeContainer.Handle())
-	assert.Equal(t, containerEntity.State.Status, workloadmeta.ContainerStatusRunning)
-	assert.True(t, containerEntity.State.Running)
-	assert.NotEmpty(t, containerEntity.CollectorTags)
 	assert.Contains(t, containerEntity.CollectorTags, fmt.Sprintf("container_name:%s", activeContainer.Handle()))
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Adds tests for the Cloud Foundry VM & Container collectors under the `workloadmeta` component.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Improve our testing coverage.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
