### PR TITLE
[NPM-2952] Prioritizes dropping empty connections when size limit reached

### DIFF
--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -501,7 +501,7 @@ func (ns *networkState) storeClosedConnections(conns []ConnectionStats) {
 			if uint32(len(client.closedConnections)) >= ns.maxClosedConns {
 				stateTelemetry.closedConnDropped.Inc(c.Type.String())
 				// Drop if c is empty or closedConnections does not have empty connections
-				if isEmpty(c) || !isEmpty(client.closedConnections[len(client.closedConnections)-1]) {
+				if isEmpty(c) || client.emptyConnsIndex == len(client.closedConnections) {
 					continue
 				}
 				delete(client.closedConnectionsKeys, client.closedConnections[client.emptyConnsIndex].Cookie)

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -258,7 +258,7 @@ func TestDropEmptyConnections(t *testing.T) {
 		state.storeClosedConnections([]ConnectionStats{conn2})
 
 		conns := state.clients[clientID].closedConnections
-		i, _ := state.clients[clientID].closedConnectionsKeys[0]
+		i := state.clients[clientID].closedConnectionsKeys[0]
 		assert.Equal(t, 3, len(conns))
 		assert.Equal(t, []ConnectionStats{conn, conn2, {}}, conns)
 		assert.Equal(t, 2, i)

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -232,8 +232,8 @@ func TestDropEmptyConnections(t *testing.T) {
 
 		state.storeClosedConnections([]ConnectionStats{conn})
 
-		conns := state.clients[clientID].closedConnections
-		_, ok := state.clients[clientID].closedConnectionsKeys[0]
+		conns := state.clients[clientID].closed.conns
+		_, ok := state.clients[clientID].closed.byCookie[0]
 
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, []ConnectionStats{conn}, conns)
@@ -257,8 +257,8 @@ func TestDropEmptyConnections(t *testing.T) {
 		conn2.LastUpdateEpoch = 100
 		state.storeClosedConnections([]ConnectionStats{conn2})
 
-		conns := state.clients[clientID].closedConnections
-		i := state.clients[clientID].closedConnectionsKeys[0]
+		conns := state.clients[clientID].closed.conns
+		i := state.clients[clientID].closed.byCookie[0]
 		assert.Equal(t, 3, len(conns))
 		assert.Equal(t, []ConnectionStats{conn, conn2, {}}, conns)
 		assert.Equal(t, 2, i)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR prioritizes dropping empty connections when the size limit for `closedConnections` is reached. It does so by keeping an index of where empty connections start.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
