### PR TITLE
Kacper murzyn/rc automatic deployments

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,7 +61,6 @@ default:
 stages:
   - .pre
   - setup
-  - rc_kubernetes_deploy
   - maintenance_jobs
   - deps_build
   - deps_fetch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,6 +47,7 @@ include:
   - /.gitlab/kitchen_common/testing.yml
   - /.gitlab/benchmarks/benchmarks.yml
   - /.gitlab/benchmarks/macrobenchmarks.yml
+  - ./gitlab/rc_kubernetes_deploy.yaml
 
 default:
   retry:
@@ -60,6 +61,7 @@ default:
 stages:
   - .pre
   - setup
+  - rc_kubernetes_deploy
   - maintenance_jobs
   - deps_build
   - deps_fetch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ include:
   - /.gitlab/kitchen_common/testing.yml
   - /.gitlab/benchmarks/benchmarks.yml
   - /.gitlab/benchmarks/macrobenchmarks.yml
-  - ./gitlab/rc_kubernetes_deploy.yaml
+  - ./gitlab/rc_kubernetes_deploy.yml
 
 default:
   retry:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ include:
   - /.gitlab/kitchen_common/testing.yml
   - /.gitlab/benchmarks/benchmarks.yml
   - /.gitlab/benchmarks/macrobenchmarks.yml
-  - ./gitlab/rc_kubernetes_deploy.yml
+  - /.gitlab/rc_kubernetes_deploy.yml
 
 default:
   retry:

--- a/.gitlab/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_kubernetes_deploy.yml
@@ -10,14 +10,14 @@ rc_kubernetes_deploy_experimental:
  # - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /7\.\d{2}\.x/' TODO - uncomment when done with testing
     when: always
   - !reference [.on_deploy_a7]
-  needs:
-  - job: docker_trigger_internal
-    artifacts: false
-  - job: docker_trigger_cluster_agent_internal
-    artifacts: false
-  - job: k8s-e2e-main # Currently only require container Argo workflow
-    artifacts: false
-    optional: true
+  # needs:
+  # - job: docker_trigger_internal
+  #   artifacts: false
+  # - job: docker_trigger_cluster_agent_internal
+  #   artifacts: false
+  # - job: k8s-e2e-main # Currently only require container Argo workflow
+  #   artifacts: false
+  #   optional: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   variables:

--- a/.gitlab/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_kubernetes_deploy.yml
@@ -27,6 +27,6 @@ rc_kubernetes_deploy_experimental:
     EXPLICIT_WORKFLOWS: "//workflows:deploy_rc.agents_rc"
   script:
     - source /root/.bashrc
+    - echo "Test"
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/k8s-datadog-agent-ops" --git-ref "kacper-murzyn/rc-automatic-deployments" --variables "OPTION_AUTOMATIC_ROLLOUT,EXPLICIT_WORKFLOWS,OPTION_PRE_SCRIPT,SKIP_PLAN_CHECK" --no-follow
-    

--- a/.gitlab/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_kubernetes_deploy.yml
@@ -1,33 +1,29 @@
 ---
-# rc_kubernetes_deploy stage
+# internal_kubernetes_deploy stage
 # Contains jobs to trigger a pipeline in our k8s-datadog-agent-ops repo to deploy release candidate build
 
-rc_kubernetes_deploy_experimental:
-  stage: rc_kubernetes_deploy
-  # rules:
-  # - if: $RC_STAGING_DEPLOYMENTS == "true"
-  #   when: always
-  # - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /7\.\d{2}\.x/' TODO - uncomment when done with testing
-  #   when: always
-  # - !reference [.on_deploy_a7]
-  # needs:
-  
-  # - job: docker_trigger_internal
-  #   artifacts: false
-  # - job: docker_trigger_cluster_agent_internal
-  #   artifacts: false
-  # - job: k8s-e2e-main # Currently only require container Argo workflow
-  #   artifacts: false
-  #   optional: true
+rc_kubernetes_deploy:
+  stage: internal_kubernetes_deploy
+  rules:
+  - if: $RC_K8S_DEPLOYMENTS == "true"
+    when: always
+  - !reference [.on_deploy_a7]
+  needs:
+  - job: docker_trigger_internal
+    artifacts: false
+  - job: docker_trigger_cluster_agent_internal
+    artifacts: false
+  - job: k8s-e2e-main # Currently only require container Argo workflow
+    artifacts: false
+    optional: true
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   variables:
     OPTION_AUTOMATIC_ROLLOUT: "true"
-    OPTION_PRE_SCRIPT: "patch-cluster-images-operator.sh env=all-staging 7.50.0-rc.3-jmx 7.50.0-rc.3"
+    OPTION_PRE_SCRIPT: "patch-cluster-images-operator.sh env=all-staging ${CI_COMMIT_REF_SLUG}-jmx ${CI_COMMIT_REF_SLUG}"
     SKIP_PLAN_CHECK: "true"
     EXPLICIT_WORKFLOWS: "//workflows:deploy_rc.agents_rc"
   script:
     - source /root/.bashrc
-    - echo "Test"
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/k8s-datadog-agent-ops" --git-ref "kacper-murzyn/rc-automatic-deployments" --variables "OPTION_AUTOMATIC_ROLLOUT,EXPLICIT_WORKFLOWS,OPTION_PRE_SCRIPT,SKIP_PLAN_CHECK" --no-follow

--- a/.gitlab/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_kubernetes_deploy.yml
@@ -22,12 +22,12 @@ rc_kubernetes_deploy_experimental:
   tags: ["arch:amd64"]
   variables:
     OPTION_AUTOMATIC_ROLLOUT: "true"
-    OPTION_PRE_SCRIPT: "patch-cluster-images-operator.sh env=all-staging ${CI_COMMIT_REF_SLUG}-jmx-${CI_COMMIT_SHORT_SHA} ${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}"
+    OPTION_PRE_SCRIPT: "patch-cluster-images-operator.sh env=all-staging 7.50.0-rc.2-jmx-d99ab6ec 7.50.0-rc.2-d99ab6ec"
     SKIP_PLAN_CHECK: "true"
     EXPLICIT_WORKFLOWS: "//workflows:deploy_rc.agents_rc"
   script:
     - source /root/.bashrc
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
-    #- inv pipeline.trigger-child-pipeline --project-name "DataDog/k8s-datadog-agent-ops" --git-ref "kacper-murzyn/rc-automatic-deployments" --variables "OPTION_AUTOMATIC_ROLLOUT,EXPLICIT_WORKFLOWS,OPTION_PRE_SCRIPT,SKIP_PLAN_CHECK" --no-follow
-    - echo $CI_COMMIT_REF_SLUG
-    - echo $CI_COMMIT_SHORT_SHA
+    - inv pipeline.trigger-child-pipeline --project-name "DataDog/k8s-datadog-agent-ops" --git-ref "kacper-murzyn/rc-automatic-deployments" --variables "OPTION_AUTOMATIC_ROLLOUT,EXPLICIT_WORKFLOWS,OPTION_PRE_SCRIPT,SKIP_PLAN_CHECK" --no-follow
+
+

--- a/.gitlab/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_kubernetes_deploy.yml
@@ -4,12 +4,12 @@
 
 rc_kubernetes_deploy_experimental:
   stage: rc_kubernetes_deploy
-  rules:
-  - if: $RC_STAGING_DEPLOYMENTS == "true"
-    when: always
+  # rules:
+  # - if: $RC_STAGING_DEPLOYMENTS == "true"
+  #   when: always
  # - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /7\.\d{2}\.x/' TODO - uncomment when done with testing
-    when: always
-  - !reference [.on_deploy_a7]
+  #   when: always
+  # - !reference [.on_deploy_a7]
   # needs:
   # - job: docker_trigger_internal
   #   artifacts: false

--- a/.gitlab/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_kubernetes_deploy.yml
@@ -10,7 +10,7 @@ rc_kubernetes_deploy_experimental:
   # - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /7\.\d{2}\.x/' TODO - uncomment when done with testing
   #   when: always
   # - !reference [.on_deploy_a7]
-  
+
   # needs:
   # - job: docker_trigger_internal
   #   artifacts: false
@@ -23,7 +23,7 @@ rc_kubernetes_deploy_experimental:
   tags: ["arch:amd64"]
   variables:
     OPTION_AUTOMATIC_ROLLOUT: "true"
-    OPTION_PRE_SCRIPT: "patch-cluster-images-operator.sh env=all-staging 7.50.0-rc.2-jmx-d99ab6ec 7.50.0-rc.2-d99ab6ec"
+    OPTION_PRE_SCRIPT: "patch-cluster-images-operator.sh env=all-staging 7.50.0-rc.2-jmx 7.50.0-rc.2"
     SKIP_PLAN_CHECK: "true"
     EXPLICIT_WORKFLOWS: "//workflows:deploy_rc.agents_rc"
   script:

--- a/.gitlab/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_kubernetes_deploy.yml
@@ -11,6 +11,7 @@ rc_kubernetes_deploy_experimental:
   #   when: always
   # - !reference [.on_deploy_a7]
   # needs:
+  
   # - job: docker_trigger_internal
   #   artifacts: false
   # - job: docker_trigger_cluster_agent_internal

--- a/.gitlab/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_kubernetes_deploy.yml
@@ -10,7 +10,6 @@ rc_kubernetes_deploy_experimental:
   # - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /7\.\d{2}\.x/' TODO - uncomment when done with testing
   #   when: always
   # - !reference [.on_deploy_a7]
-
   # needs:
   # - job: docker_trigger_internal
   #   artifacts: false

--- a/.gitlab/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_kubernetes_deploy.yml
@@ -25,5 +25,6 @@ rc_kubernetes_deploy:
     EXPLICIT_WORKFLOWS: "//workflows:deploy_rc.agents_rc"
   script:
     - source /root/.bashrc
+    - set +x
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
-    - inv pipeline.trigger-child-pipeline --project-name "DataDog/k8s-datadog-agent-ops" --git-ref "kacper-murzyn/rc-automatic-deployments" --variables "OPTION_AUTOMATIC_ROLLOUT,EXPLICIT_WORKFLOWS,OPTION_PRE_SCRIPT,SKIP_PLAN_CHECK" --no-follow
+    - inv pipeline.trigger-child-pipeline --project-name "DataDog/k8s-datadog-agent-ops" --git-ref "main" --variables "OPTION_AUTOMATIC_ROLLOUT,EXPLICIT_WORKFLOWS,OPTION_PRE_SCRIPT,SKIP_PLAN_CHECK" --no-follow

--- a/.gitlab/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_kubernetes_deploy.yml
@@ -1,0 +1,31 @@
+---
+# rc_kubernetes_deploy stage
+# Contains jobs to trigger a pipeline in our k8s-datadog-agent-ops repo to deploy release candidate build
+
+rc_kubernetes_deploy_experimental:
+  stage: rc_kubernetes_deploy
+  rules:
+  - if: $RC_STAGING_DEPLOYMENTS == "true"
+    when: always
+ # - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /7\.\d{2}\.x/' TODO - uncomment when done with testing
+    when: always
+  - !reference [.on_deploy_a7]
+  needs:
+  - job: docker_trigger_internal
+    artifacts: false
+  - job: docker_trigger_cluster_agent_internal
+    artifacts: false
+  - job: k8s-e2e-main # Currently only require container Argo workflow
+    artifacts: false
+    optional: true
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  variables:
+    OPTION_AUTOMATIC_ROLLOUT: "true"
+    OPTION_PRE_SCRIPT: "patch-cluster-images-operator.sh env=all-staging ${CI_COMMIT_REF_SLUG}-jmx-${CI_COMMIT_SHORT_SHA} ${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}"
+    SKIP_PLAN_CHECK: "true"
+    EXPLICIT_WORKFLOWS: "//workflows:deploy_rc.agents_rc"
+  script:
+    - source /root/.bashrc
+    - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
+    - inv pipeline.trigger-child-pipeline --project-name "DataDog/k8s-datadog-agent-ops" --git-ref "kacper-murzyn/rc-automatic-deployments" --variables "OPTION_AUTOMATIC_ROLLOUT,EXPLICIT_WORKFLOWS,OPTION_PRE_SCRIPT,SKIP_PLAN_CHECK" --no-follow

--- a/.gitlab/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_kubernetes_deploy.yml
@@ -23,7 +23,7 @@ rc_kubernetes_deploy_experimental:
   tags: ["arch:amd64"]
   variables:
     OPTION_AUTOMATIC_ROLLOUT: "true"
-    OPTION_PRE_SCRIPT: "patch-cluster-images-operator.sh env=all-staging 7.50.0-rc.2-jmx 7.50.0-rc.2"
+    OPTION_PRE_SCRIPT: "patch-cluster-images-operator.sh env=all-staging 7.50.0-rc.3-jmx 7.50.0-rc.3"
     SKIP_PLAN_CHECK: "true"
     EXPLICIT_WORKFLOWS: "//workflows:deploy_rc.agents_rc"
   script:

--- a/.gitlab/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_kubernetes_deploy.yml
@@ -7,7 +7,7 @@ rc_kubernetes_deploy_experimental:
   # rules:
   # - if: $RC_STAGING_DEPLOYMENTS == "true"
   #   when: always
- # - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /7\.\d{2}\.x/' TODO - uncomment when done with testing
+  # - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /7\.\d{2}\.x/' TODO - uncomment when done with testing
   #   when: always
   # - !reference [.on_deploy_a7]
   # needs:

--- a/.gitlab/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_kubernetes_deploy.yml
@@ -10,6 +10,7 @@ rc_kubernetes_deploy_experimental:
   # - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /7\.\d{2}\.x/' TODO - uncomment when done with testing
   #   when: always
   # - !reference [.on_deploy_a7]
+  
   # needs:
   # - job: docker_trigger_internal
   #   artifacts: false

--- a/.gitlab/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_kubernetes_deploy.yml
@@ -10,7 +10,6 @@ rc_kubernetes_deploy_experimental:
   # - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /7\.\d{2}\.x/' TODO - uncomment when done with testing
   #   when: always
   # - !reference [.on_deploy_a7]
-  
   # needs:
   # - job: docker_trigger_internal
   #   artifacts: false

--- a/.gitlab/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_kubernetes_deploy.yml
@@ -29,5 +29,4 @@ rc_kubernetes_deploy_experimental:
     - source /root/.bashrc
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/k8s-datadog-agent-ops" --git-ref "kacper-murzyn/rc-automatic-deployments" --variables "OPTION_AUTOMATIC_ROLLOUT,EXPLICIT_WORKFLOWS,OPTION_PRE_SCRIPT,SKIP_PLAN_CHECK" --no-follow
-
-
+    

--- a/.gitlab/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_kubernetes_deploy.yml
@@ -28,4 +28,6 @@ rc_kubernetes_deploy_experimental:
   script:
     - source /root/.bashrc
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
-    - inv pipeline.trigger-child-pipeline --project-name "DataDog/k8s-datadog-agent-ops" --git-ref "kacper-murzyn/rc-automatic-deployments" --variables "OPTION_AUTOMATIC_ROLLOUT,EXPLICIT_WORKFLOWS,OPTION_PRE_SCRIPT,SKIP_PLAN_CHECK" --no-follow
+    #- inv pipeline.trigger-child-pipeline --project-name "DataDog/k8s-datadog-agent-ops" --git-ref "kacper-murzyn/rc-automatic-deployments" --variables "OPTION_AUTOMATIC_ROLLOUT,EXPLICIT_WORKFLOWS,OPTION_PRE_SCRIPT,SKIP_PLAN_CHECK" --no-follow
+    - echo $CI_COMMIT_REF_SLUG
+    - echo $CI_COMMIT_SHORT_SHA

--- a/tasks/libs/pipeline_tools.py
+++ b/tasks/libs/pipeline_tools.py
@@ -88,7 +88,7 @@ def trigger_agent_pipeline(
     deploy=False,
     all_builds=False,
     kitchen_tests=False,
-    rc_staging_deployments=False,
+    rc_k8s_deployments=False,
 ):
     """
     Trigger a pipeline on the datadog-agent repositories. Multiple options are available:
@@ -124,8 +124,8 @@ def trigger_agent_pipeline(
     if branch is not None:
         args["BUCKET_BRANCH"] = branch
 
-    if rc_staging_deployments:
-        args["RC_STAGING_DEPLOYMENTS"] = "true"
+    if rc_k8s_deployments:
+        args["RC_K8S_DEPLOYMENTS"] = "true"
 
     print(
         "Creating pipeline for datadog-agent on branch/tag {} with args:\n{}".format(  # noqa: FS002

--- a/tasks/libs/pipeline_tools.py
+++ b/tasks/libs/pipeline_tools.py
@@ -88,6 +88,7 @@ def trigger_agent_pipeline(
     deploy=False,
     all_builds=False,
     kitchen_tests=False,
+    rc_staging_deployments=False,
 ):
     """
     Trigger a pipeline on the datadog-agent repositories. Multiple options are available:
@@ -122,6 +123,9 @@ def trigger_agent_pipeline(
 
     if branch is not None:
         args["BUCKET_BRANCH"] = branch
+
+    if rc_staging_deployments:
+        args["RC_STAGING_DEPLOYMENTS"] = "true"
 
     print(
         "Creating pipeline for datadog-agent on branch/tag {} with args:\n{}".format(  # noqa: FS002

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -211,7 +211,7 @@ def run(
     deploy=False,
     all_builds=True,
     kitchen_tests=True,
-    rc_staging_deployments=False,
+    rc_k8s_deployments=False,
 ):
     """
     Run a pipeline on the given git ref (--git-ref <git ref>), or on the current branch if --here is given.
@@ -312,7 +312,7 @@ def run(
             deploy=deploy,
             all_builds=all_builds,
             kitchen_tests=kitchen_tests,
-            rc_staging_deployments=rc_staging_deployments,
+            rc_k8s_deployments=rc_k8s_deployments,
         )
     except FilteredOutException:
         print(color_message(f"ERROR: pipeline does not match any workflow rule. Rules:\n{workflow_rules()}", "red"))

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -211,6 +211,7 @@ def run(
     deploy=False,
     all_builds=True,
     kitchen_tests=True,
+    rc_staging_deployments=False,
 ):
     """
     Run a pipeline on the given git ref (--git-ref <git ref>), or on the current branch if --here is given.
@@ -311,6 +312,7 @@ def run(
             deploy=deploy,
             all_builds=all_builds,
             kitchen_tests=kitchen_tests,
+            rc_staging_deployments=rc_staging_deployments,
         )
     except FilteredOutException:
         print(color_message(f"ERROR: pipeline does not match any workflow rule. Rules:\n{workflow_rules()}", "red"))

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1132,12 +1132,12 @@ Make sure that milestone is open before trying again.""",
 
 
 @task
-def build_rc(ctx, major_versions="6,7", patch_version=False, staging_deployments=False):
+def build_rc(ctx, major_versions="6,7", patch_version=False, k8s_deployments=False):
     """
     To be done after the PR created by release.create-rc is merged, with the same options
     as release.create-rc.
 
-    staging_deployments - when set to True the child pipeline deploying to k8s staging clusters would be triggred.
+    k8s_deployments - when set to True the child pipeline deploying to subset of k8s staging clusters would be triggered.
 
     Tags the new RC versions on the current commit, and creates the build pipeline for these
     new tags.
@@ -1208,7 +1208,7 @@ def build_rc(ctx, major_versions="6,7", patch_version=False, staging_deployments
         major_versions=major_versions,
         repo_branch="beta",
         deploy=True,
-        rc_staging_deployments=staging_deployments,
+        rc_k8s_deployments=k8s_deployments,
     )
 
 

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1137,7 +1137,7 @@ def build_rc(ctx, major_versions="6,7", patch_version=False, k8s_deployments=Fal
     To be done after the PR created by release.create-rc is merged, with the same options
     as release.create-rc.
 
-    k8s_deployments - when set to True the child pipeline deploying to subset of k8s staging clusters would be triggered.
+    k8s_deployments - when set to True the child pipeline deploying to subset of k8s staging clusters will be triggered.
 
     Tags the new RC versions on the current commit, and creates the build pipeline for these
     new tags.

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1132,10 +1132,12 @@ Make sure that milestone is open before trying again.""",
 
 
 @task
-def build_rc(ctx, major_versions="6,7", patch_version=False):
+def build_rc(ctx, major_versions="6,7", patch_version=False, staging_deployments=False):
     """
     To be done after the PR created by release.create-rc is merged, with the same options
     as release.create-rc.
+
+    staging_deployments - when set to True the child pipeline deploying to k8s staging clusters would be triggred.
 
     Tags the new RC versions on the current commit, and creates the build pipeline for these
     new tags.
@@ -1206,6 +1208,7 @@ def build_rc(ctx, major_versions="6,7", patch_version=False):
         major_versions=major_versions,
         repo_branch="beta",
         deploy=True,
+        rc_staging_deployments=staging_deployments,
     )
 
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a flag to `build_rc` invoke task which, when set, adds a job to the build pipeline responsible for automatic deployment of the RC build to k8s staging clusters (corresponding workflow will be added in k8s-datadog-agent repository - https://github.com/DataDog/k8s-datadog-agent-ops/pull/2638)

### Motivation

Automation of the Agent Release Candidate build and verification process.
At the moment there is usually a gap between the moment when RC images are ready and when staging k8s deployments can start. This change aims to remove this gap and help making RC testing faster.

### Additional Notes

This change assumes that next automation steps would be made by calling invoke tasks within the gitlab pipelines. As long as we believe this is the right approach, then this PR makes sense for the long term plan.

### Describe how to test/QA your changes

This change was tested on branch (with corresponding branch in k8s-datadog-agent repository). To be able to verify it e2e we need to run it from the main/release branch for real RC build. This should happen during next Agent release cycle.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
