### PR TITLE
[corechecks/snmp] Fix profile metadata nil panic

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/profile/profile_resolver.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_resolver.go
@@ -100,6 +100,9 @@ func mergeProfileDefinition(targetDefinition *profiledefinition.ProfileDefinitio
 	targetDefinition.Metrics = append(targetDefinition.Metrics, baseDefinition.Metrics...)
 	targetDefinition.MetricTags = append(targetDefinition.MetricTags, baseDefinition.MetricTags...)
 	targetDefinition.StaticTags = append(targetDefinition.StaticTags, baseDefinition.StaticTags...)
+	if targetDefinition.Metadata == nil {
+		targetDefinition.Metadata = make(profiledefinition.MetadataConfig)
+	}
 	for baseResName, baseResource := range baseDefinition.Metadata {
 		if _, ok := targetDefinition.Metadata[baseResName]; !ok {
 			targetDefinition.Metadata[baseResName] = profiledefinition.NewMetadataResourceConfig()

--- a/pkg/collector/corechecks/snmp/internal/profile/testing_utils.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/testing_utils.go
@@ -10,33 +10,16 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/mohae/deepcopy"
+
 	"github.com/DataDog/datadog-agent/pkg/config"
 
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
 )
 
 // CopyProfileDefinition copies a profile, it's used for testing
-// TODO: Use deepcopy library instead?
 func CopyProfileDefinition(profileDef profiledefinition.ProfileDefinition) profiledefinition.ProfileDefinition {
-	newDef := profiledefinition.ProfileDefinition{}
-	newDef.Metrics = append(newDef.Metrics, profileDef.Metrics...)
-	newDef.MetricTags = append(newDef.MetricTags, profileDef.MetricTags...)
-	newDef.StaticTags = append(newDef.StaticTags, profileDef.StaticTags...)
-	newDef.Metadata = make(profiledefinition.MetadataConfig)
-	newDef.Device = profileDef.Device
-	newDef.Extends = append(newDef.Extends, profileDef.Extends...)
-	newDef.SysObjectIds = append(newDef.SysObjectIds, profileDef.SysObjectIds...)
-
-	for resName, resource := range profileDef.Metadata {
-		resConfig := profiledefinition.MetadataResourceConfig{}
-		resConfig.Fields = make(map[string]profiledefinition.MetadataField)
-		for fieldName, field := range resource.Fields {
-			resConfig.Fields[fieldName] = field
-		}
-		resConfig.IDTags = append(resConfig.IDTags, resource.IDTags...)
-		newDef.Metadata[resName] = resConfig
-	}
-	return newDef
+	return deepcopy.Copy(profileDef).(profiledefinition.ProfileDefinition)
 }
 
 // SetConfdPathAndCleanProfiles is used for testing only

--- a/pkg/collector/corechecks/snmp/internal/test/zipprofiles.d/snmp.d/default_profiles/def-p1.yaml
+++ b/pkg/collector/corechecks/snmp/internal/test/zipprofiles.d/snmp.d/default_profiles/def-p1.yaml
@@ -12,3 +12,13 @@ metrics:
   - symbol:
       OID: 1.2.3.5
       name: default_p1_metric
+
+# metadata section helps test the bug related to nil metadata
+# that is fixed by this PR: https://github.com/DataDog/datadog-agent/pull/20859
+metadata:
+  device:
+    fields:
+      name:
+        symbol:
+          OID: 1.3.6.1.2.1.1.5.0
+          name: sysName


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
[corechecks/snmp] Fix profile metadata nil panic

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fix panic caused by nil metadata here: https://github.com/DataDog/datadog-agent/pull/20859/files#diff-ce15762cefd6108cbf228ca1f56d6cfca63d23a95e7082b44203dec45f41b663R108

Only happens when downloaded profiles.json.gz (unlike yaml unmarshaller, the json unmarshaller used for downloaded profiles will generate a nil metadata field)

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
