### PR TITLE
usm: http2: Change the LRU flag to share the LRU accross CPUs

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/maps-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/maps-defs.h
@@ -11,7 +11,7 @@ BPF_HASH_MAP(http2_static_table, u8, static_table_value_t, 20)
 
 /* http2_dynamic_table is the map that holding the supported dynamic values - the index is the static index and the
    conn tuple and it is value is the buffer which contains the dynamic string. */
-BPF_LRU_MAP(http2_dynamic_table, dynamic_table_index_t, dynamic_table_entry_t, 0)
+BPF_LRU_MAP(http2_dynamic_table, dynamic_table_index_t, dynamic_table_entry_t, !BPF_F_NO_COMMON_LRU)
 
 /* http2_dynamic_counter_table is a map that holding the current dynamic values amount, in order to use for the
    internal calculation of the internal index in the http2_dynamic_table, it is hold by conn_tup to support different


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Changes the flag of `http2_dynamic_table` to share LRU across CPUs.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Today, our `http2_dynamic_table` didn't share the LRU across CPUs, which resulted in removing wrong entries instead of the global LRU. That caused flakiness in our algorithm, as the wrong values were removed, and we failed to capture the traffic.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
CPU negligible change (4%)
![image](https://github.com/DataDog/datadog-agent/assets/17148247/fc006ec5-c808-40c1-b03d-940585fa20fe)

RSS negligible drop (2%)
![image](https://github.com/DataDog/datadog-agent/assets/17148247/12e925a0-21f2-45e0-864a-dce26c7aeaa1)

WSS negligible drop (2%)
![image](https://github.com/DataDog/datadog-agent/assets/17148247/2f3a9c02-7b80-4448-9ad3-172a08050294)

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
