### PR TITLE
Refactor agent integrations software definitions: Simplify blocks and reduce their use

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -8,6 +8,9 @@ require 'json'
 
 name 'datadog-agent-integrations-py2'
 
+license "BSD-3-Clause"
+license_file "./LICENSE"
+
 dependency 'datadog-agent'
 dependency 'datadog-agent-integrations-py2-dependencies'
 
@@ -77,9 +80,6 @@ filtered_agent_requirements_in = 'agent_requirements-py2.in'
 agent_requirements_in = 'agent_requirements.in'
 
 build do
-  license "BSD-3-Clause"
-  license_file "./LICENSE"
-
   # The dir for confs
   if osx_target?
     conf_dir = "#{install_dir}/etc/conf.d"
@@ -105,101 +105,100 @@ build do
   }
 
   # Install the checks along with their dependencies
-  block do
-    if windows_target?
-      wheel_build_dir = "#{windows_safe_path(project_dir)}\\.wheels"
-      build_deps_dir = "#{windows_safe_path(project_dir)}\\.build_deps"
-    else
-      wheel_build_dir = "#{project_dir}/.wheels"
-      build_deps_dir = "#{project_dir}/.build_deps"
-    end
+  if windows_target?
+    wheel_build_dir = "#{windows_safe_path(project_dir)}\\.wheels"
+    build_deps_dir = "#{windows_safe_path(project_dir)}\\.build_deps"
+  else
+    wheel_build_dir = "#{project_dir}/.wheels"
+    build_deps_dir = "#{project_dir}/.build_deps"
+  end
 
-    #
-    # Prepare the build env, these dependencies are only needed to build and
-    # install the core integrations.
-    #
-    command "#{pip} download --dest #{build_deps_dir} hatchling==0.25.1", :env => pre_build_env
-    command "#{pip} download --dest #{build_deps_dir} setuptools==40.9.0", :env => pre_build_env # Version from ./setuptools2.rb
-    command "#{pip} install wheel==0.37.1", :env => pre_build_env # Pin to the last version that supports Python 2
-    command "#{pip} install setuptools-scm==5.0.2", :env => pre_build_env # Pin to the last version that supports Python 2
-    command "#{pip} install pip-tools==5.4.0", :env => pre_build_env
-    uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools']
-    nix_build_env = {
-      "PIP_FIND_LINKS" => "#{build_deps_dir}",
-      "PIP_CONFIG_FILE" => "#{pip_config_file}",
-      "CFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
-      "CXXFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
-      "LDFLAGS" => "-L#{install_dir}/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib",
-      "LD_RUN_PATH" => "#{install_dir}/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib",
-      "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
+  #
+  # Prepare the build env, these dependencies are only needed to build and
+  # install the core integrations.
+  #
+  command "#{pip} download --dest #{build_deps_dir} hatchling==0.25.1", :env => pre_build_env
+  command "#{pip} download --dest #{build_deps_dir} setuptools==40.9.0", :env => pre_build_env # Version from ./setuptools2.rb
+  command "#{pip} install wheel==0.37.1", :env => pre_build_env # Pin to the last version that supports Python 2
+  command "#{pip} install setuptools-scm==5.0.2", :env => pre_build_env # Pin to the last version that supports Python 2
+  command "#{pip} install pip-tools==5.4.0", :env => pre_build_env
+  uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools']
+  nix_build_env = {
+    "PIP_FIND_LINKS" => "#{build_deps_dir}",
+    "PIP_CONFIG_FILE" => "#{pip_config_file}",
+    "CFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
+    "CXXFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
+    "LDFLAGS" => "-L#{install_dir}/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib",
+    "LD_RUN_PATH" => "#{install_dir}/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib",
+    "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
+  }
+  win_build_env = {
+    "PIP_FIND_LINKS" => "#{build_deps_dir}",
+    "PIP_CONFIG_FILE" => "#{pip_config_file}",
+  }
+  # Some libraries (looking at you, aerospike-client-python) need EXT_CFLAGS instead of CFLAGS.
+  nix_specific_build_env = {
+    "aerospike" => nix_build_env.merge({"EXT_CFLAGS" => nix_build_env["CFLAGS"] + " -std=gnu99"}),
+    # Always build pyodbc from source to link to the embedded version of libodbc
+    "pyodbc" => nix_build_env.merge({"PIP_NO_BINARY" => "pyodbc"}),
+  }
+  win_specific_build_env = {}
+
+
+  # On Linux & Windows, specify the C99 standard explicitly to avoid issues while building some
+  # wheels (eg. ddtrace).
+  # Not explicitly setting that option has caused us problems in the past on SUSE, where the ddtrace
+  # wheel has to be manually built, as the C code in ddtrace doesn't follow the C89 standard (the default value of std).
+  # Note: We don't set this on MacOS, as on MacOS we need to build a bunch of packages & C extensions that
+  # don't have precompiled MacOS wheels. When building C extensions, the CFLAGS variable is added to
+  # the command-line parameters, even when compiling C++ code, where -std=c99 is invalid.
+  # See: https://github.com/python/cpython/blob/v2.7.18/Lib/distutils/sysconfig.py#L222
+  if linux_target? || windows_target?
+    nix_build_env["CFLAGS"] += " -std=c99"
+  end
+
+  #
+  # Prepare the requirements file containing ALL the dependencies needed by
+  # any integration. This will provide the "static Python environment" of the Agent.
+  # We don't use the .in file provided by the base check directly because we
+  # want to filter out things before installing.
+  #
+  if windows_target?
+    static_reqs_in_file = "#{windows_safe_path(project_dir)}\\datadog_checks_base\\datadog_checks\\base\\data\\#{agent_requirements_in}"
+    static_reqs_out_folder = "#{windows_safe_path(project_dir)}\\"
+    static_reqs_out_file = static_reqs_out_folder + filtered_agent_requirements_in
+    compiled_reqs_file_path = "#{windows_safe_path(install_dir)}\\#{agent_requirements_file}"
+  else
+    static_reqs_in_file = "#{project_dir}/datadog_checks_base/datadog_checks/base/data/#{agent_requirements_in}"
+    static_reqs_out_folder = "#{project_dir}/"
+    static_reqs_out_file = static_reqs_out_folder + filtered_agent_requirements_in
+    compiled_reqs_file_path = "#{install_dir}/#{agent_requirements_file}"
+  end
+
+  specific_build_env = windows_target? ? win_specific_build_env : nix_specific_build_env
+  build_env = windows_target? ? win_build_env : nix_build_env
+  cwd = windows_target? ? "#{windows_safe_path(project_dir)}\\datadog_checks_base" : "#{project_dir}/datadog_checks_base"
+
+  # Creating a hash containing the requirements and requirements file path associated to every lib
+  requirements_custom = Hash.new()
+  specific_build_env.each do |lib, env|
+    lib_compiled_req_file_path = (windows_target? ? "#{windows_safe_path(install_dir)}\\" : "#{install_dir}/") + "agent_#{lib}_requirements-py2.txt"
+    requirements_custom[lib] = {
+      "req_lines" => Array.new,
+      "req_file_path" => static_reqs_out_folder + lib + "-py2.in",
+      "compiled_req_file_path" => lib_compiled_req_file_path,
     }
-    win_build_env = {
-      "PIP_FIND_LINKS" => "#{build_deps_dir}",
-      "PIP_CONFIG_FILE" => "#{pip_config_file}",
-    }
-    # Some libraries (looking at you, aerospike-client-python) need EXT_CFLAGS instead of CFLAGS.
-    nix_specific_build_env = {
-      "aerospike" => nix_build_env.merge({"EXT_CFLAGS" => nix_build_env["CFLAGS"] + " -std=gnu99"}),
-      # Always build pyodbc from source to link to the embedded version of libodbc
-      "pyodbc" => nix_build_env.merge({"PIP_NO_BINARY" => "pyodbc"}),
-    }
-    win_specific_build_env = {}
+  end
 
+  # Remove any excluded requirements from the static-environment req file
+  requirements = Array.new
 
-    # On Linux & Windows, specify the C99 standard explicitly to avoid issues while building some
-    # wheels (eg. ddtrace).
-    # Not explicitly setting that option has caused us problems in the past on SUSE, where the ddtrace
-    # wheel has to be manually built, as the C code in ddtrace doesn't follow the C89 standard (the default value of std).
-    # Note: We don't set this on MacOS, as on MacOS we need to build a bunch of packages & C extensions that
-    # don't have precompiled MacOS wheels. When building C extensions, the CFLAGS variable is added to
-    # the command-line parameters, even when compiling C++ code, where -std=c99 is invalid.
-    # See: https://github.com/python/cpython/blob/v2.7.18/Lib/distutils/sysconfig.py#L222
-    if linux_target? || windows_target?
-      nix_build_env["CFLAGS"] += " -std=c99"
-    end
-
-    #
-    # Prepare the requirements file containing ALL the dependencies needed by
-    # any integration. This will provide the "static Python environment" of the Agent.
-    # We don't use the .in file provided by the base check directly because we
-    # want to filter out things before installing.
-    #
-    if windows_target?
-      static_reqs_in_file = "#{windows_safe_path(project_dir)}\\datadog_checks_base\\datadog_checks\\base\\data\\#{agent_requirements_in}"
-      static_reqs_out_folder = "#{windows_safe_path(project_dir)}\\"
-      static_reqs_out_file = static_reqs_out_folder + filtered_agent_requirements_in
-      compiled_reqs_file_path = "#{windows_safe_path(install_dir)}\\#{agent_requirements_file}"
-    else
-      static_reqs_in_file = "#{project_dir}/datadog_checks_base/datadog_checks/base/data/#{agent_requirements_in}"
-      static_reqs_out_folder = "#{project_dir}/"
-      static_reqs_out_file = static_reqs_out_folder + filtered_agent_requirements_in
-      compiled_reqs_file_path = "#{install_dir}/#{agent_requirements_file}"
-    end
-
-    # Remove any excluded requirements from the static-environment req file
-    requirements = Array.new
-
-    # Creating a hash containing the requirements and requirements file path associated to every lib
-    requirements_custom = Hash.new()
-
-    specific_build_env = windows_target? ? win_specific_build_env : nix_specific_build_env
-    build_env = windows_target? ? win_build_env : nix_build_env
-    cwd = windows_target? ? "#{windows_safe_path(project_dir)}\\datadog_checks_base" : "#{project_dir}/datadog_checks_base"
-
-    specific_build_env.each do |lib, env|
-      lib_compiled_req_file_path = (windows_target? ? "#{windows_safe_path(install_dir)}\\" : "#{install_dir}/") + "agent_#{lib}_requirements-py2.txt"
-      requirements_custom[lib] = {
-        "req_lines" => Array.new,
-        "req_file_path" => static_reqs_out_folder + lib + "-py2.in",
-        "compiled_req_file_path" => lib_compiled_req_file_path,
-      }
-    end
-
+  block "Create filtered requirements" do
     File.open("#{static_reqs_in_file}", 'r+').readlines().each do |line|
       next if excluded_packages.any? { |package_regex| line.match(package_regex) }
 
       if line.start_with?('psycopg[binary]') && !windows_target?
-          line.sub! 'psycopg[binary]', 'psycopg[c]'
+        line.sub! 'psycopg[binary]', 'psycopg[c]'
       end
       # Keeping the custom env requirements lines apart to install them with a specific env
       requirements_custom.each do |lib, lib_req|
@@ -215,67 +214,71 @@ build do
     # Adding pympler for memory debug purposes
     requirements.push("pympler==0.7")
 
-    # Render the filtered requirements file
+  end
+
+  # Render the filtered requirements file
+  erb source: "static_requirements.txt.erb",
+      dest: "#{static_reqs_out_file}",
+      mode: 0640,
+      vars: { requirements: requirements }
+
+  # Render the filtered libraries that are to be built with different env var
+  requirements_custom.each do |lib, lib_req|
     erb source: "static_requirements.txt.erb",
-        dest: "#{static_reqs_out_file}",
+        dest: "#{lib_req["req_file_path"]}",
         mode: 0640,
-        vars: { requirements: requirements }
+        vars: { requirements: lib_req["req_lines"] }
+  end
 
-    # Render the filtered libraries that are to be built with different env var
-    requirements_custom.each do |lib, lib_req|
-      erb source: "static_requirements.txt.erb",
-          dest: "#{lib_req["req_file_path"]}",
-          mode: 0640,
-          vars: { requirements: lib_req["req_lines"] }
-    end
+  # Increasing pip max retries (default: 5 times) and pip timeout (default 15 seconds) to avoid blocking network errors
+  pip_max_retries = 20
+  pip_timeout = 20
 
-    # Increasing pip max retries (default: 5 times) and pip timeout (default 15 seconds) to avoid blocking network errors
-    pip_max_retries = 20
-    pip_timeout = 20
+  # Use pip-compile to create the final requirements file. Notice when we invoke `pip` through `python -m pip <...>`,
+  # there's no need to refer to `pip`, the interpreter will pick the right script.
+  command "#{python} -m pip wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => build_env, :cwd => cwd
+  command "#{python} -m pip install datadog_checks_base --no-deps --no-index --find-links=#{wheel_build_dir}"
+  command "#{python} -m piptools compile --generate-hashes --output-file #{compiled_reqs_file_path} #{static_reqs_out_file} " \
+          "--pip-args \"--retries #{pip_max_retries} --timeout #{pip_timeout}\"", :env => build_env
+  # Pip-compiling seperately each lib that needs a custom build installation
+  specific_build_env.each do |lib, env|
+    command "#{python} -m piptools compile --generate-hashes --output-file #{requirements_custom[lib]["compiled_req_file_path"]} #{requirements_custom[lib]["req_file_path"]} " \
+            "--pip-args \"--retries #{pip_max_retries} --timeout #{pip_timeout}\"", :env => env
+  end
 
-    # Use pip-compile to create the final requirements file. Notice when we invoke `pip` through `python -m pip <...>`,
-    # there's no need to refer to `pip`, the interpreter will pick the right script.
-    command "#{python} -m pip wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => build_env, :cwd => cwd
-    command "#{python} -m pip install datadog_checks_base --no-deps --no-index --find-links=#{wheel_build_dir}"
-    command "#{python} -m piptools compile --generate-hashes --output-file #{compiled_reqs_file_path} #{static_reqs_out_file} " \
-      "--pip-args \"--retries #{pip_max_retries} --timeout #{pip_timeout}\"", :env => build_env
-    # Pip-compiling seperately each lib that needs a custom build installation
-    specific_build_env.each do |lib, env|
-      command "#{python} -m piptools compile --generate-hashes --output-file #{requirements_custom[lib]["compiled_req_file_path"]} #{requirements_custom[lib]["req_file_path"]} " \
-      "--pip-args \"--retries #{pip_max_retries} --timeout #{pip_timeout}\"", :env => env
-    end
+  #
+  # Install static-environment requirements that the Agent and all checks will use
+  #
 
-    #
-    # Install static-environment requirements that the Agent and all checks will use
-    #
-
-    # First we install the dependencies that need specific flags
-    specific_build_env.each do |lib, env|
-      command "#{python} -m pip install --no-deps --require-hashes -r #{requirements_custom[lib]["compiled_req_file_path"]}", :env => env
-      # Remove the file after use so it is not shipped
-      delete "#{requirements_custom[lib]["compiled_req_file_path"]}"
-    end
-
-    # Then we install the rest (already installed libraries will be ignored) with the main flags
-    command "#{python} -m pip install --no-deps --require-hashes -r #{compiled_reqs_file_path}", :env => build_env
+  # First we install the dependencies that need specific flags
+  specific_build_env.each do |lib, env|
+    command "#{python} -m pip install --no-deps --require-hashes -r #{requirements_custom[lib]["compiled_req_file_path"]}", :env => env
     # Remove the file after use so it is not shipped
-    delete "#{compiled_reqs_file_path}"
+    delete "#{requirements_custom[lib]["compiled_req_file_path"]}"
+  end
 
-    #
-    # Install Core integrations
-    #
+  # Then we install the rest (already installed libraries will be ignored) with the main flags
+  command "#{python} -m pip install --no-deps --require-hashes -r #{compiled_reqs_file_path}", :env => build_env
+  # Remove the file after use so it is not shipped
+  delete "#{compiled_reqs_file_path}"
 
-    # Create a constraint file after installing all the core dependencies and before any integration
-    # This is then used as a constraint file by the integration command to avoid messing with the agent's python environment
-    command "#{pip} freeze > #{install_dir}/#{final_constraints_file}"
+  #
+  # Install Core integrations
+  #
 
-    if windows_target?
-        cached_wheels_dir = "#{windows_safe_path(wheel_build_dir)}\\.cached"
-    else
-        cached_wheels_dir = "#{wheel_build_dir}/.cached"
-    end
-    checks_to_install = Array.new
+  # Create a constraint file after installing all the core dependencies and before any integration
+  # This is then used as a constraint file by the integration command to avoid messing with the agent's python environment
+  command "#{pip} freeze > #{install_dir}/#{final_constraints_file}"
 
+  if windows_target?
+    cached_wheels_dir = "#{windows_safe_path(wheel_build_dir)}\\.cached"
+  else
+    cached_wheels_dir = "#{wheel_build_dir}/.cached"
+  end
+
+  checks_to_install = Array.new
+
+  block "Collect integrations to install" do
     # Go through every integration package in `integrations-core`, build and install
     Dir.glob("#{project_dir}/*").each do |check_dir|
       check = check_dir.split('/').last
@@ -314,167 +317,142 @@ build do
 
       checks_to_install.push(check)
     end
+  end
 
+  installed_list = Array.new
+  cache_bucket = ENV.fetch('INTEGRATION_WHEELS_CACHE_BUCKET', '')
+  block "Install cached wheels" do
     tasks_dir_in = windows_safe_path(Dir.pwd)
-    cache_bucket = ENV.fetch('INTEGRATION_WHEELS_CACHE_BUCKET', '')
-    cache_branch = `cd .. && inv release.get-release-json-value base_branch`.strip
+    cache_branch = (shellout! "inv release.get-release-json-value base_branch", cwd: File.expand_path('..', tasks_dir_in)).stdout.strip
     # On windows, `aws` actually executes Ruby's AWS SDK, but we want the Python one
     awscli = if windows_target? then '"c:\Program files\python39\scripts\aws"' else 'aws' end
     if cache_bucket != ''
       mkdir cached_wheels_dir
-      command "inv -e agent.get-integrations-from-cache " \
-        "--python 2 --bucket #{cache_bucket} " \
-        "--branch #{cache_branch || 'main'} " \
-        "--integrations-dir #{windows_safe_path(project_dir)} " \
-        "--target-dir #{cached_wheels_dir} " \
-        "--integrations #{checks_to_install.join(',')} " \
-        "--awscli #{awscli}",
-        :cwd => tasks_dir_in
+      shellout! "inv -e agent.get-integrations-from-cache " \
+                "--python 2 --bucket #{cache_bucket} " \
+                "--branch #{cache_branch || 'main'} " \
+                "--integrations-dir #{windows_safe_path(project_dir)} " \
+                "--target-dir #{cached_wheels_dir} " \
+                "--integrations #{checks_to_install.join(',')} " \
+                "--awscli #{awscli}",
+                :cwd => tasks_dir_in
 
       # install all wheels from cache in one pip invocation to speed things up
       if windows_target?
-        command "#{python} -m pip install --no-deps --no-index " \
-          "--find-links #{windows_safe_path(cached_wheels_dir)} -r #{windows_safe_path(cached_wheels_dir)}\\found.txt"
+        shellout! "#{python} -m pip install --no-deps --no-index " \
+                  "--find-links #{windows_safe_path(cached_wheels_dir)} -r #{windows_safe_path(cached_wheels_dir)}\\found.txt"
       else
-        command "#{pip} install --no-deps --no-index " \
-          " --find-links #{cached_wheels_dir} -r #{cached_wheels_dir}/found.txt"
+        shellout! "#{pip} install --no-deps --no-index " \
+                  " --find-links #{cached_wheels_dir} -r #{cached_wheels_dir}/found.txt"
       end
     end
 
-    block do
-      # we have to do this operation in block, so that it can access files created by the
-      # inv agent.get-integrations-from-cache command
-
-      # get list of integration wheels already installed from cache
-      installed_list = Array.new
-      if cache_bucket != ''
-        if windows_target?
-          installed_out = `#{python} -m pip list --format json`
-        else
-          installed_out = `#{pip} list --format json`
-        end
-        if $?.exitstatus == 0
-          installed = JSON.parse(installed_out)
-          installed.each do |package|
-            package.each do |key, value|
-              if key == "name" && value.start_with?("datadog-")
-                installed_list.push(value["datadog-".length..-1])
-              end
+    # get list of integration wheels already installed from cache
+    if cache_bucket != ''
+      if windows_target?
+        installed_out = (shellout! "#{python} -m pip list --format json").stdout
+      else
+        installed_out = (shellout! "#{pip} list --format json").stdout
+      end
+      if $?.exitstatus == 0
+        installed = JSON.parse(installed_out)
+        installed.each do |package|
+          package.each do |key, value|
+            if key == "name" && value.start_with?("datadog-")
+              installed_list.push(value["datadog-".length..-1])
             end
           end
-        else
-          raise "Failed to list pip installed packages"
         end
+      else
+        raise "Failed to list pip installed packages"
       end
+    end
+  end
 
-      checks_to_install.each do |check|
-        check_dir = File.join(project_dir, check)
-        check_conf_dir = "#{conf_dir}/#{check}.d"
-        # For each conf file, if it already exists, that means the `datadog-agent` software def
-        # wrote it first. In that case, since the agent's confs take precedence, skip the conf
+  checks_to_install.each do |check|
+    check_dir = File.join(project_dir, check)
+    check_conf_dir = "#{conf_dir}/#{check}.d"
 
-        # Copy the check config to the conf directories
-        conf_file_example = "#{check_dir}/datadog_checks/#{check}/data/conf.yaml.example"
-        if File.exist? conf_file_example
-          mkdir check_conf_dir
-          copy conf_file_example, "#{check_conf_dir}/" unless File.exist? "#{check_conf_dir}/conf.yaml.example"
-        end
-
-        # Copy the default config, if it exists
-        conf_file_default = "#{check_dir}/datadog_checks/#{check}/data/conf.yaml.default"
-        if File.exist? conf_file_default
-          mkdir check_conf_dir
-          copy conf_file_default, "#{check_conf_dir}/" unless File.exist? "#{check_conf_dir}/conf.yaml.default"
-        end
-
-        # Copy the metric file, if it exists
-        metrics_yaml = "#{check_dir}/datadog_checks/#{check}/data/metrics.yaml"
-        if File.exist? metrics_yaml
-          mkdir check_conf_dir
-          copy metrics_yaml, "#{check_conf_dir}/" unless File.exist? "#{check_conf_dir}/metrics.yaml"
-        end
-
-        # We don't have auto_conf on windows yet
-        auto_conf_yaml = "#{check_dir}/datadog_checks/#{check}/data/auto_conf.yaml"
-        if File.exist? auto_conf_yaml
-          mkdir check_conf_dir
-          copy auto_conf_yaml, "#{check_conf_dir}/" unless File.exist? "#{check_conf_dir}/auto_conf.yaml"
-        end
-
-        # Copy SNMP profiles
-        profile_folders = ['profiles', 'default_profiles']
-        profile_folders.each do |profile_folder|
-            folder_path = "#{check_dir}/datadog_checks/#{check}/data/#{profile_folder}"
-            if File.exist? folder_path
-              copy folder_path, "#{check_conf_dir}/"
-            end
-        end
-
-        # pip < 21.2 replace underscores by dashes in package names per https://pip.pypa.io/en/stable/news/#v21-2
-        # whether or not this might switch back in the future is not guaranteed, so we check for both name
-        # with dashes and underscores
-        if installed_list.include?(check) || installed_list.include?(check.gsub('_', '-'))
-          next
-        end
-
-        if windows_target?
-          command "#{python} -m pip wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => win_build_env, :cwd => "#{windows_safe_path(project_dir)}\\#{check}"
-          command "#{python} -m pip install datadog-#{check} --no-deps --no-index --find-links=#{wheel_build_dir}"
-        else
-          command "#{pip} wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => nix_build_env, :cwd => "#{project_dir}/#{check}"
-          command "#{pip} install datadog-#{check} --no-deps --no-index --find-links=#{wheel_build_dir}"
-        end
-        if cache_bucket != '' && ENV.fetch('INTEGRATION_WHEELS_SKIP_CACHE_UPLOAD', '') == '' && cache_branch != nil
-          command "inv -e agent.upload-integration-to-cache " \
-            "--python 2 --bucket #{cache_bucket} " \
-            "--branch #{cache_branch} " \
-            "--integrations-dir #{windows_safe_path(project_dir)} " \
-            "--build-dir #{wheel_build_dir} " \
-            "--integration #{check} " \
-            "--awscli #{awscli}",
-            :cwd => tasks_dir_in
-        end
-      end
-
-      # From now on we don't need piptools anymore, uninstall its deps so we don't include them in the final artifact
-      uninstall_buildtime_deps.each do |dep|
-        if windows_target?
-          command "#{python} -m pip uninstall -y #{dep}"
-        else
-          command "#{pip} uninstall -y #{dep}"
+    # For each conf file, if it already exists, that means the `datadog-agent` software def
+    # wrote it first. In that case, since the agent's confs take precedence, skip the conf
+    conf_files = ["conf.yaml.example", "conf.yaml.default", "metrics.yaml", "auto_conf.yaml"]
+    conf_files.each do |filename|
+      src = windows_safe_path(check_dir,"datadog_checks", check, "data", filename)
+      if File.exist? src
+        mkdir check_conf_dir
+        dest = check_conf_dir
+        # Requires a block because requires info only available at build time
+        block "Copy #{src} to #{dest} without overwriting" do
+          FileUtils.cp_r(src, dest) unless File.exist(windows_safe_path(dest, filename))
         end
       end
     end
 
-    block do
-      # We have to run these operations in block, so they get applied after operations
-      # from the last block
-
-      # Patch applies to only one file: set it explicitly as a target, no need for -p
-      if windows_target?
-        patch :source => "create-regex-at-runtime.patch", :target => "#{python_2_embedded}/Lib/site-packages/yaml/reader.py"
-        patch :source => "remove-maxfile-maxpath-psutil.patch", :target => "#{python_2_embedded}/Lib/site-packages/psutil/__init__.py"
-      else
-        patch :source => "create-regex-at-runtime.patch", :target => "#{install_dir}/embedded/lib/python2.7/site-packages/yaml/reader.py"
-        patch :source => "remove-maxfile-maxpath-psutil.patch", :target => "#{install_dir}/embedded/lib/python2.7/site-packages/psutil/__init__.py"
-      end
-
-      # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
-      if windows_target?
-        command "#{python} -m pip check"
-      else
-        command "#{pip} check"
+    # Copy SNMP profiles
+    profile_folders = ['profiles', 'default_profiles']
+    profile_folders.each do |profile_folder|
+      folder_path = "#{check_dir}/datadog_checks/#{check}/data/#{profile_folder}"
+      if File.exist? folder_path
+        copy folder_path, "#{check_conf_dir}/"
       end
     end
 
-    block do
-      # Removing tests that don't need to be shipped in the embedded folder
-      if windows_target?
-        delete "#{python_2_embedded}/Lib/site-packages/Cryptodome/SelfTest/"
-      else
-        delete "#{install_dir}/embedded/lib/python2.7/site-packages/Cryptodome/SelfTest/"
-      end
+    # pip < 21.2 replace underscores by dashes in package names per https://pip.pypa.io/en/stable/news/#v21-2
+    # whether or not this might switch back in the future is not guaranteed, so we check for both name
+    # with dashes and underscores
+    if installed_list.include?(check) || installed_list.include?(check.gsub('_', '-'))
+      next
     end
+
+    if windows_target?
+      command "#{python} -m pip wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => win_build_env, :cwd => "#{windows_safe_path(project_dir)}\\#{check}"
+      command "#{python} -m pip install datadog-#{check} --no-deps --no-index --find-links=#{wheel_build_dir}"
+    else
+      command "#{pip} wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => nix_build_env, :cwd => "#{project_dir}/#{check}"
+      command "#{pip} install datadog-#{check} --no-deps --no-index --find-links=#{wheel_build_dir}"
+    end
+    if cache_bucket != '' && ENV.fetch('INTEGRATION_WHEELS_SKIP_CACHE_UPLOAD', '') == '' && cache_branch != nil
+      command "inv -e agent.upload-integration-to-cache " \
+              "--python 2 --bucket #{cache_bucket} " \
+              "--branch #{cache_branch} " \
+              "--integrations-dir #{windows_safe_path(project_dir)} " \
+              "--build-dir #{wheel_build_dir} " \
+              "--integration #{check} " \
+              "--awscli #{awscli}",
+              :cwd => tasks_dir_in
+    end
+  end
+
+  # From now on we don't need piptools anymore, uninstall its deps so we don't include them in the final artifact
+  uninstall_buildtime_deps.each do |dep|
+    if windows_target?
+      command "#{python} -m pip uninstall -y #{dep}"
+    else
+      command "#{pip} uninstall -y #{dep}"
+    end
+  end
+
+  # Patch applies to only one file: set it explicitly as a target, no need for -p
+  if windows_target?
+    patch :source => "create-regex-at-runtime.patch", :target => "#{python_2_embedded}/Lib/site-packages/yaml/reader.py"
+    patch :source => "remove-maxfile-maxpath-psutil.patch", :target => "#{python_2_embedded}/Lib/site-packages/psutil/__init__.py"
+  else
+    patch :source => "create-regex-at-runtime.patch", :target => "#{install_dir}/embedded/lib/python2.7/site-packages/yaml/reader.py"
+    patch :source => "remove-maxfile-maxpath-psutil.patch", :target => "#{install_dir}/embedded/lib/python2.7/site-packages/psutil/__init__.py"
+  end
+
+  # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
+  if windows_target?
+    command "#{python} -m pip check"
+  else
+    command "#{pip} check"
+  end
+
+  # Removing tests that don't need to be shipped in the embedded folder
+  if windows_target?
+    delete "#{python_2_embedded}/Lib/site-packages/Cryptodome/SelfTest/"
+  else
+    delete "#{install_dir}/embedded/lib/python2.7/site-packages/Cryptodome/SelfTest/"
   end
 
   # Ship `requirements-agent-release.txt` file containing the versions of every check shipped with the agent

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -369,57 +369,58 @@ build do
     end
   end
 
-  checks_to_install.each do |check|
-    check_dir = File.join(project_dir, check)
-    check_conf_dir = "#{conf_dir}/#{check}.d"
+  block "Install integrations" do
+    # This needs to be done in a block because `checks_to_install` can only be known at build-time
+    checks_to_install.each do |check|
+      check_dir = File.join(project_dir, check)
+      check_conf_dir = "#{conf_dir}/#{check}.d"
 
-    # For each conf file, if it already exists, that means the `datadog-agent` software def
-    # wrote it first. In that case, since the agent's confs take precedence, skip the conf
-    conf_files = ["conf.yaml.example", "conf.yaml.default", "metrics.yaml", "auto_conf.yaml"]
-    conf_files.each do |filename|
-      src = windows_safe_path(check_dir,"datadog_checks", check, "data", filename)
-      if File.exist? src
-        mkdir check_conf_dir
+      # For each conf file, if it already exists, that means the `datadog-agent` software def
+      # wrote it first. In that case, since the agent's confs take precedence, skip the conf
+      conf_files = ["conf.yaml.example", "conf.yaml.default", "metrics.yaml", "auto_conf.yaml"]
+
+      conf_files.each do |filename|
+        src = windows_safe_path(check_dir,"datadog_checks", check, "data", filename)
         dest = check_conf_dir
-        # Requires a block because requires info only available at build time
-        block "Copy #{src} to #{dest} without overwriting" do
-          FileUtils.cp_r(src, dest) unless File.exist(windows_safe_path(dest, filename))
+        if File.exist?(src) and !File.exist?(windows_safe_path(dest, filename))
+          FileUtils.mkdir_p(dest)
+          FileUtils.cp_r(src, dest)
         end
       end
-    end
 
-    # Copy SNMP profiles
-    profile_folders = ['profiles', 'default_profiles']
-    profile_folders.each do |profile_folder|
-      folder_path = "#{check_dir}/datadog_checks/#{check}/data/#{profile_folder}"
-      if File.exist? folder_path
-        copy folder_path, "#{check_conf_dir}/"
+      # Copy SNMP profiles
+      profile_folders = ['profiles', 'default_profiles']
+      profile_folders.each do |profile_folder|
+        folder_path = "#{check_dir}/datadog_checks/#{check}/data/#{profile_folder}"
+        if File.exist? folder_path
+          FileUtils.cp_r folder_path, "#{check_conf_dir}/"
+        end
       end
-    end
 
-    # pip < 21.2 replace underscores by dashes in package names per https://pip.pypa.io/en/stable/news/#v21-2
-    # whether or not this might switch back in the future is not guaranteed, so we check for both name
-    # with dashes and underscores
-    if installed_list.include?(check) || installed_list.include?(check.gsub('_', '-'))
-      next
-    end
+      # pip < 21.2 replace underscores by dashes in package names per https://pip.pypa.io/en/stable/news/#v21-2
+      # whether or not this might switch back in the future is not guaranteed, so we check for both name
+      # with dashes and underscores
+      if installed_list.include?(check) || installed_list.include?(check.gsub('_', '-'))
+        next
+      end
 
-    if windows_target?
-      command "#{python} -m pip wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => win_build_env, :cwd => "#{windows_safe_path(project_dir)}\\#{check}"
-      command "#{python} -m pip install datadog-#{check} --no-deps --no-index --find-links=#{wheel_build_dir}"
-    else
-      command "#{pip} wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => nix_build_env, :cwd => "#{project_dir}/#{check}"
-      command "#{pip} install datadog-#{check} --no-deps --no-index --find-links=#{wheel_build_dir}"
-    end
-    if cache_bucket != '' && ENV.fetch('INTEGRATION_WHEELS_SKIP_CACHE_UPLOAD', '') == '' && cache_branch != nil
-      command "inv -e agent.upload-integration-to-cache " \
-              "--python 2 --bucket #{cache_bucket} " \
-              "--branch #{cache_branch} " \
-              "--integrations-dir #{windows_safe_path(project_dir)} " \
-              "--build-dir #{wheel_build_dir} " \
-              "--integration #{check} " \
-              "--awscli #{awscli}",
-              :cwd => tasks_dir_in
+      if windows_target?
+        shellout! "#{python} -m pip wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => win_build_env, :cwd => "#{windows_safe_path(project_dir)}\\#{check}"
+        shellout! "#{python} -m pip install datadog-#{check} --no-deps --no-index --find-links=#{wheel_build_dir}"
+      else
+        shellout! "#{pip} wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => nix_build_env, :cwd => "#{project_dir}/#{check}"
+        shellout! "#{pip} install datadog-#{check} --no-deps --no-index --find-links=#{wheel_build_dir}"
+      end
+      if cache_bucket != '' && ENV.fetch('INTEGRATION_WHEELS_SKIP_CACHE_UPLOAD', '') == '' && cache_branch != nil
+        shellout! "inv -e agent.upload-integration-to-cache " \
+                  "--python 2 --bucket #{cache_bucket} " \
+                  "--branch #{cache_branch} " \
+                  "--integrations-dir #{windows_safe_path(project_dir)} " \
+                  "--build-dir #{wheel_build_dir} " \
+                  "--integration #{check} " \
+                  "--awscli #{awscli}",
+                  :cwd => tasks_dir_in
+      end
     end
   end
 

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -8,6 +8,9 @@ require 'json'
 
 name 'datadog-agent-integrations-py3'
 
+license "BSD-3-Clause"
+license_file "./LICENSE"
+
 dependency 'datadog-agent'
 dependency 'datadog-agent-integrations-py3-dependencies'
 
@@ -89,9 +92,6 @@ filtered_agent_requirements_in = 'agent_requirements-py3.in'
 agent_requirements_in = 'agent_requirements.in'
 
 build do
-  license "BSD-3-Clause"
-  license_file "./LICENSE"
-
   # The dir for confs
   if osx_target?
     conf_dir = "#{install_dir}/etc/conf.d"
@@ -114,121 +114,119 @@ build do
   }
 
   # Install the checks along with their dependencies
-  block do
-    if windows_target?
-      wheel_build_dir = "#{windows_safe_path(project_dir)}\\.wheels"
-      build_deps_dir = "#{windows_safe_path(project_dir)}\\.build_deps"
-    else
-      wheel_build_dir = "#{project_dir}/.wheels"
-      build_deps_dir = "#{project_dir}/.build_deps"
-    end
+  if windows_target?
+    wheel_build_dir = "#{windows_safe_path(project_dir)}\\.wheels"
+    build_deps_dir = "#{windows_safe_path(project_dir)}\\.build_deps"
+  else
+    wheel_build_dir = "#{project_dir}/.wheels"
+    build_deps_dir = "#{project_dir}/.build_deps"
+  end
 
-    #
-    # Prepare the build env, these dependencies are only needed to build and
-    # install the core integrations.
-    #
-    command "#{python} -m pip download --dest #{build_deps_dir} hatchling==0.25.1", :env => pre_build_env
-    command "#{python} -m pip download --dest #{build_deps_dir} setuptools==66.1.1", :env => pre_build_env # Version from ./setuptools3.rb
-    command "#{python} -m pip install wheel==0.38.4", :env => pre_build_env
-    command "#{python} -m pip install pip-tools==7.3.0", :env => pre_build_env
-    uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools']
-    nix_build_env = {
-      "PIP_FIND_LINKS" => "#{build_deps_dir}",
-      "PIP_CONFIG_FILE" => "#{pip_config_file}",
-      # Specify C99 standard explicitly to avoid issues while building some
-      # wheels (eg. ddtrace)
-      "CFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
-      "CXXFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
-      "LDFLAGS" => "-L#{install_dir}/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib",
-      "LD_RUN_PATH" => "#{install_dir}/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib",
-      "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
-    }
+  #
+  # Prepare the build env, these dependencies are only needed to build and
+  # install the core integrations.
+  #
+  command "#{python} -m pip download --dest #{build_deps_dir} hatchling==0.25.1", :env => pre_build_env
+  command "#{python} -m pip download --dest #{build_deps_dir} setuptools==66.1.1", :env => pre_build_env # Version from ./setuptools3.rb
+  command "#{python} -m pip install wheel==0.38.4", :env => pre_build_env
+  command "#{python} -m pip install pip-tools==7.3.0", :env => pre_build_env
+  uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools']
+  nix_build_env = {
+    "PIP_FIND_LINKS" => "#{build_deps_dir}",
+    "PIP_CONFIG_FILE" => "#{pip_config_file}",
+    # Specify C99 standard explicitly to avoid issues while building some
+    # wheels (eg. ddtrace)
+    "CFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
+    "CXXFLAGS" => "-I#{install_dir}/embedded/include -I/opt/mqm/inc",
+    "LDFLAGS" => "-L#{install_dir}/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib",
+    "LD_RUN_PATH" => "#{install_dir}/embedded/lib -L/opt/mqm/lib64 -L/opt/mqm/lib",
+    "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
+  }
 
-    win_build_env = {
-      "PIP_FIND_LINKS" => "#{build_deps_dir}",
-      "PIP_CONFIG_FILE" => "#{pip_config_file}",
-    }
+  win_build_env = {
+    "PIP_FIND_LINKS" => "#{build_deps_dir}",
+    "PIP_CONFIG_FILE" => "#{pip_config_file}",
+  }
 
-    # On Linux & Windows, specify the C99 standard explicitly to avoid issues while building some
-    # wheels (eg. ddtrace).
-    # Not explicitly setting that option has caused us problems in the past on SUSE, where the ddtrace
-    # wheel has to be manually built, as the C code in ddtrace doesn't follow the C89 standard (the default value of std).
-    # Note: We don't set this on MacOS, as on MacOS we need to build a bunch of packages & C extensions that
-    # don't have precompiled MacOS wheels. When building C extensions, the CFLAGS variable is added to
-    # the command-line parameters, even when compiling C++ code, where -std=c99 is invalid.
-    # See: https://github.com/python/cpython/blob/v3.8.8/Lib/distutils/sysconfig.py#L227
-    if linux_target? || windows_target?
-      nix_build_env["CFLAGS"] += " -std=c99"
-    end
+  # Some libraries (looking at you, aerospike-client-python) need EXT_CFLAGS instead of CFLAGS.
+  nix_specific_build_env = {
+    "aerospike" => nix_build_env.merge({"EXT_CFLAGS" => nix_build_env["CFLAGS"] + " -std=gnu99"}),
+    # Always build pyodbc from source to link to the embedded version of libodbc
+    "pyodbc" => nix_build_env.merge({"PIP_NO_BINARY" => "pyodbc"}),
+  }
+  win_specific_build_env = {}
 
-    # We only have gcc 10.4.0 on linux for now
-    if linux_target?
-      nix_build_env["CC"] = "/opt/gcc-#{gcc_version}/bin/gcc"
-      nix_build_env["CXX"] = "/opt/gcc-#{gcc_version}/bin/g++"
-    end
+  # On Linux & Windows, specify the C99 standard explicitly to avoid issues while building some
+  # wheels (eg. ddtrace).
+  # Not explicitly setting that option has caused us problems in the past on SUSE, where the ddtrace
+  # wheel has to be manually built, as the C code in ddtrace doesn't follow the C89 standard (the default value of std).
+  # Note: We don't set this on MacOS, as on MacOS we need to build a bunch of packages & C extensions that
+  # don't have precompiled MacOS wheels. When building C extensions, the CFLAGS variable is added to
+  # the command-line parameters, even when compiling C++ code, where -std=c99 is invalid.
+  # See: https://github.com/python/cpython/blob/v3.8.8/Lib/distutils/sysconfig.py#L227
+  if linux_target? || windows_target?
+    nix_build_env["CFLAGS"] += " -std=c99"
+  end
 
-    # Some libraries (looking at you, aerospike-client-python) need EXT_CFLAGS instead of CFLAGS.
-    nix_specific_build_env = {
-      "aerospike" => nix_build_env.merge({"EXT_CFLAGS" => nix_build_env["CFLAGS"] + " -std=gnu99"}),
-      # Always build pyodbc from source to link to the embedded version of libodbc
-      "pyodbc" => nix_build_env.merge({"PIP_NO_BINARY" => "pyodbc"}),
-    }
+  # We only have gcc 10.4.0 on linux for now
+  if linux_target?
+    nix_build_env["CC"] = "/opt/gcc-#{gcc_version}/bin/gcc"
+    nix_build_env["CXX"] = "/opt/gcc-#{gcc_version}/bin/g++"
+  end
 
-    win_specific_build_env = {}
-
-    # We need to explicitly specify RUSTFLAGS for libssl and libcrypto
-    # See https://github.com/pyca/cryptography/issues/8614#issuecomment-1489366475
-    if redhat_target? && !arm_target?
-        nix_specific_build_env["cryptography"] = nix_build_env.merge(
-            {
-                "RUSTFLAGS" => "-C link-arg=-Wl,-rpath,#{install_dir}/embedded/lib",
-                "OPENSSL_DIR" => "#{install_dir}/embedded/",
-                # We have a manually installed dependency (snowflake connector) that already installed cryptography (but without the flags)
-                # We force reinstall it from source to be sure we use the flag
-                "PIP_NO_CACHE_DIR" => "off",
-                "PIP_FORCE_REINSTALL" => "1",
-            }
-        )
-    end
-
-    #
-    # Prepare the requirements file containing ALL the dependencies needed by
-    # any integration. This will provide the "static Python environment" of the Agent.
-    # We don't use the .in file provided by the base check directly because we
-    # want to filter out things before installing.
-    #
-    if windows_target?
-      static_reqs_in_file = "#{windows_safe_path(project_dir)}\\datadog_checks_base\\datadog_checks\\base\\data\\#{agent_requirements_in}"
-      static_reqs_out_folder = "#{windows_safe_path(project_dir)}\\"
-      static_reqs_out_file = static_reqs_out_folder + filtered_agent_requirements_in
-      compiled_reqs_file_path = "#{windows_safe_path(install_dir)}\\#{agent_requirements_file}"
-    else
-      static_reqs_in_file = "#{project_dir}/datadog_checks_base/datadog_checks/base/data/#{agent_requirements_in}"
-      static_reqs_out_folder = "#{project_dir}/"
-      static_reqs_out_file = static_reqs_out_folder + filtered_agent_requirements_in
-      compiled_reqs_file_path = "#{install_dir}/#{agent_requirements_file}"
-    end
-
-    # Remove any excluded requirements from the static-environment req file
-    requirements = Array.new
-
-    # Creating a hash containing the requirements and requirements file path associated to every lib
-    requirements_custom = Hash.new()
-
-    specific_build_env = windows_target? ? win_specific_build_env : nix_specific_build_env
-    build_env = windows_target? ? win_build_env : nix_build_env
-    cwd_base = windows_target? ? "#{windows_safe_path(project_dir)}\\datadog_checks_base" : "#{project_dir}/datadog_checks_base"
-    cwd_downloader = windows_target? ? "#{windows_safe_path(project_dir)}\\datadog_checks_downloader" : "#{project_dir}/datadog_checks_downloader"
-
-    specific_build_env.each do |lib, env|
-      lib_compiled_req_file_path = (windows_target? ? "#{windows_safe_path(install_dir)}\\" : "#{install_dir}/") + "agent_#{lib}_requirements-py3.txt"
-      requirements_custom[lib] = {
-        "req_lines" => Array.new,
-        "req_file_path" => static_reqs_out_folder + lib + "-py3.in",
-        "compiled_req_file_path" => lib_compiled_req_file_path,
+  # We need to explicitly specify RUSTFLAGS for libssl and libcrypto
+  # See https://github.com/pyca/cryptography/issues/8614#issuecomment-1489366475
+  if redhat_target? && !arm_target?
+    nix_specific_build_env["cryptography"] = nix_build_env.merge(
+      {
+        "RUSTFLAGS" => "-C link-arg=-Wl,-rpath,#{install_dir}/embedded/lib",
+        "OPENSSL_DIR" => "#{install_dir}/embedded/",
+        # We have a manually installed dependency (snowflake connector) that already installed cryptography (but without the flags)
+        # We force reinstall it from source to be sure we use the flag
+        "PIP_NO_CACHE_DIR" => "off",
+        "PIP_FORCE_REINSTALL" => "1",
       }
-    end
+    )
+  end
 
+  #
+  # Prepare the requirements file containing ALL the dependencies needed by
+  # any integration. This will provide the "static Python environment" of the Agent.
+  # We don't use the .in file provided by the base check directly because we
+  # want to filter out things before installing.
+  #
+  if windows_target?
+    static_reqs_in_file = "#{windows_safe_path(project_dir)}\\datadog_checks_base\\datadog_checks\\base\\data\\#{agent_requirements_in}"
+    static_reqs_out_folder = "#{windows_safe_path(project_dir)}\\"
+    static_reqs_out_file = static_reqs_out_folder + filtered_agent_requirements_in
+    compiled_reqs_file_path = "#{windows_safe_path(install_dir)}\\#{agent_requirements_file}"
+  else
+    static_reqs_in_file = "#{project_dir}/datadog_checks_base/datadog_checks/base/data/#{agent_requirements_in}"
+    static_reqs_out_folder = "#{project_dir}/"
+    static_reqs_out_file = static_reqs_out_folder + filtered_agent_requirements_in
+    compiled_reqs_file_path = "#{install_dir}/#{agent_requirements_file}"
+  end
+
+  specific_build_env = windows_target? ? win_specific_build_env : nix_specific_build_env
+  build_env = windows_target? ? win_build_env : nix_build_env
+  cwd_base = windows_target? ? "#{windows_safe_path(project_dir)}\\datadog_checks_base" : "#{project_dir}/datadog_checks_base"
+  cwd_downloader = windows_target? ? "#{windows_safe_path(project_dir)}\\datadog_checks_downloader" : "#{project_dir}/datadog_checks_downloader"
+
+  # Creating a hash containing the requirements and requirements file path associated to every lib
+  requirements_custom = Hash.new()
+  specific_build_env.each do |lib, env|
+    lib_compiled_req_file_path = (windows_target? ? "#{windows_safe_path(install_dir)}\\" : "#{install_dir}/") + "agent_#{lib}_requirements-py3.txt"
+    requirements_custom[lib] = {
+      "req_lines" => Array.new,
+      "req_file_path" => static_reqs_out_folder + lib + "-py3.in",
+      "compiled_req_file_path" => lib_compiled_req_file_path,
+    }
+  end
+
+  # Remove any excluded requirements from the static-environment req file
+  requirements = Array.new
+
+  block "Create filtered requirements" do
     File.open("#{static_reqs_in_file}", 'r+').readlines().each do |line|
       next if excluded_packages.any? { |package_regex| line.match(package_regex) }
 
@@ -275,11 +273,11 @@ build do
     command "#{python} -m pip wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => build_env, :cwd => cwd_downloader
     command "#{python} -m pip install datadog_checks_downloader --no-deps --no-index --find-links=#{wheel_build_dir}"
     command "#{python} -m piptools compile --generate-hashes --output-file #{compiled_reqs_file_path} #{static_reqs_out_file} " \
-      "--pip-args \"--retries #{pip_max_retries} --timeout #{pip_timeout}\"", :env => build_env
+            "--pip-args \"--retries #{pip_max_retries} --timeout #{pip_timeout}\"", :env => build_env
     # Pip-compiling seperately each lib that needs a custom build installation
     specific_build_env.each do |lib, env|
       command "#{python} -m piptools compile --generate-hashes --output-file #{requirements_custom[lib]["compiled_req_file_path"]} #{requirements_custom[lib]["req_file_path"]} " \
-      "--pip-args \"--retries #{pip_max_retries} --timeout #{pip_timeout}\"", :env => env
+              "--pip-args \"--retries #{pip_max_retries} --timeout #{pip_timeout}\"", :env => env
     end
 
     #
@@ -295,7 +293,7 @@ build do
     # Then we install the rest (already installed libraries will be ignored) with the main flags
     command "#{python} -m pip install --no-deps --require-hashes -r #{compiled_reqs_file_path}", :env => build_env
     # Remove the file after use so it is not shipped
-     delete "#{compiled_reqs_file_path}"
+    delete "#{compiled_reqs_file_path}"
 
     #
     # Install Core integrations
@@ -306,85 +304,85 @@ build do
     command "#{python} -m pip freeze > #{install_dir}/#{final_constraints_file}"
 
     if windows_target?
-        cached_wheels_dir = "#{windows_safe_path(wheel_build_dir)}\\.cached"
+      cached_wheels_dir = "#{windows_safe_path(wheel_build_dir)}\\.cached"
     else
-        cached_wheels_dir = "#{wheel_build_dir}/.cached"
+      cached_wheels_dir = "#{wheel_build_dir}/.cached"
     end
+
     checks_to_install = Array.new
 
-    # Go through every integration package in `integrations-core`, build and install
-    Dir.glob("#{project_dir}/*").each do |check_dir|
-      check = check_dir.split('/').last
+    block "Collect integrations to install" do
+      # Go through every integration package in `integrations-core`, build and install
+      Dir.glob("#{project_dir}/*").each do |check_dir|
+        check = check_dir.split('/').last
 
-      # do not install excluded integrations
-      next if !File.directory?("#{check_dir}") || excluded_folders.include?(check)
+        # do not install excluded integrations
+        next if !File.directory?("#{check_dir}") || excluded_folders.include?(check)
 
-      # If there is no manifest file, then we should assume the folder does not
-      # contain a working check and move onto the next
-      manifest_file_path = "#{check_dir}/manifest.json"
+        # If there is no manifest file, then we should assume the folder does not
+        # contain a working check and move onto the next
+        manifest_file_path = "#{check_dir}/manifest.json"
 
-      # If there is no manifest file, then we should assume the folder does not
-      # contain a working check and move onto the next
-      File.exist?(manifest_file_path) || next
+        # If there is no manifest file, then we should assume the folder does not
+        # contain a working check and move onto the next
+        File.exist?(manifest_file_path) || next
 
-      manifest = JSON.parse(File.read(manifest_file_path))
-      if manifest.key?("supported_os")
-        manifest["supported_os"].include?(os) || next
-      else
-        if os == "mac_os"
-          tag = "Supported OS::macOS"
+        manifest = JSON.parse(File.read(manifest_file_path))
+        if manifest.key?("supported_os")
+          manifest["supported_os"].include?(os) || next
         else
-          tag = "Supported OS::#{os.capitalize}"
+          if os == "mac_os"
+            tag = "Supported OS::macOS"
+          else
+            tag = "Supported OS::#{os.capitalize}"
+          end
+
+          manifest["tile"]["classifier_tags"].include?(tag) || next
         end
 
-        manifest["tile"]["classifier_tags"].include?(tag) || next
-      end
+        File.file?("#{check_dir}/setup.py") || File.file?("#{check_dir}/pyproject.toml") || next
+        # Check if it supports Python 3.
+        support = `inv agent.check-supports-python-version #{check_dir} 3`
+        if support == "False"
+          log.info(log_key) { "Skipping '#{check}' since it does not support Python 3." }
+          next
+        end
 
-      File.file?("#{check_dir}/setup.py") || File.file?("#{check_dir}/pyproject.toml") || next
-      # Check if it supports Python 3.
-      support = `inv agent.check-supports-python-version #{check_dir} 3`
-      if support == "False"
-        log.info(log_key) { "Skipping '#{check}' since it does not support Python 3." }
-        next
+        checks_to_install.push(check)
       end
-
-      checks_to_install.push(check)
     end
 
-    tasks_dir_in = windows_safe_path(Dir.pwd)
+    installed_list = Array.new
     cache_bucket = ENV.fetch('INTEGRATION_WHEELS_CACHE_BUCKET', '')
-    cache_branch = `cd .. && inv release.get-release-json-value base_branch`.strip
-    # On windows, `aws` actually executes Ruby's AWS SDK, but we want the Python one
-    awscli = if windows_target? then '"c:\Program files\python39\scripts\aws"' else 'aws' end
-    if cache_bucket != ''
-      mkdir cached_wheels_dir
-      command "inv -e agent.get-integrations-from-cache " \
-        "--python 3 --bucket #{cache_bucket} " \
-        "--branch #{cache_branch || 'main'} " \
-        "--integrations-dir #{windows_safe_path(project_dir)} " \
-        "--target-dir #{cached_wheels_dir} " \
-        "--integrations #{checks_to_install.join(',')} " \
-        "--awscli #{awscli}",
-        :cwd => tasks_dir_in
+    block "Install cached wheels" do
+      tasks_dir_in = windows_safe_path(Dir.pwd)
+      cache_branch = (shellout! "inv release.get-release-json-value base_branch", cwd: File.expand_path('..', tasks_dir_in)).stdout.strip
+      # On windows, `aws` actually executes Ruby's AWS SDK, but we want the Python one
+      awscli = if windows_target? then '"c:\Program files\python39\scripts\aws"' else 'aws' end
+      if cache_bucket != ''
+        mkdir cached_wheels_dir
+        shellout! "inv -e agent.get-integrations-from-cache " \
+                  "--python 3 --bucket #{cache_bucket} " \
+                  "--branch #{cache_branch || 'main'} " \
+                  "--integrations-dir #{windows_safe_path(project_dir)} " \
+                  "--target-dir #{cached_wheels_dir} " \
+                  "--integrations #{checks_to_install.join(',')} " \
+                  "--awscli #{awscli}",
+                  :cwd => tasks_dir_in
 
-      # install all wheels from cache in one pip invocation to speed things up
-      if windows_target?
-        command "#{python} -m pip install --no-deps --no-index " \
-          " --find-links #{windows_safe_path(cached_wheels_dir)} -r #{windows_safe_path(cached_wheels_dir)}\\found.txt"
-      else
-        command "#{python} -m pip install --no-deps --no-index " \
-          "--find-links #{cached_wheels_dir} -r #{cached_wheels_dir}/found.txt"
+        # install all wheels from cache in one pip invocation to speed things up
+        if windows_target?
+          shellout! "#{python} -m pip install --no-deps --no-index " \
+                    " --find-links #{windows_safe_path(cached_wheels_dir)} -r #{windows_safe_path(cached_wheels_dir)}\\found.txt"
+        else
+          shellout! "#{python} -m pip install --no-deps --no-index " \
+                    "--find-links #{cached_wheels_dir} -r #{cached_wheels_dir}/found.txt"
+        end
       end
-    end
-
-    block do
-      # we have to do this operation in block, so that it can access files created by the
-      # inv agent.get-integrations-from-cache command
 
       # get list of integration wheels already installed from cache
-      installed_list = Array.new
       if cache_bucket != ''
-        installed_out = `#{python} -m pip list --format json`
+        installed_out = (shellout! "#{python} -m pip list --format json").stdout
         if $?.exitstatus == 0
           installed = JSON.parse(installed_out)
           installed.each do |package|
@@ -398,104 +396,82 @@ build do
           raise "Failed to list pip installed packages"
         end
       end
-
-      checks_to_install.each do |check|
-        check_dir = File.join(project_dir, check)
-        check_conf_dir = "#{conf_dir}/#{check}.d"
-        # For each conf file, if it already exists, that means the `datadog-agent` software def
-        # wrote it first. In that case, since the agent's confs take precedence, skip the conf
-
-        # Copy the check config to the conf directories
-        conf_file_example = "#{check_dir}/datadog_checks/#{check}/data/conf.yaml.example"
-        if File.exist? conf_file_example
-          mkdir check_conf_dir
-          copy conf_file_example, "#{check_conf_dir}/" unless File.exist? "#{check_conf_dir}/conf.yaml.example"
-        end
-
-        # Copy the default config, if it exists
-        conf_file_default = "#{check_dir}/datadog_checks/#{check}/data/conf.yaml.default"
-        if File.exist? conf_file_default
-          mkdir check_conf_dir
-          copy conf_file_default, "#{check_conf_dir}/" unless File.exist? "#{check_conf_dir}/conf.yaml.default"
-        end
-
-        # Copy the metric file, if it exists
-        metrics_yaml = "#{check_dir}/datadog_checks/#{check}/data/metrics.yaml"
-        if File.exist? metrics_yaml
-          mkdir check_conf_dir
-          copy metrics_yaml, "#{check_conf_dir}/" unless File.exist? "#{check_conf_dir}/metrics.yaml"
-        end
-
-        # We don't have auto_conf on windows yet
-        auto_conf_yaml = "#{check_dir}/datadog_checks/#{check}/data/auto_conf.yaml"
-        if File.exist? auto_conf_yaml
-          mkdir check_conf_dir
-          copy auto_conf_yaml, "#{check_conf_dir}/" unless File.exist? "#{check_conf_dir}/auto_conf.yaml"
-        end
-
-        # Copy SNMP profiles
-        profile_folders = ['profiles', 'default_profiles']
-        profile_folders.each do |profile_folder|
-            folder_path = "#{check_dir}/datadog_checks/#{check}/data/#{profile_folder}"
-            if File.exist? folder_path
-              copy folder_path, "#{check_conf_dir}/"
-            end
-        end
-
-        # pip < 21.2 replace underscores by dashes in package names per https://pip.pypa.io/en/stable/news/#v21-2
-        # whether or not this might switch back in the future is not guaranteed, so we check for both name
-        # with dashes and underscores
-        if installed_list.include?(check) || installed_list.include?(check.gsub('_', '-'))
-          next
-        end
-
-        if windows_target?
-          command "#{python} -m pip wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => win_build_env, :cwd => "#{windows_safe_path(project_dir)}\\#{check}"
-        else
-          command "#{python} -m pip wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => nix_build_env, :cwd => "#{project_dir}/#{check}"
-        end
-        command "#{python} -m pip install datadog-#{check} --no-deps --no-index --find-links=#{wheel_build_dir}"
-        if cache_bucket != '' && ENV.fetch('INTEGRATION_WHEELS_SKIP_CACHE_UPLOAD', '') == '' && cache_branch != nil
-          command "inv -e agent.upload-integration-to-cache " \
-            "--python 3 --bucket #{cache_bucket} " \
-            "--branch #{cache_branch} " \
-            "--integrations-dir #{windows_safe_path(project_dir)} " \
-            "--build-dir #{wheel_build_dir} " \
-            "--integration #{check} " \
-            "--awscli #{awscli}",
-            :cwd => tasks_dir_in
-        end
-      end
-
-      # From now on we don't need piptools anymore, uninstall its deps so we don't include them in the final artifact
-      uninstall_buildtime_deps.each do |dep|
-        command "#{python} -m pip uninstall -y #{dep}"
-      end
     end
 
-    block do
-      # We have to run these operations in block, so they get applied after operations
-      # from the last block
+    checks_to_install.each do |check|
+      check_dir = File.join(project_dir, check)
+      check_conf_dir = "#{conf_dir}/#{check}.d"
 
-      # Patch applies to only one file: set it explicitly as a target, no need for -p
+      # For each conf file, if it already exists, that means the `datadog-agent` software def
+      # wrote it first. In that case, since the agent's confs take precedence, skip the conf
+      conf_files = ["conf.yaml.example", "conf.yaml.default", "metrics.yaml", "auto_conf.yaml"]
+      conf_files.each do |filename|
+        src = windows_safe_path(check_dir,"datadog_checks", check, "data", filename)
+        if File.exist? src
+          mkdir check_conf_dir
+          dest = check_conf_dir
+          # Requires a block because requires info only available at build time
+          block "Copy #{src} to #{dest} without overwriting" do
+            FileUtils.cp_r(src, dest) unless File.exist(windows_safe_path(dest, filename))
+          end
+        end
+      end
+
+      # Copy SNMP profiles
+      profile_folders = ['profiles', 'default_profiles']
+      profile_folders.each do |profile_folder|
+        folder_path = "#{check_dir}/datadog_checks/#{check}/data/#{profile_folder}"
+        if File.exist? folder_path
+          copy folder_path, "#{check_conf_dir}/"
+        end
+      end
+
+      # pip < 21.2 replace underscores by dashes in package names per https://pip.pypa.io/en/stable/news/#v21-2
+      # whether or not this might switch back in the future is not guaranteed, so we check for both name
+      # with dashes and underscores
+      if installed_list.include?(check) || installed_list.include?(check.gsub('_', '-'))
+        next
+      end
+
       if windows_target?
-        patch :source => "remove-maxfile-maxpath-psutil.patch", :target => "#{python_3_embedded}/Lib/site-packages/psutil/__init__.py"
+        command "#{python} -m pip wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => win_build_env, :cwd => "#{windows_safe_path(project_dir)}\\#{check}"
       else
-        patch :source => "remove-maxfile-maxpath-psutil.patch", :target => "#{install_dir}/embedded/lib/python3.11/site-packages/psutil/__init__.py"
+        command "#{python} -m pip wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => nix_build_env, :cwd => "#{project_dir}/#{check}"
       end
-
-      # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
-      command "#{python} -m pip check"
+      command "#{python} -m pip install datadog-#{check} --no-deps --no-index --find-links=#{wheel_build_dir}"
+      if cache_bucket != '' && ENV.fetch('INTEGRATION_WHEELS_SKIP_CACHE_UPLOAD', '') == '' && cache_branch != nil
+        command "inv -e agent.upload-integration-to-cache " \
+                "--python 3 --bucket #{cache_bucket} " \
+                "--branch #{cache_branch} " \
+                "--integrations-dir #{windows_safe_path(project_dir)} " \
+                "--build-dir #{wheel_build_dir} " \
+                "--integration #{check} " \
+                "--awscli #{awscli}",
+                :cwd => tasks_dir_in
+      end
     end
 
-    block do
-      # Removing tests that don't need to be shipped in the embedded folder
-      if windows_target?
-        delete "#{python_3_embedded}/Lib/site-packages/Cryptodome/SelfTest/"
-      else
-        delete "#{install_dir}/embedded/lib/python3.11/site-packages/Cryptodome/SelfTest/"
-      end
+    # From now on we don't need piptools anymore, uninstall its deps so we don't include them in the final artifact
+    uninstall_buildtime_deps.each do |dep|
+      command "#{python} -m pip uninstall -y #{dep}"
     end
+
+    # Patch applies to only one file: set it explicitly as a target, no need for -p
+    if windows_target?
+      patch :source => "remove-maxfile-maxpath-psutil.patch", :target => "#{python_3_embedded}/Lib/site-packages/psutil/__init__.py"
+    else
+      patch :source => "remove-maxfile-maxpath-psutil.patch", :target => "#{install_dir}/embedded/lib/python3.11/site-packages/psutil/__init__.py"
+    end
+
+    # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
+    command "#{python} -m pip check"
+  end
+
+  # Removing tests that don't need to be shipped in the embedded folder
+  if windows_target?
+    delete "#{python_3_embedded}/Lib/site-packages/Cryptodome/SelfTest/"
+  else
+    delete "#{install_dir}/embedded/lib/python3.11/site-packages/Cryptodome/SelfTest/"
   end
 
   # Ship `requirements-agent-release.txt` file containing the versions of every check shipped with the agent


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Attempt at simplifying current build scripts.

### Motivation

Working on related tasks, I found the use of `block`s confusing. Future work on AITS-269 might also benefit from some preparatory cleanup.

### Additional Notes

A big part of the diff is just indentation from removing blocks.

An important thing to understand is how these scripts run. The ruby scripts themselves are executed at "load time", but a big part of what they do is build a list of commands that are actually run at "build time". All Omnibus `Builder` methods are designed to build that list of commands. `block`'s are sort of a *escape hatch* here which allow you to write Ruby code that will be executed at "build time"; we can't fully get around using them in cases where we need to compute some stuff dynamically at "build time". But using `Builder` methods inside these `block`'s makes the flow of execution very hard to understand, because it means adding "build time" commands at "build time" rather than at "load time".

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
