### PR TITLE
[OTEL-1174] Include apm.trace_buffer in config_template.yaml

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1572,6 +1572,12 @@ api_key:
   # - ns2
   # - system-ns
 
+  ## @param trace_buffer - integer - optional
+  ## @env DD_APM_TRACE_BUFFER - integer - optional
+  ## Specifies the size of trace payloads to buffer before dropping them. If unset, trace payloads are unbuffered.
+  #
+  # trace_buffer: 100
+
   {{- if .InternalProfiling -}}
   ## @param profiling - custom object - optional
   ## Enter specific configurations for internal profiling.


### PR DESCRIPTION
### What does this PR do?

[OTEL-1174](https://datadoghq.atlassian.net/browse/OTEL-1174) Include apm.trace_buffer in config_template.yaml

### Motivation

The config `apm.trace_buffer` is useful to prevent trace payloads from being dropped in trace agent, especially for OTLP traces.
https://github.com/DataDog/datadog-agent/blob/94bf73e2c594c18b6568b5892ddb51ee4349fdcb/comp/trace/config/setup.go#L274-L275  
However it is not documented in config_template.yaml. This PR adds it.

### Additional Notes

This config exists for a long time. It just lacks documentation.

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.


[OTEL-1174]: https://datadoghq.atlassian.net/browse/OTEL-1174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ