### PR TITLE
Rename jmx check name prefix to dd.internal.jmx_check_name

### DIFF
--- a/comp/dogstatsd/server/enrich.go
+++ b/comp/dogstatsd/server/enrich.go
@@ -22,7 +22,7 @@ var (
 	entityIDTagPrefix    = "dd.internal.entity_id:"
 	entityIDIgnoreValue  = "none"
 	CardinalityTagPrefix = constants.CardinalityTagPrefix
-	jmxCheckNamePrefix   = "jmx_check_name:"
+	jmxCheckNamePrefix   = "dd.internal.jmx_check_name:"
 )
 
 // enrichConfig contains static parameters used in various enrichment

--- a/comp/dogstatsd/server/enrich_test.go
+++ b/comp/dogstatsd/server/enrich_test.go
@@ -1317,7 +1317,7 @@ func TestEnrichTags(t *testing.T) {
 		{
 			name: "opt-out, entity id present, uds origin present",
 			args: args{
-				tags:          []string{"env:prod", "dd.internal.entity_id:pod-uid", "dd.internal.card:none", "host:", "jmx_domain:org.apache", "jmx_check_name:customcheck"},
+				tags:          []string{"env:prod", "dd.internal.entity_id:pod-uid", "dd.internal.card:none", "host:", "jmx_domain:org.apache", "dd.internal.jmx_check_name:customcheck"},
 				originFromUDS: "originID",
 				originFromMsg: []byte("none"),
 				conf: enrichConfig{
@@ -1369,30 +1369,30 @@ func TestEnrichTagsWithJMXCheckName(t *testing.T) {
 		wantedMetricSource metrics.MetricSource
 	}{
 		{
-			name:               "jmx_check_name:kafka, should give MetricSourceKafka",
-			jmxCheckName:       "jmx_check_name:kafka",
-			tags:               []string{"env:prod", "jmx_check_name:kafka"},
+			name:               "dd.internal.jmx_check_name:kafka, should give MetricSourceKafka",
+			jmxCheckName:       "dd.internal.jmx_check_name:kafka",
+			tags:               []string{"env:prod", "dd.internal.jmx_check_name:kafka"},
 			wantedTags:         []string{"env:prod"},
 			wantedMetricSource: metrics.MetricSourceKafka,
 		},
 		{
-			name:               "jmx_check_name:cassandra, should give MetricSourceCassandra",
-			jmxCheckName:       "jmx_check_name:cassandra",
-			tags:               []string{"foo", "jmx_check_name:cassandra"},
+			name:               "dd.internal.jmx_check_name:cassandra, should give MetricSourceCassandra",
+			jmxCheckName:       "dd.internal.jmx_check_name:cassandra",
+			tags:               []string{"foo", "dd.internal.jmx_check_name:cassandra"},
 			wantedTags:         []string{"foo"},
 			wantedMetricSource: metrics.MetricSourceCassandra,
 		},
 		{
-			name:               "jmx_check_name:tomcat, with jmx_domain tag should still set MetricSource",
-			jmxCheckName:       "jmx_check_name:tomcat",
-			tags:               []string{"foo", "jmx_domain:testdomain", "jmx_check_name:tomcat"},
+			name:               "dd.internal.jmx_check_name:tomcat, with jmx_domain tag should still set MetricSource",
+			jmxCheckName:       "dd.internal.jmx_check_name:tomcat",
+			tags:               []string{"foo", "jmx_domain:testdomain", "dd.internal.jmx_check_name:tomcat"},
 			wantedTags:         []string{"foo", "jmx_domain:testdomain"},
 			wantedMetricSource: metrics.MetricSourceTomcat,
 		},
 		{
-			name:               "jmx_check_name:thisisacustomcheck, should give MetricSourceJmxCustom",
-			jmxCheckName:       "jmx_check_name:thisisacustomcheck",
-			tags:               []string{"env:prod", "jmx_check_name:thisisacustomcheck"},
+			name:               "dd.internal.jmx_check_name:thisisacustomcheck, should give MetricSourceJmxCustom",
+			jmxCheckName:       "dd.internal.jmx_check_name:thisisacustomcheck",
+			tags:               []string{"env:prod", "dd.internal.jmx_check_name:thisisacustomcheck"},
 			wantedTags:         []string{"env:prod"},
 			wantedMetricSource: metrics.MetricSourceJmxCustom,
 		},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Renames jmx check name prefix to dd.internal.jmx_check_name
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Makes the tag more unique in case customers are already using `jmx_check_name`
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
See https://github.com/DataDog/datadog-agent/pull/20567
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
