### PR TITLE
Fix EvtFormatMessage crash

### DIFF
--- a/releasenotes/notes/fix-evtformatmessage-crash-c19b297722e0a34d.yaml
+++ b/releasenotes/notes/fix-evtformatmessage-crash-c19b297722e0a34d.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Add a workaround for a bug in a Windows API that can cause the Agent to
+    crash when collecting forwarded events from the Windows Event Log.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Fixes the cause of a crash (and buffer overrun) that can happen when collecting Windows Event Logs. The crash is almost guaranteed to reproduce when collecting [forwarded events](https://learn.microsoft.com/en-us/windows/win32/wec/setting-up-a-source-initiated-subscription).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The root cause is actually a bug in the Windows API [EvtFormatMessage](https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtformatmessage). `EvtFormatMessage` uses the common WinAPI pattern where
* call once with `Buffer=NULL, BufferSize=0` to get the size of the data
* allocate your buffer
* call again to fill the buffer with data.

This is demonstrated in the Microsoft example [Formatting Event Messages](https://learn.microsoft.com/en-us/windows/win32/wes/formatting-event-messages).

However, `EvtFormatMessage` always writes 2 bytes past the output `BufferUsed` and the input `BufferSize` values. The documentation does NOT say if `BufferUsed` or `BufferSize` are intended to include the null terminating character, but in a debugger you can see `BufferUsed` DOES include the null terminating character in its count. So `EvtFormatMessage` is actually writing TWO null terminating characters to your `Buffer`. It writes this extra null terminating character
* even if `Buffer` is NULL
* even if the +2 causes the memcpy to exceed the input `BufferSize`
* even if the `BufferSize` and source size are 0.

During testing, the `memcpy` source buffer has three null-term characters, so `memcpy` will not overrun the source buffer.

The most reliable way to trigger the bug is with forwarded events, which contain a `RenderingInfo` section, which may have empty (0 length) values.
Example, the following command creates the following `RenderingInfo` XML when the event is forwarded.
```PowerShell
eventcreate.exe /T ERROR /ID 1000 /L APPLICATION /D "custom forwarded event"
```
```xml
<RenderingInfo Culture="en-US">
  <Message>custom forwarded event</Message> 
  <Level>Error</Level> 
  <Task /> 
  <Opcode>Info</Opcode> 
  <Channel /> 
  <Provider /> 
  <Keywords>
    <Keyword>Classic</Keyword> 
  </Keywords>
</RenderingInfo>
```

Given this event, If you call this to get the buffer size
```cpp
EvtFormatMessage(publisherMetadata, event, 0, 0, 0, EvtFormatMessageTask, 0, NULL, &BufferUsed)
```

Then the call will crash when it tries to write the extra null term char to your NULL buffer. Since `Task` is empty/zero-length, and your `BufferSize` is 0, `EvtFormatMessage` thinks there's enough space to write the "data".

https://datadoghq.atlassian.net/browse/WINA-365

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Previously affected versions of the Agent may be able to avoid the crash by changing the Windows Event Collector subscription setting to exclude the `RenderingInfo` section from the forwarded event.
```PowerShell
wecutil set-subscription <NAME> /cf:Events
```

The default behavior (include `RenderingInfo`) can be restored with
```PowerShell
wecutil set-subscription <NAME> /cf:RenderedText
```

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Follow the forwarded events tests in the [QA plan](https://datadoghq.atlassian.net/l/cp/eK5pEESN)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
