### PR TITLE
[CONTINT-3328] Move sort functions to their own package

### DIFF
--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+	"github.com/DataDog/datadog-agent/pkg/util/sort"
 )
 
 var (
@@ -238,7 +239,7 @@ func newServerCompat(cfg config.Reader, log logComponent.Component, capture repl
 	if staticTags := util.GetStaticTagsSlice(context.TODO()); staticTags != nil {
 		extraTags = append(extraTags, staticTags...)
 	}
-	util.SortUniqInPlace(extraTags)
+	sort.UniqInPlace(extraTags)
 
 	entityIDPrecedenceEnabled := cfg.GetBool("dogstatsd_entity_id_precedence")
 

--- a/comp/metadata/host/utils/tags.go
+++ b/comp/metadata/host/utils/tags.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
-	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/gce"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
@@ -22,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	k8s "github.com/DataDog/datadog-agent/pkg/util/kubernetes/hostinfo"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/sort"
 )
 
 var (
@@ -177,7 +177,7 @@ func GetHostTags(ctx context.Context, cached bool, conf config.Reader) *Tags {
 	}
 
 	t := &Tags{
-		System:              util.SortUniqInPlace(hostTags),
+		System:              sort.UniqInPlace(hostTags),
 		GoogleCloudPlatform: gceTags,
 	}
 

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -23,9 +23,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/sort"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -399,7 +399,7 @@ func (agg *BufferedAggregator) handleSenderSample(ss senderMetricSample) {
 		if ss.commit {
 			checkSampler.commit(timeNowNano())
 		} else {
-			ss.metricSample.Tags = util.SortUniqInPlace(ss.metricSample.Tags)
+			ss.metricSample.Tags = sort.UniqInPlace(ss.metricSample.Tags)
 			checkSampler.addSample(ss.metricSample)
 		}
 	} else {
@@ -415,7 +415,7 @@ func (agg *BufferedAggregator) handleSenderBucket(checkBucket senderHistogramBuc
 	tlmProcessed.Inc("", "histogram_bucket")
 
 	if checkSampler, ok := agg.checkSamplers[checkBucket.id]; ok {
-		checkBucket.bucket.Tags = util.SortUniqInPlace(checkBucket.bucket.Tags)
+		checkBucket.bucket.Tags = sort.UniqInPlace(checkBucket.bucket.Tags)
 		checkSampler.addBucket(checkBucket.bucket)
 	} else {
 		log.Debugf("CheckSampler with ID '%s' doesn't exist, can't handle histogram bucket", checkBucket.id)

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -22,9 +22,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
-	coreutil "github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	sortutil "github.com/DataDog/datadog-agent/pkg/util/sort"
 
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpintegration"
@@ -255,7 +255,7 @@ func (c *CheckConfig) RebuildMetadataMetricsAndTags() {
 
 // UpdateDeviceIDAndTags updates DeviceID and DeviceIDTags
 func (c *CheckConfig) UpdateDeviceIDAndTags() {
-	c.DeviceIDTags = coreutil.SortUniqInPlace(c.getDeviceIDTags())
+	c.DeviceIDTags = sortutil.UniqInPlace(c.getDeviceIDTags())
 	c.DeviceID = c.Namespace + ":" + c.IPAddress
 }
 

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -255,7 +255,7 @@ func (c *CheckConfig) RebuildMetadataMetricsAndTags() {
 
 // UpdateDeviceIDAndTags updates DeviceID and DeviceIDTags
 func (c *CheckConfig) UpdateDeviceIDAndTags() {
-	c.DeviceIDTags = sortutil.UniqInPlace(c.getDeviceIDTags())
+	c.DeviceIDTags = c.getDeviceIDTags()
 	c.DeviceID = c.Namespace + ":" + c.IPAddress
 }
 
@@ -293,7 +293,7 @@ func (c *CheckConfig) GetNetworkTags() []string {
 // warning: changing getDeviceIDTags logic might lead to different deviceID
 func (c *CheckConfig) getDeviceIDTags() []string {
 	tags := []string{deviceNamespaceTagKey + ":" + c.Namespace, deviceIPTagKey + ":" + c.IPAddress}
-	sort.Strings(tags)
+	sortutil.UniqInPlace(tags)
 	return tags
 }
 

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -14,8 +14,8 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/epforwarder"
-	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	sortutil "github.com/DataDog/datadog-agent/pkg/util/sort"
 
 	devicemetadata "github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
@@ -36,7 +36,7 @@ const ciscoNetworkProtocolIPv6 = "20"
 // ReportNetworkDeviceMetadata reports device metadata
 func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckConfig, store *valuestore.ResultValueStore, origTags []string, collectTime time.Time, deviceStatus devicemetadata.DeviceStatus, diagnoses []devicemetadata.DiagnosisMetadata) {
 	tags := common.CopyStrings(origTags)
-	tags = util.SortUniqInPlace(tags)
+	tags = sortutil.UniqInPlace(tags)
 
 	metadataStore := buildMetadataStore(config.Metadata, store)
 

--- a/pkg/tagset/hashless_tags_accumulator.go
+++ b/pkg/tagset/hashless_tags_accumulator.go
@@ -5,7 +5,7 @@
 
 package tagset
 
-import "github.com/DataDog/datadog-agent/pkg/util"
+import "github.com/DataDog/datadog-agent/pkg/util/sort"
 
 // HashlessTagsAccumulator allows to build a slice of tags, in a context where the hashes for
 // those tags are not useful.
@@ -59,7 +59,7 @@ func (h *HashlessTagsAccumulator) Copy() []string {
 
 // SortUniq sorts and remove duplicate in place
 func (h *HashlessTagsAccumulator) SortUniq() {
-	h.data = util.SortUniqInPlace(h.data)
+	h.data = sort.UniqInPlace(h.data)
 }
 
 // Reset resets the size of the builder to 0 without discarding the internal

--- a/pkg/util/cloudproviders/cloudproviders.go
+++ b/pkg/util/cloudproviders/cloudproviders.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
-	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/sort"
 
 	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 
@@ -141,7 +141,7 @@ func GetHostAliases(ctx context.Context) []string {
 	}
 	wg.Wait()
 
-	return util.SortUniqInPlace(aliases)
+	return sort.UniqInPlace(aliases)
 }
 
 // GetPublicIPv4 returns the public IPv4 from different providers

--- a/pkg/util/sort/sort.go
+++ b/pkg/util/sort/sort.go
@@ -1,9 +1,10 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2023-present Datadog, Inc.
 
-package util
+// Package sort contains util functions to sort slices of tags
+package sort
 
 // InsertionSortThreshold is the slice size after which we should consider
 // using the stdlib sort method instead of the InsertionSort implemented below.

--- a/pkg/util/sort/sort_test.go
+++ b/pkg/util/sort/sort_test.go
@@ -1,9 +1,11 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2023-present Datadog, Inc.
 
-package util
+//go:build test
+
+package sort
 
 import (
 	"testing"

--- a/pkg/util/sort/sort_uniq.go
+++ b/pkg/util/sort/sort_uniq.go
@@ -1,15 +1,15 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2023-present Datadog, Inc.
 
-package util
+package sort
 
 import "sort"
 
-// SortUniqInPlace sorts and remove duplicates from elements in place
+// UniqInPlace sorts and remove duplicates from elements in place
 // The returned slice is a subslice of elements
-func SortUniqInPlace(elements []string) []string {
+func UniqInPlace(elements []string) []string {
 	if len(elements) < 2 {
 		return elements
 	}

--- a/pkg/util/sort/sort_uniq_test.go
+++ b/pkg/util/sort/sort_uniq_test.go
@@ -1,9 +1,11 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2023-present Datadog, Inc.
 
-package util
+//go:build test
+
+package sort
 
 import (
 	"fmt"
@@ -13,9 +15,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSortUniqInPlace(t *testing.T) {
+func TestUniqInPlace(t *testing.T) {
 	elements := []string{"tag3:tagggg", "tag2:tagval", "tag1:tagval", "tag2:tagval"}
-	elements = SortUniqInPlace(elements)
+	elements = UniqInPlace(elements)
 
 	assert.ElementsMatch(t, elements, []string{"tag1:tagval", "tag2:tagval", "tag3:tagggg"})
 }
@@ -35,7 +37,7 @@ func benchmarkDeduplicateTags(b *testing.B, numberOfTags int) {
 
 	for n := 0; n < b.N; n++ {
 		copy(tempTags, tags)
-		SortUniqInPlace(tempTags)
+		UniqInPlace(tempTags)
 	}
 }
 func BenchmarkDeduplicateTags(b *testing.B) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR moves sort functions to their own package.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
In https://github.com/DataDog/datadog-agent/pull/20094 we need to call them in a package that is also importing the util package, causing an import cycle.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
N/A
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
N/A

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
N/A
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
