### PR TITLE
[CONTINT-3441][pkg/clusteragent] Use patch instead of update in language detection patcher

### DIFF
--- a/pkg/clusteragent/languagedetection/patcher.go
+++ b/pkg/clusteragent/languagedetection/patcher.go
@@ -9,6 +9,7 @@ package languagedetection
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	langUtil "github.com/DataDog/datadog-agent/pkg/languagedetection/util"
@@ -17,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/util/retry"
@@ -121,35 +123,6 @@ func (lp *LanguagePatcher) detectedNewLanguages(namespacedOwnerRef *NamespacedOw
 	return false
 }
 
-// Updates the existing annotations based on the detected languages.
-// Currently we only add languages to the annotations.
-func (lp *LanguagePatcher) getUpdatedOwnerAnnotations(currentAnnotations map[string]string, containerslanguages langUtil.ContainersLanguages) (map[string]string, int) {
-	if currentAnnotations == nil {
-		currentAnnotations = make(map[string]string)
-	}
-
-	// Add the existing language annotations into containers languages object
-	existingContainersLanguages := langUtil.NewContainersLanguages()
-	existingContainersLanguages.ParseAnnotations(currentAnnotations)
-
-	// Append the potentially new languages to the containers languages object
-	languagesBeforeUpdate := existingContainersLanguages.TotalLanguages()
-	for container, languageset := range containerslanguages {
-		existingContainersLanguages.GetOrInitializeLanguageset(container).Merge(languageset)
-	}
-	languagesAfterUpdate := existingContainersLanguages.TotalLanguages()
-
-	// Convert containers languages into annotations map
-	updatedLanguageAnnotations := existingContainersLanguages.ToAnnotations()
-
-	for annotationKey, annotationValue := range updatedLanguageAnnotations {
-		currentAnnotations[annotationKey] = annotationValue
-	}
-
-	addedLanguages := languagesAfterUpdate - languagesBeforeUpdate
-	return currentAnnotations, addedLanguages
-}
-
 // patches the owner with the corresponding language annotations
 func (lp *LanguagePatcher) patchOwner(namespacedOwnerRef *NamespacedOwnerReference, containerslanguages langUtil.ContainersLanguages) error {
 	ownerGVR, err := getGVR(namespacedOwnerRef)
@@ -159,25 +132,25 @@ func (lp *LanguagePatcher) patchOwner(namespacedOwnerRef *NamespacedOwnerReferen
 
 	if !lp.detectedNewLanguages(namespacedOwnerRef, containerslanguages) {
 		// No need to patch
+		SkippedPatches.Inc(namespacedOwnerRef.Kind, namespacedOwnerRef.Name, namespacedOwnerRef.namespace)
 		return nil
 	}
 
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		owner, err := lp.k8sClient.Resource(ownerGVR).Namespace(namespacedOwnerRef.namespace).Get(context.TODO(), namespacedOwnerRef.Name, metav1.GetOptions{})
+
+		langAnnotations := containerslanguages.ToAnnotations()
+
+		// Serialize the patch data
+		patchData, err := json.Marshal(map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": langAnnotations,
+			},
+		})
 		if err != nil {
 			return err
 		}
 
-		currentAnnotations := owner.GetAnnotations()
-		updatedAnnotations, addedLanguages := lp.getUpdatedOwnerAnnotations(currentAnnotations, containerslanguages)
-		if addedLanguages == 0 {
-			// No need to patch owner because no new languages were added
-			SkippedPatches.Inc()
-			return nil
-		}
-		owner.SetAnnotations(updatedAnnotations)
-
-		_, err = lp.k8sClient.Resource(ownerGVR).Namespace(namespacedOwnerRef.namespace).Update(context.TODO(), owner, metav1.UpdateOptions{})
+		_, err = lp.k8sClient.Resource(ownerGVR).Namespace(namespacedOwnerRef.namespace).Patch(context.TODO(), namespacedOwnerRef.Name, types.MergePatchType, patchData, metav1.PatchOptions{})
 		if err != nil {
 			PatchRetries.Inc(namespacedOwnerRef.Kind, namespacedOwnerRef.Name, namespacedOwnerRef.namespace)
 		}

--- a/pkg/clusteragent/languagedetection/patcher_test.go
+++ b/pkg/clusteragent/languagedetection/patcher_test.go
@@ -248,56 +248,6 @@ func TestDetectedNewLanguages(t *testing.T) {
 	assert.True(t, lp.detectedNewLanguages(&namespacedOwnerReference, detectedContainersLanguages))
 }
 
-func TestGetUpdatedOwnerAnnotations(t *testing.T) {
-	lp := newMockLanguagePatcher(nil, nil)
-
-	mockContainersLanguages := langUtil.NewContainersLanguages()
-	mockContainersLanguages.GetOrInitializeLanguageset("container-1").Parse("cpp,java,python")
-	mockContainersLanguages.GetOrInitializeLanguageset("container-2").Parse("python,ruby")
-	mockContainersLanguages.GetOrInitializeLanguageset("container-3").Parse("cpp")
-	mockContainersLanguages.GetOrInitializeLanguageset("container-4").Parse("")
-
-	// Case of existing annotations
-	mockCurrentAnnotations := map[string]string{
-		"annotationkey1": "annotationvalue1",
-		"annotationkey2": "annotationvalue2",
-		"apm.datadoghq.com/container-1.languages": "java,python",
-		"apm.datadoghq.com/container-2.languages": "cpp",
-	}
-
-	expectedUpdatedAnnotations := map[string]string{
-		"annotationkey1": "annotationvalue1",
-		"annotationkey2": "annotationvalue2",
-		"apm.datadoghq.com/container-1.languages": "cpp,java,python",
-		"apm.datadoghq.com/container-2.languages": "cpp,python,ruby",
-		"apm.datadoghq.com/container-3.languages": "cpp",
-	}
-
-	expectedAddedLanguages := 4
-
-	actualUpdatedAnnotations, actualAddedLanguages := lp.getUpdatedOwnerAnnotations(mockCurrentAnnotations, mockContainersLanguages)
-
-	assert.Equal(t, expectedAddedLanguages, actualAddedLanguages)
-	assert.Equal(t, expectedUpdatedAnnotations, actualUpdatedAnnotations)
-
-	// Case of non-existing annotations
-	mockCurrentAnnotations = nil
-
-	expectedUpdatedAnnotations = map[string]string{
-		"apm.datadoghq.com/container-1.languages": "cpp,java,python",
-		"apm.datadoghq.com/container-2.languages": "python,ruby",
-		"apm.datadoghq.com/container-3.languages": "cpp",
-	}
-
-	expectedAddedLanguages = 6
-
-	actualUpdatedAnnotations, actualAddedLanguages = lp.getUpdatedOwnerAnnotations(mockCurrentAnnotations, mockContainersLanguages)
-
-	assert.Equal(t, expectedAddedLanguages, actualAddedLanguages)
-	assert.Equal(t, expectedUpdatedAnnotations, actualUpdatedAnnotations)
-
-}
-
 func TestPatchOwner(t *testing.T) {
 	mockK8sClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
 	lp := newMockLanguagePatcher(mockK8sClient, workloadmeta.NewMockStore())
@@ -348,7 +298,7 @@ func TestPatchOwner(t *testing.T) {
 
 	expectedAnnotations := map[string]string{
 		"apm.datadoghq.com/container-1.languages": "cpp,java,python",
-		"apm.datadoghq.com/container-2.languages": "cpp,python,ruby",
+		"apm.datadoghq.com/container-2.languages": "python,ruby",
 		"apm.datadoghq.com/container-3.languages": "cpp",
 		"annotationkey1": "annotationvalue1",
 		"annotationkey2": "annotationvalue2",
@@ -459,7 +409,7 @@ func TestPatchAllOwners(t *testing.T) {
 					"annotationkey1": "annotationvalue1",
 					"annotationkey2": "annotationvalue2",
 					"apm.datadoghq.com/container-1.languages": "java,python",
-					"apm.datadoghq.com/container-2.languages": "cpp",
+					"apm.datadoghq.com/container-2.languages": "python",
 				},
 			},
 			"spec": map[string]interface{}{},
@@ -503,7 +453,7 @@ func TestPatchAllOwners(t *testing.T) {
 
 	expectedAnnotationsA := map[string]string{
 		"apm.datadoghq.com/container-1.languages":      "cpp,java,python",
-		"apm.datadoghq.com/container-2.languages":      "cpp,python,ruby",
+		"apm.datadoghq.com/container-2.languages":      "python,ruby",
 		"apm.datadoghq.com/init.container-3.languages": "cpp",
 		"annotationkey1": "annotationvalue1",
 		"annotationkey2": "annotationvalue2",

--- a/pkg/clusteragent/languagedetection/telemetry.go
+++ b/pkg/clusteragent/languagedetection/telemetry.go
@@ -47,7 +47,7 @@ var (
 	SkippedPatches = telemetry.NewCounterWithOpts(
 		subsystem,
 		"skipped_patch",
-		[]string{},
+		[]string{"owner_kind", "owner_name", "namespace"},
 		"Tracks the number of times a patch was skipped because no new languages are detected",
 		commonOpts,
 	)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR improves the patching method in the language detection patcher by using `patch` instead of `update` in order to set the language annotations on the resource object.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Using a `patch` instead an `update` reduces the network traffic and limits data exchange only to necessary data with the API server. 

This can result in significant improvement as the number of patching requests increase. This can happen mainly in clusters with large number of deployments. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
- The patcher uses the merge strategy in order not to unset previously set annotations. It only merges the new annotations with the existing ones.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
- A side effect of using `patch` is that it will override languages that already exist in the language annotations. For example, if we have an annotation `"apm.datadoghq.com/notes-app-deployment.languages": "java,js"`, then sending a `patch` that sets `apm.datadoghq.com/notes-app-deployment.languages` to `java` will result in removing `js` from the annotation value. This situation might happen, although rarely, when multiple cluster agents are running the patching logic to patcher annotations. However, this should not be an issue currently with this feature because only the cluster agent will be patching annotations. The possibility of conflict and data loss is something to keep in mind if more than 1 cluster agent patch objects with annotations.

### Describe how to test/QA your changes

Same testing plan as [this PR](https://github.com/DataDog/datadog-agent/pull/19636).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
