### PR TITLE
[CONTINT-3204][pkg/clusteragent/admission] Inject automatically libraries of auto-detected libraries into pods

### DIFF
--- a/pkg/clusteragent/admission/metrics/metrics.go
+++ b/pkg/clusteragent/admission/metrics/metrics.go
@@ -37,10 +37,10 @@ var (
 		[]string{}, "Time left before the certificate expires in hours.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 	MutationAttempts = telemetry.NewGaugeWithOpts("admission_webhooks", "mutation_attempts",
-		[]string{"mutation_type", "injected", "language"}, "Number of pod mutation attempts by mutation type (agent config, standard tags, lib injection).",
+		[]string{"mutation_type", "injected", "language", "auto_detected"}, "Number of pod mutation attempts by mutation type (agent config, standard tags, lib injection).",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 	MutationErrors = telemetry.NewGaugeWithOpts("admission_webhooks", "mutation_errors",
-		[]string{"mutation_type", "reason", "language"}, "Number of mutation failures by mutation type (agent config, standard tags, lib injection).",
+		[]string{"mutation_type", "reason", "language", "auto_detected"}, "Number of mutation failures by mutation type (agent config, standard tags, lib injection).",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 	WebhooksReceived = telemetry.NewCounterWithOpts("admission_webhooks", "webhooks_received",
 		[]string{}, "Number of mutation webhook requests received.",
@@ -60,10 +60,10 @@ var (
 		telemetry.Options{NoDoubleUnderscoreSep: true},
 	)
 	LibInjectionAttempts = telemetry.NewCounterWithOpts("admission_webhooks", "library_injection_attempts",
-		[]string{"language", "injected"}, "Number of pod library injection attempts by language.",
+		[]string{"language", "injected", "auto_detected"}, "Number of pod library injection attempts by language.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 	LibInjectionErrors = telemetry.NewCounterWithOpts("admission_webhooks", "library_injection_errors",
-		[]string{"language"}, "Number of library injection failures by language",
+		[]string{"language", "auto_detected"}, "Number of library injection failures by language",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 	RemoteConfigs = telemetry.NewGaugeWithOpts("admission_webhooks", "rc_provider_configs",
 		[]string{}, "Number of valid remote configurations.",

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation.go
@@ -200,7 +200,7 @@ func extractLibInfo(pod *corev1.Pod, containerRegistry string) ([]libInfo, bool)
 		libInfoList = extractLibrariesFromAnnotations(pod, containerRegistry, libInfoMap)
 
 		// If user doesn't provide langages information, try getting the languages from process languages auto-detection. The langages information are available in workloadmeta-store and attached on the pod's owner.
-		if len(libInfoList) == 0 {
+		if len(libInfoList) == 0 && config.Datadog.GetBool("admission_controller.inject_auto_detected_libraries") {
 			libInfoList = extractLibrariesFromOwnerAnnotations(pod, containerRegistry)
 			if len(libInfoList) > 0 {
 				autoDetected = true

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation.go
@@ -199,7 +199,7 @@ func extractLibInfo(pod *corev1.Pod, containerRegistry string) ([]libInfo, bool)
 	if shouldInject(pod) {
 		libInfoList = extractLibrariesFromAnnotations(pod, containerRegistry, libInfoMap)
 
-		// Try getting the languages from the owner of the pod from workloadmeta
+		// If user doesn't provide langages information, try getting the languages from process languages auto-detection. The langages information are available in workloadmeta-store and attached on the pod's owner.
 		if len(libInfoList) == 0 {
 			libInfoList = extractLibrariesFromOwnerAnnotations(pod, containerRegistry)
 			if len(libInfoList) > 0 {

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation.go
@@ -84,8 +84,6 @@ const (
 	customLibAnnotationKeyFormat     = "admission.datadoghq.com/%s-lib.custom-image"
 	libVersionAnnotationKeyCtrFormat = "admission.datadoghq.com/%s.%s-lib.version"
 	customLibAnnotationKeyCtrFormat  = "admission.datadoghq.com/%s.%s-lib.custom-image"
-
-	imageFormat = "%s/dd-lib-%s-init:%s"
 )
 
 var (
@@ -100,6 +98,11 @@ func InjectAutoInstrumentation(rawPod []byte, _ string, ns string, _ *authentica
 
 func initContainerName(lang language) string {
 	return fmt.Sprintf("datadog-lib-%s-init", lang)
+}
+
+func libImageName(registry string, lang language, tag string) string {
+	imageFormat := "%s/dd-lib-%s-init:%s"
+	return fmt.Sprintf(imageFormat, registry, lang, tag)
 }
 
 func injectAutoInstrumentation(pod *corev1.Pod, _ string, _ dynamic.Interface) error {
@@ -127,12 +130,12 @@ func injectAutoInstrumentation(pod *corev1.Pod, _ string, _ dynamic.Interface) e
 	}
 
 	containerRegistry := config.Datadog.GetString("admission_controller.auto_instrumentation.container_registry")
-	libsToInject := extractLibInfo(pod, containerRegistry)
+	libsToInject, autoDetected := extractLibInfo(pod, containerRegistry)
 	if len(libsToInject) == 0 {
 		return nil
 	}
 
-	return injectAutoInstruConfig(pod, libsToInject)
+	return injectAutoInstruConfig(pod, libsToInject, autoDetected)
 }
 
 func isNsTargeted(ns string) bool {
@@ -164,7 +167,7 @@ func getAllLibsToInject(ns, registry string) map[string]libInfo {
 			}
 			libsToInject[string(lang)] = libInfo{
 				lang:  lang,
-				image: fmt.Sprintf(imageFormat, registry, lang, libVersion),
+				image: libImageName(registry, lang, libVersion),
 			}
 		}
 	}
@@ -179,9 +182,10 @@ type libInfo struct {
 
 // extractLibInfo returns the language, the image,
 // and a boolean indicating whether the library should be injected into the pod
-func extractLibInfo(pod *corev1.Pod, containerRegistry string) []libInfo {
+func extractLibInfo(pod *corev1.Pod, containerRegistry string) ([]libInfo, bool) {
 	libInfoMap := map[string]libInfo{}
 	var libInfoList []libInfo
+	var autoDetected = false
 
 	// Inject all libraries if Single Step Instrumentation is enabled
 	if isApmInstrumentationEnabled(pod.Namespace) {
@@ -194,11 +198,14 @@ func extractLibInfo(pod *corev1.Pod, containerRegistry string) []libInfo {
 	// The library version specified via annotation on the Pod takes precedence over libraries injected with Single Step Instrumentation
 	if shouldInject(pod) {
 		libInfoList = extractLibrariesFromAnnotations(pod, containerRegistry, libInfoMap)
-	}
 
-	// Try getting the languages from the owner of the pod from workloadmeta
-	if len(libInfoList) == 0 {
-		libInfoList = extractLibrariesFromOwnerAnnotations(pod, containerRegistry)
+		// Try getting the languages from the owner of the pod from workloadmeta
+		if len(libInfoList) == 0 {
+			libInfoList = extractLibrariesFromOwnerAnnotations(pod, containerRegistry)
+			if len(libInfoList) > 0 {
+				autoDetected = true
+			}
+		}
 	}
 
 	if len(libInfoList) == 0 {
@@ -217,17 +224,17 @@ func extractLibInfo(pod *corev1.Pod, containerRegistry string) []libInfo {
 			for _, lang := range supportedLanguages {
 				libInfoList = append(libInfoList, libInfo{
 					lang:  lang,
-					image: fmt.Sprintf(imageFormat, containerRegistry, lang, version),
+					image: libImageName(containerRegistry, lang, version),
 				})
 			}
 		}
 	}
 
-	return libInfoList
+	return libInfoList, autoDetected
 }
 
 // extractLibrariesFromOwnerAnnotations constructs the libraries to be injected if the languages
-// were stored in workloadmeta store based on owner annotations.
+// were stored in workloadmeta store based on owner annotations (for example: Deployment, Daemonset, Statefulset).
 func extractLibrariesFromOwnerAnnotations(pod *corev1.Pod, registry string) []libInfo {
 	libList := []libInfo{}
 
@@ -300,7 +307,7 @@ func extractLibrariesFromAnnotations(
 
 			libVersionAnnotation := strings.ToLower(fmt.Sprintf(libVersionAnnotationKeyCtrFormat, ctr.Name, lang))
 			if version, found := annotations[libVersionAnnotation]; found {
-				image := fmt.Sprintf(imageFormat, registry, lang, version)
+				image := libImageName(registry, lang, version)
 				log.Debugf(
 					"Found version library annotation for %s, will inject %s to container %s",
 					string(lang), image, ctr.Name,
@@ -316,7 +323,7 @@ func extractLibrariesFromAnnotations(
 	return libList
 }
 
-func injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo) error {
+func injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo, autoDetected bool) error {
 	var lastError error
 
 	initContainerToInject := make(map[language]string)
@@ -325,8 +332,8 @@ func injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo) error {
 		injected := false
 		langStr := string(lib.lang)
 		defer func() {
-			metrics.LibInjectionAttempts.Inc(langStr, strconv.FormatBool(injected))
-			metrics.MutationAttempts.Inc(metrics.LibInjectionMutationType, strconv.FormatBool(injected), langStr)
+			metrics.LibInjectionAttempts.Inc(langStr, strconv.FormatBool(injected), strconv.FormatBool(autoDetected))
+			metrics.MutationAttempts.Inc(metrics.LibInjectionMutationType, strconv.FormatBool(injected), langStr, strconv.FormatBool(autoDetected))
 		}()
 
 		var err error
@@ -382,15 +389,15 @@ func injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo) error {
 					valFunc: rubyEnvValFunc,
 				}})
 		default:
-			metrics.LibInjectionErrors.Inc(langStr)
-			metrics.MutationErrors.Inc(metrics.LibInjectionMutationType, "unsupported language", langStr)
+			metrics.LibInjectionErrors.Inc(langStr, strconv.FormatBool(autoDetected))
+			metrics.MutationErrors.Inc(metrics.LibInjectionMutationType, "unsupported language", langStr, strconv.FormatBool(autoDetected))
 			lastError = fmt.Errorf("language %q is not supported. Supported languages are %v", lib.lang, supportedLanguages)
 			continue
 		}
 
 		if err != nil {
-			metrics.LibInjectionErrors.Inc(langStr)
-			metrics.MutationErrors.Inc(metrics.LibInjectionMutationType, "requirements config error", langStr)
+			metrics.LibInjectionErrors.Inc(langStr, strconv.FormatBool(autoDetected))
+			metrics.MutationErrors.Inc(metrics.LibInjectionMutationType, "requirements config error", langStr, strconv.FormatBool(autoDetected))
 			lastError = err
 			log.Errorf("Error injecting library config requirements: %s", err)
 		}
@@ -404,16 +411,16 @@ func injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo) error {
 		err := injectLibInitContainer(pod, image, lang)
 		if err != nil {
 			langStr := string(lang)
-			metrics.LibInjectionErrors.Inc(langStr)
-			metrics.MutationErrors.Inc(metrics.LibInjectionMutationType, "cannot inject init container", langStr)
+			metrics.LibInjectionErrors.Inc(langStr, strconv.FormatBool(autoDetected))
+			metrics.MutationErrors.Inc(metrics.LibInjectionMutationType, "cannot inject init container", langStr, strconv.FormatBool(autoDetected))
 			lastError = err
 			log.Errorf("Cannot inject init container into pod %s: %s", podString(pod), err)
 		}
 		err = injectLibConfig(pod, lang)
 		if err != nil {
 			langStr := string(lang)
-			metrics.LibInjectionErrors.Inc(langStr)
-			metrics.MutationErrors.Inc(metrics.LibInjectionMutationType, "cannot inject lib config", langStr)
+			metrics.LibInjectionErrors.Inc(langStr, strconv.FormatBool(autoDetected))
+			metrics.MutationErrors.Inc(metrics.LibInjectionMutationType, "cannot inject lib config", langStr, strconv.FormatBool(autoDetected))
 			lastError = err
 			log.Errorf("Cannot inject library configuration into pod %s: %s", podString(pod), err)
 		}
@@ -421,8 +428,8 @@ func injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo) error {
 
 	// try to inject all if the annotation is set
 	if err := injectLibConfig(pod, "all"); err != nil {
-		metrics.LibInjectionErrors.Inc("all")
-		metrics.MutationErrors.Inc(metrics.LibInjectionMutationType, "cannot inject lib config", "all")
+		metrics.LibInjectionErrors.Inc("all", strconv.FormatBool(autoDetected))
+		metrics.MutationErrors.Inc(metrics.LibInjectionMutationType, "cannot inject lib config", "all", strconv.FormatBool(autoDetected))
 		lastError = err
 		log.Errorf("Cannot inject library configuration into pod %s: %s", podString(pod), err)
 	}

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation.go
@@ -253,6 +253,8 @@ func extractLibrariesFromOwnerAnnotations(pod *corev1.Pod, registry string) []li
 	switch ownerKind {
 	case "Deployment":
 		libList = getLibListFromDeploymentAnnotations(store, ownerName, pod.Namespace, registry)
+	default:
+		log.Debugf("This ownerKind:%s is not yet supported by the process language auto-detection feature", ownerKind)
 	}
 
 	return libList

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation.go
@@ -238,6 +238,9 @@ func extractLibrariesFromOwnerAnnotations(pod *corev1.Pod, registry string) []li
 
 	// TODO [Workloadmeta][Component Framework]: Use workloadmeta store as a component
 	store := workloadmeta.GetGlobalStore()
+	if store == nil {
+		return libList
+	}
 
 	// Currently we only support deployments
 	switch ownerKind {

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
@@ -226,7 +226,7 @@ func TestInjectAutoInstruConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := injectAutoInstruConfig(tt.pod, tt.libsToInject)
+			err := injectAutoInstruConfig(tt.pod, tt.libsToInject, false)
 			require.False(t, (err != nil) != tt.wantErr)
 			if err != nil {
 				return
@@ -606,7 +606,7 @@ func TestExtractLibInfo(t *testing.T) {
 			if tt.setupConfig != nil {
 				tt.setupConfig()
 			}
-			libsToInject := extractLibInfo(tt.pod, tt.containerRegistry)
+			libsToInject, _ := extractLibInfo(tt.pod, tt.containerRegistry)
 			require.ElementsMatch(t, tt.expectedLibsToInject, libsToInject)
 		})
 	}

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_util.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_util.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+// Package mutate implements the mutations needed by the auto-instrumentation feature.
+package mutate
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// getOwnerNameAndKind returns the name and kind of the first owner of the pod if it exists
+// if the first owner is a replicaset, it returns the name
+func getOwnerNameAndKind(pod *corev1.Pod) (string, string, bool) {
+	owners := pod.GetOwnerReferences()
+
+	if len(owners) == 0 {
+		return "", "", false
+	}
+
+	owner := owners[0]
+	ownerName, ownerKind := owner.Name, owner.Kind
+
+	if ownerKind == "ReplicaSet" {
+		deploymentName := kubernetes.ParseDeploymentForReplicaSet(ownerName)
+		if deploymentName != "" {
+			ownerKind = "Deployment"
+			ownerName = deploymentName
+		}
+	}
+
+	return ownerName, ownerKind, true
+}
+
+func getLibListFromDeploymentAnnotations(store workloadmeta.Store, deploymentName, ns, registry string) []libInfo {
+	libList := []libInfo{}
+
+	// populate libInfoList using the languages found in workloadmeta
+	id := fmt.Sprintf("%s/%s", ns, deploymentName)
+	deployment, err := store.GetKubernetesDeployment(id)
+	if err != nil {
+		return libList
+	}
+
+	for containerName, languages := range deployment.ContainerLanguages {
+		for _, lang := range languages {
+			imageToInject := fmt.Sprintf(imageFormat, registry, lang.Name, "latest")
+			libList = append(libList, libInfo{ctrName: containerName, lang: language(lang.Name), image: imageToInject})
+		}
+	}
+
+	// Languages detected for init containers are not processed by the admission controller.
+
+	return libList
+}

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_util.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_util.go
@@ -51,7 +51,7 @@ func getLibListFromDeploymentAnnotations(store workloadmeta.Store, deploymentNam
 
 	for containerName, languages := range deployment.ContainerLanguages {
 		for _, lang := range languages {
-			imageToInject := fmt.Sprintf(imageFormat, registry, lang.Name, "latest")
+			imageToInject := libImageName(registry, language(lang.Name), "latest")
 			libList = append(libList, libInfo{ctrName: containerName, lang: language(lang.Name), image: imageToInject})
 		}
 	}

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_util_test.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_util_test.go
@@ -8,7 +8,6 @@
 package mutate
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -145,9 +144,9 @@ func TestGetLibListFromDeploymentAnnotations(t *testing.T) {
 			namespace:      "default",
 			registry:       "registry",
 			expectedLibList: []libInfo{
-				{ctrName: "container-1", lang: "java", image: fmt.Sprintf(imageFormat, "registry", "java", "latest")},
-				{ctrName: "container-1", lang: "js", image: fmt.Sprintf(imageFormat, "registry", "js", "latest")},
-				{ctrName: "container-2", lang: "python", image: fmt.Sprintf(imageFormat, "registry", "python", "latest")},
+				{ctrName: "container-1", lang: "java", image: libImageName("registry", "java", "latest")},
+				{ctrName: "container-1", lang: "js", image: libImageName("registry", "js", "latest")},
+				{ctrName: "container-2", lang: "python", image: libImageName("registry", "python", "latest")},
 			},
 		},
 		{
@@ -156,9 +155,9 @@ func TestGetLibListFromDeploymentAnnotations(t *testing.T) {
 			namespace:      "custom",
 			registry:       "registry",
 			expectedLibList: []libInfo{
-				{ctrName: "container-1", lang: "ruby", image: fmt.Sprintf(imageFormat, "registry", "ruby", "latest")},
-				{ctrName: "container-1", lang: "python", image: fmt.Sprintf(imageFormat, "registry", "python", "latest")},
-				{ctrName: "container-2", lang: "java", image: fmt.Sprintf(imageFormat, "registry", "java", "latest")},
+				{ctrName: "container-1", lang: "ruby", image: libImageName("registry", "ruby", "latest")},
+				{ctrName: "container-1", lang: "python", image: libImageName("registry", "python", "latest")},
+				{ctrName: "container-2", lang: "java", image: libImageName("registry", "java", "latest")},
 			},
 		},
 	}

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_util_test.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_util_test.go
@@ -1,0 +1,175 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package mutate
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestGetOwnerNameAndKind(t *testing.T) {
+	tests := []struct {
+		name         string
+		pod          *corev1.Pod
+		expectedName string
+		expectedKind string
+		wantFound    bool
+	}{
+		{
+			name:         "Pod with no parent",
+			pod:          fakePod("orphan-pod"),
+			expectedName: "",
+			expectedKind: "",
+			wantFound:    false,
+		},
+		{
+			name:         "Pod with replicaset parent, and no deployment grandparent",
+			pod:          fakePodWithParent("default", nil, nil, nil, "replicaset", "dummy-rs"),
+			expectedName: "dummy-rs",
+			expectedKind: "ReplicaSet",
+			wantFound:    true,
+		},
+		{
+			name:         "Pod with replicaset parent, and deployment grandparent",
+			pod:          fakePodWithParent("default", nil, nil, nil, "replicaset", "dummy-rs-12344"),
+			expectedName: "dummy-rs",
+			expectedKind: "Deployment",
+			wantFound:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, kind, found := getOwnerNameAndKind(tt.pod)
+			require.Equal(t, found, tt.wantFound)
+			require.Equal(t, name, tt.expectedName)
+			require.Equal(t, kind, tt.expectedKind)
+
+		})
+	}
+}
+
+func assertEqualLibInjection(actualLibs []libInfo, expectedLibs []libInfo) bool {
+
+	actualLibsAsSet := make(map[libInfo]struct{})
+	expectedLibsAsSet := make(map[libInfo]struct{})
+
+	for _, li := range actualLibs {
+		actualLibsAsSet[li] = struct{}{}
+	}
+
+	for _, li := range expectedLibs {
+		expectedLibsAsSet[li] = struct{}{}
+	}
+
+	return reflect.DeepEqual(actualLibsAsSet, expectedLibsAsSet)
+}
+
+func TestGetLibListFromDeploymentAnnotations(t *testing.T) {
+	mockStore := workloadmeta.NewMockStore()
+
+	//java, js, python, dotnet, ruby
+
+	mockStore.SetEntity(&workloadmeta.KubernetesDeployment{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesDeployment,
+			ID:   "default/dummy",
+		},
+		ContainerLanguages: map[string][]languagemodels.Language{
+			"container-1": {
+				{
+					Name: "java",
+				},
+				{
+					Name: "js",
+				},
+			},
+			"container-2": {
+				{
+					Name: "python",
+				},
+			},
+		},
+	})
+
+	mockStore.SetEntity(&workloadmeta.KubernetesDeployment{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesDeployment,
+			ID:   "custom/dummy",
+		},
+		ContainerLanguages: map[string][]languagemodels.Language{
+			"container-1": {
+				{
+					Name: "ruby",
+				},
+				{
+					Name: "python",
+				},
+			},
+			"container-2": {
+				{
+					Name: "java",
+				},
+			},
+		},
+	})
+
+	tests := []struct {
+		name            string
+		deploymentName  string
+		namespace       string
+		registry        string
+		expectedLibList []libInfo
+	}{
+		{
+			name:            "Deployment with no annotations",
+			deploymentName:  "deployment-no-annotations",
+			namespace:       "default",
+			registry:        "",
+			expectedLibList: []libInfo{},
+		},
+		{
+			name:           "Deployment with some annotations in default namespace",
+			deploymentName: "dummy",
+			namespace:      "default",
+			registry:       "registry",
+			expectedLibList: []libInfo{
+				{ctrName: "container-1", lang: "java", image: fmt.Sprintf(imageFormat, "registry", "java", "latest")},
+				{ctrName: "container-1", lang: "js", image: fmt.Sprintf(imageFormat, "registry", "js", "latest")},
+				{ctrName: "container-2", lang: "python", image: fmt.Sprintf(imageFormat, "registry", "python", "latest")},
+			},
+		},
+		{
+			name:           "Deployment with some annotations in custom namespace",
+			deploymentName: "dummy",
+			namespace:      "custom",
+			registry:       "registry",
+			expectedLibList: []libInfo{
+				{ctrName: "container-1", lang: "ruby", image: fmt.Sprintf(imageFormat, "registry", "ruby", "latest")},
+				{ctrName: "container-1", lang: "python", image: fmt.Sprintf(imageFormat, "registry", "python", "latest")},
+				{ctrName: "container-2", lang: "java", image: fmt.Sprintf(imageFormat, "registry", "java", "latest")},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			libList := getLibListFromDeploymentAnnotations(mockStore, tt.deploymentName, tt.namespace, tt.registry)
+
+			if !assertEqualLibInjection(libList, tt.expectedLibList) {
+				t.Fatalf("Expected %s, got %s", tt.expectedLibList, libList)
+			}
+		})
+	}
+}

--- a/pkg/clusteragent/admission/mutate/config.go
+++ b/pkg/clusteragent/admission/mutate/config.go
@@ -87,11 +87,11 @@ func InjectConfig(rawPod []byte, _ string, ns string, _ *authenticationv1.UserIn
 func injectConfig(pod *corev1.Pod, _ string, _ dynamic.Interface) error {
 	var injectedConfig, injectedEntity bool
 	defer func() {
-		metrics.MutationAttempts.Inc(metrics.ConfigMutationType, strconv.FormatBool(injectedConfig || injectedEntity), "")
+		metrics.MutationAttempts.Inc(metrics.ConfigMutationType, strconv.FormatBool(injectedConfig || injectedEntity), "", "")
 	}()
 
 	if pod == nil {
-		metrics.MutationErrors.Inc(metrics.ConfigMutationType, "nil pod", "")
+		metrics.MutationErrors.Inc(metrics.ConfigMutationType, "nil pod", "", "")
 		return errors.New("cannot inject config into nil pod")
 	}
 
@@ -112,7 +112,7 @@ func injectConfig(pod *corev1.Pod, _ string, _ dynamic.Interface) error {
 		injectedEnv = injectEnv(pod, dogstatsdURLSocketEnvVar) || injectedEnv
 		injectedConfig = injectedEnv || injectedVol
 	default:
-		metrics.MutationErrors.Inc(metrics.ConfigMutationType, "unknown mode", "")
+		metrics.MutationErrors.Inc(metrics.ConfigMutationType, "unknown mode", "", "")
 		return fmt.Errorf("invalid injection mode %q", mode)
 	}
 

--- a/pkg/clusteragent/admission/mutate/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cws_instrumentation.go
@@ -128,15 +128,15 @@ func (ci *CWSInstrumentation) InjectCWSCommandInstrumentation(rawPodExecOptions 
 func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodExecOptions, name string, ns string, userInfo *authenticationv1.UserInfo, _ dynamic.Interface, apiClient kubernetes.Interface) error {
 	var injected bool
 	defer func() {
-		metrics.MutationAttempts.Inc(metrics.CWSExecInstrumentation, strconv.FormatBool(injected), "")
+		metrics.MutationAttempts.Inc(metrics.CWSExecInstrumentation, strconv.FormatBool(injected), "", "")
 	}()
 
 	if exec == nil || userInfo == nil {
-		metrics.MutationErrors.Inc(metrics.CWSExecInstrumentation, "nil exec or user info", "")
+		metrics.MutationErrors.Inc(metrics.CWSExecInstrumentation, "nil exec or user info", "", "")
 		return fmt.Errorf("cannot inject CWS instrumentation into nil exec options or nil userInfo")
 	}
 	if len(exec.Command) == 0 {
-		metrics.MutationErrors.Inc(metrics.CWSExecInstrumentation, "empty command", "")
+		metrics.MutationErrors.Inc(metrics.CWSExecInstrumentation, "empty command", "", "")
 		return nil
 	}
 
@@ -148,7 +148,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 	// check if the pod has been instrumented
 	pod, err := apiClient.CoreV1().Pods(ns).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil || pod == nil {
-		metrics.MutationErrors.Inc(metrics.CWSExecInstrumentation, "cannot get pod", "")
+		metrics.MutationErrors.Inc(metrics.CWSExecInstrumentation, "cannot get pod", "", "")
 		return fmt.Errorf("couldn't describe pod %s in namespace %s from the API server: %w", name, ns, err)
 	}
 
@@ -167,7 +167,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 	// prepare the user session context
 	userSessionCtx, err := usersessions.PrepareK8SUserSessionContext(userInfo, cwsUserSessionDataMaxSize)
 	if err != nil {
-		metrics.MutationErrors.Inc(metrics.CWSExecInstrumentation, "cannot serialize user info", "")
+		metrics.MutationErrors.Inc(metrics.CWSExecInstrumentation, "cannot serialize user info", "", "")
 		log.Debugf("ignoring instrumentation of %s: %v", podString(pod), err)
 		return err
 	}
@@ -214,11 +214,11 @@ func (ci *CWSInstrumentation) InjectCWSPodInstrumentation(rawPod []byte, _ strin
 func (ci *CWSInstrumentation) injectCWSPodInstrumentation(pod *corev1.Pod, ns string, _ dynamic.Interface) error {
 	var injected bool
 	defer func() {
-		metrics.MutationAttempts.Inc(metrics.CWSPodInstrumentation, strconv.FormatBool(injected), "")
+		metrics.MutationAttempts.Inc(metrics.CWSPodInstrumentation, strconv.FormatBool(injected), "", "")
 	}()
 
 	if pod == nil {
-		metrics.MutationErrors.Inc(metrics.CWSPodInstrumentation, "nil pod", "")
+		metrics.MutationErrors.Inc(metrics.CWSPodInstrumentation, "nil pod", "", "")
 		return fmt.Errorf("cannot inject CWS instrumentation into nil pod")
 	}
 

--- a/pkg/clusteragent/admission/mutate/tags.go
+++ b/pkg/clusteragent/admission/mutate/tags.go
@@ -67,11 +67,11 @@ func InjectTags(rawPod []byte, _ string, ns string, _ *authenticationv1.UserInfo
 func injectTags(pod *corev1.Pod, ns string, dc dynamic.Interface) error {
 	var injected bool
 	defer func() {
-		metrics.MutationAttempts.Inc(metrics.TagsMutationType, strconv.FormatBool(injected), "")
+		metrics.MutationAttempts.Inc(metrics.TagsMutationType, strconv.FormatBool(injected), "", "")
 	}()
 
 	if pod == nil {
-		metrics.MutationErrors.Inc(metrics.TagsMutationType, "nil pod", "")
+		metrics.MutationErrors.Inc(metrics.TagsMutationType, "nil pod", "", "")
 		return errors.New("cannot inject tags into nil pod")
 	}
 
@@ -91,7 +91,7 @@ func injectTags(pod *corev1.Pod, ns string, dc dynamic.Interface) error {
 		if pod.GetNamespace() != "" {
 			ns = pod.GetNamespace()
 		} else {
-			metrics.MutationErrors.Inc(metrics.TagsMutationType, "empty namespace", "")
+			metrics.MutationErrors.Inc(metrics.TagsMutationType, "empty namespace", "", "")
 			return errors.New("cannot get standard tags from parent object: empty namespace")
 		}
 	}
@@ -104,7 +104,7 @@ func injectTags(pod *corev1.Pod, ns string, dc dynamic.Interface) error {
 
 	owner, err := getOwner(owners[0], ns, dc)
 	if err != nil {
-		metrics.MutationErrors.Inc(metrics.TagsMutationType, "cannot get owner", "")
+		metrics.MutationErrors.Inc(metrics.TagsMutationType, "cannot get owner", "", "")
 		return err
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1065,6 +1065,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.enabled", false)
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.fallback_to_file_provider", false)                                // to be enabled only in e2e tests
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.file_provider_path", "/etc/datadog-agent/patch/auto-instru.json") // to be used only in e2e tests
+	config.BindEnvAndSetDefault("admission_controller.inject_auto_detected_libraries", true)                                                         // allows injecting libraries for languages detected by automatic language detection feature
 	config.BindEnv("admission_controller.auto_instrumentation.init_resources.cpu")
 	config.BindEnv("admission_controller.auto_instrumentation.init_resources.memory")
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.inject_all.namespaces", []string{})

--- a/releasenotes-dca/notes/inject_language_libraries_in_admission_controller-63eae7f820cc0f45.yaml
+++ b/releasenotes-dca/notes/inject_language_libraries_in_admission_controller-63eae7f820cc0f45.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    Enable `APM` library injection in `cluster-agent` admission controller based on automatic language detection annotations.
+    [Beta] Enable `APM` library injection in `cluster-agent` admission controller based on automatic language detection annotations.

--- a/releasenotes-dca/notes/inject_language_libraries_in_admission_controller-63eae7f820cc0f45.yaml
+++ b/releasenotes-dca/notes/inject_language_libraries_in_admission_controller-63eae7f820cc0f45.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Enable `APM` library injection in `cluster-agent` admission controller based on automatic language detection annotations.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR allows the cluster-agent admission controller to inject libraries to pods based on languages that were automatically detected by the automatic language detection feature.

### Motivation

The language detection client and server allow patching pod owners with language annotations representing languages that were detected for each container. 

The annotations look as such: `"apm.datadoghq.com/notes-app-deployment.languages": "java,js"` 

The information found in the language annotations are then stored in workloadmeta as such: 
```
=== Entity kubernetes_deployment sources(merged):[kubeapiserver] id: default/notes-app-deployment ===
----------- Entity ID -----------
Kind: kubernetes_deployment ID: default/notes-app-deployment
----------- Languages -----------
Container notes-app-deployment=>[java,js]
===
```

When a new pod is created for that specific deployment, if no annotations were manually specified in the pod manifest, the admission controller should check if languages were already auto-detected and stored in workloadmeta. If this is the case, language libraries should be injected accordingly. 

### Additional Notes
- Currently only deployments are supported
- In case no languages were automatically detected, the admission controller behaviour falls back to injecting the libraries of all supported languages. 


### Describe how to test/QA your changes

- Deploy the cluster agent and agent on a cluster (e.g. locally on minikube) with the admission controller enabled. You might also want to set `mutateUnlabelled` to `true` as indicated [here](https://docs.datadoghq.com/containers/cluster_agent/admission_controller/?tab=helm). You should also enable language detection on the cluster agent. You can use the following template:
```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  kubelet:
    tlsVerify: false
  collectEvents: true
  leaderElection: true


agents:
  useHostNetwork: true

clusterAgent:
  enabled: true
  admissionController:
    enabled: true
    mutateUnlabelled: true
  env:
    - name: DD_LANGUAGE_DETECTION_ENABLED
      value: true
```
- Create a deployment with some language annotations set on it. You can use the following template:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: notes-app-deployment
  labels:
    app: notes-app
    admission.datadoghq.com/enabled: "true"
  annotations:
    "apm.datadoghq.com/notes-app-deployment.languages": "java,js"

spec:
  replicas: 2
  selector:
    matchLabels:
      app: notes-app
  template:
    metadata:
      labels:
        app: notes-app
        admission.datadoghq.com/enabled: "true"
    spec:
      containers:
        - name: notes-app-deployment
          image: pavansa/notes-app
          resources:
            requests:
              cpu: "100m"
          imagePullPolicy: IfNotPresent
          ports:
            - containerPort: 3000
```
- Create the deployment by running `kubectl apply -f deployment.yaml`
- Check the 2 created pods with `kubectl get pod <pod-name> -o yaml`. You should be able to see environment variables and volumes injected for each of the specified languages. (In this case, `java` and `js`). (You might need to delete the 2 pods that are created first and the initContainers and volumes will be injected on the pods that are created after that). The output of the command should include something similar to the following in the initContainers section:
```
initContainers:
  - command:
    - sh
    - copy-lib.sh
    - /datadog-lib
    env:
    - name: DD_ENTITY_ID
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: metadata.uid
    - name: DD_DOGSTATSD_URL
      value: unix:///var/run/datadog/dsd.socket
    - name: DD_TRACE_AGENT_URL
      value: unix:///var/run/datadog/apm.socket
    image: gcr.io/datadoghq/dd-lib-js-init:latest
    imagePullPolicy: Always
    name: datadog-lib-js-init
    resources: {}
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /datadog-lib
      name: datadog-auto-instrumentation
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-s2gw5
      readOnly: true
  - command:
    - sh
    - copy-lib.sh
    - /datadog-lib
    env:
    - name: DD_ENTITY_ID
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: metadata.uid
    - name: DD_DOGSTATSD_URL
      value: unix:///var/run/datadog/dsd.socket
    - name: DD_TRACE_AGENT_URL
      value: unix:///var/run/datadog/apm.socket
    image: gcr.io/datadoghq/dd-lib-java-init:latest
    imagePullPolicy: Always
    name: datadog-lib-java-init
    resources: {}
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /datadog-lib
      name: datadog-auto-instrumentation
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-s2gw5
      readOnly: true
```
### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
