### PR TITLE
[CONTINT-3328] Fix tag corruption in KSM core check

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -928,25 +928,23 @@ func TestSendTelemetry(t *testing.T) {
 				{
 					name:     "kubernetes_state.telemetry.metrics.count.total",
 					val:      5,
-					tags:     []string{"kube_cluster_name:foo"},
 					hostname: "",
 				},
 				{
 					name:     "kubernetes_state.telemetry.metrics.count",
 					val:      2,
-					tags:     []string{"kube_cluster_name:foo", "resource_name:baz"},
+					tags:     []string{"resource_name:baz"},
 					hostname: "",
 				},
 				{
 					name:     "kubernetes_state.telemetry.metrics.count",
 					val:      3,
-					tags:     []string{"kube_cluster_name:foo", "resource_name:bar"},
+					tags:     []string{"resource_name:bar"},
 					hostname: "",
 				},
 				{
 					name:     "kubernetes_state.telemetry.unknown_metrics.count",
 					val:      1,
-					tags:     []string{"kube_cluster_name:foo"},
 					hostname: "",
 				},
 			},
@@ -1131,14 +1129,15 @@ func TestKSMCheck_hostnameAndTags(t *testing.T) {
 			wantHostname: "",
 		},
 		{
-			name: "add check instance tags",
+			// instance tags are added in the sender by `initTags`. They do not need to be provided as arguments in sender functions.
+			name: "do not add check instance tags",
 			config: &KSMConfig{
 				Tags: []string{"instance:tag"},
 			},
 			args: args{
 				labels: map[string]string{"foo_label": "foo_value"},
 			},
-			wantTags:     []string{"foo_label:foo_value", "instance:tag"},
+			wantTags:     []string{"foo_label:foo_value"},
 			wantHostname: "",
 		},
 		{

--- a/releasenotes-dca/notes/fix-telemetry-parameter-in-ksm-0c97ee52a1f67f5a.yaml
+++ b/releasenotes-dca/notes/fix-telemetry-parameter-in-ksm-0c97ee52a1f67f5a.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fixed a bug in the ``kubernetes_state_core`` check that caused tag corruption when ``telemetry`` was set to ``true``.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR should fix a bug in KSM causing tag corruption when `telemetry: true` is set.

Full investigation notes: https://datadoghq.atlassian.net/wiki/spaces/~63ed3a63bc0f9b3a16fca94b/pages/3218604034/resource+name+tag+added+to+every+ksm+metric.

TL;DR: During the investigation, we noticed that:

- Tags set in the check config are already added in CommonConfigure, so we add them twice and remove them in the aggregator.
- It is possible `k.instance.Tags` has a capacity different from its length. As a result, `append()` can modify the underlying array instead of copying it.
- Using `append(k.instance.Tags, "my_tag:value")` directly in the RawSender can cause a complex data race that adds `my_tag:value` to `k.instance.Tags`, thus to every ksm metric.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
KSM should have correct tags and values.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
During the investigation, we also noted that pre-sorting tags could positively affect performances. See https://github.com/DataDog/datadog-agent/pull/20679
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs
None
<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1.  Make sure the data race is fixed
Deploy the Agent with helm using:
```
datadog:
  tags:
    - env:test-env
    - region:test-region
    - perimeter:test-perimeter
  clusterName: YOUR_CLUSTER_NAME
clusterAgent:
  confd:
    kubernetes_state_core.yaml: |-
      init_config:
      instances:
        - collectors:
          - secrets
          - verticalpodautoscalers
          - apiservices
          - customresourcedefinitions
          - nodes
          - pods
          - services
          - resourcequotas
          - replicationcontrollers
          - limitranges
          - persistentvolumeclaims
          - persistentvolumes
          - namespaces
          - endpoints
          - daemonsets
          - deployments
          - replicasets
          - statefulsets
          - cronjobs
          - jobs
          - horizontalpodautoscalers
          - poddisruptionbudgets
          - storageclasses
          - volumeattachments
          - ingresses
          telemetry: true
          tags:
            - cluster_name:YOUR_CLUSTER_NAME
            - kube_cluster_name:YOUR_CLUSTER_NAME
```
Make sure that `resource_name` is set only for `kubernetes_state.telemetry.metrics.count`.

2. Make sure tagging is still correct
Try adding tags `DD_TAGS` in the ksm config under `tags` or add global tags and make sure they are added to every ksm metric.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
