### PR TITLE
AP-2391 Modify test function to be able to run tests only on modified packages

### DIFF
--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -73,7 +73,7 @@ tests_deb-x64-py3:
     PYTHON_RUNTIMES: '3'
     CONDA_ENV: ddpy3
 
-tests_deb-x64-py-targeted:
+tests_deb-x64-py-fast:
   extends:
     - .rtloader_tests
     - .linux_tests

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -84,6 +84,7 @@ tests_deb-x64-py-fast:
     PYTHON_RUNTIMES: '3'
     CONDA_ENV: ddpy3
     EXTRAPARAMS: '--only-modified-packages'
+  allow_failure: true
 
 
 lint_linux-x64:

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -25,7 +25,7 @@
     - pushd test/kitchen
     - inv -e kitchen.invoke-unit-tests
     - popd
-    - inv -e test $FLAVORS --skip-linters --race --profile --rerun-fails=2 --python-runtimes "$PYTHON_RUNTIMES" --cpus $KUBERNETES_CPU_REQUEST $EXTRA_OPTS --save-result-json test_output.json --junit-tar "junit-${CI_JOB_NAME}.tgz"
+    - inv -e test $FLAVORS --skip-linters --race --profile --rerun-fails=2 --python-runtimes "$PYTHON_RUNTIMES" --cpus $KUBERNETES_CPU_REQUEST $EXTRA_OPTS --save-result-json test_output.json --junit-tar "junit-${CI_JOB_NAME}.tgz" $EXTRAPARAMS
   artifacts:
     expire_in: 2 weeks
     when: always
@@ -72,6 +72,19 @@ tests_deb-x64-py3:
   variables:
     PYTHON_RUNTIMES: '3'
     CONDA_ENV: ddpy3
+
+tests_deb-x64-py-targeted:
+  extends:
+    - .rtloader_tests
+    - .linux_tests
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs: ["go_deps", "go_tools_deps"]
+  variables:
+    PYTHON_RUNTIMES: '3'
+    CONDA_ENV: ddpy3
+    EXTRAPARAMS: '--only-modified-packages'
+
 
 lint_linux-x64:
   extends:

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -73,7 +73,7 @@ tests_deb-x64-py3:
     PYTHON_RUNTIMES: '3'
     CONDA_ENV: ddpy3
 
-tests_deb-x64-py-fast:
+tests_deb-x64-py3-fast:
   extends:
     - .rtloader_tests
     - .linux_tests

--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -74,6 +74,7 @@ tests_windows-x64-fast:
     PYTHON_RUNTIMES: 3
     ARCH: "x64"
     EXTRAPARAMS: '--only-modified-packages'
+  allow_failure: true
 
 lint_windows-x64:
   extends: .lint_windows_base

--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -26,6 +26,7 @@
       -e JUNIT_TAR="c:\mnt\junit-${CI_JOB_NAME}.tgz"
       -e VCPKG_BINARY_SOURCES="clear;x-azblob,${vcpkgBlobSaSUrl}"
       -e PIP_INDEX_URL=${PIP_INDEX_URL}
+      -e EXTRAPARAMS="${EXTRAPARAMS}"
       486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
       c:\mnt\tasks\winbuildscripts\unittests.bat
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
@@ -66,6 +67,13 @@ tests_windows-x64:
   variables:
     PYTHON_RUNTIMES: 3
     ARCH: "x64"
+
+tests_windows-x64-fast:
+  extends: .tests_windows_base
+  variables:
+    PYTHON_RUNTIMES: 3
+    ARCH: "x64"
+    EXTRAPARAMS: '--only-modified-packages'
 
 lint_windows-x64:
   extends: .lint_windows_base

--- a/pkg/collector/corechecks/net/ntp.go
+++ b/pkg/collector/corechecks/net/ntp.go
@@ -174,7 +174,7 @@ func (c *NTPCheck) Run() error {
 	if err != nil {
 		log.Error(err)
 
-		sender.ServiceCheck("ntp.in_sync", servicecheck.ServiceCheckCritical, "", nil, serviceCheckMessage)
+		sender.ServiceCheck("ntp.in_sync", servicecheck.ServiceCheckUnknown, "", nil, serviceCheckMessage)
 		c.lastCollection = time.Now()
 		sender.Commit()
 

--- a/pkg/collector/corechecks/net/ntp.go
+++ b/pkg/collector/corechecks/net/ntp.go
@@ -174,7 +174,7 @@ func (c *NTPCheck) Run() error {
 	if err != nil {
 		log.Error(err)
 
-		sender.ServiceCheck("ntp.in_sync", servicecheck.ServiceCheckUnknown, "", nil, serviceCheckMessage)
+		sender.ServiceCheck("ntp.in_sync", servicecheck.ServiceCheckCritical, "", nil, serviceCheckMessage)
 		c.lastCollection = time.Now()
 		sender.Commit()
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -54,6 +54,7 @@ from .test import (
     codecov,
     download_tools,
     e2e_tests,
+    get_modified_packages,
     install_shellcheck,
     install_tools,
     integration_tests,
@@ -115,6 +116,8 @@ ns.add_task(junit_macos_repack)
 ns.add_task(fuzz)
 ns.add_task(go_fix)
 ns.add_task(build_messagetable)
+
+ns.add_task(get_modified_packages)
 
 # add namespaced tasks to the root
 ns.add_collection(agent)

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -1161,7 +1161,7 @@ def get_modified_packages(ctx) -> List[GoModule]:
 
 
 def get_modified_files(ctx):
-    last_main_commit = ctx.run("git rev-parse main", hide=True).stdout
+    last_main_commit = ctx.run("git merge-base HEAD origin/main", hide=True).stdout
     print(f"Checking diff from {last_main_commit} commit on main branch")
 
     modified_files = ctx.run(f"git diff --name-only {last_main_commit}", hide=True).stdout.splitlines()

--- a/tasks/winbuildscripts/unittests.ps1
+++ b/tasks/winbuildscripts/unittests.ps1
@@ -81,7 +81,7 @@ if($err -ne 0){
 }
 
 & inv -e install-tools
-& inv -e test --skip-linters --junit-tar="$Env:JUNIT_TAR" --race --profile --rerun-fails=2 --cpus 8 --arch $archflag --python-runtimes="$Env:PY_RUNTIMES" --python-home-2=$Env:Python2_ROOT_DIR --python-home-3=$Env:Python3_ROOT_DIR --save-result-json C:\mnt\test_output.json
+& inv -e test --skip-linters --junit-tar="$Env:JUNIT_TAR" --race --profile --rerun-fails=2 --cpus 8 --arch $archflag --python-runtimes="$Env:PY_RUNTIMES" --python-home-2=$Env:Python2_ROOT_DIR --python-home-3=$Env:Python3_ROOT_DIR --save-result-json C:\mnt\test_output.json $Env:EXTRAPARAMS
 
 $err = $LASTEXITCODE
 Write-Host Test result is $err


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Add option to be able to launch unit tests only on package that are modified.
Modified files are taken from the diff between the latest commit and the most recent common commit between main and the dev branch

It adds a new unit test job for Linux and for Windows that will for now run along with the normal unit tests. To let us analyze the differences between the two

A follow up PR will add an extra job to check the difference of behaviour between the "fast" unit tests and the normal unit tests. To have information about the number of false positives or speed increase with the "fast"unit-tests


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Improve unit test speed

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

If the experiment is successful we'll need to do some modifications:
- run fast unit test on PR only
- run all the tests on main branch and merge queue branch
- add the ability to compare with base branch different from `main`, `7.48.0` for example for fix PRs

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
