### PR TITLE
Fix typed nil returned from metrics provider

### DIFF
--- a/pkg/util/containers/metrics/provider/provider.go
+++ b/pkg/util/containers/metrics/provider/provider.go
@@ -106,7 +106,12 @@ func newProvider() *GenericProvider {
 // The best collector may change depending on other collectors availability.
 // You should not cache the result from this function.
 func (mp *GenericProvider) GetCollector(runtime string) Collector {
-	return mp.collectors[Runtime(runtime)]
+	// we can't return mp.collectors[runtime] directly because it will return a typed nil
+	if runtime, found := mp.collectors[Runtime(runtime)]; found {
+		return runtime
+	}
+
+	return nil
 }
 
 // GetMetaCollector returns the meta collector.


### PR DESCRIPTION
### What does this PR do?

Fix a panic when calling metrics provider if no provider is available for a given runtime due to returning a typed nil.

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

A scenario involving this is run `integration-core` CI. Manual QA as part of parent PR #20273

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
