### PR TITLE
Add hard stop timeout to Windows services

### DIFF
--- a/cmd/agent/windows/service/service.go
+++ b/cmd/agent/windows/service/service.go
@@ -17,6 +17,7 @@ import (
 )
 
 type service struct {
+	servicemain.DefaultSettings
 	errChan <-chan error
 	ctxChan chan context.Context
 }

--- a/cmd/dogstatsd/main_windows.go
+++ b/cmd/dogstatsd/main_windows.go
@@ -61,7 +61,9 @@ func main() {
 	}
 }
 
-type service struct{}
+type service struct {
+	servicemain.DefaultSettings
+}
 
 func (s *service) Name() string {
 	return ServiceName

--- a/cmd/process-agent/main_windows.go
+++ b/cmd/process-agent/main_windows.go
@@ -30,6 +30,7 @@ const (
 )
 
 type service struct {
+	servicemain.DefaultSettings
 	globalParams *command.GlobalParams
 }
 

--- a/cmd/security-agent/main_windows.go
+++ b/cmd/security-agent/main_windows.go
@@ -38,6 +38,7 @@ import (
 )
 
 type service struct {
+	servicemain.DefaultSettings
 }
 
 var (

--- a/cmd/system-probe/main_windows.go
+++ b/cmd/system-probe/main_windows.go
@@ -23,6 +23,7 @@ import (
 )
 
 type service struct {
+	servicemain.DefaultSettings
 	errChan <-chan error
 	ctxChan chan context.Context
 }

--- a/cmd/trace-agent/subcommands/run/service_windows.go
+++ b/cmd/trace-agent/subcommands/run/service_windows.go
@@ -9,9 +9,11 @@ import (
 	"context"
 
 	tracecfg "github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/servicemain"
 )
 
 type service struct {
+	servicemain.DefaultSettings
 	cliParams       *RunParams
 	defaultConfPath string
 }

--- a/pkg/util/fxutil/timeout.go
+++ b/pkg/util/fxutil/timeout.go
@@ -27,6 +27,10 @@ const (
 // Before fx the Agent did not have any start/stop timeouts, it would hang indefinitely. As we have
 // have been adding more fx.Hooks we began hitting flaky tests with expired fx timeouts.
 // We use a large timeout value by default to minimize the chance that customers will be impacted by the timeout.
+// However, note that most platforms service managers send SIGKILL after a timeout
+//   - upstart default is 5 seconds
+//   - see pkg/util/winutil/servicemain/servicemain.go:Service.HardStopTimeout
+//
 // We can revisit this once we can better characterize the agent start/stop behavior and be intentional
 // about timeout values
 func TemporaryAppTimeouts() fx.Option {

--- a/pkg/util/winutil/servicemain/servicemain.go
+++ b/pkg/util/winutil/servicemain/servicemain.go
@@ -30,14 +30,14 @@ const (
 	DefaultHardStopTimeout = 15 * time.Second
 	// EnvHardStopTimeoutOverride is an environment variable that a user can set
 	// to override DefaultHardStopTimeout.
-	EnvHardStopTimeoutOverride = "DD_SERVICE_STOP_TIMEOUT_SECONDS"
+	EnvHardStopTimeoutOverride = "DD_WINDOWS_SERVICE_STOP_TIMEOUT_SECONDS"
 )
 
 // DefaultSettings provides default values to Service implementations when embedded
 type DefaultSettings struct{}
 
 // HardStopTimeout provides a default hard stop timeout for Service implementations,
-// and allows a user to override the default by setting the DD_SERVICE_STOP_TIMEOUT_SECONDS
+// and allows a user to override the default by setting the DD_WINDOWS_SERVICE_STOP_TIMEOUT_SECONDS
 // environment variable.
 func (s *DefaultSettings) HardStopTimeout() time.Duration {
 	timeString, found := os.LookupEnv(EnvHardStopTimeoutOverride)

--- a/pkg/util/winutil/servicemain/servicemain.go
+++ b/pkg/util/winutil/servicemain/servicemain.go
@@ -12,6 +12,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 	"unsafe"
@@ -22,6 +24,32 @@ import (
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
 )
+
+const (
+	// DefaultHardStopTimeout is a default value. See Service.HardStopTimeout for details.
+	DefaultHardStopTimeout = 15 * time.Second
+	// EnvHardStopTimeoutOverride is an environment variable that a user can set
+	// to override DefaultHardStopTimeout.
+	EnvHardStopTimeoutOverride = "DD_SERVICE_STOP_TIMEOUT_SECONDS"
+)
+
+// DefaultSettings provides default values to Service implementations when embedded
+type DefaultSettings struct{}
+
+// HardStopTimeout provides a default hard stop timeout for Service implementations,
+// and allows a user to override the default by setting the DD_SERVICE_STOP_TIMEOUT_SECONDS
+// environment variable.
+func (s *DefaultSettings) HardStopTimeout() time.Duration {
+	timeString, found := os.LookupEnv(EnvHardStopTimeoutOverride)
+	if !found {
+		return DefaultHardStopTimeout
+	}
+	timeValue, err := strconv.Atoi(timeString)
+	if err != nil {
+		return DefaultHardStopTimeout
+	}
+	return time.Duration(timeValue) * time.Second
+}
 
 // Service defines the interface that applications should implement to run as Windows Services
 type Service interface {
@@ -38,15 +66,38 @@ type Service interface {
 	// Run() implements all application logic and is run when the service status is SERVICE_RUNNING.
 	//
 	// The provided context is cancellable. Run() must monitor ctx.Done() and return as soon as possible
-	// when it is set. There is no standard time limit, it is up to the program performing the service stop.
-	// The Services.msc snap-in has a 125 second limit, if the operating system is rebooting there is a 20 second limit.
-	// https://learn.microsoft.com/en-us/windows/win32/services/service-control-handler-function
+	// when it is set. If Run() does not return after the context is set the process will exit after
+	// the duration returned by HardStopTimeout()
 	//
 	// The service will exit when Run() returns. Run() must return for the service status to be be updated to SERVICE_STOPPED.
 	// If the process exits without setting SERVICE_STOPPED, Service Control Manager (SCM) will treat
 	// this as an unexpected exit and enter failure/recovery, regardless of the process exit code.
 	// https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_failure_actionsa
 	Run(ctx context.Context) error
+
+	// Most platforms send SIGKILL if the service does not respond to the initial SIGTERM
+	// within a set amount of time. The set amount of time differs between platforms but
+	// is usually also configurable
+	// - upstart: 5 seconds
+	// - systemd: 90 seconds
+	// However, on Windows most service manager tools let the process stay running if it does not stop,
+	// with different timeouts, and there is no standard way to configure a timeout.
+	// - PowerShell Restart-Service: (no kill) error after 30 seconds for dependent services
+	//                               (no kill) no timeout for a single service
+	// - net stop: (no kill) error after 20 seconds
+	// - sc stop: does not wait/block
+	// - Services.msc: (no kill) error after 125 seconds
+	// - Host/OS shutdown: shutdown after 20 seconds
+	// https://learn.microsoft.com/en-us/windows/win32/services/service-control-handler-function
+	//
+	// This means that on Windows if our service hangs on stop then it may need to be force killed
+	// by the user, and may cause uninstall to fail. CM tools like our Ansible plugin use Restart-Service,
+	// when the configuration changes so it is troublesome for the user if Restart-Service fails.
+	//
+	// It seems useful to keep this timeout under the commonly used Windows tools error timeouts, so
+	// we set it that way for now. However our primary requirement is it be less than the Agent
+	// installer timeout (3 minutes).
+	HardStopTimeout() time.Duration
 }
 
 // ErrCleanStopAfterInit should be returned from Service.Init() to report SERVICE_RUNNING and then exit without error after
@@ -221,21 +272,42 @@ func (s *controlHandler) Execute(args []string, r <-chan svc.ChangeRequest, chan
 		changes <- svc.Status{State: svc.StopPending}
 	}()
 
+	// context for Run()
 	ctx, cancelfunc := context.WithCancel(context.Background())
 	defer cancelfunc()
+	// context for exit timeout
+	cleanExitCtx, cancelCleanExit := context.WithCancel(context.Background())
+	defer cancelCleanExit()
 
 	// goroutine to handle service control requests
 	// https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nc-winsvc-lphandler_function
-	go s.controlHandlerLoop(cancelfunc, r, changes)
+	go s.controlHandlerLoop(cancelfunc, cancelCleanExit, r, changes)
 
 	// Now that we are in SERVICE_RUNNING state, start the exit gate timer.
 	exitGate := runTimeExitGate()
 
 	if executeRun {
-		// Run the actual agent/service
-		err = s.service.Run(ctx)
-		if err != nil {
-			s.eventlog(messagestrings.MSG_SERVICE_FAILED, err.Error())
+		err = nil
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			// Run the actual agent/service
+			err = s.service.Run(ctx)
+			if err != nil {
+				s.eventlog(messagestrings.MSG_SERVICE_FAILED, err.Error())
+			}
+		}()
+		select {
+		case <-done:
+			if err != nil {
+				// since exitGate is meant to avoid an error, if we are returning
+				// with an error then we can skip the exitGate.
+				return
+			}
+		case <-cleanExitCtx.Done():
+			s.eventlog(messagestrings.MSG_SERVICE_FAILED, "service did not cleanly shutdown in a timely manner, hard stopping service")
+			// since exitGate is meant to avoid an error, if we are returning
+			// with an error then we can skip the exitGate.
 			return
 		}
 	}
@@ -248,7 +320,7 @@ func (s *controlHandler) Execute(args []string, r <-chan svc.ChangeRequest, chan
 	return
 }
 
-func (s *controlHandler) controlHandlerLoop(cancelFunc context.CancelFunc, r <-chan svc.ChangeRequest, changes chan<- svc.Status) {
+func (s *controlHandler) controlHandlerLoop(cancelFunc context.CancelFunc, cancelCleanExit context.CancelFunc, r <-chan svc.ChangeRequest, changes chan<- svc.Status) {
 	for c := range r {
 		switch c.Cmd {
 		case svc.Interrogate:
@@ -262,10 +334,21 @@ func (s *controlHandler) controlHandlerLoop(cancelFunc context.CancelFunc, r <-c
 			s.eventlog(messagestrings.MSG_RECEIVED_STOP_SVC_COMMAND, s.service.Name())
 			cancelFunc()
 			// We set SERVICE_STOP_PENDING, so SCM won't send anymore control requests
+			// Start our exit timeout timer
+			go s.terminateProcessOnTimeout(cancelCleanExit)
 			return
 		default:
 			// unexpected control
 			s.eventlog(messagestrings.MSG_UNEXPECTED_CONTROL_REQUEST, fmt.Sprintf("%d", c.Cmd))
 		}
 	}
+}
+
+// Does not directly call os.Exit/TerminateProcess.
+// We cancel a context that causes controlHandler.Execute to return and cause the service
+// to properly shutdown (from Windows perspective), which eventually returns to main to exit.
+// Any shutdown operations the Agent may be in the middle of will be abruptly halted, like with a SIGKILL.
+func (s *controlHandler) terminateProcessOnTimeout(cancelCleanExit context.CancelFunc) {
+	<-time.After(time.Duration(s.service.HardStopTimeout()))
+	cancelCleanExit()
 }

--- a/releasenotes/notes/add-windows-agent-stop-timeout-024333b37e995ba5.yaml
+++ b/releasenotes/notes/add-windows-agent-stop-timeout-024333b37e995ba5.yaml
@@ -1,0 +1,9 @@
+---
+enhancements:
+  - |
+    Add a stop timeout to the Windows Agent services. If an Agent service
+    does not cleanly stop within 15 seconds after receiving a stop command
+    from the Service Control Manager the service will hard stop.
+    The timeout can be configured by setting the DD_WINDOWS_SERVICE_STOP_TIMEOUT_SECONDS
+    environment variable.
+    Agent stop timeouts are logged to the Windows Event Log and can be monitored and alerted on.

--- a/releasenotes/notes/add-windows-agent-stop-timeout-024333b37e995ba5.yaml
+++ b/releasenotes/notes/add-windows-agent-stop-timeout-024333b37e995ba5.yaml
@@ -3,7 +3,7 @@ enhancements:
   - |
     Add a stop timeout to the Windows Agent services. If an Agent service
     does not cleanly stop within 15 seconds after receiving a stop command
-    from the Service Control Manager the service will hard stop.
+    from the Service Control Manager, the service will hard stop.
     The timeout can be configured by setting the DD_WINDOWS_SERVICE_STOP_TIMEOUT_SECONDS
     environment variable.
     Agent stop timeouts are logged to the Windows Event Log and can be monitored and alerted on.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Previously, after receiving a service stop command, if the agent never returned/finished then the service could be stuck in STOP_PENDING forever.

This PR adds a hard stop timeout to the Agent's Windows Services, to ensure the services do not hang forever after receiving a stop command.

The timeout defaults to 15 seconds after the service stop signal is received, and can be configured by setting  the `DD_WINDOWS_SERVICE_STOP_TIMEOUT_SECONDS` environment variable.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Bring Windows service behavior in line with other platforms whose service managers send SIGKILL after some configurable timeout.

This should help prevent configuration management and/or deployment failures due to the Agent services refusing to stop. For example, PowerShell `Restart-Service` will return an error after 30 seconds if a dependent service (e.g. process-agent/trace-agent) does not stop, and then it won't send a stop signal to the core datadog-agent service.

https://datadoghq.atlassian.net/browse/WINA-452

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->
Similar to https://github.com/DataDog/datadog-agent/pull/18875, however this new service timeout will apply regardless of if the agent is hanging in `fx.OnStop` handlers or not. I think we should keep the `fx` timeouts at their temporary long timeout values to allow the platforms service managers to configure/manage the stop timeout.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Enable live process collection in `datadog.yaml`
```yaml
process_config:
  process_collection:
    enabled: true
```
Start the agent, and ensure process-agent is running
```PowerShell
Start-Service datadogagent
```
Disconnect your test VM from the network, this triggers a hang in process-agent's shutdown procedure.
Stop the agent, and ensure that process-agent takes 15 seconds to stop, and that the Stop-Service command finishes without an error.
```PowerShell
Stop-Service -Force -Verbose datadogagent
```

If the process-agent does not hang on shutdown, then you might need to modify the code [like this](https://github.com/DataDog/datadog-agent/pull/20769#issuecomment-1805031697) to to artificially introduce a hang.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
