### PR TITLE
[CSPM] Fix missing container metadata for dbconfig logs

### DIFF
--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -495,7 +495,13 @@ func (a *Agent) reportDBConfigurationFromSystemProbe(ctx context.Context, pid in
 		return err
 	}
 	if resource != nil {
-		a.reportResourceLog(defaultCheckIntervalLowPriority, NewResourceLog(a.opts.Hostname, resource.Type, resource.Config))
+		dbResourceLog := NewResourceLog(a.opts.Hostname, resource.Type, resource.Config)
+		if cID := resource.ContainerID; cID != "" {
+			dbResourceLog.Container = &CheckContainerMeta{
+				ContainerID: cID,
+			}
+		}
+		a.reportResourceLog(defaultCheckIntervalLowPriority, dbResourceLog)
 	}
 	return nil
 }

--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -448,7 +448,7 @@ func (a *Agent) runDBConfigurationsExport(ctx context.Context) {
 			} else {
 				err := a.reportDBConfigurationFromSystemProbe(ctx, pid)
 				if err != nil {
-					log.Errorf("error evaluating cross-container benchmark from system-probe: %v", err)
+					log.Infof("error evaluating cross-container benchmark from system-probe: %v", err)
 				}
 			}
 		}
@@ -463,12 +463,12 @@ func (a *Agent) reportDBConfigurationFromSystemProbe(ctx context.Context, pid in
 		return fmt.Errorf("system-probe socket client was not created")
 	}
 
-	qs := new(url.Values)
+	qs := make(url.Values)
 	qs.Add("pid", strconv.FormatInt(int64(pid), 10))
 	sysProbeComplianceModuleURL := &url.URL{
 		Scheme:   "http",
 		Host:     "unix",
-		Path:     "/dbconfig",
+		Path:     "/compliance/dbconfig",
 		RawQuery: qs.Encode(),
 	}
 


### PR DESCRIPTION
### What does this PR do?

Contains two fixes:

- add missing container metadata that were not properly forwarded from the loaded dbconfig resources
- fix the path to the compliance module endpoint

### Motivation

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
