### PR TITLE
AMLII-764 send retry queue capacity telemetry by default

### DIFF
--- a/comp/forwarder/defaultforwarder/default_forwarder.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder.go
@@ -477,45 +477,40 @@ func (f *DefaultForwarder) sendHTTPTransactions(transactions []*transaction.HTTP
 	if f.internalState.Load() == Stopped {
 		return fmt.Errorf("the forwarder is not started")
 	}
-	if f.config.GetBool("telemetry.enabled") {
-		f.retryQueueDurationCapacityMutex.Lock()
-		defer f.retryQueueDurationCapacityMutex.Unlock()
 
-		now := time.Now()
-		for _, t := range transactions {
-			forwarder := f.domainForwarders[t.Domain]
-			forwarder.sendHTTPTransactions(t)
+	f.retryQueueDurationCapacityMutex.Lock()
+	defer f.retryQueueDurationCapacityMutex.Unlock()
 
-			if f.queueDurationCapacity != nil {
-				if err := f.queueDurationCapacity.OnTransaction(t, forwarder.domain, now); err != nil {
-					f.log.Errorf("Cannot add a transaction to queueDurationCapacity: %v", err)
-				}
-			}
-		}
+	now := time.Now()
+	for _, t := range transactions {
+		forwarder := f.domainForwarders[t.Domain]
+		forwarder.sendHTTPTransactions(t)
 
 		if f.queueDurationCapacity != nil {
-			if capacities, err := f.queueDurationCapacity.ComputeCapacity(now); err != nil {
-				f.log.Errorf("Cannot compute the capacity of the retry queues: %v", err)
-			} else {
-				telemetry := telemetry.GetStatsTelemetryProvider()
-				metricPrefix := "datadog.agent.retry_queue_duration."
-				for domain, t := range capacities {
-					tags := []string{
-						"agent:" + f.agentName,
-						"domain:" + domain,
-					}
-					telemetry.Gauge(metricPrefix+"capacity_secs", t.Capacity.Seconds(), tags)
-					telemetry.Gauge(metricPrefix+"bytes_per_sec", t.BytesPerSec, tags)
-					telemetry.Gauge(metricPrefix+"capacity_bytes", float64(t.AvailableSpace), tags)
-				}
+			if err := f.queueDurationCapacity.OnTransaction(t, forwarder.domain, now); err != nil {
+				f.log.Errorf("Cannot add a transaction to queueDurationCapacity: %v", err)
 			}
 		}
-	} else {
-		for _, t := range transactions {
-			forwarder := f.domainForwarders[t.Domain]
-			forwarder.sendHTTPTransactions(t)
+	}
+
+	if f.queueDurationCapacity != nil {
+		if capacities, err := f.queueDurationCapacity.ComputeCapacity(now); err != nil {
+			f.log.Errorf("Cannot compute the capacity of the retry queues: %v", err)
+		} else {
+			telemetry := telemetry.GetStatsTelemetryProvider()
+			metricPrefix := "datadog.agent.retry_queue_duration."
+			for domain, t := range capacities {
+				tags := []string{
+					"agent:" + f.agentName,
+					"domain:" + domain,
+				}
+				telemetry.Gauge(metricPrefix+"capacity_secs", t.Capacity.Seconds(), tags)
+				telemetry.Gauge(metricPrefix+"bytes_per_sec", t.BytesPerSec, tags)
+				telemetry.Gauge(metricPrefix+"capacity_bytes", float64(t.AvailableSpace), tags)
+			}
 		}
 	}
+
 	return nil
 }
 

--- a/releasenotes/notes/retry-queue-telemetry-da01ce071b2b08f9.yaml
+++ b/releasenotes/notes/retry-queue-telemetry-da01ce071b2b08f9.yaml
@@ -1,0 +1,6 @@
+enhancements:
+- |
+  Always report the following telemetry metrics about the retry queue capacity:
+    * ``datadog.agent.retry_queue_duration.capacity_secs``
+    * ``datadog.agent.retry_queue_duration.bytes_per_sec``
+    * ``datadog.agent.retry_queue_duration.capacity_bytes``


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Report `datadog.agent.retry_queue_duration.*` metrics by default.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

These metrics are useful to the customers when allocating resources to the agent.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the agent with the `DD_LOG_LEVEL=debug DD_LOG_PAYLOADS=true DD_TELEMETRY_ENABLED=false` and observe that the agent still sends the following metrics with non-zero values:

- `datadog.agent.retry_queue_duration.capacity_secs`
- `datadog.agent.retry_queue_duration.bytes_per_sec`
- `datadog.agent.retry_queue_duration.capacity_bytes`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
