### PR TITLE
Restore misconfigured kitchen test and remove the one for install-script since we now have Debian 9 AMI for new-e2e

### DIFF
--- a/.gitlab/kitchen_testing/debian.yml
+++ b/.gitlab/kitchen_testing/debian.yml
@@ -32,9 +32,9 @@
 
 .kitchen_scenario_debian_a7_x64:
   variables:
-    KITCHEN_OSVERS: "debian-9"
+    KITCHEN_OSVERS: "debian-9,debian-10,debian-11,debian-12"
     KITCHEN_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
-    DEFAULT_KITCHEN_OSVERS: "debian-9"
+    DEFAULT_KITCHEN_OSVERS: "debian-11"
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_debian
@@ -76,15 +76,6 @@ kitchen_debian_install_script_agent-a6_arm64:
   extends:
     - .kitchen_os_with_cws
     - .kitchen_scenario_debian_a6_arm64
-    - .kitchen_test_install_script_agent
-
-kitchen_debian_install_script_agent-a7_x64:
-  # Run install script test on branches, on a reduced number of platforms
-  rules:
-    !reference [.on_all_kitchen_builds_a7]
-  extends:
-    - .kitchen_os_with_cws
-    - .kitchen_scenario_debian_a7_x64
     - .kitchen_test_install_script_agent
 
 kitchen_debian_install_script_agent-a7_arm64:

--- a/.gitlab/kitchen_tests_upload.yml
+++ b/.gitlab/kitchen_tests_upload.yml
@@ -31,7 +31,6 @@ kitchen_tests_upload_common:
     - kitchen_debian_install_script_agent-a6_arm64
     - kitchen_debian_install_script_agent-a6_x64
     - kitchen_debian_install_script_agent-a7_arm64
-    - kitchen_debian_install_script_agent-a7_x64
     - kitchen_debian_install_script_dogstatsd-a7
     - kitchen_debian_install_script_heroku_agent-a6
     - kitchen_debian_install_script_heroku_agent-a7

--- a/.gitlab/new-e2e_testing/debian.yml
+++ b/.gitlab/new-e2e_testing/debian.yml
@@ -5,7 +5,7 @@
 
 .new-e2e_debian_a7_x64:
   variables:
-    E2E_OSVERS: "debian-10,debian-11,debian-12"
+    E2E_OSVERS: "debian-9,debian-10,debian-11,debian-12"
     E2E_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
     E2E_BRANCH_OSVERS: "debian-11"
   needs: ["deploy_deb_testing-a7_x64"]

--- a/test/new-e2e/tests/agent-platform/platforms/platforms.json
+++ b/test/new-e2e/tests/agent-platform/platforms/platforms.json
@@ -1,5 +1,6 @@
 {
     "debian": {
+        "debian-9":  "ami-0272fcfb8ca47d813",
         "debian-10": "ami-041540a5c191757a0",
         "debian-11": "ami-09e24b0cfe072ecef",
         "debian-12": "ami-06db4d78cb1d3bbf9"


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Remove kitchen test for install script on debian x64

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Remove kitchen!
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
