### PR TITLE
[ASCII-890] Wait for fakeintake to be ready when creating client

### DIFF
--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -84,10 +84,8 @@ type Client struct {
 	processDiscoveryAggregator aggregator.ProcessDiscoveryAggregator
 }
 
-// NewClient creates a new fake intake client
-// fakeIntakeURL: the host of the fake Datadog intake server
-func NewClient(t *testing.T, fakeIntakeURL string) *Client {
-	client := &Client{
+func newClientNoWait(fakeIntakeURL string) *Client {
+	return &Client{
 		fakeIntakeURL:              strings.TrimSuffix(fakeIntakeURL, "/"),
 		metricAggregator:           aggregator.NewMetricAggregator(),
 		checkRunAggregator:         aggregator.NewCheckRunAggregator(),
@@ -97,7 +95,12 @@ func NewClient(t *testing.T, fakeIntakeURL string) *Client {
 		containerAggregator:        aggregator.NewContainerAggregator(),
 		processDiscoveryAggregator: aggregator.NewProcessDiscoveryAggregator(),
 	}
+}
 
+// NewClient creates a new fake intake client and requires it to be healthy.
+// fakeIntakeURL: the host of the fake Datadog intake server
+func NewClient(t *testing.T, fakeIntakeURL string) *Client {
+	client := newClientNoWait(fakeIntakeURL)
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		assert.NoError(ct, client.GetServerHealth())
 	}, 5*time.Minute, 20*time.Second)

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -103,7 +103,7 @@ func NewClient(t *testing.T, fakeIntakeURL string) *Client {
 	client := newClientNoWait(fakeIntakeURL)
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		assert.NoError(ct, client.GetServerHealth())
-	}, 5*time.Minute, 20*time.Second)
+	}, 5*time.Minute, 500*time.Millisecond)
 
 	return client
 }

--- a/test/fakeintake/client/client_integration_test.go
+++ b/test/fakeintake/client/client_integration_test.go
@@ -39,7 +39,7 @@ func TestIntegrationClient(t *testing.T) {
 		isReady := <-ready
 		require.True(t, isReady)
 
-		client := NewClient(fi.URL())
+		client := NewClient(t, fi.URL())
 		// max wait for 500 ms
 		err := backoff.Retry(client.GetServerHealth, backoff.WithMaxRetries(backoff.NewConstantBackOff(100*time.Millisecond), 5))
 		require.NoError(t, err, "Failed waiting for fakeintake")
@@ -64,7 +64,7 @@ func TestIntegrationClient(t *testing.T) {
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-		client := NewClient(fi.URL())
+		client := NewClient(t, fi.URL())
 		// max wait for 250 ms
 		err = backoff.Retry(client.GetServerHealth, backoff.WithMaxRetries(backoff.NewConstantBackOff(10*time.Millisecond), 25))
 		require.NoError(t, err, "Failed waiting for fakeintake")
@@ -92,7 +92,7 @@ func TestIntegrationClient(t *testing.T) {
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-		client := NewClient(fi.URL())
+		client := NewClient(t, fi.URL())
 		// max wait for 250 ms
 		err = backoff.Retry(client.GetServerHealth, backoff.WithMaxRetries(backoff.NewConstantBackOff(10*time.Millisecond), 25))
 		require.NoError(t, err, "Failed waiting for fakeintake")

--- a/test/fakeintake/client/client_test.go
+++ b/test/fakeintake/client/client_test.go
@@ -61,7 +61,7 @@ func TestClient(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewClient(ts.URL)
+		client := NewClient(t, ts.URL)
 		payloads, err := client.getFakePayloads("/foo/bar")
 		assert.NoError(t, err, "Error getting payloads")
 		assert.Equal(t, 3, len(payloads))
@@ -76,7 +76,7 @@ func TestClient(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewClient(ts.URL)
+		client := NewClient(t, ts.URL)
 		payloads, err := client.getFakePayloads("/foo/bar")
 		assert.Error(t, err, "Expecting error")
 		assert.Nil(t, payloads)
@@ -88,7 +88,7 @@ func TestClient(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewClient(ts.URL)
+		client := NewClient(t, ts.URL)
 		err := client.getMetrics()
 		assert.NoError(t, err)
 		assert.True(t, client.metricAggregator.ContainsPayloadName("system.load.1"))
@@ -103,7 +103,7 @@ func TestClient(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewClient(ts.URL)
+		client := NewClient(t, ts.URL)
 		metrics, err := client.getMetric("snmp.ifAdminStatus")
 		assert.NoError(t, err)
 		assert.NotEmpty(t, aggregator.FilterByTags(metrics, []string{"interface:lo", "snmp_profile:generic-router"}))
@@ -116,7 +116,7 @@ func TestClient(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewClient(ts.URL)
+		client := NewClient(t, ts.URL)
 		metrics, err := client.FilterMetrics("snmp.sysUpTimeInstance",
 			WithTags[*aggregator.MetricSeries]([]string{"snmp_device:172.25.0.3", "snmp_profile:generic-router"}),
 			WithMetricValueHigherThan(4226040),
@@ -132,7 +132,7 @@ func TestClient(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewClient(ts.URL)
+		client := NewClient(t, ts.URL)
 		err := client.getCheckRuns()
 		assert.NoError(t, err)
 		assert.True(t, client.checkRunAggregator.ContainsPayloadName("snmp.can_check"))
@@ -147,7 +147,7 @@ func TestClient(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewClient(ts.URL)
+		client := NewClient(t, ts.URL)
 		checks, err := client.GetCheckRun("datadog.agent.check_status")
 		assert.NoError(t, err)
 		assert.NotEmpty(t, aggregator.FilterByTags(checks, []string{"check:snmp"}))
@@ -160,7 +160,7 @@ func TestClient(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewClient(ts.URL)
+		client := NewClient(t, ts.URL)
 		err := client.getLogs()
 		assert.NoError(t, err)
 		assert.True(t, client.logAggregator.ContainsPayloadName("testapp"))
@@ -173,7 +173,7 @@ func TestClient(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewClient(ts.URL)
+		client := NewClient(t, ts.URL)
 		logs, err := client.getLog("testapp")
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(logs))
@@ -188,7 +188,7 @@ func TestClient(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewClient(ts.URL)
+		client := NewClient(t, ts.URL)
 		logs, err := client.FilterLogs("testapp", WithMessageMatching(`^hello.*`), WithMessageContaining("hello there, can you hear"))
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(logs))
@@ -204,7 +204,7 @@ func TestClient(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewClient(ts.URL)
+		client := NewClient(t, ts.URL)
 		err := client.GetServerHealth()
 		assert.NoError(t, err)
 	})
@@ -219,7 +219,7 @@ func TestClient(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewClient(ts.URL)
+		client := NewClient(t, ts.URL)
 		err := client.FlushServerAndResetAggregators()
 		assert.NoError(t, err)
 	})
@@ -230,7 +230,7 @@ func TestClient(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewClient(ts.URL)
+		client := NewClient(t, ts.URL)
 		flare, err := client.GetLatestFlare()
 		assert.NoError(t, err)
 		assert.Equal(t, flare.GetEmail(), "test")
@@ -256,7 +256,7 @@ func TestClient(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewClient(ts.URL)
+		client := NewClient(t, ts.URL)
 		err := client.getProcesses()
 		require.NoError(t, err)
 		assert.True(t, client.processAggregator.ContainsPayloadName("i-078e212"))
@@ -281,7 +281,7 @@ func TestClient(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewClient(ts.URL)
+		client := NewClient(t, ts.URL)
 		err := client.getContainers()
 		require.NoError(t, err)
 		assert.True(t, client.containerAggregator.ContainsPayloadName("i-078e212"))
@@ -306,7 +306,7 @@ func TestClient(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		client := NewClient(ts.URL)
+		client := NewClient(t, ts.URL)
 		err := client.getProcessDiscoveries()
 		require.NoError(t, err)
 		assert.True(t, client.processDiscoveryAggregator.ContainsPayloadName("i-078e212"))

--- a/test/fakeintake/go.mod
+++ b/test/fakeintake/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/kr/pretty v0.3.1
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.8.4
 )
 
 require (

--- a/test/fakeintake/go.sum
+++ b/test/fakeintake/go.sum
@@ -13,7 +13,6 @@ github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gogo/protobuf v1.0.0 h1:2jyBKDKU/8v3v2xVR2PtiWQviFUyiaGk2rpfyFT8rTM=
@@ -27,15 +26,9 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/test/new-e2e/pkg/utils/e2e/client/fakeintake.go
+++ b/test/new-e2e/pkg/utils/e2e/client/fakeintake.go
@@ -8,10 +8,11 @@ package client
 import (
 	"testing"
 
-	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
 	"github.com/DataDog/test-infra-definitions/common/utils"
 	infraFakeintake "github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
+
+	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
 )
 
 var _ pulumiStackInitializer = (*Fakeintake)(nil)
@@ -22,7 +23,9 @@ type Fakeintake struct {
 	*fakeintake.Client
 }
 
-// NewFakeintake creates a new instance of
+// NewFakeintake creates a new instance of a fakeintake connected to a [infraFakeintake.ConnectionExporter].
+//
+// [infraFakeintake.ConnectionExporter]: https://pkg.go.dev/github.com/DataDog/test-infra-definitions@main/components/datadog/fakeintake#ConnectionExporter
 func NewFakeintake(exporter *infraFakeintake.ConnectionExporter) *Fakeintake {
 	return &Fakeintake{deserializer: exporter}
 }
@@ -31,11 +34,11 @@ func NewFakeintake(exporter *infraFakeintake.ConnectionExporter) *Fakeintake {
 // This method is called by [CallStackInitializers] using reflection.
 //
 //lint:ignore U1000 Ignore unused function as this function is called using reflection
-func (fi *Fakeintake) initFromPulumiStack(_ *testing.T, stackResult auto.UpResult) error {
+func (fi *Fakeintake) initFromPulumiStack(t *testing.T, stackResult auto.UpResult) error {
 	clientData, err := fi.deserializer.Deserialize(stackResult)
 	if err != nil {
 		return err
 	}
-	fi.Client = fakeintake.NewClient("http://" + clientData.Host)
+	fi.Client = fakeintake.NewClient(t, "http://"+clientData.Host)
 	return nil
 }

--- a/test/new-e2e/tests/agent-shared-components/forwarder/nss_failover_test.go
+++ b/test/new-e2e/tests/agent-shared-components/forwarder/nss_failover_test.go
@@ -112,20 +112,6 @@ func TestMultiFakeintakeSuite(t *testing.T) {
 	e2e.Run(t, &multiFakeIntakeSuite{}, multiFakeintakeStackDef())
 }
 
-// SetupSuite waits for both fakeintakes to be ready before running tests.
-func (v *multiFakeIntakeSuite) SetupSuite() {
-	v.Suite.SetupSuite() // need to call the original definition of SetupSuite
-
-	fakeintake1 := v.Env().Fakeintake1
-	fakeintake2 := v.Env().Fakeintake2
-
-	// Wait for the fakeintakes to be ready to avoid 503
-	require.EventuallyWithT(v.T(), func(c *assert.CollectT) {
-		assert.NoError(c, fakeintake1.GetServerHealth())
-		assert.NoError(c, fakeintake2.GetServerHealth())
-	}, intakeMaxWaitTime, intakeTick)
-}
-
 // TestNSSFailover tests that the agent correctly picks-up an NSS change of the intake.
 //
 // The test uses two fakeintakes to represent two backends, and the /etc/hosts file for the NSS source,

--- a/test/new-e2e/tests/agent-subcommands/flare/flare_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/flare/flare_common_test.go
@@ -9,13 +9,12 @@ package flare
 import (
 	_ "embed"
 	"testing"
-	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/test/fakeintake/client/flare"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type baseFlareSuite struct {
@@ -39,11 +38,6 @@ func (v *baseFlareSuite) TestFlareDefaultFiles() {
 }
 
 func requestAgentFlareAndFetchFromFakeIntake(t *testing.T, agent client.Agent, fakeintake *client.Fakeintake, flareArgs ...client.AgentArgsOption) flare.Flare {
-	// Wait for the fakeintake to be ready to avoid 503 when sending the flare
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.NoError(c, fakeintake.Client.GetServerHealth())
-	}, 5*time.Minute, 20*time.Second)
-
 	_ = agent.Flare(flareArgs...)
 
 	flare, err := fakeintake.Client.GetLatestFlare()

--- a/test/new-e2e/tests/containers/ecs_test.go
+++ b/test/new-e2e/tests/containers/ecs_test.go
@@ -12,11 +12,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ecs"
+
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/infra"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ecs"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	awsecs "github.com/aws/aws-sdk-go-v2/service/ecs"
@@ -54,7 +55,7 @@ func (suite *ecsSuite) SetupSuite() {
 	suite.Require().NoError(err)
 
 	fakeintakeHost := stackOutput.Outputs["fakeintake-host"].Value.(string)
-	suite.Fakeintake = fakeintake.NewClient(fmt.Sprintf("http://%s", fakeintakeHost))
+	suite.Fakeintake = fakeintake.NewClient(suite.T(), fmt.Sprintf("http://%s", fakeintakeHost))
 	suite.ecsClusterName = stackOutput.Outputs["ecs-cluster-name"].Value.(string)
 	suite.clusterName = suite.ecsClusterName
 

--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -13,10 +13,11 @@ import (
 	"path"
 	"testing"
 
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/eks"
+
 	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/infra"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/eks"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/stretchr/testify/suite"
@@ -54,7 +55,7 @@ func (suite *eksSuite) SetupSuite() {
 	}
 
 	fakeintakeHost := stackOutput.Outputs["fakeintake-host"].Value.(string)
-	suite.Fakeintake = fakeintake.NewClient(fmt.Sprintf("http://%s", fakeintakeHost))
+	suite.Fakeintake = fakeintake.NewClient(suite.T(), fmt.Sprintf("http://%s", fakeintakeHost))
 	suite.KubeClusterName = stackOutput.Outputs["kube-cluster-name"].Value.(string)
 	suite.AgentLinuxHelmInstallName = stackOutput.Outputs["agent-linux-helm-install-name"].Value.(string)
 	suite.AgentWindowsHelmInstallName = stackOutput.Outputs["agent-windows-helm-install-name"].Value.(string)

--- a/test/new-e2e/tests/containers/kindvm_test.go
+++ b/test/new-e2e/tests/containers/kindvm_test.go
@@ -12,10 +12,11 @@ import (
 	"path"
 	"testing"
 
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/kindvm"
+
 	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/infra"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/kindvm"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/stretchr/testify/suite"
@@ -53,7 +54,7 @@ func (suite *kindSuite) SetupSuite() {
 	}
 
 	fakeintakeHost := stackOutput.Outputs["fakeintake-host"].Value.(string)
-	suite.Fakeintake = fakeintake.NewClient(fmt.Sprintf("http://%s", fakeintakeHost))
+	suite.Fakeintake = fakeintake.NewClient(suite.T(), fmt.Sprintf("http://%s", fakeintakeHost))
 	suite.KubeClusterName = stackOutput.Outputs["kube-cluster-name"].Value.(string)
 	suite.AgentLinuxHelmInstallName = stackOutput.Outputs["agent-linux-helm-install-name"].Value.(string)
 	suite.AgentWindowsHelmInstallName = "none"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
When creating a fakeintake client, wait for it to be ready, and fail the test if it was never ready.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Currently tests can start without the fakeintake being ready so it's quite common to get a 503 during a test when trying to contact it. Waiting for it to be ready when initializing the client would avoid this issue.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
I considered there was no scenario where it would make sense to not wait for the fakeintake to be ready, so this behavior cannot be prevented as it is. We can always add an option if the need arises.

The timeout (5min) and tick (20sec) are very arbitrary, feel free to open a suggestion if they should be changed.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
