### PR TITLE
No longer pin oscrypto as snowflake-connector-python no longer depends on it

### DIFF
--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -39,13 +39,7 @@ build do
     }
   end
 
-  # We need a newer version of oscrypto than the one released to get a fix for a bug
-  # that gets triggered when having double digits on the OpenSSL version
-  # (https://github.com/wbond/oscrypto/issues/75).
-  # We can remove the oscrypto pinning once the fix becomes part of a new release
-  oscrypto_commit = "d5f3437ed24257895ae1edd9e503cfb352e635a8"
-
   # Adding pyopenssl==23.3.0 here is a temporary workaround so that we don't get
   # conflict because of the `cryptography` version we ship with the agent.
-  command "#{pip} install pyopenssl==23.3.0 . \"oscrypto @ git+https://github.com/wbond/oscrypto.git@#{oscrypto_commit}\"", :env => build_env
+  command "#{pip} install pyopenssl==23.3.0 .", :env => build_env
 end


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Drop the extra oscrypto pin when installing `snowflake-connector-python`.

### Motivation

https://github.com/snowflakedb/snowflake-connector-python/releases/tag/v3.4.0:
> Removed dependencies on pycryptodomex and oscrypto. All connections now go through OpenSSL via the cryptography library, which was already a dependency.

### Additional Notes

UPDATE: I've tested the Snowflake integration locally on an agent build that uses openssl 3.0.12, to ensure that dropping this doesn't cause a regression.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Confirm that the snowflake integration works on an agent distribution that uses double digits in a version segment.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
