### PR TITLE
Enable container image collection by default

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1118,7 +1118,7 @@ func InitConfig(config Config) {
 	bindEnvAndSetLogsConfigKeys(config, "container_lifecycle.")
 
 	// Container image configuration
-	config.BindEnvAndSetDefault("container_image.enabled", false)
+	config.BindEnvAndSetDefault("container_image.enabled", true)
 	bindEnvAndSetLogsConfigKeys(config, "container_image.")
 
 	// Remote process collector

--- a/releasenotes/notes/enable_contimage-e958765b0f81a9a4.yaml
+++ b/releasenotes/notes/enable_contimage-e958765b0f81a9a4.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Enable container image collection by default.


### PR DESCRIPTION
### What does this PR do?

Enable container image image collection by default.

### Motivation

Container image collection feature has been in beta for a while. The EP track is now GA.

### Additional Notes

This feature has been enabled in the Helm chart with DataDog/helm-charts#1228.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the agent and check that the `container-image` check is running.

```
agent status
```
```
[…]
==========
Aggregator
==========
[…]
  container-images: 6
[…]
```

or

```
agent checkconfig
```
```
[…]
=== container_image check ===
Configuration provider: file
Configuration source: file:/etc/datadog-agent/conf.d/container_image.d/conf.yaml.default
Config for instance ID: container_image:2ac6bde1700038e4
{}
~
Auto-discovery IDs:
* _container_image
===
[…]
```

Note that since DataDog/helm-charts#1228, this feature is enabled by the public Helm chart `3.45.0` or newer.
So, in order to test that the feature is now properly enabled by default in the agent itself, we need:
* either to use a public Helm chart `3.44.0` or older;
* or deploy the agent with something else than the Helm chart;
* or manually remove the setting of the `DD_CONTAINER_IMAGE_ENABLED` environment variable in the agent pod manifest.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
