### PR TITLE
[CWS] fix broken lineage check for process activity

### DIFF
--- a/pkg/security/probe/errors.go
+++ b/pkg/security/probe/errors.go
@@ -7,34 +7,3 @@
 
 // Package probe holds probe related files
 package probe
-
-import (
-	"fmt"
-
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
-)
-
-// ErrNoProcessContext defines an error for event without process context
-type ErrNoProcessContext struct {
-	Err error
-}
-
-// Error implements the error interface
-func (e *ErrNoProcessContext) Error() string {
-	return e.Err.Error()
-}
-
-// Unwrap implements the error interface
-func (e *ErrNoProcessContext) Unwrap() error {
-	return e.Err
-}
-
-// ErrProcessBrokenLineage returned when a process lineage is broken
-type ErrProcessBrokenLineage struct {
-	PIDContext model.PIDContext
-}
-
-// Error implements the error interface
-func (e *ErrProcessBrokenLineage) Error() string {
-	return fmt.Sprintf("broken process lineage, pid: %d", e.PIDContext.Pid)
-}

--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -335,8 +335,8 @@ func (p *Probe) playSnapshot() {
 		event.Exec.Process = &entry.Process
 		event.ProcessContext.Process.ContainerID = entry.ContainerID
 
-		if !entry.HasCompleteLineage() {
-			event.Error = &ErrProcessBrokenLineage{PIDContext: entry.PIDContext}
+		if _, err := entry.HasValidLineage(); err != nil {
+			event.Error = &model.ErrProcessBrokenLineage{Err: err}
 		}
 
 		events = append(events, event)
@@ -509,14 +509,6 @@ func (p *Probe) onEventLost(perfMapName string, perEvent map[string]uint64) {
 // setProcessContext set the process context, should return false if the event shouldn't be dispatched
 func (p *Probe) setProcessContext(eventType model.EventType, event *model.Event) bool {
 	entry, isResolved := p.fieldHandlers.ResolveProcessCacheEntry(event)
-	if !eventWithNoProcessContext(eventType) {
-		if !isResolved {
-			event.Error = &ErrNoProcessContext{Err: errors.New("process context not resolved")}
-		} else if !entry.HasValidLineage() {
-			event.Error = &ErrProcessBrokenLineage{PIDContext: entry.PIDContext}
-			p.resolvers.ProcessResolver.CountBrokenLineage()
-		}
-	}
 	event.ProcessCacheEntry = entry
 	if event.ProcessCacheEntry == nil {
 		panic("should always return a process cache entry")
@@ -530,6 +522,15 @@ func (p *Probe) setProcessContext(eventType model.EventType, event *model.Event)
 
 	if process.IsKThread(event.ProcessContext.PPid, event.ProcessContext.Pid) {
 		return false
+	}
+
+	if !eventWithNoProcessContext(eventType) {
+		if !isResolved {
+			event.Error = &model.ErrNoProcessContext{Err: errors.New("process context not resolved")}
+		} else if _, err := entry.HasValidLineage(); err != nil {
+			event.Error = &model.ErrProcessBrokenLineage{Err: err}
+			p.resolvers.ProcessResolver.CountBrokenLineage()
+		}
 	}
 
 	// flush exited process

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -155,6 +155,7 @@ func (m *Monitor) ProcessEvent(event *model.Event) {
 	if event.Error == nil {
 		return
 	}
+
 	var notCritical *path.ErrPathResolutionNotCritical
 	if errors.As(event.Error, &notCritical) {
 		return
@@ -165,22 +166,19 @@ func (m *Monitor) ProcessEvent(event *model.Event) {
 		m.probe.DispatchCustomEvent(
 			NewAbnormalEvent(events.AbnormalPathRuleID, events.AbnormalPathRuleDesc, event, m.probe, pathErr.Err),
 		)
-		return
 	}
 
-	var processContextErr *ErrNoProcessContext
+	var processContextErr *model.ErrNoProcessContext
 	if errors.As(event.Error, &processContextErr) {
 		m.probe.DispatchCustomEvent(
 			NewAbnormalEvent(events.NoProcessContextErrorRuleID, events.NoProcessContextErrorRuleDesc, event, m.probe, event.Error),
 		)
-		return
 	}
 
-	var brokenLineageErr *ErrProcessBrokenLineage
+	var brokenLineageErr *model.ErrProcessBrokenLineage
 	if errors.As(event.Error, &brokenLineageErr) {
 		m.probe.DispatchCustomEvent(
 			NewAbnormalEvent(events.BrokenProcessLineageErrorRuleID, events.BrokenProcessLineageErrorRuleDesc, event, m.probe, event.Error),
 		)
-		return
 	}
 }

--- a/pkg/security/resolvers/process/resolver_linux.go
+++ b/pkg/security/resolvers/process/resolver_linux.go
@@ -500,7 +500,7 @@ func (p *Resolver) insertForkEntry(entry *model.ProcessCacheEntry, inode uint64,
 
 	if entry.Pid != 1 {
 		parent := p.entryCache[entry.PPid]
-		if entry.PPid >= 1 && (parent == nil || parent.FileEvent.Inode != inode) {
+		if entry.PPid >= 1 && inode != 0 && (parent == nil || parent.FileEvent.Inode != inode) {
 			if candidate := p.resolve(entry.PPid, entry.PPid, inode, true); candidate != nil {
 				parent = candidate
 			} else {
@@ -522,7 +522,7 @@ func (p *Resolver) insertForkEntry(entry *model.ProcessCacheEntry, inode uint64,
 func (p *Resolver) insertExecEntry(entry *model.ProcessCacheEntry, inode uint64, source uint64) {
 	prev := p.entryCache[entry.Pid]
 	if prev != nil {
-		if prev.FileEvent.Inode != inode {
+		if inode != 0 && prev.FileEvent.Inode != inode {
 			entry.IsParentMissing = true
 			p.inodeErrStats.Inc()
 		}

--- a/pkg/security/secl/model/errors.go
+++ b/pkg/security/secl/model/errors.go
@@ -37,3 +37,66 @@ type ErrInvalidKeyPath struct {
 func (e *ErrInvalidKeyPath) Error() string {
 	return fmt.Sprintf("invalid inode/mountID couple: %d/%d", e.Inode, e.MountID)
 }
+
+// ErrProcessMissingParentNode used when the lineage is incorrect in term of pid/ppid
+type ErrProcessMissingParentNode struct {
+	PID         uint32
+	PPID        uint32
+	ContainerID string
+}
+
+func (e *ErrProcessMissingParentNode) Error() string {
+	return fmt.Sprintf("parent node missing: PID(%d), PPID(%d), ID(%s)", e.PID, e.PPID, e.ContainerID)
+}
+
+// ErrProcessWrongParentNode used when the lineage is correct in term of pid/ppid but an exec parent is missing
+type ErrProcessWrongParentNode struct {
+	PID         uint32
+	PPID        uint32
+	ContainerID string
+}
+
+func (e *ErrProcessWrongParentNode) Error() string {
+	return fmt.Sprintf("wrong parent node: PID(%d), PPID(%d), ID(%s)", e.PID, e.PPID, e.ContainerID)
+}
+
+// ErrProcessIncompleteLineage used when the lineage is incorrect in term of pid/ppid
+type ErrProcessIncompleteLineage struct {
+	PID         uint32
+	PPID        uint32
+	ContainerID string
+}
+
+func (e *ErrProcessIncompleteLineage) Error() string {
+	return fmt.Sprintf("parent node missing: PID(%d), PPID(%d), ID(%s)", e.PID, e.PPID, e.ContainerID)
+}
+
+// ErrNoProcessContext defines an error for event without process context
+type ErrNoProcessContext struct {
+	Err error
+}
+
+// Error implements the error interface
+func (e *ErrNoProcessContext) Error() string {
+	return e.Err.Error()
+}
+
+// Unwrap implements the error interface
+func (e *ErrNoProcessContext) Unwrap() error {
+	return e.Err
+}
+
+// ErrProcessBrokenLineage returned when a process lineage is broken
+type ErrProcessBrokenLineage struct {
+	Err error
+}
+
+// Unwrap implements the error interface
+func (e *ErrProcessBrokenLineage) Unwrap() error {
+	return e.Err
+}
+
+// Error implements the error interface
+func (e *ErrProcessBrokenLineage) Error() string {
+	return fmt.Sprintf("broken process lineage: %v", e.Err)
+}

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -341,6 +341,10 @@ type Process struct {
 	IsParentMissing bool `field:"-"`         // Indicates the direct parent is missing
 
 	Source uint64 `field:"-" json:"-"`
+
+	// lineage
+	hasValidLineage *bool `field:"-"`
+	lineageError    error `field:"-"`
 }
 
 // ExecEvent represents a exec event

--- a/pkg/security/secl/model/process_cache_entry_unix.go
+++ b/pkg/security/secl/model/process_cache_entry_unix.go
@@ -23,35 +23,47 @@ func (pc *ProcessCacheEntry) SetAncestor(parent *ProcessCacheEntry) {
 		pc.Ancestor.Release()
 	}
 
+	pc.hasValidLineage = nil
 	pc.Ancestor = parent
 	pc.Parent = &parent.Process
 	parent.Retain()
 }
 
-// HasCompleteLineage returns false if, from the entry, we cannot ascend the ancestors list to PID 1
-func (pc *ProcessCacheEntry) HasCompleteLineage() bool {
+func hasValidLineage(pc *ProcessCacheEntry) (bool, error) {
+	var (
+		pid, ppid uint32
+		ctrID     string
+		err       error
+	)
+
 	for pc != nil {
+		if pc.hasValidLineage != nil {
+			return *pc.hasValidLineage, pc.lineageError
+		}
+
+		pid, ppid, ctrID = pc.Pid, pc.PPid, pc.ContainerID
+
+		if pc.IsParentMissing {
+			err = &ErrProcessMissingParentNode{PID: pid, PPID: ppid, ContainerID: ctrID}
+		}
+
 		if pc.Pid == 1 {
-			return true
+			if pc.Ancestor == nil {
+				return err == nil, err
+			}
+			return false, &ErrProcessWrongParentNode{PID: pid, PPID: pc.Ancestor.Pid, ContainerID: ctrID}
 		}
 		pc = pc.Ancestor
 	}
-	return false
+
+	return false, &ErrProcessIncompleteLineage{PID: pid, PPID: ppid, ContainerID: ctrID}
 }
 
 // HasValidLineage returns false if, from the entry, we cannot ascend the ancestors list to PID 1 or if a new is having a missing parent
-func (pc *ProcessCacheEntry) HasValidLineage() bool {
-	for pc != nil {
-		if pc.IsParentMissing {
-			return false
-		}
-
-		if pc.Pid == 1 {
-			return true
-		}
-		pc = pc.Ancestor
-	}
-	return false
+func (pc *ProcessCacheEntry) HasValidLineage() (bool, error) {
+	res, err := hasValidLineage(pc)
+	pc.hasValidLineage, pc.lineageError = &res, err
+	return res, err
 }
 
 // Exit a process

--- a/pkg/security/secl/model/process_cache_entry_unix_test.go
+++ b/pkg/security/secl/model/process_cache_entry_unix_test.go
@@ -1,0 +1,86 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build unix
+// +build unix
+
+// Package model holds model related files
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasValidLineage(t *testing.T) {
+	newPCE := func(pid uint32, parent *ProcessCacheEntry, isParentMissing bool) *ProcessCacheEntry {
+		pce := &ProcessCacheEntry{
+			ProcessContext: ProcessContext{
+				Process: Process{
+					PIDContext: PIDContext{
+						Pid: pid,
+					},
+
+					IsParentMissing: isParentMissing,
+				},
+				Ancestor: parent,
+			},
+		}
+		if parent != nil {
+			pce.PPid = parent.Pid
+		}
+
+		return pce
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		pid1 := newPCE(1, nil, false)
+		child1 := newPCE(2, pid1, false)
+		child2 := newPCE(3, child1, false)
+
+		isValid, err := child2.HasValidLineage()
+		assert.True(t, isValid)
+		assert.Nil(t, err)
+	})
+
+	t.Run("pid1-missing", func(t *testing.T) {
+		child1 := newPCE(2, nil, false)
+		child2 := newPCE(3, child1, false)
+
+		isValid, err := child2.HasValidLineage()
+		assert.False(t, isValid)
+		assert.NotNil(t, err)
+
+		var mn *ErrProcessIncompleteLineage
+		assert.ErrorAs(t, err, &mn)
+	})
+
+	t.Run("two-pid1", func(t *testing.T) {
+		pid1 := newPCE(1, nil, false)
+		child1 := newPCE(1, pid1, false)
+		child2 := newPCE(3, child1, false)
+
+		isValid, err := child2.HasValidLineage()
+		assert.False(t, isValid)
+		assert.NotNil(t, err)
+
+		var mn *ErrProcessWrongParentNode
+		assert.ErrorAs(t, err, &mn)
+	})
+
+	t.Run("parent-missing", func(t *testing.T) {
+		pid1 := newPCE(1, nil, false)
+		child1 := newPCE(2, pid1, true)
+		child2 := newPCE(3, child1, false)
+
+		isValid, err := child2.HasValidLineage()
+		assert.False(t, isValid)
+		assert.NotNil(t, err)
+
+		var mn *ErrProcessMissingParentNode
+		assert.ErrorAs(t, err, &mn)
+	})
+}

--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -452,9 +452,12 @@ func (at *ActivityTree) CreateProcessNode(entry *model.ProcessCacheEntry, genera
 		return nil, false, nil
 	}
 
-	// check the lineage now, we have to do it only once
-	if !entry.HasCompleteLineage() {
-		return nil, false, ErrBrokenLineage
+	if _, err := entry.HasValidLineage(); err != nil {
+		// check if the node belongs to the container
+		var mn *model.ErrProcessMissingParentNode
+		if !errors.As(err, &mn) {
+			return nil, false, ErrBrokenLineage
+		}
 	}
 
 	// Check if entry or one of its parents cookies are in CookieToProcessNode while building the branch we're trying to

--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -665,8 +665,16 @@ func (adm *ActivityDumpManager) SearchTracedProcessCacheEntryCallback(ad *Activi
 		defer ad.Unlock()
 
 		// check process lineage
-		if !ad.MatchesSelector(entry) || !entry.HasCompleteLineage() {
+		if !ad.MatchesSelector(entry) {
 			return
+		}
+
+		if _, err := entry.HasValidLineage(); err != nil {
+			// check if the node belongs to the container
+			var mn *model.ErrProcessMissingParentNode
+			if !errors.As(err, &mn) {
+				return
+			}
 		}
 
 		// compute the list of ancestors, we need to start inserting them from the root

--- a/pkg/security/security_profile/tests/activity_tree_test.go
+++ b/pkg/security/security_profile/tests/activity_tree_test.go
@@ -140,7 +140,7 @@ func TestActivityTree_CreateProcessNode(t *testing.T) {
 
 	tests := []testIteration{
 
-		// check process with broken lineage (parent with pid != 1)
+		// check process with broken lineage (parent with pid != 1 && containerID != "")
 		{
 			testName:              "broken_lineage",
 			resetActivityTree:     true,

--- a/releasenotes/notes/fix-cws-broken-lineage-check-fc1426a52ed223e0.yaml
+++ b/releasenotes/notes/fix-cws-broken-lineage-check-fc1426a52ed223e0.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix the CWS broken lineage check for process activity.

--- a/releasenotes/notes/fix-cws-broken-lineage-check-fc1426a52ed223e0.yaml
+++ b/releasenotes/notes/fix-cws-broken-lineage-check-fc1426a52ed223e0.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix the CWS broken lineage check for process activity.
+    Fix the broken lineage check for process activity in CWS.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This is a backport of #20394. It fixes the broken lineage check. It doesn't apply the check on parent inode equal to zero as they can come from the snapshot or an cache eviction.



<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
