### PR TITLE
[USMON-623] Mitigate races causing Go TLS test failures

### DIFF
--- a/pkg/network/ebpf/c/protocols/classification/defs.h
+++ b/pkg/network/ebpf/c/protocols/classification/defs.h
@@ -34,6 +34,8 @@
 #define FLAG_NPM_ENABLED            1 << 2
 #define FLAG_TCP_CLOSE_DELETION     1 << 3
 #define FLAG_SOCKET_FILTER_DELETION 1 << 4
+#define FLAG_SERVER_SIDE            1 << 5
+#define FLAG_CLIENT_SIDE            1 << 6
 
 // The enum below represents all different protocols we're able to
 // classify. Entries are segmented such that it is possible to infer the

--- a/pkg/network/ebpf/c/protocols/http/http.h
+++ b/pkg/network/ebpf/c/protocols/http/http.h
@@ -74,6 +74,15 @@ static __always_inline void http_parse_data(char const *p, http_packet_t *packet
     }
 }
 
+// this is merely added here to improve readibility of code.
+// HTTP monitoring code is executed in two "contexts":
+// * via a socket filter program, which is used for monitoring plain traffic;
+// * via a uprobe-based programs, for the purposes of tracing encrypted traffic (SSL, Go TLS, Java TLS etc);
+// When code is executed from uprobes, skb_info is null;
+static __always_inline bool is_uprobe_context(skb_info_t *skb_info) {
+    return skb_info == NULL;
+}
+
 static __always_inline bool http_closed(skb_info_t *skb_info) {
     return (skb_info && skb_info->tcp_flags&(TCPHDR_FIN|TCPHDR_RST));
 }
@@ -84,7 +93,26 @@ static __always_inline bool http_closed(skb_info_t *skb_info) {
 // * A segment with the beginning of a response (packet_type == HTTP_RESPONSE);
 // * A segment with a (FIN|RST) flag set;
 static __always_inline bool http_seen_before(http_transaction_t *http, skb_info_t *skb_info, http_packet_t packet_type) {
-    if (!skb_info) {
+    if (is_uprobe_context(skb_info)) {
+        // The purpose of setting tcp_seq = 0 in the context of uprobe tracing
+        // is innocuous for the most part (as this field will almost aways be 0)
+        // The only reason we do this here is to *minimize* the chance of a race
+        // condition that happens sometimes in the context of uprobe-based tracing:
+        //
+        // 1) handle_request for c1 (uprobe)
+        // 2) socket filter triggers termination code for c1 (server -> FIN -> client)
+        // 3) handle_response for c1 (uprobe)
+        // 4) socket filter triggers termination code for c1 (client -> FIN -> server)
+        //
+        // The problem is that 2) and 3) might happen in parallel, and 2) may
+        // delete the the eBPF data *before* 4) executes and flushes the data
+        // with both request and response information to userspace.
+        //
+        // Since we check if (skb_info->tcp_seq == HTTP_TERMINATING) evaluates
+        // to true before flushing and deleting the eBPF map data, setting it to
+        // 0 here gives a chance for the late response to "cancel" the map
+        // deletion.
+        http->tcp_seq = 0;
         return false;
     }
 
@@ -170,12 +198,15 @@ static __always_inline void http_process(http_event_t *event, skb_info_t *skb_in
         http->response_last_seen = bpf_ktime_get_ns();
     }
 
-    if (http_closed(skb_info)) {
+    if (http->tcp_seq == HTTP_TERMINATING) {
         http_batch_enqueue_wrapper(tuple, http);
-        bpf_map_delete_elem(&http_in_flight, tuple);
+        // Check a second time to minimize the chance of accidentally deleting a
+        // map entry if there is a race with a late response.
+        // Please refer to comments in `http_seen_before` for more context.
+        if (http->tcp_seq == HTTP_TERMINATING) {
+            bpf_map_delete_elem(&http_in_flight, tuple);
+        }
     }
-
-    return;
 }
 
 // this function is called by the socket-filter program to decide whether or not we should inspect

--- a/pkg/network/tracer/tracer_usm_linux_test.go
+++ b/pkg/network/tracer/tracer_usm_linux_test.go
@@ -818,7 +818,7 @@ func testHTTPGoTLSCaptureNewProcess(t *testing.T, cfg *config.Config) {
 	// Setup
 	closeServer := testutil.HTTPServer(t, serverAddr, testutil.Options{
 		EnableTLS:       true,
-		EnableKeepAlive: true,
+		EnableKeepAlive: false,
 	})
 	t.Cleanup(closeServer)
 
@@ -859,7 +859,7 @@ func testHTTPGoTLSCaptureAlreadyRunning(t *testing.T, cfg *config.Config) {
 	// Setup
 	closeServer := testutil.HTTPServer(t, serverAddr, testutil.Options{
 		EnableTLS:       true,
-		EnableKeepAlive: true,
+		EnableKeepAlive: false,
 	})
 	t.Cleanup(closeServer)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Mitigates 2 race scenarios currently causing Go TLS test flakiness:
* Race in `connection_protocol` deletion;
* Race in HTTP termination code, where FIN packets are processed before uprobe programs handling the response data;


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

There is an internal document where these issues are described at length: https://datadoghq.atlassian.net/wiki/spaces/UT/pages/3275687462/Go+TLS+test+flakiness

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
