### PR TITLE
http2: Extract conn tuple from http2_stream_t

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -83,7 +83,6 @@ typedef struct {
 } http2_stream_key_t;
 
 typedef struct {
-    conn_tuple_t tup;
     __u64 response_last_seen;
     __u64 request_started;
 
@@ -94,6 +93,11 @@ typedef struct {
 
     __u8 request_path[HTTP2_MAX_PATH_LEN] __attribute__((aligned(8)));
 } http2_stream_t;
+
+typedef struct {
+    conn_tuple_t tuple;
+    http2_stream_t stream;
+} http2_event_t;
 
 typedef struct {
     dynamic_table_index_t dynamic_index;

--- a/pkg/network/ebpf/c/protocols/http2/decoding.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding.h
@@ -281,7 +281,7 @@ static __always_inline void handle_end_of_stream(http2_stream_t *current_stream,
     // response end of stream;
     current_stream->response_last_seen = bpf_ktime_get_ns();
 
-    const u32 zero = 0;
+    const __u32 zero = 0;
     http2_event_t *event = bpf_map_lookup_elem(&http2_scratch_buffer, &zero);
     if (event) {
         bpf_memcpy(&event->tuple, &http2_stream_key_template->tup, sizeof(conn_tuple_t));

--- a/pkg/network/ebpf/c/protocols/http2/maps-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/maps-defs.h
@@ -35,6 +35,10 @@ BPF_PERCPU_ARRAY_MAP(http2_frames_to_process, __u32, http2_tail_call_state_t, 1)
 /* Allocating a stream on the heap, the stream is used to save the current stream info. */
 BPF_PERCPU_ARRAY_MAP(http2_stream_heap, __u32, http2_stream_t, 1)
 
+/* This map acts as a scratch buffer for "preparing" http2_event_t objects before they're
+   enqueued. The primary motivation here is to save eBPF stack memory. */
+BPF_PERCPU_ARRAY_MAP(http2_scratch_buffer, __u32, http2_event_t, 1)
+
 /* Allocating a ctx on the heap, in order to save the ctx between the current stream. */
 BPF_PERCPU_ARRAY_MAP(http2_ctx_heap, __u32, http2_ctx_t, 1)
 

--- a/pkg/network/ebpf/c/protocols/http2/usm-events.h
+++ b/pkg/network/ebpf/c/protocols/http2/usm-events.h
@@ -4,6 +4,6 @@
 #include "protocols/http2/decoding-defs.h"
 #include "protocols/events.h"
 
-USM_EVENTS_INIT(http2, http2_stream_t, HTTP2_BATCH_SIZE);
+USM_EVENTS_INIT(http2, http2_event_t, HTTP2_BATCH_SIZE);
 
 #endif

--- a/pkg/network/protocols/http2/model_test.go
+++ b/pkg/network/protocols/http2/model_test.go
@@ -48,8 +48,10 @@ func TestHTTP2Path(t *testing.T) {
 			copy(arr[:], buf)
 
 			request := &EbpfTx{
-				Request_path: arr,
-				Path_size:    uint8(len(buf)),
+				Stream: http2Stream{
+					Request_path: arr,
+					Path_size:    uint8(len(buf)),
+				},
 			}
 
 			outBuf := make([]byte, 200)

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -129,7 +129,7 @@ func (p *protocol) Name() string {
 }
 
 const (
-	mapSizeValue = 10240
+	mapSizeValue = 1024
 )
 
 // ConfigureOptions add the necessary options for http2 monitoring to work,

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -129,7 +129,7 @@ func (p *protocol) Name() string {
 }
 
 const (
-	mapSizeValue = 1024
+	mapSizeValue = 10240
 )
 
 // ConfigureOptions add the necessary options for http2 monitoring to work,
@@ -246,11 +246,11 @@ func (p *protocol) setupMapCleaner(mgr *manager.Manager) {
 			return false
 		}
 
-		if updated := int64(http2Txn.Response_last_seen); updated > 0 {
+		if updated := int64(http2Txn.Stream.Response_last_seen); updated > 0 {
 			return (now - updated) > ttl
 		}
 
-		started := int64(http2Txn.Request_started)
+		started := int64(http2Txn.Stream.Request_started)
 		return started > 0 && (now-started) > ttl
 	})
 

--- a/pkg/network/protocols/http2/types.go
+++ b/pkg/network/protocols/http2/types.go
@@ -21,7 +21,8 @@ type connTuple = C.conn_tuple_t
 type http2DynamicTableIndex C.dynamic_table_index_t
 type http2DynamicTableEntry C.dynamic_table_entry_t
 type http2StreamKey C.http2_stream_key_t
-type EbpfTx C.http2_stream_t
+type http2Stream C.http2_stream_t
+type EbpfTx C.http2_event_t
 
 type StaticTableEnumValue = C.static_table_value_t
 

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -32,8 +32,7 @@ type http2StreamKey struct {
 	Id        uint32
 	Pad_cgo_0 [4]byte
 }
-type EbpfTx struct {
-	Tup                   connTuple
+type http2Stream struct {
 	Response_last_seen    uint64
 	Request_started       uint64
 	Response_status_code  uint16
@@ -42,6 +41,10 @@ type EbpfTx struct {
 	Request_end_of_stream bool
 	Pad_cgo_0             [3]byte
 	Request_path          [160]uint8
+}
+type EbpfTx struct {
+	Tuple  connTuple
+	Stream http2Stream
 }
 
 type StaticTableEnumValue = uint8


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Removes `conn_tuple_t` field from `http2_stream_t` struct.
Similar to https://github.com/DataDog/datadog-agent/pull/20942

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We can remove the instance of conn_tuple_t from http2_stream_t, and by that minimize the size of http2_in_flight map. The conn_tuple_t field in http2_stream_t is redundant as it exists in the key of the map. Alongside we removing the duplication, we introduce a new struct called http2_event_t which composes both conn_tuple_t and http2_stream_t struct, and send http2_event_t to the user mode. By that, we reduce the size of http2_in_flight without affecting the events sent to the usermode.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Before:
```
57574: hash  name http2_in_flight  flags 0x0
	key 56B  value 232B  max_entries 65536  memlock 18874368B
	btf_id 121637
```
After:
```
57465: hash  name http2_in_flight  flags 0x0
	key 56B  value 184B  max_entries 65536  memlock 15728640B
	btf_id 121474
```

Reduces 3MB (16%) from the map size (and the agent's WSS) for 65536 entries. The change is linear with the number of entries.
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
