### PR TITLE
Add a need dependency to deploy_dca to make it more resilient

### DIFF
--- a/.gitlab/deploy_dca.yml
+++ b/.gitlab/deploy_dca.yml
@@ -9,7 +9,11 @@ include:
 .deploy_containers-dca-base:
   extends: .docker_publish_job_definition
   stage: deploy_dca
-  dependencies: []
+  needs:
+    - job: "docker_build_cluster_agent_amd64"
+      artifacts: false
+    - job: "docker_build_cluster_agent_arm64"
+      artifacts: false
   before_script:
     - source /root/.bashrc
     - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv agent.version --major-version 7 --url-safe)"; fi
@@ -18,46 +22,34 @@ include:
     - export IMG_SOURCES="${IMG_BASE_SRC}-amd64,${IMG_BASE_SRC}-arm64"
     - export IMG_DESTINATIONS="${CLUSTER_AGENT_REPOSITORY}:${VERSION}"
 
-
 deploy_containers-dca:
   extends: .deploy_containers-dca-base
-  rules:
-    !reference [.on_deploy_a7_manual_auto_on_rc]
-
+  rules: !reference [.on_deploy_a7_manual_auto_on_rc]
 
 deploy_containers-dca-rc:
   extends: .deploy_containers-dca-base
-  rules:
-    !reference [.on_deploy_a7_rc]
+  rules: !reference [.on_deploy_a7_rc]
   variables:
     VERSION: rc
-
 
 deploy_containers-dca-latest:
   extends: .deploy_containers-dca-base
-  rules:
-    !reference [.on_deploy_a7_manual_final]
+  rules: !reference [.on_deploy_a7_manual_final]
   variables:
     VERSION: latest
 
-
 deploy_containers-dca_internal:
   extends: .deploy_containers-dca-base
-  rules:
-    !reference [.on_deploy_a7_internal_manual_final]
-
+  rules: !reference [.on_deploy_a7_internal_manual_final]
 
 deploy_containers-dca_internal-rc:
   extends: .deploy_containers-dca-base
-  rules:
-    !reference [.on_deploy_a7_internal_rc]
+  rules: !reference [.on_deploy_a7_internal_rc]
   variables:
     VERSION: rc
 
-
 deploy_containers-dca_internal-latest:
   extends: .deploy_containers-dca-base
-  rules:
-    !reference [.on_deploy_a7_internal_manual_final]
+  rules: !reference [.on_deploy_a7_internal_manual_final]
   variables:
     VERSION: latest


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Change the way the jobs from deploy_dca can be triggered in the pipeline
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Without `needs` clause, all deploy_dca jobs depend on the previous job execution (currently 
`deploy_containers-cws-instrumentation-rc` in `deploy_cws_instrumentation` stage. As a consequence a failure of the latter prevents execution of the whole stage like in [this](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/23213775) pipeline. Insert a needs clause to reflect the real job dependency
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
cf @sblumenthal 
Triggered a [full pipeline with deploy](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/23758744)
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
