### PR TITLE
Use DMI on Azure VM to get host aliases

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -816,6 +816,7 @@ func InitConfig(config Config) {
 
 	// Azure
 	config.BindEnvAndSetDefault("azure_hostname_style", "os")
+	config.BindEnvAndSetDefault("azure_vm_use_dmi", true) // should the agent leverage DMI information to know if it's running on Azure VM or not. Enabling this will add the instance ID from DMI to the host alias list.
 
 	// IBM cloud
 	// We use a long timeout here since the metadata and token API can be very slow sometimes.

--- a/pkg/util/cloudproviders/azure/dmi.go
+++ b/pkg/util/cloudproviders/azure/dmi.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package azure
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/dmi"
+	"github.com/DataDog/datadog-agent/pkg/util/fargate"
+)
+
+func isBoardVendorAzureVM() bool {
+	if !config.Datadog.GetBool("azure_vm_use_dmi") {
+		return false
+	}
+	return dmi.GetBoardVendor() == DMIBoardVendor
+}
+
+// getAzureVMIDFromDMI fetches the Azure VM id for current host from DMI
+//
+// On Azure VM instances (older than 2014-09-18) dmi information contains the Azure VM Unique ID for the host. We check that the board vendor is
+// Microsoft Corporation before using it. Source : https://azure.microsoft.com/en-us/blog/accessing-and-using-azure-vm-unique-id/
+func getAzureVMIDFromDMI() ([]string, error) {
+	// we don't want to collect anything on Fargate
+	if fargate.IsFargateInstance() {
+		return []string{}, fmt.Errorf("host alias detection through DMI is disabled on Fargate")
+	}
+
+	if !config.Datadog.GetBool("azure_vm_use_dmi") {
+		return []string{}, fmt.Errorf("'azure_vm_use_dmi' is disabled")
+	}
+
+	if !isBoardVendorAzureVM() {
+		return []string{}, fmt.Errorf("board vendor is not Microsoft Corporation")
+	}
+
+	productUUID := dmi.GetProductUUID()
+	return []string{strings.ToLower(productUUID)}, nil
+}


### PR DESCRIPTION
### What does this PR do?

* The Agent now leverages DMI information on Unix to get the instance ID on Azure Virtual Machines when the metadata endpoint fails or is not accessible. The vm ID is exposed through DMI at `/sys/devices/virtual/dmi/id/product_uuid`.

This will not change the hostname of the Agent upon upgrading but will add to the list of host aliases.

### Motivation

* Similar to https://github.com/DataDog/datadog-agent/pull/15051
* On Azure RedHat OpenShift (ARO), the metadata endpoint can only be reached by pods that are using `hostNetwork: true`. `hostNetwork` is a setting that does not necessarily play well with K8s network policies, so we could have the Agent retrieve the `vmId` through the file similar to the EC2 behaviour, and that way, `hostNetwork` would not be necessary for the Agent to get the vm id to avoid duplicate hosts.

### Additional Notes

* It appears on ARO, the `product_uuid` and the `vmId` bytes are not ordered correctly. This was the case on "regular" Azure VMs, but was seemingly addressed by https://github.com/Azure/WALinuxAgent/pull/839, but the issue is still present on ARO VMs : 
**Regular VM**
```
azureuser@timothee-dmi-test:~$ curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance/compute/vmId?api-version=2017-04-02&format=text"
03383c2f-c225-4d78-a1a6-05b7dd8a7bc4
azureuser@timothee-dmi-test:~$ cat /sys/devices/virtual/dmi/id/product_uuid
03383c2f-c225-4d78-a1a6-05b7dd8a7bc4
```

**ARO VM**
```
[root@keisukesandbox-x9ck8-worker-japaneast1-bzvb6 /]# curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance/compute/vmId?api-version=2017-04-02&format=text"
83246c0f-a7fa-4fdd-be0e-8cab4c465f68
[root@keisukesandbox-x9ck8-worker-japaneast1-bzvb6 /]# cat /sys/devices/virtual/dmi/id/product_uuid
0f6c2483-faa7-dd4f-be0e-8cab4c465f68
```
We have the inversion that is fixed by : 
```
        return '-'.join([
                textutil.swap_hexstring(parts[0], width=2),
                textutil.swap_hexstring(parts[1], width=2),
                textutil.swap_hexstring(parts[2], width=2),
                parts[3],
                parts[4]
            ])
```

To discuss with ASC

### Possible Drawbacks / Trade-offs

* Increased pressure on the host back-end with aliases that were not retrieved previously ?

### Describe how to test/QA your changes

* In an ARO cluster, install the Agent without using hostNetwork: true. Ensure the vm id is retrieved and set as an alias.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
