### PR TITLE
Allow for junit.tar.gz file within kitchen tarball folder

### DIFF
--- a/tasks/libs/junit_upload.py
+++ b/tasks/libs/junit_upload.py
@@ -147,7 +147,10 @@ def junit_upload_from_tgz(junit_tgz, codeowners_path=".github/CODEOWNERS"):
 
     # handle weird kitchen bug where it places the tarball in a subdirectory of the same name
     if os.path.isdir(junit_tgz):
-        junit_tgz = os.path.join(junit_tgz, os.path.basename(junit_tgz))
+        tmp_tgz = os.path.join(junit_tgz, os.path.basename(junit_tgz))
+        if not os.path.isfile(tmp_tgz):
+            tmp_tgz = os.path.join(junit_tgz, "junit.tar.gz")
+        junit_tgz = tmp_tgz
 
     xmlcounts = {}
     with tempfile.TemporaryDirectory() as unpack_dir:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Allows for a file named `junit.tar.gz` within the provided tarball path

### Motivation

Kitchen sometimes creates folders instead of tarballs with the right name. Previously we handled an identically named tarball within the folder. I recently saw a file named `junit.tar.gz` within. See the [failing job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/370837037) and [artifacts](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/370837001/artifacts/browse/test/kitchen/kitchen-junit-amazonlinux2-4-14-ec2-x86_64.tar.gz/) from the source job. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
