### PR TITLE
Add Ubuntu and Debian VM images

### DIFF
--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -380,7 +380,7 @@ kernel_matrix_testing_run_tests_x64:
     ARCH: "x86_64"
   parallel:
     matrix:
-      - TAG: ["ubuntu_18.04", "ubuntu_20.04", "ubuntu_22.04", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_37", "fedora_38", "debian_10", "debian_11", "debian_12"]
+      - TAG: ["ubuntu_16.04", "ubuntu_18.04", "ubuntu_20.04", "ubuntu_22.04", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_37", "fedora_38", "debian_10", "debian_11", "debian_12"]
 
 kernel_matrix_testing_run_tests_arm64:
   extends:

--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -393,7 +393,7 @@ kernel_matrix_testing_run_tests_arm64:
     ARCH: "arm64"
   parallel:
     matrix:
-      - TAG: ["ubuntu_20.04", "ubuntu_22.04", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_37", "fedora_38", "debian_10", "debian_11", "debian_12"]
+      - TAG: ["ubuntu_18.04", "ubuntu_20.04", "ubuntu_22.04", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_37", "fedora_38", "debian_10", "debian_11", "debian_12"]
 
 .kernel_matrix_testing_cleanup:
   stage: kernel_matrix_testing

--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -393,7 +393,7 @@ kernel_matrix_testing_run_tests_arm64:
     ARCH: "arm64"
   parallel:
     matrix:
-      - TAG: ["ubuntu_20.04", "ubuntu_22.04", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_37", "fedora_38", "debian_12"]
+      - TAG: ["ubuntu_20.04", "ubuntu_22.04", "amzn_4.14", "amzn_5.4", "amzn_5.10", "fedora_37", "fedora_38", "debian_10", "debian_11", "debian_12"]
 
 .kernel_matrix_testing_cleanup:
   stage: kernel_matrix_testing

--- a/tasks/kernel_matrix_testing/download.py
+++ b/tasks/kernel_matrix_testing/download.py
@@ -26,6 +26,8 @@ rootfs_amd64 = {
     "Fedora-Cloud-Base-36.amd64.qcow2",
     "Fedora-Cloud-Base-37.amd64.qcow2",
     "Fedora-Cloud-Base-38.amd64.qcow2",
+    "debian-10-generic-amd64.qcow2",
+    "debian-11-generic-amd64.qcow2",
 }
 
 rootfs_arm64 = {
@@ -41,6 +43,8 @@ rootfs_arm64 = {
     "Fedora-Cloud-Base-36.arm64.qcow2",
     "Fedora-Cloud-Base-37.arm64.qcow2",
     "Fedora-Cloud-Base-38.arm64.qcow2",
+    "debian-10-generic-arm64.qcow2",
+    "debian-11-generic-arm64.qcow2",
 }
 
 archs_mapping = {

--- a/tasks/kernel_matrix_testing/vmconfig.py
+++ b/tasks/kernel_matrix_testing/vmconfig.py
@@ -73,6 +73,8 @@ distributions = {
     "fedora_36": "fedora_36",
     "fedora_37": "fedora_37",
     "fedora_38": "fedora_38",
+    "debian_10": "debian_10",
+    "debian_11": "debian_11",
 }
 distro_arch_mapping = {"x86_64": "amd64", "arm64": "arm64"}
 images_path_local = {
@@ -85,10 +87,12 @@ images_path_local = {
     "amzn_5.4": "file:///home/kernel-version-testing/rootfs/amzn2-kvm-2.0-{arch}-5.4.qcow2",
     "amzn_5.10": "file:///home/kernel-version-testing/rootfs/amzn2-kvm-2.0-{arch}-5.10.qcow2",
     "amzn_5.15": "file:///home/kernel-version-testing/rootfs/amzn2-kvm-2.0-{arch}-5.15.qcow2",
-    "fedora_35": "file:///home/kernel-version-testing/rootfs/Fedora-Cloud-Base-35.amd64.qcow2",
-    "fedora_36": "file:///home/kernel-version-testing/rootfs/Fedora-Cloud-Base-36.amd64.qcow2",
-    "fedora_37": "file:///home/kernel-version-testing/rootfs/Fedora-Cloud-Base-37.amd64.qcow2",
-    "fedora_38": "file:///home/kernel-version-testing/rootfs/Fedora-Cloud-Base-38.amd64.qcow2",
+    "fedora_35": "file:///home/kernel-version-testing/rootfs/Fedora-Cloud-Base-35.{arch}.qcow2",
+    "fedora_36": "file:///home/kernel-version-testing/rootfs/Fedora-Cloud-Base-36.{arch}.qcow2",
+    "fedora_37": "file:///home/kernel-version-testing/rootfs/Fedora-Cloud-Base-37.{arch}.qcow2",
+    "fedora_38": "file:///home/kernel-version-testing/rootfs/Fedora-Cloud-Base-38.{arch}.qcow2",
+    "debian_10": "file:///home/kernel-version-testing/rootfs/debian-10-generic-{arch}.qcow2",
+    "debian_11": "file:///home/kernel-version-testing/rootfs/debian-11-generic-{arch}.qcow2",
 }
 
 images_path_s3 = {
@@ -105,6 +109,8 @@ images_path_s3 = {
     "fedora_36": "{url_base}Fedora-Cloud-Base-36.{arch}.qcow2",
     "fedora_37": "{url_base}Fedora-Cloud-Base-37.{arch}.qcow2",
     "fedora_38": "{url_base}Fedora-Cloud-Base-38.{arch}.qcow2",
+    "debian_10": "{url_base}debian-10-generic-{arch}.qcow2",
+    "debian_11": "{url_base}debian-11-generic-{arch}.qcow2",
 }
 
 images_name = {
@@ -121,6 +127,8 @@ images_name = {
     "fedora_36": "Fedora-Cloud-Base-36.{arch}.qcow2",
     "fedora_37": "Fedora-Cloud-Base-37.{arch}.qcow2",
     "fedora_38": "Fedora-Cloud-Base-38.{arch}.qcow2",
+    "debian_10": "debian-10-generic-{arch}.qcow2",
+    "debian_11": "debian-11-generic-{arch}.qcow2",
 }
 
 TICK = "\u2713"
@@ -138,6 +146,8 @@ table = [
     ["fedora 36 - v5.17.5", TICK, TICK],
     ["fedora 37 - v6.0.7", TICK, TICK],
     ["fedora 38 - v6.2.9", TICK, TICK],
+    ["debian 10 - v4.19.0", TICK, TICK],
+    ["debian 11 - v5.10.0", TICK, TICK],
 ]
 
 consoles = {"x86_64": "ttyS0", "arm64": "ttyAMA0"}

--- a/test/new-e2e/system-probe/config/vmconfig-arm64.json
+++ b/test/new-e2e/system-probe/config/vmconfig-arm64.json
@@ -9,7 +9,7 @@
                 {
                     "dir": "bionic-server-cloudimg-arm64.qcow2",
                     "tag": "ubuntu_18.04",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bionic-server-cloudimg-arm64.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/bionic-server-cloudimg-arm64.qcow2.xz"
                 },
                 {
                     "dir": "focal-server-cloudimg-arm64.qcow2",

--- a/test/new-e2e/system-probe/config/vmconfig-arm64.json
+++ b/test/new-e2e/system-probe/config/vmconfig-arm64.json
@@ -42,6 +42,16 @@
                     "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/Fedora-Cloud-Base-38.arm64.qcow2.xz"
                 },
                 {
+                    "dir": "debian-10-generic-arm64.qcow2",
+                    "tag": "debian_10",
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/debian-10-generic-arm64.qcow2.xz-test-only"
+                },
+                {
+                    "dir": "debian-11-generic-arm64.qcow2",
+                    "tag": "debian_11",
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/debian-11-generic-arm64.qcow2.xz-test-only"
+                },
+                {
                     "dir": "debian-12-generic-arm64.qcow2",
                     "tag": "debian_12",
                     "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/debian-12-generic-arm64.qcow2.xz"

--- a/test/new-e2e/system-probe/config/vmconfig-arm64.json
+++ b/test/new-e2e/system-probe/config/vmconfig-arm64.json
@@ -7,6 +7,11 @@
             "console_type": "file",
             "kernels": [
                 {
+                    "dir": "bionic-server-cloudimg-arm64.qcow2",
+                    "tag": "ubuntu_18.04",
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bionic-server-cloudimg-arm64.qcow2.xz"
+                },
+                {
                     "dir": "focal-server-cloudimg-arm64.qcow2",
                     "tag": "ubuntu_20.04",
                     "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/focal-server-cloudimg-arm64.qcow2.xz"

--- a/test/new-e2e/system-probe/config/vmconfig-x64.json
+++ b/test/new-e2e/system-probe/config/vmconfig-x64.json
@@ -7,6 +7,11 @@
             "console_type": "file",
             "kernels": [
                 {
+                    "dir": "xenial-server-cloudimg-amd64.qcow2",
+                    "tag": "ubuntu_16.04",
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/usama.saqib/standard-ubuntu-build/xenial-server-cloudimg-amd64.qcow2.xz"
+                },
+                {
                     "dir": "bionic-server-cloudimg-amd64.qcow2",
                     "tag": "ubuntu_18.04",
                     "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/bionic-server-cloudimg-amd64.qcow2.xz"

--- a/test/new-e2e/system-probe/config/vmconfig-x64.json
+++ b/test/new-e2e/system-probe/config/vmconfig-x64.json
@@ -9,7 +9,7 @@
                 {
                     "dir": "xenial-server-cloudimg-amd64.qcow2",
                     "tag": "ubuntu_16.04",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/usama.saqib/standard-ubuntu-build/xenial-server-cloudimg-amd64.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/xenial-server-cloudimg-amd64.qcow2.xz"
                 },
                 {
                     "dir": "bionic-server-cloudimg-amd64.qcow2",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR adds debian-10, debian-11 and ubuntu-18 images for ARM64 tests.
It also add Ubuntu-16 for AMD64 tests.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
