### PR TITLE
Fix runtime setting registration of goroutine profiling

### DIFF
--- a/cmd/system-probe/subcommands/run/settings.go
+++ b/cmd/system-probe/subcommands/run/settings.go
@@ -25,7 +25,10 @@ func initRuntimeSettings() error {
 	if err := commonsettings.RegisterRuntimeSetting(&commonsettings.RuntimeBlockProfileRate{ConfigPrefix: configPrefix, Config: pkgconfig.SystemProbe}); err != nil {
 		return err
 	}
-	if err := commonsettings.RegisterRuntimeSetting(&commonsettings.ProfilingGoroutines{ConfigPrefix: configPrefix, Config: pkgconfig.SystemProbe}); err != nil {
+	profilingGoRoutines := commonsettings.NewProfilingGoroutines()
+	profilingGoRoutines.Config = pkgconfig.SystemProbe
+	profilingGoRoutines.ConfigPrefix = configPrefix
+	if err := commonsettings.RegisterRuntimeSetting(profilingGoRoutines); err != nil {
 		return err
 	}
 	if err := commonsettings.RegisterRuntimeSetting(&commonsettings.ProfilingRuntimeSetting{SettingName: "internal_profiling", Service: "system-probe", ConfigPrefix: configPrefix, Config: pkgconfig.SystemProbe}); err != nil {

--- a/pkg/config/settings/runtime_setting.go
+++ b/pkg/config/settings/runtime_setting.go
@@ -7,7 +7,6 @@
 package settings
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -45,7 +44,7 @@ type RuntimeSetting interface {
 // RegisterRuntimeSetting keeps track of configurable settings
 func RegisterRuntimeSetting(setting RuntimeSetting) error {
 	if _, ok := runtimeSettings[setting.Name()]; ok {
-		return errors.New("duplicated settings detected")
+		return fmt.Errorf("duplicated settings detected: %s", setting.Name())
 	}
 	runtimeSettings[setting.Name()] = setting
 	return nil

--- a/pkg/config/settings/runtime_settings_test.go
+++ b/pkg/config/settings/runtime_settings_test.go
@@ -6,6 +6,7 @@
 package settings
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -65,7 +66,7 @@ func TestRuntimeSettings(t *testing.T) {
 
 	err = RegisterRuntimeSetting(&runtimeSetting)
 	assert.NotNil(t, err)
-	assert.Equal(t, "duplicated settings detected", err.Error())
+	assert.Equal(t, fmt.Sprintf("duplicated settings detected: %s", runtimeSetting.Name()), err.Error())
 }
 
 func TestLogLevel(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fix registration of goroutine profiling runtime setting, along with the internal profiling as it was skipped because of the previous error.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fix a bug introduced in https://github.com/DataDog/datadog-agent/pull/20591

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
