### PR TITLE
[USMO-649] Increase dynamic table counter and table map sizes

### DIFF
--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -129,7 +129,8 @@ func (p *protocol) Name() string {
 }
 
 const (
-	mapSizeValue = 1024
+	mapSizeValue        = 1024
+	dynamicMapSizeValue = 1024 * 10
 )
 
 // ConfigureOptions add the necessary options for http2 monitoring to work,
@@ -144,11 +145,11 @@ func (p *protocol) ConfigureOptions(mgr *manager.Manager, opts *manager.Options)
 	}
 
 	opts.MapSpecEditors[dynamicTable] = manager.MapSpecEditor{
-		MaxEntries: mapSizeValue,
+		MaxEntries: dynamicMapSizeValue,
 		EditorFlag: manager.EditMaxEntries,
 	}
 	opts.MapSpecEditors[dynamicTableCounter] = manager.MapSpecEditor{
-		MaxEntries: mapSizeValue,
+		MaxEntries: dynamicMapSizeValue,
 		EditorFlag: manager.EditMaxEntries,
 	}
 	opts.MapSpecEditors[http2IterationsTable] = manager.MapSpecEditor{

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -130,7 +130,7 @@ func (p *protocol) Name() string {
 
 const (
 	mapSizeValue        = 1024
-	dynamicMapSizeValue = 1024 * 10
+	dynamicMapSizeValue = 10240
 )
 
 // ConfigureOptions add the necessary options for http2 monitoring to work,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Increase the http2_dynamic_t and http2_dynamic_c map sizes.

The sizes and its effects:

**Before the change:**
```
http2_dynamic_t
key 56B  value 168B  max_entries 1024  memlock 229376B btf_id 223528
```

```
http2_dynamic_c
key 48B  value 8B  max_entries 1024  memlock 57344B btf_id 223505
```

**After the change:**
```
http2_dynamic_t
key 56B  value 168B  max_entries 10240  memlock 2293760B btf_id 223320
```

```
http2_dynamic_c
key 48B  value 8B  max_entries 10240  memlock 573440B btf_id 223317
```

The total amount will be increased by 2.5MB, but it should be offset by the changes outlined in [PR](https://github.com/DataDog/datadog-agent/pull/20947), resulting in a relatively equal total.


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We're encountering the maximum size limit of our current maps within the HTTP/2 flow in the staging environment. To prevent potential issues, we need to extend the sizes.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
