### PR TITLE
[ASCII-145] Extract collector to a subpackage of status

### DIFF
--- a/cmd/agent/gui/agent.go
+++ b/cmd/agent/gui/agent.go
@@ -54,11 +54,12 @@ func ping(w http.ResponseWriter, r *http.Request) {
 func getStatus(w http.ResponseWriter, r *http.Request, invAgent inventoryagent.Component) {
 	statusType := mux.Vars(r)["type"]
 
-	var stats map[string]interface{}
-	var err error
+	var (
+		stats map[string]interface{}
+		err   error
+	)
 	if statusType == "collector" {
 		stats = collector.GetStatus()
-		err = nil
 	} else {
 		verbose := r.URL.Query().Get("verbose") == "true"
 		stats, err = status.GetStatus(verbose, invAgent)

--- a/cmd/agent/gui/agent.go
+++ b/cmd/agent/gui/agent.go
@@ -59,7 +59,7 @@ func getStatus(w http.ResponseWriter, r *http.Request, invAgent inventoryagent.C
 		err   error
 	)
 	if statusType == "collector" {
-		stats = collector.GetStatus()
+		stats = collector.GetStatusInfo()
 	} else {
 		verbose := r.URL.Query().Get("verbose") == "true"
 		stats, err = status.GetStatus(verbose, invAgent)

--- a/pkg/status/collector/collector.go
+++ b/pkg/status/collector/collector.go
@@ -3,7 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
-// Package collector fetch information from different agent chekcs from expvar
+// Package collector fetch information needed to render the 'collector' section of the status page.
+// This will, in time, be migrated to the collector package/comp.
 package collector
 
 import (
@@ -11,18 +12,17 @@ import (
 	"expvar"
 )
 
-// PopulateStatus populates stats with collector information
-func PopulateStatus(stats map[string]interface{}) {
-	status := GetStatus()
-	for key, value := range status {
-		stats[key] = value
-	}
-}
-
-// GetStatus retrives collector information
-func GetStatus() map[string]interface{} {
+// GetStatusInfo retrives collector information
+func GetStatusInfo() map[string]interface{} {
 	stats := make(map[string]interface{})
 
+	PopulateStatus(stats)
+
+	return stats
+}
+
+// PopulateStatus populates stats with collector information
+func PopulateStatus(stats map[string]interface{}) {
 	runnerStatsJSON := []byte(expvar.Get("runner").String())
 	runnerStats := make(map[string]interface{})
 	json.Unmarshal(runnerStatsJSON, &runnerStats) //nolint:errcheck
@@ -92,6 +92,4 @@ func GetStatus() map[string]interface{} {
 	} else {
 		stats["agent_metadata"] = map[string]string{}
 	}
-
-	return stats
 }

--- a/pkg/status/collector/collector.go
+++ b/pkg/status/collector/collector.go
@@ -87,9 +87,4 @@ func PopulateStatus(stats map[string]interface{}) {
 		}
 	}
 	stats["inventories"] = checkMetadata
-	if data, ok := inventoriesStats["agent_metadata"]; ok {
-		stats["agent_metadata"] = data
-	} else {
-		stats["agent_metadata"] = map[string]string{}
-	}
 }

--- a/pkg/status/collector/collector.go
+++ b/pkg/status/collector/collector.go
@@ -1,0 +1,97 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package collector fetch information from different agent chekcs from expvar
+package collector
+
+import (
+	"encoding/json"
+	"expvar"
+)
+
+// UpdateStatus populates stats with collector information
+func UpdateStatus(stats map[string]interface{}) {
+	status := GetStatus()
+	for key, value := range status {
+		stats[key] = value
+	}
+}
+
+// GetStatus retrives collector information
+func GetStatus() map[string]interface{} {
+	stats := make(map[string]interface{})
+
+	runnerStatsJSON := []byte(expvar.Get("runner").String())
+	runnerStats := make(map[string]interface{})
+	json.Unmarshal(runnerStatsJSON, &runnerStats) //nolint:errcheck
+	stats["runnerStats"] = runnerStats
+
+	autoConfigStatsJSON := []byte(expvar.Get("autoconfig").String())
+	autoConfigStats := make(map[string]interface{})
+	json.Unmarshal(autoConfigStatsJSON, &autoConfigStats) //nolint:errcheck
+	stats["autoConfigStats"] = autoConfigStats
+
+	checkSchedulerStatsJSON := []byte(expvar.Get("CheckScheduler").String())
+	checkSchedulerStats := make(map[string]interface{})
+	json.Unmarshal(checkSchedulerStatsJSON, &checkSchedulerStats) //nolint:errcheck
+	stats["checkSchedulerStats"] = checkSchedulerStats
+
+	pyLoaderData := expvar.Get("pyLoader")
+	if pyLoaderData != nil {
+		pyLoaderStatsJSON := []byte(pyLoaderData.String())
+		pyLoaderStats := make(map[string]interface{})
+		json.Unmarshal(pyLoaderStatsJSON, &pyLoaderStats) //nolint:errcheck
+		stats["pyLoaderStats"] = pyLoaderStats
+	} else {
+		stats["pyLoaderStats"] = nil
+	}
+
+	pythonInitData := expvar.Get("pythonInit")
+	if pythonInitData != nil {
+		pythonInitJSON := []byte(pythonInitData.String())
+		pythonInit := make(map[string]interface{})
+		json.Unmarshal(pythonInitJSON, &pythonInit) //nolint:errcheck
+		stats["pythonInit"] = pythonInit
+	} else {
+		stats["pythonInit"] = nil
+	}
+
+	inventories := expvar.Get("inventories")
+	var inventoriesStats map[string]interface{}
+	if inventories != nil {
+		inventoriesStatsJSON := []byte(inventories.String())
+		json.Unmarshal(inventoriesStatsJSON, &inventoriesStats) //nolint:errcheck
+	}
+
+	checkMetadata := map[string]map[string]string{}
+	if data, ok := inventoriesStats["check_metadata"]; ok {
+		for _, instances := range data.(map[string]interface{}) {
+			for _, instance := range instances.([]interface{}) {
+				metadata := map[string]string{}
+				checkHash := ""
+				for k, v := range instance.(map[string]interface{}) {
+					if vStr, ok := v.(string); ok {
+						if k == "config.hash" {
+							checkHash = vStr
+						} else if k != "config.provider" {
+							metadata[k] = vStr
+						}
+					}
+				}
+				if checkHash != "" && len(metadata) != 0 {
+					checkMetadata[checkHash] = metadata
+				}
+			}
+		}
+	}
+	stats["checkMetadata"] = checkMetadata
+	if data, ok := inventoriesStats["agent_metadata"]; ok {
+		stats["agent_metadata"] = data
+	} else {
+		stats["agent_metadata"] = map[string]string{}
+	}
+
+	return stats
+}

--- a/pkg/status/collector/collector.go
+++ b/pkg/status/collector/collector.go
@@ -86,7 +86,7 @@ func GetStatus() map[string]interface{} {
 			}
 		}
 	}
-	stats["checkMetadata"] = checkMetadata
+	stats["inventories"] = checkMetadata
 	if data, ok := inventoriesStats["agent_metadata"]; ok {
 		stats["agent_metadata"] = data
 	} else {

--- a/pkg/status/collector/collector.go
+++ b/pkg/status/collector/collector.go
@@ -11,8 +11,8 @@ import (
 	"expvar"
 )
 
-// UpdateStatus populates stats with collector information
-func UpdateStatus(stats map[string]interface{}) {
+// PopulateStatus populates stats with collector information
+func PopulateStatus(stats map[string]interface{}) {
 	status := GetStatus()
 	for key, value := range status {
 		stats[key] = value

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -126,19 +126,14 @@ func GetAndFormatStatus(invAgent inventoryagent.Component) ([]byte, error) {
 
 // GetCheckStatusJSON gets the status of a single check as JSON
 func GetCheckStatusJSON(c check.Check, cs *checkstats.Stats) ([]byte, error) {
-<<<<<<< HEAD
-	stats := make(map[string]interface{})
-	stats = getRunnerStats(stats)
-	checks := stats["runnerStats"].(map[string]interface{})["Checks"].(map[string]interface{})
-=======
-	s := collector.GetStatus()
+	s := collector.GetStatusInfo()
 
 	checks := s["runnerStats"].(map[string]interface{})["Checks"].(map[string]interface{})
->>>>>>> ff866964ad (use collector package to just collect check information)
+
 	checks[c.String()] = make(map[checkid.ID]interface{})
 	checks[c.String()].(map[checkid.ID]interface{})[c.ID()] = cs
 
-	statusJSON, err := json.Marshal(stats)
+	statusJSON, err := json.Marshal(s)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -32,6 +32,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
 	logsStatus "github.com/DataDog/datadog-agent/pkg/logs/status"
 	"github.com/DataDog/datadog-agent/pkg/snmp/traps"
+	"github.com/DataDog/datadog-agent/pkg/status/collector"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
@@ -125,9 +126,15 @@ func GetAndFormatStatus(invAgent inventoryagent.Component) ([]byte, error) {
 
 // GetCheckStatusJSON gets the status of a single check as JSON
 func GetCheckStatusJSON(c check.Check, cs *checkstats.Stats) ([]byte, error) {
+<<<<<<< HEAD
 	stats := make(map[string]interface{})
 	stats = getRunnerStats(stats)
 	checks := stats["runnerStats"].(map[string]interface{})["Checks"].(map[string]interface{})
+=======
+	s := collector.GetStatus()
+
+	checks := s["runnerStats"].(map[string]interface{})["Checks"].(map[string]interface{})
+>>>>>>> ff866964ad (use collector package to just collect check information)
 	checks[c.String()] = make(map[checkid.ID]interface{})
 	checks[c.String()].(map[checkid.ID]interface{})[c.ID()] = cs
 
@@ -350,14 +357,6 @@ func getCommonStatus(invAgent inventoryagent.Component) (map[string]interface{},
 	return stats, nil
 }
 
-func getRunnerStats(stats map[string]interface{}) map[string]interface{} {
-	runnerStatsJSON := []byte(expvar.Get("runner").String())
-	runnerStats := make(map[string]interface{})
-	json.Unmarshal(runnerStatsJSON, &runnerStats) //nolint:errcheck
-	stats["runnerStats"] = runnerStats
-	return stats
-}
-
 func expvarStats(stats map[string]interface{}, invAgent inventoryagent.Component) (map[string]interface{}, error) {
 	var err error
 	forwarderStatsJSON := []byte(expvar.Get("forwarder").String())
@@ -365,17 +364,7 @@ func expvarStats(stats map[string]interface{}, invAgent inventoryagent.Component
 	json.Unmarshal(forwarderStatsJSON, &forwarderStats) //nolint:errcheck
 	stats["forwarderStats"] = forwarderStats
 
-	stats = getRunnerStats(stats)
-
-	autoConfigStatsJSON := []byte(expvar.Get("autoconfig").String())
-	autoConfigStats := make(map[string]interface{})
-	json.Unmarshal(autoConfigStatsJSON, &autoConfigStats) //nolint:errcheck
-	stats["autoConfigStats"] = autoConfigStats
-
-	checkSchedulerStatsJSON := []byte(expvar.Get("CheckScheduler").String())
-	checkSchedulerStats := make(map[string]interface{})
-	json.Unmarshal(checkSchedulerStatsJSON, &checkSchedulerStats) //nolint:errcheck
-	stats["checkSchedulerStats"] = checkSchedulerStats
+	collector.UpdateStatus(stats)
 
 	aggregatorStatsJSON := []byte(expvar.Get("aggregator").String())
 	aggregatorStats := make(map[string]interface{})
@@ -407,26 +396,6 @@ func expvarStats(stats map[string]interface{}, invAgent inventoryagent.Component
 		stats["dogstatsdStats"] = dogstatsdStats
 	}
 
-	pyLoaderData := expvar.Get("pyLoader")
-	if pyLoaderData != nil {
-		pyLoaderStatsJSON := []byte(pyLoaderData.String())
-		pyLoaderStats := make(map[string]interface{})
-		json.Unmarshal(pyLoaderStatsJSON, &pyLoaderStats) //nolint:errcheck
-		stats["pyLoaderStats"] = pyLoaderStats
-	} else {
-		stats["pyLoaderStats"] = nil
-	}
-
-	pythonInitData := expvar.Get("pythonInit")
-	if pythonInitData != nil {
-		pythonInitJSON := []byte(pythonInitData.String())
-		pythonInit := make(map[string]interface{})
-		json.Unmarshal(pythonInitJSON, &pythonInit) //nolint:errcheck
-		stats["pythonInit"] = pythonInit
-	} else {
-		stats["pythonInit"] = nil
-	}
-
 	hostnameStatsJSON := []byte(expvar.Get("hostname").String())
 	hostnameStats := make(map[string]interface{})
 	json.Unmarshal(hostnameStatsJSON, &hostnameStats) //nolint:errcheck
@@ -436,36 +405,6 @@ func expvarStats(stats map[string]interface{}, invAgent inventoryagent.Component
 	if ntpOffset != nil && ntpOffset.String() != "" {
 		stats["ntpOffset"], err = strconv.ParseFloat(expvar.Get("ntpOffset").String(), 64)
 	}
-
-	inventories := expvar.Get("inventories")
-	var inventoriesStats map[string]interface{}
-	if inventories != nil {
-		inventoriesStatsJSON := []byte(inventories.String())
-		json.Unmarshal(inventoriesStatsJSON, &inventoriesStats) //nolint:errcheck
-	}
-
-	checkMetadata := map[string]map[string]string{}
-	if data, ok := inventoriesStats["check_metadata"]; ok {
-		for _, instances := range data.(map[string]interface{}) {
-			for _, instance := range instances.([]interface{}) {
-				metadata := map[string]string{}
-				checkHash := ""
-				for k, v := range instance.(map[string]interface{}) {
-					if vStr, ok := v.(string); ok {
-						if k == "config.hash" {
-							checkHash = vStr
-						} else if k != "config.provider" {
-							metadata[k] = vStr
-						}
-					}
-				}
-				if checkHash != "" && len(metadata) != 0 {
-					checkMetadata[checkHash] = metadata
-				}
-			}
-		}
-	}
-	stats["inventories"] = checkMetadata
 
 	// invAgent can be nil when generating a status page for some agent where inventory is not enabled
 	// (clusteragent, security-agent, ...).

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -364,7 +364,7 @@ func expvarStats(stats map[string]interface{}, invAgent inventoryagent.Component
 	json.Unmarshal(forwarderStatsJSON, &forwarderStats) //nolint:errcheck
 	stats["forwarderStats"] = forwarderStats
 
-	collector.UpdateStatus(stats)
+	collector.PopulateStatus(stats)
 
 	aggregatorStatsJSON := []byte(expvar.Get("aggregator").String())
 	aggregatorStats := make(map[string]interface{})

--- a/pkg/status/templates/collector.tmpl
+++ b/pkg/status/templates/collector.tmpl
@@ -18,7 +18,7 @@ Collector
 
   Running Checks
   ==============
-{{- with .RunnerStats }}
+{{- with .runnerStats }}
   {{- if and (not .Runs) (not .Checks)}}
     No checks have run yet
   {{end -}}
@@ -43,10 +43,10 @@ Collector
       Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}
       Last Execution Date : {{formatUnixTime .UpdateTimestamp}}
       Last Successful Execution Date : {{ if .LastSuccessDate }}{{formatUnixTime .LastSuccessDate}}{{ else }}Never{{ end }}
-      {{- if $.CheckMetadata }}
-      {{- if index $.CheckMetadata .CheckID }}
+      {{- if $.inventories }}
+      {{- if index $.inventories .CheckID }}
       metadata:
-      {{- range $k, $v := index $.CheckMetadata .CheckID }}
+      {{- range $k, $v := index $.inventories .CheckID }}
         {{ $k }}: {{ $v }}
       {{- end }}
       {{- end }}
@@ -93,7 +93,7 @@ Collector
   {{- end }}
 {{- end }}
 
-{{- with .AutoConfigStats }}
+{{- with .autoConfigStats }}
   {{- if .ConfigErrors}}
   Config Errors
   ==============
@@ -105,7 +105,7 @@ Collector
   {{- end}}
 {{- end }}
 
-{{- with .CheckSchedulerStats }}
+{{- with .checkSchedulerStats }}
   {{- if .LoaderErrors}}
   Loading Errors
   ==============


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Trying to decompose the status package into sub-packages.

This PR extracts fetching the collector information into a separate sub-package `status/collector`

That sub-package allows consumers of the status package who only care about collector information to use `status/collector` rather than the entire status package.

Also, I removed the indirection for rendering the collector information. I think the main reason for that indirection is that the agent cluster process does not want to show the collector information for certain keys. I simply `nil` does keys:

```go
stats["pyLoaderStats"] = nil
stats["pythonInit"] = nil
stats["inventories"] = nil
```

I made sure that the keys match the status map and templates.

I also removed the `OnlyCheck` key as it is not mentioned on any template. 

I'm planning to continue working on splitting the status package in other PRs. I want to focus on small PRs easier to review rather than creating a big PR 😄 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Running `agent status` should produce the correct output.
- Launching the GUI `agent launch-gui` and validate that validate the collector tab shows the correct information

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
