### PR TITLE
[USMON-390] Enable direct flush of events from socket filter programs

### DIFF
--- a/pkg/network/ebpf/c/protocols/events.h
+++ b/pkg/network/ebpf/c/protocols/events.h
@@ -28,7 +28,7 @@
         return val > 0;                                                                                 \
     }                                                                                                   \
                                                                                                         \
-    static __always_inline void name##_batch_flush(struct pt_regs *ctx) {                               \
+    static __always_inline void name##_batch_flush(void *ctx) {                                         \
         if (!is_##name##_monitoring_enabled()) {                                                        \
             return;                                                                                     \
         }                                                                                               \
@@ -128,6 +128,16 @@ static __always_inline bool __enqueue_event(batch_data_t *batch, void *event, si
     bpf_memcpy(&batch->data[offset], event, event_size);
     batch->len++;
     return true;
+}
+
+// convenience helper function for determining if bpf_perf_event_output helper
+// is available for socket filter programs. this constant is injected via the
+// constant editor during load time and should evaluate to true on hosts running
+// kernel >= 5.4
+static __always_inline bool is_direct_flush_supported() {
+    __u64 val = 0;
+    LOAD_CONSTANT("direct_flush_supported", val);
+    return val > 0;
 }
 
 #define _LOG(protocol, message, args...) \

--- a/pkg/network/ebpf/c/protocols/http/http.h
+++ b/pkg/network/ebpf/c/protocols/http/http.h
@@ -250,6 +250,9 @@ int socket__http_filter(struct __sk_buff* skb) {
 
     read_into_buffer_skb((char *)event.http.request_fragment, skb, skb_info.data_off);
     http_process(&event, &skb_info, NO_TAGS);
+    if (is_direct_flush_supported()) {
+        http_batch_flush(skb);
+    }
     return 0;
 }
 

--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/offsetguess"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/buildmode"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	manager "github.com/DataDog/ebpf-manager"
 )
@@ -72,6 +73,7 @@ type ebpfProgram struct {
 	cfg                   *config.Config
 	tailCallRouter        []manager.TailCallRoute
 	connectionProtocolMap *ebpf.Map
+	kversion              kernel.Version
 
 	enabledProtocols  []*protocols.ProtocolSpec
 	disabledProtocols []*protocols.ProtocolSpec
@@ -82,6 +84,11 @@ type ebpfProgram struct {
 }
 
 func newEBPFProgram(c *config.Config, sockFD, connectionProtocolMap *ebpf.Map, bpfTelemetry *errtelemetry.EBPFTelemetry) (*ebpfProgram, error) {
+	kversion, err := kernel.HostVersion()
+	if err != nil {
+		log.Warnf("unable to detect kernel version. some features might be disabled: %s", err)
+	}
+
 	mgr := &manager.Manager{
 		Maps: []*manager.Map{
 			{Name: protocols.TLSDispatcherProgramsMap},
@@ -135,6 +142,7 @@ func newEBPFProgram(c *config.Config, sockFD, connectionProtocolMap *ebpf.Map, b
 		Manager:               errtelemetry.NewManager(mgr, bpfTelemetry),
 		cfg:                   c,
 		connectionProtocolMap: connectionProtocolMap,
+		kversion:              kversion,
 	}
 
 	opensslSpec.Factory = newSSLProgramProtocolFactory(mgr, sockFD, bpfTelemetry)
@@ -352,6 +360,10 @@ func (e *ebpfProgram) init(buf bytecode.AssetReader, options manager.Options) er
 	options.ConstantEditors = append(options.ConstantEditors,
 		manager.ConstantEditor{Name: "ephemeral_range_begin", Value: uint64(begin)},
 		manager.ConstantEditor{Name: "ephemeral_range_end", Value: uint64(end)})
+
+	// Enable event flushes from socket filter programs if possible
+	isDirectFlushSupported := e.kversion >= kernel.VersionCode(5, 4, 0)
+	utils.AddBoolConst(&options, isDirectFlushSupported, "direct_flush_supported")
 
 	for _, p := range e.Manager.Probes {
 		options.ActivatedProbes = append(options.ActivatedProbes, &manager.ProbeSelector{ProbeIdentificationPair: p.ProbeIdentificationPair})


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Enable direct flush of USM event batches from socket filter programs. 

### Motivation

Reduce reliance on external probes to perform the event flushes. Historically we've called `bpf_perf_event_output` from a separate probe because socket filter programs didn't have access to this eBPF helper until Kernel 5.4.
Although we have chosen a tracepoint (`tracepoint/net/netif_receive_skb`) that has a good "correlation" with the execution of socket filter programs (by being  in some of the same call paths), we occasionally run into a problem of lack of CPU affinity in the sense that multiple USM events are generated from a certain CPU (via the execution of socket filter programs), but `tracepoint/net/netif_receive_skb` doesn't get executed as often in the CPU to flush all events, which causes datapoints to be dropped once all USM batches are filled up.

This PR addresses this issue by making sure that event generation and flushing happen in the same place.

### Additional Notes

As previously noted the improvement will only apply to Kernels >= 5.4.

#### Load testing results

No noticeable impact in terms of system resources based on data from our load test environment:

![system-probe working set (avg)](https://github.com/DataDog/datadog-agent/assets/692520/edc0b0d0-b68a-4ba4-b123-3ed514245c07)
![avg _system_ CPU usage (%) (autosmoothed, by env)](https://github.com/DataDog/datadog-agent/assets/692520/d89a8d65-f9fb-494b-aea8-5ec729ba03dd)
![system-probe avg k8s CPU Usage by env](https://github.com/DataDog/datadog-agent/assets/692520/8b1d8a05-5e07-4b36-9f0c-0dd61764ca95)

(note that the purple color refers to the baseline agent, which looks slightly worse but I would regard it as noise)

However, there is a positive impact in terms of data correctness on pathological workloads where the the flushing tracepoint wasn't getting executed often enough (this was taken from a node in one of our staging clusters):


<img width="396" alt="Screenshot 2024-01-02 at 3 17 31 PM" src="https://github.com/DataDog/datadog-agent/assets/692520/b90bc6ad-faea-4065-9ec0-234ac8690312">



### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
