### PR TITLE
CI: fix omnibus version check to allow for stable branches (#20953)

### DIFF
--- a/.gitlab/do_not_merge.yml
+++ b/.gitlab/do_not_merge.yml
@@ -24,8 +24,5 @@ do-not-merge:
             echo "This workflow fails so that the pull request cannot be merged"
             exit 1
           fi
-      - test "$(inv -e release.get-release-json-value --key=nightly::OMNIBUS_RUBY_VERSION)" = "datadog-5.5.0" || exit 1
-      - test "$(inv -e release.get-release-json-value --key=nightly::OMNIBUS_SOFTWARE_VERSION)" = "master" || exit 1
-      - test "$(inv -e release.get-release-json-value --key=nightly-a7::OMNIBUS_RUBY_VERSION)" = "datadog-5.5.0" || exit 1
-      - test "$(inv -e release.get-release-json-value --key=nightly-a7::OMNIBUS_SOFTWARE_VERSION)" = "master" || exit 1
+      - inv -e release.check-omnibus-branches || exit 1
       - exit 0

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1370,3 +1370,16 @@ def update_last_stable(_, major_versions="6,7"):
         version.major = major
         release_json['last_stable'][str(major)] = str(version)
     _save_release_json(release_json)
+
+
+@task
+def check_omnibus_branches(_):
+    for branch in ['nightly', 'nightly-a7']:
+        omnibus_ruby_version = _get_release_json_value(f'{branch}::OMNIBUS_RUBY_VERSION')
+        omnibus_software_version = _get_release_json_value(f'{branch}::OMNIBUS_SOFTWARE_VERSION')
+        version_re = re.compile(r'(\d+)\.(\d+)\.x')
+        if omnibus_ruby_version != 'datadog-5.5.0' and not version_re.match(omnibus_ruby_version):
+            raise Exit(code=1, message=f'omnibus-ruby version [{omnibus_ruby_version}] is not mergeable')
+        if omnibus_software_version != 'master' and not version_re.match(omnibus_software_version):
+            raise Exit(code=1, message=f'omnibus-software version [{omnibus_software_version}] is not mergeable')
+    return True


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This is a backport of https://github.com/DataDog/datadog-agent/pull/20953

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
