### PR TITLE
[CWS] Use admission controller to get container tags at container startup

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -12,6 +12,9 @@ LABEL org.opencontainers.image.source "https://github.com/DataDog/datadog-agent"
 
 WORKDIR /output
 
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt install --no-install-recommends -y gcc libc6-dev libseccomp-dev
+
 COPY datadog-cluster-agent.$TARGETARCH opt/datadog-agent/bin/datadog-cluster-agent
 COPY ./conf.d etc/datadog-agent/conf.d
 COPY ./datadog-cluster.yaml etc/datadog-agent/datadog-cluster.yaml
@@ -30,8 +33,6 @@ RUN chmod 755 entrypoint.sh \
 FROM builder AS nosys-seccomp
 COPY nosys-seccomp/nosys.c   /tmp/nosys.c
 COPY nosys-seccomp/nosys.sym /tmp/nosys.sym
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update && apt install --no-install-recommends -y gcc libc6-dev libseccomp-dev
 RUN gcc -pipe -Wall -Wextra -O2 -shared -fPIC -Wl,--version-script=/tmp/nosys.sym -o /tmp/nosys.so /tmp/nosys.c -lseccomp
 
 ####################################

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -352,6 +352,7 @@ func start(log log.Component, config config.Component, telemetry telemetry.Compo
 			} else {
 				server.Register(pkgconfig.Datadog.GetString("admission_controller.cws_instrumentation.pod_endpoint"), cwsInstrumentation.InjectCWSPodInstrumentation, apiCl.DynamicCl, apiCl.Cl)
 				server.Register(pkgconfig.Datadog.GetString("admission_controller.cws_instrumentation.command_endpoint"), cwsInstrumentation.InjectCWSCommandInstrumentation, apiCl.DynamicCl, apiCl.Cl)
+				server.Register(pkgconfig.Datadog.GetString("admission_controller.cws_instrumentation.workload_tags_endpoint"), cwsInstrumentation.InjectCWSWorkloadTags, apiCl.DynamicCl, apiCl.Cl)
 			}
 
 			// Start the k8s admission webhook server

--- a/pkg/clusteragent/admission/metrics/metrics.go
+++ b/pkg/clusteragent/admission/metrics/metrics.go
@@ -23,6 +23,7 @@ const (
 	LibInjectionMutationType = "lib_injection"
 	CWSPodInstrumentation    = "cws_pod_instrumentation"
 	CWSExecInstrumentation   = "cws_exec_instrumentation"
+	CWSWorkloadTags          = "cws_workload_tags"
 )
 
 // Telemetry metrics

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation.go
@@ -158,10 +158,10 @@ func injectAutoInstrumentation(pod *corev1.Pod, _ string, _ dynamic.Interface) e
 	// Inject env variables used for Onboarding KPIs propagation
 	if isApmInstrumentationEnabled(pod.Namespace) {
 		// if Single Step Instrumentation is enabled, inject DD_INSTRUMENTATION_INSTALL_TYPE:k8s_single_step
-		_ = injectEnv(pod, singleStepInstrumentationInstallTypeEnvVar)
+		_ = injectEnvIntoPod(pod, singleStepInstrumentationInstallTypeEnvVar)
 	} else {
 		// if local library injection is enabled, inject DD_INSTRUMENTATION_INSTALL_TYPE:k8s_lib_injection
-		_ = injectEnv(pod, localLibraryInstrumentationInstallTypeEnvVar)
+		_ = injectEnvIntoPod(pod, localLibraryInstrumentationInstallTypeEnvVar)
 	}
 
 	return injectAutoInstruConfig(pod, libsToInject, autoDetected)
@@ -177,14 +177,14 @@ func injectApmTelemetryConfig(pod *corev1.Pod) {
 		Name:  instrumentationInstallTimeEnvVarName,
 		Value: instrumentationInstallTime,
 	}
-	_ = injectEnv(pod, instrumentationInstallTimeEnvVar)
+	_ = injectEnvIntoPod(pod, instrumentationInstallTimeEnvVar)
 
 	// inject DD_INSTRUMENTATION_INSTALL_ID with UUID created during the Agent install time
 	instrumentationInstallIDEnvVar := corev1.EnvVar{
 		Name:  instrumentationInstallIDEnvVarName,
 		Value: os.Getenv(instrumentationInstallIDEnvVarName),
 	}
-	_ = injectEnv(pod, instrumentationInstallIDEnvVar)
+	_ = injectEnvIntoPod(pod, instrumentationInstallIDEnvVar)
 }
 
 func isNsTargeted(ns string) bool {
@@ -387,7 +387,7 @@ func injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo, autoDetecte
 			metrics.MutationAttempts.Inc(metrics.LibInjectionMutationType, strconv.FormatBool(injected), langStr, strconv.FormatBool(autoDetected))
 		}()
 
-		_ = injectEnv(pod, localLibraryInstrumentationInstallTypeEnvVar)
+		_ = injectEnvIntoPod(pod, localLibraryInstrumentationInstallTypeEnvVar)
 		var err error
 		switch lib.lang {
 		case java:
@@ -495,7 +495,7 @@ func injectAutoInstruConfig(pod *corev1.Pod, libsToInject []libInfo, autoDetecte
 			libConfig.ServiceName = pointer.Ptr(name)
 		}
 		for _, env := range libConfig.ToEnvs() {
-			_ = injectEnv(pod, env)
+			_ = injectEnvIntoPod(pod, env)
 		}
 	}
 

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation.go
@@ -640,7 +640,7 @@ func injectLibConfig(pod *corev1.Pod, lang language) error {
 		return fmt.Errorf("invalid json config in annotation %s=%s: %w", configAnnotKey, confString, err)
 	}
 	for _, env := range libConfig.ToEnvs() {
-		_ = injectEnv(pod, env)
+		_ = injectEnvIntoPod(pod, env)
 	}
 
 	return nil

--- a/pkg/clusteragent/admission/mutate/common.go
+++ b/pkg/clusteragent/admission/mutate/common.go
@@ -226,7 +226,7 @@ func shouldInject(pod *corev1.Pod) bool {
 		}
 	}
 
-	return isApmInstrumentationEnabled(pod.GetNamespace()) || config.Datadog.GetBool("admission_controller.mutate_unlabelled")
+	return config.Datadog.GetBool("admission_controller.mutate_unlabelled") || isApmInstrumentationEnabled(pod.GetNamespace())
 }
 
 // isApmInstrumentationEnabled indicates if Single Step Instrumentation is enabled for the namespace in the cluster

--- a/pkg/clusteragent/admission/mutate/common_test.go
+++ b/pkg/clusteragent/admission/mutate/common_test.go
@@ -142,7 +142,7 @@ func Test_injectEnv(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := injectEnv(tt.args.pod, tt.args.env)
+			got := injectEnvIntoPod(tt.args.pod, tt.args.env)
 			if got != tt.injected {
 				t.Errorf("injectEnv() = %v, want %v", got, tt.injected)
 			}

--- a/pkg/clusteragent/admission/mutate/config.go
+++ b/pkg/clusteragent/admission/mutate/config.go
@@ -102,21 +102,21 @@ func injectConfig(pod *corev1.Pod, _ string, _ dynamic.Interface) error {
 	mode := injectionMode(pod, config.Datadog.GetString("admission_controller.inject_config.mode"))
 	switch mode {
 	case hostIP:
-		injectedConfig = injectEnv(pod, agentHostIPEnvVar)
+		injectedConfig = injectEnvIntoPod(pod, agentHostIPEnvVar)
 	case service:
-		injectedConfig = injectEnv(pod, agentHostServiceEnvVar)
+		injectedConfig = injectEnvIntoPod(pod, agentHostServiceEnvVar)
 	case socket:
 		volume, volumeMount := buildVolume(datadogVolumeName, config.Datadog.GetString("admission_controller.inject_config.socket_path"), true)
 		injectedVol := injectVolume(pod, volume, volumeMount)
-		injectedEnv := injectEnv(pod, traceURLSocketEnvVar)
-		injectedEnv = injectEnv(pod, dogstatsdURLSocketEnvVar) || injectedEnv
+		injectedEnv := injectEnvIntoPod(pod, traceURLSocketEnvVar)
+		injectedEnv = injectEnvIntoPod(pod, dogstatsdURLSocketEnvVar) || injectedEnv
 		injectedConfig = injectedEnv || injectedVol
 	default:
 		metrics.MutationErrors.Inc(metrics.ConfigMutationType, "unknown mode", "", "")
 		return fmt.Errorf("invalid injection mode %q", mode)
 	}
 
-	injectedEntity = injectEnv(pod, ddEntityIDEnvVar)
+	injectedEntity = injectEnvIntoPod(pod, ddEntityIDEnvVar)
 
 	return nil
 }

--- a/pkg/clusteragent/admission/mutate/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cws_instrumentation.go
@@ -41,8 +41,7 @@ const (
 	CWSInstrumentationPodLabelEnabled = "admission.datadoghq.com/cws-instrumentation.enabled"
 )
 
-var labelsToWorkloadEnv = [][2]string{
-	{kubeutil.EnvTagLabelKey, "DD_WORKLOAD_ENV"},
+var labelsToWorkloadEnv = []labelToEnv{
 	{kubeutil.ServiceTagLabelKey, "DD_WORKLOAD_SERVICE"},
 	{kubeutil.KubeAppNameLabelKey, "DD_WORKLOAD_SERVICE"},
 	{kubeutil.VersionTagLabelKey, "DD_WORKLOAD_VERSION"},

--- a/pkg/clusteragent/admission/mutate/tags_test.go
+++ b/pkg/clusteragent/admission/mutate/tags_test.go
@@ -85,7 +85,7 @@ func Test_injectTagsFromLabels(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			found, injected := injectTagsFromLabels(tt.labels, tt.pod)
+			found, injected := injectTagsFromLabels(tt.labels, tt.pod, standardLabelsToEnv)
 			assert.Equal(t, tt.found, found)
 			assert.Equal(t, tt.injected, injected)
 			assert.Len(t, tt.pod.Spec.Containers, 1)
@@ -166,7 +166,7 @@ func Test_injectTags(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := injectTags(tt.pod, "ns", nil)
+			err := injectStandardTags(tt.pod, "ns", nil)
 			assert.NoError(t, err)
 			assert.Len(t, tt.pod.Spec.Containers, 1)
 			assert.Len(t, tt.wantPodFunc().Spec.Containers, 1)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1073,6 +1073,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.enabled", false)
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.pod_endpoint", "/inject-pod-cws")
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.command_endpoint", "/inject-command-cws")
+	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.workload_tags_endpoint", "/inject-tags-cws")
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.include", []string{})
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.exclude", []string{})
 	config.BindEnvAndSetDefault("admission_controller.cws_instrumentation.mutate_unlabelled", true)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1053,7 +1053,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("admission_controller.inject_config.trace_agent_socket", "unix:///var/run/datadog/apm.socket")
 	config.BindEnvAndSetDefault("admission_controller.inject_config.dogstatsd_socket", "unix:///var/run/datadog/dsd.socket")
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.enabled", true)
-	config.BindEnvAndSetDefault("admission_controller.inject_tags.workload_tags", false)
+	config.BindEnvAndSetDefault("admission_controller.inject_tags.workload_context", false)
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.endpoint", "/injecttags")
 	config.BindEnvAndSetDefault("admission_controller.pod_owners_cache_validity", 10) // in minutes
 	config.BindEnvAndSetDefault("admission_controller.namespace_selector_fallback", false)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1053,6 +1053,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("admission_controller.inject_config.trace_agent_socket", "unix:///var/run/datadog/apm.socket")
 	config.BindEnvAndSetDefault("admission_controller.inject_config.dogstatsd_socket", "unix:///var/run/datadog/dsd.socket")
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.enabled", true)
+	config.BindEnvAndSetDefault("admission_controller.inject_tags.workload_tags", false)
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.endpoint", "/injecttags")
 	config.BindEnvAndSetDefault("admission_controller.pod_owners_cache_validity", 10) // in minutes
 	config.BindEnvAndSetDefault("admission_controller.namespace_selector_fallback", false)

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -15,7 +15,17 @@ import (
 const (
 	// ServiceEnvVar environment variable used to report service
 	ServiceEnvVar = "DD_SERVICE"
+	// WorkloadServiceEnvVar environment variable used to report service when DD_SERVICE is not defined
+	WorkloadServiceEnvVar = "DD_WORKLOAD_SERVICE"
 )
+
+var workloadLabelsAsEnvVars = map[string]string{
+	WorkloadServiceEnvVar:    "service",
+	"DD_WORKLOAD_IMAGE_NAME": "image_name",
+	"DD_WORKLOAD_IMAGE_TAG":  "image_tag",
+	"DD_WORKLOAD_VERSION":    "version",
+	"DD_WORKLOAD_ENV":        "env",
+}
 
 // NewEvent returns a new event
 func NewEvent(fh *FieldHandlers) *model.Event {

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -24,7 +24,6 @@ var workloadLabelsAsEnvVars = map[string]string{
 	"DD_WORKLOAD_IMAGE_NAME": "image_name",
 	"DD_WORKLOAD_IMAGE_TAG":  "image_tag",
 	"DD_WORKLOAD_VERSION":    "version",
-	"DD_WORKLOAD_ENV":        "env",
 }
 
 // NewEvent returns a new event

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -79,10 +79,12 @@ func (r *Releasable) OnRelease() {
 // ContainerContext holds the container context of an event
 type ContainerContext struct {
 	Releasable
-	ID        string   `field:"id,handler:ResolveContainerID"`                              // SECLDoc[id] Definition:`ID of the container`
-	CreatedAt uint64   `field:"created_at,handler:ResolveContainerCreatedAt"`               // SECLDoc[created_at] Definition:`Timestamp of the creation of the container``
-	Tags      []string `field:"tags,handler:ResolveContainerTags,opts:skip_ad,weight:9999"` // SECLDoc[tags] Definition:`Tags of the container`
-	Resolved  bool     `field:"-"`
+	ID                 string   `field:"id,handler:ResolveContainerID"`                              // SECLDoc[id] Definition:`ID of the container`
+	CreatedAt          uint64   `field:"created_at,handler:ResolveContainerCreatedAt"`               // SECLDoc[created_at] Definition:`Timestamp of the creation of the container``
+	Tags               []string `field:"tags,handler:ResolveContainerTags,opts:skip_ad,weight:9999"` // SECLDoc[tags] Definition:`Tags of the container`
+	Resolved           bool     `field:"-" json:"-"`
+	EnvTagsResolved    bool     `field:"-" json:"-"`
+	RemoteTagsResolved bool     `field:"-" json:"-"`
 }
 
 // Status defines the possible status of a profile as a bitmask

--- a/pkg/security/security_profile/profile/manager.go
+++ b/pkg/security/security_profile/profile/manager.go
@@ -672,7 +672,16 @@ func (m *SecurityProfileManager) LookupEventInProfiles(event *model.Event) {
 		return
 	}
 
-	selector, err := cgroupModel.NewWorkloadSelector(utils.GetTagValue("image_name", event.ContainerContext.Tags), utils.GetTagValue("image_tag", event.ContainerContext.Tags))
+	imageName := utils.GetTagValue("image_name", event.ContainerContext.Tags)
+	if imageName == "" {
+		return
+	}
+	imageTag := utils.GetTagValue("image_tag", event.ContainerContext.Tags)
+	if imageTag == "" {
+		imageTag = "latest"
+	}
+
+	selector, err := cgroupModel.NewWorkloadSelector(imageName, imageTag)
 	if err != nil {
 		return
 	}

--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -43,9 +43,9 @@ const (
 	tagKeyKubeAppManagedBy = "kube_app_managed_by"
 
 	// Standard tag - Environment variables
-	envVarEnv     = "DD_ENV"
-	envVarVersion = "DD_VERSION"
-	envVarService = "DD_SERVICE"
+	envVarEnv     = kubernetes.EnvTagEnvVar
+	envVarVersion = kubernetes.VersionTagEnvVar
+	envVarService = kubernetes.ServiceTagEnvVar
 
 	// Docker label keys
 	dockerLabelEnv     = "com.datadoghq.tags.env"

--- a/test/e2e/argo-workflows/templates/datadog-agent.yaml
+++ b/test/e2e/argo-workflows/templates/datadog-agent.yaml
@@ -182,7 +182,7 @@ spec:
                 value: {{inputs.parameters.dd-url}}
               - name: DD_ADMISSION_CONTROLLER_INJECT_TAGS_ENABLED
                 value: "true"
-              - name: DD_ADMISSION_CONTROLLER_INJECT_TAGS_WORKLOAD_TAGS
+              - name: DD_ADMISSION_CONTROLLER_CWS_INSTRUMENTATION_INJECT_WORKLOAD_TAGS
                 value: "true"
           EOF
 

--- a/test/e2e/argo-workflows/templates/datadog-agent.yaml
+++ b/test/e2e/argo-workflows/templates/datadog-agent.yaml
@@ -180,6 +180,10 @@ spec:
                 value: "false"
               - name: DATADOG_HOST
                 value: {{inputs.parameters.dd-url}}
+              - name: DD_ADMISSION_CONTROLLER_INJECT_TAGS_ENABLED
+                value: "true"
+              - name: DD_ADMISSION_CONTROLLER_INJECT_TAGS_WORKLOAD_TAGS
+                value: "true"
           EOF
 
           helm repo add datadog https://helm.datadoghq.com

--- a/test/e2e/cws-tests/tests/lib/kubernetes.py
+++ b/test/e2e/cws-tests/tests/lib/kubernetes.py
@@ -20,6 +20,9 @@ class KubernetesHelper(LogGetter):
         self.namespace = namespace
         self.pod_name = None
 
+    def create_pod(self, body):
+        return self.api_client.create_namespaced_pod(namespace=self.namespace, body=body)
+
     def select_pod_name(self, label_selector):
         resp = self.api_client.list_namespaced_pod(namespace=self.namespace, label_selector=label_selector)
         for i in resp.items:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR adds the ability for the admission controller to inject information about the running workload
(such as image name, image tag) as environment variables.

This PR is a rewritten version of https://github.com/DataDog/datadog-agent/pull/16673 on
top of the CWS instrumentation.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

With this PR, the security probe is able to resolve the workload at the first event of it, without having to wait for the tagger to resolve the tags (which can take a few seconds). This allows to apply security profiles at the very beginning of a workload startup.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
