### PR TITLE
pkg/trace/api: fix double-close deadlock

### DIFF
--- a/pkg/trace/api/listener.go
+++ b/pkg/trace/api/listener.go
@@ -78,12 +78,16 @@ func (ln *measuredListener) flushMetrics() {
 
 type onCloseConn struct {
 	net.Conn
-	onClose func()
+	closeOnce sync.Once
+	onClose   func()
 }
 
 func (c *onCloseConn) Close() error {
-	err := c.Conn.Close()
-	c.onClose()
+	var err error
+	c.closeOnce.Do(func() {
+		err = c.Conn.Close()
+		c.onClose()
+	})
 	return err
 }
 

--- a/pkg/trace/api/listener.go
+++ b/pkg/trace/api/listener.go
@@ -78,8 +78,8 @@ func (ln *measuredListener) flushMetrics() {
 
 type onCloseConn struct {
 	net.Conn
-	closeOnce sync.Once
 	onClose   func()
+	closeOnce sync.Once
 }
 
 func (c *onCloseConn) Close() error {
@@ -92,7 +92,7 @@ func (c *onCloseConn) Close() error {
 }
 
 func OnCloseConn(c net.Conn, onclose func()) net.Conn {
-	return &onCloseConn{c, onclose}
+	return &onCloseConn{c, onclose, sync.Once{}}
 }
 
 // Accept implements net.Listener and keeps counts on connection statuses.

--- a/pkg/trace/api/listener_test.go
+++ b/pkg/trace/api/listener_test.go
@@ -153,3 +153,19 @@ func TestMeasuredListener(t *testing.T) {
 	assert.EqualValues(call.Calls[0].Tags, []string{"status:timedout"})
 	assert.EqualValues(call.Calls[0].Value, 1)
 }
+
+func TestOnCloseConn(t *testing.T) {
+
+	var closed int
+	p, _ := net.Pipe()
+	c := OnCloseConn(p, func() {
+		closed++
+	})
+
+	c.Close()
+	assert.Equal(t, 1, closed)
+	// Make sure multiple close calls don't execute the
+	// callback multiple times.
+	c.Close()
+	assert.Equal(t, 1, closed)
+}

--- a/releasenotes/notes/fix-apm-shutdown-35851730f8c9dad5.yaml
+++ b/releasenotes/notes/fix-apm-shutdown-35851730f8c9dad5.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix a deadlock issue which can prevent the trace-agent from shutting down.


### PR DESCRIPTION
The onCloseConn does not guard against multiple invocations of Close, meaning the side-effects can be executed multiple times. This can result in a deadlock on the shutdown routine, resulting in the agent failing to shut down.

This change introduces a sync.Once element to ensure onCloseConn only executes its callback once.

Cherry-pick of #20759 
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
