### PR TITLE
[CI] Raise error if `golangci-lint` exit code is neither 0 nor 7 for the `show-linter-issues` invoke task

### DIFF
--- a/tasks/show_linters_issues/show_linters_issues.py
+++ b/tasks/show_linters_issues/show_linters_issues.py
@@ -17,6 +17,9 @@ from .golangci_lint_parser import (
 FIRST_COMMIT_HASH = "52a313fe7f5e8e16d487bc5dc770038bc234608b"
 # See https://go.dev/doc/install/source#environment for all available combinations of GOOS x GOARCH.
 CI_TESTED_OS_AND_ARCH = ["linux,arm64", "linux,amd64", "windows,amd64", "darwin,amd64"]
+# Used to differentiate classic errors (exit code 1) with real linter errors exit code.
+# If you modify it, do not use 0 or 1.
+GOLANGCI_EXIT_CODE = 7
 
 
 def check_if_team_exists(team: str):
@@ -40,9 +43,13 @@ def run_linters_for_each_os_x_arch(ctx, platforms, command, show_output):
     for tested_os, tested_arch in platforms:
         env = {"GOOS": tested_os, "GOARCH": tested_arch}
         print(f"Running linters for {tested_os}_{tested_arch}...")
-        results_per_os_x_arch[f"{tested_os}_{tested_arch}"] = ctx.run(
-            command, env=env, warn=True, hide=not show_output
-        ).stdout
+        command_run = ctx.run(command, env=env, hide=not show_output, warn=True)
+        # If the exit code is neither 0 (no linter errors) nor GOLANGCI_EXIT_CODE (existing linter errors), then there's an error in the command.
+        if command_run.exited not in [0, GOLANGCI_EXIT_CODE]:
+            raise Exit(
+                f"The command below failed with exit code {command_run.exited}.\n{command}\nError: {command_run.stderr}"
+            )
+        results_per_os_x_arch[f"{tested_os}_{tested_arch}"] = command_run.stdout
     return merge_results(results_per_os_x_arch)
 
 
@@ -72,7 +79,9 @@ def show_linters_issues(
     if filter_team:
         filter_team = filter_team.lower()
     check_if_team_exists(filter_team)
-    golangci_lint_kwargs = f'"--new-from-rev {from_commit_hash} --print-issued-lines=false"'
+    golangci_lint_kwargs = (
+        f'"--new-from-rev {from_commit_hash} --print-issued-lines=false --issues-exit-code {GOLANGCI_EXIT_CODE}"'
+    )
     command = f"inv lint-go --golangci-lint-kwargs {golangci_lint_kwargs} --headless-mode"
 
     if build_tags:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR raises error if `golangci-lint` exit code is neither 0 nor 7 for the `show-linter-issues` invoke task.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

As of today if you have a error such as `go not found` or `golangci-lint` not found, the error will be silenced. This PR fixes this and display the error.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
