### PR TITLE
Adding cpu manager metrics to kubelet core check

### DIFF
--- a/pkg/collector/corechecks/containers/kubelet/provider/kubelet/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/kubelet/provider.go
@@ -73,8 +73,10 @@ var (
 	}
 
 	counterMetrics = map[string]string{
-		"kubelet_evictions":           "kubelet.evictions",
-		"kubelet_pleg_discard_events": "kubelet.pleg.discard_events",
+		"kubelet_evictions":                          "kubelet.evictions",
+		"kubelet_pleg_discard_events":                "kubelet.pleg.discard_events",
+		"kubelet_cpu_manager_pinning_errors_total":   "kubelet.cpu_manager.pinning_errors_total",
+		"kubelet_cpu_manager_pinning_requests_total": "kubelet.cpu_manager.pinning_requests_total",
 	}
 
 	volumeMetrics = map[string]string{

--- a/pkg/collector/corechecks/containers/kubelet/provider/kubelet/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/kubelet/provider_test.go
@@ -107,6 +107,8 @@ var (
 		common.KubeletMetricsPrefix + "rest.client.latency.sum",
 		common.KubeletMetricsPrefix + "rest.client.requests",
 		common.KubeletMetricsPrefix + "kubelet.evictions",
+		common.KubeletMetricsPrefix + "kubelet.cpu_manager.pinning_errors_total",
+		common.KubeletMetricsPrefix + "kubelet.cpu_manager.pinning_requests_total",
 	}
 )
 

--- a/pkg/collector/corechecks/containers/kubelet/testdata/kubelet_metrics_1_21.txt
+++ b/pkg/collector/corechecks/containers/kubelet/testdata/kubelet_metrics_1_21.txt
@@ -312,6 +312,12 @@ kubelet_containers_per_pod_count_bucket{le="16"} 30
 kubelet_containers_per_pod_count_bucket{le="+Inf"} 30
 kubelet_containers_per_pod_count_sum 38
 kubelet_containers_per_pod_count_count 30
+# HELP kubelet_cpu_manager_pinning_errors_total [ALPHA] The number of cpu core allocations which required pinning failed.
+# TYPE kubelet_cpu_manager_pinning_errors_total counter
+kubelet_cpu_manager_pinning_errors_total 7
+# HELP kubelet_cpu_manager_pinning_requests_total [ALPHA] The number of cpu core allocations which required pinning.
+# TYPE kubelet_cpu_manager_pinning_requests_total counter
+kubelet_cpu_manager_pinning_requests_total 28
 # HELP kubelet_docker_operations_duration_seconds [ALPHA] Latency in seconds of Docker operations. Broken down by operation type.
 # TYPE kubelet_docker_operations_duration_seconds histogram
 kubelet_docker_operations_duration_seconds_bucket{operation_type="create_container",le="0.005"} 0

--- a/releasenotes/notes/add-cpu_manager-metrics-to-kubelet-check-ff2421e1c3e47d8e.yaml
+++ b/releasenotes/notes/add-cpu_manager-metrics-to-kubelet-check-ff2421e1c3e47d8e.yaml
@@ -8,7 +8,4 @@
 ---
 features:
   - |
-    List new features here, or remove this section.
-enhancements:
-  - |
     Adds the following CPU manager metrics to the kubelet core check: `kubernetes_core.kubelet.cpu_manager.pinning_errors_total`, `kubernetes_core.kubelet.cpu_manager.pinning_requests_total`.

--- a/releasenotes/notes/add-cpu_manager-metrics-to-kubelet-check-ff2421e1c3e47d8e.yaml
+++ b/releasenotes/notes/add-cpu_manager-metrics-to-kubelet-check-ff2421e1c3e47d8e.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    List new features here, or remove this section.
+enhancements:
+  - |
+    Adds the following CPU manager metrics to the kubelet core check: `kubernetes_core.kubelet.cpu_manager.pinning_errors_total`, `kubernetes_core.kubelet.cpu_manager.pinning_requests_total`.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Adds the following CPU manager metrics to the kubelet core check: `kubernetes_core.kubelet.cpu_manager.pinning_errors_total`, `kubernetes_core.kubelet.cpu_manager.pinning_requests_total`.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
https://datadoghq.atlassian.net/browse/CONTINT-92 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Kubernetes must be v1.26+
Metrics should be exposed in prometheus format via /metrics endpoint.
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
