### PR TITLE
Add internal telemetry to track perf buffer / ring buffer usage

### DIFF
--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -92,9 +92,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 }
 
 // run starts the main loop.
-//
-//nolint:revive // TODO(EBPF) Fix revive linter
-func run(log log.Component, config config.Component, telemetry telemetry.Component, sysprobeconfig sysprobeconfig.Component, rcclient rcclient.Component, cliParams *cliParams) error {
+func run(log log.Component, _ config.Component, telemetry telemetry.Component, sysprobeconfig sysprobeconfig.Component, rcclient rcclient.Component, cliParams *cliParams) error {
 	defer func() {
 		stopSystemProbe(cliParams)
 	}()
@@ -287,6 +285,9 @@ func startSystemProbe(cliParams *cliParams, log log.Component, telemetry telemet
 		if cfg.TelemetryEnabled {
 			http.Handle("/telemetry", telemetry.Handler())
 			telemetry.RegisterCollector(ebpf.NewDebugFsStatCollector())
+			if pc := ebpf.NewPerfUsageCollector(); pc != nil {
+				telemetry.RegisterCollector(pc)
+			}
 		}
 		go func() {
 			common.ExpvarServer = &http.Server{

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.3.1-0.20231115110321-54ec306d83b2
 	// do not update datadog-operator to 1.2.1 because the indirect dependency github.com/DataDog/datadog-api-client-go/v2 v2.15.0 is trigger a huge Go heap memory increase.
 	github.com/DataDog/datadog-operator v1.1.0
-	github.com/DataDog/ebpf-manager v0.3.8
+	github.com/DataDog/ebpf-manager v0.3.9-0.20231205194341-02cf03860a43
 	github.com/DataDog/go-tuf v1.0.2-0.5.2
 	github.com/DataDog/gopsutil v1.2.2
 	github.com/DataDog/nikos v1.12.1

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.3.1-0.20231115110321-54ec306d83b2
 	// do not update datadog-operator to 1.2.1 because the indirect dependency github.com/DataDog/datadog-api-client-go/v2 v2.15.0 is trigger a huge Go heap memory increase.
 	github.com/DataDog/datadog-operator v1.1.0
-	github.com/DataDog/ebpf-manager v0.3.9-0.20231205194341-02cf03860a43
+	github.com/DataDog/ebpf-manager v0.3.9
 	github.com/DataDog/go-tuf v1.0.2-0.5.2
 	github.com/DataDog/gopsutil v1.2.2
 	github.com/DataDog/nikos v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/DataDog/datadog-go/v5 v5.3.1-0.20231115110321-54ec306d83b2 h1:E9taSkw
 github.com/DataDog/datadog-go/v5 v5.3.1-0.20231115110321-54ec306d83b2/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/datadog-operator v1.1.0 h1:cSZqKarzM66GR0T1pPPZVopz4oPm3ltcRyqJ/h/6eJg=
 github.com/DataDog/datadog-operator v1.1.0/go.mod h1:3aWOjI4EaE1jYVN6llOXygA9nasy70GCa1XnTIWNoCY=
-github.com/DataDog/ebpf-manager v0.3.9-0.20231205194341-02cf03860a43 h1:/q6O9r5Eu5hKC1BaqwYmsiQtFyq+xMSCTKp5xskUMJo=
-github.com/DataDog/ebpf-manager v0.3.9-0.20231205194341-02cf03860a43/go.mod h1:GQ0AnVyn0Oi+NzBOBP1UB5kHGa5YZRxlFDhg4VGAo3s=
+github.com/DataDog/ebpf-manager v0.3.9 h1:ysIyB7eGjjUSenxV43BoDBrauOwj+pzjlLwwi4Ly8t8=
+github.com/DataDog/ebpf-manager v0.3.9/go.mod h1:GQ0AnVyn0Oi+NzBOBP1UB5kHGa5YZRxlFDhg4VGAo3s=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2 h1:uTE/QEU0oYtHnebKSMbxap7XMG5603WQxNP/UX63E7k=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2/go.mod h1:JgKVGTsjdTdtJjNyxRZjcs81/rng6LJ3XX/0D7Y12Gc=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe h1:RO40ywnX/vZLi4Pb4jRuFGgQQBYGIIoQ6u+P2MIgFOA=

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/DataDog/datadog-go/v5 v5.3.1-0.20231115110321-54ec306d83b2 h1:E9taSkw
 github.com/DataDog/datadog-go/v5 v5.3.1-0.20231115110321-54ec306d83b2/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/datadog-operator v1.1.0 h1:cSZqKarzM66GR0T1pPPZVopz4oPm3ltcRyqJ/h/6eJg=
 github.com/DataDog/datadog-operator v1.1.0/go.mod h1:3aWOjI4EaE1jYVN6llOXygA9nasy70GCa1XnTIWNoCY=
-github.com/DataDog/ebpf-manager v0.3.8 h1:Y0TBoSzwe90iamiO8Zy09g/XoTLbSg9aaiSDxCg+D9w=
-github.com/DataDog/ebpf-manager v0.3.8/go.mod h1:ULRKNrj8WbMQG8WdkRfS46y8xrTYV2Og8HKBR3SP6uY=
+github.com/DataDog/ebpf-manager v0.3.9-0.20231205194341-02cf03860a43 h1:/q6O9r5Eu5hKC1BaqwYmsiQtFyq+xMSCTKp5xskUMJo=
+github.com/DataDog/ebpf-manager v0.3.9-0.20231205194341-02cf03860a43/go.mod h1:GQ0AnVyn0Oi+NzBOBP1UB5kHGa5YZRxlFDhg4VGAo3s=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2 h1:uTE/QEU0oYtHnebKSMbxap7XMG5603WQxNP/UX63E7k=
 github.com/DataDog/extendeddaemonset v0.9.0-rc.2/go.mod h1:JgKVGTsjdTdtJjNyxRZjcs81/rng6LJ3XX/0D7Y12Gc=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe h1:RO40ywnX/vZLi4Pb4jRuFGgQQBYGIIoQ6u+P2MIgFOA=

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -110,7 +110,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "max_conns_per_message"), defaultConnsMessageBatchSize)
 
 	cfg.BindEnvAndSetDefault(join(spNS, "debug_port"), 0)
-	cfg.BindEnvAndSetDefault(join(spNS, "telemetry_enabled"), true, "DD_TELEMETRY_ENABLED")
+	cfg.BindEnvAndSetDefault(join(spNS, "telemetry_enabled"), false, "DD_TELEMETRY_ENABLED")
 	cfg.BindEnvAndSetDefault(join(spNS, "health_port"), int64(0), "DD_SYSTEM_PROBE_HEALTH_PORT")
 
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.enabled"), false, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_ENABLED")

--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -34,6 +34,9 @@ type Config struct {
 	// ProcRoot is the root path to the proc filesystem
 	ProcRoot string
 
+	// InternalTelemetryEnabled indicates whether internal prometheus telemetry is enabled
+	InternalTelemetryEnabled bool
+
 	// EnableTracepoints enables use of tracepoints instead of kprobes for probing syscalls (if available on system)
 	EnableTracepoints bool
 
@@ -93,6 +96,7 @@ func NewConfig() *Config {
 		ExcludedBPFLinuxVersions: cfg.GetStringSlice(key(spNS, "excluded_linux_versions")),
 		EnableTracepoints:        cfg.GetBool(key(spNS, "enable_tracepoints")),
 		ProcRoot:                 kernel.ProcFSRoot(),
+		InternalTelemetryEnabled: cfg.GetBool(key(spNS, "telemetry_enabled")),
 
 		EnableCORE: cfg.GetBool(key(spNS, "enable_co_re")),
 		BTFPath:    cfg.GetString(key(spNS, "btf_path")),

--- a/pkg/ebpf/perf_metrics.go
+++ b/pkg/ebpf/perf_metrics.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
+//go:build linux_bpf
 
 package ebpf
 

--- a/pkg/ebpf/perf_metrics.go
+++ b/pkg/ebpf/perf_metrics.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux_bpf
+//go:build linux
 
 package ebpf
 

--- a/pkg/ebpf/perf_metrics.go
+++ b/pkg/ebpf/perf_metrics.go
@@ -97,7 +97,7 @@ func (p *perfUsageCollector) Collect(metrics chan<- prometheus.Metric) {
 
 			count := float64(usage[cpu])
 			p.usage.WithLabelValues(mapName, mapType, cpuString).Set(count)
-			p.usagePct.WithLabelValues().Set(100 * (count / size))
+			p.usagePct.WithLabelValues(mapName, mapType, cpuString).Set(100 * (count / size))
 			p.size.WithLabelValues(mapName, mapType, cpuString).Set(size)
 			p.lost.WithLabelValues(mapName, mapType, cpuString).Add(float64(lost[cpu]))
 		}
@@ -114,7 +114,7 @@ func (p *perfUsageCollector) Collect(metrics chan<- prometheus.Metric) {
 		cpuString := "0"
 		count := float64(usage)
 		p.usage.WithLabelValues(mapName, mapType, cpuString).Set(count)
-		p.usagePct.WithLabelValues().Set(100 * (count / size))
+		p.usagePct.WithLabelValues(mapName, mapType, cpuString).Set(100 * (count / size))
 		p.size.WithLabelValues(mapName, mapType, cpuString).Set(size)
 	}
 

--- a/pkg/ebpf/perf_metrics.go
+++ b/pkg/ebpf/perf_metrics.go
@@ -1,0 +1,158 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package ebpf
+
+import (
+	"strconv"
+	"sync"
+
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/cilium/ebpf"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	perfCollector *perfUsageCollector
+)
+
+type perfUsageCollector struct {
+	mtx      sync.Mutex
+	usage    *prometheus.GaugeVec
+	usagePct *prometheus.GaugeVec
+	size     *prometheus.GaugeVec
+	lost     *prometheus.CounterVec
+
+	perfMaps    []*manager.PerfMap
+	ringBuffers []*manager.RingBuffer
+}
+
+// NewPerfUsageCollector creates a prometheus.Collector for perf buffer and ring buffer metrics
+func NewPerfUsageCollector() prometheus.Collector {
+	perfCollector = &perfUsageCollector{
+		usage: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Subsystem: "ebpf__perf",
+				Name:      "_usage",
+				Help:      "gauge tracking bytes usage of a perf buffer (per-cpu) or ring buffer",
+			},
+			[]string{"map_name", "map_type", "cpu_num"},
+		),
+		usagePct: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Subsystem: "ebpf__perf",
+				Name:      "_usage_pct",
+				Help:      "gauge tracking percentage usage of a perf buffer (per-cpu) or ring buffer",
+			},
+			[]string{"map_name", "map_type", "cpu_num"},
+		),
+		size: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Subsystem: "ebpf__perf",
+				Name:      "_size",
+				Help:      "gauge tracking total size of a perf buffer (per-cpu) or ring buffer",
+			},
+			[]string{"map_name", "map_type", "cpu_num"},
+		),
+		lost: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Subsystem: "ebpf__perf",
+				Name:      "_lost",
+				Help:      "counter tracking lost samples of a perf buffer (per-cpu)",
+			},
+			[]string{"map_name", "map_type", "cpu_num"},
+		),
+	}
+	return perfCollector
+}
+
+// Describe implements prometheus.Collector.Describe
+func (p *perfUsageCollector) Describe(descs chan<- *prometheus.Desc) {
+	p.usage.Describe(descs)
+	p.size.Describe(descs)
+	p.usagePct.Describe(descs)
+	p.lost.Describe(descs)
+}
+
+// Collect implements prometheus.Collector.Collect
+func (p *perfUsageCollector) Collect(metrics chan<- prometheus.Metric) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	for _, pm := range p.perfMaps {
+		mapName, mapType := pm.Name, ebpf.PerfEventArray.String()
+		size := float64(pm.BufferSize())
+		usage, lost := pm.Telemetry()
+		if usage == nil || lost == nil {
+			continue
+		}
+
+		for cpu := range usage {
+			cpuString := strconv.Itoa(cpu)
+
+			count := float64(usage[cpu])
+			p.usage.WithLabelValues(mapName, mapType, cpuString).Set(count)
+			p.usagePct.WithLabelValues().Set(100 * (count / size))
+			p.size.WithLabelValues(mapName, mapType, cpuString).Set(size)
+			p.lost.WithLabelValues(mapName, mapType, cpuString).Add(float64(lost[cpu]))
+		}
+	}
+
+	for _, rb := range p.ringBuffers {
+		mapName, mapType := rb.Name, ebpf.RingBuf.String()
+		size := float64(rb.BufferSize())
+		usage, ok := rb.Telemetry()
+		if !ok {
+			continue
+		}
+
+		cpuString := "0"
+		count := float64(usage)
+		p.usage.WithLabelValues(mapName, mapType, cpuString).Set(count)
+		p.usagePct.WithLabelValues().Set(100 * (count / size))
+		p.size.WithLabelValues(mapName, mapType, cpuString).Set(size)
+	}
+
+	p.usage.Collect(metrics)
+	p.usagePct.Collect(metrics)
+	p.size.Collect(metrics)
+	p.lost.Collect(metrics)
+}
+
+// ReportPerfMapTelemetry starts reporting the telemetry for the provided PerfMap
+func ReportPerfMapTelemetry(pm *manager.PerfMap) {
+	if perfCollector == nil {
+		return
+	}
+	perfCollector.registerPerfMap(pm)
+}
+
+// ReportRingBufferTelemetry starts reporting the telemetry for the provided RingBuffer
+func ReportRingBufferTelemetry(rb *manager.RingBuffer) {
+	if perfCollector == nil {
+		return
+	}
+	perfCollector.registerRingBuffer(rb)
+}
+
+func (p *perfUsageCollector) registerPerfMap(pm *manager.PerfMap) {
+	if !pm.TelemetryEnabled {
+		return
+	}
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	p.perfMaps = append(p.perfMaps, pm)
+}
+
+func (p *perfUsageCollector) registerRingBuffer(rb *manager.RingBuffer) {
+	if !rb.TelemetryEnabled {
+		return
+	}
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	p.ringBuffers = append(p.ringBuffers, rb)
+}

--- a/pkg/ebpf/perf_metrics_nonlinux.go
+++ b/pkg/ebpf/perf_metrics_nonlinux.go
@@ -7,9 +7,21 @@
 
 package ebpf
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // NewPerfUsageCollector returns nil
 func NewPerfUsageCollector() prometheus.Collector {
 	return nil
 }
+
+// ReportPerfMapTelemetry starts reporting the telemetry for the provided PerfMap
+func ReportPerfMapTelemetry(_ *manager.PerfMap) {}
+
+// ReportRingBufferTelemetry starts reporting the telemetry for the provided RingBuffer
+func ReportRingBufferTelemetry(_ *manager.RingBuffer) {}
+
+// UnregisterTelemetry unregisters the PerfMap and RingBuffers from telemetry
+func UnregisterTelemetry(_ *manager.Manager) {}

--- a/pkg/ebpf/perf_metrics_nonlinux.go
+++ b/pkg/ebpf/perf_metrics_nonlinux.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux
+
+package ebpf
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// NewPerfUsageCollector returns nil
+func NewPerfUsageCollector() prometheus.Collector {
+	return nil
+}

--- a/pkg/ebpf/perf_metrics_nonlinux.go
+++ b/pkg/ebpf/perf_metrics_nonlinux.go
@@ -3,12 +3,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !linux_bpf
+//go:build !linux
 
 package ebpf
 
 import (
-	manager "github.com/DataDog/ebpf-manager"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -16,12 +15,3 @@ import (
 func NewPerfUsageCollector() prometheus.Collector {
 	return nil
 }
-
-// ReportPerfMapTelemetry starts reporting the telemetry for the provided PerfMap
-func ReportPerfMapTelemetry(_ *manager.PerfMap) {}
-
-// ReportRingBufferTelemetry starts reporting the telemetry for the provided RingBuffer
-func ReportRingBufferTelemetry(_ *manager.RingBuffer) {}
-
-// UnregisterTelemetry unregisters the PerfMap and RingBuffers from telemetry
-func UnregisterTelemetry(_ *manager.Manager) {}

--- a/pkg/ebpf/perf_metrics_nonlinux.go
+++ b/pkg/ebpf/perf_metrics_nonlinux.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !linux
+//go:build !linux_bpf
 
 package ebpf
 

--- a/pkg/network/protocols/events/configuration.go
+++ b/pkg/network/protocols/events/configuration.go
@@ -77,11 +77,9 @@ func setupPerfMap(proto string, m *manager.Manager) {
 			RecordHandler:      handler.RecordHandler,
 			LostHandler:        handler.LostHandler,
 			RecordGetter:       handler.RecordGetter,
-			TelemetryEnabled:   true,
 		},
 	}
 	m.PerfMaps = append(m.PerfMaps, pm)
-	ddebpf.ReportPerfMapTelemetry(pm)
 
 	handlerMux.Lock()
 	if handlerByProtocol == nil {

--- a/pkg/network/protocols/events/configuration.go
+++ b/pkg/network/protocols/events/configuration.go
@@ -69,7 +69,7 @@ func setupPerfMap(proto string, m *manager.Manager) {
 	}
 
 	handler := ddebpf.NewPerfHandler(100)
-	m.PerfMaps = append(m.PerfMaps, &manager.PerfMap{
+	pm := &manager.PerfMap{
 		Map: manager.Map{Name: mapName},
 		PerfMapOptions: manager.PerfMapOptions{
 			PerfRingBufferSize: 16 * os.Getpagesize(),
@@ -77,8 +77,11 @@ func setupPerfMap(proto string, m *manager.Manager) {
 			RecordHandler:      handler.RecordHandler,
 			LostHandler:        handler.LostHandler,
 			RecordGetter:       handler.RecordGetter,
+			TelemetryEnabled:   true,
 		},
-	})
+	}
+	m.PerfMaps = append(m.PerfMaps, pm)
+	ddebpf.ReportPerfMapTelemetry(pm)
 
 	handlerMux.Lock()
 	if handlerByProtocol == nil {

--- a/pkg/network/tracer/connection/fentry/manager.go
+++ b/pkg/network/tracer/connection/fentry/manager.go
@@ -35,18 +35,19 @@ func initManager(mgr *errtelemetry.Manager, closedHandler *ebpf.PerfHandler) {
 		{Name: probes.MapErrTelemetryMap},
 		{Name: probes.HelperErrTelemetryMap},
 	}
-	mgr.PerfMaps = []*manager.PerfMap{
-		{
-			Map: manager.Map{Name: probes.ConnCloseEventMap},
-			PerfMapOptions: manager.PerfMapOptions{
-				PerfRingBufferSize: 8 * os.Getpagesize(),
-				Watermark:          1,
-				RecordHandler:      closedHandler.RecordHandler,
-				LostHandler:        closedHandler.LostHandler,
-				RecordGetter:       closedHandler.RecordGetter,
-			},
+	pm := &manager.PerfMap{
+		Map: manager.Map{Name: probes.ConnCloseEventMap},
+		PerfMapOptions: manager.PerfMapOptions{
+			PerfRingBufferSize: 8 * os.Getpagesize(),
+			Watermark:          1,
+			RecordHandler:      closedHandler.RecordHandler,
+			LostHandler:        closedHandler.LostHandler,
+			RecordGetter:       closedHandler.RecordGetter,
+			TelemetryEnabled:   true,
 		},
 	}
+	mgr.PerfMaps = []*manager.PerfMap{pm}
+	ebpf.ReportPerfMapTelemetry(pm)
 
 	for funcName := range programs {
 		p := &manager.Probe{

--- a/pkg/network/tracer/connection/fentry/manager.go
+++ b/pkg/network/tracer/connection/fentry/manager.go
@@ -14,11 +14,12 @@ import (
 	manager "github.com/DataDog/ebpf-manager"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	errtelemetry "github.com/DataDog/datadog-agent/pkg/network/telemetry"
 )
 
-func initManager(mgr *errtelemetry.Manager, closedHandler *ebpf.PerfHandler) {
+func initManager(mgr *errtelemetry.Manager, closedHandler *ebpf.PerfHandler, cfg *config.Config) {
 	mgr.Maps = []*manager.Map{
 		{Name: probes.ConnMap},
 		{Name: probes.TCPStatsMap},
@@ -43,7 +44,7 @@ func initManager(mgr *errtelemetry.Manager, closedHandler *ebpf.PerfHandler) {
 			RecordHandler:      closedHandler.RecordHandler,
 			LostHandler:        closedHandler.LostHandler,
 			RecordGetter:       closedHandler.RecordGetter,
-			TelemetryEnabled:   true,
+			TelemetryEnabled:   cfg.InternalTelemetryEnabled,
 		},
 	}
 	mgr.PerfMaps = []*manager.PerfMap{pm}

--- a/pkg/network/tracer/connection/fentry/tracer.go
+++ b/pkg/network/tracer/connection/fentry/tracer.go
@@ -46,7 +46,7 @@ func LoadTracer(config *config.Config, mgrOpts manager.Options, perfHandlerTCP *
 			return fmt.Errorf("invalid probe configuration: %v", err)
 		}
 
-		initManager(m, perfHandlerTCP)
+		initManager(m, perfHandlerTCP, config)
 
 		file, err := os.Stat("/proc/self/ns/pid")
 

--- a/pkg/network/tracer/connection/kprobe/manager.go
+++ b/pkg/network/tracer/connection/kprobe/manager.go
@@ -14,6 +14,7 @@ import (
 	manager "github.com/DataDog/ebpf-manager"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	errtelemetry "github.com/DataDog/datadog-agent/pkg/network/telemetry"
 )
@@ -69,7 +70,7 @@ var mainProbes = []probes.ProbeFuncName{
 	probes.UDPSendPageReturn,
 }
 
-func initManager(mgr *errtelemetry.Manager, closedHandler *ebpf.PerfHandler, runtimeTracer bool) error {
+func initManager(mgr *errtelemetry.Manager, closedHandler *ebpf.PerfHandler, runtimeTracer bool, cfg *config.Config) error {
 	mgr.Maps = []*manager.Map{
 		{Name: probes.ConnMap},
 		{Name: probes.TCPStatsMap},
@@ -103,7 +104,7 @@ func initManager(mgr *errtelemetry.Manager, closedHandler *ebpf.PerfHandler, run
 			RecordHandler:      closedHandler.RecordHandler,
 			LostHandler:        closedHandler.LostHandler,
 			RecordGetter:       closedHandler.RecordGetter,
-			TelemetryEnabled:   true,
+			TelemetryEnabled:   cfg.InternalTelemetryEnabled,
 		},
 	}
 	mgr.PerfMaps = []*manager.PerfMap{pm}

--- a/pkg/network/tracer/connection/kprobe/manager.go
+++ b/pkg/network/tracer/connection/kprobe/manager.go
@@ -95,18 +95,19 @@ func initManager(mgr *errtelemetry.Manager, closedHandler *ebpf.PerfHandler, run
 		{Name: probes.ClassificationProgsMap},
 		{Name: probes.TCPCloseProgsMap},
 	}
-	mgr.PerfMaps = []*manager.PerfMap{
-		{
-			Map: manager.Map{Name: probes.ConnCloseEventMap},
-			PerfMapOptions: manager.PerfMapOptions{
-				PerfRingBufferSize: 8 * os.Getpagesize(),
-				Watermark:          1,
-				RecordHandler:      closedHandler.RecordHandler,
-				LostHandler:        closedHandler.LostHandler,
-				RecordGetter:       closedHandler.RecordGetter,
-			},
+	pm := &manager.PerfMap{
+		Map: manager.Map{Name: probes.ConnCloseEventMap},
+		PerfMapOptions: manager.PerfMapOptions{
+			PerfRingBufferSize: 8 * os.Getpagesize(),
+			Watermark:          1,
+			RecordHandler:      closedHandler.RecordHandler,
+			LostHandler:        closedHandler.LostHandler,
+			RecordGetter:       closedHandler.RecordGetter,
+			TelemetryEnabled:   true,
 		},
 	}
+	mgr.PerfMaps = []*manager.PerfMap{pm}
+	ebpf.ReportPerfMapTelemetry(pm)
 	for _, funcName := range mainProbes {
 		p := &manager.Probe{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -187,7 +187,7 @@ func LoadTracer(cfg *config.Config, mgrOpts manager.Options, perfHandlerTCP *dde
 
 func loadTracerFromAsset(buf bytecode.AssetReader, runtimeTracer, coreTracer bool, config *config.Config, mgrOpts manager.Options, perfHandlerTCP *ddebpf.PerfHandler, bpfTelemetry *errtelemetry.EBPFTelemetry) (*manager.Manager, func(), error) {
 	m := errtelemetry.NewManager(&manager.Manager{}, bpfTelemetry)
-	if err := initManager(m, perfHandlerTCP, runtimeTracer); err != nil {
+	if err := initManager(m, perfHandlerTCP, runtimeTracer, config); err != nil {
 		return nil, nil, fmt.Errorf("could not initialize manager: %w", err)
 	}
 

--- a/pkg/network/tracer/connection/tracer.go
+++ b/pkg/network/tracer/connection/tracer.go
@@ -328,6 +328,7 @@ func (t *tracer) Stop() {
 	t.stopOnce.Do(func() {
 		close(t.exitTelemetry)
 		ebpfcheck.RemoveNameMappings(t.m)
+		ddebpf.UnregisterTelemetry(t.m)
 		_ = t.m.Stop(manager.CleanAll)
 		t.closeConsumer.Stop()
 		if t.closeTracer != nil {

--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -230,6 +230,7 @@ func (e *ebpfProgram) Close() error {
 		return nil
 	}
 	e.executePerProtocol(e.enabledProtocols, "stop", stopProtocolWrapper, nil)
+	ddebpf.UnregisterTelemetry(e.Manager.Manager)
 	return e.Stop(manager.CleanAll)
 }
 

--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -368,6 +368,12 @@ func (e *ebpfProgram) init(buf bytecode.AssetReader, options manager.Options) er
 	for _, p := range supported {
 		p.Instance.ConfigureOptions(e.Manager.Manager, &options)
 	}
+	if e.cfg.InternalTelemetryEnabled {
+		for _, pm := range e.PerfMaps {
+			pm.TelemetryEnabled = true
+			ddebpf.ReportPerfMapTelemetry(pm)
+		}
+	}
 
 	// Add excluded functions from disabled protocols
 	for _, p := range notSupported {

--- a/pkg/network/usm/sharedlibraries/ebpf.go
+++ b/pkg/network/usm/sharedlibraries/ebpf.go
@@ -54,7 +54,7 @@ func newEBPFProgram(c *config.Config, bpfTelemetry *errtelemetry.EBPFTelemetry) 
 			RecordHandler:      perfHandler.RecordHandler,
 			LostHandler:        perfHandler.LostHandler,
 			RecordGetter:       perfHandler.RecordGetter,
-			TelemetryEnabled:   true,
+			TelemetryEnabled:   c.InternalTelemetryEnabled,
 		},
 	}
 	mgr := &manager.Manager{

--- a/pkg/network/usm/sharedlibraries/ebpf.go
+++ b/pkg/network/usm/sharedlibraries/ebpf.go
@@ -113,6 +113,7 @@ func (e *ebpfProgram) GetPerfHandler() *ddebpf.PerfHandler {
 }
 
 func (e *ebpfProgram) Stop() {
+	ddebpf.UnregisterTelemetry(e.Manager.Manager)
 	e.Manager.Stop(manager.CleanAll) //nolint:errcheck
 	e.perfHandler.Stop()
 }

--- a/pkg/network/usm/sharedlibraries/ebpf.go
+++ b/pkg/network/usm/sharedlibraries/ebpf.go
@@ -44,22 +44,23 @@ type ebpfProgram struct {
 
 func newEBPFProgram(c *config.Config, bpfTelemetry *errtelemetry.EBPFTelemetry) *ebpfProgram {
 	perfHandler := ddebpf.NewPerfHandler(100)
-	mgr := &manager.Manager{
-		PerfMaps: []*manager.PerfMap{
-			{
-				Map: manager.Map{
-					Name: sharedLibrariesPerfMap,
-				},
-				PerfMapOptions: manager.PerfMapOptions{
-					PerfRingBufferSize: 8 * os.Getpagesize(),
-					Watermark:          1,
-					RecordHandler:      perfHandler.RecordHandler,
-					LostHandler:        perfHandler.LostHandler,
-					RecordGetter:       perfHandler.RecordGetter,
-				},
-			},
+	pm := &manager.PerfMap{
+		Map: manager.Map{
+			Name: sharedLibrariesPerfMap,
+		},
+		PerfMapOptions: manager.PerfMapOptions{
+			PerfRingBufferSize: 8 * os.Getpagesize(),
+			Watermark:          1,
+			RecordHandler:      perfHandler.RecordHandler,
+			LostHandler:        perfHandler.LostHandler,
+			RecordGetter:       perfHandler.RecordGetter,
+			TelemetryEnabled:   true,
 		},
 	}
+	mgr := &manager.Manager{
+		PerfMaps: []*manager.PerfMap{pm},
+	}
+	ddebpf.ReportPerfMapTelemetry(pm)
 
 	probeIDs := getSysOpenHooksIdentifiers()
 	for _, identifier := range probeIDs {

--- a/pkg/security/probe/eventstream/reorderer/perfmap.go
+++ b/pkg/security/probe/eventstream/reorderer/perfmap.go
@@ -47,7 +47,7 @@ func (m *OrderedPerfMap) Init(mgr *manager.Manager, config *config.Config) error
 		RecordHandler:    m.reOrderer.HandleEvent,
 		LostHandler:      m.handleLostEvents,
 		RecordGetter:     m.recordPool.Get,
-		TelemetryEnabled: true,
+		TelemetryEnabled: config.InternalTelemetryEnabled,
 	}
 
 	if config.EventStreamBufferSize != 0 {

--- a/pkg/security/probe/eventstream/reorderer/perfmap.go
+++ b/pkg/security/probe/eventstream/reorderer/perfmap.go
@@ -19,6 +19,7 @@ import (
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf/perf"
 
+	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/config"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/eventstream"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -26,7 +27,7 @@ import (
 )
 
 // OrderedPerfMap implements the EventStream interface
-// using an eBPF perf map associated with a event reorder.
+// using an eBPF perf map associated with an event reorderer.
 type OrderedPerfMap struct {
 	perfMap          *manager.PerfMap
 	lostEventCounter eventstream.LostEventCounter
@@ -43,20 +44,21 @@ func (m *OrderedPerfMap) Init(mgr *manager.Manager, config *config.Config) error
 	}
 
 	m.perfMap.PerfMapOptions = manager.PerfMapOptions{
-		RecordHandler: m.reOrderer.HandleEvent,
-		LostHandler:   m.handleLostEvents,
-		RecordGetter:  m.recordPool.Get,
+		RecordHandler:    m.reOrderer.HandleEvent,
+		LostHandler:      m.handleLostEvents,
+		RecordGetter:     m.recordPool.Get,
+		TelemetryEnabled: true,
 	}
 
 	if config.EventStreamBufferSize != 0 {
 		m.perfMap.PerfMapOptions.PerfRingBufferSize = config.EventStreamBufferSize
 	}
 
+	ddebpf.ReportPerfMapTelemetry(m.perfMap)
 	return nil
 }
 
-//nolint:revive // TODO(SEC) Fix revive linter
-func (m *OrderedPerfMap) handleLostEvents(CPU int, count uint64, perfMap *manager.PerfMap, manager *manager.Manager) {
+func (m *OrderedPerfMap) handleLostEvents(CPU int, count uint64, perfMap *manager.PerfMap, _ *manager.Manager) {
 	seclog.Tracef("lost %d events", count)
 	if m.lostEventCounter != nil {
 		m.lostEventCounter.CountLostEvent(count, perfMap.Name, CPU)

--- a/pkg/security/probe/eventstream/ringbuffer/ringbuffer.go
+++ b/pkg/security/probe/eventstream/ringbuffer/ringbuffer.go
@@ -9,12 +9,13 @@
 package ringbuffer
 
 import (
-	"errors"
+	"fmt"
 	"sync"
 
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf/ringbuf"
 
+	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/config"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/eventstream"
 )
@@ -30,35 +31,33 @@ type RingBuffer struct {
 // Init the ring buffer
 func (rb *RingBuffer) Init(mgr *manager.Manager, config *config.Config) error {
 	var ok bool
-	if rb.ringBuffer, ok = mgr.GetRingBuffer("events"); !ok {
-		return errors.New("couldn't find events ring buffer")
+	if rb.ringBuffer, ok = mgr.GetRingBuffer(eventstream.EventStreamMap); !ok {
+		return fmt.Errorf("couldn't find %q ring buffer", eventstream.EventStreamMap)
 	}
 
 	rb.ringBuffer.RingBufferOptions = manager.RingBufferOptions{
 		RecordGetter: func() *ringbuf.Record {
 			return rb.recordPool.Get().(*ringbuf.Record)
 		},
-		RecordHandler: rb.handleEvent,
+		RecordHandler:    rb.handleEvent,
+		TelemetryEnabled: true,
 	}
 
 	if config.EventStreamBufferSize != 0 {
 		rb.ringBuffer.RingBufferOptions.RingBufferSize = config.EventStreamBufferSize
 	}
 
+	ddebpf.ReportRingBufferTelemetry(rb.ringBuffer)
 	return nil
 }
 
 // Start the event stream.
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (rb *RingBuffer) Start(wg *sync.WaitGroup) error {
+func (rb *RingBuffer) Start(_ *sync.WaitGroup) error {
 	return rb.ringBuffer.Start()
 }
 
 // SetMonitor set the monitor
-//
-//nolint:revive // TODO(SEC) Fix revive linter
-func (rb *RingBuffer) SetMonitor(counter eventstream.LostEventCounter) {}
+func (rb *RingBuffer) SetMonitor(_ eventstream.LostEventCounter) {}
 
 func (rb *RingBuffer) handleEvent(record *ringbuf.Record, _ *manager.RingBuffer, _ *manager.Manager) {
 	rb.handler(0, record.RawSample)

--- a/pkg/security/probe/eventstream/ringbuffer/ringbuffer.go
+++ b/pkg/security/probe/eventstream/ringbuffer/ringbuffer.go
@@ -40,7 +40,7 @@ func (rb *RingBuffer) Init(mgr *manager.Manager, config *config.Config) error {
 			return rb.recordPool.Get().(*ringbuf.Record)
 		},
 		RecordHandler:    rb.handleEvent,
-		TelemetryEnabled: true,
+		TelemetryEnabled: config.InternalTelemetryEnabled,
 	}
 
 	if config.EventStreamBufferSize != 0 {

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1256,6 +1256,7 @@ func (p *EBPFProbe) Close() error {
 	p.wg.Wait()
 
 	ebpfcheck.RemoveNameMappings(p.Manager)
+	commonebpf.UnregisterTelemetry(p.Manager)
 	// Stopping the manager will stop the perf map reader and unload eBPF programs
 	if err := p.Manager.Stop(manager.CleanAll); err != nil {
 		return err


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Adds internal telemetry to track perf buffer and ring buffer usage and lost events.

### Motivation

Better understanding of relative utilization of these features.

### Additional Notes

Waiting on https://github.com/DataDog/ebpf-manager/pull/165

The gauges will report the maximum value in a collection interval, reseting to `0` if not updated in an interval.

Metrics reported:
- `datadog.system_probe.ebpf.perf.usage` with tags `map_name`, `map_type`, and `cpu_num`
- `datadog.system_probe.ebpf.perf.usage_pct` with tags `map_name`, `map_type`, and `cpu_num`
- `datadog.system_probe.ebpf.perf.size` with tags `map_name`, `map_type`, and `cpu_num`
- `datadog.system_probe.ebpf.perf.lost` with tags `map_name`, `map_type`, and `cpu_num`

`cpu_num` is only relevant on perf buffers since ring buffers work across all CPUs.

https://datadoghq.atlassian.net/browse/EBPF-248

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
