### PR TITLE
[CWS] remove force GC calls

### DIFF
--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -1540,10 +1540,6 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 		seclog.Warnf("constant fetcher failed: %v", err)
 		return nil, err
 	}
-	// the constant fetching mechanism can be quite memory intensive, between kernel header downloading,
-	// runtime compilation, BTF parsing...
-	// let's ensure the GC has run at this point before doing further memory intensive stuff
-	runtime.GC()
 
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, constantfetch.CreateConstantEditors(p.constantOffsets)...)
 

--- a/pkg/security/resolvers/resolvers_linux.go
+++ b/pkg/security/resolvers/resolvers_linux.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"runtime"
 	"sort"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -213,7 +212,6 @@ func (r *Resolvers) Snapshot() error {
 		return err
 	}
 
-	runtime.GC()
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR removes 2 `runtime.GC()` calls that are no longer necessary.
- the one in the resolver is duplicated since the caller is already doing a runtime.GC just after the call
- the one about constant fetching is no longer needed since the underlying packages have made considerable improvements in memory usage

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

No real QA needed, just need to keep this PR in mind if some strange memory issue occurs during QA

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
