### PR TITLE
[process-agent] reduce allocations in parseStatContent

### DIFF
--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -665,6 +665,11 @@ func (p *probe) parseStatContent(statContent []byte, sInfo *statInfo, pid int32,
 			buffer = append(buffer, c)
 			prevCharIsSpace = false
 		}
+
+		if spaces > 20 {
+			// last item so break out of the loop as we don't need to parse the rest of the content
+			break
+		}
 	}
 
 	if spaces < 20 { // We access index 20 and below, so this is just a safety check.

--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -575,6 +575,11 @@ func parseBytesToUint(buf []byte, base int, bitSize int) (uint64, error) {
 	return strconv.ParseUint(*(*string)(unsafe.Pointer(&buf)), base, bitSize)
 }
 
+func parseBytesToFloat(buf []byte, bitSize int) (float64, error) {
+	// Safety: We are not modifying the contents of the byte slice.
+	return strconv.ParseFloat(*(*string)(unsafe.Pointer(&buf)), bitSize)
+}
+
 func parseMemInfo(value, key []byte, memInfo *MemoryInfoStat) {
 	value = bytes.TrimSuffix(value, []byte("kB"))
 	value = bytes.TrimSpace(value)
@@ -621,30 +626,43 @@ func (p *probe) parseStatContent(statContent []byte, sInfo *statInfo, pid int32,
 	// use spaces and prevCharIsSpace to simulate strings.Fields() to avoid allocation
 	spaces := 0
 	prevCharIsSpace := false
-	var ppidStr, flagStr, utimeStr, stimeStr, startTimeStr string
+	var buffer []byte
 
 	for _, c := range content {
 		if unicode.IsSpace(rune(c)) {
 			if !prevCharIsSpace {
+				switch spaces {
+				case 2:
+					if ppid, err := parseBytesToInt(buffer, 10, 32); err == nil {
+						sInfo.ppid = int32(ppid)
+					}
+				case 7:
+					if flags, err := parseBytesToUint(buffer, 10, 32); err == nil {
+						sInfo.flags = uint32(flags)
+					}
+				case 12:
+					if utime, err := parseBytesToFloat(buffer, 64); err == nil {
+						sInfo.cpuStat.User = utime / p.clockTicks
+					}
+				case 13:
+					if stime, err := parseBytesToFloat(buffer, 64); err == nil {
+						sInfo.cpuStat.System = stime / p.clockTicks
+					}
+				case 20:
+					if t, err := parseBytesToUint(buffer, 10, 64); err == nil {
+						ctime := (t / uint64(p.clockTicks)) + p.bootTime.Load()
+						// convert create time into milliseconds
+						sInfo.createTime = int64(ctime * 1000)
+					}
+				}
 				spaces++
+				buffer = buffer[:0]
 			}
 			prevCharIsSpace = true
 			continue
 		} else {
+			buffer = append(buffer, c)
 			prevCharIsSpace = false
-		}
-
-		switch spaces {
-		case 2:
-			ppidStr += string(c)
-		case 7:
-			flagStr += string(c)
-		case 12:
-			utimeStr += string(c)
-		case 13:
-			stimeStr += string(c)
-		case 20:
-			startTimeStr += string(c)
 		}
 	}
 
@@ -652,25 +670,6 @@ func (p *probe) parseStatContent(statContent []byte, sInfo *statInfo, pid int32,
 		return sInfo
 	}
 
-	ppid, err := strconv.ParseInt(ppidStr, 10, 32)
-	if err == nil {
-		sInfo.ppid = int32(ppid)
-	}
-
-	flags, err := strconv.ParseUint(flagStr, 10, 32)
-	if err == nil {
-		sInfo.flags = uint32(flags)
-	}
-
-	utime, err := strconv.ParseFloat(utimeStr, 64)
-	if err == nil {
-		sInfo.cpuStat.User = utime / p.clockTicks
-	}
-
-	stime, err := strconv.ParseFloat(stimeStr, 64)
-	if err == nil {
-		sInfo.cpuStat.System = stime / p.clockTicks
-	}
 	// the nice parameter location seems to be different for various procfs,
 	// so we fetch that using syscall
 	snice, err := syscall.Getpriority(syscall.PRIO_PROCESS, int(pid))
@@ -679,13 +678,6 @@ func (p *probe) parseStatContent(statContent []byte, sInfo *statInfo, pid int32,
 	}
 
 	sInfo.cpuStat.Timestamp = now.Unix()
-
-	t, err := strconv.ParseUint(startTimeStr, 10, 64)
-	if err == nil {
-		ctime := (t / uint64(p.clockTicks)) + p.bootTime.Load()
-		// convert create time into milliseconds
-		sInfo.createTime = int64(ctime * 1000)
-	}
 
 	return sInfo
 }

--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -626,7 +626,8 @@ func (p *probe) parseStatContent(statContent []byte, sInfo *statInfo, pid int32,
 	// use spaces and prevCharIsSpace to simulate strings.Fields() to avoid allocation
 	spaces := 0
 	prevCharIsSpace := false
-	var buffer []byte
+	// pre-size the buffer to avoid allocations
+	buffer := make([]byte, 0, 32)
 
 	for _, c := range content {
 		if unicode.IsSpace(rune(c)) {

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -622,6 +622,42 @@ func BenchmarkParseStatusLine(b *testing.B) {
 	}
 }
 
+func BenchmarkParseStatContent(b *testing.B) {
+	probe := getProbeWithPermission()
+	defer probe.Close()
+
+	// hard code the bootTime so we get consistent calculation for createTime
+	probe.bootTime.Store(1606181252)
+	now := time.Now()
+
+	testCases := []struct {
+		name string
+		line []byte
+	}{
+		{
+			name: "normal process",
+			line: []byte("1 (systemd) S 0 1 1 0 -1 4194560 425768 306165945 70 4299 4890 2184 563120 375308 20 0 1 0 15 189849600 1541 18446744073709551615 94223912931328 94223914360080 140733806473072 140733806469312 140053573122579 0 671173123 4096 1260 1 0 0 17 0 0 0 155 0 0 94223914368000 942\n23914514184 94223918080000 140733806477086 140733806477133 140733806477133 140733806477283 0"),
+		},
+		{
+			name: "command line has brackets around",
+			line: []byte("1 ((sd-pam)) S 0 1 1 0 -1 4194560 425768 306165945 70 4299 4890 2184 563120 375308 20 0 1 0 15 189849600 1541 18446744073709551615 94223912931328 94223914360080 140733806473072 140733806469312 140053573122579 0 671173123 4096 1260 1 0 0 17 0 0 0 155 0 0 94223914368000 942\n23914514184 94223918080000 140733806477086 140733806477133 140733806477133 140733806477283 0"),
+		},
+		{
+			name: "fields are separated by multiple white spaces",
+			line: []byte("5  (kworker/0:0H)   S 2 0 0 0 -1   69238880 0 0  0 0  0 0 0 0 0  -20 1 0 17 0 0 18446744073709551615 0 0 0 0 0 0 0 2147483647 0 0 0 0 17 0 0 0 0 0 0 0 0 0 0 0 0 0 0"),
+		},
+		{
+			name: "flags are greater than int32",
+			line: []byte("44 (kintegrityd/0) S 2 0 0 0 -1 2216722496 0 0 0 0 0 0 0 0 20 0 1 0 31 0 0 18446744073709551615 0 0 0 0 0 0 0 2147483647 0 18446744071579499573 0 0 17 0 0 0 0 0 0"),
+		},
+	}
+	for i := 0; i < b.N; i++ {
+		for _, tc := range testCases {
+			probe.parseStatContent(tc.line, &statInfo{cpuStat: &CPUTimesStat{}}, int32(1), now)
+		}
+	}
+}
+
 func TestParseStatusTestFS(t *testing.T) {
 	t.Setenv("HOST_PROC", "resources/test_procfs/proc/")
 	testParseStatus(t, WithProcFSRoot("resources/test_procfs/proc/"))
@@ -809,6 +845,7 @@ func TestParseStatContent(t *testing.T) {
 		isKernelThread bool
 	}{
 		{
+			name: "normal process",
 			line: []byte("1 (systemd) S 0 1 1 0 -1 4194560 425768 306165945 70 4299 4890 2184 563120 375308 20 0 1 0 15 189849600 1541 18446744073709551615 94223912931328 94223914360080 140733806473072 140733806469312 140053573122579 0 671173123 4096 1260 1 0 0 17 0 0 0 155 0 0 94223914368000 942\n23914514184 94223918080000 140733806477086 140733806477133 140733806477133 140733806477283 0"),
 			expected: &statInfo{
 				ppid:       0,

--- a/releasenotes/notes/process-agent-improve-parse-stat-content-allocations-8c6fd48fb63649f1.yaml
+++ b/releasenotes/notes/process-agent-improve-parse-stat-content-allocations-8c6fd48fb63649f1.yaml
@@ -1,0 +1,3 @@
+---
+enhancements:
+  - Process-Agent: Improved parsing performance of the '/proc/pid/stat' file in (linux-only)

--- a/releasenotes/notes/process-agent-improve-parse-stat-content-allocations-8c6fd48fb63649f1.yaml
+++ b/releasenotes/notes/process-agent-improve-parse-stat-content-allocations-8c6fd48fb63649f1.yaml
@@ -1,3 +1,3 @@
 ---
 enhancements:
-  - Process-Agent: Improved parsing performance of the '/proc/pid/stat' file in (linux-only)
+  - Process-Agent: Improved parsing performance of the '/proc/pid/stat' file (Linux only)


### PR DESCRIPTION
### What does this PR do?

This is a PR inspired by https://github.com/DataDog/datadog-agent/pull/20559 to reduce allocation when parsing the `/proc/$pid/stat` file. The following changes are introduced in the PR.
- Fill a pre-allocated buffer for each field. When the value matches a position of interest then perform non-allocating `[]byte` to numeral conversion. This reduces the allocation to zero from the original implmentation. 
- Break out of the loop after the last field of interest. This is about halfway through parsing of the file as there are about 52 fields in total according to: https://man7.org/linux/man-pages/man5/proc.5.html

### Benchmark Results

**Baseline**
```sh
BenchmarkParseStatContent-4       170738              6936 ns/op             544 B/op        108 allocs/op
PASS
ok      github.com/DataDog/datadog-agent/pkg/process/procutil   2.662s
```

**Use buffer and skip `[]byte` to string conversion**
```sh
BenchmarkParseStatContent-4       248408              4802 ns/op             224 B/op         12 allocs/op
PASS
ok      github.com/DataDog/datadog-agent/pkg/process/procutil   2.693s
```

**Pre-sizing buffer**
```sh
BenchmarkParseStatContent-4       243747              4768 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/DataDog/datadog-agent/pkg/process/procutil   2.896s
```

**Breaking out early from loop**
```sh
BenchmarkParseStatContent-4       485961              2352 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/DataDog/datadog-agent/pkg/process/procutil   2.869s
```

**Original vs Final**
```
name                old time/op    new time/op    delta
ParseStatContent-4    7.74µs ± 6%    2.30µs ± 4%   -70.22%  (p=0.000 n=9+9)

name                old alloc/op   new alloc/op   delta
ParseStatContent-4      544B ± 0%        0B       -100.00%  (p=0.000 n=10+10)

name                old allocs/op  new allocs/op  delta
ParseStatContent-4       108 ± 0%         0       -100.00%  (p=0.000 n=10+10)
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
