### PR TITLE
[CWS] speed up functional tests

### DIFF
--- a/pkg/security/tests/activity_dumps_loadcontroller_test.go
+++ b/pkg/security/tests/activity_dumps_loadcontroller_test.go
@@ -49,7 +49,7 @@ func TestActivityDumpsLoadControllerTimeout(t *testing.T) {
 		activityDumpLoadControllerPeriod:    testActivityDumpLoadControllerPeriod,
 		activityDumpLoadControllerTimeout:   time.Minute,
 	}
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, opts)
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, withStaticOpts(opts))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +100,7 @@ func TestActivityDumpsLoadControllerEventTypes(t *testing.T) {
 
 	expectedFormats := []string{"json", "protobuf"}
 	testActivityDumpTracedEventTypes := []string{"exec", "open", "syscalls", "dns", "bind"}
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, testOpts{
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, withStaticOpts(testOpts{
 		enableActivityDump:                  true,
 		activityDumpRateLimiter:             testActivityDumpRateLimiter,
 		activityDumpTracedCgroupsCount:      testActivityDumpTracedCgroupsCount,
@@ -110,7 +110,7 @@ func TestActivityDumpsLoadControllerEventTypes(t *testing.T) {
 		activityDumpLocalStorageFormats:     expectedFormats,
 		activityDumpTracedEventTypes:        testActivityDumpTracedEventTypes,
 		activityDumpLoadControllerPeriod:    testActivityDumpLoadControllerPeriod,
-	})
+	}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,7 +188,7 @@ func TestActivityDumpsLoadControllerRateLimiter(t *testing.T) {
 
 	expectedFormats := []string{"json", "protobuf"}
 	testActivityDumpTracedEventTypes := []string{"exec", "open", "syscalls", "dns", "bind"}
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, testOpts{
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, withStaticOpts(testOpts{
 		enableActivityDump:                  true,
 		activityDumpRateLimiter:             testActivityDumpRateLimiter,
 		activityDumpTracedCgroupsCount:      testActivityDumpTracedCgroupsCount,
@@ -198,7 +198,7 @@ func TestActivityDumpsLoadControllerRateLimiter(t *testing.T) {
 		activityDumpLocalStorageFormats:     expectedFormats,
 		activityDumpTracedEventTypes:        testActivityDumpTracedEventTypes,
 		activityDumpLoadControllerPeriod:    testActivityDumpLoadControllerPeriod,
-	})
+	}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -43,7 +43,7 @@ func TestActivityDumps(t *testing.T) {
 
 	expectedFormats := []string{"json", "protobuf"}
 	testActivityDumpTracedEventTypes := []string{"exec", "open", "syscalls", "dns", "bind"}
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, testOpts{
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, withStaticOpts(testOpts{
 		enableActivityDump:                  true,
 		activityDumpRateLimiter:             testActivityDumpRateLimiter,
 		activityDumpTracedCgroupsCount:      testActivityDumpTracedCgroupsCount,
@@ -53,7 +53,7 @@ func TestActivityDumps(t *testing.T) {
 		activityDumpLocalStorageFormats:     expectedFormats,
 		activityDumpTracedEventTypes:        testActivityDumpTracedEventTypes,
 		activityDumpCleanupPeriod:           testActivityDumpCleanupPeriod,
-	})
+	}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/bind_test.go
+++ b/pkg/security/tests/bind_test.go
@@ -37,7 +37,7 @@ func TestBindEvent(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/bpf_test.go
+++ b/pkg/security/tests/bpf_test.go
@@ -31,7 +31,7 @@ func TestBPFEventLoad(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func TestBPFEventMap(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +101,7 @@ func TestBPFCwsMapConstant(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/chmod_test.go
+++ b/pkg/security/tests/chmod_test.go
@@ -25,7 +25,7 @@ func TestChmod(t *testing.T) {
 		Expression: `chmod.file.path == "{{.Root}}/test-chmod" && chmod.file.destination.rights in [0707, 0717, 0757] && chmod.file.uid == 98 && chmod.file.gid == 99`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -35,7 +35,7 @@ func TestChown32(t *testing.T) {
 		Expression: `chown.file.path == "{{.Root}}/test-symlink" && chown.file.destination.uid in [100, 101, 102, 103, 104, 105, 106] && chown.file.destination.gid in [200, 201, 202, 203, 204, 205, 206]`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{ruleDef, ruleDef2}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{ruleDef, ruleDef2})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/chown_test.go
+++ b/pkg/security/tests/chown_test.go
@@ -46,7 +46,7 @@ func TestChown(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -58,7 +58,7 @@ func TestOctogonConstants(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, secconfig, err := genTestConfigs(dir, testOpts{}, "")
+	_, secconfig, err := genTestConfigs(dir, testOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/container_test.go
+++ b/pkg/security/tests/container_test.go
@@ -30,7 +30,7 @@ func TestContainerCreatedAt(t *testing.T) {
 			Expression: `container.id != "" && container.created_at > 3s && open.file.path == "{{.Root}}/test-open-delay"`,
 		},
 	}
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +106,7 @@ func TestContainerScopedVariable(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/dentry_test.go
+++ b/pkg/security/tests/dentry_test.go
@@ -82,7 +82,7 @@ func TestDentryResolutionERPC(t *testing.T) {
 		Expression: fmt.Sprintf(`open.file.path == "{{.Root}}/parent/%s" && open.flags & O_CREAT != 0`, basename),
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{disableMapDentryResolution: true})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{disableMapDentryResolution: true}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +132,7 @@ func TestDentryResolutionMap(t *testing.T) {
 		Expression: fmt.Sprintf(`open.file.path == "{{.Root}}/parent/%s" && open.flags & O_CREAT != 0`, basename),
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{disableERPCDentryResolution: true})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{disableERPCDentryResolution: true}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,7 +181,7 @@ func BenchmarkERPCDentryResolutionSegment(b *testing.B) {
 		Expression: `open.file.path == "{{.Root}}/aa/bb/cc/dd/ee" && open.flags & O_CREAT != 0`,
 	}
 
-	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, testOpts{disableMapDentryResolution: true})
+	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{disableMapDentryResolution: true}))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -245,7 +245,7 @@ func BenchmarkERPCDentryResolutionPath(b *testing.B) {
 		Expression: `open.file.path == "{{.Root}}/aa/bb/cc/dd/ee" && open.flags & O_CREAT != 0`,
 	}
 
-	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, testOpts{disableMapDentryResolution: true})
+	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{disableMapDentryResolution: true}))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -309,7 +309,7 @@ func BenchmarkMapDentryResolutionSegment(b *testing.B) {
 		Expression: `open.file.path == "{{.Root}}/aa/bb/cc/dd/ee" && open.flags & O_CREAT != 0`,
 	}
 
-	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, testOpts{disableERPCDentryResolution: true})
+	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{disableERPCDentryResolution: true}))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -373,7 +373,7 @@ func BenchmarkMapDentryResolutionPath(b *testing.B) {
 		Expression: `open.file.path == "{{.Root}}/aa/bb/cc/dd/ee" && open.flags & O_CREAT != 0`,
 	}
 
-	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, testOpts{disableERPCDentryResolution: true})
+	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{disableERPCDentryResolution: true}))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/security/tests/discarders_stress_test.go
+++ b/pkg/security/tests/discarders_stress_test.go
@@ -176,7 +176,7 @@ func runTestDiscarders(t *testing.T, metrics map[string]*metric) {
 			Expression: fmt.Sprintf(`unlink.file.path =~ "{{.Root}}/files_generator_root/%s/no-approver-*"`, noDiscardersDirName),
 		},
 	}
-	test, err := newTestModule(t, nil, rules, testOpts{enableActivityDump: false})
+	test, err := newTestModule(t, nil, rules, withStaticOpts(testOpts{enableActivityDump: false}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/dns_test.go
+++ b/pkg/security/tests/dns_test.go
@@ -52,7 +52,7 @@ func TestDNS(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/eventmonitor_test.go
+++ b/pkg/security/tests/eventmonitor_test.go
@@ -95,13 +95,13 @@ func (fc *FakeEventConsumer) Copy(incomingEvent *model.Event) any {
 
 func TestEventMonitor(t *testing.T) {
 	var fc *FakeEventConsumer
-	test, err := newTestModule(t, nil, nil, testOpts{
+	test, err := newTestModule(t, nil, nil, withStaticOpts(testOpts{
 		disableRuntimeSecurity: true,
 		preStartCallback: func(test *testModule) {
 			fc = NewFakeEventConsumer(test.eventMonitor)
 			test.eventMonitor.RegisterEventConsumer(fc)
 		},
-	})
+	}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/fields_test.go
+++ b/pkg/security/tests/fields_test.go
@@ -28,7 +28,7 @@ func TestFieldsResolver(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -55,7 +55,7 @@ func TestFilterOpenBasenameApprover(t *testing.T) {
 		Expression: fmt.Sprintf(`open.file.path == "{{.Root}}/%s"`, basename),
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +107,7 @@ func TestFilterOpenLeafDiscarder(t *testing.T) {
 		Expression: `open.filename =~ "{{.Root}}/no-approver-*" && open.flags & (O_CREAT | O_SYNC) > 0`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +167,7 @@ func TestFilterOpenLeafDiscarderActivityDump(t *testing.T) {
 		Expression: `open.filename =~ "{{.Root}}/no-approver-*" && open.flags & (O_CREAT | O_SYNC) > 0`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{enableActivityDump: true})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{enableActivityDump: true}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -243,7 +243,7 @@ func testFilterOpenParentDiscarder(t *testing.T, parents ...string) {
 		Expression: `open.file.path =~ "{{.Root}}/no-approver-*" && open.flags & (O_CREAT | O_SYNC) > 0`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -319,7 +319,7 @@ func TestFilterDiscarderMask(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -387,7 +387,7 @@ func TestFilterRenameFileDiscarder(t *testing.T) {
 		Expression: `open.filename =~ "{{.Root}}/a*/test"`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -471,7 +471,7 @@ func TestFilterRenameFolderDiscarder(t *testing.T) {
 		Expression: `open.filename =~ "{{.Root}}/a*/test"`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -549,7 +549,7 @@ func TestFilterOpenFlagsApprover(t *testing.T) {
 		Expression: `open.flags & (O_SYNC | O_NOCTTY) > 0`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -610,7 +610,7 @@ func TestFilterDiscarderRetention(t *testing.T) {
 	}
 	defer testDrive.Close()
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{testDir: testDrive.Root()})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{testDir: testDrive.Root()}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -610,7 +610,7 @@ func TestFilterDiscarderRetention(t *testing.T) {
 	}
 	defer testDrive.Close()
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{testDir: testDrive.Root()}))
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, withDynamicOpts(dynamicTestOpts{testDir: testDrive.Root()}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/hardlink_test.go
+++ b/pkg/security/tests/hardlink_test.go
@@ -29,7 +29,7 @@ func runHardlinkTests(t *testing.T, opts testOpts) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, opts)
+	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(opts))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/kernel_module_test.go
+++ b/pkg/security/tests/kernel_module_test.go
@@ -111,7 +111,7 @@ func TestKworker(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +200,7 @@ func TestLoadModule(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -347,7 +347,7 @@ func TestUnloadModule(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/latency_test.go
+++ b/pkg/security/tests/latency_test.go
@@ -91,7 +91,7 @@ func benchLatencyDNS(t *testing.T, rule *rules.RuleDefinition, executable string
 	if rule != nil {
 		var ruleDefs []*rules.RuleDefinition
 		ruleDefs = append(ruleDefs, rule)
-		test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+		test, err := newTestModule(t, nil, ruleDefs)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/security/tests/link_test.go
+++ b/pkg/security/tests/link_test.go
@@ -29,7 +29,7 @@ func TestLink(t *testing.T) {
 		Expression: `link.file.path == "{{.Root}}/test-link" && link.file.destination.path == "{{.Root}}/test2-link" && link.file.uid == 98 && link.file.gid == 99 && link.file.destination.uid == 98 && link.file.destination.gid == 99`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/macros_test.go
+++ b/pkg/security/tests/macros_test.go
@@ -37,7 +37,7 @@ func TestMacros(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, macros, ruleDefs, testOpts{})
+	test, err := newTestModule(t, macros, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/mkdir_test.go
+++ b/pkg/security/tests/mkdir_test.go
@@ -36,7 +36,7 @@ func TestMkdir(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +166,7 @@ func TestMkdirError(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/mmap_test.go
+++ b/pkg/security/tests/mmap_test.go
@@ -28,7 +28,7 @@ func TestMMapEvent(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -931,6 +931,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 		testMod.st = st
 		testMod.cmdWrapper = cmdWrapper
 		testMod.t = t
+		testMod.opts.dynamicOpts = opts.dynamicOpts
 		if testMod.tracePipe, err = testMod.startTracing(); err != nil {
 			return testMod, err
 		}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -239,7 +239,6 @@ const (
 )
 
 type testOpts struct {
-	testDir                                    string
 	disableFilters                             bool
 	disableApprovers                           bool
 	enableActivityDump                         bool
@@ -273,6 +272,7 @@ type testOpts struct {
 }
 
 type dynamicTestOpts struct {
+	testDir                  string
 	disableAbnormalPathCheck bool
 }
 
@@ -286,8 +286,7 @@ func (s *stringSlice) Set(value string) error {
 }
 
 func (to testOpts) Equal(opts testOpts) bool {
-	return to.testDir == opts.testDir &&
-		to.disableApprovers == opts.disableApprovers &&
+	return to.disableApprovers == opts.disableApprovers &&
 		to.enableActivityDump == opts.enableActivityDump &&
 		to.activityDumpRateLimiter == opts.activityDumpRateLimiter &&
 		to.activityDumpTagRules == opts.activityDumpTagRules &&
@@ -905,7 +904,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 		return nil, err
 	}
 
-	st, err := newSimpleTest(t, macroDefs, ruleDefs, opts.staticOpts.testDir)
+	st, err := newSimpleTest(t, macroDefs, ruleDefs, opts.dynamicOpts.testDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -44,7 +44,7 @@ func TestMount(t *testing.T) {
 	}
 	defer testDrive.Close()
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{testDir: testDrive.Root()})
+	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{testDir: testDrive.Root()}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +160,7 @@ func TestMountPropagated(t *testing.T) {
 		Expression: fmt.Sprintf(`chmod.file.path == "{{.Root}}/dir1-bind-mounted/test-drive/test-file"`),
 	}}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -318,7 +318,7 @@ func TestMountSnapshot(t *testing.T) {
 	defer tmpfsMountA.unmount(0)
 	defer bindMountA.unmount(0)
 
-	test, err := newTestModule(t, nil, nil, testOpts{testDir: testDrive.Root()})
+	test, err := newTestModule(t, nil, nil, withStaticOpts(testOpts{testDir: testDrive.Root()}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -412,7 +412,7 @@ func TestMountEvent(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{testDir: testDrive.Root()})
+	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{testDir: testDrive.Root()}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -44,7 +44,7 @@ func TestMount(t *testing.T) {
 	}
 	defer testDrive.Close()
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{testDir: testDrive.Root()}))
+	test, err := newTestModule(t, nil, ruleDefs, withDynamicOpts(dynamicTestOpts{testDir: testDrive.Root()}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -318,7 +318,7 @@ func TestMountSnapshot(t *testing.T) {
 	defer tmpfsMountA.unmount(0)
 	defer bindMountA.unmount(0)
 
-	test, err := newTestModule(t, nil, nil, withStaticOpts(testOpts{testDir: testDrive.Root()}))
+	test, err := newTestModule(t, nil, nil, withDynamicOpts(dynamicTestOpts{testDir: testDrive.Root()}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -412,7 +412,7 @@ func TestMountEvent(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{testDir: testDrive.Root()}))
+	test, err := newTestModule(t, nil, ruleDefs, withDynamicOpts(dynamicTestOpts{testDir: testDrive.Root()}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/mprotect_test.go
+++ b/pkg/security/tests/mprotect_test.go
@@ -28,7 +28,7 @@ func TestMProtectEvent(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/network_device_test.go
+++ b/pkg/security/tests/network_device_test.go
@@ -46,7 +46,7 @@ func TestNetDevice(t *testing.T) {
 		Expression: `dns.question.type == A && dns.question.name == "google.com" && process.file.name == "testsuite"`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +155,7 @@ func TestTCFilters(t *testing.T) {
 		Expression: `dns.question.type == A`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -47,7 +47,7 @@ func TestNetworkCIDR(t *testing.T) {
 		Expression: fmt.Sprintf(`dns.question.type == A && dns.question.name == "google.com" && process.file.name == "testsuite" && network.destination.ip in [%s]`, strings.Join(nameserversCIDR, ", ")),
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -35,7 +35,7 @@ func TestOpen(t *testing.T) {
 		Expression: `open.file.path == "{{.Root}}/test-open" && open.flags & O_CREAT != 0`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -337,7 +337,7 @@ func TestOpenMetadata(t *testing.T) {
 		Expression: `open.file.path == "{{.Root}}/test-open" && open.file.uid == 98 && open.file.gid == 99`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -382,7 +382,7 @@ func TestOpenDiscarded(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -433,7 +433,7 @@ func openMountByID(mountID int) (f *os.File, err error) {
 }
 
 func benchmarkOpenSameFile(b *testing.B, disableFilters bool, rules ...*rules.RuleDefinition) {
-	test, err := newTestModule(b, nil, rules, testOpts{disableFilters: disableFilters})
+	test, err := newTestModule(b, nil, rules, withStaticOpts(testOpts{disableFilters: disableFilters}))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -503,7 +503,7 @@ func createFolder(current string, filesPerFolder, maxDepth int) error {
 }
 
 func benchmarkFind(b *testing.B, filesPerFolder, maxDepth int, rules ...*rules.RuleDefinition) {
-	test, err := newTestModule(b, nil, rules, testOpts{})
+	test, err := newTestModule(b, nil, rules)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/security/tests/overlayfs_test.go
+++ b/pkg/security/tests/overlayfs_test.go
@@ -106,7 +106,7 @@ func TestOverlayFS(t *testing.T) {
 	}
 	defer testDrive.Close()
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{testDir: testDrive.Root()})
+	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{testDir: testDrive.Root()}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/overlayfs_test.go
+++ b/pkg/security/tests/overlayfs_test.go
@@ -106,7 +106,7 @@ func TestOverlayFS(t *testing.T) {
 	}
 	defer testDrive.Close()
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{testDir: testDrive.Root()}))
+	test, err := newTestModule(t, nil, ruleDefs, withDynamicOpts(dynamicTestOpts{testDir: testDrive.Root()}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/probe_monitor_test.go
+++ b/pkg/security/tests/probe_monitor_test.go
@@ -31,8 +31,7 @@ func TestRulesetLoaded(t *testing.T) {
 		Expression: `open.file.path == "/aaaaaaaaaaaaaaaaaaaaaaaaa" && open.flags & O_CREAT != 0`,
 	}
 
-	probeMonitorOpts := testOpts{}
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, probeMonitorOpts)
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,8 +73,7 @@ func TestHeartbeatSent(t *testing.T) {
 		Expression: `open.file.path == "/aaaaaaaaaaaaaaaaaaaaaaaaa" && open.flags & O_CREAT != 0`,
 	}
 
-	probeMonitorOpts := testOpts{}
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, probeMonitorOpts)
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +110,7 @@ func truncatedParents(t *testing.T, opts testOpts) {
 		Expression: `open.file.path =~ "*/a/**" && open.flags & O_CREAT != 0`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, opts)
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, withStaticOpts(opts))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/probe_monitor_test.go
+++ b/pkg/security/tests/probe_monitor_test.go
@@ -98,7 +98,7 @@ func TestHeartbeatSent(t *testing.T) {
 	})
 }
 
-func truncatedParents(t *testing.T, opts testOpts) {
+func truncatedParents(t *testing.T, staticOpts testOpts, dynamicOpts dynamicTestOpts) {
 	var truncatedParents string
 	for i := 0; i < model.MaxPathDepth; i++ {
 		truncatedParents += "a/"
@@ -110,7 +110,7 @@ func truncatedParents(t *testing.T, opts testOpts) {
 		Expression: `open.file.path =~ "*/a/**" && open.flags & O_CREAT != 0`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, withStaticOpts(opts))
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, withStaticOpts(staticOpts), withDynamicOpts(dynamicOpts))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,9 +176,9 @@ func cleanupABottomUp(path string) {
 }
 
 func TestTruncatedParentsMap(t *testing.T) {
-	truncatedParents(t, testOpts{disableERPCDentryResolution: true, disableAbnormalPathCheck: true})
+	truncatedParents(t, testOpts{disableERPCDentryResolution: true}, dynamicTestOpts{disableAbnormalPathCheck: true})
 }
 
 func TestTruncatedParentsERPC(t *testing.T) {
-	truncatedParents(t, testOpts{disableMapDentryResolution: true, disableAbnormalPathCheck: true})
+	truncatedParents(t, testOpts{disableMapDentryResolution: true}, dynamicTestOpts{disableAbnormalPathCheck: true})
 }

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -56,7 +56,7 @@ func TestProcess(t *testing.T) {
 		Expression: fmt.Sprintf(`process.user != "" && process.file.name == "%s" && open.file.path == "{{.Root}}/test-process"`, path.Base(executable)),
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{ruleDef}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{ruleDef})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +166,7 @@ func TestProcessContext(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -964,7 +964,7 @@ func TestProcessEnvsWithValue(t *testing.T) {
 		envsWithValue: []string{"LD_PRELOAD"},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, opts)
+	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(opts))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -995,7 +995,7 @@ func TestProcessExecCTime(t *testing.T) {
 		Expression: "exec.file.change_time < 30s",
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{ruleDef}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{ruleDef})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1023,7 +1023,7 @@ func TestProcessPIDVariable(t *testing.T) {
 		Expression: `open.file.path =~ "/proc/*/maps" && open.file.path != "/proc/${process.pid}/maps"`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{ruleDef}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{ruleDef})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1107,7 +1107,7 @@ func TestProcessScopedVariable(t *testing.T) {
 			`&& open.file.path == "${var5}-3"`,
 	}}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1165,7 +1165,7 @@ func TestTimestampVariable(t *testing.T) {
 		Expression: `open.file.path == "{{.Root}}/test-open-2" && ${process.timestamp1} > 0s && ${process.timestamp1} < 3s`,
 	}}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1204,7 +1204,7 @@ func TestProcessExec(t *testing.T) {
 		Expression: fmt.Sprintf(`exec.file.path == "%s" && exec.args == "/dev/null"`, executable),
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{ruleDef}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{ruleDef})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1250,7 +1250,7 @@ func TestProcessMetadata(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1317,7 +1317,7 @@ func TestProcessExecExit(t *testing.T) {
 		Expression: fmt.Sprintf(`exec.file.path == "%s" && exec.args in [~"*01010101*"]`, executable),
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1413,7 +1413,7 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1568,7 +1568,7 @@ func TestProcessIsThread(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1646,7 +1646,7 @@ func TestProcessExit(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1784,7 +1784,7 @@ func TestProcessBusybox(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1986,7 +1986,7 @@ chmod 755 pyscript.py
 		ruleList = append(ruleList, test.rule)
 	}
 
-	testModule, err := newTestModule(t, nil, ruleList, testOpts{})
+	testModule, err := newTestModule(t, nil, ruleList)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2029,7 +2029,7 @@ func TestProcessResolution(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2189,7 +2189,7 @@ func TestProcessFilelessExecution(t *testing.T) {
 		}
 	}
 
-	testModule, err := newTestModule(t, nil, ruleList, testOpts{})
+	testModule, err := newTestModule(t, nil, ruleList)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2256,7 +2256,7 @@ func TestKillAction(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/ptrace_test.go
+++ b/pkg/security/tests/ptrace_test.go
@@ -27,7 +27,7 @@ func TestPTraceEvent(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/rename_test.go
+++ b/pkg/security/tests/rename_test.go
@@ -274,7 +274,7 @@ func TestRenameReuseInode(t *testing.T) {
 	}
 	defer testDrive.Close()
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{testDir: testDrive.Root()}))
+	test, err := newTestModule(t, nil, ruleDefs, withDynamicOpts(dynamicTestOpts{testDir: testDrive.Root()}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/rename_test.go
+++ b/pkg/security/tests/rename_test.go
@@ -31,7 +31,7 @@ func TestRename(t *testing.T) {
 		Expression: `rename.file.path == "{{.Root}}/test-rename" && rename.file.uid == 98 && rename.file.gid == 99 && rename.file.destination.path == "{{.Root}}/test2-rename" && rename.file.destination.uid == 98 && rename.file.destination.gid == 99`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,7 +211,7 @@ func TestRenameInvalidate(t *testing.T) {
 		Expression: `rename.file.path in ["{{.Root}}/test-rename", "{{.Root}}/test2-rename"]`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -274,7 +274,7 @@ func TestRenameReuseInode(t *testing.T) {
 	}
 	defer testDrive.Close()
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{testDir: testDrive.Root()})
+	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{testDir: testDrive.Root()}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -350,7 +350,7 @@ func TestRenameFolder(t *testing.T) {
 		Expression: `open.file.name == "test-rename" && (open.flags & O_CREAT) > 0`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/rmdir_test.go
+++ b/pkg/security/tests/rmdir_test.go
@@ -29,7 +29,7 @@ func TestRmdir(t *testing.T) {
 		Expression: `rmdir.file.path in ["{{.Root}}/test-rmdir", "{{.Root}}/test-unlink-rmdir"] && rmdir.file.uid == 0 && rmdir.file.gid == 0`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,7 +170,7 @@ func TestRmdirInvalidate(t *testing.T) {
 		Expression: `rmdir.file.path =~ "{{.Root}}/test-rmdir-*"`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/sbom_test.go
+++ b/pkg/security/tests/sbom_test.go
@@ -27,7 +27,7 @@ func TestSBOM(t *testing.T) {
 				`&& open.file.package.name == "base-files" && process.file.path != "" && process.file.package.name == "coreutils"`,
 		},
 	}
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{enableSBOM: true})
+	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{enableSBOM: true}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/security_profile_test.go
+++ b/pkg/security/tests/security_profile_test.go
@@ -42,7 +42,7 @@ func TestSecurityProfile(t *testing.T) {
 	outputDir := t.TempDir()
 	os.MkdirAll(outputDir, 0755)
 	defer os.RemoveAll(outputDir)
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, testOpts{
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, withStaticOpts(testOpts{
 		enableActivityDump:                  true,
 		activityDumpRateLimiter:             200,
 		activityDumpTracedCgroupsCount:      3,
@@ -54,7 +54,7 @@ func TestSecurityProfile(t *testing.T) {
 		enableSecurityProfile:               true,
 		securityProfileDir:                  outputDir,
 		securityProfileWatchDir:             true,
-	})
+	}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,7 +224,7 @@ func TestAnomalyDetection(t *testing.T) {
 	outputDir := t.TempDir()
 	os.MkdirAll(outputDir, 0755)
 	defer os.RemoveAll(outputDir)
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, testOpts{
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, withStaticOpts(testOpts{
 		enableActivityDump:                      true,
 		activityDumpRateLimiter:                 200,
 		activityDumpTracedCgroupsCount:          3,
@@ -239,7 +239,7 @@ func TestAnomalyDetection(t *testing.T) {
 		anomalyDetectionMinimumStablePeriodExec: time.Second,
 		anomalyDetectionMinimumStablePeriodDNS:  time.Second,
 		anomalyDetectionWarmupPeriod:            time.Second,
-	})
+	}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -408,7 +408,7 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 	outputDir := t.TempDir()
 	os.MkdirAll(outputDir, 0755)
 	defer os.RemoveAll(outputDir)
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, testOpts{
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, withStaticOpts(testOpts{
 		enableActivityDump:                      true,
 		activityDumpRateLimiter:                 200,
 		activityDumpTracedCgroupsCount:          3,
@@ -424,7 +424,7 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 		anomalyDetectionMinimumStablePeriodDNS:  0,
 		anomalyDetectionWarmupPeriod:            3 * time.Second,
 		tagsResolver:                            NewFakeMonoResolver(),
-	})
+	}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -578,7 +578,7 @@ func TestSecurityProfileReinsertionPeriod(t *testing.T) {
 	os.MkdirAll(outputDir, 0755)
 	defer os.RemoveAll(outputDir)
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, testOpts{
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, withStaticOpts(testOpts{
 		enableActivityDump:                      true,
 		activityDumpRateLimiter:                 200,
 		activityDumpTracedCgroupsCount:          3,
@@ -592,7 +592,7 @@ func TestSecurityProfileReinsertionPeriod(t *testing.T) {
 		securityProfileWatchDir:                 true,
 		anomalyDetectionMinimumStablePeriodExec: 10 * time.Second,
 		anomalyDetectionMinimumStablePeriodDNS:  10 * time.Second,
-	})
+	}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -773,7 +773,7 @@ func TestSecurityProfileAutoSuppression(t *testing.T) {
 			Expression: `dns.question.type == A && dns.question.name == "foo.bar"`,
 		},
 	}
-	test, err := newTestModule(t, nil, rulesDef, testOpts{
+	test, err := newTestModule(t, nil, rulesDef, withStaticOpts(testOpts{
 		enableActivityDump:                      true,
 		activityDumpRateLimiter:                 200,
 		activityDumpTracedCgroupsCount:          3,
@@ -787,7 +787,7 @@ func TestSecurityProfileAutoSuppression(t *testing.T) {
 		securityProfileWatchDir:                 true,
 		anomalyDetectionMinimumStablePeriodExec: reinsertPeriod,
 		anomalyDetectionMinimumStablePeriodDNS:  reinsertPeriod,
-	})
+	}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/selinux_test.go
+++ b/pkg/security/tests/selinux_test.go
@@ -60,7 +60,7 @@ func TestSELinux(t *testing.T) {
 	}
 	defer setBoolValue(TestBoolName, savedBoolValue)
 
-	test, err := newTestModule(t, nil, ruleset, testOpts{})
+	test, err := newTestModule(t, nil, ruleset)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +157,7 @@ func TestSELinuxCommitBools(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleset, testOpts{})
+	test, err := newTestModule(t, nil, ruleset)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/serializers_test.go
+++ b/pkg/security/tests/serializers_test.go
@@ -38,7 +38,7 @@ func fetchRealisticEventSerializerInner(tb testing.TB) *serializers.EventSeriali
 		Expression: `open.file.path == "{{.Root}}/test-open" && open.flags & O_CREAT != 0`,
 	}
 
-	test, err := newTestModule(tb, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(tb, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/pkg/security/tests/signal_test.go
+++ b/pkg/security/tests/signal_test.go
@@ -32,7 +32,7 @@ func TestSignalEvent(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/snapshot_replay_test.go
+++ b/pkg/security/tests/snapshot_replay_test.go
@@ -24,13 +24,13 @@ func TestSnapshotReplay(t *testing.T) {
 
 	var gotEvent bool
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{ruleDef}, testOpts{
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{ruleDef}, withStaticOpts(testOpts{
 		snapshotRuleMatchHandler: func(testMod *testModule, e *model.Event, r *rules.Rule) {
 			assertTriggeredRule(t, r, "test_rule_snapshot_replay")
 			testMod.validateExecSchema(t, e)
 			gotEvent = true
 		},
-	})
+	}))
 
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/security/tests/span_test.go
+++ b/pkg/security/tests/span_test.go
@@ -34,7 +34,7 @@ func TestSpan(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/splice_test.go
+++ b/pkg/security/tests/splice_test.go
@@ -26,7 +26,7 @@ func TestSpliceEvent(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/stress_test.go
+++ b/pkg/security/tests/stress_test.go
@@ -35,7 +35,7 @@ func stressOpen(t *testing.T, rule *rules.RuleDefinition, pathname string, size 
 		ruleDefs = append(ruleDefs, rule)
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +177,7 @@ func stressExec(t *testing.T, rule *rules.RuleDefinition, pathname string, execu
 		ruleDefs = append(ruleDefs, rule)
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/threat_score_test.go
+++ b/pkg/security/tests/threat_score_test.go
@@ -62,7 +62,7 @@ func TestActivityDumpsThreatScore(t *testing.T) {
 
 	expectedFormats := []string{"json", "protobuf"}
 	testActivityDumpTracedEventTypes := []string{"exec", "open", "syscalls", "dns", "bind"}
-	test, err := newTestModule(t, nil, rules, testOpts{
+	test, err := newTestModule(t, nil, rules, withStaticOpts(testOpts{
 		enableActivityDump:                  true,
 		activityDumpRateLimiter:             testActivityDumpRateLimiter,
 		activityDumpTracedCgroupsCount:      testActivityDumpTracedCgroupsCount,
@@ -72,7 +72,7 @@ func TestActivityDumpsThreatScore(t *testing.T) {
 		activityDumpLocalStorageFormats:     expectedFormats,
 		activityDumpTracedEventTypes:        testActivityDumpTracedEventTypes,
 		activityDumpTagRules:                true,
-	})
+	}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/unlink_test.go
+++ b/pkg/security/tests/unlink_test.go
@@ -29,7 +29,7 @@ func TestUnlink(t *testing.T) {
 		Expression: `unlink.file.path in ["{{.Root}}/test-unlink", "{{.Root}}/test-unlinkat"] && unlink.file.uid == 98 && unlink.file.gid == 99`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +157,7 @@ func TestUnlinkInvalidate(t *testing.T) {
 		Expression: `unlink.file.path =~ "{{.Root}}/test-unlink-*"`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/user_session_test.go
+++ b/pkg/security/tests/user_session_test.go
@@ -30,7 +30,7 @@ func TestK8SUserSession(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/usergroup_test.go
+++ b/pkg/security/tests/usergroup_test.go
@@ -111,7 +111,7 @@ func TestUserGroup(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/utimes_test.go
+++ b/pkg/security/tests/utimes_test.go
@@ -27,7 +27,7 @@ func TestUtimes(t *testing.T) {
 		Expression: `utimes.file.path == "{{.Root}}/test-utime" && utimes.file.uid == 98 && utimes.file.gid == 99`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{ruleDef}, testOpts{})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{ruleDef})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/xattr_test.go
+++ b/pkg/security/tests/xattr_test.go
@@ -33,7 +33,7 @@ func TestSetXAttr(t *testing.T) {
 	}
 	defer testDrive.Close()
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{testDir: testDrive.Root()}))
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, withDynamicOpts(dynamicTestOpts{testDir: testDrive.Root()}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +164,7 @@ func TestRemoveXAttr(t *testing.T) {
 	}
 	defer testDrive.Close()
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{testDir: testDrive.Root()}))
+	test, err := newTestModule(t, nil, ruleDefs, withDynamicOpts(dynamicTestOpts{testDir: testDrive.Root()}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/xattr_test.go
+++ b/pkg/security/tests/xattr_test.go
@@ -33,7 +33,7 @@ func TestSetXAttr(t *testing.T) {
 	}
 	defer testDrive.Close()
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{testDir: testDrive.Root()})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, withStaticOpts(testOpts{testDir: testDrive.Root()}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +164,7 @@ func TestRemoveXAttr(t *testing.T) {
 	}
 	defer testDrive.Close()
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{testDir: testDrive.Root()})
+	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{testDir: testDrive.Root()}))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### What does this PR do?

The main slowing factor for CWS functional tests is the change of options passed to the manager leading to a complete deletion then creation of a new eBPF module (detach old probes, load BPF programs, attach ...).

To improve the situation this PR:
- split options into static (requiring a reload if there is a change) and dynamic (not requiring a full reload)
- try to move option that currently are static into the dynamic category

Before this PR: 33 full reloads
With this PR: 21 full reloads

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
