### PR TITLE
[CWS] add internal dump

### DIFF
--- a/pkg/security/events/custom.go
+++ b/pkg/security/events/custom.go
@@ -60,6 +60,10 @@ const (
 
 	// RefreshUserCacheRuleID is the rule ID used to refresh users and groups cache
 	RefreshUserCacheRuleID = "refresh_user_cache"
+
+	// InternalCoreDumpRuleID
+	InternalCoreDumpRuleID   = "internal_core_dump"
+	InternalCoreDumpRuleDesc = "Internal Core Dump"
 )
 
 // CustomEventCommonFields represents the fields common to all custom events
@@ -92,6 +96,7 @@ func AllCustomRuleIDs() []string {
 		AnomalyDetectionRuleID,
 		NoProcessContextErrorRuleID,
 		BrokenProcessLineageErrorRuleID,
+		InternalCoreDumpRuleID,
 	}
 }
 

--- a/pkg/security/events/rate_limiter.go
+++ b/pkg/security/events/rate_limiter.go
@@ -38,6 +38,7 @@ var (
 		AbnormalPathRuleID:              NewStdLimiter(rate.Every(30*time.Second), 1),
 		NoProcessContextErrorRuleID:     NewStdLimiter(rate.Every(30*time.Second), 1),
 		BrokenProcessLineageErrorRuleID: NewStdLimiter(rate.Every(30*time.Second), 1),
+		InternalCoreDumpRuleID:          NewStdLimiter(rate.Every(30*time.Second), 1),
 	}
 )
 

--- a/pkg/security/module/server_linux.go
+++ b/pkg/security/module/server_linux.go
@@ -32,7 +32,7 @@ func (a *APIServer) DumpDiscarders(ctx context.Context, params *api.DumpDiscarde
 func (a *APIServer) DumpProcessCache(ctx context.Context, params *api.DumpProcessCacheParams) (*api.SecurityDumpProcessCacheMessage, error) { //nolint:revive // TODO fix revive unused-parameter
 	resolvers := a.probe.GetResolvers()
 
-	filename, err := resolvers.ProcessResolver.Dump(params.WithArgs)
+	filename, err := resolvers.ProcessResolver.ToDot(params.WithArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/probe/coredump.go
+++ b/pkg/security/probe/coredump.go
@@ -1,0 +1,87 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package probe
+
+import (
+	"bytes"
+	"compress/gzip"
+	json "encoding/json"
+
+	"github.com/DataDog/datadog-agent/pkg/security/events"
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+)
+
+// CoreDump defines an internal core dump
+type CoreDump struct {
+	resolvers  *resolvers.Resolvers
+	definition *rules.CoreDumpDefinition
+	event      events.EventMarshaler
+}
+
+// NewCoreDump returns a new core dump
+func NewCoreDump(def *rules.CoreDumpDefinition, resolvers *resolvers.Resolvers, event events.EventMarshaler) *CoreDump {
+	return &CoreDump{
+		resolvers:  resolvers,
+		definition: def,
+		event:      event,
+	}
+}
+
+func (cd *CoreDump) ToJSON() ([]byte, error) {
+	data, err := cd.event.ToJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	content := struct {
+		Event   json.RawMessage
+		Process json.RawMessage
+		Mount   json.RawMessage
+		Dentry  json.RawMessage
+	}{
+		Event: data,
+	}
+
+	if cd.definition.Process {
+		data, _ := cd.resolvers.ProcessResolver.ToJSON()
+		content.Process = data
+	}
+
+	if cd.definition.Mount {
+		data, _ := cd.resolvers.MountResolver.ToJSON()
+		content.Mount = data
+	}
+
+	if cd.definition.Dentry {
+		data, _ := cd.resolvers.DentryResolver.ToJSON()
+		content.Dentry = data
+	}
+
+	data, err = json.Marshal(content)
+	if err != nil {
+		return nil, err
+	}
+
+	if cd.definition.NoCompression {
+		return data, nil
+	}
+
+	buf := &bytes.Buffer{}
+	gzWriter := gzip.NewWriter(buf)
+	gzWriter.Write(data)
+	gzWriter.Close()
+
+	dump := struct {
+		Data []byte
+	}{
+		Data: buf.Bytes(),
+	}
+
+	return json.Marshal(dump)
+}

--- a/pkg/security/resolvers/dentry/resolver.go
+++ b/pkg/security/resolvers/dentry/resolver.go
@@ -9,6 +9,7 @@
 package dentry
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -747,6 +748,47 @@ func (dr *Resolver) Start(manager *manager.Manager) error {
 	model.ByteOrder.PutUint32(dr.erpcRequest.Data[24:28], uint32(dr.erpcSegmentSize))
 
 	return nil
+}
+
+// ToJSON return a json version of the cache
+func (dr *Resolver) ToJSON() ([]byte, error) {
+	dump := struct {
+		Entries []json.RawMessage
+	}{}
+
+	for mountID, cache := range dr.cache {
+		e := struct {
+			MountID uint32
+			Entries []struct {
+				PathKey   model.PathKey
+				PathEntry PathEntry
+			}
+		}{
+			MountID: mountID,
+		}
+
+		for _, key := range cache.Keys() {
+			value, exists := cache.Get(key)
+			if !exists {
+				continue
+			}
+
+			e.Entries = append(e.Entries, struct {
+				PathKey   model.PathKey
+				PathEntry PathEntry
+			}{
+				PathKey:   key,
+				PathEntry: value,
+			})
+		}
+
+		data, err := json.Marshal(e)
+		if err == nil {
+			dump.Entries = append(dump.Entries, data)
+		}
+	}
+
+	return json.Marshal(dump)
 }
 
 // Close cleans up the eRPC segment

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -9,6 +9,7 @@
 package mount
 
 import (
+	"encoding/json"
 	"path"
 	"strings"
 	"sync"
@@ -605,6 +606,25 @@ func (mr *Resolver) SendStats() error {
 	}
 
 	return mr.statsdClient.Gauge(metrics.MetricMountResolverCacheSize, float64(len(mr.mounts)), []string{}, 1.0)
+}
+
+// ToJSON return a json version of the cache
+func (mr *Resolver) ToJSON() ([]byte, error) {
+	dump := struct {
+		Entries []json.RawMessage
+	}{}
+
+	mr.lock.RLock()
+	defer mr.lock.RUnlock()
+
+	for _, mount := range mr.mounts {
+		d, err := json.Marshal(mount)
+		if err == nil {
+			dump.Entries = append(dump.Entries, d)
+		}
+	}
+
+	return json.Marshal(dump)
 }
 
 // NewResolver instantiates a new mount resolver

--- a/pkg/security/rules/bundled_policy_provider_linux.go
+++ b/pkg/security/rules/bundled_policy_provider_linux.go
@@ -15,7 +15,7 @@ var bundledPolicyRules = []*rules.RuleDefinition{{
 	ID:         events.RefreshUserCacheRuleID,
 	Expression: `rename.file.destination.path in [ "/etc/passwd", "/etc/group" ]`,
 	Actions: []rules.ActionDefinition{{
-		InternalCallbackDefinition: &rules.InternalCallbackDefinition{},
+		InternalCallback: &rules.InternalCallbackDefinition{},
 	}},
 	Silent: true,
 }}

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -119,14 +119,15 @@ func (rd *RuleDefinition) MergeWith(rd2 *RuleDefinition) error {
 
 // ActionDefinition describes a rule action section
 type ActionDefinition struct {
-	Set                        *SetDefinition `yaml:"set"`
-	InternalCallbackDefinition *InternalCallbackDefinition
-	Kill                       *KillDefinition `yaml:"kill"`
+	Set              *SetDefinition `yaml:"set"`
+	InternalCallback *InternalCallbackDefinition
+	Kill             *KillDefinition     `yaml:"kill"`
+	CoreDump         *CoreDumpDefinition `yaml:"coredump"`
 }
 
 // Check returns an error if the action in invalid
 func (a *ActionDefinition) Check() error {
-	if a.Set == nil && a.InternalCallbackDefinition == nil && a.Kill == nil {
+	if a.Set == nil && a.InternalCallback == nil && a.Kill == nil && a.CoreDump == nil {
 		return errors.New("either 'set' or 'kill' section of an action must be specified")
 	}
 
@@ -173,6 +174,14 @@ type InternalCallbackDefinition struct{}
 // KillDefinition describes the 'kill' section of a rule action
 type KillDefinition struct {
 	Signal string `yaml:"signal"`
+}
+
+// CoreDump describes the 'coredump' action
+type CoreDumpDefinition struct {
+	Process       bool `yaml:"process"`
+	Mount         bool `yaml:"mount"`
+	Dentry        bool `yaml:"dentry"`
+	NoCompression bool `yaml:"no_compression"`
 }
 
 // Rule describes a rule of a ruleset


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR adds a way to generate an event with a dump of the major cache used by CWS based on a rule action

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
