### PR TITLE
tasks: share common macos workflow code

### DIFF
--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -10,12 +10,12 @@ from .libs.github_actions_tools import (
     print_workflow_conclusion,
     trigger_macos_workflow,
 )
-from .utils import DEFAULT_BRANCH, load_release_versions
+from .release import _get_release_json_value
+from .utils import DEFAULT_BRANCH
 
 
-def _trigger_macos_workflow(ctx, release, destination, retry_download, retry_interval, **kwargs):
-    env = load_release_versions(ctx, release)
-    github_action_ref = env["MACOS_BUILD_VERSION"]
+def _trigger_macos_workflow(release, destination, retry_download, retry_interval, **kwargs):
+    github_action_ref = _get_release_json_value(f'{release}::MACOS_BUILD_VERSION')
 
     run = trigger_macos_workflow(
         github_action_ref=github_action_ref,
@@ -37,7 +37,7 @@ def _trigger_macos_workflow(ctx, release, destination, retry_download, retry_int
 
 @task
 def trigger_macos_build(
-    ctx,
+    _,
     datadog_agent_ref=DEFAULT_BRANCH,
     release_version="nightly-a7",
     major_version="7",
@@ -48,7 +48,6 @@ def trigger_macos_build(
     retry_interval=10,
 ):
     _trigger_macos_workflow(
-        ctx,
         # Provide the release version to be able to fetch the associated
         # macos-build branch from release.json for all workflows...
         release_version,
@@ -71,7 +70,7 @@ def trigger_macos_build(
 
 @task
 def trigger_macos_test(
-    ctx,
+    _,
     datadog_agent_ref=DEFAULT_BRANCH,
     release_version="nightly-a7",
     python_runtimes="3",
@@ -81,7 +80,6 @@ def trigger_macos_test(
     retry_interval=10,
 ):
     _trigger_macos_workflow(
-        ctx,
         release_version,
         destination,
         retry_download,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR refactors the macOS workflow triggering into a common function in order to reduce the duplicated boilerplate

### Motivation

This will simplify adding new workflows without having to duplicate the boilerplate, which we'll need to do for APL-2393

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
