### PR TITLE
Fix setupFipsLogsConfig() calls for NDM.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1675,7 +1675,6 @@ func setupFipsEndpoints(config Config) error {
 	// HTTP for now, will soon be updated to HTTPS
 	protocol := "http://"
 	if config.GetBool("fips.https") {
-		log.Warnf("JMW FIPS using https???????????")
 		protocol = "https://"
 		config.Set("skip_ssl_validation", !config.GetBool("fips.tls_verify"), model.SourceAgentRuntime)
 	}
@@ -1706,22 +1705,20 @@ func setupFipsEndpoints(config Config) error {
 	setupFipsLogsConfig(config, "database_monitoring.samples.", urlFor(databasesMonitoringSamples))
 
 	// Network devices
-	// JMW
-	//setupFipsLogsConfig(config, "network_devices.metadata.", urlFor(networkDevicesMetadata))
-	//setupFipsLogsConfig(config, "network_devices.snmp_traps.forwarder.", urlFor(networkDevicesSnmpTraps))
-	//setupFipsLogsConfig(config, "network_devices.netflow.forwarder.", urlFor(networkDevicesNetflow))
-	// JMW should we set/overwrite dd_url too?
-	setupFipsLogsConfig(config, "network_devices.metadata.logs_dd_url", urlFor(networkDevicesMetadata))
-	setupFipsLogsConfig(config, "network_devices.snmp_traps.forwarder.logs_dd_url", urlFor(networkDevicesSnmpTraps))
-	setupFipsLogsConfig(config, "network_devices.netflow.forwarder.logs_dd_url", urlFor(networkDevicesNetflow))
+	setupFipsLogsConfig(config, "network_devices.metadata.", urlFor(networkDevicesMetadata))
+	setupFipsLogsConfig(config, "network_devices.snmp_traps.forwarder.", urlFor(networkDevicesSnmpTraps))
+	setupFipsLogsConfig(config, "network_devices.netflow.forwarder.", urlFor(networkDevicesNetflow))
 
-	log.Warnf("JMW network_devices.metadata.dd_url = %s", config.GetString("network_devices.metadata.dd_url"))
-	log.Warnf("JMW network_devices.snmp_traps.forwarder.dd_url = %s", config.GetString("network_devices.snmp_traps.forwarder.dd_url"))
-	log.Warnf("JMW network_devices.netflow.forwarder.dd_url = %s", config.GetString("network_devices.netflow.forwarder.dd_url"))
+	//fmt.Printf("JMWJMW network_devices.metadata.dd_url = %s\n", config.GetString("network_devices.metadata.dd_url"))
+	//fmt.Printf("JMWJMW network_devices.snmp_traps.forwarder.dd_url = %s\n", config.GetString("network_devices.snmp_traps.forwarder.dd_url"))
+	//fmt.Printf("JMWJMW network_devices.netflow.forwarder.dd_url = %s\n", config.GetString("network_devices.netflow.forwarder.dd_url"))
 
-	log.Warnf("JMW network_devices.metadata.logs_dd_url = %s", config.GetString("network_devices.metadata.logs_dd_url"))
-	log.Warnf("JMW network_devices.snmp_traps.forwarder.logs_dd_url = %s", config.GetString("network_devices.snmp_traps.forwarder.logs_dd_url"))
-	log.Warnf("JMW network_devices.netflow.forwarder.logs_dd_url = %s", config.GetString("network_devices.netflow.forwarder.logs_dd_url"))
+	//fmt.Printf("JMWJMW network_devices.metadata.logs_dd_url = %s\n", config.GetString("network_devices.metadata.logs_dd_url"))
+	//fmt.Printf("JMWJMW network_devices.snmp_traps.forwarder.logs_dd_url = %s\n", config.GetString("network_devices.snmp_traps.forwarder.logs_dd_url"))
+	//fmt.Printf("JMWJMW network_devices.netflow.forwarder.logs_dd_url = %s\n", config.GetString("network_devices.netflow.forwarder.logs_dd_url"))
+	log.Warnf("JMW network_devices.metadata.logs_dd_url = %s\n", config.GetString("network_devices.metadata.logs_dd_url"))
+	log.Warnf("JMW network_devices.snmp_traps.forwarder.logs_dd_url = %s\n", config.GetString("network_devices.snmp_traps.forwarder.logs_dd_url"))
+	log.Warnf("JMW network_devices.netflow.forwarder.logs_dd_url = %s\n", config.GetString("network_devices.netflow.forwarder.logs_dd_url"))
 
 	// Orchestrator Explorer
 	config.Set("orchestrator_explorer.orchestrator_dd_url", protocol+urlFor(orchestratorExplorer), model.SourceAgentRuntime)
@@ -1733,13 +1730,23 @@ func setupFipsEndpoints(config Config) error {
 }
 
 func setupFipsLogsConfig(config Config, configPrefix string, url string) {
+
+	//if strings.HasPrefix(configPrefix, "network_devices") {
+	//fmt.Printf("JMW configPrefix = %s url = %s\n", configPrefix, url)
+	//fmt.Printf("JMW before %s = %v\n", configPrefix+"use_http", config.GetBool(configPrefix+"use_http"))
+	//fmt.Printf("JMW before %s = %v\n", configPrefix+"logs_no_ssl", config.GetBool(configPrefix+"logs_no_ssl"))
+	//fmt.Printf("JMW before %s = %v\n", configPrefix+"logs_dd_url", config.GetString(configPrefix+"logs_dd_url"))
+	//}
+
 	config.Set(configPrefix+"use_http", true, model.SourceAgentRuntime)
 	config.Set(configPrefix+"logs_no_ssl", !config.GetBool("fips.https"), model.SourceAgentRuntime)
 	config.Set(configPrefix+"logs_dd_url", url, model.SourceAgentRuntime)
 
-	log.Warnf("JMW network_devices.metadata.logs_dd_url.use_http = %s", config.GetString("network_devices.metadata.logs_dd_url.use_http"))
-	log.Warnf("JMW network_devices.snmp_traps.forwarder.logs_dd_url.use_http = %s", config.GetString("network_devices.snmp_traps.forwarder.logs_dd_url.use_http"))
-	log.Warnf("JMW network_devices.netflow.forwarder.logs_dd_url.use_http = %s", config.GetString("network_devices.netflow.forwarder.logs_dd_url.use_http"))
+	//if strings.HasPrefix(configPrefix, "network_devices") {
+	//fmt.Printf("JMW after %s = %v\n", configPrefix+"use_http", config.GetBool(configPrefix+"use_http"))
+	//fmt.Printf("JMW after %s = %v\n", configPrefix+"logs_no_ssl", config.GetBool(configPrefix+"logs_no_ssl"))
+	//fmt.Printf("JMW after %s = %v\n", configPrefix+"logs_dd_url", config.GetString(configPrefix+"logs_dd_url"))
+	//}
 }
 
 // ResolveSecrets merges all the secret values from origin into config. Secret values

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1675,6 +1675,7 @@ func setupFipsEndpoints(config Config) error {
 	// HTTP for now, will soon be updated to HTTPS
 	protocol := "http://"
 	if config.GetBool("fips.https") {
+		log.Warnf("JMW FIPS using https???????????")
 		protocol = "https://"
 		config.Set("skip_ssl_validation", !config.GetBool("fips.tls_verify"), model.SourceAgentRuntime)
 	}
@@ -1705,9 +1706,22 @@ func setupFipsEndpoints(config Config) error {
 	setupFipsLogsConfig(config, "database_monitoring.samples.", urlFor(databasesMonitoringSamples))
 
 	// Network devices
-	setupFipsLogsConfig(config, "network_devices.metadata.", urlFor(networkDevicesMetadata))
-	setupFipsLogsConfig(config, "network_devices.snmp_traps.forwarder.", urlFor(networkDevicesSnmpTraps))
-	setupFipsLogsConfig(config, "network_devices.netflow.forwarder.", urlFor(networkDevicesNetflow))
+	// JMW
+	//setupFipsLogsConfig(config, "network_devices.metadata.", urlFor(networkDevicesMetadata))
+	//setupFipsLogsConfig(config, "network_devices.snmp_traps.forwarder.", urlFor(networkDevicesSnmpTraps))
+	//setupFipsLogsConfig(config, "network_devices.netflow.forwarder.", urlFor(networkDevicesNetflow))
+	// JMW should we set/overwrite dd_url too?
+	setupFipsLogsConfig(config, "network_devices.metadata.logs_dd_url", urlFor(networkDevicesMetadata))
+	setupFipsLogsConfig(config, "network_devices.snmp_traps.forwarder.logs_dd_url", urlFor(networkDevicesSnmpTraps))
+	setupFipsLogsConfig(config, "network_devices.netflow.forwarder.logs_dd_url", urlFor(networkDevicesNetflow))
+
+	log.Warnf("JMW network_devices.metadata.dd_url = %s", config.GetString("network_devices.metadata.dd_url"))
+	log.Warnf("JMW network_devices.snmp_traps.forwarder.dd_url = %s", config.GetString("network_devices.snmp_traps.forwarder.dd_url"))
+	log.Warnf("JMW network_devices.netflow.forwarder.dd_url = %s", config.GetString("network_devices.netflow.forwarder.dd_url"))
+
+	log.Warnf("JMW network_devices.metadata.logs_dd_url = %s", config.GetString("network_devices.metadata.logs_dd_url"))
+	log.Warnf("JMW network_devices.snmp_traps.forwarder.logs_dd_url = %s", config.GetString("network_devices.snmp_traps.forwarder.logs_dd_url"))
+	log.Warnf("JMW network_devices.netflow.forwarder.logs_dd_url = %s", config.GetString("network_devices.netflow.forwarder.logs_dd_url"))
 
 	// Orchestrator Explorer
 	config.Set("orchestrator_explorer.orchestrator_dd_url", protocol+urlFor(orchestratorExplorer), model.SourceAgentRuntime)
@@ -1722,6 +1736,10 @@ func setupFipsLogsConfig(config Config, configPrefix string, url string) {
 	config.Set(configPrefix+"use_http", true, model.SourceAgentRuntime)
 	config.Set(configPrefix+"logs_no_ssl", !config.GetBool("fips.https"), model.SourceAgentRuntime)
 	config.Set(configPrefix+"logs_dd_url", url, model.SourceAgentRuntime)
+
+	log.Warnf("JMW network_devices.metadata.logs_dd_url.use_http = %s", config.GetString("network_devices.metadata.logs_dd_url.use_http"))
+	log.Warnf("JMW network_devices.snmp_traps.forwarder.logs_dd_url.use_http = %s", config.GetString("network_devices.snmp_traps.forwarder.logs_dd_url.use_http"))
+	log.Warnf("JMW network_devices.netflow.forwarder.logs_dd_url.use_http = %s", config.GetString("network_devices.netflow.forwarder.logs_dd_url.use_http"))
 }
 
 // ResolveSecrets merges all the secret values from origin into config. Secret values

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -571,7 +571,9 @@ api_key:
   ## - database_monitoring.metrics.dd_url
   ## - database_monitoring.activity.dd_url
   ## - database_monitoring.samples.dd_url
-  ## - network_devices.metadata.dd_url
+  ## - network_devices.metadata.logs_dd_url
+  ## - network_devices.snmp_traps.forwarder.logs_dd_url
+  ## - network_devices.netflow.forwarder.logs_dd_url
   #
   ## The agent will also ignore 'proxy.*' settings and environment variables related to proxy (HTTP_PROXY, HTTPS_PROXY,
   ## DD_PROXY_HTTP and DD_PROXY_HTTPS).


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
