### PR TITLE
remove go from KMT microvms

### DIFF
--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -357,7 +357,7 @@ kernel_matrix_testing_setup_env:
     - GO_VERSION=$(inv go-version)
     - !reference [.setup_ssh_config]
     # ssh into each micro-vm and run initialization script. This script will also run the tests.
-    - NESTED_VM_CMD="/home/ubuntu/connector -host ${MICRO_VM_IP} -user root -ssh-file /home/kernel-version-testing/ddvm_rsa -vm-cmd 'bash /root/fetch_dependencies.sh ${ARCH} && /micro-vm-init.sh ${GO_VERSION} ${RETRY} ${ARCH}'"
+    - NESTED_VM_CMD="/home/ubuntu/connector -host ${MICRO_VM_IP} -user root -ssh-file /home/kernel-version-testing/ddvm_rsa -vm-cmd 'bash /root/fetch_dependencies.sh ${ARCH} && /micro-vm-init.sh ${RETRY} ${ARCH}'"
     - $CI_PROJECT_DIR/connector-$ARCH -host $INSTANCE_IP -user ubuntu -ssh-file $AWS_EC2_SSH_KEY_FILE -vm-cmd "${NESTED_VM_CMD}"
     - ssh metal_instance "scp ${MICRO_VM_IP}:/ci-visibility/junit.tar.gz /home/ubuntu/junit.tar.gz"
     - ssh metal_instance "scp ${MICRO_VM_IP}:/ci-visibility/testjson.tar.gz /home/ubuntu/testjson.tar.gz"

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -20,7 +20,6 @@ from .kernel_matrix_testing.init_kmt import (
 )
 from .kernel_matrix_testing.tool import Exit, ask, info, warn
 from .system_probe import EMBEDDED_SHARE_DIR
-from .update_go import _get_repo_go_version
 
 try:
     from tabulate import tabulate
@@ -360,10 +359,7 @@ def prepare(ctx, vms, stack=None, arch=None, ssh_key="", rebuild_deps=False, pac
 
 
 @task
-def test(ctx, vms, stack=None, packages="", run=None, retry=2, rebuild_deps=False, ssh_key="", go_version=None):
-    if not go_version:
-        go_version = _get_repo_go_version()
-
+def test(ctx, vms, stack=None, packages="", run=None, retry=2, rebuild_deps=False, ssh_key=""):
     stack = check_and_get_stack(stack)
     if not stacks.stack_exists(stack):
         raise Exit(f"Stack {stack} does not exist. Please create with 'inv kmt.stack-create --stack=<name>'")
@@ -378,7 +374,7 @@ def test(ctx, vms, stack=None, packages="", run=None, retry=2, rebuild_deps=Fals
     run_cmd_vms(
         ctx,
         stack,
-        f"bash /micro-vm-init.sh {go_version} {retry} {platform.machine()} {' '.join(args)}",
+        f"bash /micro-vm-init.sh {retry} {platform.machine()} {' '.join(args)}",
         target_vms,
         "",
         allow_fail=True,

--- a/test/new-e2e/system-probe/config/vmconfig.json
+++ b/test/new-e2e/system-probe/config/vmconfig.json
@@ -9,52 +9,52 @@
                 {
                     "dir": "bionic-server-cloudimg-amd64.qcow2",
                     "tag": "ubuntu_18.04",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bionic-server-cloudimg-amd64.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/bionic-server-cloudimg-amd64.qcow2.xz"
                 },
                 {
                     "dir": "focal-server-cloudimg-amd64.qcow2",
                     "tag": "ubuntu_20.04",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/focal-server-cloudimg-amd64.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/focal-server-cloudimg-amd64.qcow2.xz"
                 },
                 {
                     "dir": "jammy-server-cloudimg-amd64.qcow2",
                     "tag": "ubuntu_22.04",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/jammy-server-cloudimg-amd64.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/jammy-server-cloudimg-amd64.qcow2.xz"
                 },
                 {
                     "dir": "amzn2-kvm-2.0-amd64-4.14.qcow2",
                     "tag": "amzn_4.14",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-amd64-4.14.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/amzn2-kvm-2.0-amd64-4.14.qcow2.xz"
                 },
                 {
                     "dir": "amzn2-kvm-2.0-amd64-5.4.qcow2",
                     "tag": "amzn_5.4",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-amd64-5.4.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/amzn2-kvm-2.0-amd64-5.4.qcow2.xz"
                 },
                 {
                     "dir": "amzn2-kvm-2.0-amd64-5.10.qcow2",
                     "tag": "amzn_5.10",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-amd64-5.10.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/amzn2-kvm-2.0-amd64-5.10.qcow2.xz"
                 },
                 {
                     "dir": "Fedora-Cloud-Base-37.amd64.qcow2",
                     "tag": "fedora_37",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-37.amd64.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/Fedora-Cloud-Base-37.amd64.qcow2.xz"
                 },
                 {
                     "dir": "Fedora-Cloud-Base-38.amd64.qcow2",
                     "tag": "fedora_38",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-38.amd64.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/Fedora-Cloud-Base-38.amd64.qcow2.xz"
                 },
                 {
                     "dir": "debian-10-generic-amd64.qcow2",
                     "tag": "debian_10",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/debian-10-generic-amd64.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/debian-10-generic-amd64.qcow2.xz"
                 },
                 {
                     "dir": "debian-11-generic-amd64.qcow2",
                     "tag": "debian_11",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/debian-11-generic-amd64.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/debian-11-generic-amd64.qcow2.xz"
                 }
             ],
             "vcpu": [
@@ -66,7 +66,7 @@
             "disks": [
                 {
                     "mount_point": "/mnt/docker",
-                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/docker-amd64.qcow2",
+                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/docker-amd64.qcow2",
                     "target": "/home/kernel-version-testing/docker-amd64.qcow2",
                     "type": "default"
                 }
@@ -81,37 +81,37 @@
                 {
                     "dir": "focal-server-cloudimg-arm64.qcow2",
                     "tag": "ubuntu_20.04",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/focal-server-cloudimg-arm64.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/focal-server-cloudimg-arm64.qcow2.xz"
                 },
                 {
                     "dir": "jammy-server-cloudimg-arm64.qcow2",
                     "tag": "ubuntu_22.04",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/jammy-server-cloudimg-arm64.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/jammy-server-cloudimg-arm64.qcow2.xz"
                 },
                 {
                     "dir": "amzn2-kvm-2.0-arm64-4.14.qcow2",
                     "tag": "amzn_4.14",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-arm64-4.14.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/amzn2-kvm-2.0-arm64-4.14.qcow2.xz"
                 },
                 {
                     "dir": "amzn2-kvm-2.0-arm64-5.4.qcow2",
                     "tag": "amzn_5.4",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-arm64-5.4.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/amzn2-kvm-2.0-arm64-5.4.qcow2.xz"
                 },
                 {
                     "dir": "amzn2-kvm-2.0-arm64-5.10.qcow2",
                     "tag": "amzn_5.10",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/amzn2-kvm-2.0-arm64-5.10.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/amzn2-kvm-2.0-arm64-5.10.qcow2.xz"
                 },
                 {
                     "dir": "Fedora-Cloud-Base-37.arm64.qcow2",
                     "tag": "fedora_37",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-37.arm64.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/Fedora-Cloud-Base-37.arm64.qcow2.xz"
                 },
                 {
                     "dir": "Fedora-Cloud-Base-38.arm64.qcow2",
                     "tag": "fedora_38",
-                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/Fedora-Cloud-Base-38.arm64.qcow2.xz"
+                    "image_source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/Fedora-Cloud-Base-38.arm64.qcow2.xz"
                 }
             ],
             "machine": "virt",
@@ -124,7 +124,7 @@
             "disks": [
                 {
                     "mount_point": "/mnt/docker",
-                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/docker-arm64.qcow2",
+                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/docker-arm64.qcow2",
                     "target": "/home/kernel-version-testing/docker-arm64.qcow2",
                     "type": "default"
                 }

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -18,6 +18,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -49,6 +50,7 @@ const (
 
 var BaseEnv = map[string]interface{}{
 	"GITLAB_CI":                "true", // force color output support to be detected
+	"GOVERSION":                runtime.Version(),
 	"DD_SYSTEM_PROBE_BPF_DIR":  filepath.Join(TestDirRoot, "pkg/ebpf/bytecode/build"),
 	"DD_SYSTEM_PROBE_JAVA_DIR": filepath.Join(TestDirRoot, "pkg/network/protocols/tls/java"),
 }

--- a/test/new-e2e/system-probe/test/micro-vm-init.sh
+++ b/test/new-e2e/system-probe/test/micro-vm-init.sh
@@ -2,16 +2,13 @@
 
 set -eo xtrace
 
-GOVERSION=$1
-RETRY_COUNT=$2
-ARCH=$3
-RUNNER_CMD="$(shift 3; echo "$*")"
+RETRY_COUNT=$1
+ARCH=$2
+RUNNER_CMD="$(shift 2; echo "$*")"
 
 KITCHEN_DOCKERS=/kitchen-docker
 
 # Add provisioning steps here !
-## Set go version correctly
-eval $(gimme "$GOVERSION")
 ## Start docker
 systemctl start docker
 ## Load docker images


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Removes attempt to use `gimme` in micro VMs. 

### Motivation

We don't need Go within the micro VMs.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
