### PR TITLE
[ksm-core] Add CreateContainerConfigError wait reason

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -13,11 +13,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/samber/lo"
+
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	ksmstore "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store"
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/samber/lo"
 )
 
 // metricTransformerFunc is used to tweak or generate new metrics from a given KSM metric
@@ -242,12 +243,13 @@ func podPhaseTransformer(s sender.Sender, name string, metric ksmstore.DDMetric,
 }
 
 var allowedWaitingReasons = map[string]struct{}{
-	"errimagepull":         {},
-	"imagepullbackoff":     {},
-	"crashloopbackoff":     {},
-	"containercreating":    {},
-	"createcontainererror": {},
-	"invalidimagename":     {},
+	"errimagepull":               {},
+	"imagepullbackoff":           {},
+	"crashloopbackoff":           {},
+	"containercreating":          {},
+	"createcontainererror":       {},
+	"invalidimagename":           {},
+	"createcontainerconfigerror": {},
 }
 
 // containerWaitingReasonTransformer validates the container waiting reasons for metric kube_pod_container_status_waiting_reason

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers_test.go
@@ -882,6 +882,27 @@ func Test_containerWaitingReasonTransformer(t *testing.T) {
 			},
 		},
 		{
+			name: "CreateContainerConfigError",
+			args: args{
+				name: "kube_pod_container_status_waiting_reason",
+				metric: ksmstore.DDMetric{
+					Val: 1,
+					Labels: map[string]string{
+						"container": "foo",
+						"pod":       "bar",
+						"namespace": "default",
+						"reason":    "CreateContainerConfigError",
+					},
+				},
+				tags: []string{"container:foo", "pod:bar", "namespace:default", "reason:CreateContainerConfigError"},
+			},
+			expected: &metricsExpected{
+				name: "kubernetes_state.container.status_report.count.waiting",
+				val:  1,
+				tags: []string{"container:foo", "pod:bar", "namespace:default", "reason:CreateContainerConfigError"},
+			},
+		},
+		{
 			name: "InvalidImageName",
 			args: args{
 				name: "kube_pod_container_status_waiting_reason",

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
@@ -36,6 +36,7 @@ var includeContainerStateReason = map[string][]string{
 		"containercreating",
 		"createcontainererror",
 		"invalidimagename",
+		"createcontainerconfigerror",
 	},
 	"terminated": {"oomkilled", "containercannotrun", "error"},
 }

--- a/releasenotes-dca/notes/ksm-createcontainerconfigerror-ac300b97b7d44494.yaml
+++ b/releasenotes-dca/notes/ksm-createcontainerconfigerror-ac300b97b7d44494.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added CreateContainerConfigError wait reason to the `kubernetes_state.container.status_report.count.waiting` metric
+    reported by the kubernetes_state_core check.


### PR DESCRIPTION
### What does this PR do?

This PR adds the `CreateContainerConfigError` reason to the reason whitelist for container status metrics in ksm-core.

### Motivation

https://datadoghq.atlassian.net/browse/CONTINT-3516

This PR mimics the changes introduced in this PR: https://github.com/DataDog/integrations-core/pull/16143

The python kube-state check is deprecated, and most customers are using the ksm-core check instead. Similarly, because of how the kubelet check is written, the change in the linked PR will never actually introduce a metric for containers with this status, as a container with this status has no container id, and is therefore filtered out of the function which generates the metric in question. 

Even still, it also mimics the change to the kubelet-core check, to keep it in sync.

### Additional Notes

It is worth calling out, as mentioned above, the linked PR introduced a change that SHOULD generate the `kubernetes.containers.state.waiting` for containers that are stuck in a `CreateContainerConfigError`. However, because of the way the function which checks this dict is written, it filters out any containers which do not have a valid container id, and containers from pods which have not yet reached a running state do not have container ids, so the metric is not actually generated.

In the future, we should refactor this behavior so that it actually works, or remove this reason, along with most of the other `waiting` whitelisted reasons, so that misleading behavior does not remain in the codebase.

### Possible Drawbacks / Trade-offs

Although the change is mimicked from the other PR for kubelet-core, it will not work, for the same reason it does not work for the kubelet check.

### Describe how to test/QA your changes

Deploy a workload with an invalid config. Example:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    app: nginx
spec:
  replicas: 1
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
        service: nginx
    spec:
      containers:
        - name: nginx
          image: nginx:latest
          resources:
            limits:
              cpu: 100m
              memory: 32Mi
            requests:
              cpu: 10m
              memory: 32Mi
          env:
            - name: SPECIAL_LEVEL_KEY
              valueFrom:
                configMapKeyRef:
                  name: special-config
                  key: special.how
          ports:
            - name: http
              containerPort: 80
```
or just add:
```
          env:
            - name: SPECIAL_LEVEL_KEY
              valueFrom:
                configMapKeyRef:
                  name: special-config
                  key: special.how
```
to any existing deployment. This should give you a pod that is stuck in a pending state with the reason `CreateContainerConfigError`

Then validate that `kubernetes_state.container.status_report.count.waiting` is reported with `reason:createcontainerconfigerror`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
