### PR TITLE
Deploy agent on metal instances launched for KMT

### DIFF
--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -289,14 +289,16 @@ upload_minimized_btfs_arm64:
     PIPELINE_ID: $CI_PIPELINE_ID
     TEAM: "ebpf-platform"
     RESOURCE_TAGS: "instance-type:${INSTANCE_TYPE},arch:${ARCH}"
+    AGENT_VERSION: "7.49"
   before_script:
+    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
     - !reference [.retrieve_linux_go_deps]
     - !reference [.kernel_matrix_testing_new_profile]
     - !reference [.write_ssh_key_file]
   script:
     - echo "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE" > $STACK_DIR
     - pulumi login $(cat $STACK_DIR | tr -d '\n')
-    - inv -e system-probe.start-microvms --provision --vmconfig=$VMCONFIG_PATH $INSTANCE_TYPE_ARG $AMI_ID_ARG --ssh-key-name=$AWS_EC2_SSH_KEY_NAME --ssh-key-path=$AWS_EC2_SSH_KEY_FILE --infra-env=$INFRA_ENV --stack-name=kernel-matrix-testing-$ARCH-$CI_PIPELINE_ID
+    - inv -e system-probe.start-microvms --provision --vmconfig=$VMCONFIG_PATH $INSTANCE_TYPE_ARG $AMI_ID_ARG --ssh-key-name=$AWS_EC2_SSH_KEY_NAME --ssh-key-path=$AWS_EC2_SSH_KEY_FILE --infra-env=$INFRA_ENV --stack-name=kernel-matrix-testing-$ARCH-$CI_PIPELINE_ID --api-key $DD_API_KEY --run-agent --agent-version $AGENT_VERSION
     - cat $CI_PROJECT_DIR/stack.output
     - pulumi logout
   after_script:

--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -289,7 +289,6 @@ upload_minimized_btfs_arm64:
     PIPELINE_ID: $CI_PIPELINE_ID
     TEAM: "ebpf-platform"
     RESOURCE_TAGS: "instance-type:${INSTANCE_TYPE},arch:${ARCH}"
-    AGENT_VERSION: "7.49"
     KUBERNETES_MEMORY_REQUEST: "12Gi"
     KUBERNETES_MEMORY_LIMIT: "16Gi"
   before_script:
@@ -302,7 +301,7 @@ upload_minimized_btfs_arm64:
   script:
     - echo "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE" > $STACK_DIR
     - pulumi login $(cat $STACK_DIR | tr -d '\n')
-    - inv -e system-probe.start-microvms --provision --vmconfig=$VMCONFIG_PATH $INSTANCE_TYPE_ARG $AMI_ID_ARG --ssh-key-name=$AWS_EC2_SSH_KEY_NAME --ssh-key-path=$AWS_EC2_SSH_KEY_FILE --infra-env=$INFRA_ENV --stack-name=kernel-matrix-testing-$ARCH-$CI_PIPELINE_ID --run-agent --agent-version=$AGENT_VERSION
+    - inv -e system-probe.start-microvms --provision --vmconfig=$VMCONFIG_PATH $INSTANCE_TYPE_ARG $AMI_ID_ARG --ssh-key-name=$AWS_EC2_SSH_KEY_NAME --ssh-key-path=$AWS_EC2_SSH_KEY_FILE --infra-env=$INFRA_ENV --stack-name=kernel-matrix-testing-$ARCH-$CI_PIPELINE_ID --run-agent
     - cat $CI_PROJECT_DIR/stack.output
     - pulumi logout
   after_script:

--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -290,6 +290,8 @@ upload_minimized_btfs_arm64:
     TEAM: "ebpf-platform"
     RESOURCE_TAGS: "instance-type:${INSTANCE_TYPE},arch:${ARCH}"
     AGENT_VERSION: "7.49"
+    KUBERNETES_MEMORY_REQUEST: "12Gi"
+    KUBERNETES_MEMORY_LIMIT: "16Gi"
   before_script:
     - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
     - !reference [.retrieve_linux_go_deps]

--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -302,7 +302,7 @@ upload_minimized_btfs_arm64:
   script:
     - echo "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE" > $STACK_DIR
     - pulumi login $(cat $STACK_DIR | tr -d '\n')
-    - inv -e system-probe.start-microvms --provision --vmconfig=$VMCONFIG_PATH $INSTANCE_TYPE_ARG $AMI_ID_ARG --ssh-key-name=$AWS_EC2_SSH_KEY_NAME --ssh-key-path=$AWS_EC2_SSH_KEY_FILE --infra-env=$INFRA_ENV --stack-name=kernel-matrix-testing-$ARCH-$CI_PIPELINE_ID --run-agent --agent-version $AGENT_VERSION
+    - inv -e system-probe.start-microvms --provision --vmconfig=$VMCONFIG_PATH $INSTANCE_TYPE_ARG $AMI_ID_ARG --ssh-key-name=$AWS_EC2_SSH_KEY_NAME --ssh-key-path=$AWS_EC2_SSH_KEY_FILE --infra-env=$INFRA_ENV --stack-name=kernel-matrix-testing-$ARCH-$CI_PIPELINE_ID --run-agent --agent-version=$AGENT_VERSION
     - cat $CI_PROJECT_DIR/stack.output
     - pulumi logout
   after_script:

--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -298,7 +298,7 @@ upload_minimized_btfs_arm64:
   script:
     - echo "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE" > $STACK_DIR
     - pulumi login $(cat $STACK_DIR | tr -d '\n')
-    - inv -e system-probe.start-microvms --provision --vmconfig=$VMCONFIG_PATH $INSTANCE_TYPE_ARG $AMI_ID_ARG --ssh-key-name=$AWS_EC2_SSH_KEY_NAME --ssh-key-path=$AWS_EC2_SSH_KEY_FILE --infra-env=$INFRA_ENV --stack-name=kernel-matrix-testing-$ARCH-$CI_PIPELINE_ID --api-key $DD_API_KEY --run-agent --agent-version $AGENT_VERSION
+    - inv -e system-probe.start-microvms --provision --vmconfig=$VMCONFIG_PATH $INSTANCE_TYPE_ARG $AMI_ID_ARG --ssh-key-name=$AWS_EC2_SSH_KEY_NAME --ssh-key-path=$AWS_EC2_SSH_KEY_FILE --infra-env=$INFRA_ENV --stack-name=kernel-matrix-testing-$ARCH-$CI_PIPELINE_ID --run-agent --agent-version $AGENT_VERSION
     - cat $CI_PROJECT_DIR/stack.output
     - pulumi logout
   after_script:

--- a/.gitlab/kernel_version_testing/system_probe.yml
+++ b/.gitlab/kernel_version_testing/system_probe.yml
@@ -293,7 +293,9 @@ upload_minimized_btfs_arm64:
     KUBERNETES_MEMORY_REQUEST: "12Gi"
     KUBERNETES_MEMORY_LIMIT: "16Gi"
   before_script:
+    - set +x
     - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
+    - set -x
     - !reference [.retrieve_linux_go_deps]
     - !reference [.kernel_matrix_testing_new_profile]
     - !reference [.write_ssh_key_file]
@@ -348,7 +350,9 @@ kernel_matrix_testing_setup_env_x64:
     AWS_EC2_SSH_KEY_FILE: $CI_PROJECT_DIR/ssh_key
     RETRY: 2
   before_script:
+    - set +x
     - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key_org2 --with-decryption --query "Parameter.Value" --out text)
+    - set -x
     - !reference [.kernel_matrix_testing_new_profile]
     - !reference [.write_ssh_key_file]
   script:

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1672,6 +1672,9 @@ def start_microvms(
     vmconfig=None,
     local=False,
     provision=False,
+    run_agent=False,
+    api_key=None,
+    agent_version=None,
 ):
     args = [
         f"--instance-type-x86 {instance_type_x86}" if instance_type_x86 else "",
@@ -1688,6 +1691,9 @@ def start_microvms(
         f"--vmconfig {vmconfig}" if vmconfig else "",
         "--run-provision" if provision else "",
         "--local" if local else "",
+        f"--run-agent {run_agent}" if run_agent else ""
+        f"--api-key {api_key}" if api_key else "",
+        f"--agent-version {agent_version}", if agent_version else "",
     ]
 
     go_args = ' '.join(filter(lambda x: x != "", args))

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1673,7 +1673,6 @@ def start_microvms(
     local=False,
     provision=False,
     run_agent=False,
-    api_key=None,
     agent_version=None,
 ):
     args = [
@@ -1692,7 +1691,6 @@ def start_microvms(
         "--run-provision" if provision else "",
         "--local" if local else "",
         f"--run-agent" if run_agent else "",
-        f"--api-key {api_key}" if api_key else "",
         f"--agent-version {agent_version}" if agent_version else "",
     ]
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1690,7 +1690,7 @@ def start_microvms(
         f"--vmconfig {vmconfig}" if vmconfig else "",
         "--run-provision" if provision else "",
         "--local" if local else "",
-        f"--run-agent" if run_agent else "",
+        "--run-agent" if run_agent else "",
         f"--agent-version {agent_version}" if agent_version else "",
     ]
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1691,7 +1691,7 @@ def start_microvms(
         f"--vmconfig {vmconfig}" if vmconfig else "",
         "--run-provision" if provision else "",
         "--local" if local else "",
-        f"--run-agent {run_agent}" if run_agent else "",
+        f"--run-agent" if run_agent else "",
         f"--api-key {api_key}" if api_key else "",
         f"--agent-version {agent_version}" if agent_version else "",
     ]

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1691,9 +1691,9 @@ def start_microvms(
         f"--vmconfig {vmconfig}" if vmconfig else "",
         "--run-provision" if provision else "",
         "--local" if local else "",
-        f"--run-agent {run_agent}" if run_agent else ""
+        f"--run-agent {run_agent}" if run_agent else "",
         f"--api-key {api_key}" if api_key else "",
-        f"--agent-version {agent_version}", if agent_version else "",
+        f"--agent-version {agent_version}" if agent_version else "",
     ]
 
     go_args = ' '.join(filter(lambda x: x != "", args))

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -22,10 +22,9 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20231113131450-99ce13afdb49
+	github.com/DataDog/test-infra-definitions v0.0.0-20231114085137-553f646b1e62
 	github.com/aws/aws-sdk-go-v2 v1.22.1
 	github.com/aws/aws-sdk-go-v2/config v1.18.40
-	github.com/DataDog/test-infra-definitions v0.0.0-20231114085137-553f646b1e62
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.130.0
 	github.com/aws/aws-sdk-go-v2/service/eks v1.29.7
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.36.4

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/DataDog/test-infra-definitions v0.0.0-20231113131450-99ce13afdb49
 	github.com/aws/aws-sdk-go-v2 v1.22.1
 	github.com/aws/aws-sdk-go-v2/config v1.18.40
+	github.com/DataDog/test-infra-definitions v0.0.0-20231114085137-553f646b1e62
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.130.0
 	github.com/aws/aws-sdk-go-v2/service/eks v1.29.7
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.36.4

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/DataDog/test-infra-definitions v0.0.0-20231114085137-553f646b1e62
 	github.com/aws/aws-sdk-go-v2 v1.22.1
 	github.com/aws/aws-sdk-go-v2/config v1.18.40
+	github.com/DataDog/test-infra-definitions v0.0.0-20231115132144-48a1dcb5f266
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.130.0
 	github.com/aws/aws-sdk-go-v2/service/eks v1.29.7
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.36.4

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -22,7 +22,7 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20231115132144-48a1dcb5f266
+	github.com/DataDog/test-infra-definitions v0.0.0-20231117170844-58b54f06414b
 	github.com/aws/aws-sdk-go-v2 v1.22.1
 	github.com/aws/aws-sdk-go-v2/config v1.18.40
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.130.0

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -22,10 +22,9 @@ require (
 	// `TEST_INFRA_DEFINITIONS_BUILDIMAGES` matches the commit sha in the module version
 	// Example: 	github.com/DataDog/test-infra-definitions v0.0.0-YYYYMMDDHHmmSS-0123456789AB
 	// => TEST_INFRA_DEFINITIONS_BUILDIMAGES: 0123456789AB
-	github.com/DataDog/test-infra-definitions v0.0.0-20231114085137-553f646b1e62
+	github.com/DataDog/test-infra-definitions v0.0.0-20231115132144-48a1dcb5f266
 	github.com/aws/aws-sdk-go-v2 v1.22.1
 	github.com/aws/aws-sdk-go-v2/config v1.18.40
-	github.com/DataDog/test-infra-definitions v0.0.0-20231115132144-48a1dcb5f266
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.130.0
 	github.com/aws/aws-sdk-go-v2/service/eks v1.29.7
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.36.4
@@ -73,7 +72,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.42 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ecs v1.29.6
+	github.com/aws/aws-sdk-go-v2/service/ecs v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.10.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.14.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.16.0 // indirect

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -12,8 +12,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.15.0 h1:5UVON1xs6Lul4d6R5TmLDqqSJ
 github.com/DataDog/datadog-api-client-go/v2 v2.15.0/go.mod h1:ZG8wS+y2rUmkRDJZQq7Og7EAPFPage+7vXcmuah2I9o=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20231114085137-553f646b1e62 h1:yjL8Eh40t6cyfnBpu+utBzwHFW8yOuIVp6eNG39i6kQ=
-github.com/DataDog/test-infra-definitions v0.0.0-20231114085137-553f646b1e62/go.mod h1:PqwpYO1dh26TxKAY1TiiMLmmSxzytx3OrXtYl086m2c=
+github.com/DataDog/test-infra-definitions v0.0.0-20231115132144-48a1dcb5f266 h1:4Dxn8f+FGGGwNrCnUBrc9aSxB4LojnLi0jW06Ht3A6E=
+github.com/DataDog/test-infra-definitions v0.0.0-20231115132144-48a1dcb5f266/go.mod h1:eyJ09i8Y8Ofu1gsfNJzL6VtIbLY0MR1atqxsculv4Lo=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=
@@ -78,8 +78,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.3.42 h1:GPUcE/Yq7Ur8YSUk6lVkoIMWnJN
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.42/go.mod h1:rzfdUlfA+jdgLDmPKjd3Chq9V7LVLYo1Nz++Wb91aRo=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.130.0 h1:a7CPCX/m+owAiAqcK8W9/SoB7EA4QUE4BddYdFyEGco=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.130.0/go.mod h1:EJlGVMO5zynmSDdvwJfFa2RzAZoHI4gVJER0h82/dYk=
-github.com/aws/aws-sdk-go-v2/service/ecs v1.29.6 h1:D8aVp/27erJY/c+BeCM2RD6/KTshRAIr5z41nncMfxU=
-github.com/aws/aws-sdk-go-v2/service/ecs v1.29.6/go.mod h1:cxbA26Kf4UlTb40f5FON22ZPNMyEVmMS82KUJZC1E1w=
+github.com/aws/aws-sdk-go-v2/service/ecs v1.30.1 h1:bOS7hAfvd8+glVAG88WnvRITe5N1vopGFHh10ORe/BI=
+github.com/aws/aws-sdk-go-v2/service/ecs v1.30.1/go.mod h1:cxbA26Kf4UlTb40f5FON22ZPNMyEVmMS82KUJZC1E1w=
 github.com/aws/aws-sdk-go-v2/service/eks v1.29.7 h1:MRBXts9pc/3RdaeLXR4HwmVhqMP70sOEYHpkgmAWDbU=
 github.com/aws/aws-sdk-go-v2/service/eks v1.29.7/go.mod h1:Nt5l6Vn68Hv0JWJ6dcQDKuBAKAfHUZSC9Ln8X/1fUMY=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.35/go.mod h1:QGF2Rs33W5MaN9gYdEQOBBFPLwTZkEhRwI33f7KIG0o=

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -12,8 +12,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.15.0 h1:5UVON1xs6Lul4d6R5TmLDqqSJ
 github.com/DataDog/datadog-api-client-go/v2 v2.15.0/go.mod h1:ZG8wS+y2rUmkRDJZQq7Og7EAPFPage+7vXcmuah2I9o=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20231113131450-99ce13afdb49 h1:X08p5axuFeIC+9UWyZukTQTvpP6YKcKxjjvB6i6NWyc=
-github.com/DataDog/test-infra-definitions v0.0.0-20231113131450-99ce13afdb49/go.mod h1:PqwpYO1dh26TxKAY1TiiMLmmSxzytx3OrXtYl086m2c=
+github.com/DataDog/test-infra-definitions v0.0.0-20231114085137-553f646b1e62 h1:yjL8Eh40t6cyfnBpu+utBzwHFW8yOuIVp6eNG39i6kQ=
+github.com/DataDog/test-infra-definitions v0.0.0-20231114085137-553f646b1e62/go.mod h1:PqwpYO1dh26TxKAY1TiiMLmmSxzytx3OrXtYl086m2c=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -12,8 +12,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.15.0 h1:5UVON1xs6Lul4d6R5TmLDqqSJ
 github.com/DataDog/datadog-api-client-go/v2 v2.15.0/go.mod h1:ZG8wS+y2rUmkRDJZQq7Og7EAPFPage+7vXcmuah2I9o=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.0-20231115132144-48a1dcb5f266 h1:4Dxn8f+FGGGwNrCnUBrc9aSxB4LojnLi0jW06Ht3A6E=
-github.com/DataDog/test-infra-definitions v0.0.0-20231115132144-48a1dcb5f266/go.mod h1:eyJ09i8Y8Ofu1gsfNJzL6VtIbLY0MR1atqxsculv4Lo=
+github.com/DataDog/test-infra-definitions v0.0.0-20231117170844-58b54f06414b h1:VZvgOpW3+l7FEAFWH4QhWix3leBwSif5nRYqh5ZAyRM=
+github.com/DataDog/test-infra-definitions v0.0.0-20231117170844-58b54f06414b/go.mod h1:eyJ09i8Y8Ofu1gsfNJzL6VtIbLY0MR1atqxsculv4Lo=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=

--- a/test/new-e2e/scenarios/system-probe/main.go
+++ b/test/new-e2e/scenarios/system-probe/main.go
@@ -52,7 +52,6 @@ func main() {
 	dependenciesDirectoryPtr := flag.String("dependencies-dir", DD_AGENT_TESTING_DIR, "directory where dependencies package is present")
 	vmconfigPathPtr := flag.String("vmconfig", defaultVMConfigPath, "vmconfig path")
 	local := flag.Bool("local", false, "is scenario running locally")
-	apiKeyPtr := flag.String("api-key", "", "API key for the datadog agent")
 	runAgentPtr := flag.Bool("run-agent", false, "Run datadog agent on the metal instance")
 	agentVersionPtr := flag.String("agent-version", "7.49", "Version of datadog-agent")
 
@@ -76,7 +75,6 @@ func main() {
 		VMConfigPath:          *vmconfigPathPtr,
 		Local:                 *local,
 		RunAgent:              *runAgentPtr,
-		APIKey:                *apiKeyPtr,
 		AgentVersion:          *agentVersionPtr,
 	}
 

--- a/test/new-e2e/scenarios/system-probe/main.go
+++ b/test/new-e2e/scenarios/system-probe/main.go
@@ -52,6 +52,9 @@ func main() {
 	dependenciesDirectoryPtr := flag.String("dependencies-dir", DD_AGENT_TESTING_DIR, "directory where dependencies package is present")
 	vmconfigPathPtr := flag.String("vmconfig", defaultVMConfigPath, "vmconfig path")
 	local := flag.Bool("local", false, "is scenario running locally")
+	apiKeyPtr := flag.String("api-key", "", "API key for the datadog agent")
+	runAgentPtr := flag.Bool("run-agent", false, "Run datadog agent on the metal instance")
+	agentVersionPtr := flag.String("agent-version", "7.49", "Version of datadog-agent")
 
 	flag.Parse()
 
@@ -72,9 +75,10 @@ func main() {
 		DependenciesDirectory: *dependenciesDirectoryPtr,
 		VMConfigPath:          *vmconfigPathPtr,
 		Local:                 *local,
+		RunAgent:              *runAgentPtr,
+		APIKey:                *apiKeyPtr,
+		AgentVersion:          *agentVersionPtr,
 	}
-
-	fmt.Printf("shutdown period: %d\n", opts.ShutdownPeriod)
 
 	err := run(*envNamePtr, *x86InstanceTypePtr, *armInstanceTypePtr, *destroyPtr, &opts)
 	if err != nil {

--- a/test/new-e2e/scenarios/system-probe/main.go
+++ b/test/new-e2e/scenarios/system-probe/main.go
@@ -53,7 +53,7 @@ func main() {
 	vmconfigPathPtr := flag.String("vmconfig", defaultVMConfigPath, "vmconfig path")
 	local := flag.Bool("local", false, "is scenario running locally")
 	runAgentPtr := flag.Bool("run-agent", false, "Run datadog agent on the metal instance")
-	agentVersionPtr := flag.String("agent-version", "7.49", "Version of datadog-agent")
+	agentVersionPtr := flag.String("agent-version", "", "Version of datadog-agent")
 
 	flag.Parse()
 

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -144,10 +144,6 @@ func getAvailabilityZone(env string, azIndx int) string {
 	return ""
 }
 
-func trueStr(t bool) string {
-	return fmt.Sprintf("%v", t)
-}
-
 func NewTestEnv(name, x86InstanceType, armInstanceType string, opts *SystemProbeEnvOpts) (*TestEnv, error) {
 	var err error
 	var sudoPassword string
@@ -187,11 +183,11 @@ func NewTestEnv(name, x86InstanceType, armInstanceType string, opts *SystemProbe
 		"microvm:microVMConfigFile":              auto.ConfigValue{Value: opts.VMConfigPath},
 		"microvm:libvirtSSHKeyFileX86":           auto.ConfigValue{Value: sshKeyX86},
 		"microvm:libvirtSSHKeyFileArm":           auto.ConfigValue{Value: sshKeyArm},
-		"microvm:provision":                      auto.ConfigValue{Value: trueStr(opts.Provision)},
+		"microvm:provision":                      auto.ConfigValue{Value: strconv.FormatBool(opts.Provision)},
 		"microvm:x86AmiID":                       auto.ConfigValue{Value: opts.X86AmiID},
 		"microvm:arm64AmiID":                     auto.ConfigValue{Value: opts.ArmAmiID},
 		"microvm:workingDir":                     auto.ConfigValue{Value: CustomAMIWorkingDir},
-		"ddagent:deploy":                         auto.ConfigValue{Value: trueStr(opts.RunAgent)},
+		"ddagent:deploy":                         auto.ConfigValue{Value: strconv.FormatBool(opts.RunAgent)},
 		"ddagent:version":                        auto.ConfigValue{Value: opts.AgentVersion},
 		"ddagent:apiKey":                         auto.ConfigValue{Value: apiKey, Secret: true},
 	}

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -188,7 +188,6 @@ func NewTestEnv(name, x86InstanceType, armInstanceType string, opts *SystemProbe
 		"microvm:arm64AmiID":                     auto.ConfigValue{Value: opts.ArmAmiID},
 		"microvm:workingDir":                     auto.ConfigValue{Value: CustomAMIWorkingDir},
 		"ddagent:deploy":                         auto.ConfigValue{Value: strconv.FormatBool(opts.RunAgent)},
-		"ddagent:version":                        auto.ConfigValue{Value: opts.AgentVersion},
 		"ddagent:apiKey":                         auto.ConfigValue{Value: apiKey, Secret: true},
 	}
 	// We cannot add defaultPrivateKeyPath if the key is in ssh-agent, otherwise passphrase is needed
@@ -201,6 +200,11 @@ func NewTestEnv(name, x86InstanceType, armInstanceType string, opts *SystemProbe
 	if opts.ShutdownPeriod != 0 {
 		config["microvm:shutdownPeriod"] = auto.ConfigValue{Value: strconv.Itoa(opts.ShutdownPeriod)}
 		config["ddinfra:aws/defaultShutdownBehavior"] = auto.ConfigValue{Value: "terminate"}
+	}
+
+	// If no agent version is provided the framework will automatically install the latest agent
+	if opts.AgentVersion != "" {
+		config["ddagent:version"] = auto.ConfigValue{Value: opts.AgentVersion}
 	}
 
 	if envVars := GetEnv(EC2TagsEnvVar, ""); envVars != "" {

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -168,7 +168,8 @@ func NewTestEnv(name, x86InstanceType, armInstanceType string, opts *SystemProbe
 		sudoPassword = ""
 	}
 
-	if opts.RunAgent && opts.APIKey == "" {
+	apiKey := GetEnv("DD_API_KEY", "")
+	if opts.RunAgent && apiKey == "" {
 		return nil, fmt.Errorf("No API Key for datadog-agent provided")
 	}
 
@@ -192,7 +193,7 @@ func NewTestEnv(name, x86InstanceType, armInstanceType string, opts *SystemProbe
 		"microvm:workingDir":                     auto.ConfigValue{Value: CustomAMIWorkingDir},
 		"ddagent:deploy":                         auto.ConfigValue{Value: trueStr(opts.RunAgent)},
 		"ddagent:version":                        auto.ConfigValue{Value: opts.AgentVersion},
-		"ddagent:apiKey":                         auto.ConfigValue{Value: opts.APIKey},
+		"ddagent:apiKey":                         auto.ConfigValue{Value: apiKey, Secret: true},
 	}
 	// We cannot add defaultPrivateKeyPath if the key is in ssh-agent, otherwise passphrase is needed
 	if opts.SSHKeyPath != "" {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR deploys the datadog-agent on the metal instances launched as part of KMT.


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Get metrics on the resource utilization of the metal instance. These can then be used to make decisions about changing instance types, and restructuring the tests for more efficient resource usage.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Associated PR in [test-infra-definitions](https://github.com/DataDog/test-infra-definitions/pull/442)

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
