### PR TITLE
[oracle] Bug fix for empty DATABASE values in query samples (DBMON-3144)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/activity.go
+++ b/pkg/collector/corechecks/oracle-dbm/activity.go
@@ -357,6 +357,13 @@ func (c *Check) SampleSession() error {
 		if sample.PdbName.Valid {
 			sessionRow.PdbName = sample.PdbName.String
 		}
+		if sessionRow.PdbName == "" {
+			if c.multitenant {
+				sessionRow.PdbName = "CDB$ROOT"
+			} else {
+				sessionRow.PdbName = c.cdbName
+			}
+		}
 		sessionRow.CdbName = c.cdbName
 		sessionRows = append(sessionRows, sessionRow)
 	}

--- a/releasenotes/notes/oracle-empty-database-name-205448e9c2fd2d84.yaml
+++ b/releasenotes/notes/oracle-empty-database-name-205448e9c2fd2d84.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Bug fix for empty database names in query samples.


### PR DESCRIPTION
### What does this PR do?

Bug fix for empty values in the `DATABASE` in query samples.

### Motivation

The bug was reported by Medicision for Oracle 11 databases.

### Additional Notes

The field `DATABASE` is derived from `@oracle.pdb`. `@oracle.pdb` isn't filled in the following cases:
- For multitenant architecture, when sessions are sometimes getting data from the `root` container database, like the background processes do. The fix is to initialize `@oracle.pdb` with  `CDB$ROOT`
- For non-CDB architecture `@oracle.pdb` isn't initialized at all. The fix is to initialize `@oracle.pdb` with the DB name.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Connect to 21c, 12c non-CDB and 11, and check that `@oracle.pdb` or DATABASE aren't empty.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
