### PR TITLE
[windows] fix windows cws service.

### DIFF
--- a/cmd/agent/subcommands/run/dependent_services_windows.go
+++ b/cmd/agent/subcommands/run/dependent_services_windows.go
@@ -56,9 +56,18 @@ var subservices = []Servicedef{
 			"network_config.enabled":          config.SystemProbe,
 			"system_probe_config.enabled":     config.SystemProbe,
 			"windows_crash_detection.enabled": config.SystemProbe,
+			"runtime_security_config.enabled": config.SystemProbe,
 		},
 		serviceName: "datadog-system-probe",
 		serviceInit: sysprobeInit,
+	},
+	{
+		name: "cws",
+		configKeys: map[string]config.Config{
+			"runtime_security_config.enabled": config.SystemProbe,
+		},
+		serviceName: "datadog-security-agent",
+		serviceInit: securityInit,
 	},
 }
 
@@ -71,6 +80,10 @@ func processInit() error {
 }
 
 func sysprobeInit() error {
+	return nil
+}
+
+func securityInit() error {
 	return nil
 }
 

--- a/cmd/security-agent/main_windows.go
+++ b/cmd/security-agent/main_windows.go
@@ -31,6 +31,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -92,6 +93,13 @@ func (s *service) Run(svcctx context.Context) error {
 		core.Bundle,
 		forwarder.Bundle,
 		fx.Provide(defaultforwarder.NewParamsWithResolvers),
+		demultiplexer.Module,
+		fx.Provide(func() demultiplexer.Params {
+			opts := aggregator.DefaultAgentDemultiplexerOptions()
+			opts.UseEventPlatformForwarder = false
+			opts.UseOrchestratorForwarder = false
+			return demultiplexer.Params{Options: opts}
+		}),
 	)
 
 	return err

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -73,6 +73,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// TODO: Similar to the agent itself, once the security agent is represented as a component, and not a function (start),
 			// this will use `fxutil.Run` instead of `fxutil.OneShot`.
+
+			// note that any changes to the arguments to OneShot need to be reflected into
+			// the service initialization in ../../main_windows.go
 			return fxutil.OneShot(start,
 				fx.Supply(params),
 				fx.Supply(core.BundleParams{

--- a/pkg/security/agent/agent.go
+++ b/pkg/security/agent/agent.go
@@ -74,8 +74,9 @@ func (rsa *RuntimeSecurityAgent) Start(reporter common.RawReporter, endpoints *c
 func (rsa *RuntimeSecurityAgent) Stop() {
 	rsa.cancel()
 	rsa.running.Store(false)
-	rsa.wg.Wait()
 	rsa.client.Close()
+	rsa.wg.Wait()
+
 }
 
 // StartEventListener starts listening for new events from system-probe


### PR DESCRIPTION
1) CWS could not run as service because FX arguments were not properly
   applied to service start.  Applied, and then made note to hopefully
   avoid this problem in the future

2) Fix Windows subservices startup to account for CWS; start CWs when
   configured in `system-probe.yaml`

3) Fix service shutdown.  Was hanging on shutdown.
### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Install agent.
Configure CWS in `system-probe.yaml` and `security-agent.yaml` to be enabled.
Ensure that starting agent starts security agent
Ensure that stopping agent stops security agent.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
