### PR TITLE
[windows] Add default security agent profile to installer when CWS is…

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -313,15 +313,6 @@ end
 # Include traps db file in snmp.d/traps_db/
 dependency 'snmp-traps'
 
-# this dependency puts few files out of the omnibus install dir and move them
-# in the final destination. This way such files will be listed in the packages
-# manifest and owned by the package manager. This is the only point in the build
-# process where we operate outside the omnibus install dir, thus the need of
-# the `extra_package_file` directive.
-# This must be the last dependency in the project.
-dependency 'datadog-agent-finalize'
-dependency 'datadog-cf-finalize'
-
 # Additional software
 if windows_target?
   if ENV['WINDOWS_DDNPM_DRIVER'] and not ENV['WINDOWS_DDNPM_DRIVER'].empty?
@@ -332,8 +323,19 @@ if windows_target?
   end
   if ENV['WINDOWS_DDPROCMON_DRIVER'] and not ENV['WINDOWS_DDPROCMON_DRIVER'].empty?
     dependency 'datadog-windows-procmon-driver'
+    ## this is a duplicate of the above dependency in linux
+    dependency 'datadog-security-agent-policies'
   end
 end
+
+# this dependency puts few files out of the omnibus install dir and move them
+# in the final destination. This way such files will be listed in the packages
+# manifest and owned by the package manager. This is the only point in the build
+# process where we operate outside the omnibus install dir, thus the need of
+# the `extra_package_file` directive.
+# This must be the last dependency in the project.
+dependency 'datadog-agent-finalize'
+dependency 'datadog-cf-finalize'
 
 if linux_target?
   extra_package_file '/etc/init/datadog-agent.conf'

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -31,7 +31,7 @@ build do
             if ENV['WINDOWS_DDPROCMON_DRIVER'] and not ENV['WINDOWS_DDPROCMON_DRIVER'].empty? and not windows_arch_i386?
               move "#{install_dir}/etc/datadog-agent/security-agent.yaml.example", conf_dir_root, :force=>true
               move "#{install_dir}/etc/datadog-agent/runtime-security.d", conf_dir_root, :force=>true
-
+              move "#{conf_dir_root}/runtime-security.d/default.policy", "#{conf_dir_root}/runtime-security.d/default.policy.example", :force=>true
             end
             if ENV['WINDOWS_APMINJECT_MODULE'] and not ENV['WINDOWS_APMINJECT_MODULE'].empty?
               move "#{install_dir}/etc/datadog-agent/apm-inject.yaml.example", conf_dir_root, :force=>true

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -30,6 +30,8 @@ build do
             end
             if ENV['WINDOWS_DDPROCMON_DRIVER'] and not ENV['WINDOWS_DDPROCMON_DRIVER'].empty? and not windows_arch_i386?
               move "#{install_dir}/etc/datadog-agent/security-agent.yaml.example", conf_dir_root, :force=>true
+              move "#{install_dir}/etc/datadog-agent/runtime-security.d", conf_dir_root, :force=>true
+
             end
             if ENV['WINDOWS_APMINJECT_MODULE'] and not ENV['WINDOWS_APMINJECT_MODULE'].empty?
               move "#{install_dir}/etc/datadog-agent/apm-inject.yaml.example", conf_dir_root, :force=>true

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ConfigCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ConfigCustomActions.cs
@@ -345,6 +345,7 @@ namespace Datadog.CustomActions
             var datadogYaml = Path.Combine(configFolder, "datadog.yaml");
             var systemProbeYaml = Path.Combine(configFolder, "system-probe.yaml");
             var securityAgentYaml = Path.Combine(configFolder, "security-agent.yaml");
+            var securityAgentProfile = Path.Combine(configFolder, "runtime-security.d", "default.policy");
             var injectionControllerYaml = Path.Combine(configFolder, "apm-inject.yaml");
             try
             {
@@ -371,6 +372,15 @@ namespace Datadog.CustomActions
                     output.Write(yaml);
                 }
 
+                // Conditionally include the security agent YAML while it is in active development to make it easier
+                // to build/ship without it.
+                if (File.Exists(securityAgentProfile + ".example"))
+                {
+                    if (!File.Exists(securityAgentProfile))
+                    {
+                        File.Copy(securityAgentProfile + ".example", securityAgentProfile);
+                    }
+                }
                 // Conditionally include the security agent YAML while it is in active development to make it easier
                 // to build/ship without it.
                 if (File.Exists(securityAgentYaml + ".example"))

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -569,6 +569,13 @@ namespace WixSetup.Datadog
                     new Files($@"{EtcSource}\extra_package_files\EXAMPLECONFSLOCATION\*")
                 ));
 
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WINDOWS_DDPROCMON_DRIVER")))
+            {
+                appData.AddDir(new Dir(new Id("security.d"),
+                                       "runtime-security.d",
+                                       new Files($@"{EtcSource}\runtime-security.d\default.policy")
+                ));
+            }
             return new Dir(new Id("%CommonAppData%"), appData)
             {
                 Attributes = { { "Name", "CommonAppData" } }

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog/AgentInstaller.cs
@@ -573,7 +573,7 @@ namespace WixSetup.Datadog
             {
                 appData.AddDir(new Dir(new Id("security.d"),
                                        "runtime-security.d",
-                                       new Files($@"{EtcSource}\runtime-security.d\default.policy")
+                                       new WixSharp.File($@"{EtcSource}\runtime-security.d\default.policy.example")
                 ));
             }
             return new Dir(new Id("%CommonAppData%"), appData)


### PR DESCRIPTION
… included


### Motivation

have default security profile when CWS is included.

### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

Install the build with CWS included.  note that `programdata\datadog\runtime-security.d\default.policy` is present

### Reviewer's Checklist
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
