### PR TITLE
Fix panic when deployment is removed, bug where node would not be removed

### DIFF
--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/deployments.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/deployments.go
@@ -32,11 +32,12 @@ type deploymentFilter struct{}
 
 func (f *deploymentFilter) filteredOut(entity workloadmeta.Entity) bool {
 	deployment := entity.(*workloadmeta.KubernetesDeployment)
-	return deployment.Env == "" &&
-		deployment.Version == "" &&
-		deployment.Service == "" &&
-		len(deployment.InitContainerLanguages) == 0 &&
-		len(deployment.ContainerLanguages) == 0
+	return deployment == nil ||
+		(deployment.Env == "" &&
+			deployment.Version == "" &&
+			deployment.Service == "" &&
+			len(deployment.InitContainerLanguages) == 0 &&
+			len(deployment.ContainerLanguages) == 0)
 }
 
 func newDeploymentStore(ctx context.Context, wlm workloadmeta.Store, client kubernetes.Interface) (*cache.Reflector, *reflectorStore) {

--- a/pkg/workloadmeta/collectors/internal/kubeapiserver/deployments_test.go
+++ b/pkg/workloadmeta/collectors/internal/kubeapiserver/deployments_test.go
@@ -282,6 +282,11 @@ func Test_Deployment_FilteredOut(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name:       "nil",
+			deployment: nil,
+			expected:   true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR fixes two bugs with the apiserver reflector_store:
1) Fixes a panic that would occur when language detection is enabled, and any deployment is removed from the cluster
```
panic: interface conversion: *v1.Deployment is not workloadmeta.Entity: missing method DeepCopy [recovered]
	panic: interface conversion: *v1.Deployment is not workloadmeta.Entity: missing method DeepCopy

goroutine 498 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x40008b08a0?})
	/go/pkg/mod/k8s.io/apimachinery@v0.27.6/pkg/util/runtime/runtime.go:56 +0xe0
panic({0x360cf40, 0x4000634810})
	/usr/local/go/src/runtime/panic.go:884 +0x1f4
github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/kubeapiserver.(*reflectorStore).Delete(0x40005a7630, {0x3b985e0?, 0x400136a000?})
	/go/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/kubeapiserver/reflector_store.go:163 +0x1d4
k8s.io/client-go/tools/cache.watchHandler({0x0?, 0x0?, 0x6a2b660?}, {0x4791838, 0x4001a38380}, {0x47c5140, 0x40005a7630}, {0x47e6fd0?, 0x3b985e0}, 0x0, ...)
	/go/pkg/mod/k8s.io/client-go@v0.27.6/tools/cache/reflector.go:757 +0x59c
k8s.io/client-go/tools/cache.(*Reflector).watch(0x40005e2690, {0x0?, 0x0?}, 0x4000d10ae0, 0x400097e2c0?)
	/go/pkg/mod/k8s.io/client-go@v0.27.6/tools/cache/reflector.go:431 +0x3c8
k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch(0x40005e2690, 0x4000d10ae0)
	/go/pkg/mod/k8s.io/client-go@v0.27.6/tools/cache/reflector.go:356 +0x2c4
k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
	/go/pkg/mod/k8s.io/client-go@v0.27.6/tools/cache/reflector.go:289 +0x28
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x400112a728?)
	/go/pkg/mod/k8s.io/apimachinery@v0.27.6/pkg/util/wait/backoff.go:226 +0x40
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x3c5a51a?, {0x4781a40, 0x40005a7680}, 0x1, 0x4000d10ae0)
	/go/pkg/mod/k8s.io/apimachinery@v0.27.6/pkg/util/wait/backoff.go:227 +0x90
k8s.io/client-go/tools/cache.(*Reflector).Run(0x40005e2690, 0x4000d10ae0)
	/go/pkg/mod/k8s.io/client-go@v0.27.6/tools/cache/reflector.go:288 +0x168
created by github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/kubeapiserver.(*collector).Start
	/go/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go:69 +0x8c
```
2) Fixes a bug where nodes which are removed would not be removed from the cluster agent workload list

### Motivation

Both of these bugs came up while QAing the agent, but neither of these bugs are new to this release

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Both of these bugs can be validated by:
1) Deploy the cluster agent with language detection enabled:
```
datadog:
  env:
    - name: DD_LANGUAGE_DETECTION_ENABLED
      value: "true"
clusterAgent:
  env:
    - name: DD_LANGUAGE_DETECTION_ENABLED
      value: "true"
```
2) Once the cluster agent is up and running, delete any deployment from the cluster, and validate that the DCA has not restarted as a result
3) Add a node to your cluster and validate that it shows up when you run `agent workload-list -v` on one of the DCA pods
4) Remove the newly added node from your cluster, validate that it no longer shows up in the output of `agent workload-list -v`
5) You can also validate the same for deployment resources (that the are created and that they then no longer persist in the workload list after being deleted from the cluster) by following the QA steps here: https://github.com/DataDog/datadog-agent/pull/20590 or here: https://github.com/DataDog/datadog-agent/pull/19007

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
