### PR TITLE
[workloadmeta] Fix panic in image_util

### DIFF
--- a/pkg/workloadmeta/image_util.go
+++ b/pkg/workloadmeta/image_util.go
@@ -20,7 +20,9 @@ const (
 // updateSBOMRepoMetadata updates entered SBOM with new metadata properties if the initial SBOM status was successful
 // and there are new repoTags and repoDigests missing in the SBOM. It returns the updated SBOM.
 func updateSBOMRepoMetadata(sbom *SBOM, repoTags, repoDigests []string) *SBOM {
-	if sbom.Status != Success || sbom.CycloneDXBOM.Metadata.Component.Properties == nil {
+	if sbom == nil || sbom.Status != Success || sbom.CycloneDXBOM == nil ||
+		sbom.CycloneDXBOM.Metadata == nil || sbom.CycloneDXBOM.Metadata.Component == nil ||
+		sbom.CycloneDXBOM.Metadata.Component.Properties == nil {
 		return sbom
 	}
 

--- a/pkg/workloadmeta/image_util_test.go
+++ b/pkg/workloadmeta/image_util_test.go
@@ -40,6 +40,72 @@ func Test_updateSBOMRepoMetadata(t *testing.T) {
 			},
 		},
 		{
+			name: "sbom is nil",
+			args: args{
+				sbom:        nil,
+				repoTags:    []string{"tag1"},
+				repoDigests: []string{"digest1"},
+			},
+			want: nil,
+		},
+		{
+			name: "CycloneDXBOM is nil",
+			args: args{
+				sbom: &SBOM{
+					Status:       Success,
+					CycloneDXBOM: nil,
+				},
+				repoTags:    []string{"tag1"},
+				repoDigests: []string{"digest1"},
+			},
+			want: &SBOM{
+				Status:       Success,
+				CycloneDXBOM: nil,
+			},
+		},
+		{
+			name: "metadata is nil",
+			args: args{
+				sbom: &SBOM{
+					Status: Success,
+					CycloneDXBOM: &cyclonedx.BOM{
+						Metadata: nil,
+					},
+				},
+				repoTags:    []string{"tag1"},
+				repoDigests: []string{"digest1"},
+			},
+			want: &SBOM{
+				Status: Success,
+				CycloneDXBOM: &cyclonedx.BOM{
+					Metadata: nil,
+				},
+			},
+		},
+		{
+			name: "component is nil",
+			args: args{
+				sbom: &SBOM{
+					Status: Success,
+					CycloneDXBOM: &cyclonedx.BOM{
+						Metadata: &cyclonedx.Metadata{
+							Component: nil,
+						},
+					},
+				},
+				repoTags:    []string{"tag1"},
+				repoDigests: []string{"digest1"},
+			},
+			want: &SBOM{
+				Status: Success,
+				CycloneDXBOM: &cyclonedx.BOM{
+					Metadata: &cyclonedx.Metadata{
+						Component: nil,
+					},
+				},
+			},
+		},
+		{
 			name: "properties is nil",
 			args: args{
 				sbom: &SBOM{


### PR DESCRIPTION
### What does this PR do?

Fixes the following panic during SBOM generation:
```
2023-11-14 13:24:47 UTC | CORE | INFO | (pkg/util/containers/metrics/provider/registry.go:99 in collectorDiscovery) | Container metrics provider discovery process finished
2023-11-14 13:24:47 UTC | CORE | WARN | (pkg/workloadmeta/collectors/internal/containerd/containerd.go:175 in stream) | error getting image: image "eu.gcr.io/datadog-staging/datadog-agent@sha256:9d4fadd7f8b445c11d444fc91e9d6c30f306ed07608604584a226291bda9c9b4": not found
2023-11-14 13:24:47 UTC | CORE | WARN | (pkg/workloadmeta/collectors/internal/containerd/containerd.go:175 in stream) | error getting image: image "sha256:df4eef994d45da531c16a05922fb9bcd4e1cb3071d4ccb48ba795829863beae8": not found
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x3cd31b6]

goroutine 454 [running]:
github.com/DataDog/datadog-agent/pkg/workloadmeta.updateSBOMRepoMetadata(0x0?, {0x0?, 0x7bd52af?, 0x5?}, {0x0?, 0x0?, 0xc001ce9000?})
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/image_util.go:23 +0x36
github.com/DataDog/datadog-agent/pkg/workloadmeta.(*ContainerImageMetadata).Merge(0xc000840500, {0x8fc4950?, 0xc00222a900?})
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/types.go:940 +0x5f
github.com/DataDog/datadog-agent/pkg/workloadmeta.(*store).handleEvents(0xc001e22a20, {0xc003470060, 0x1, 0x0?})
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/store.go:700 +0xcb4
github.com/DataDog/datadog-agent/pkg/workloadmeta.(*store).Start.func1()
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/store.go:98 +0x145
created by github.com/DataDog/datadog-agent/pkg/workloadmeta.(*store).Start
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/store.go:91 +0x95
```

### Motivation

Agent pods are crashlooping in staging with this error

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Follow the set up steps outlined in this PR: https://github.com/DataDog/datadog-agent/pull/20437

Then delete an image from a node. The agent running on that node should not crash as a result


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
