### PR TITLE
pkg/trace/api: fix container tagging over UDS

### DIFF
--- a/pkg/trace/api/container_linux.go
+++ b/pkg/trace/api/container_linux.go
@@ -29,6 +29,9 @@ type ucredKey struct{}
 //
 // If the connection c is not a *net.UnixConn, the unchanged context is returned.
 func connContext(ctx context.Context, c net.Conn) context.Context {
+	if oc, ok := c.(*onCloseConn); ok {
+		c = oc.Conn
+	}
 	s, ok := c.(*net.UnixConn)
 	if !ok {
 		return ctx

--- a/pkg/trace/api/container_linux_test.go
+++ b/pkg/trace/api/container_linux_test.go
@@ -51,6 +51,7 @@ func TestConnContext(t *testing.T) {
 	if err := os.Chmod(sockPath, 0o722); err != nil {
 		t.Fatalf("error setting socket permissions: %v", err)
 	}
+	ln = NewMeasuredListener(ln, "uds_connections", 10)
 	defer ln.Close()
 
 	s := &http.Server{

--- a/pkg/trace/api/listener.go
+++ b/pkg/trace/api/listener.go
@@ -8,6 +8,7 @@ package api
 import (
 	"errors"
 	"net"
+	"sync"
 	"time"
 
 	"go.uber.org/atomic"
@@ -26,6 +27,7 @@ type measuredListener struct {
 	errored  *atomic.Uint32 // errored connection count
 	exit     chan struct{}  // exit signal channel (on Close call)
 	sem      chan struct{}  // Used to limit active connections
+	stop     sync.Once
 }
 
 // NewMeasuredListener wraps ln and emits metrics every 10 seconds. The metric name is
@@ -52,7 +54,6 @@ func NewMeasuredListener(ln net.Listener, name string, maxConn int) net.Listener
 func (ln *measuredListener) run() {
 	tick := time.NewTicker(10 * time.Second)
 	defer tick.Stop()
-	defer close(ln.exit)
 	for {
 		select {
 		case <-tick.C:
@@ -112,16 +113,17 @@ func (ln *measuredListener) Accept() (net.Conn, error) {
 }
 
 // Close implements net.Listener.
-func (ln measuredListener) Close() error {
+func (ln *measuredListener) Close() error {
 	err := ln.Listener.Close()
 	ln.flushMetrics()
-	ln.exit <- struct{}{}
-	<-ln.exit
+	ln.stop.Do(func() {
+		close(ln.exit)
+	})
 	return err
 }
 
 // Addr implements net.Listener.
-func (ln measuredListener) Addr() net.Addr { return ln.Listener.Addr() }
+func (ln *measuredListener) Addr() net.Addr { return ln.Listener.Addr() }
 
 // rateLimitedListener wraps a regular TCPListener with rate limiting.
 type rateLimitedListener struct {

--- a/releasenotes/notes/fix-uds-tagging-ca55006e201cb283.yaml
+++ b/releasenotes/notes/fix-uds-tagging-ca55006e201cb283.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: fix a regression in the Trace Agent, causing container tagging
+    with UDS and cgroup v2 to fail

--- a/releasenotes/notes/fix-uds-tagging-ca55006e201cb283.yaml
+++ b/releasenotes/notes/fix-uds-tagging-ca55006e201cb283.yaml
@@ -8,5 +8,5 @@
 ---
 fixes:
   - |
-    APM: fix a regression in the Trace Agent, causing container tagging
+    APM: fix a regression in the Trace Agent that caused container tagging
     with UDS and cgroup v2 to fail


### PR DESCRIPTION
### What does this PR do?

This commit correctly checks for the new connection type and pulls the UDS credentials out of it.

### Motivation

We introduced a new connection type in #17917 which caused our special case for UDS to fail, resulting in the loss of container tags for users using UDS container tagging on cgroup v2 hosts.


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
