### PR TITLE
[omnibus] Fix parsing of Status in dpkginfo probe

### DIFF
--- a/omnibus/config/patches/openscap/dpkginfo-status-fix.patch
+++ b/omnibus/config/patches/openscap/dpkginfo-status-fix.patch
@@ -1,0 +1,25 @@
+commit d3397b17e413856f3ca8e072cd789ee1bb7e778f
+Author: David du Colombier <djc@datadoghq.com>
+Date:   Fri Nov 17 12:28:17 2023 +0100
+
+    Fix parsing of Status in dpkginfo probe
+    
+    This change fixes a mistake made during a last-minute
+    change in 557ddeed1e3e234a655ad77a691869554064b293.
+    
+    The parsing the Status was incorrect and all
+    packages were considered as deinstalled.
+
+diff --git a/src/OVAL/probes/unix/linux/dpkginfo-helper.c b/src/OVAL/probes/unix/linux/dpkginfo-helper.c
+index 2ba9fb474..fcbb8d150 100644
+--- a/src/OVAL/probes/unix/linux/dpkginfo-helper.c
++++ b/src/OVAL/probes/unix/linux/dpkginfo-helper.c
+@@ -125,7 +125,7 @@ struct dpkginfo_reply_t* dpkginfo_get_by_name(const char *name, int *err)
+ 			}
+ 		} else if (reply != NULL) {
+ 			if (strcmp(key, "Status") == 0) {
+-				if (strcmp(value, "install") != 0) {
++				if (strncmp(value, "install", 7) != 0) {
+ 					// Package deinstalled.
+ 					dD("Package \"%s\" has been deinstalled.", name);
+ 					dpkginfo_free_reply(reply);

--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -58,6 +58,7 @@ build do
   patch source: "rpm-verbosity-err.patch", env: env # decrease rpmlog verbosity level to ERR
   patch source: "session-print-syschar.patch", env: env # add a function to print system characteristics
   patch source: "memusage-cgroup.patch", env: env # consider cgroup when determining memory usage
+  patch source: "dpkginfo-status-fix.patch", env: env # fix parsing of status in dpkginfo probe
 
   patch source: "oval_probe_session_reset.patch", env: env # use oval_probe_session_reset instead of oval_probe_session_reinit
 


### PR DESCRIPTION
### What does this PR do?

This change fixes the parsing of Status
in dpkginfo probe.

The parsing the Status was incorrect and all
packages were considered as deinstalled.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
