### PR TITLE
Fix error log during cluster check runner init

### DIFF
--- a/pkg/autodiscovery/providers/clusterchecks.go
+++ b/pkg/autodiscovery/providers/clusterchecks.go
@@ -200,6 +200,7 @@ func (c *ClusterChecksConfigProvider) heartbeatSender(ctx context.Context) {
 				} else {
 					telemetry.Errors.Inc(names.ClusterChecks)
 					log.Warnf("Unable to send extra heartbeat to Cluster Agent, err: %v", err)
+					extraHeartbeatTime = currentTime
 				}
 			}
 
@@ -211,7 +212,7 @@ func (c *ClusterChecksConfigProvider) heartbeatSender(ctx context.Context) {
 
 func (c *ClusterChecksConfigProvider) postHeartbeat(ctx context.Context) error {
 	if c.dcaClient == nil {
-		return errors.New("DCA Client not initialized by main provider, cannot post heartbeat")
+		return errors.New("DCA Client not initialized by main provider yet, cannot post heartbeat, wait for init completion")
 	}
 
 	status := types.NodeStatus{

--- a/pkg/autodiscovery/providers/clusterchecks.go
+++ b/pkg/autodiscovery/providers/clusterchecks.go
@@ -195,13 +195,12 @@ func (c *ClusterChecksConfigProvider) heartbeatSender(ctx context.Context) {
 				postCtx, cancel := context.WithTimeout(ctx, postStatusTimeout)
 				defer cancel()
 				if err := c.postHeartbeat(postCtx); err == nil {
-					extraHeartbeatTime = currentTime
 					log.Infof("Sent extra heartbeat at: %v", currentTime)
 				} else {
 					telemetry.Errors.Inc(names.ClusterChecks)
 					log.Warnf("Unable to send extra heartbeat to Cluster Agent, err: %v", err)
-					extraHeartbeatTime = currentTime
 				}
+				extraHeartbeatTime = currentTime
 			}
 
 		case <-ctx.Done():

--- a/releasenotes/notes/fix_repeating_error_log_in_clc-7950ee986a560770.yaml
+++ b/releasenotes/notes/fix_repeating_error_log_in_clc-7950ee986a560770.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix spewing error message ("DCA Client not initialized by main provider, cannot post heartbeat") in the cluster check runner log during clc initialization

--- a/releasenotes/notes/fix_repeating_error_log_in_clc-7950ee986a560770.yaml
+++ b/releasenotes/notes/fix_repeating_error_log_in_clc-7950ee986a560770.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix spewing error message ("DCA Client not initialized by main provider, cannot post heartbeat") in the cluster check runner log during clc initialization
+    Fix a spewing error message ("DCA Client not initialized by main provider, cannot post heartbeat") in the cluster check runner log during CLC initialization.


### PR DESCRIPTION
[CONS-5758](https://datadoghq.atlassian.net/browse/CONS-5758)
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Reduce error log in CLC init

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
A lot of heartbeat failure were found before CLC init completed because postHeartbeat is in another go routine which is not blocked by the init. Example log:
```
2023-11-16 15:37:02 UTC | CORE | WARN | (pkg/autodiscovery/providers/clusterchecks.go:202 in heartbeatSender) | Unable to send extra heartbeat to Cluster Agent, err: DCA Client not initialized by main provider, cannot post heartbeat
2023-11-16 15:37:03 UTC | CORE | WARN | (pkg/autodiscovery/providers/clusterchecks.go:202 in heartbeatSender) | Unable to send extra heartbeat to Cluster Agent, err: DCA Client not initialized by main provider, cannot post heartbeat
2023-11-16 15:37:04 UTC | CORE | WARN | (pkg/autodiscovery/providers/clusterchecks.go:202 in heartbeatSender) | Unable to send extra heartbeat to Cluster Agent, err: DCA Client not initialized by main provider, cannot post heartbeat
2023-11-16 15:37:05 UTC | CORE | WARN | (pkg/autodiscovery/providers/clusterchecks.go:202 in heartbeatSender) | Unable to send extra heartbeat to Cluster Agent, err: DCA Client not initialized by main provider, cannot post heartbeat
2023-11-16 15:37:06 UTC | CORE | WARN | (pkg/autodiscovery/providers/clusterchecks.go:202 in heartbeatSender) | Unable to send extra heartbeat to Cluster Agent, err: DCA Client not initialized by main provider, cannot post heartbeat
2023-11-16 15:37:07 UTC | CORE | WARN | (pkg/autodiscovery/providers/clusterchecks.go:202 in heartbeatSender) | Unable to send extra heartbeat to Cluster Agent, err: DCA Client not initialized by main provider, cannot post heartbeat
2023-11-16 15:37:08 UTC | CORE | WARN | (pkg/autodiscovery/providers/clusterchecks.go:202 in heartbeatSender) | Unable to send extra heartbeat to Cluster Agent, err: DCA Client not initialized by main provider, cannot post heartbeat
2023-11-16 15:37:09 UTC | CORE | WARN | (pkg/autodiscovery/providers/clusterchecks.go:202 in heartbeatSender) | Unable to send extra heartbeat to Cluster Agent, err: DCA Client not initialized by main provider, cannot post heartbeat
2023-11-16 15:37:10 UTC | CORE | WARN | (pkg/autodiscovery/providers/clusterchecks.go:202 in heartbeatSender) | Unable to send extra heartbeat to Cluster Agent, err: DCA Client not initialized by main provider, cannot post heartbeat
2023-11-16 15:37:11 UTC | CORE | WARN | (pkg/autodiscovery/providers/clusterchecks.go:202 in heartbeatSender) | Unable to send extra heartbeat to Cluster Agent, err: DCA Client not initialized by main provider, cannot post heartbeat
2023-11-16 15:37:11 UTC | CORE | INFO | (pkg/api/security/security.go:190 in getClusterAgentAuthToken) | Using configured cluster_agent.auth_token
2023-11-16 15:37:11 UTC | CORE | INFO | (pkg/util/clusteragent/clusteragent.go:135 in init) | Successfully connected to the Datadog Cluster Agent 7.50.0-rc.2+commit.d99ab6e
```

Several clients created tickets asking for the root cause of this error:
TicketID: 1385513 and 1306312

The fix is to add a timer of 5s and let heartbeat wait after sending one error log. 
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
After the fix, the cluster check runner log (kubectl logs datadog-agent-linux-cluster-agent-xxxxxx) should be like this: only one warning appears
```
2023-11-16 19:03:03 UTC | CORE | INFO | (cmd/agent/subcommands/run/command.go:425 in startAgent) | Hostname is: minyi-test-k8s-worker
2023-11-16 19:03:04 UTC | CORE | WARN | (pkg/autodiscovery/providers/clusterchecks.go:202 in heartbeatSender) | Unable to send extra heartbeat to Cluster Agent, err: DCA Client not initialized by main provider yet, cannot post heartbeat, wait for init completion
2023-11-16 19:03:07 UTC | CORE | INFO | (pkg/api/security/security.go:251 in saveAuthToken) | Wrote auth token
2023-11-16 19:03:07 UTC | CORE | INFO | (pkg/api/security/security.go:145 in fetchAuthToken) | Saved a new authentication token to /etc/datadog-agent/auth_token
2023-11-16 19:03:07 UTC | CORE | INFO | (pkg/api/security/security.go:190 in getClusterAgentAuthToken) | Using configured cluster_agent.auth_token
2023-11-16 19:03:07 UTC | CORE | INFO | (cmd/agent/subcommands/run/command.go:501 in startAgent) | GUI server port -1 specified: not starting the GUI.
2023-11-16 19:03:07 UTC | CORE | INFO | (pkg/util/installinfo/install_info.go:92 in logVersionHistoryToFile) | Cannot read file: /opt/datadog-agent/run/version-history.json, will create a new one. open /opt/datadog-agent/run/version-history.json: no such file or directory
2023-11-16 19:03:07 UTC | CORE | INFO | (pkg/collector/runner/runner.go:96 in ensureMinWorkers) | Runner 1 added 4 workers (total: 4)
2023-11-16 19:03:07 UTC | CORE | INFO | (pkg/autodiscovery/autoconfig.go:199 in LoadAndRun) | Started config provider "file"
2023-11-16 19:03:07 UTC | CORE | INFO | (pkg/api/security/security.go:190 in getClusterAgentAuthToken) | Using configured cluster_agent.auth_token
2023-11-16 19:03:07 UTC | CORE | ERROR | (pkg/autodiscovery/config_poller.go:211 in collect) | Unable to collect configurations from provider cluster-checks: temporary failure in clusterAgentClient, will retry later: "https://10.96.245.228:5005/version" is unavailable: Get "https://10.96.245.228:5005/version": dial tcp 10.96.245.228:5005: connect: connection refused
2023-11-16 19:03:07 UTC | CORE | INFO | (pkg/autodiscovery/autoconfig.go:197 in LoadAndRun) | Started config provider "cluster-checks", polled every 10s
2023-11-16 19:03:07 UTC | CORE | WARN | (pkg/metadata/helper.go:78 in SetupMetadataCollection) | Metadata collection disabled, only do that if another agent/dogstatsd is running on this host
2023-11-16 19:03:08 UTC | CORE | INFO | (pkg/util/cloudproviders/cloudproviders.go:70 in DetectCloudProvider) | No cloud provider detected
2023-11-16 19:03:11 UTC | CORE | INFO | (comp/forwarder/defaultforwarder/transaction/transaction.go:387 in internalProcess) | Successfully posted payload to "https://7-50-0-app.agent.datadoghq.com/api/v2/series", the agent will only log transaction success every 500 transactions
2023-11-16 19:03:17 UTC | CORE | INFO | (pkg/api/security/security.go:190 in getClusterAgentAuthToken) | Using configured cluster_agent.auth_token
2023-11-16 19:03:17 UTC | CORE | ERROR | (pkg/autodiscovery/config_poller.go:149 in poll) | Cache processing of cluster-checks configuration provider failed: temporary failure in clusterAgentClient, will retry later: "https://10.96.245.228:5005/version" is unavailable: Get "https://10.96.245.228:5005/version": dial tcp 10.96.245.228:5005: connect: connection refused
2023-11-16 19:03:27 UTC | CORE | INFO | (pkg/api/security/security.go:190 in getClusterAgentAuthToken) | Using configured cluster_agent.auth_token
2023-11-16 19:03:28 UTC | CORE | INFO | (pkg/util/clusteragent/clusteragent.go:135 in init) | Successfully connected to the Datadog Cluster Agent 7.50.0-rc.2+git.17.2c0ae8e.commit.2c0ae8e956
```



<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.


[CONS-5758]: https://datadoghq.atlassian.net/browse/CONS-5758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ