### PR TITLE
[corechecks/helm] Improve tests

### DIFF
--- a/pkg/collector/corechecks/cluster/helm/helm_test.go
+++ b/pkg/collector/corechecks/cluster/helm/helm_test.go
@@ -322,7 +322,8 @@ func TestRun_withCollectEvents(t *testing.T) {
 
 	eventsAllowedDelta := 10 * time.Second
 
-	secret, err := secretForRelease(&rel, time.Now().Add(10))
+	// The creation timestamp of the secret needs to be after the check start. Otherwise, the event will not be emitted.
+	secret, err := secretForRelease(&rel, check.startTS.Add(10))
 	require.NoError(t, err)
 
 	k8sClient := fake.NewSimpleClientset()
@@ -411,7 +412,8 @@ func TestRun_skipEventForExistingRelease(t *testing.T) {
 		Namespace: "default",
 	}
 
-	secret, err := secretForRelease(&rel, time.Now().Add(-10))
+	// The creation timestamp for the secret needs to be before the check start to simulate an existing release.
+	secret, err := secretForRelease(&rel, check.startTS.Add(-10))
 	require.NoError(t, err)
 
 	k8sClient := fake.NewSimpleClientset()

--- a/pkg/collector/corechecks/cluster/helm/helm_test.go
+++ b/pkg/collector/corechecks/cluster/helm/helm_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -278,8 +279,10 @@ func TestRun(t *testing.T) {
 			// are not necessarily emitted in the first run. It depends on
 			// whether the check had time to process the events.
 
-			check.CommonConfigure(mockedSender.GetSenderManager(), 0, nil, nil, "")
-			err := check.Run()
+			err := check.CommonConfigure(mockedSender.GetSenderManager(), 0, nil, nil, "")
+			require.NoError(t, err)
+
+			err = check.Run()
 			assert.NoError(t, err)
 
 			assert.Eventually(t, func() bool { // Wait until the events are processed
@@ -330,7 +333,9 @@ func TestRun_withCollectEvents(t *testing.T) {
 	mockedSender.SetupAcceptAll()
 
 	// First run to set up the informers.
-	check.CommonConfigure(mockedSender.GetSenderManager(), 0, nil, nil, "")
+	err = check.CommonConfigure(mockedSender.GetSenderManager(), 0, nil, nil, "")
+	require.NoError(t, err)
+
 	err = check.Run()
 	assert.NoError(t, err)
 
@@ -419,7 +424,8 @@ func TestRun_skipEventForExistingRelease(t *testing.T) {
 	// Create a new release and check that we never send an event for it
 	_, err = k8sClient.CoreV1().Secrets("default").Create(context.TODO(), secret, metav1.CreateOptions{})
 	assert.NoError(t, err)
-	check.CommonConfigure(mockedSender.GetSenderManager(), 0, nil, nil, "")
+	err = check.CommonConfigure(mockedSender.GetSenderManager(), 0, nil, nil, "")
+	require.NoError(t, err)
 	err = check.Run()
 	assert.NoError(t, err)
 	mockedSender.AssertNotCalled(t, "Event")
@@ -553,8 +559,9 @@ func TestRun_ServiceCheck(t *testing.T) {
 
 			k8sClient := fake.NewSimpleClientset()
 			check.informerFactory = informers.NewSharedInformerFactory(k8sClient, time.Minute)
-			check.CommonConfigure(mockedSender.GetSenderManager(), 0, nil, nil, "")
-			err := check.Run()
+			err := check.CommonConfigure(mockedSender.GetSenderManager(), 0, nil, nil, "")
+			require.NoError(t, err)
+			err = check.Run()
 			assert.NoError(t, err)
 
 			// "my_datadog" release should report OK.

--- a/pkg/collector/corechecks/cluster/helm/helm_test.go
+++ b/pkg/collector/corechecks/cluster/helm/helm_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
 )
 
-var testTimeout = 10 * time.Second
-var testTicker = 5 * time.Millisecond
+var testTimeout = 30 * time.Second
+var testTicker = 100 * time.Millisecond
 
 func TestRun(t *testing.T) {
 	releases := []release{


### PR DESCRIPTION

### What does this PR do?

Improves the tests of the Helm check:
- Adds some missing error checks.
- Uses `require` instead of `assert` where appropriate.
- Adds comments clarifying a couple of things.
- Adjusts the timeout and the ticker frequency to try to avoid flakiness in the tests.


### Describe how to test/QA your changes

Skip.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
