### PR TITLE
Remove fips-proxy temporary configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1685,18 +1685,7 @@ func setupFipsEndpoints(config Config) error {
 	os.Unsetenv("HTTP_PROXY")
 	os.Unsetenv("HTTPS_PROXY")
 
-	// We're creating a temporary configuration which will be merged to the main config later.
-	// Internally, Viper uses multiple storages for the configuration values and values from datadog.yaml are stored
-	// in a different place from where overrides (created with config.Set(...)) are stored.
-	// Some products are using UnmarshalKey() which either uses overridden data or either configuration file data but not
-	// both at the same time (see https://github.com/spf13/viper/issues/1106)
-	//
-	// Because of that we cannot rely on Set() because it creates overridden data and then UnmarshalKey() will only use the
-	// option created with Set() instead of using option from Set() + option from configuration file.
-	// Instead we merge all the options we need into the main configuration (basically we dynamically add data to the place
-	// where configuration file data are stored)
-	fipsConfig := NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
-	fipsConfig.Set("fips.https", config.GetBool("fips.https"), pkgconfigmodel.SourceAgentRuntime)
+	config.Set("fips.https", config.GetBool("fips.https"), pkgconfigmodel.SourceAgentRuntime)
 
 	// HTTP for now, will soon be updated to HTTPS
 	protocol := "http://"
@@ -1709,40 +1698,49 @@ func setupFipsEndpoints(config Config) error {
 	// config_template.yaml
 
 	// Metrics
-	fipsConfig.Set("dd_url", protocol+urlFor(metrics), pkgconfigmodel.SourceAgentRuntime)
+	config.Set("dd_url", protocol+urlFor(metrics), pkgconfigmodel.SourceAgentRuntime)
 
 	// Logs
-	setupFipsLogsConfig(fipsConfig, "logs_config.", urlFor(logs))
+	setupFipsLogsConfig(config, "logs_config.", urlFor(logs))
 
 	// APM
-	fipsConfig.Set("apm_config.apm_dd_url", protocol+urlFor(traces), pkgconfigmodel.SourceAgentRuntime)
+	config.Set("apm_config.apm_dd_url", protocol+urlFor(traces), pkgconfigmodel.SourceAgentRuntime)
 	// Adding "/api/v2/profile" because it's not added to the 'apm_config.profiling_dd_url' value by the Agent
-	fipsConfig.Set("apm_config.profiling_dd_url", protocol+urlFor(profiles)+"/api/v2/profile", pkgconfigmodel.SourceAgentRuntime)
-	fipsConfig.Set("apm_config.telemetry.dd_url", protocol+urlFor(instrumentationTelemetry), pkgconfigmodel.SourceAgentRuntime)
+	config.Set("apm_config.profiling_dd_url", protocol+urlFor(profiles)+"/api/v2/profile", pkgconfigmodel.SourceAgentRuntime)
+	config.Set("apm_config.telemetry.dd_url", protocol+urlFor(instrumentationTelemetry), pkgconfigmodel.SourceAgentRuntime)
 
 	// Processes
-	fipsConfig.Set("process_config.process_dd_url", protocol+urlFor(processes), pkgconfigmodel.SourceAgentRuntime)
+	config.Set("process_config.process_dd_url", protocol+urlFor(processes), pkgconfigmodel.SourceAgentRuntime)
 
 	// Database monitoring
 	// Historically we used a different port for samples because the intake hostname defined in epforwarder.go was different
 	// (even though the underlying IPs were the same as the ones for DBM metrics intake hostname). We're keeping 2 ports for backward compatibility reason.
-	setupFipsLogsConfig(fipsConfig, "database_monitoring.metrics.", urlFor(databasesMonitoringMetrics))
-	setupFipsLogsConfig(fipsConfig, "database_monitoring.activity.", urlFor(databasesMonitoringMetrics))
-	setupFipsLogsConfig(fipsConfig, "database_monitoring.samples.", urlFor(databasesMonitoringSamples))
+	setupFipsLogsConfig(config, "database_monitoring.metrics.", urlFor(databasesMonitoringMetrics))
+	setupFipsLogsConfig(config, "database_monitoring.activity.", urlFor(databasesMonitoringMetrics))
+	setupFipsLogsConfig(config, "database_monitoring.samples.", urlFor(databasesMonitoringSamples))
 
 	// Network devices
-	setupFipsLogsConfig(fipsConfig, "network_devices.metadata.", urlFor(networkDevicesMetadata))
-	setupFipsLogsConfig(fipsConfig, "network_devices.snmp_traps.forwarder.", urlFor(networkDevicesSnmpTraps))
-	setupFipsLogsConfig(fipsConfig, "network_devices.netflow.forwarder.", urlFor(networkDevicesNetflow))
+	// Internally, Viper uses multiple storages for the configuration values and values from datadog.yaml are stored
+	// in a different place from where overrides (created with config.Set(...)) are stored.
+	// Some NDM products are using UnmarshalKey() which either uses overridden data or either configuration file data but not
+	// both at the same time (see https://github.com/spf13/viper/issues/1106)
+	//
+	// Because of that we need to put all the NDM config in the overridden data store (using Set) in order to get
+	// data from the config + data created by the FIPS mode when using UnmarshalKey()
+
+	config.Set("network_devices.snmp_traps", config.Get("network_devices.snmp_traps"), pkgconfigmodel.SourceAgentRuntime)
+	setupFipsLogsConfig(config, "network_devices.metadata.", urlFor(networkDevicesMetadata))
+	config.Set("network_devices.netflow", config.Get("network_devices.netflow"), pkgconfigmodel.SourceAgentRuntime)
+	setupFipsLogsConfig(config, "network_devices.snmp_traps.forwarder.", urlFor(networkDevicesSnmpTraps))
+	setupFipsLogsConfig(config, "network_devices.netflow.forwarder.", urlFor(networkDevicesNetflow))
 
 	// Orchestrator Explorer
-	fipsConfig.Set("orchestrator_explorer.orchestrator_dd_url", protocol+urlFor(orchestratorExplorer), pkgconfigmodel.SourceAgentRuntime)
+	config.Set("orchestrator_explorer.orchestrator_dd_url", protocol+urlFor(orchestratorExplorer), pkgconfigmodel.SourceAgentRuntime)
 
 	// CWS
-	setupFipsLogsConfig(fipsConfig, "runtime_security_config.endpoints.", urlFor(runtimeSecurity))
+	setupFipsLogsConfig(config, "runtime_security_config.endpoints.", urlFor(runtimeSecurity))
 
-	// Merge the configurations
-	return config.MergeConfigMap(fipsConfig.AllSettings())
+	return nil
 }
 
 func setupFipsLogsConfig(config Config, configPrefix string, url string) {


### PR DESCRIPTION
### What does this PR do?

Remove temporary fips config + use `Set()` on SNMP traps and Netflow config

### Motivation

https://github.com/DataDog/datadog-agent/pull/20791 introduce a temporary config to deal with NDM startup problem when FIPS is enabled. The goal was to put all data related to NDM (config file + option created by FIPS mode) to the same place (see [Get()](https://github.com/spf13/viper/blob/v1.17.0/viper.go#L894), it was `config file` in this case)

The problem is that env variables have precedence over config file so if `DD_URL` was set it will have priority over the option defined when `fips.enabled` is set to `true` which is not something we want as it breaks compliance.

Instead, we should put everything in `override` because it has precedence over `env`.

### Additional Notes



### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

##### Agent setup

```yaml
fips:
    enabled: true
    https: false

dd_url: dummy_dd_url

network_devices:
  metadata:
    logs_dd_url: dummy_metadata_val
  netflow:
    enabled: true
    forwarder: 
      logs_dd_url: dummy_netflow_value
    listeners:
      - flow_type: netflow5
        bind_host: 127.0.0.1
        port: 2055
    aggregator_flush_interval: 10
  snmp_traps:
    enabled: true
    forwarder:
        logs_dd_url: dummy_traps_value
```

and run the Agent using this script

```
#!/bin/sh

export DD_URL=http://env_dd_url:6000
export DD_LOGS_CONFIG_LOGS_DD_URL=env_logs_config_dd_url:6001
export DD_APM_CONFIG_APM_DD_URL=http://env_apm_url:6002
export DD_APM_CONFIG_PROFILING_DD_URL=http://env_profiling_url:6003
export DD_PROCESS_CONFIG_PROCESS_DD_URL=http://env_process_url:6004

export DD_DATABASE_MONITORING_METRICS_LOGS_DD_URL=env_dbm_metrics_url:6005
export DD_DATABASE_MONITORING_METRICS_LOGS_NO_SSL=false
export DD_DATABASE_MONITORING_ACTIVITY_LOGS_DD_URL=env_dbm_activity_url:6006
export DD_DATABASE_MONITORING_ACTIVITY_LOGS_NO_SSL=false
export DD_DATABASE_MONITORING_SAMPLES_LOGS_DD_URL=env_dbm_samples_url:6007
export DD_DATABASE_MONITORING_SAMPLES_LOGS_NO_SSL=false

export DD_NETWORK_DEVICES_METADATA_LOGS_DD_URL=env_ndm_meta_url:6008
export DD_NETWORK_DEVICES_METADATA_LOGS_NO_SSL=false
export DD_NETWORK_DEVICES_SNMP_TRAPS_FORWARDER_LOGS_DD_URL=env_ndm_snmp_url:6009
export DD_NETWORK_DEVICES_SNMP_TRAPS_FORWARDER_LOGS_NO_SSL=false
export DD_NETWORK_DEVICES_NETFLOW_FORWARDER_LOGS_DD_URL=env_ndm_netflow_url:6010
export DD_NETWORK_DEVICES_NETFLOW_FORWARDER_LOGS_NO_SSL=false

datadog-agent run
```

##### Checks

1. Run this script and check that it outputs "Success"
```
#!/bin/bash

config=$(./bin/agent/agent config)


case "$config" in
  *"dummy_dd_url"* | \
  *"dummy_metadata_value"* | \
  *"dummy_traps_value"* | \
  *"dummy_netflow_value"* | \
  *"env_dd_url"* | \
  *"env_logs_config_dd_url"* | \
  *"env_apm_url"* | \
  *"env_profiling_url"* | \
  *"env_process_url"* | \
  *"env_dbm_metrics_url"* | \
  *"env_dbm_activity_url"* | \
  *"env_dbm_samples_url"* | \
  *"env_ndm_meta_url"* | \
  *"env_ndm_snmp_url"* | \
  *"env_ndm_netflow_url"*)
    echo "Bad configuration has been found"
    ;;
  *)
    echo "Success"
    ;;
esac
```

2. Run `datadog-agent status` and verify that Netflow section mentions something like (Total listeners should not be 0)
```
Total Listeners: 1
Open Listeners: 1
Closed Listeners: 0

=== Open Listener Details ===
---------
BindHost: 127.0.0.1
FlowType: netflow5
Port: 2055
Workers: 1
Namespace: default
Flows Received: 0
---------
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
