### PR TITLE
[Do not merge] Decouple pulumi from E2E framework

### DIFF
--- a/test/new-e2e/examples/customenv_with_filemanager_test.go
+++ b/test/new-e2e/examples/customenv_with_filemanager_test.go
@@ -24,7 +24,7 @@ type fileManagerSuiteEx7 struct {
 	e2e.Suite[e2e.VMEnv]
 }
 
-func fileManagerVMStackDef(localFolderPath string, remoteFolderPath string) *e2e.StackDefinition[e2e.VMEnv] {
+func fileManagerVMStackDef(localFolderPath string, remoteFolderPath string) e2e.InfraProvider[e2e.VMEnv] {
 	return e2e.EnvFactoryStackDef(func(ctx *pulumi.Context) (*e2e.VMEnv, error) {
 		vm, err := ec2vm.NewEc2VM(ctx, ec2params.WithOS(ec2os.UbuntuOS))
 		if err != nil {

--- a/test/new-e2e/examples/customenv_with_two_vm_test.go
+++ b/test/new-e2e/examples/customenv_with_two_vm_test.go
@@ -22,7 +22,7 @@ type multiVMEnv struct {
 	AppVM  client.VM
 }
 
-func multiEC2VMStackDef() *e2e.StackDefinition[multiVMEnv] {
+func multiEC2VMStackDef() e2e.InfraProvider[multiVMEnv] {
 	return e2e.EnvFactoryStackDef(func(ctx *pulumi.Context) (*multiVMEnv, error) {
 		mainVM, err := ec2vm.NewEc2VM(ctx, ec2params.WithOS(ec2os.UbuntuOS), ec2params.WithName("main"))
 		if err != nil {

--- a/test/new-e2e/pkg/utils/e2e/e2e_test.go
+++ b/test/new-e2e/pkg/utils/e2e/e2e_test.go
@@ -18,7 +18,7 @@ type e2eSuite struct {
 	*Suite[struct{}]
 	stackName       string
 	runFctCallCount int
-	updateEnvStack  *StackDefinition[struct{}]
+	updateEnvStack  InfraProvider[struct{}]
 }
 
 func TestE2ESuite(t *testing.T) {
@@ -54,7 +54,7 @@ func (s *e2eSuite) Test3_UpdateEnv() {
 	s.Require().Equal(2, s.runFctCallCount)
 }
 
-func (s *e2eSuite) createStack(stackName string) *StackDefinition[struct{}] {
+func (s *e2eSuite) createStack(stackName string) InfraProvider[struct{}] {
 	return EnvFactoryStackDef(func(ctx *pulumi.Context) (*struct{}, error) {
 		s.stackName = stackName
 		s.runFctCallCount++
@@ -91,14 +91,14 @@ func (s *skipDeleteOnFailureSuite) Test3() {
 	s.UpdateEnv(s.updateStack("Test3"))
 }
 
-func (s *skipDeleteOnFailureSuite) updateStack(testName string) *StackDefinition[struct{}] {
+func (s *skipDeleteOnFailureSuite) updateStack(testName string) InfraProvider[struct{}] {
 	return EnvFactoryStackDef(func(ctx *pulumi.Context) (*struct{}, error) {
 		s.testsRun = append(s.testsRun, testName)
 		return &struct{}{}, nil
 	})
 }
 
-func newSuite[Env any](stackName string, stackDef *StackDefinition[Env], options ...params.Option) *Suite[Env] {
+func newSuite[Env any](stackName string, stackDef InfraProvider[Env], options ...params.Option) *Suite[Env] {
 	testSuite := Suite[Env]{}
 	testSuite.initSuite(stackName, stackDef, options...)
 	return &testSuite

--- a/test/new-e2e/pkg/utils/e2e/infra_provider.go
+++ b/test/new-e2e/pkg/utils/e2e/infra_provider.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package e2e
+
+import (
+	"context"
+	"testing"
+)
+
+// InfraProvider is an interface that provides methods for managing testing infrastructure
+type InfraProvider[Env any] interface {
+	ProvisionInfraAndInitializeEnv(ctx context.Context, t *testing.T, name string, failOnMissing bool) (*Env, error)
+	DeleteInfra(ctx context.Context, name string) error
+}

--- a/test/new-e2e/pkg/utils/e2e/params/params.go
+++ b/test/new-e2e/pkg/utils/e2e/params/params.go
@@ -8,7 +8,7 @@ package params
 
 // Params implements [e2e.Suite] options
 type Params struct {
-	StackName string
+	Name string
 
 	// Setting DevMode allows to skip deletion regardless of test results
 	// Unavailable in CI.
@@ -20,11 +20,11 @@ type Params struct {
 // Option is an optional function parameter type for e2e options
 type Option = func(*Params)
 
-// WithStackName overrides the default stack name.
+// WithName overrides the default infrastructure name.
 // This function is useful only when using [Run].
-func WithStackName(stackName string) func(*Params) {
+func WithName(name string) func(*Params) {
 	return func(options *Params) {
-		options.StackName = stackName
+		options.Name = name
 	}
 }
 

--- a/test/new-e2e/pkg/utils/e2e/pulumi_provider.go
+++ b/test/new-e2e/pkg/utils/e2e/pulumi_provider.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/infra"
+)
+
+var _ InfraProvider[int] = (*PulumiProvider[int])(nil)
+
+// PulumiProvider leverages pulumi to create and manage testing infrastructure
+type PulumiProvider[Env any] struct {
+	envFactory func(ctx *pulumi.Context) (*Env, error)
+	configMap  runner.ConfigMap
+
+	stackManager *infra.StackManager
+}
+
+// NewPulumiProvider returns a new PulumiProvider
+func NewPulumiProvider[Env any](envFactory func(ctx *pulumi.Context) (*Env, error), configMap runner.ConfigMap) *PulumiProvider[Env] {
+	return &PulumiProvider[Env]{
+		envFactory:   envFactory,
+		configMap:    configMap,
+		stackManager: infra.GetStackManager(),
+	}
+}
+
+// ProvisionInfraAndInitializeEnv uses a pulumi stack manager to initialize a pulumi stack & pass the resulting UpResult to
+// any clients in the environment which implement the pulumiStackInitializer interface
+func (ps *PulumiProvider[Env]) ProvisionInfraAndInitializeEnv(ctx context.Context, t *testing.T, name string, failOnMissing bool) (*Env, error) {
+	var env *Env
+
+	deployFunc := func(ctx *pulumi.Context) error {
+		var err error
+		env, err = ps.envFactory(ctx)
+		return err
+	}
+	_, stackResult, err := ps.stackManager.GetStackNoDeleteOnFailure(ctx, name, ps.configMap, deployFunc, failOnMissing)
+	if err != nil {
+		return nil, err
+	}
+
+	err = client.CallStackInitializers(t, env, stackResult)
+	return env, err
+}
+
+// DeleteInfra deletes the pulumi stack
+func (ps *PulumiProvider[Env]) DeleteInfra(ctx context.Context, name string) error {
+	return ps.stackManager.DeleteStack(ctx, name)
+}

--- a/test/new-e2e/pkg/utils/e2e/stack_definition.go
+++ b/test/new-e2e/pkg/utils/e2e/stack_definition.go
@@ -21,20 +21,9 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-// StackDefinition contains a Pulumi stack definition
-type StackDefinition[Env any] struct {
-	envFactory func(ctx *pulumi.Context) (*Env, error)
-	configMap  runner.ConfigMap
-}
-
-// NewStackDef creates a custom definition
-func NewStackDef[Env any](envFactory func(ctx *pulumi.Context) (*Env, error), configMap runner.ConfigMap) *StackDefinition[Env] {
-	return &StackDefinition[Env]{envFactory: envFactory, configMap: configMap}
-}
-
 // EnvFactoryStackDef creates a custom stack definition
-func EnvFactoryStackDef[Env any](envFactory func(ctx *pulumi.Context) (*Env, error)) *StackDefinition[Env] {
-	return NewStackDef(envFactory, runner.ConfigMap{})
+func EnvFactoryStackDef[Env any](envFactory func(ctx *pulumi.Context) (*Env, error)) InfraProvider[Env] {
+	return NewPulumiProvider(envFactory, runner.ConfigMap{})
 }
 
 // VMEnv contains a VM environment
@@ -46,13 +35,13 @@ type VMEnv struct {
 // See [ec2vm.Params] for available options.
 //
 // [ec2vm.Params]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/scenarios/aws/vm/ec2VM#Params
-func EC2VMStackDef(options ...ec2params.Option) *StackDefinition[VMEnv] {
+func EC2VMStackDef(options ...ec2params.Option) InfraProvider[VMEnv] {
 	noop := func(vm.VM) (VMEnv, error) { return VMEnv{}, nil }
 	return CustomEC2VMStackDef(noop, options...)
 }
 
 // CustomEC2VMStackDef creates a custom stack definition containing a virtual machine
-func CustomEC2VMStackDef[T any](fct func(vm.VM) (T, error), options ...ec2params.Option) *StackDefinition[VMEnv] {
+func CustomEC2VMStackDef[T any](fct func(vm.VM) (T, error), options ...ec2params.Option) InfraProvider[VMEnv] {
 	return EnvFactoryStackDef(func(ctx *pulumi.Context) (*VMEnv, error) {
 		vm, err := ec2vm.NewEc2VM(ctx, options...)
 		if err != nil {
@@ -151,7 +140,7 @@ func WithFakeIntakeParams(options ...fakeintakeparams.Option) func(*AgentStackDe
 // [agentclientparams.Params]: https://pkg.go.dev/github.com/DataDog/datadog-agent@main/test/new-e2e/pkg/utils/e2e/client/agentclientparams#Params
 //
 // [fakeintakeparams.Params]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/components/scenario/aws/fakeintake/fakeintakeparams#Params
-func AgentStackDef(options ...func(*AgentStackDefParam) error) *StackDefinition[AgentEnv] {
+func AgentStackDef(options ...func(*AgentStackDefParam) error) InfraProvider[AgentEnv] {
 	return EnvFactoryStackDef(
 		func(ctx *pulumi.Context) (*AgentEnv, error) {
 			params, err := newAgentStackDefParam(options...)
@@ -181,7 +170,7 @@ func AgentStackDef(options ...func(*AgentStackDefParam) error) *StackDefinition[
 // See [agent.Params] for available options.
 //
 // [agent.Params]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/components/datadog/agent#Params
-func AgentStackDefWithDefaultVMAndAgentClient(options ...agentparams.Option) *StackDefinition[AgentEnv] {
+func AgentStackDefWithDefaultVMAndAgentClient(options ...agentparams.Option) InfraProvider[AgentEnv] {
 	return AgentStackDef(WithAgentParams(options...))
 }
 
@@ -204,7 +193,7 @@ type FakeIntakeEnv struct {
 // [ec2vm.Params]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/scenarios/aws/vm/ec2VM#Params
 // [agent.Params]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/components/datadog/agent#Params
 // [agentclientparams.Params]: https://pkg.go.dev/github.com/DataDog/datadog-agent@main/test/new-e2e/pkg/utils/e2e/client/agentclientparams#Params
-func FakeIntakeStackDef(options ...func(*AgentStackDefParam) error) *StackDefinition[FakeIntakeEnv] {
+func FakeIntakeStackDef(options ...func(*AgentStackDefParam) error) InfraProvider[FakeIntakeEnv] {
 	return EnvFactoryStackDef(
 		func(ctx *pulumi.Context) (*FakeIntakeEnv, error) {
 			params, err := newAgentStackDefParam(options...)
@@ -242,7 +231,7 @@ func FakeIntakeStackDef(options ...func(*AgentStackDefParam) error) *StackDefini
 // See [agent.Params] for available options.
 //
 // [agent.Params]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/components/datadog/agent#Params
-func FakeIntakeStackDefWithDefaultVMAndAgentClient(options ...agentparams.Option) *StackDefinition[FakeIntakeEnv] {
+func FakeIntakeStackDefWithDefaultVMAndAgentClient(options ...agentparams.Option) InfraProvider[FakeIntakeEnv] {
 	return FakeIntakeStackDef(WithAgentParams(options...))
 }
 
@@ -256,7 +245,7 @@ type DockerEnv struct {
 // See [dockerparams.Params] for available options for params.
 //
 // [dockerparams.Params]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/components/datadog/agent/dockerparams#Params
-func DockerStackDef(params ...dockerparams.Option) *StackDefinition[DockerEnv] {
+func DockerStackDef(params ...dockerparams.Option) InfraProvider[DockerEnv] {
 	return EnvFactoryStackDef(
 		func(ctx *pulumi.Context) (*DockerEnv, error) {
 			docker, err := docker.NewDaemon(ctx, params...)

--- a/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
+++ b/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
@@ -69,7 +69,7 @@ func TestInstallScript(t *testing.T) {
 		t.Run(fmt.Sprintf("test install script on %s", osVers), func(tt *testing.T) {
 			tt.Parallel()
 			fmt.Printf("Testing %s", osVers)
-			e2e.Run(tt, &installScriptSuite{cwsSupported: cwsSupported}, e2e.EC2VMStackDef(ec2params.WithImageName(platformJSON[*platform][osVers], e2eOs.AMD64Arch, osMapping[*platform])), params.WithStackName(fmt.Sprintf("install-script-test-%v-%v", os.Getenv("CI_PIPELINE_ID"), osVers)))
+			e2e.Run(tt, &installScriptSuite{cwsSupported: cwsSupported}, e2e.EC2VMStackDef(ec2params.WithImageName(platformJSON[*platform][osVers], e2eOs.AMD64Arch, osMapping[*platform])), params.WithName(fmt.Sprintf("install-script-test-%v-%v", os.Getenv("CI_PIPELINE_ID"), osVers)))
 		})
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Decouples pulumi from the E2E framework by adding the `InfraProvider` interface which abstracts away all pulumi-specific operations.

Existing E2E tests are unaffected by this change, with a few minor exceptions:
- `agent-platform/install-script/install_script_test.go` requires 1 function call to be changed (`WithStackName` -> `WithName`)
    - note that this function was renamed simply in order to make it more generic, but if making this modification is a problem, the name can be changed back.
- the `customenv_with_filemanager_test.go` and `customenv_with_two_vm_test.go` examples require a return type to be changed (`*e2e.StackDefinition` -> `e2e.InfraProvider`)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
