### PR TITLE
[CWS] Keep snapshot probes after completion

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/procfs.h
+++ b/pkg/security/ebpf/c/include/hooks/procfs.h
@@ -7,7 +7,7 @@
 #include "helpers/filesystem.h"
 #include "helpers/utils.h"
 
-// used during the snapshot thus this kprobe will present only at the snapshot
+// used by both snapshot and process resolver fallback
 HOOK_ENTRY("security_inode_getattr")
 int hook_security_inode_getattr(ctx_t *ctx) {
     if (!is_runtime_request()) {

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -309,7 +309,7 @@ func (p *Probe) Setup() error {
 
 	needRawSyscalls := p.isNeededForActivityDump(model.SyscallsEventType.String())
 
-	if err := p.updateProbes(defaultEventTypes, true, needRawSyscalls); err != nil {
+	if err := p.updateProbes(defaultEventTypes, needRawSyscalls); err != nil {
 		return err
 	}
 
@@ -1106,7 +1106,7 @@ func (p *Probe) validEventTypeForConfig(eventType string) bool {
 
 // updateProbes applies the loaded set of rules and returns a report
 // of the applied approvers for it.
-func (p *Probe) updateProbes(ruleEventTypes []eval.EventType, useSnapshotProbes, needRawSyscalls bool) error {
+func (p *Probe) updateProbes(ruleEventTypes []eval.EventType, needRawSyscalls bool) error {
 	// event types enabled either by event handlers or by rules
 	eventTypes := append([]eval.EventType{}, defaultEventTypes...)
 	eventTypes = append(eventTypes, ruleEventTypes...)
@@ -1122,11 +1122,7 @@ func (p *Probe) updateProbes(ruleEventTypes []eval.EventType, useSnapshotProbes,
 		}
 	}
 
-	var activatedProbes []manager.ProbesSelector
-
-	if useSnapshotProbes {
-		activatedProbes = append(activatedProbes, probes.SnapshotSelectors(p.useFentry)...)
-	}
+	activatedProbes := probes.SnapshotSelectors(p.useFentry)
 
 	// extract probe to activate per the event types
 	for eventType, selectors := range probes.GetSelectorsPerEventType(p.useFentry) {
@@ -1438,7 +1434,7 @@ func (p *Probe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetReport, e
 		}
 	}
 
-	if err := p.updateProbes(rs.GetEventTypes(), false, needRawSyscalls); err != nil {
+	if err := p.updateProbes(rs.GetEventTypes(), needRawSyscalls); err != nil {
 		return nil, fmt.Errorf("failed to select probes: %w", err)
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Keep the security_inode_attr kprobe/fentry after snapshot.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

These probes are also used by process cache fallbacks.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
