### PR TITLE
fix hostname resolution in kube_apiserver provider

### DIFF
--- a/pkg/util/kubernetes/apiserver/common/common_linux.go
+++ b/pkg/util/kubernetes/apiserver/common/common_linux.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
 
+// GetSelfPodName returns hostname from DD_POD_NAME in helm chart, if not found, use os.hostname
 func GetSelfPodName() (string, error) {
 	if podName, ok := os.LookupEnv("DD_POD_NAME"); ok {
 		return podName, nil

--- a/pkg/util/kubernetes/apiserver/common/common_linux.go
+++ b/pkg/util/kubernetes/apiserver/common/common_linux.go
@@ -5,7 +5,7 @@
 
 //go:build kubeapiserver && linux
 
-package leaderelection
+package common
 
 import (
 	"fmt"
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
 
-func getSelfPodName() (string, error) {
+func GetSelfPodName() (string, error) {
 	if podName, ok := os.LookupEnv("DD_POD_NAME"); ok {
 		return podName, nil
 	}

--- a/pkg/util/kubernetes/apiserver/common/common_nolinux.go
+++ b/pkg/util/kubernetes/apiserver/common/common_nolinux.go
@@ -5,13 +5,13 @@
 
 //go:build kubeapiserver && !linux
 
-package leaderelection
+package common
 
 import (
 	"os"
 )
 
-func getSelfPodName() (string, error) {
+func GetSelfPodName() (string, error) {
 	if podName, ok := os.LookupEnv("DD_POD_NAME"); ok {
 		return podName, nil
 	}

--- a/pkg/util/kubernetes/apiserver/common/common_nolinux.go
+++ b/pkg/util/kubernetes/apiserver/common/common_nolinux.go
@@ -11,6 +11,7 @@ import (
 	"os"
 )
 
+// GetSelfPodName returns hostname from DD_POD_NAME in helm chart, if not found, use os.hostname
 func GetSelfPodName() (string, error) {
 	if podName, ok := os.LookupEnv("DD_POD_NAME"); ok {
 		return podName, nil

--- a/pkg/util/kubernetes/apiserver/hostname.go
+++ b/pkg/util/kubernetes/apiserver/hostname.go
@@ -14,9 +14,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 )
 
-// HostNodeName retrieves the hostname from the apiserver, assuming our hostname
-// is the pod name. It connects to the apiserver, and returns the node name where
-// our pod is scheduled.
+// HostNodeName retrieves the hostname from the apiserver, pod name will be retrieved from DD_POD_NAME.
+// It connects to the apiserver, and returns the node name where our pod is scheduled.
 // Tested in the TestHostnameProvider integration test
 func HostNodeName(ctx context.Context) (string, error) {
 	c, err := GetAPIClient()

--- a/pkg/util/kubernetes/apiserver/hostname.go
+++ b/pkg/util/kubernetes/apiserver/hostname.go
@@ -25,7 +25,7 @@ func HostNodeName(ctx context.Context) (string, error) {
 	}
 	podName, err := common.GetSelfPodName()
 	if err != nil {
-		return "", fmt.Errorf("could not fetch our hostname: %s", err)
+		return "", fmt.Errorf("could not fetch our self pod name: %w", err)
 	}
 
 	nodeName, err := c.GetNodeForPod(ctx, common.GetMyNamespace(), podName)

--- a/pkg/util/kubernetes/apiserver/hostname.go
+++ b/pkg/util/kubernetes/apiserver/hostname.go
@@ -10,7 +10,6 @@ package apiserver
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 )
@@ -24,7 +23,7 @@ func HostNodeName(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("could not connect to the apiserver: %s", err)
 	}
-	podName, err := os.Hostname()
+	podName, err := common.GetSelfPodName()
 	if err != nil {
 		return "", fmt.Errorf("could not fetch our hostname: %s", err)
 	}

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -130,7 +130,7 @@ func (le *LeaderEngine) init() error {
 	var err error
 
 	if le.HolderIdentity == "" {
-		le.HolderIdentity, err = getSelfPodName()
+		le.HolderIdentity, err = common.GetSelfPodName()
 		if err != nil {
 			log.Debugf("cannot get pod name: %s", err)
 			return err

--- a/releasenotes/notes/fix-hostname-resolution-in-kubeapiserver-13658d6681c543dd.yaml
+++ b/releasenotes/notes/fix-hostname-resolution-in-kubeapiserver-13658d6681c543dd.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Resolve the issue with hostname resolution in the kube_apiserver provider when the useHostNetwork setting is enabled."

--- a/releasenotes/notes/fix-hostname-resolution-in-kubeapiserver-13658d6681c543dd.yaml
+++ b/releasenotes/notes/fix-hostname-resolution-in-kubeapiserver-13658d6681c543dd.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    Resolve the issue with hostname resolution in the kube_apiserver provider when the useHostNetwork setting is enabled."
+    Resolve the issue with hostname resolution in the kube_apiserver provider when the useHostNetwork setting is enabled.


### PR DESCRIPTION
[CONS-5910](https://datadoghq.atlassian.net/browse/CONS-5910)
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Fix HostNodeName resolution in kube_apiserver provider

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
DD_POD_NAME ([pr](https://github.com/DataDog/datadog-agent/pull/17305)) was recently added helm chart which fixed DCA leader election. However, the [hostname resolution](https://github.com/DataDog/datadog-agent/blob/eb49edfe58f811c4bdd6c7cd71d15176302e0485/pkg/util/kubernetes/apiserver/hostname.go#L18-L37) is still broken because it doesn’t use DD_POD_NAME yet. 
Current logic is when useHostNetwork is true, os.hostname does NOT return pod name which breaks GetNodeForPod.
Proposed logic is doing the same as what we do for leaderelection which use DD_POD_NAME as pod name. If DD_POD_NAME is not set, we fall back to os.Hostname() which is same as current method. 


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Run k8s locally with current agent/cluster-agent version
```
clusterAgent:
    useHostNetwork: true
```
and enable debug level log
```
datadog:
  logLevel: DEBUG
```
This error will be found in the log 
`2023-11-09 20:50:02 UTC | CLUSTER | DEBUG | (pkg/util/hostname/container.go:37 in callContainerProvider) | error calling provider 'kube_apiserver': could not fetch the host nodename from the apiserver: pods "minyi-test-k8s-worker" not found`

switch to new version, hostname will be resolved now
```
2023-11-09 21:03:14 UTC | CLUSTER | DEBUG | (pkg/util/hostname/container.go:34 in callContainerProvider) | GetHostname trying provider 'kube_apiserver' ...
2023-11-09 21:03:14 UTC | CLUSTER | DEBUG | (pkg/util/kubernetes/apiserver/apiserver.go:461 in connect) | Connected to kubernetes apiserver, version v1
2023-11-09 21:03:14 UTC | CLUSTER | INFO | (pkg/util/kubernetes/clustername/clustername.go:78 in getClusterName) | Got cluster name kind-minyi-test-k8s from config
2023-11-09 21:03:14 UTC | CLUSTER | INFO | (pkg/util/kubernetes/clustername/clustername.go:129 in getClusterName) | Using cluster name kind-minyi-test-k8s from the node label
2023-11-09 21:03:14 UTC | CLUSTER | DEBUG | (pkg/util/hostname/providers.go:174 in GetWithProvider) | hostname provider 'container' successfully found hostname 'minyi-test-k8s-worker-kind-minyi-test-k8s'
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.


[CONS-5910]: https://datadoghq.atlassian.net/browse/CONS-5910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ