### PR TITLE
[AMLII-1178] logs/tailers: rephrase process_raw_message feature warning notice

### DIFF
--- a/pkg/logs/tailers/journald/tailer.go
+++ b/pkg/logs/tailers/journald/tailer.go
@@ -55,10 +55,9 @@ type Tailer struct {
 // NewTailer returns a new tailer.
 func NewTailer(source *sources.LogSource, outputChan chan *message.Message, journal Journal, processRawMessage bool) *Tailer {
 	if len(source.Config.ProcessingRules) > 0 && processRawMessage {
-		log.Warn("Log processing rules with the journald collection will change in a future version of the Agent:")
-		log.Warn("The processing will soon apply on the message content only instead of on the structured log (e.g. on the collected JSON).")
-		log.Warn("In order to immediately switch to this new behaviour, set 'process_raw_message' to 'false' in your logs integration config.")
-		log.Warn("Please reach Datadog support if you have more questions.")
+		log.Warn("The logs processing rules can now be applied to the message content only instead of the whole JSON-structured log (e.g. on the collected JSON). This behavior will be the default behavior in a future version of the Agent.")
+		log.Warn("In order to immediately switch to this new behavior, set 'process_raw_message' to 'false' in your logs integration config and adapt your processing rules accordingly.")
+		log.Warn("Please contact Datadog support for more information.")
 		telemetry.GetStatsTelemetryProvider().Gauge(processor.UnstructuredProcessingMetricName, 1, []string{"tailer:journald"})
 	}
 

--- a/pkg/logs/tailers/journald/tailer.go
+++ b/pkg/logs/tailers/journald/tailer.go
@@ -55,7 +55,7 @@ type Tailer struct {
 // NewTailer returns a new tailer.
 func NewTailer(source *sources.LogSource, outputChan chan *message.Message, journal Journal, processRawMessage bool) *Tailer {
 	if len(source.Config.ProcessingRules) > 0 && processRawMessage {
-		log.Warn("The logs processing rules currently apply to the raw JSON-structured log. These rules can now be applied to the message content only, and this behavior will be the default behavior in a future version of the Agent.")
+		log.Warn("The logs processing rules currently apply to the raw journald JSON-structured log. These rules can now be applied to the message content only, and this behavior will be the default behavior in a future version of the Agent.")
 		log.Warn("In order to immediately switch to this new behavior, set 'process_raw_message' to 'false' in your logs integration config and adapt your processing rules accordingly.")
 		log.Warn("Please contact Datadog support for more information.")
 		telemetry.GetStatsTelemetryProvider().Gauge(processor.UnstructuredProcessingMetricName, 1, []string{"tailer:journald"})

--- a/pkg/logs/tailers/journald/tailer.go
+++ b/pkg/logs/tailers/journald/tailer.go
@@ -55,7 +55,7 @@ type Tailer struct {
 // NewTailer returns a new tailer.
 func NewTailer(source *sources.LogSource, outputChan chan *message.Message, journal Journal, processRawMessage bool) *Tailer {
 	if len(source.Config.ProcessingRules) > 0 && processRawMessage {
-		log.Warn("The logs processing rules currently apply to the raw journald JSON-structured log. These rules can now be applied to the message content only, and this behavior will be the default behavior in a future version of the Agent.")
+		log.Warn("The logs processing rules currently apply to the raw journald JSON-structured log. These rules can now be applied to the message content only, and we plan to make this the default behavior in the future.")
 		log.Warn("In order to immediately switch to this new behavior, set 'process_raw_message' to 'false' in your logs integration config and adapt your processing rules accordingly.")
 		log.Warn("Please contact Datadog support for more information.")
 		telemetry.GetStatsTelemetryProvider().Gauge(processor.UnstructuredProcessingMetricName, 1, []string{"tailer:journald"})

--- a/pkg/logs/tailers/journald/tailer.go
+++ b/pkg/logs/tailers/journald/tailer.go
@@ -55,7 +55,7 @@ type Tailer struct {
 // NewTailer returns a new tailer.
 func NewTailer(source *sources.LogSource, outputChan chan *message.Message, journal Journal, processRawMessage bool) *Tailer {
 	if len(source.Config.ProcessingRules) > 0 && processRawMessage {
-		log.Warn("The logs processing rules can now be applied to the message content only instead of the whole JSON-structured log (e.g. on the collected JSON). This behavior will be the default behavior in a future version of the Agent.")
+		log.Warn("The logs processing rules currently apply to the raw JSON-structured log. These rules can now be applied to the message content only, and this behavior will be the default behavior in a future version of the Agent.")
 		log.Warn("In order to immediately switch to this new behavior, set 'process_raw_message' to 'false' in your logs integration config and adapt your processing rules accordingly.")
 		log.Warn("Please contact Datadog support for more information.")
 		telemetry.GetStatsTelemetryProvider().Gauge(processor.UnstructuredProcessingMetricName, 1, []string{"tailer:journald"})

--- a/pkg/logs/tailers/windowsevent/tailer.go
+++ b/pkg/logs/tailers/windowsevent/tailer.go
@@ -123,10 +123,9 @@ func NewTailer(evtapi evtapi.API, source *sources.LogSource, config *Config, out
 	}
 
 	if len(source.Config.ProcessingRules) > 0 && config.ProcessRawMessage {
-		log.Warn("Log processing rules with the Windows Events collection will change in a future version of the Agent:")
-		log.Warn("The processing will soon apply on the message content only instead of on the structured log (e.g. on the internal JSON).")
-		log.Warn("In order to immediately switch to this new behaviour, set 'process_raw_message' to 'false' in your logs integration config.")
-		log.Warn("Please reach Datadog support if you have more questions.")
+	    log.Warn("The logs processing rules can now be applied to the message content only instead of the whole JSON-structured log (e.g. on the internal JSON). This behavior will be the default behavior in a future version of the Agent.")
+		log.Warn("In order to immediately switch to this new behavior, set 'process_raw_message' to 'false' in your logs integration config and adapt your processing rules accordingly.")
+		log.Warn("Please contact Datadog support for more information.")
 		telemetry.GetStatsTelemetryProvider().Gauge(processor.UnstructuredProcessingMetricName, 1, []string{"tailer:windowsevent"})
 	}
 

--- a/pkg/logs/tailers/windowsevent/tailer.go
+++ b/pkg/logs/tailers/windowsevent/tailer.go
@@ -123,7 +123,7 @@ func NewTailer(evtapi evtapi.API, source *sources.LogSource, config *Config, out
 	}
 
 	if len(source.Config.ProcessingRules) > 0 && config.ProcessRawMessage {
-		log.Warn("The logs processing rules currently apply to the raw internal windowsevent log structure. These rules can now be applied to the message content only, and this behavior will be the default behavior in a future version of the Agent.")
+		log.Warn("The logs processing rules currently apply to the raw internal windowsevent log structure. These rules can now be applied to the message content only, and we plan to make this the default behavior in the future.")
 		log.Warn("In order to immediately switch to this new behavior, set 'process_raw_message' to 'false' in your logs integration config and adapt your processing rules accordingly.")
 		log.Warn("Please contact Datadog support for more information.")
 		telemetry.GetStatsTelemetryProvider().Gauge(processor.UnstructuredProcessingMetricName, 1, []string{"tailer:windowsevent"})

--- a/pkg/logs/tailers/windowsevent/tailer.go
+++ b/pkg/logs/tailers/windowsevent/tailer.go
@@ -123,7 +123,7 @@ func NewTailer(evtapi evtapi.API, source *sources.LogSource, config *Config, out
 	}
 
 	if len(source.Config.ProcessingRules) > 0 && config.ProcessRawMessage {
-		log.Warn("The logs processing rules currently apply to the raw internal log structure. These rules can now be applied to the message content only, and this behavior will be the default behavior in a future version of the Agent.")
+		log.Warn("The logs processing rules currently apply to the raw internal windowsevent log structure. These rules can now be applied to the message content only, and this behavior will be the default behavior in a future version of the Agent.")
 		log.Warn("In order to immediately switch to this new behavior, set 'process_raw_message' to 'false' in your logs integration config and adapt your processing rules accordingly.")
 		log.Warn("Please contact Datadog support for more information.")
 		telemetry.GetStatsTelemetryProvider().Gauge(processor.UnstructuredProcessingMetricName, 1, []string{"tailer:windowsevent"})

--- a/pkg/logs/tailers/windowsevent/tailer.go
+++ b/pkg/logs/tailers/windowsevent/tailer.go
@@ -123,7 +123,7 @@ func NewTailer(evtapi evtapi.API, source *sources.LogSource, config *Config, out
 	}
 
 	if len(source.Config.ProcessingRules) > 0 && config.ProcessRawMessage {
-	    log.Warn("The logs processing rules can now be applied to the message content only instead of the whole JSON-structured log (e.g. on the internal JSON). This behavior will be the default behavior in a future version of the Agent.")
+		log.Warn("The logs processing rules currently apply to the raw internal log structure. These rules can now be applied to the message content only, and this behavior will be the default behavior in a future version of the Agent.")
 		log.Warn("In order to immediately switch to this new behavior, set 'process_raw_message' to 'false' in your logs integration config and adapt your processing rules accordingly.")
 		log.Warn("Please contact Datadog support for more information.")
 		telemetry.GetStatsTelemetryProvider().Gauge(processor.UnstructuredProcessingMetricName, 1, []string{"tailer:windowsevent"})


### PR DESCRIPTION
### What does this PR do?

Rephrasing warning messages about the `process_raw_message` configuration flag.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
