### PR TITLE
usm: tests: Fixed classification tests flakiness

### DIFF
--- a/pkg/network/protocols/amqp/server.go
+++ b/pkg/network/protocols/amqp/server.go
@@ -29,5 +29,5 @@ func RunServer(t testing.TB, serverAddr, serverPort string) error {
 
 	t.Helper()
 	dir, _ := testutil.CurDir()
-	return protocolsUtils.RunDockerServer(t, "amqp", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile(fmt.Sprintf(".*started TCP listener on .*%s.*", serverPort)), protocolsUtils.DefaultTimeout)
+	return protocolsUtils.RunDockerServer(t, "amqp", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile(fmt.Sprintf(".*started TCP listener on .*%s.*", serverPort)), protocolsUtils.DefaultTimeout, 3)
 }

--- a/pkg/network/protocols/amqp/testdata/docker-compose.yml
+++ b/pkg/network/protocols/amqp/testdata/docker-compose.yml
@@ -8,3 +8,9 @@ services:
     environment:
       - "RABBITMQ_DEFAULT_PASS=${PASS:-guest}"
       - "RABBITMQ_DEFAULT_USER=${USER:-guest}"
+    networks:
+      - amqp
+
+networks:
+  amqp:
+    driver: bridge

--- a/pkg/network/protocols/kafka/server.go
+++ b/pkg/network/protocols/kafka/server.go
@@ -24,5 +24,5 @@ func RunServer(t testing.TB, serverAddr, serverPort string) error {
 
 	t.Helper()
 	dir, _ := testutil.CurDir()
-	return protocolsUtils.RunDockerServer(t, "kafka", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile(`.*started \(kafka.server.KafkaServer\).*`), 3*time.Minute)
+	return protocolsUtils.RunDockerServer(t, "kafka", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile(`.*started \(kafka.server.KafkaServer\).*`), 1*time.Minute, 3)
 }

--- a/pkg/network/protocols/kafka/testdata/docker-compose.yml
+++ b/pkg/network/protocols/kafka/testdata/docker-compose.yml
@@ -7,6 +7,10 @@ services:
       - "2181:2181"
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
+    networks:
+      - kafka
+    tmpfs:
+      - /bitnami/zookeeper/data
   kafka:
     image: bitnami/kafka:3.4
     ports:
@@ -20,5 +24,14 @@ services:
       - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
       - ALLOW_PLAINTEXT_LISTENER=yes
       - KAFKA_CFG_DELETE_TOPIC_ENABLE=true
+      - KAFKA_CFG_ZOOKEEPER_CONNECTION_TIMEOUT_MS=30000
     depends_on:
       - zookeeper
+    networks:
+      - kafka
+    tmpfs:
+      - /bitnami/kafka/data
+
+networks:
+  kafka:
+    driver: bridge

--- a/pkg/network/protocols/mongo/server.go
+++ b/pkg/network/protocols/mongo/server.go
@@ -27,5 +27,5 @@ func RunServer(t testing.TB, serverAddress, serverPort string) error {
 		"MONGO_PASSWORD=" + Pass,
 	}
 	dir, _ := testutil.CurDir()
-	return protocolsUtils.RunDockerServer(t, "mongo", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile(fmt.Sprintf(".*Waiting for connections.*port.*:%s.*", serverPort)), protocolsUtils.DefaultTimeout)
+	return protocolsUtils.RunDockerServer(t, "mongo", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile(fmt.Sprintf(".*Waiting for connections.*port.*:%s.*", serverPort)), protocolsUtils.DefaultTimeout, 3)
 }

--- a/pkg/network/protocols/mongo/testdata/docker-compose.yml
+++ b/pkg/network/protocols/mongo/testdata/docker-compose.yml
@@ -7,3 +7,11 @@ services:
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_USER:-root}
       - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD:-password}
+    networks:
+      - mongo
+    tmpfs:
+      - /data/db
+
+networks:
+  mongo:
+    driver: bridge

--- a/pkg/network/protocols/mysql/server.go
+++ b/pkg/network/protocols/mysql/server.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 	protocolsUtils "github.com/DataDog/datadog-agent/pkg/network/protocols/testutil"
@@ -29,5 +28,5 @@ func RunServer(t testing.TB, serverAddr, serverPort string) error {
 
 	t.Helper()
 	dir, _ := testutil.CurDir()
-	return protocolsUtils.RunDockerServer(t, "MYSQL", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile(fmt.Sprintf(".*ready for connections.*port: %s.*", serverPort)), 10*time.Minute)
+	return protocolsUtils.RunDockerServer(t, "MYSQL", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile(fmt.Sprintf(".*ready for connections.*port: %s.*", serverPort)), protocolsUtils.DefaultTimeout, 3)
 }

--- a/pkg/network/protocols/mysql/testdata/docker-compose.yml
+++ b/pkg/network/protocols/mysql/testdata/docker-compose.yml
@@ -10,4 +10,9 @@ services:
       - ${MYSQL_ADDR:-127.0.0.1}:${MYSQL_PORT:-3306}:3306
     tmpfs:
       - /var/lib/mysql
+    networks:
+      - mysql
 
+networks:
+  mysql:
+    driver: bridge

--- a/pkg/network/protocols/postgres/server.go
+++ b/pkg/network/protocols/postgres/server.go
@@ -23,5 +23,5 @@ func RunServer(t testing.TB, serverAddr string, serverPort string) error {
 
 	dir, _ := testutil.CurDir()
 
-	return protocolsUtils.RunDockerServer(t, "postgres", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile(`.*\[1].*database system is ready to accept connections`), protocolsUtils.DefaultTimeout)
+	return protocolsUtils.RunDockerServer(t, "postgres", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile(`.*\[1].*database system is ready to accept connections`), protocolsUtils.DefaultTimeout, 3)
 }

--- a/pkg/network/protocols/postgres/testdata/docker-compose.yml
+++ b/pkg/network/protocols/postgres/testdata/docker-compose.yml
@@ -10,3 +10,9 @@ services:
      POSTGRES_USER: admin
      POSTGRES_PASSWORD: password
      POSTGRES_DB: testdb
+   networks:
+     - postgres
+
+networks:
+  postgres:
+    driver: bridge

--- a/pkg/network/protocols/redis/server.go
+++ b/pkg/network/protocols/redis/server.go
@@ -21,5 +21,5 @@ func RunServer(t testing.TB, serverAddr, serverPort string) error {
 
 	t.Helper()
 	dir, _ := testutil.CurDir()
-	return protocolsUtils.RunDockerServer(t, "redis", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile(".*Ready to accept connections"), protocolsUtils.DefaultTimeout)
+	return protocolsUtils.RunDockerServer(t, "redis", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile(".*Ready to accept connections"), protocolsUtils.DefaultTimeout, 3)
 }

--- a/pkg/network/protocols/redis/testdata/docker-compose.yml
+++ b/pkg/network/protocols/redis/testdata/docker-compose.yml
@@ -7,3 +7,9 @@ services:
       - ${REDIS_ADDR:-127.0.0.1}:${REDIS_PORT:-6379}:6379
     environment:
       - "ALLOW_EMPTY_PASSWORD=yes"
+    networks:
+      - redis
+
+networks:
+  redis:
+    driver: bridge

--- a/pkg/network/protocols/testutil/serverutils.go
+++ b/pkg/network/protocols/testutil/serverutils.go
@@ -25,7 +25,20 @@ const (
 // - dockerPath is the path for the docker-compose.
 // - env is any environment variable required for running the server.
 // - serverStartRegex is a regex to be matched on the server logs to ensure it started correctly.
-func RunDockerServer(t testing.TB, serverName, dockerPath string, env []string, serverStartRegex *regexp.Regexp, timeout time.Duration) error {
+func RunDockerServer(t testing.TB, serverName, dockerPath string, env []string, serverStartRegex *regexp.Regexp, timeout time.Duration, retryCount int) error {
+	var err error
+	for i := 0; i < retryCount; i++ {
+		err = runDockerServer(t, serverName, dockerPath, env, serverStartRegex, timeout)
+		if err == nil {
+			return nil
+		}
+		t.Logf("failed to start %s server, retrying: %v", serverName, err)
+		time.Sleep(5 * time.Second)
+	}
+	return err
+}
+
+func runDockerServer(t testing.TB, serverName, dockerPath string, env []string, serverStartRegex *regexp.Regexp, timeout time.Duration) error {
 	t.Helper()
 	// Ensuring no previous instances exists.
 	c := exec.Command("docker-compose", "-f", dockerPath, "down", "--remove-orphans")
@@ -35,7 +48,7 @@ func RunDockerServer(t testing.TB, serverName, dockerPath string, env []string, 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	cmd := exec.CommandContext(ctx, "docker-compose", "-f", dockerPath, "up", "--force-recreate", "--remove-orphans")
+	cmd := exec.CommandContext(ctx, "docker-compose", "-f", dockerPath, "up", "--force-recreate", "--remove-orphans", "-V")
 	patternScanner := NewScanner(serverStartRegex, make(chan struct{}, 1))
 
 	cmd.Stdout = patternScanner
@@ -43,6 +56,7 @@ func RunDockerServer(t testing.TB, serverName, dockerPath string, env []string, 
 	cmd.Env = append(cmd.Env, env...)
 	err := cmd.Start()
 	require.NoErrorf(t, err, "could not start %s with docker-compose", serverName)
+
 	t.Cleanup(func() {
 		cancel()
 		_ = cmd.Wait()
@@ -62,6 +76,7 @@ func RunDockerServer(t testing.TB, serverName, dockerPath string, env []string, 
 			}
 		case <-patternScanner.DoneChan:
 			t.Logf("%s server pid (docker) %d is ready", serverName, cmd.Process.Pid)
+
 			return nil
 		case <-time.After(timeout):
 			patternScanner.PrintLogs(t)

--- a/pkg/network/protocols/tls/gotls/testutil/server.go
+++ b/pkg/network/protocols/tls/gotls/testutil/server.go
@@ -20,5 +20,5 @@ func RunServer(t testing.TB, serverPort string) error {
 
 	t.Helper()
 	dir, _ := testutil.CurDir()
-	return protocolsUtils.RunDockerServer(t, "https-gotls", dir+"/../testdata/docker-compose.yml", env, regexp.MustCompile("go-httpbin listening on https://0.0.0.0:8080"), protocolsUtils.DefaultTimeout)
+	return protocolsUtils.RunDockerServer(t, "https-gotls", dir+"/../testdata/docker-compose.yml", env, regexp.MustCompile("go-httpbin listening on https://0.0.0.0:8080"), protocolsUtils.DefaultTimeout, 3)
 }

--- a/pkg/network/protocols/tls/java/testutil/inject.go
+++ b/pkg/network/protocols/tls/java/testutil/inject.go
@@ -47,7 +47,7 @@ func RunJavaVersion(t testing.TB, version, class string, testdir string, waitFor
 		"TESTDIR=" + testdir,
 	}
 
-	return protocolsUtils.RunDockerServer(t, version, dir+"/../testdata/docker-compose.yml", env, waitFor, protocolsUtils.DefaultTimeout)
+	return protocolsUtils.RunDockerServer(t, version, dir+"/../testdata/docker-compose.yml", env, waitFor, protocolsUtils.DefaultTimeout, 3)
 }
 
 // FindProcessByCommandLine gets a proc name and part of its command line, and returns all PIDs matched for those conditions.
@@ -97,7 +97,7 @@ func RunJavaVersionAndWaitForRejection(t testing.TB, version, class string, test
 	}
 	configureLoggerForTest(t, &l)
 
-	require.NoError(t, protocolsUtils.RunDockerServer(t, version, dir+"/../testdata/docker-compose.yml", env, waitForCondition, time.Second*15))
+	require.NoError(t, protocolsUtils.RunDockerServer(t, version, dir+"/../testdata/docker-compose.yml", env, waitForCondition, time.Second*15, 3))
 	pids, err := FindProcessByCommandLine("java", class)
 	require.NoError(t, err)
 	require.Lenf(t, pids, 1, "found more process (%d) than expected (1)", len(pids))

--- a/pkg/network/protocols/tls/openssl/openssl.go
+++ b/pkg/network/protocols/tls/openssl/openssl.go
@@ -26,7 +26,7 @@ func RunServerOpenssl(t *testing.T, serverPort string, clientCount int, args ...
 
 	t.Helper()
 	dir, _ := testutil.CurDir()
-	return protocolsUtils.RunDockerServer(t, "openssl-server", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile("ACCEPT"), protocolsUtils.DefaultTimeout)
+	return protocolsUtils.RunDockerServer(t, "openssl-server", dir+"/testdata/docker-compose.yml", env, regexp.MustCompile("ACCEPT"), protocolsUtils.DefaultTimeout, 3)
 }
 
 // RunClientOpenssl launches an openssl client.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

1. Introduces a retry mechanism to avoid temporary issues with spinning dockers
2. Use dedicated network for each docker-compose file to avoid errors like `network not found` we had

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Fixed flakiness in classification tests
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
