### PR TITLE
Avoid having to do type coercion as part of fetching the statsu common stats.

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -49,11 +49,6 @@ func GetStatus(verbose bool) (map[string]interface{}, error) {
 	}
 	stats["verbose"] = verbose
 	stats["config"] = getPartialConfig()
-	metadata := stats["metadata"].(*hostMetadataUtils.Payload)
-	hostTags := make([]string, 0, len(metadata.HostTags.System)+len(metadata.HostTags.GoogleCloudPlatform))
-	hostTags = append(hostTags, metadata.HostTags.System...)
-	hostTags = append(hostTags, metadata.HostTags.GoogleCloudPlatform...)
-	stats["hostTags"] = hostTags
 
 	pythonVersion := python.GetPythonVersion()
 	stats["python_version"] = strings.Split(pythonVersion, " ")[0]
@@ -337,7 +332,12 @@ func getCommonStatus() (map[string]interface{}, error) {
 
 	stats["version"] = version.AgentVersion
 	stats["flavor"] = flavor.GetFlavor()
-	stats["metadata"] = hostMetadataUtils.GetFromCache(context.TODO(), config.Datadog)
+	metadata := hostMetadataUtils.GetFromCache(context.TODO(), config.Datadog)
+	stats["metadata"] = metadata
+	hostTags := make([]string, 0, len(metadata.HostTags.System)+len(metadata.HostTags.GoogleCloudPlatform))
+	hostTags = append(hostTags, metadata.HostTags.System...)
+	hostTags = append(hostTags, metadata.HostTags.GoogleCloudPlatform...)
+	stats["hostTags"] = hostTags
 	stats["conf_file"] = config.Datadog.ConfigFileUsed()
 	stats["pid"] = os.Getpid()
 	stats["go_version"] = runtime.Version()


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

When fetching the host metadata information from the metadata component. With the metadata information, we can infer the host tags. However, the process was done in two separate functions. This caused us to have to convert from an interface into `metadata.Payload`.

We can avoid that extra step if we collect the host tags on the same function we collect the metadata.

The information is used on the `header.tmpl`. This template is used by all three agent status types: normal mode, cluster, and security agent.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Group fetching related status information in the same function. Reduce the number of interface coercion. 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Did I miss anything? Is the cluster agent not supposed to display `hostTags`? Here is the PR that introduced those changes in the first place https://github.com/DataDog/datadog-agent/pull/5749

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Run the status command for normal and cluster mode and make sure the result is the correct 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
