### PR TITLE
Pre-allocate `eventsBySourceType` to events length

### DIFF
--- a/pkg/serializer/internal/metrics/events.go
+++ b/pkg/serializer/internal/metrics/events.go
@@ -67,7 +67,7 @@ func (events Events) Marshal() ([]byte, error) {
 }
 
 func (events Events) getEventsBySourceType() map[string][]*event.Event {
-	eventsBySourceType := make(map[string][]*event.Event)
+	eventsBySourceType := make(map[string][]*event.Event, len(events))
 	for _, e := range events {
 		sourceTypeName := e.SourceTypeName
 		if sourceTypeName == "" {


### PR DESCRIPTION
### What does this PR do?

This commit pre-allocates a temporary type that is used only temporarily when marshalling events to JSON in a non-streaming fashion. Profiles suggest it's an allocation/CPU center. This change only marginally improves the micro-benchmarks, shaving 1/8 of the time off, from 8 seconds to 7, without adjusting allocations.

### Additional Notes

A comment in the code suggests that the function will be removed when v2 of the API is available, so perhaps this function does need removed now.
