### PR TITLE
fixing remove type tag logic

### DIFF
--- a/pkg/collector/corechecks/containers/kubelet/provider/slis/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/slis/provider.go
@@ -56,21 +56,15 @@ func (p *Provider) sliHealthCheck(metricFam *prom.MetricFamily, sender sender.Se
 	for _, metric := range metricFam.Samples {
 		metricSuffix := string(metric.Metric["__name__"])
 		tags := p.MetricTags(metric)
-		typePresent := false
 		for i, tag := range tags {
 			if strings.HasPrefix(tag, "name:") {
 				tags[i] = strings.Replace(tag, "name:", "sli_name:", 1)
 			}
-			if strings.HasPrefix(tag, "type:") {
-				typePresent = true
-			}
 		}
 
-		if typePresent {
-			tags = lo.Filter(tags, func(x string, index int) bool {
-				return x != "type:"
-			})
-		}
+		tags = lo.Filter(tags, func(x string, index int) bool {
+			return strings.HasPrefix(x, "type") != true
+		})
 
 		switch metricSuffix {
 		case "kubernetes_healthchecks_total":

--- a/pkg/collector/corechecks/containers/kubelet/provider/slis/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/slis/provider.go
@@ -63,7 +63,7 @@ func (p *Provider) sliHealthCheck(metricFam *prom.MetricFamily, sender sender.Se
 		}
 
 		tags = lo.Filter(tags, func(x string, index int) bool {
-			return strings.HasPrefix(x, "type") != true
+			return !strings.HasPrefix(x, "type")
 		})
 
 		switch metricSuffix {

--- a/pkg/collector/corechecks/containers/kubelet/provider/slis/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/slis/provider_test.go
@@ -201,11 +201,15 @@ func TestProvider_Provide(t *testing.T) {
 				t.Errorf("Collect() error = %v, wantErr %v", err, tt.want.err)
 				return
 			}
+
+			type_tag := []string{"type:healthz"}
 			for _, metric := range tt.want.metrics {
 				if metric.name == common.KubeletMetricsPrefix+"slis.kubernetes_healthcheck" {
 					mockSender.AssertMetric(t, "Gauge", metric.name, metric.value, "", metric.tags)
+					mockSender.AssertMetricNotTaggedWith(t, "Gauge", metric.name, type_tag)
 				} else {
 					mockSender.AssertMetric(t, "Count", metric.name, metric.value, "", metric.tags)
+					mockSender.AssertMetricNotTaggedWith(t, "Count", metric.name, type_tag)
 				}
 			}
 		})

--- a/pkg/collector/corechecks/containers/kubelet/provider/slis/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/slis/provider_test.go
@@ -202,14 +202,14 @@ func TestProvider_Provide(t *testing.T) {
 				return
 			}
 
-			type_tag := []string{"type:healthz"}
+			typeTag := []string{"type:healthz"}
 			for _, metric := range tt.want.metrics {
 				if metric.name == common.KubeletMetricsPrefix+"slis.kubernetes_healthcheck" {
 					mockSender.AssertMetric(t, "Gauge", metric.name, metric.value, "", metric.tags)
-					mockSender.AssertMetricNotTaggedWith(t, "Gauge", metric.name, type_tag)
+					mockSender.AssertMetricNotTaggedWith(t, "Gauge", metric.name, typeTag)
 				} else {
 					mockSender.AssertMetric(t, "Count", metric.name, metric.value, "", metric.tags)
-					mockSender.AssertMetricNotTaggedWith(t, "Count", metric.name, type_tag)
+					mockSender.AssertMetricNotTaggedWith(t, "Count", metric.name, typeTag)
 				}
 			}
 		})


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Fixes logic in removing `type` tag

### Motivation
QA from: https://github.com/DataDog/datadog-agent/pull/20723 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
