### PR TITLE
[e2e] use json format to list stacks

### DIFF
--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -7,7 +7,6 @@ import os
 import os.path
 import shutil
 import tempfile
-from collections import namedtuple
 from pathlib import Path
 from typing import List
 

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -188,9 +188,6 @@ def _clean_locks():
             print(f"🗑️ Deleted lock: {subdir}")
 
 
-Stack = namedtuple('Stack', ['name', 'workspaceDirectory'])
-
-
 def _clean_stacks(ctx: Context):
     print("🧹 Clean up stack")
     stacks = _get_existing_stacks(ctx)
@@ -205,57 +202,43 @@ def _clean_stacks(ctx: Context):
         _remove_stack(ctx, stack)
 
 
-def _get_existing_stacks(ctx: Context) -> List[Stack]:
-    # running in temp dir and `pulumi-workspace` subfolder as this is where datadog-agent test
-    # stacks are stored.
-    workspace_dirs = [tempfile.gettempdir()]
-    workspace_subdirs_root = os.path.join(tempfile.gettempdir(), "pulumi-workspace")
-    if os.path.isdir(workspace_subdirs_root):
-        for entry in os.listdir(Path(workspace_subdirs_root)):
-            subdir = os.path.join(workspace_subdirs_root, entry)
-            if os.path.isdir(subdir):
-                workspace_dirs.append(subdir)
-    e2e_stacks: List[Stack] = []
-    for workspace_dir in workspace_dirs:
-        with ctx.cd(workspace_dir):
-            output = ctx.run("PULUMI_SKIP_UPDATE_CHECK=true pulumi stack ls --json", pty=True)
-            if output is None or not output:
-                return []
-            stacks_data = json.loads(output.stdout)
-            for stack in stacks_data:
-                if "name" not in stack:
-                    print(f"Skipping stack {stack} as it does not have a name")
-                    continue
-                stack_name = stack["name"]
-                print(f"Adding stack {stack_name}")
-                e2e_stacks.append(Stack(stack_name, workspace_dir))
-            return e2e_stacks
+def _get_existing_stacks(ctx: Context) -> List[str]:
+    e2e_stacks: List[str] = []
+    output = ctx.run("PULUMI_SKIP_UPDATE_CHECK=true pulumi stack ls --all --project e2elocal --json", pty=True)
+    if output is None or not output:
+        return []
+    stacks_data = json.loads(output.stdout)
+    for stack in stacks_data:
+        if "name" not in stack:
+            print(f"Skipping stack {stack} as it does not have a name")
+            continue
+        stack_name = stack["name"]
+        print(f"Adding stack {stack_name}")
+        e2e_stacks.append(stack_name)
+    return e2e_stacks
 
 
-def _destroy_stack(ctx: Context, stack: Stack):
+def _destroy_stack(ctx: Context, stack: str):
     # running in temp dir as this is where datadog-agent test
     # stacks are stored. It is expected to fail on stacks existing locally
     # with resources removed by agent-sandbox clean up job
-    with ctx.cd(stack.workspaceDirectory):
+    with ctx.cd(tempfile.gettempdir()):
         ret = ctx.run(
-            f"PULUMI_SKIP_UPDATE_CHECK=true pulumi destroy --stack {stack.name} --yes --remove --skip-preview",
+            f"PULUMI_SKIP_UPDATE_CHECK=true pulumi destroy --stack {stack} --yes --remove --skip-preview",
             pty=True,
             warn=True,
         )
         if ret is not None and ret.exited != 0:
             # run with refresh on first destroy attempt failure
             ctx.run(
-                f"PULUMI_SKIP_UPDATE_CHECK=true pulumi destroy --stack {stack.name} -r --yes --remove --skip-preview",
+                f"PULUMI_SKIP_UPDATE_CHECK=true pulumi destroy --stack {stack} -r --yes --remove --skip-preview",
                 pty=True,
                 warn=True,
             )
 
 
-def _remove_stack(ctx: Context, stack: Stack):
-    # running in temp dir as this is where datadog-agent test
-    # stacks are stored
-    with ctx.cd(stack.workspaceDirectory):
-        ctx.run(f"PULUMI_SKIP_UPDATE_CHECK=true pulumi stack rm --force --yes --stack {stack.name}", pty=True)
+def _remove_stack(ctx: Context, stack: str):
+    ctx.run(f"PULUMI_SKIP_UPDATE_CHECK=true pulumi stack rm --force --yes --stack {stack}", pty=True)
 
 
 def _get_pulumi_about(ctx: Context) -> dict:

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -218,13 +218,15 @@ def _get_existing_stacks(ctx: Context) -> List[Stack]:
     e2e_stacks: List[Stack] = []
     for workspace_dir in workspace_dirs:
         with ctx.cd(workspace_dir):
-            output = ctx.run("PULUMI_SKIP_UPDATE_CHECK=true pulumi stack ls", pty=True)
+            output = ctx.run("PULUMI_SKIP_UPDATE_CHECK=true pulumi stack ls --json", pty=True)
             if output is None or not output:
                 return []
-            lines = output.stdout.splitlines()
-            lines = lines[1:]  # skip headers
-            for line in lines:
-                stack_name = line.split(" ")[0]
+            stacks_data = json.loads(output.stdout)
+            for stack in stacks_data:
+                if "name" not in stack:
+                    print(f"Skipping stack {stack} as it does not have a name")
+                    continue
+                stack_name = stack["name"]
                 print(f"Adding stack {stack_name}")
                 e2e_stacks.append(Stack(stack_name, workspace_dir))
             return e2e_stacks


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Use `json` output format to list existing stacks in e2e cleanup task

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

json format reduce stack list parsing errors. Follow up to address https://github.com/DataDog/datadog-agent/pull/20630#discussion_r1384756280

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
