### PR TITLE
Add JMX wildcard_domain_query_count and bean_match_ratio to agent status

### DIFF
--- a/pkg/status/templates/jmxfetch.tmpl
+++ b/pkg/status/templates/jmxfetch.tmpl
@@ -65,9 +65,8 @@ JMXFetch
       instance_bean_count: {{ .instance_bean_count }}
       instance_attribute_count: {{ .instance_attribute_count }}
       instance_metric_count: {{ .instance_metric_count }}
-      instance_domains_queried: {{ .instance_domains_queried }}
-      instance_wildcard_query_count: {{ .instance_wildcard_query_count }}
-      instance_attribute_match_ratio: {{ .instance_attribute_match_ratio }}
+      instance_wildcard_domain_query_count: {{ .instance_wildcard_domain_query_count }}
+      instance_bean_match_ratio: {{ .instance_bean_match_ratio }}
           {{- end -}}
       {{- end }}
     {{- end }}

--- a/pkg/status/templates/jmxfetch.tmpl
+++ b/pkg/status/templates/jmxfetch.tmpl
@@ -65,6 +65,9 @@ JMXFetch
       instance_bean_count: {{ .instance_bean_count }}
       instance_attribute_count: {{ .instance_attribute_count }}
       instance_metric_count: {{ .instance_metric_count }}
+      instance_domains_queried: {{ .instance_domains_queried }}
+      instance_wildcard_query_count: {{ .instance_wildcard_query_count }}
+      instance_attribute_match_ratio: {{ .instance_attribute_match_ratio }}
           {{- end -}}
       {{- end }}
     {{- end }}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Displays `instance_wildcard_domain_query_count` and `instance_bean_match_ratio` under JMXFetch when `agent status -v` is run.
<img width="335" alt="image" src="https://github.com/DataDog/datadog-agent/assets/35050708/a06ee1b2-48fc-41d5-bce7-de050e8d694e">

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Display telemetry for bean/attribute matching

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Related to https://github.com/DataDog/jmxfetch/pull/487
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Run `agent status -v` with jmx instance running and observe the output.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
