### PR TITLE
Add `--enable-fat` flag to gmp build

### DIFF
--- a/omnibus/config/software/gmp.rb
+++ b/omnibus/config/software/gmp.rb
@@ -35,7 +35,7 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
   env["CFLAGS"] << " -fPIC"
 
-  # With `--enable-flat`, CPU feature detection is done at runtime, improving compatibility
+  # With `--enable-fat`, CPU feature detection is done at runtime, improving compatibility
   configure "--disable-static --enable-fat", env: env
 
   make "-j #{workers}", env: env

--- a/omnibus/config/software/gmp.rb
+++ b/omnibus/config/software/gmp.rb
@@ -35,7 +35,8 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
   env["CFLAGS"] << " -fPIC"
 
-  configure "--disable-static", env: env
+  # With `--enable-flat`, CPU feature detection is done at runtime, improving compatibility
+  configure "--disable-static --enable-fat", env: env
 
   make "-j #{workers}", env: env
   make "install", env: env

--- a/releasenotes/notes/gmp-enable-fat-fa0493913eb0ec3d.yaml
+++ b/releasenotes/notes/gmp-enable-fat-fa0493913eb0ec3d.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed the cause of some crashes related to CPU instruction
+    incompatibility happening under certain CPUs when making calls to
+    the included libgmp library.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

It adds the [`--enable-fat`](https://gmplib.org/manual/Build-Options#index-Fat-binary) flag when compiling `libgmp`.

### Motivation

We've had a few support cases where the Agent was crashing with a `SIGILL` / `Illegal instruction` error. Running the Agent with `gdb` showed `libgmp` to be the culprit. Some digging lead to discovering this flag that enables runtime (as opposed to build-time) detection of CPU features, which should help with this.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

The size of the compiled library might increase as a result.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
