### PR TITLE
[CSPM] Add a system-probe module to perform compliance checks

### DIFF
--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -149,7 +149,7 @@ func load() (*Config, error) {
 		(c.ModuleIsEnabled(NetworkTracerModule) && cfg.GetBool(evNS("network_process.enabled"))) {
 		c.EnabledModules[EventMonitorModule] = struct{}{}
 	}
-	if cfg.GetBool(secNS("enabled")) {
+	if cfg.GetBool(secNS("enabled")) && cfg.GetBool(secNS("compliance_module.enabled")) {
 		c.EnabledModules[ComplianceModule] = struct{}{}
 	}
 	if cfg.GetBool(spNS("process_config.enabled")) {

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -37,6 +37,7 @@ const (
 	EBPFModule                   ModuleName = "ebpf"
 	LanguageDetectionModule      ModuleName = "language_detection"
 	WindowsCrashDetectModule     ModuleName = "windows_crash_detection"
+	ComplianceModule             ModuleName = "compliance"
 )
 
 // Config represents the configuration options for the system-probe
@@ -147,6 +148,9 @@ func load() (*Config, error) {
 		cfg.GetBool(evNS("process.enabled")) ||
 		(c.ModuleIsEnabled(NetworkTracerModule) && cfg.GetBool(evNS("network_process.enabled"))) {
 		c.EnabledModules[EventMonitorModule] = struct{}{}
+	}
+	if cfg.GetBool(secNS("enabled")) {
+		c.EnabledModules[ComplianceModule] = struct{}{}
 	}
 	if cfg.GetBool(spNS("process_config.enabled")) {
 		c.EnabledModules[ProcessModule] = struct{}{}

--- a/cmd/system-probe/modules/all_linux.go
+++ b/cmd/system-probe/modules/all_linux.go
@@ -23,6 +23,7 @@ var All = []module.Factory{
 	Process,
 	DynamicInstrumentation,
 	LanguageDetectionModule,
+	ComplianceModule,
 }
 
 func inactivityEventLog(duration time.Duration) {

--- a/cmd/system-probe/modules/compliance.go
+++ b/cmd/system-probe/modules/compliance.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
+//go:build linux
+
 package modules
 
 import (

--- a/cmd/system-probe/modules/compliance.go
+++ b/cmd/system-probe/modules/compliance.go
@@ -1,0 +1,95 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package modules
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	"github.com/DataDog/datadog-agent/cmd/system-probe/utils"
+	"github.com/DataDog/datadog-agent/pkg/compliance/dbconfig"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"go.uber.org/atomic"
+	"google.golang.org/grpc"
+)
+
+// ComplianceModule is a system-probe module that exposes an HTTP api to
+// perform compliance checks that require more privileges than security-agent
+// can offer.
+//
+// For instance, being able to run cross-container checks at runtime by directly
+// accessing the /proc/<pid>/root mount point.
+var ComplianceModule = module.Factory{
+	Name:             config.ComplianceModule,
+	ConfigNamespaces: []string{},
+	Fn: func(cfg *config.Config) (module.Module, error) {
+		return &complianceModule{}, nil
+	},
+}
+
+type complianceModule struct {
+	performedChecks atomic.Uint64
+}
+
+// Close is a noop (implements module.Module)
+func (*complianceModule) Close() {
+}
+
+// GetStats returns statistics related to the compliance module (implements module.Module)
+func (m *complianceModule) GetStats() map[string]interface{} {
+	return map[string]interface{}{
+		"performed_checks": m.performedChecks.Load(),
+	}
+}
+
+// RegisterGRPC is a noop (implements module.Module)
+func (*complianceModule) RegisterGRPC(grpc.ServiceRegistrar) error {
+	return nil
+}
+
+// Register implements module.Module.
+func (m *complianceModule) Register(router *module.Router) error {
+	router.HandleFunc("/dbconfig", utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, m.handleScanDBConfig))
+	return nil
+}
+
+func (m *complianceModule) handleError(writer http.ResponseWriter, request *http.Request, status int, err error) {
+	_ = log.Errorf("module compliance: failed to properly handle %s request: %s", request.URL.Path, err)
+	writer.WriteHeader(status)
+}
+
+func (m *complianceModule) handleScanDBConfig(writer http.ResponseWriter, request *http.Request) {
+	m.performedChecks.Add(1)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	qs := request.URL.Query()
+	pid, err := strconv.ParseInt(qs.Get("pid"), 10, 32)
+	if err != nil {
+		m.handleError(writer, request, http.StatusBadRequest, fmt.Errorf("pid query paramater is not an integer: %w", err))
+		return
+	}
+
+	resource, ok := dbconfig.LoadDBResourceFromPID(ctx, int32(pid))
+	if !ok {
+		m.handleError(writer, request, http.StatusNotFound, fmt.Errorf("resource not found for pid=%d", pid))
+		return
+	}
+
+	writer.Header().Set("Content-Type", "application/json")
+	writer.WriteHeader(http.StatusOK)
+	e := json.NewEncoder(writer)
+	if err := e.Encode(resource); err != nil {
+		_ = log.Errorf("module compliance: failed to properly handle %s request: could not send response %s", request.URL.Path, err)
+	}
+}

--- a/cmd/system-probe/modules/compliance_test.go
+++ b/cmd/system-probe/modules/compliance_test.go
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package modules
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/compliance/dbconfig"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComplianceModuleNoProcess(t *testing.T) {
+	{
+		url := "/dbconfig"
+		statusCode, _, respBody := doDBConfigRequest(t, url)
+		require.Equal(t, http.StatusBadRequest, statusCode)
+		require.Len(t, respBody, 0)
+	}
+
+	{
+		url := "/dbconfig?pid=0"
+		statusCode, _, respBody := doDBConfigRequest(t, url)
+		require.Equal(t, http.StatusNotFound, statusCode)
+		require.Len(t, respBody, 0)
+	}
+}
+
+func TestComplianceCheckModuleWithProcess(t *testing.T) {
+	tmp := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pid := launchFakeProcess(ctx, t, tmp, "postgres")
+	url := fmt.Sprintf("/dbconfig?pid=%d", pid)
+	statusCode, headers, respBody := doDBConfigRequest(t, url)
+	require.Equal(t, http.StatusOK, statusCode)
+	require.Equal(t, "application/json", headers.Get("Content-Type"))
+
+	var resource *dbconfig.DBResource
+	if err := json.Unmarshal(respBody, &resource); err != nil {
+		t.Fatal(err)
+	}
+	require.Nil(t, resource)
+}
+
+func launchFakeProcess(ctx context.Context, t *testing.T, tmp, procname string) int {
+	// creates a symlink to /usr/bin/sleep to be able to create a fake
+	// postgres process.
+	sleepPath, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skipf("could not find sleep util")
+	}
+	fakePgPath := filepath.Join(tmp, procname)
+	if err := os.Symlink(sleepPath, fakePgPath); err != nil {
+		t.Fatalf("could not create fake process symlink: %v", err)
+	}
+	if err := os.Chmod(fakePgPath, 0700); err != nil {
+		t.Fatalf("could not chmod fake process symlink: %v", err)
+	}
+
+	cmd := exec.CommandContext(ctx, fakePgPath, "5")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("could not start fake process %q: %v", procname, err)
+	}
+
+	return cmd.Process.Pid
+}
+
+func doDBConfigRequest(t *testing.T, url string) (int, http.Header, []byte) {
+	rec := httptest.NewRecorder()
+
+	m := &complianceModule{}
+	m.handleScanDBConfig(rec, httptest.NewRequest(http.MethodGet, url, nil))
+
+	response := rec.Result()
+
+	defer response.Body.Close()
+	resBytes, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	return response.StatusCode, response.Header, resBytes
+}

--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -11,15 +11,21 @@ package compliance
 import (
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"expvar"
 	"fmt"
 	"hash/fnv"
+	"io"
 	"math/rand"
+	"net/http"
+	"net/url"
+	"strconv"
 	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/compliance/aptconfig"
+	"github.com/DataDog/datadog-agent/pkg/compliance/dbconfig"
 	"github.com/DataDog/datadog-agent/pkg/compliance/k8sconfig"
 	"github.com/DataDog/datadog-agent/pkg/compliance/metrics"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -80,6 +86,10 @@ type AgentOptions struct {
 	// EnabledConfigurationExporters lists configuration exporter that shall be
 	// enabled.
 	EnabledConfigurationExporters []ConfigurationExporter
+
+	// SysProbeClient is the HTTP client to allow the execution of benchmarks
+	// from system-probe. see: cmd/system-probe/modules/compliance.go
+	SysProbeClient *http.Client
 }
 
 // ConfigurationExporter is an enum type defining all configuration export
@@ -93,6 +103,10 @@ const (
 
 	// AptExporter exports local APT configuration data.
 	AptExporter
+
+	// DBExporter exports local or containerized DB application configuration
+	// data.
+	DBExporter
 )
 
 // Agent is the compliance agent that is responsible for running compliance
@@ -232,6 +246,13 @@ func (a *Agent) Start() error {
 			wg.Add(1)
 			go func() {
 				a.runKubernetesConfigurationsExport(ctx)
+				wg.Done()
+			}()
+
+		case DBExporter:
+			wg.Add(1)
+			go func() {
+				a.runDBConfigurationsExport(ctx)
 				wg.Done()
 			}()
 		}
@@ -406,9 +427,90 @@ func (a *Agent) runAptConfigurationExport(ctx context.Context) {
 	}
 }
 
+func (a *Agent) runDBConfigurationsExport(ctx context.Context) {
+	checkInterval := a.opts.CheckIntervalLowPriority
+	runTicker := time.NewTicker(checkInterval)
+	defer runTicker.Stop()
+
+	for runCount := uint64(0); ; runCount++ {
+		if sleepRandomJitter(ctx, checkInterval, runCount, a.opts.Hostname, "db-configuration") {
+			return
+		}
+		pids := dbconfig.ListProcesses(ctx)
+		for containerID, pid := range pids {
+			// if the process does not run in any form of container, containerID
+			// is the empty string "" and it can be run locally
+			if containerID == "" {
+				resource, ok := dbconfig.LoadDBResourceFromPID(ctx, pid)
+				if ok {
+					a.reportResourceLog(defaultCheckIntervalLowPriority, NewResourceLog(a.opts.Hostname, resource.Type, resource.Config))
+				}
+			} else {
+				err := a.reportDBConfigurationFromSystemProbe(ctx, pid)
+				if err != nil {
+					log.Errorf("error evaluating cross-container benchmark from system-probe: %v", err)
+				}
+			}
+		}
+		if sleepAborted(ctx, runTicker.C) {
+			return
+		}
+	}
+}
+
+func (a *Agent) reportDBConfigurationFromSystemProbe(ctx context.Context, pid int32) error {
+	if a.opts.SysProbeClient == nil {
+		return fmt.Errorf("system-probe socket client was not created")
+	}
+
+	qs := new(url.Values)
+	qs.Add("pid", strconv.FormatInt(int64(pid), 10))
+	sysProbeComplianceModuleURL := &url.URL{
+		Scheme:   "http",
+		Host:     "unix",
+		Path:     "/dbconfig",
+		RawQuery: qs.Encode(),
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sysProbeComplianceModuleURL.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := a.opts.SysProbeClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("error running cross-container benchmark: %s", resp.Status)
+	}
+
+	var resource *dbconfig.DBResource
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(body, &resource); err != nil {
+		return err
+	}
+	if resource != nil {
+		a.reportResourceLog(defaultCheckIntervalLowPriority, NewResourceLog(a.opts.Hostname, resource.Type, resource.Config))
+	}
+	return nil
+}
+
 func (a *Agent) reportResourceLog(resourceTTL time.Duration, resourceLog *ResourceLog) {
+	store := workloadmeta.GetGlobalStore()
 	expireAt := time.Now().Add(2 * resourceTTL).Truncate(1 * time.Second)
 	resourceLog.ExpireAt = &expireAt
+	if store != nil && resourceLog.Container != nil {
+		if ctnr, _ := store.GetContainer(resourceLog.Container.ContainerID); ctnr != nil {
+			resourceLog.Container.ImageID = ctnr.Image.ID
+			resourceLog.Container.ImageName = ctnr.Image.Name
+			resourceLog.Container.ImageTag = ctnr.Image.Tag
+		}
+	}
 	a.opts.Reporter.ReportEvent(resourceLog)
 }
 

--- a/pkg/compliance/dbconfig/loader.go
+++ b/pkg/compliance/dbconfig/loader.go
@@ -120,7 +120,7 @@ func LoadDBResourceFromPID(ctx context.Context, pid int32) (resource *DBResource
 		return
 	}
 	containerID, ok := utils.GetProcessContainerID(pid)
-	if !ok || containerID == "" {
+	if !ok {
 		return
 	}
 	hostroot, ok := utils.GetProcessRootPath(pid)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1192,6 +1192,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("compliance_config.enabled", false)
 	config.BindEnvAndSetDefault("compliance_config.xccdf.enabled", false) // deprecated, use host_benchmarks instead
 	config.BindEnvAndSetDefault("compliance_config.host_benchmarks.enabled", false)
+	config.BindEnvAndSetDefault("compliance_config.database_benchmarks.enabled", false)
 	config.BindEnvAndSetDefault("compliance_config.check_interval", 20*time.Minute)
 	config.BindEnvAndSetDefault("compliance_config.check_max_events_per_run", 100)
 	config.BindEnvAndSetDefault("compliance_config.dir", "/etc/datadog-agent/compliance.d")

--- a/pkg/config/system_probe_cws.go
+++ b/pkg/config/system_probe_cws.go
@@ -30,6 +30,7 @@ func initCWSSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.remote_configuration.enabled", true)
 	cfg.BindEnvAndSetDefault("runtime_security_config.direct_send_from_system_probe", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.use_secruntime_track", false)
+	cfg.BindEnvAndSetDefault("runtime_security_config.compliance_module.enabled", false)
 
 	// CWS - activity dump
 	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.enabled", true)


### PR DESCRIPTION
### What does this PR do?

This PR adds a new module to the system-probe binary in order to perform compliance checks accross containers. Specifically to fetch containerized DB applications configurations on which we can perform compliance checks.

The module exposes an endpoint that loads and parses the configuration files of a few known databases applications: Cassandra, MondoDB and PostgreSQL. It then returns the parsed data to the caller, security-agent in our case. The configuration file is located either by parsing the command line arguments of the associated DB process (identified by its PID) or looking at default known paths in /etc.

### Motivation

Being able to perform cross-container compliance checks from security-agent relying on system-probe.

### Additional Notes

Performance impact:

The overall overhead of this module should be minimal. Also it will not be called by default in the release to have time to QA the impact.

1. adding dependency on pkg/compliance/dbconfig only adds ~63KB to the unstripped binary size
2. compliance module's endpoint should only be called one every three hours by our security-agent.
3. the actual workload of this module only consists of loading a few configuration files of typically ~10s of kilobytes and perform a basic parsing to structure the data in JSON. Guardrails are in place to make sure we do not read more that 1MB of data per config files.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Launching the agent in a k8s environment and setting `compliance_config.db_benchmarks.enabled` to `true` alongside a container running a postgres, cassandra or mongodb and see if configuration logs are sent to the compliance track.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
