### PR TITLE
[CI] Fix `git diff` on Windows runners

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,7 +10,7 @@ go.sum -diff -merge linguist-generated=true
 pkg/security/probe/constantfetch/btfhub/constants.json -diff -merge linguist-generated=true
 
 # Fix `git diff` when running on the below file formats.
-# Our windows build image uses MinGit which tries to use the astextplain diff algorithm.
+# Our windows build image uses MinGit which tries to use the astextplain diff algorithm (https://git-scm.com/docs/gitattributes#_setting_the_internal_diff_algorithm).
 # The astextplain binary is not embedded in the docker image making the git diff command fail when one of the below file formats is in the diff.
 # The error is:
 # ```

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,42 @@ go.sum -diff -merge linguist-generated=true
 *_easyjson.go -diff -merge
 *_easyjson.go linguist-generated=true
 pkg/security/probe/constantfetch/btfhub/constants.json -diff -merge linguist-generated=true
+
+# Fix `git diff` when running on the below file formats.
+# Our windows build image uses MinGit which tries to use the astextplain diff algorithm.
+# The astextplain binary is not embedded in the docker image making the git diff command fail when one of the below file formats is in the diff.
+# The error is:
+# ```
+# error: cannot spawn astexplain: No such files or directory
+# fatal: unable to read files diff
+# ```
+# We're overriding the MinGit default gitattributes config to avoid using astextplain on the file formats below.
+# The MinGit's gitconfig file still have the problematic config though it should not use it anymore:
+# ```
+# [diff "astextplain"]
+#	textconv = astextplain
+# ```
+
+
+*.doc	diff
+*.DOC	diff
+*.docx	diff
+*.DOCX	diff
+*.docm	diff
+*.DOCM	diff
+*.dot	diff
+*.DOT	diff
+*.dotx	diff
+*.DOTX	diff
+*.dotm	diff
+*.DOTM	diff
+*.pdf	diff
+*.PDF	diff
+*.rtf	diff
+*.RTF	diff
+*.ods	diff
+*.ODS	diff
+*.odf	diff
+*.ODF	diff
+*.odt	diff
+*.ODT	diff


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR changes the [diff algorithm](https://git-scm.com/docs/gitattributes#_setting_the_internal_diff_algorithm) used on some files.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

On the windows runners' containers, we use `MinGit` (Minimal Git for Windows) which is a reduced sized `Git`. When running `git diff` between 2 commits, if one file in the diff has its format in `*.doc, *.docx, *.docm, *.dot, *.dotx, *.dotm, *.pdf, *.rtf, *.ods, *.odf, *.odt`, the command will fail with:
```
error: cannot spawn astexplain: No such files or directory
fatal: unable to read files diff
```
The `git diff` tries to run `astextplain` because of the config files:

**gitconfig**
```
➜ cat ~/Downloads/MinGit-2.26.2-64-bit/etc/gitconfig
...
[diff "astextplain"]
	textconv = astextplain
...
```
**gitattributes**
```
➜  cat ~/Downloads/MinGit-2.26.2-64-bit/etc/gitattributes
*.doc	diff=astextplain
*.DOC	diff=astextplain
*.docx	diff=astextplain
*.DOCX	diff=astextplain
*.docm	diff=astextplain
*.DOCM	diff=astextplain
*.dot	diff=astextplain
*.DOT	diff=astextplain
*.dotx	diff=astextplain
*.DOTX	diff=astextplain
*.dotm	diff=astextplain
*.DOTM	diff=astextplain
*.pdf	diff=astextplain
*.PDF	diff=astextplain
*.rtf	diff=astextplain
*.RTF	diff=astextplain
*.ods	diff=astextplain
*.ODS	diff=astextplain
*.odf	diff=astextplain
*.ODF	diff=astextplain
*.odt	diff=astextplain
*.ODT	diff=astextplain
```
The `astextplain` binary is not embedded in our MinGit version (`2.26.2`) (not sure why tbh), which is the reason why it fails. 
That's why we're overriding the MinGit default `gitattributes` config to avoid using `astextplain` on the file formats above.
The MinGit's `gitconfig` file still have the problematic config though it should not use it anymore.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This PR will fix the linters that broke in #19506. Because the `new-from-rev` [feature in golanci-lint](https://golangci-lint.run/usage/faq/#how-to-integrate-golangci-lint-into-large-project-with-thousands-of-issues) uses a `git diff` to work.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
