### PR TITLE
Remove load balancer and API Key checks in status tests

### DIFF
--- a/test/new-e2e/tests/agent-subcommands/subcommands_test.go
+++ b/test/new-e2e/tests/agent-subcommands/subcommands_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/fakeintake/fakeintakeparams"
 
 	"github.com/cenkalti/backoff"
 	"github.com/stretchr/testify/assert"
@@ -29,7 +30,7 @@ type subcommandWithFakeIntakeSuite struct {
 
 func TestSubcommandSuite(t *testing.T) {
 	e2e.Run(t, &subcommandSuite{}, e2e.AgentStackDef())
-	e2e.Run(t, &subcommandWithFakeIntakeSuite{}, e2e.FakeIntakeStackDef())
+	e2e.Run(t, &subcommandWithFakeIntakeSuite{}, e2e.FakeIntakeStackDef(e2e.WithFakeIntakeParams(fakeintakeparams.WithoutLoadBalancer())))
 }
 
 // section contains the content status of a specific section (e.g. Forwarder)
@@ -144,9 +145,8 @@ func (v *subcommandSuite) TestDefaultInstallStatus() {
 			shouldNotContain: []string{"No endpoints information. The agent may be misconfigured."},
 		},
 		{
-			name:             "Forwarder",
-			shouldBePresent:  true,
-			shouldNotContain: []string{"API Keys errors"},
+			name:            "Forwarder",
+			shouldBePresent: true,
 		},
 		{
 			name:            "JMXFetch",


### PR DESCRIPTION
### What does this PR do?

Don't create a Load balancer when running these tests + remove a check 

### Motivation

- LB does not provide value + removal is super slow
- Forwarder check is failing because we don't use the fakeintake anymore

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
