### PR TITLE
[NDM] Fix Netflow custom fields default field override

### DIFF
--- a/comp/netflow/goflowlib/additionalfields/netflow.go
+++ b/comp/netflow/goflowlib/additionalfields/netflow.go
@@ -9,7 +9,6 @@ package additionalfields
 
 import (
 	"bytes"
-	"encoding/hex"
 	"errors"
 	"github.com/DataDog/datadog-agent/comp/netflow/common"
 	"github.com/DataDog/datadog-agent/comp/netflow/config"
@@ -36,7 +35,7 @@ func mapAdditionalField(additionalFields common.AdditionalFields, v []byte, cfg 
 	} else if cfg.Type == common.String {
 		additionalFields[cfg.Destination] = string(bytes.Trim(v, "\x00")) // Removing trailing null chars
 	} else {
-		additionalFields[cfg.Destination] = hex.EncodeToString(v)
+		additionalFields[cfg.Destination] = v
 	}
 }
 

--- a/comp/netflow/goflowlib/additionalfields/netflow_test.go
+++ b/comp/netflow/goflowlib/additionalfields/netflow_test.go
@@ -92,7 +92,7 @@ func Test_ProcessMessageNetFlowAdditionalFields(t *testing.T) {
 				},
 			},
 			expectedCollectedFields: []common.AdditionalFields{{
-				"test_field": "2d0c",
+				"test_field": []byte{45, 12},
 			}},
 		},
 		{

--- a/comp/netflow/goflowlib/convert.go
+++ b/comp/netflow/goflowlib/convert.go
@@ -8,6 +8,7 @@
 package goflowlib
 
 import (
+	"encoding/hex"
 	flowpb "github.com/netsampler/goflow2/pb"
 
 	"github.com/DataDog/datadog-agent/comp/netflow/common"
@@ -74,6 +75,11 @@ func applyAdditionalFields(flow *common.Flow, additionalFields common.Additional
 		if applied {
 			// We replaced a field of common.Flow with an additional field, no need to keep it in the map
 			delete(additionalFields, destination)
+		} else {
+			if field, ok := fieldValue.([]byte); ok {
+				// Write []byte as hex string for readability
+				additionalFields[destination] = bytesToHexString(field)
+			}
 		}
 	}
 	flow.AdditionalFields = additionalFields
@@ -83,63 +89,69 @@ func applyAdditionalField(flow *common.Flow, destination string, fieldValue any)
 	// Make sure FlowFieldsTypes includes the type of the following fields
 	switch destination {
 	case "direction":
-		setValue(&flow.Direction, fieldValue)
+		setInt(&flow.Direction, fieldValue)
 	case "start":
-		setValue(&flow.StartTimestamp, fieldValue)
+		setInt(&flow.StartTimestamp, fieldValue)
 	case "end":
-		setValue(&flow.EndTimestamp, fieldValue)
+		setInt(&flow.EndTimestamp, fieldValue)
 	case "bytes":
-		setValue(&flow.Bytes, fieldValue)
+		setInt(&flow.Bytes, fieldValue)
 	case "packets":
-		setValue(&flow.Packets, fieldValue)
+		setInt(&flow.Packets, fieldValue)
 	case "ether_type":
-		setValue(&flow.EtherType, fieldValue)
+		setInt(&flow.EtherType, fieldValue)
 	case "ip_protocol":
-		setValue(&flow.IPProtocol, fieldValue)
+		setInt(&flow.IPProtocol, fieldValue)
 	case "exporter.ip":
-		setValue(&flow.ExporterAddr, fieldValue)
+		setBytes(&flow.ExporterAddr, fieldValue)
 	case "source.ip":
-		setValue(&flow.SrcAddr, fieldValue)
+		setBytes(&flow.SrcAddr, fieldValue)
 	case "source.port":
 		var port uint64
-		setValue(&port, fieldValue)
+		setInt(&port, fieldValue)
 		flow.SrcPort = int32(port)
 	case "source.mac":
-		setValue(&flow.SrcMac, fieldValue)
+		setInt(&flow.SrcMac, fieldValue)
 	case "source.mask":
-		setValue(&flow.SrcMask, fieldValue)
+		setInt(&flow.SrcMask, fieldValue)
 	case "destination.ip":
-		setValue(&flow.DstAddr, fieldValue)
+		setBytes(&flow.DstAddr, fieldValue)
 	case "destination.port":
 		var port uint64
-		setValue(&port, fieldValue)
+		setInt(&port, fieldValue)
 		flow.DstPort = int32(port)
 	case "destination.mac":
-		setValue(&flow.DstMac, fieldValue)
+		setInt(&flow.DstMac, fieldValue)
 	case "destination.mask":
-		setValue(&flow.DstMask, fieldValue)
+		setInt(&flow.DstMask, fieldValue)
 	case "ingress.interface":
-		setValue(&flow.InputInterface, fieldValue)
+		setInt(&flow.InputInterface, fieldValue)
 	case "egress.interface":
-		setValue(&flow.OutputInterface, fieldValue)
+		setInt(&flow.OutputInterface, fieldValue)
 	case "tcp_flags":
-		setValue(&flow.TCPFlags, fieldValue)
+		setInt(&flow.TCPFlags, fieldValue)
 	case "next_hop.ip":
-		setValue(&flow.NextHop, fieldValue)
+		setBytes(&flow.NextHop, fieldValue)
 	case "tos":
-		setValue(&flow.Tos, fieldValue)
+		setInt(&flow.Tos, fieldValue)
 	default:
 		return false
 	}
 	return true
 }
 
-type flowFieldsTypes interface {
-	uint64 | uint32 | []byte
+func setInt[T uint64 | uint32](field *T, value any) {
+	if v, ok := value.(uint64); ok {
+		*field = T(v)
+	}
 }
 
-func setValue[T flowFieldsTypes](field *T, value any) {
-	if v, ok := value.(T); ok {
+func setBytes(field *[]byte, value any) {
+	if v, ok := value.([]byte); ok {
 		*field = v
 	}
+}
+
+func bytesToHexString(value []byte) string {
+	return hex.EncodeToString(value)
 }

--- a/comp/netflow/goflowlib/convert.go
+++ b/comp/netflow/goflowlib/convert.go
@@ -74,7 +74,7 @@ func applyAdditionalFields(flow *common.Flow, additionalFields common.Additional
 	for destination, fieldValue := range additionalFields {
 		applied := applyAdditionalField(flow, destination, fieldValue)
 		if !applied {
-			// Additional fields need to be stored in the map
+			// Additional field need to be stored in the new map
 			if field, ok := fieldValue.([]byte); ok {
 				// Write []byte as hex string for readability
 				processedFields[destination] = bytesToHexString(field)

--- a/comp/netflow/goflowlib/convert.go
+++ b/comp/netflow/goflowlib/convert.go
@@ -70,19 +70,20 @@ func convertFlowType(flowType flowpb.FlowMessage_FlowType) common.FlowType {
 }
 
 func applyAdditionalFields(flow *common.Flow, additionalFields common.AdditionalFields) {
+	processedFields := make(common.AdditionalFields)
 	for destination, fieldValue := range additionalFields {
 		applied := applyAdditionalField(flow, destination, fieldValue)
-		if applied {
-			// We replaced a field of common.Flow with an additional field, no need to keep it in the map
-			delete(additionalFields, destination)
-		} else {
+		if !applied {
+			// Additional fields need to be stored in the map
 			if field, ok := fieldValue.([]byte); ok {
 				// Write []byte as hex string for readability
-				additionalFields[destination] = bytesToHexString(field)
+				processedFields[destination] = bytesToHexString(field)
+			} else {
+				processedFields[destination] = fieldValue
 			}
 		}
 	}
-	flow.AdditionalFields = additionalFields
+	flow.AdditionalFields = processedFields
 }
 
 func applyAdditionalField(flow *common.Flow, destination string, fieldValue any) bool {

--- a/comp/netflow/goflowlib/convert.go
+++ b/comp/netflow/goflowlib/convert.go
@@ -70,6 +70,10 @@ func convertFlowType(flowType flowpb.FlowMessage_FlowType) common.FlowType {
 }
 
 func applyAdditionalFields(flow *common.Flow, additionalFields common.AdditionalFields) {
+	if additionalFields == nil {
+		return
+	}
+
 	processedFields := make(common.AdditionalFields)
 	for destination, fieldValue := range additionalFields {
 		applied := applyAdditionalField(flow, destination, fieldValue)

--- a/comp/netflow/goflowlib/convert_test.go
+++ b/comp/netflow/goflowlib/convert_test.go
@@ -132,8 +132,9 @@ func TestConvertFlowWithAdditionalFields(t *testing.T) {
 		NextHop:        []byte{10, 10, 10, 30},
 	},
 		AdditionalFields: map[string]any{
-			"bytes":        uint64(1000),
-			"custom_field": "test",
+			"bytes":             uint64(1000),
+			"custom_field":      "test",
+			"custom_byte_field": []byte{1, 2, 3, 4},
 		},
 	}
 	expectedFlow := common.Flow{
@@ -161,7 +162,7 @@ func TestConvertFlowWithAdditionalFields(t *testing.T) {
 		OutputInterface:  20,
 		Tos:              3,
 		NextHop:          []byte{10, 10, 10, 30},
-		AdditionalFields: map[string]any{"custom_field": "test"},
+		AdditionalFields: map[string]any{"custom_field": "test", "custom_byte_field": "01020304"},
 	}
 	actualFlow := ConvertFlowWithAdditionalFields(&srcFlow, "my-ns")
 	assert.Equal(t, expectedFlow, *actualFlow)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
The current implementation would only allow overriding default fields if the fields were `uint64`, because :
- if the default field type is `uint32`, we would not try to convert `uint64` to `uint32`, and thus not override
- if the default field type is `[]byte`, we would try to write a string (because byte arrays were converted to string) to it and thus not override

This PR converts `uint64` to the correct int size for a given field (i.e `uint32` or `uint64`) using the `setInt` function
Hex string are now generated after applying additional fields, so that we can write the correct []byte array using the `setBytes` function

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
