### PR TITLE
[oracle] Adding Oracle Active Data Guard support

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/data_guard.go
+++ b/pkg/collector/corechecks/oracle-dbm/data_guard.go
@@ -37,7 +37,7 @@ func (c *Check) dataGuard() error {
 	var d vDatabase
 	err = getWrapper(c, &d, "SELECT database_role, open_mode FROM v$database")
 	if err != nil {
-		return fmt.Errorf("%s failed to query database role %w", c.logPrompt)
+		return fmt.Errorf("%s failed to query database role %w", c.logPrompt, err)
 	}
 	c.databaseRole = d.DatabaseRole
 	c.openMode = d.OpenMode

--- a/pkg/collector/corechecks/oracle-dbm/data_guard.go
+++ b/pkg/collector/corechecks/oracle-dbm/data_guard.go
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle
+
+package oracle
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle-dbm/common"
+)
+
+const invalidLagValue = 10000000
+
+func fixTags(c *Check) {
+	c.tags = make([]string, len(c.tagsWithoutDbRole))
+	copy(c.tags, c.tagsWithoutDbRole)
+	if c.databaseRole != "" {
+		roleTag := strings.ToLower(strings.ReplaceAll(string(c.databaseRole), " ", "_"))
+		c.tags = append(c.tags, "database_role:"+roleTag)
+	}
+	c.tagsString = strings.Join(c.tags, ",")
+}
+
+type dataguardStats struct {
+	Name  string          `db:"NAME"`
+	Value sql.NullFloat64 `db:"VALUE"`
+}
+
+func (c *Check) dataGuard() error {
+	if c.hostingType != selfManaged {
+		return nil
+	}
+	var n uint16
+	err := getWrapper(c, &n, "SELECT 1 n FROM v$dataguard_config WHERE ROWNUM = 1")
+	if err != nil {
+		return fmt.Errorf("failed to query v$dataguard_config %w", err)
+	}
+	if n != 1 {
+		return nil
+	}
+	var d vDatabase
+	err = getWrapper(c, &d, "SELECT database_role, open_mode FROM v$database")
+	if err != nil {
+		return fmt.Errorf("failed to query database role")
+	}
+	c.databaseRole = d.DatabaseRole
+	c.openMode = d.OpenMode
+	fixTags(c)
+
+	sender, err := c.GetSender()
+	if err != nil {
+		return fmt.Errorf("failed to initialize sender: %w", err)
+	}
+	var stats []dataguardStats
+	err = selectWrapper(c, &stats, `SELECT name, EXTRACT(DAY from TO_DSINTERVAL(value)*86400) value 
+	FROM v$dataguard_stats WHERE name IN ('apply lag','transport lag')`)
+	if err != nil {
+		return fmt.Errorf("failed to query data guard statistics %w", err)
+	}
+	for _, s := range stats {
+		var v float64
+		if s.Value.Valid {
+			v = s.Value.Float64
+		} else {
+			v = invalidLagValue
+		}
+		sender.Gauge(fmt.Sprintf("%s.%s", common.IntegrationName, strings.ReplaceAll(string(s.Name), " ", "_")), v, "", c.tags)
+	}
+	sender.Commit()
+	return nil
+}

--- a/pkg/collector/corechecks/oracle-dbm/init.go
+++ b/pkg/collector/corechecks/oracle-dbm/init.go
@@ -134,6 +134,7 @@ func (c *Check) init() error {
 	c.hostingType = ht
 	c.tagsWithoutDbRole = make([]string, len(tags))
 	copy(c.tagsWithoutDbRole, tags)
+	copy(c.tags, tags)
 
 	c.fqtEmitted = getFqtEmittedCache()
 	c.planEmitted = getPlanEmittedCache(c)

--- a/pkg/collector/corechecks/oracle-dbm/init.go
+++ b/pkg/collector/corechecks/oracle-dbm/init.go
@@ -10,15 +10,9 @@ package oracle
 import (
 	"database/sql"
 	"fmt"
-	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
-
-type vDatabase struct {
-	Name string `db:"NAME"`
-	Cdb  string `db:"CDB"`
-}
 
 type vInstance struct {
 	HostName     sql.NullString `db:"HOST_NAME"`
@@ -138,9 +132,8 @@ func (c *Check) init() error {
 
 	tags = append(tags, fmt.Sprintf("hosting_type:%s", ht))
 	c.hostingType = ht
-	c.tags = make([]string, len(tags))
-	copy(c.tags, tags)
-	c.tagsString = strings.Join(tags, ",")
+	c.tagsWithoutDbRole = make([]string, len(tags))
+	copy(c.tagsWithoutDbRole, tags)
 
 	c.fqtEmitted = getFqtEmittedCache()
 	c.planEmitted = getPlanEmittedCache(c)

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -171,7 +171,6 @@ func (c *Check) Run() error {
 	metricIntervalExpired := checkIntervalExpired(&c.metricLastRun, c.config.MetricCollectionInterval)
 
 	if metricIntervalExpired {
-		log.Tracef("%s fixtags here2", c.logPrompt)
 		if c.dbmEnabled {
 			err := c.dataGuard()
 			if err != nil {
@@ -224,7 +223,6 @@ func (c *Check) Run() error {
 	}
 
 	if c.dbmEnabled {
-		//if c.config.QuerySamples.Enabled && c.openMode != "MOUNTED" {
 		if c.config.QuerySamples.Enabled {
 			err := c.SampleSession()
 			if err != nil {

--- a/pkg/collector/corechecks/oracle-dbm/sql_wrappers.go
+++ b/pkg/collector/corechecks/oracle-dbm/sql_wrappers.go
@@ -31,6 +31,9 @@ func handleError(c *Check, db **sqlx.DB, err error) error {
 	if err == nil {
 		return err
 	}
+	if strings.Contains(err.Error(), "no rows in result") {
+		return nil
+	}
 	isPrivilegeError, err := handlePrivilegeError(c, err)
 	if err != nil && isPrivilegeError {
 		return err

--- a/releasenotes/notes/oracle-active-data-guard-d64cf6efbefcb3cf.yaml
+++ b/releasenotes/notes/oracle-active-data-guard-d64cf6efbefcb3cf.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add support for Oracle Active Data Guard.


### PR DESCRIPTION
### What does this PR do?

Adding Oracle Active Data Guard support.

### Describe how to test/QA your changes

Connect the Agent to a regular (no Data Guard), primary and standby database.

Stop log transportation and check the `transport_lag` and `apply_lag`.

Check that the `hosting_type` tag is initialized for all three databases. Check metrics, query metrics and FQT payloads.

Check that the `database_role` is initialized correctly for primary and standby. The database without the Data Guard configuration shouldn't have the tag.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
