### PR TITLE
[SNMP] Run traps server as a separate `fx.App`

### DIFF
--- a/comp/snmptraps/bundle.go
+++ b/comp/snmptraps/bundle.go
@@ -8,13 +8,7 @@
 package snmptraps
 
 import (
-	"github.com/DataDog/datadog-agent/comp/snmptraps/config/configimpl"
-	"github.com/DataDog/datadog-agent/comp/snmptraps/formatter/formatterimpl"
-	"github.com/DataDog/datadog-agent/comp/snmptraps/forwarder/forwarderimpl"
-	"github.com/DataDog/datadog-agent/comp/snmptraps/listener/listenerimpl"
-	"github.com/DataDog/datadog-agent/comp/snmptraps/oidresolver/oidresolverimpl"
 	"github.com/DataDog/datadog-agent/comp/snmptraps/server/serverimpl"
-	"github.com/DataDog/datadog-agent/comp/snmptraps/status/statusimpl"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -22,11 +16,5 @@ import (
 
 // Bundle defines the fx options for this bundle.
 var Bundle = fxutil.Bundle(
-	configimpl.Module,
-	formatterimpl.Module,
-	forwarderimpl.Module,
-	listenerimpl.Module,
-	oidresolverimpl.Module,
-	statusimpl.Module,
 	serverimpl.Module,
 )

--- a/comp/snmptraps/server/component.go
+++ b/comp/snmptraps/server/component.go
@@ -11,4 +11,7 @@ package server
 // team: network-device-monitoring
 
 // Component is the component type.
-type Component interface{}
+type Component interface {
+	Running() bool
+	Error() error
+}

--- a/comp/snmptraps/server/serverimpl/server.go
+++ b/comp/snmptraps/server/serverimpl/server.go
@@ -49,6 +49,7 @@ type injections struct {
 	HNService hostname.Component
 	Demux     demultiplexer.Component
 	Logger    log.Component
+	Status    status.Component
 }
 
 // TrapsServer implements the SNMP traps service.
@@ -84,13 +85,13 @@ func newServer(lc fx.Lifecycle, deps dependencies) server.Component {
 			HNService: deps.HNService,
 			Demux:     deps.Demux,
 			Logger:    deps.Logger,
+			Status:    stat,
 		}),
 		configimpl.Module,
 		formatterimpl.Module,
 		forwarderimpl.Module,
 		listenerimpl.Module,
 		oidresolverimpl.Module,
-		fx.Provide(stat),
 		fx.Invoke(func(_ forwarder.Component, _ listener.Component) {}),
 	)
 	server := &TrapsServer{app: app, stat: stat}

--- a/comp/snmptraps/server/serverimpl/server.go
+++ b/comp/snmptraps/server/serverimpl/server.go
@@ -42,6 +42,7 @@ type dependencies struct {
 	Logger    log.Component
 }
 
+// injections bundles the injectables passed from the main app to the subapp.
 type injections struct {
 	fx.Out
 	Conf      config.Component
@@ -102,6 +103,7 @@ func newServer(lc fx.Lifecycle, deps dependencies) server.Component {
 		OnStart: func(ctx context.Context) error {
 			err := app.Start(ctx)
 			if err != nil {
+				deps.Logger.Errorf("Failed to start snmp-traps server: %s", err)
 				server.stat.SetStartError(err)
 			} else {
 				server.running = true

--- a/comp/snmptraps/status/component.go
+++ b/comp/snmptraps/status/component.go
@@ -15,4 +15,6 @@ type Component interface {
 	GetTrapsPackets() int64
 	AddTrapsPacketsAuthErrors(int64)
 	GetTrapsPacketsAuthErrors() int64
+	SetStartError(error)
+	GetStartError() error
 }

--- a/comp/snmptraps/status/statusimpl/mock.go
+++ b/comp/snmptraps/status/statusimpl/mock.go
@@ -27,6 +27,7 @@ func newMock() status.Component {
 type mockManager struct {
 	trapsPackets, trapsPacketsAuthErrors int64
 	lock                                 sync.Mutex
+	err                                  error
 }
 
 func (s *mockManager) AddTrapsPackets(i int64) {
@@ -51,4 +52,14 @@ func (s *mockManager) GetTrapsPacketsAuthErrors() int64 {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	return s.trapsPacketsAuthErrors
+}
+
+func (s *mockManager) SetStartError(err error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.err = err
+}
+
+func (s *mockManager) GetStartError() error {
+	return s.err
 }


### PR DESCRIPTION
### What does this PR do?

This PR removes the components of the SNMP traps server from the main agent `fx.App`, except for the server itself, and causes the server run a separate `fx.App` for the traps server.

This means that

1. No components will even be initialized if the traps server is disabled by configuration, and
2. Any errors generated by server initialization or startup can be logged and exposed to the agent status view, but will *not* be returned to fx, so the rest of the agent will run normally even if the traps service fails.

### Motivation

The original SNMP traps PR, #19789, caused incident 23581 by breaking unrelated tests, and was reverted by #20773.

The tests broke for two reasons:

1. The `OIDResolver` component was always initialized, regardless of whether the agent was configured to enable the traps server. This initialization requires reading a database of traps from disk, and fails if there are no files in the directory it is expecting to find data in.
3. Each component of the traps service was registered with the main `fx.App` for the agent, and `fx` aborts the whole application if any component fails to initialize.

Separating the traps server into its own subapplication means that none of its subcomponents are even initialized unless the server is configured to run. It also means that the server can trap errors in the subapplication and report them without causing fx to abort the rest of the application.

### Additional Notes

Some dependency injection frameworks have native support for this sort of "subinjector" pattern, but to the best of my knowledge `uber.fx` does not, so the closest thing is to simply run an unrelated `fx.App` and forward errors etc. to the main one as needed. If this is a pattern we want to use more generally, we might consider proposing it as a feature of `uber.fx`.

This PR is based against #20806, which is simply a copy of the now-reverted
#19789, so that the diff highlights what is changed compared to the broken version.

This is part of both NDMII-2298 and NDMII-287.

### Possible Drawbacks / Trade-offs

It muddies the component structure a little to have components that aren't actually registered with the primary app.

Perhaps these should all be moved to a subdirectory of `serverimpl` and removed from `comp/README.md` to reflect the fact that they are implementation details of the server and not intended for general use?

### Describe how to test/QA your changes

The behavior of the SNMP traps server should not change, so basic SNMP traps QA should suffice.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
