### PR TITLE
[NDM] Netflow additional fields: Rename Bytes to Hex and Varint to Integer

### DIFF
--- a/comp/netflow/common/flow.go
+++ b/comp/netflow/common/flow.go
@@ -97,33 +97,33 @@ type FieldType string
 var (
 	// String type is used to configure a textual additional field
 	String FieldType = "string"
-	// Varint type is used to configure an integer additional field
-	Varint FieldType = "varint"
-	// Bytes type is used to configure a hex additional field
-	Bytes FieldType = "bytes"
+	// Integer type is used to configure an integer additional field
+	Integer FieldType = "integer"
+	// Hex type is used to configure a hex additional field
+	Hex FieldType = "hex"
 	// DefaultFieldTypes contains types for default payload fields
 	DefaultFieldTypes = map[string]FieldType{
-		"direction":         Varint,
-		"start":             Varint,
-		"end":               Varint,
-		"bytes":             Varint,
-		"packets":           Varint,
-		"ether_type":        Varint,
-		"ip_protocol":       Varint,
-		"exporter.ip":       Bytes,
-		"source.ip":         Bytes,
-		"source.port":       Varint,
-		"source.mac":        Varint,
-		"source.mask":       Varint,
-		"destination.ip":    Bytes,
-		"destination.port":  Varint,
-		"destination.mac":   Varint,
-		"destination.mask":  Varint,
-		"ingress.interface": Varint,
-		"egress.interface":  Varint,
-		"tcp_flags":         Varint,
-		"next_hop.ip":       Bytes,
-		"tos":               Varint,
+		"direction":         Integer,
+		"start":             Integer,
+		"end":               Integer,
+		"bytes":             Integer,
+		"packets":           Integer,
+		"ether_type":        Integer,
+		"ip_protocol":       Integer,
+		"exporter.ip":       Hex,
+		"source.ip":         Hex,
+		"source.port":       Integer,
+		"source.mac":        Integer,
+		"source.mask":       Integer,
+		"destination.ip":    Hex,
+		"destination.port":  Integer,
+		"destination.mac":   Integer,
+		"destination.mask":  Integer,
+		"ingress.interface": Integer,
+		"egress.interface":  Integer,
+		"tcp_flags":         Integer,
+		"next_hop.ip":       Hex,
+		"tos":               Integer,
 	}
 )
 

--- a/comp/netflow/config/config_test.go
+++ b/comp/netflow/config/config_test.go
@@ -202,7 +202,7 @@ network_devices:
 								Field:       8,
 								Destination: "source.port",
 								Endian:      "",
-								Type:        "varint", // Ensure type is correctly overridden
+								Type:        "integer", // Ensure type is correctly overridden
 							},
 						},
 					},

--- a/comp/netflow/goflowlib/additionalfields/netflow.go
+++ b/comp/netflow/goflowlib/additionalfields/netflow.go
@@ -26,7 +26,7 @@ func decodeUNumberWithEndianness(b []byte, out *uint64, endianness common.Endian
 
 func mapAdditionalField(additionalFields common.AdditionalFields, v []byte, cfg config.Mapping) {
 	// TODO : Add more types (IP address, timestamp, ...)
-	if cfg.Type == common.Varint {
+	if cfg.Type == common.Integer {
 		var dstVar uint64
 		err := decodeUNumberWithEndianness(v, &dstVar, cfg.Endian)
 		if err != nil {

--- a/comp/netflow/goflowlib/additionalfields/netflow_test.go
+++ b/comp/netflow/goflowlib/additionalfields/netflow_test.go
@@ -55,7 +55,7 @@ func Test_ProcessMessageNetFlowAdditionalFields(t *testing.T) {
 				123: {
 					Field:       123,
 					Destination: "test_field",
-					Type:        common.Varint,
+					Type:        common.Integer,
 				},
 			},
 			expectedCollectedFields: []common.AdditionalFields{{
@@ -108,7 +108,7 @@ func Test_ProcessMessageNetFlowAdditionalFields(t *testing.T) {
 				123: {
 					Field:       123,
 					Destination: "test_field",
-					Type:        common.Varint,
+					Type:        common.Integer,
 				},
 				124: {
 					Field:       124,
@@ -134,12 +134,12 @@ func Test_ProcessMessageNetFlowAdditionalFields(t *testing.T) {
 				123: {
 					Field:       123,
 					Destination: "test_field",
-					Type:        common.Varint,
+					Type:        common.Integer,
 				},
 				126: {
 					Field:       126,
 					Destination: "missing_field",
-					Type:        common.Varint,
+					Type:        common.Integer,
 				},
 			},
 			expectedCollectedFields: []common.AdditionalFields{{

--- a/comp/netflow/server/integration_test.go
+++ b/comp/netflow/server/integration_test.go
@@ -161,7 +161,7 @@ func TestNetFlow_IntegrationTest_AdditionalFields(t *testing.T) {
 						{
 							Field:       11,
 							Destination: "source.port", // Inverting source and destination port to test
-							Type:        common.Varint,
+							Type:        common.Integer,
 						},
 						{
 							Field:       7,
@@ -170,7 +170,7 @@ func TestNetFlow_IntegrationTest_AdditionalFields(t *testing.T) {
 						{
 							Field:       32,
 							Destination: "icmp_type",
-							Type:        common.Bytes,
+							Type:        common.Hex,
 						},
 					},
 				}},
@@ -224,17 +224,17 @@ func BenchmarkNetflowAdditionalFields(b *testing.B) {
 		{
 			Field:       11,
 			Destination: "source.port",
-			Type:        common.Varint,
+			Type:        common.Integer,
 		},
 		{
 			Field:       7,
 			Destination: "destination.port",
-			Type:        common.Varint,
+			Type:        common.Integer,
 		},
 		{
 			Field:       32,
 			Destination: "icmp_type",
-			Type:        common.Bytes,
+			Type:        common.Hex,
 		},
 	})
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Renames Netflow additional fields types
- `varint` -> `integer`
- `bytes` -> `hex`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
