### PR TITLE
[Do not merge] Add local infra provider

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -466,6 +466,11 @@
 /test/kitchen/test/integration/win-user/ @DataDog/windows-agent
 /test/fakeintake/                       @DataDog/agent-e2e-testing
 /test/new-e2e/                          @DataDog/agent-e2e-testing
+/test/new-e2e/pkg/utils/localinfra                              @DataDog/windows-agent @DataDog/windows-kernel-integrations
+/test/new-e2e/pkg/utils/e2e/client/ssh_vm.go                    @DataDog/windows-agent @DataDog/windows-kernel-integrations
+/test/new-e2e/pkg/utils/e2e/client/connection_initializer.go    @DataDog/windows-agent @DataDog/windows-kernel-integrations
+/test/new-e2e/pkg/utils/e2e/local_definition.go                 @DataDog/windows-agent @DataDog/windows-kernel-integrations
+/test/new-e2e/pkg/utils/e2e/local_provider.go                   @DataDog/windows-agent @DataDog/windows-kernel-integrations
 /test/new-e2e/language-detection        @DataDog/processes
 /test/new-e2e/system-probe              @DataDog/ebpf-platform
 /test/new-e2e/scenarios/system-probe    @DataDog/ebpf-platform

--- a/test/new-e2e/examples/vmenv_withlocal_test.go
+++ b/test/new-e2e/examples/vmenv_withlocal_test.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package examples
+
+import (
+	"flag"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/localinfra/localvmparams"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2params"
+	"github.com/stretchr/testify/assert"
+)
+
+var runLocally = flag.Bool("runLocally", false, "run tests on a local VM")
+
+type vmSuiteExample struct {
+	e2e.Suite[e2e.VMEnv]
+}
+
+func TestVMSuiteEx(t *testing.T) {
+	if *runLocally {
+		homeDir, _ := os.UserHomeDir()
+		e2e.Run(t, &vmSuiteExample{}, e2e.LocalVMDef(localvmparams.WithJSONFile(path.Join(homeDir, ".test_config.json"))))
+	} else {
+		e2e.Run(t, &vmSuiteExample{}, e2e.EC2VMStackDef(ec2params.WithOS(ec2os.WindowsOS)))
+	}
+}
+
+func (v *vmSuiteExample) TestItIsWindows() {
+	res := v.Env().VM.Execute("dir C:\\")
+	assert.Contains(v.T(), res, "Windows")
+}

--- a/test/new-e2e/pkg/utils/e2e/client/connection_initializer.go
+++ b/test/new-e2e/pkg/utils/e2e/client/connection_initializer.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package client
+
+import (
+	"fmt"
+	"github.com/DataDog/test-infra-definitions/common/utils"
+	"reflect"
+	"testing"
+)
+
+// connectionInitializer defines a method which is used to initialize an connection between
+// testing infrastructure and clients
+type connectionInitializer interface {
+	// InitFromConnection initializes the instance from ssh connection data.
+	// This method is called by [CallConnectionInitializers] using reflection.
+	initFromConnection(t *testing.T, conns map[string]*utils.Connection) error
+}
+
+// CallConnectionInitializers validates an environment struct and initializes a connection to the testing infrastructure.
+func CallConnectionInitializers[Env any](t *testing.T, env *Env, conns map[string]*utils.Connection) error {
+	fields, err := getFields(env)
+
+	for _, field := range fields {
+		initializer := field.connInitializer
+		if reflect.TypeOf(initializer).Kind() == reflect.Ptr && reflect.ValueOf(initializer).IsNil() {
+			return fmt.Errorf("the field %v of %v is nil", field.name, reflect.TypeOf(env))
+		}
+
+		if err = initializer.initFromConnection(t, conns); err != nil {
+			return err
+		}
+	}
+
+	return err
+}

--- a/test/new-e2e/pkg/utils/e2e/client/pulumi_stack_initializer.go
+++ b/test/new-e2e/pkg/utils/e2e/client/pulumi_stack_initializer.go
@@ -49,6 +49,7 @@ func CallStackInitializers[Env any](t *testing.T, env *Env, upResult auto.UpResu
 
 type field struct {
 	stackInitializer pulumiStackInitializer
+	connInitializer  connectionInitializer
 	name             string
 }
 
@@ -70,11 +71,19 @@ func getFields[Env any](env *Env) ([]field, error) {
 			return nil, fmt.Errorf("the field %v in %v is not exported", fieldName, envType)
 		}
 
-		initializer, ok := envValue.Field(i).Interface().(pulumiStackInitializer)
+		stackInitializer, ok := envValue.Field(i).Interface().(pulumiStackInitializer)
 		if ok {
 			fields = append(fields, field{
-				stackInitializer: initializer,
+				stackInitializer: stackInitializer,
 				name:             fieldName,
+			})
+		}
+
+		connInitializer, ok := envValue.Field(i).Interface().(connectionInitializer)
+		if ok {
+			fields = append(fields, field{
+				connInitializer: connInitializer,
+				name:            fieldName,
 			})
 		}
 	}

--- a/test/new-e2e/pkg/utils/e2e/client/ssh_vm.go
+++ b/test/new-e2e/pkg/utils/e2e/client/ssh_vm.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package client
+
+import (
+	"testing"
+
+	"github.com/DataDog/test-infra-definitions/common/utils"
+	commonos "github.com/DataDog/test-infra-definitions/components/os"
+)
+
+var _ connectionInitializer = (*SSHVM)(nil)
+var _ VM = (*SSHVM)(nil)
+
+// SSHVM is a type that implements [e2e.client.VM] and uses an SSH connection
+// to setup the connection with the VM.
+type SSHVM struct {
+	VM
+
+	vmName string
+	osType commonos.Type
+}
+
+func NewSSHVM(vmName string, osType commonos.Type) *SSHVM {
+	return &SSHVM{vmName: vmName, osType: osType}
+}
+
+// initFromConnection initializes the instance from an ssh connection to the test VM
+// This method is called by [CallConnectionInitializers] using reflection.
+//
+//lint:ignore U1000 Ignore unused function as this function is called using reflection
+func (vm *SSHVM) initFromConnection(t *testing.T, conns map[string]*utils.Connection) error {
+	conn := conns[vm.vmName]
+
+	var err error
+	vm.VM, err = NewVMClient(t, conn, vm.osType)
+	return err
+}

--- a/test/new-e2e/pkg/utils/e2e/local_definition.go
+++ b/test/new-e2e/pkg/utils/e2e/local_definition.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package e2e
+
+import (
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/localinfra"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/localinfra/localvmparams"
+)
+
+// LocalVMDef creates a test environment containing a local virtual machine.
+// See [localvmparams.Params] for available options.
+func LocalVMDef(options ...localvmparams.Option) InfraProvider[VMEnv] {
+	return NewLocalProvider(
+		func(vmManager *localinfra.LocalVMManager) (*VMEnv, error) {
+			vm, err := localinfra.NewLocalVM(options...)
+			if err != nil {
+				return nil, err
+			}
+			vmManager.AddVM(vm)
+
+			return &VMEnv{
+				VM: client.NewSSHVM(vm.Name(), vm.OSType()),
+			}, nil
+		},
+	)
+}

--- a/test/new-e2e/pkg/utils/e2e/local_provider.go
+++ b/test/new-e2e/pkg/utils/e2e/local_provider.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/localinfra"
+)
+
+var _ InfraProvider[int] = (*LocalProvider[int])(nil)
+
+// LocalProvider creates and manages local testing infrastructure
+type LocalProvider[Env any] struct {
+	envFactory func(vmManager *localinfra.LocalVMManager) (*Env, error)
+
+	vmManager *localinfra.LocalVMManager
+}
+
+// NewLocalProvider returns a new LocalProvider
+func NewLocalProvider[Env any](envFactory func(vmManager *localinfra.LocalVMManager) (*Env, error)) *LocalProvider[Env] {
+	return &LocalProvider[Env]{
+		envFactory: envFactory,
+		vmManager:  localinfra.GetLocalVMManager(),
+	}
+}
+
+// ProvisionInfraAndInitializeEnv uses a local VM manager to provision a VM & pass the resulting SSH connection to
+// any clients in the environment which implement the connectionInitializer interface
+func (li *LocalProvider[Env]) ProvisionInfraAndInitializeEnv(_ context.Context, t *testing.T, _ string, _ bool) (*Env, error) {
+	env, err := li.envFactory(li.vmManager)
+	if err != nil {
+		return nil, fmt.Errorf("error instantiating env: %s", err)
+	}
+
+	connResult, err := li.vmManager.Provision()
+	if err != nil {
+		return nil, fmt.Errorf("error provisioning local testing infra: %s", err)
+	}
+
+	err = client.CallConnectionInitializers(t, env, connResult)
+	return env, err
+}
+
+// DeleteInfra deletes all local VMs
+func (li *LocalProvider[Env]) DeleteInfra(_ context.Context, _ string) error {
+	allErrs := li.vmManager.Delete()
+	if len(allErrs) > 0 {
+		return fmt.Errorf("%d error(s) deleting local testing infra: %v", len(allErrs), allErrs)
+	}
+	return nil
+}

--- a/test/new-e2e/pkg/utils/localinfra/local_vm.go
+++ b/test/new-e2e/pkg/utils/localinfra/local_vm.go
@@ -1,0 +1,101 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package localinfra
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/localinfra/localvmparams"
+	"io"
+	"math/rand"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/DataDog/test-infra-definitions/common/utils"
+	commonos "github.com/DataDog/test-infra-definitions/components/os"
+)
+
+// LocalVM represents a local virtual machine
+type LocalVM struct {
+	params *localvmparams.Params
+	name   string
+
+	// VM state
+	isUp bool
+	conn *utils.Connection
+}
+
+// NewLocalVM instantiates a new LocalVM definition
+func NewLocalVM(options ...localvmparams.Option) (*LocalVM, error) {
+	params, err := localvmparams.NewParams(options...)
+	if err != nil {
+		return nil, err
+	}
+
+	// name is a pseudo-random string which can be used to uniquely identify this VM
+	seededRand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	name := strconv.Itoa(seededRand.Int())
+
+	vm := &LocalVM{params: params, name: name, isUp: false}
+
+	if params.JSONFile != "" {
+		err := vm.initFromJSONFile(params.JSONFile)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return vm, nil
+}
+
+// Name returns the unique name of this VM
+func (v *LocalVM) Name() string {
+	return v.name
+}
+
+// OSType returns the os type of this VM
+func (v *LocalVM) OSType() commonos.Type {
+	return v.params.OSType
+}
+
+func (v *LocalVM) initFromJSONFile(jsonFile string) error {
+	type localEnvSSHConfig struct {
+		User    string `json:"ssh_user"`
+		Address string `json:"ssh_address"`
+	}
+
+	file, err := os.Open(jsonFile)
+	if err != nil {
+		return fmt.Errorf("error opening %s: %s", jsonFile, err)
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return fmt.Errorf("error reading %s: %s", jsonFile, err)
+	}
+
+	var sshConfig localEnvSSHConfig
+	err = json.Unmarshal(data, &sshConfig)
+	if err != nil {
+		return fmt.Errorf("error unmarshalling data in %s: %s", jsonFile, err)
+	}
+
+	v.conn = &utils.Connection{User: sshConfig.User, Host: sshConfig.Address}
+	v.isUp = true
+	return nil
+}
+
+func (v *LocalVM) getConnection() (*utils.Connection, error) {
+	if !v.isUp {
+		return nil, fmt.Errorf("error getting SSH connection to VM: VM is not running")
+	}
+	if v.conn == nil {
+		return nil, fmt.Errorf("error getting SSH connection to VM: VM is up, but SSH connection has not been established")
+	}
+	return v.conn, nil
+}

--- a/test/new-e2e/pkg/utils/localinfra/local_vm_manager.go
+++ b/test/new-e2e/pkg/utils/localinfra/local_vm_manager.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package localinfra
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/DataDog/test-infra-definitions/common/utils"
+)
+
+var (
+	vmManager     *LocalVMManager
+	initVMManager sync.Once
+)
+
+// LocalVMManager handles the creation and deletion of local VMs
+type LocalVMManager struct {
+	vms []*LocalVM
+}
+
+// GetLocalVMManager returns a vm manager, initialising on first call
+func GetLocalVMManager() *LocalVMManager {
+	initVMManager.Do(func() {
+		vmManager = newLocalVMManager()
+	})
+
+	return vmManager
+}
+
+func newLocalVMManager() *LocalVMManager {
+	return &LocalVMManager{}
+}
+
+// AddVM registers a new localVM definition for provisioning
+func (m *LocalVMManager) AddVM(vm *LocalVM) {
+	m.vms = append(m.vms, vm)
+}
+
+// Provision brings up all VMs which have been added to the manager
+func (m *LocalVMManager) Provision() (map[string]*utils.Connection, error) {
+	connections := map[string]*utils.Connection{}
+
+	for _, vm := range m.vms {
+		conn, err := m.create(vm)
+		if err != nil {
+			return map[string]*utils.Connection{}, err
+		}
+
+		connections[vm.name] = conn
+	}
+
+	return connections, nil
+}
+
+// Delete deletes all VMs which have been added to the manager
+func (m *LocalVMManager) Delete() []error {
+	errors := []error{}
+	for _, vm := range m.vms {
+		err := m.delete(vm)
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+	return errors
+}
+
+func (m *LocalVMManager) create(vm *LocalVM) (*utils.Connection, error) {
+	if vm.isUp {
+		return vm.getConnection()
+	}
+	return nil, fmt.Errorf("provisioning of new local VMs is not yet implemented")
+}
+
+func (m *LocalVMManager) delete(vm *LocalVM) error {
+	return nil
+}

--- a/test/new-e2e/pkg/utils/localinfra/localvmparams/localvmparams.go
+++ b/test/new-e2e/pkg/utils/localinfra/localvmparams/localvmparams.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package localvmparams
+
+import (
+	commonos "github.com/DataDog/test-infra-definitions/components/os"
+)
+
+// Params defines the parameters for provisioning a local VM.
+// The Params configuration uses the [Functional options pattern].
+//
+// The available options are:
+//   - [WithJSONFile]
+//   - [WithOSType]
+//
+// [Functional options pattern]: https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
+type Params struct {
+	JSONFile string
+	OSType   commonos.Type
+}
+
+// Option alias to a functional option changing a given Params instance
+type Option func(*Params) error
+
+// NewParams creates a new instance of Agent client params
+func NewParams(options ...Option) (*Params, error) {
+	p := &Params{
+		OSType: commonos.WindowsType,
+	}
+
+	return applyOptions(p, options...)
+}
+
+func applyOptions(instance *Params, options ...Option) (*Params, error) {
+	for _, o := range options {
+		err := o(instance)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return instance, nil
+}
+
+// WithJSONFile provides a path to json file containing the ssh connection information
+// of an existing local VM.
+// If this parameter is passed, a new VM will not be provisioned; instead, a connection
+// to the existing VM will be established and used for the tests.
+func WithJSONFile(file string) Option {
+	return func(p *Params) error {
+		p.JSONFile = file
+
+		return nil
+	}
+}
+
+// WithOSType defines the OS of the desired local VM
+func WithOSType(osType commonos.Type) Option {
+	return func(p *Params) error {
+		p.OSType = osType
+
+		return nil
+	}
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Adds support for running E2E tests on local infrastructure, using the abstraction added in https://github.com/DataDog/datadog-agent/pull/20667.

Updates the codeowners to reflect windows-agent/WKIT ownership of local testing files.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
