### PR TITLE
[NPM-3068] Ensure a full request/response happens during conntrack offset guessing

### DIFF
--- a/pkg/network/tracer/offsetguess/conntrack.go
+++ b/pkg/network/tracer/offsetguess/conntrack.go
@@ -369,6 +369,10 @@ func (e *conntrackEventGenerator) Generate(status GuessWhat, expected *fieldValu
 				return err
 			}
 
+			e.udpConn.Write([]byte("ping"))
+			out := make([]byte, 4)
+			e.udpConn.Read(out)
+
 			return e.populateUDPExpectedValues(expected)
 		})
 		if err != nil {

--- a/pkg/network/tracer/offsetguess/conntrack.go
+++ b/pkg/network/tracer/offsetguess/conntrack.go
@@ -369,9 +369,13 @@ func (e *conntrackEventGenerator) Generate(status GuessWhat, expected *fieldValu
 				return err
 			}
 
-			e.udpConn.Write([]byte("ping"))
+			if _, err := e.udpConn.Write([]byte("ping")); err != nil {
+				return err
+			}
 			out := make([]byte, 4)
-			e.udpConn.Read(out)
+			if _, err := e.udpConn.Read(out); err != nil {
+				return err
+			}
 
 			return e.populateUDPExpectedValues(expected)
 		})

--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -1084,7 +1084,8 @@ func newUDPServer(addr string) (string, func(), error) {
 				return
 			}
 
-			ln.WriteTo(pong, caddr)
+			// TODO: error check
+			_, _ = ln.WriteTo(pong, caddr)
 		}
 	}()
 

--- a/pkg/network/tracer/offsetguess/tracer.go
+++ b/pkg/network/tracer/offsetguess/tracer.go
@@ -1071,16 +1071,20 @@ func newUDPServer(addr string) (string, func(), error) {
 	}
 
 	done := make(chan struct{})
+
+	pong := []byte("pong")
 	go func() {
 		defer close(done)
 
 		b := make([]byte, 10)
 		for {
 			_ = ln.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
-			_, _, err := ln.ReadFrom(b)
+			_, caddr, err := ln.ReadFrom(b)
 			if err != nil && !os.IsTimeout(err) {
 				return
 			}
+
+			ln.WriteTo(pong, caddr)
 		}
 	}()
 


### PR DESCRIPTION
We have been seeing sporadic conntrack test failures in CI, and sporadic failures to initialize the eBPF conntracker internally.

For background, offset guessing for a single field works within a loop where the same event is repeadly generated, and an ebpf program reads the contents of a function param at a candidate offset which is advanced with every iteration of the loop until the contents at that candidate offset match the contents at an event.

```
while guessing:
    ev := eventGenerator.Generate() // generates a UDP connection, populates guessed with the current guessed offsets
    if guessed[field] == ev[field]
      field = next field to guess
    else:
      candidate offset for field ++
```

This PR may help solve the problem by ensuring that during conntrack offset guessing each Generate() event ensures a UDP connection is established all the way (i.e. writes and then reads). Before this change, the Generate() event only ran a net.Dial, which might not have reliably caused a conntrack entry to be established.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
