### PR TITLE
Use minimal fakeintake image, with curl installed

### DIFF
--- a/test/fakeintake/Dockerfile
+++ b/test/fakeintake/Dockerfile
@@ -2,7 +2,11 @@
 # syntax=docker/dockerfile:1
 
 ## Build
-FROM golang:1.19-buster AS build
+FROM golang:1.20.11-alpine3.18 AS build
+
+# need gcc to build with CGO_ENABLED=1
+# need musl-dev to get stdlib.h
+RUN apk add musl-dev gcc
 
 WORKDIR /app
 
@@ -16,12 +20,15 @@ COPY api/*.go ./api/
 COPY app/*.go ./app/
 COPY aggregator/*.go ./aggregator/
 
-RUN go build -o /build app/main.go
+# need to explicitely run with CGO enabled
+RUN CGO_ENABLED=1 go build -o /build app/main.go
 
 ## Deploy
-FROM ubuntu:22.04
+FROM alpine:3.18
 
 WORKDIR /
+
+RUN apk add curl
 
 COPY --from=build /build /fakeintake
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Change fakeintake Dockerfile to use a smaller image, and install curl. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The former final image had a disk size of 82Mo (ubuntu:22.04, 37.5Mo compressed), the new one has a size of 26.9 Mo (alpine:3.18 + curl, 15.2 Mo compressed).
`curl` is needed to define the health probe command of the container.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Gave `distroless` a try to gain a few more Mo but it doesn't contain a package manager nor a shell, and copying from the build image didn't seem to work, so I gave that up.

We can gain another 5Mo on the image disk size by removing debug information from the go binary (`-ldflags="-s -w"`).

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
