### PR TITLE
[CWS] ensure `struct path_leaf_t` has the same size on go and C sides

### DIFF
--- a/pkg/security/ebpf/c/include/structs/dentry_resolver.h
+++ b/pkg/security/ebpf/c/include/structs/dentry_resolver.h
@@ -9,7 +9,7 @@ struct path_key_t {
     u32 path_id;
 };
 
-struct __attribute__((__packed__)) path_leaf_t {
+struct path_leaf_t {
   struct path_key_t parent;
   char name[DR_MAX_SEGMENT_LENGTH + 1];
   u16 len;

--- a/pkg/security/ebpf/c/include/structs/dentry_resolver.h
+++ b/pkg/security/ebpf/c/include/structs/dentry_resolver.h
@@ -9,7 +9,7 @@ struct path_key_t {
     u32 path_id;
 };
 
-struct path_leaf_t {
+struct __attribute__((__packed__)) path_leaf_t {
   struct path_key_t parent;
   char name[DR_MAX_SEGMENT_LENGTH + 1];
   u16 len;

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -842,9 +842,10 @@ const PathLeafSize = PathKeySize + MaxSegmentLength + 1 + 2 + 6 // path_key + na
 
 // PathLeaf is the go representation of the eBPF path_leaf_t structure
 type PathLeaf struct {
-	Parent PathKey
-	Name   [MaxSegmentLength + 1]byte
-	Len    uint16
+	Parent  PathKey
+	Name    [MaxSegmentLength + 1]byte
+	Len     uint16
+	Padding [6]uint8
 }
 
 // GetName returns the path value as a string


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Starting with cilium/ebpf v0.12.2 the iterator and lookup methods on maps are more strict on the size of objects, especially failing if the size is not what is expected by the map.

This was for example the case with `struct path_leaf_t` that had some padding at the end meaning that the C and the Go sides were disagreeing on the size of the struct.

This PR fixes this issue by matching the padding on the Go side. We could also pack the struct, but this could result in unaligned memory access which would be not great.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
