### PR TITLE
usm: http2: Print conn tuple of http2_stream_t instance

### DIFF
--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -128,7 +128,8 @@ func (tx *EbpfTx) DynamicTags() []string {
 func (tx *EbpfTx) String() string {
 	var output strings.Builder
 	output.WriteString("http2.ebpfTx{")
-	output.WriteString("Method: '" + tx.Method().String() + "', ")
+	output.WriteString(fmt.Sprintf("[%s] [%s ⇄ %s] ", tx.family(), tx.sourceEndpoint(), tx.destEndpoint()))
+	output.WriteString(" Method: '" + tx.Method().String() + "', ")
 	buf := make([]byte, len(tx.Request_path))
 	path, ok := tx.Path(buf)
 	if ok {
@@ -136,6 +137,35 @@ func (tx *EbpfTx) String() string {
 	}
 	output.WriteString("}")
 	return output.String()
+}
+
+func (tx *EbpfTx) family() ebpf.ConnFamily {
+	if tx.Tup.Metadata&uint32(ebpf.IPv6) != 0 {
+		return ebpf.IPv6
+	}
+	return ebpf.IPv4
+}
+
+func (tx *EbpfTx) sourceAddress() util.Address {
+	if tx.family() == ebpf.IPv4 {
+		return util.V4Address(uint32(tx.Tup.Saddr_l))
+	}
+	return util.V6Address(tx.Tup.Saddr_l, tx.Tup.Saddr_h)
+}
+
+func (tx *EbpfTx) sourceEndpoint() string {
+	return net.JoinHostPort(tx.sourceAddress().String(), strconv.Itoa(int(tx.Tup.Sport)))
+}
+
+func (tx *EbpfTx) destAddress() util.Address {
+	if tx.family() == ebpf.IPv4 {
+		return util.V4Address(uint32(tx.Tup.Daddr_l))
+	}
+	return util.V6Address(tx.Tup.Daddr_l, tx.Tup.Daddr_h)
+}
+
+func (tx *EbpfTx) destEndpoint() string {
+	return net.JoinHostPort(tx.destAddress().String(), strconv.Itoa(int(tx.Tup.Dport)))
 }
 
 func (t http2StreamKey) family() ebpf.ConnFamily {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Print conn tuple of http2_stream_t instance
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
better information when debugging the tests.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
