### PR TITLE
mount resolver: remove unused `mountToPids`

### DIFF
--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -69,7 +69,6 @@ type Resolver struct {
 	statsdClient    statsd.ClientInterface
 	lock            sync.RWMutex
 	mounts          map[uint32]*model.Mount
-	mountToPids     map[uint32]map[uint32]struct{}
 	pidToMounts     map[uint32]map[uint32]*model.Mount
 	minMountID      uint32 // used to find the first userspace visible mount ID
 	redemption      *simplelru.LRU[uint32, *redemptionEntry]
@@ -179,16 +178,6 @@ func (mr *Resolver) delete(mount *model.Mount) {
 
 func (mr *Resolver) finalize(mount *model.Mount) {
 	delete(mr.mounts, mount.MountID)
-
-	if pids, exists := mr.mountToPids[mount.MountID]; exists {
-		for pid := range pids {
-			if mounts, exists := mr.pidToMounts[pid]; exists {
-				delete(mounts, mount.MountID)
-			}
-		}
-		delete(mr.mountToPids, mount.MountID)
-	}
-
 }
 
 // Delete a mount from the cache
@@ -254,17 +243,11 @@ func (mr *Resolver) DelPid(pid uint32) {
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
 
-	mounts, exists := mr.pidToMounts[pid]
+	_, exists := mr.pidToMounts[pid]
 	if !exists {
 		return
 	}
 	delete(mr.pidToMounts, pid)
-
-	for _, mount := range mounts {
-		if pids, exists := mr.mountToPids[mount.MountID]; exists {
-			delete(pids, pid)
-		}
-	}
 }
 
 func (mr *Resolver) insert(m *model.Mount, pid uint32) {
@@ -616,7 +599,6 @@ func NewResolver(statsdClient statsd.ClientInterface, cgroupsResolver *cgroup.Re
 		lock:            sync.RWMutex{},
 		mounts:          make(map[uint32]*model.Mount),
 		pidToMounts:     make(map[uint32]map[uint32]*model.Mount),
-		mountToPids:     make(map[uint32]map[uint32]struct{}),
 		cacheHitsStats:  atomic.NewInt64(0),
 		procHitsStats:   atomic.NewInt64(0),
 		cacheMissStats:  atomic.NewInt64(0),

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -243,10 +243,6 @@ func (mr *Resolver) DelPid(pid uint32) {
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
 
-	_, exists := mr.pidToMounts[pid]
-	if !exists {
-		return
-	}
 	delete(mr.pidToMounts, pid)
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

`mountToPids` is read from, but never written to. This PR removes it completely
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
