### PR TITLE
Update systemd.*.service.erb

### DIFF
--- a/omnibus/config/templates/init-scripts-agent/systemd.process.service.erb
+++ b/omnibus/config/templates/init-scripts-agent/systemd.process.service.erb
@@ -8,6 +8,7 @@ Type=simple
 PIDFile=<%= install_dir %>/run/process-agent.pid
 User=dd-agent
 Restart=on-failure
+EnvironmentFile=-<%= etc_dir %>/environment
 ExecStart=<%= install_dir %>/embedded/bin/process-agent --cfgpath=<%= etc_dir %>/datadog.yaml --sysprobe-config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/process-agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.

--- a/omnibus/config/templates/init-scripts-agent/systemd.security.service.erb
+++ b/omnibus/config/templates/init-scripts-agent/systemd.security.service.erb
@@ -8,6 +8,7 @@ ConditionPathExists=<%= etc_dir %>/security-agent.yaml
 Type=simple
 PIDFile=<%= install_dir %>/run/security-agent.pid
 Restart=on-failure
+EnvironmentFile=-<%= etc_dir %>/environment
 ExecStart=<%= install_dir %>/embedded/bin/security-agent start -c <%= etc_dir %>/datadog.yaml -c <%= etc_dir %>/security-agent.yaml --sysprobe-config <%= etc_dir %>/system-probe.yaml -p <%= install_dir %>/run/security-agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.

--- a/omnibus/config/templates/init-scripts-agent/systemd.sysprobe.service.erb
+++ b/omnibus/config/templates/init-scripts-agent/systemd.sysprobe.service.erb
@@ -10,6 +10,7 @@ ConditionPathExists=<%= etc_dir %>/system-probe.yaml
 Type=simple
 PIDFile=<%= install_dir %>/run/system-probe.pid
 Restart=on-failure
+EnvironmentFile=-<%= etc_dir %>/environment
 ExecStart=<%= install_dir %>/embedded/bin/system-probe run --config=<%= etc_dir %>/system-probe.yaml --pid=<%= install_dir %>/run/system-probe.pid
 ExecReload=/bin/kill -HUP $MAINPID
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,

--- a/omnibus/config/templates/init-scripts-agent/systemd.trace.service.erb
+++ b/omnibus/config/templates/init-scripts-agent/systemd.trace.service.erb
@@ -8,6 +8,7 @@ Type=simple
 PIDFile=<%= install_dir %>/run/trace-agent.pid
 User=dd-agent
 Restart=on-failure
+EnvironmentFile=-<%= etc_dir %>/environment
 ExecStart=<%= install_dir %>/embedded/bin/trace-agent --config <%= etc_dir %>/datadog.yaml --pidfile <%= install_dir %>/run/trace-agent.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,
 # it is also supported to have it here.

--- a/releasenotes/notes/EnvironmentFile-for-other-Agent-services-091f6000c1eaa93f.yaml
+++ b/releasenotes/notes/EnvironmentFile-for-other-Agent-services-091f6000c1eaa93f.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - >
+    Results of `agent config` did not reflect the actual runtime config for the other services. 
+    This will have other Datadog Agent services (e.g. trace-agent) running as a systemd service read the same environment variables from a text file `/etc/datadog-agent/environment` as the core agent process.

--- a/releasenotes/notes/EnvironmentFile-for-other-Agent-services-091f6000c1eaa93f.yaml
+++ b/releasenotes/notes/EnvironmentFile-for-other-Agent-services-091f6000c1eaa93f.yaml
@@ -1,4 +1,4 @@
 fixes:
   - >
     Results of `agent config` did not reflect the actual runtime config for the other services. 
-    This will have other Datadog Agent services (e.g. trace-agent) running as a systemd service read the same environment variables from a text file `/etc/datadog-agent/environment` as the core agent process.
+    This will have other Datadog Agent services (e.g. trace-agent) running as a systemd service read the same environment variables from a text file `/etc/datadog-agent/environment` as the core Agent process.


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

- Adds EnvironmentFile to all systemd unit files
- Same as https://github.com/DataDog/datadog-agent/pull/16017 but applied to other Agent services

### Motivation

- Trace Agent did not pickup envvvars from `/etc/datadog-agent/environment`

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- create file `/etc/datadog-agent/environment` with content
```
DD_APM_NON_LOCAL_TRAFFIC=true
```
- Restart `datadog-agent-trace` 
- Check if trace-agent is listening on all interfaces instead of localhost: `netstat -plant |grep trace-agent`
  - expected:  `tcp6       0      0 :::8126                 :::*                    LISTEN      PID/trace-agent`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
