### PR TITLE
[CWS] fix mount propagated test

### DIFF
--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -225,7 +225,6 @@ func TestMountPropagated(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			return os.Chmod(file, 0700)
 		}, func(event *model.Event, rule *rules.Rule) {
-			t.Log(event.Open.File.PathnameStr)
 			assert.Equal(t, "chmod", event.GetType(), "wrong event type")
 			assert.Equal(t, file, event.Chmod.File.PathnameStr, "wrong path")
 		})

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -170,6 +170,7 @@ func TestMountPropagated(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer os.RemoveAll(dir1Path)
 
 	testDrivePath := path.Join(dir1Path, "test-drive")
 	if err := os.MkdirAll(testDrivePath, 0755); err != nil {
@@ -177,11 +178,10 @@ func TestMountPropagated(t *testing.T) {
 	}
 	defer os.RemoveAll(testDrivePath)
 
-	testDrive, err := newTestDrive(t, "xfs", []string{}, testDrivePath)
-	if err != nil {
+	if _, err := newTestDrive(t, "xfs", []string{}, testDrivePath); err != nil {
 		t.Fatal(err)
 	}
-	defer testDrive.Close()
+	// we do not defer close the test drive, this is done manually later
 
 	dir1BindMntPath, _, err := test.Path("dir1-bind-mounted")
 	if err != nil {

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -183,6 +183,11 @@ func TestMountPropagated(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
+		if testEnvironment == DockerEnvironment {
+			testDrive.Close()
+			return
+		}
+
 		if err := testDrive.DetachDevice(); err != nil {
 			fmt.Printf("failed to detach device: %v", err)
 		}

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -178,10 +178,15 @@ func TestMountPropagated(t *testing.T) {
 	}
 	defer os.RemoveAll(testDrivePath)
 
-	if _, err := newTestDrive(t, "xfs", []string{}, testDrivePath); err != nil {
+	testDrive, err := newTestDrive(t, "xfs", []string{}, testDrivePath)
+	if err != nil {
 		t.Fatal(err)
 	}
-	// we do not defer close the test drive, this is done manually later
+	defer func() {
+		if err := testDrive.DetachDevice(); err != nil {
+			fmt.Printf("failed to detach device: %v", err)
+		}
+	}()
 
 	dir1BindMntPath, _, err := test.Path("dir1-bind-mounted")
 	if err != nil {

--- a/pkg/security/tests/testdrive.go
+++ b/pkg/security/tests/testdrive.go
@@ -134,22 +134,36 @@ func (td *testDrive) lsof() string {
 	return string(output)
 }
 
-func (td *testDrive) unmount() error {
+func (td *testDrive) Unmount() error {
 	return td.mount.unmount(syscall.MNT_FORCE)
 }
 
-func (td *testDrive) Close() {
-	if err := td.unmount(); err != nil {
-		fmt.Printf("failed to unmount test drive: %s (lsof: %s)\n", err, td.lsof())
-	}
+func (td *testDrive) DetachDevice() error {
 	if td.dev != nil {
 		if err := td.dev.Detach(); err != nil {
-			fmt.Printf("failed to detach test drive: %s (lsof: %s)\n", err, td.lsof())
+			return err
 		}
 		if err := retry.Do(td.dev.Remove); err != nil {
-			fmt.Printf("failed to remove test drive: %s (lsof: %s)\n", err, td.lsof())
+			return err
 		}
 	}
-	os.Remove(td.file.Name())
-	os.RemoveAll(td.Root())
+
+	if err := os.Remove(td.file.Name()); err != nil {
+		return err
+	}
+
+	if err := os.RemoveAll(td.Root()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (td *testDrive) Close() {
+	if err := td.Unmount(); err != nil {
+		fmt.Printf("failed to unmount test drive: %s (lsof: %s)\n", err, td.lsof())
+	}
+
+	if err := td.DetachDevice(); err != nil {
+		fmt.Printf("failed to detach test drive: %s (lsof: %s)\n", err, td.lsof())
+	}
 }

--- a/pkg/security/tests/testdrive.go
+++ b/pkg/security/tests/testdrive.go
@@ -140,14 +140,14 @@ func (td *testDrive) unmount() error {
 
 func (td *testDrive) Close() {
 	if err := td.unmount(); err != nil {
-		fmt.Printf("failed to unmount test drive: %s (lsof: %s)", err, td.lsof())
+		fmt.Printf("failed to unmount test drive: %s (lsof: %s)\n", err, td.lsof())
 	}
 	if td.dev != nil {
 		if err := td.dev.Detach(); err != nil {
-			fmt.Printf("failed to detach test drive: %s (lsof: %s)", err, td.lsof())
+			fmt.Printf("failed to detach test drive: %s (lsof: %s)\n", err, td.lsof())
 		}
 		if err := retry.Do(td.dev.Remove); err != nil {
-			fmt.Printf("failed to remove test drive: %s (lsof: %s)", err, td.lsof())
+			fmt.Printf("failed to remove test drive: %s (lsof: %s)\n", err, td.lsof())
 		}
 	}
 	os.Remove(td.file.Name())


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

The `TestMountPropagated` had some issues unmounting at the end of the test. This PR cleans up the test and fix the issue with unmounting.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
