### PR TITLE
Remove Autodiscovery deps in config package

### DIFF
--- a/pkg/autodiscovery/common/types/prometheus.go
+++ b/pkg/autodiscovery/common/types/prometheus.go
@@ -7,6 +7,7 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -143,6 +144,15 @@ type ADConfig struct {
 type InclExcl struct {
 	Incl map[string]string `mapstructure:"include" yaml:"include,omitempty" json:"include,omitempty"`
 	Excl map[string]string `mapstructure:"exclude" yaml:"exclude,omitempty" json:"exclude,omitempty"`
+}
+
+// PrometheusScrapeChecksTransformer unmarshals a prometheus check.
+func PrometheusScrapeChecksTransformer(in string) ([]*PrometheusCheck, error) {
+	var promChecks []*PrometheusCheck
+	if err := json.Unmarshal([]byte(in), &promChecks); err != nil {
+		return promChecks, fmt.Errorf(`"prometheus_scrape.checks" can not be parsed: %v`, err)
+	}
+	return promChecks, nil
 }
 
 // Init prepares the PrometheusCheck structure and defaults its values

--- a/pkg/autodiscovery/common/types/prometheus_test.go
+++ b/pkg/autodiscovery/common/types/prometheus_test.go
@@ -180,3 +180,16 @@ func TestPrometheusCheck_IsIncluded(t *testing.T) {
 		})
 	}
 }
+
+func TestPrometheusScrapeChecksTransformer(t *testing.T) {
+	input := `[{"configurations":[{"timeout":5,"send_distribution_buckets":true}],"autodiscovery":{"kubernetes_container_names":["my-app"],"kubernetes_annotations":{"include":{"custom_label":"true"}}}}]`
+	expected := []*PrometheusCheck{
+		{
+			Instances: []*OpenmetricsInstance{{Timeout: 5, DistributionBuckets: true}},
+			AD:        &ADConfig{KubeContainerNames: []string{"my-app"}, KubeAnnotations: &InclExcl{Incl: map[string]string{"custom_label": "true"}}},
+		},
+	}
+
+	value, _ := PrometheusScrapeChecksTransformer(input)
+	assert.EqualValues(t, value, expected)
+}

--- a/pkg/autodiscovery/listeners/common.go
+++ b/pkg/autodiscovery/listeners/common.go
@@ -101,11 +101,16 @@ func (f *containerFilters) IsExcluded(filter containers.FilterType, annotations 
 // getPrometheusIncludeAnnotations returns the Prometheus AD include annotations based on the Prometheus config
 func getPrometheusIncludeAnnotations() types.PrometheusAnnotations {
 	annotations := types.PrometheusAnnotations{}
-	checks := []*types.PrometheusCheck{}
-	err := config.Datadog.UnmarshalKey("prometheus_scrape.checks", &checks)
-	if err != nil {
-		log.Warnf("Couldn't get configurations from 'prometheus_scrape.checks': %v", err)
-		return annotations
+	tmpConfigString := config.Datadog.GetString("prometheus_scrape.checks")
+
+	var checks []*types.PrometheusCheck
+	if len(tmpConfigString) > 0 {
+		var err error
+		checks, err = types.PrometheusScrapeChecksTransformer(tmpConfigString)
+		if err != nil {
+			log.Warnf("Couldn't get configurations from 'prometheus_scrape.checks': %v", err)
+			return annotations
+		}
 	}
 
 	if len(checks) == 0 {

--- a/pkg/autodiscovery/listeners/common_test.go
+++ b/pkg/autodiscovery/listeners/common_test.go
@@ -6,6 +6,7 @@
 package listeners
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common/types"
@@ -196,12 +197,12 @@ func TestGetPrometheusIncludeAnnotations(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockConfig := config.Mock(t)
 
-			originalChecks := []*types.PrometheusCheck{}
-			err := mockConfig.UnmarshalKey("prometheus_scrape.checks", &originalChecks)
-			assert.NoError(t, err)
+			val := mockConfig.GetString("prometheus_scrape.checks")
+			assert.Equal(t, val, "")
 
-			mockConfig.SetWithoutSource("prometheus_scrape.checks", tt.config)
-			defer mockConfig.SetWithoutSource("prometheus_scrape.checks", originalChecks)
+			confBytes, _ := json.Marshal(tt.config)
+			mockConfig.SetWithoutSource("prometheus_scrape.checks", string(confBytes))
+			defer mockConfig.SetWithoutSource("prometheus_scrape.checks", "")
 
 			assert.EqualValues(t, tt.want, getPrometheusIncludeAnnotations())
 		})

--- a/pkg/autodiscovery/listeners/kube_services_test.go
+++ b/pkg/autodiscovery/listeners/kube_services_test.go
@@ -415,7 +415,6 @@ func TestShouldIgnore(t *testing.T) {
 				promInclAnnot:     getPrometheusIncludeAnnotations(),
 				targetAllServices: tt.targetAll,
 			}
-
 			assert.Equal(t, tt.want, l.shouldIgnore(tt.ksvc))
 		})
 	}

--- a/pkg/autodiscovery/providers/prometheus_common.go
+++ b/pkg/autodiscovery/providers/prometheus_common.go
@@ -14,8 +14,7 @@ import (
 // getPrometheusConfigs reads and initializes the openmetrics checks from the configuration
 // It defines a default openmetrics instances with default AD if the checks configuration is empty
 func getPrometheusConfigs() ([]*types.PrometheusCheck, error) {
-	checks := []*types.PrometheusCheck{}
-	err := config.Datadog.UnmarshalKey("prometheus_scrape.checks", &checks)
+	checks, err := types.PrometheusScrapeChecksTransformer(config.Datadog.GetString("prometheus_scrape.checks"))
 	if err != nil {
 		return []*types.PrometheusCheck{}, err
 	}

--- a/pkg/autodiscovery/providers/prometheus_common_test.go
+++ b/pkg/autodiscovery/providers/prometheus_common_test.go
@@ -6,6 +6,7 @@
 package providers
 
 import (
+	"encoding/json"
 	"regexp"
 	"testing"
 
@@ -196,7 +197,8 @@ func TestGetPrometheusConfigs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config.Datadog.SetWithoutSource("prometheus_scrape.checks", tt.config)
+			confBytes, _ := json.Marshal(tt.config)
+			config.Datadog.SetWithoutSource("prometheus_scrape.checks", string(confBytes))
 			checks, err := getPrometheusConfigs()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getPrometheusConfigs() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,7 +23,6 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common/types"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
 	pkgconfigenv "github.com/DataDog/datadog-agent/pkg/config/env"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
@@ -126,15 +125,6 @@ var (
 
 // List of integrations allowed to be configured by RC by default
 var defaultAllowedRCIntegrations = []string{}
-
-// PrometheusScrapeChecksTransformer unmarshals a prometheus check.
-func PrometheusScrapeChecksTransformer(in string) interface{} {
-	var promChecks []*types.PrometheusCheck
-	if err := json.Unmarshal([]byte(in), &promChecks); err != nil {
-		log.Warnf(`"prometheus_scrape.checks" can not be parsed: %v`, err)
-	}
-	return promChecks
-}
 
 // ConfigurationProviders helps unmarshalling `config_providers` config param
 type ConfigurationProviders struct {
@@ -670,8 +660,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("prometheus_scrape.enabled", false)           // Enables the prometheus config provider
 	config.BindEnvAndSetDefault("prometheus_scrape.service_endpoints", false) // Enables Service Endpoints checks in the prometheus config provider
 	config.BindEnv("prometheus_scrape.checks")                                // Defines any extra prometheus/openmetrics check configurations to be handled by the prometheus config provider
-	config.SetEnvKeyTransformer("prometheus_scrape.checks", PrometheusScrapeChecksTransformer)
-	config.BindEnvAndSetDefault("prometheus_scrape.version", 1) // Version of the openmetrics check to be scheduled by the Prometheus auto-discovery
+	config.BindEnvAndSetDefault("prometheus_scrape.version", 1)               // Version of the openmetrics check to be scheduled by the Prometheus auto-discovery
 
 	// Network Devices Monitoring
 	bindEnvAndSetLogsConfigKeys(config, "network_devices.metadata.")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common/types"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
@@ -643,18 +642,6 @@ network_devices:
 `
 	config = SetupConfFromYAML(datadogYaml)
 	assert.Equal(t, "dev", config.GetString("network_devices.namespace"))
-}
-
-func TestPrometheusScrapeChecksTransformer(t *testing.T) {
-	input := `[{"configurations":[{"timeout":5,"send_distribution_buckets":true}],"autodiscovery":{"kubernetes_container_names":["my-app"],"kubernetes_annotations":{"include":{"custom_label":"true"}}}}]`
-	expected := []*types.PrometheusCheck{
-		{
-			Instances: []*types.OpenmetricsInstance{{Timeout: 5, DistributionBuckets: true}},
-			AD:        &types.ADConfig{KubeContainerNames: []string{"my-app"}, KubeAnnotations: &types.InclExcl{Incl: map[string]string{"custom_label": "true"}}},
-		},
-	}
-
-	assert.EqualValues(t, PrometheusScrapeChecksTransformer(input), expected)
 }
 
 func TestUsePodmanLogsAndDockerPathOverride(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Remove unnecessary`pkg/autodiscovery/common/types` dependency in `config` package.

### Motivation

Remove the need to create a go.mod in `pkg/autodiscovery/common/types` and remove the need of  https://github.com/DataDog/datadog-agent/pull/20233

### Additional Notes

Using `viper.SetEnvKeyTransformer()` was a nice idea, but it was creating an unwanted dependency to the `pkg/autodiscovery/common/types`. I think this PR is a trade off between using all viper capability and make the package `config` reusable.

Also I think a major refactoring of the `config` package should append at some point to split the configuration by `fx.Component`, so we don't have all the config in on package but instead a modular config based on can be used in an agent.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Test that the option `prometheus_scrape.checks` is still working, and that the `prometheus scrape` feature is working

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
