### PR TITLE
macOS: split linting & testing

### DIFF
--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -27,3 +27,22 @@ tests_macos:
       - junit-*-repacked.tgz
     reports:
       junit: "**/junit-out-*.xml"
+
+lint_macos:
+  stage: source_test
+  rules:
+    !reference [.on_a6]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  variables:
+    PYTHON_RUNTIMES: '3'
+  script:
+    - source /root/.bashrc
+    - export GITHUB_KEY_B64=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_key_b64 --with-decryption --query "Parameter.Value" --out text)
+    - export GITHUB_APP_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_app_id --with-decryption --query "Parameter.Value" --out text)
+    - export GITHUB_INSTALLATION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_installation_id --with-decryption --query "Parameter.Value" --out text)
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache .
+    - export VERSION_CACHE_CONTENT=$(cat agent-version.cache | base64 -)
+    - !reference [.setup_python_mirror_linux]
+    - python3 -m pip install -r tasks/libs/requirements-github.txt
+    - inv -e github.trigger-macos-lint --datadog-agent-ref "$CI_COMMIT_SHA" --python-runtimes "$PYTHON_RUNTIMES" --version-cache "$VERSION_CACHE_CONTENT"

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -14,7 +14,7 @@ from .release import _get_release_json_value
 from .utils import DEFAULT_BRANCH
 
 
-def _trigger_macos_workflow(release, destination, retry_download, retry_interval, **kwargs):
+def _trigger_macos_workflow(release, destination=None, retry_download=0, retry_interval=0, **kwargs):
     github_action_ref = _get_release_json_value(f'{release}::MACOS_BUILD_VERSION')
 
     run = trigger_macos_workflow(
@@ -102,9 +102,6 @@ def trigger_macos_lint(
 ):
     _trigger_macos_workflow(
         release_version,
-        None,
-        0,
-        0,
         workflow_name="lint.yaml",
         datadog_agent_ref=datadog_agent_ref,
         python_runtimes=python_runtimes,

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -93,6 +93,26 @@ def trigger_macos_test(
 
 
 @task
+def trigger_macos_lint(
+    _,
+    datadog_agent_ref=DEFAULT_BRANCH,
+    release_version="nightly-a7",
+    python_runtimes="3",
+    version_cache=None,
+):
+    _trigger_macos_workflow(
+        release_version,
+        None,
+        0,
+        0,
+        workflow_name="lint.yaml",
+        datadog_agent_ref=datadog_agent_ref,
+        python_runtimes=python_runtimes,
+        version_cache_file_content=version_cache,
+    )
+
+
+@task
 def lint_codeowner(_):
     """
     Check every package in `pkg` has an owner

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -29,7 +29,8 @@ def _trigger_macos_workflow(release, destination, retry_download, retry_interval
 
     print_workflow_conclusion(workflow_conclusion, workflow_url)
 
-    download_with_retry(download_artifacts, run, destination, retry_download, retry_interval)
+    if destination:
+        download_with_retry(download_artifacts, run, destination, retry_download, retry_interval)
 
     if workflow_conclusion != "success":
         raise Exit(code=1)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR adds a new job that's solely responsible for macos code linting

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This will hopefully improve our macOS jobs duration by running them in parallel.  https://datadoghq.atlassian.net/browse/APL-2393

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

This is based on top of #20856 and the commits from this PR are also included here until the freeze is lifted

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
