### PR TITLE
[CWS] first pass of cleanup to functional tests

### DIFF
--- a/pkg/security/tests/latency_test.go
+++ b/pkg/security/tests/latency_test.go
@@ -91,8 +91,7 @@ func benchLatencyDNS(t *testing.T, rule *rules.RuleDefinition, executable string
 	if rule != nil {
 		var ruleDefs []*rules.RuleDefinition
 		ruleDefs = append(ruleDefs, rule)
-		test, err := newTestModule(t, nil, ruleDefs,
-			testOpts{eventsCountThreshold: 1000000})
+		test, err := newTestModule(t, nil, ruleDefs, testOpts{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -311,7 +311,8 @@ func (to testOpts) Equal(opts testOpts) bool {
 		to.disableAbnormalPathCheck == opts.disableAbnormalPathCheck &&
 		to.disableRuntimeSecurity == opts.disableRuntimeSecurity &&
 		to.enableSBOM == opts.enableSBOM &&
-		to.snapshotRuleMatchHandler == nil && opts.snapshotRuleMatchHandler == nil
+		to.snapshotRuleMatchHandler == nil && opts.snapshotRuleMatchHandler == nil &&
+		to.preStartCallback == nil && opts.preStartCallback == nil
 }
 
 type testModule struct {

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -262,7 +262,6 @@ type testOpts struct {
 	anomalyDetectionMinimumStablePeriodDNS     time.Duration
 	anomalyDetectionWarmupPeriod               time.Duration
 	disableDiscarders                          bool
-	eventsCountThreshold                       int
 	disableERPCDentryResolution                bool
 	disableMapDentryResolution                 bool
 	envsWithValue                              []string
@@ -306,7 +305,6 @@ func (to testOpts) Equal(opts testOpts) bool {
 		to.anomalyDetectionWarmupPeriod == opts.anomalyDetectionWarmupPeriod &&
 		to.disableDiscarders == opts.disableDiscarders &&
 		to.disableFilters == opts.disableFilters &&
-		to.eventsCountThreshold == opts.eventsCountThreshold &&
 		to.disableERPCDentryResolution == opts.disableERPCDentryResolution &&
 		to.disableMapDentryResolution == opts.disableMapDentryResolution &&
 		reflect.DeepEqual(to.envsWithValue, opts.envsWithValue) &&
@@ -736,10 +734,6 @@ func genTestConfigs(dir string, opts testOpts, testDir string) (*emconfig.Config
 		return nil, nil, err
 	}
 
-	if opts.eventsCountThreshold == 0 {
-		opts.eventsCountThreshold = 100000000
-	}
-
 	if opts.activityDumpRateLimiter == 0 {
 		opts.activityDumpRateLimiter = 500
 	}
@@ -803,7 +797,6 @@ func genTestConfigs(dir string, opts testOpts, testDir string) (*emconfig.Config
 		"AnomalyDetectionMinimumStablePeriodExec":    opts.anomalyDetectionMinimumStablePeriodExec,
 		"AnomalyDetectionMinimumStablePeriodDNS":     opts.anomalyDetectionMinimumStablePeriodDNS,
 		"AnomalyDetectionWarmupPeriod":               opts.anomalyDetectionWarmupPeriod,
-		"EventsCountThreshold":                       opts.eventsCountThreshold,
 		"ErpcDentryResolutionEnabled":                erpcDentryResolutionEnabled,
 		"MapDentryResolutionEnabled":                 mapDentryResolutionEnabled,
 		"LogPatterns":                                logPatterns,

--- a/pkg/security/tests/overlayfs_test.go
+++ b/pkg/security/tests/overlayfs_test.go
@@ -106,7 +106,7 @@ func TestOverlayFS(t *testing.T) {
 	}
 	defer testDrive.Close()
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{testDir: testDrive.Root(), disableApprovers: true})
+	test, err := newTestModule(t, nil, ruleDefs, testOpts{testDir: testDrive.Root()})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -2256,7 +2256,7 @@ func TestKillAction(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{disableDiscarders: true, eventsCountThreshold: 1000})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR represents the first part from https://github.com/DataDog/datadog-agent/pull/20762, cleaning up some options provided to test modules. It also removes the option `eventsCountThreshold` that is not really used currently.


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
