### PR TITLE
Submit KMT environment setup failure metrics

### DIFF
--- a/test/new-e2e/scenarios/system-probe/main.go
+++ b/test/new-e2e/scenarios/system-probe/main.go
@@ -4,7 +4,6 @@
 // Copyright 2016-present Datadog, Inc.
 
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/test/new-e2e/system-probe/connector/main.go
+++ b/test/new-e2e/system-probe/connector/main.go
@@ -4,6 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Package main implements the SSH connector between gitlab runners, metal instances, and micro VMs
+
 package main
 
 import (

--- a/test/new-e2e/system-probe/connector/main.go
+++ b/test/new-e2e/system-probe/connector/main.go
@@ -4,7 +4,6 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Package main implements the SSH connector between gitlab runners, metal instances, and micro VMs
-
 package main
 
 import (

--- a/test/new-e2e/system-probe/connector/main.go
+++ b/test/new-e2e/system-probe/connector/main.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !windows
+
 // Package main implements the SSH connector between gitlab runners, metal instances, and micro VMs
 package main
 

--- a/test/new-e2e/system-probe/connector/main.go
+++ b/test/new-e2e/system-probe/connector/main.go
@@ -8,7 +8,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -22,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"golang.org/x/crypto/ssh"
 
+	"github.com/DataDog/datadog-agent/test/new-e2e/system-probe/connector/metric"
 	"github.com/DataDog/datadog-agent/test/new-e2e/system-probe/connector/sshtools"
 )
 
@@ -132,7 +132,7 @@ func run() (err error) {
 	var failType string
 	result := fail
 	defer func() {
-		if serr := submitExecutionMetric(cinfo, failType, result); serr != nil {
+		if serr := metric.SubmitExecutionMetric(buildMetric(cinfo, failType, result)); serr != nil {
 			err = serr
 		}
 	}()
@@ -199,29 +199,4 @@ func buildMetric(cinfo connectorInfo, failType, result string) datadogV2.MetricP
 			},
 		},
 	}
-}
-
-func submitExecutionMetric(cinfo connectorInfo, failType, result string) error {
-	if _, ok := os.LookupEnv("DD_API_KEY"); !ok {
-		fmt.Fprintf(os.Stderr, "skipping sending metric because DD_API_KEY not present")
-		return nil
-	}
-
-	metricBody := buildMetric(cinfo, failType, result)
-
-	ctx := datadog.NewDefaultContext(context.Background())
-	configuration := datadog.NewConfiguration()
-	apiClient := datadog.NewAPIClient(configuration)
-	api := datadogV2.NewMetricsApi(apiClient)
-	resp, r, err := api.SubmitMetrics(ctx, metricBody, *datadogV2.NewSubmitMetricsOptionalParameters())
-
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-		return fmt.Errorf("error when calling `MetricsApi.SubmitMetrics`: %v", err)
-	}
-
-	responseContent, _ := json.MarshalIndent(resp, "", "  ")
-	fmt.Fprintf(os.Stdout, "Response from `MetricsApi.SubmitMetrics`:\n%s\n", responseContent)
-
-	return nil
 }

--- a/test/new-e2e/system-probe/connector/metric/metric.go
+++ b/test/new-e2e/system-probe/connector/metric/metric.go
@@ -5,7 +5,7 @@
 
 //go:build !windows
 
-// This package is responsible for emitting metrics to Datadog
+// Package metric is responsible for emitting metrics to Datadog
 package metric
 
 import (

--- a/test/new-e2e/system-probe/connector/metric/metric.go
+++ b/test/new-e2e/system-probe/connector/metric/metric.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/DataDog/datadog-api-client-go/api/v1/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 )
 
-func SubmitExecutionMetric(metric datadogV2.MetricPayload, failType, result string) error {
+func SubmitExecutionMetric(metricBody datadogV2.MetricPayload) error {
 	if _, ok := os.LookupEnv("DD_API_KEY"); !ok {
 		fmt.Fprintf(os.Stderr, "skipping sending metric because DD_API_KEY not present")
 		return nil

--- a/test/new-e2e/system-probe/connector/metric/metric.go
+++ b/test/new-e2e/system-probe/connector/metric/metric.go
@@ -4,7 +4,6 @@
 // Copyright 2016-present Datadog, Inc.
 
 //go:build !windows
-// +build !windows
 
 package metric
 

--- a/test/new-e2e/system-probe/connector/metric/metric.go
+++ b/test/new-e2e/system-probe/connector/metric/metric.go
@@ -10,6 +10,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 )
 
+// SubmitExecutionMetric accepts metrics and submits it to Datadog.
 func SubmitExecutionMetric(metricBody datadogV2.MetricPayload) error {
 	if _, ok := os.LookupEnv("DD_API_KEY"); !ok {
 		fmt.Fprintf(os.Stderr, "skipping sending metric because DD_API_KEY not present")

--- a/test/new-e2e/system-probe/connector/metric/metric.go
+++ b/test/new-e2e/system-probe/connector/metric/metric.go
@@ -5,6 +5,7 @@
 
 //go:build !windows
 
+// This package is responsible for emitting metrics to Datadog
 package metric
 
 import (

--- a/test/new-e2e/system-probe/connector/metric/metric.go
+++ b/test/new-e2e/system-probe/connector/metric/metric.go
@@ -1,3 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+// +build !windows
+
 package metric
 
 import (

--- a/test/new-e2e/system-probe/connector/metric/metric.go
+++ b/test/new-e2e/system-probe/connector/metric/metric.go
@@ -1,0 +1,34 @@
+package metric
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/DataDog/datadog-api-client-go/api/v1/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+func SubmitExecutionMetric(metric datadogV2.MetricPayload, failType, result string) error {
+	if _, ok := os.LookupEnv("DD_API_KEY"); !ok {
+		fmt.Fprintf(os.Stderr, "skipping sending metric because DD_API_KEY not present")
+		return nil
+	}
+
+	ctx := datadog.NewDefaultContext(context.Background())
+	configuration := datadog.NewConfiguration()
+	apiClient := datadog.NewAPIClient(configuration)
+	api := datadogV2.NewMetricsApi(apiClient)
+	resp, r, err := api.SubmitMetrics(ctx, metricBody, *datadogV2.NewSubmitMetricsOptionalParameters())
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+		return fmt.Errorf("error when calling `MetricsApi.SubmitMetrics`: %v", err)
+	}
+
+	responseContent, _ := json.MarshalIndent(resp, "", "  ")
+	fmt.Fprintf(os.Stdout, "Response from `MetricsApi.SubmitMetrics`:\n%s\n", responseContent)
+
+	return nil
+}

--- a/test/new-e2e/system-probe/errors.go
+++ b/test/new-e2e/system-probe/errors.go
@@ -38,24 +38,24 @@ var errors = []handledError{
 	// Retry if we failed to dial libvirt.
 	// Libvirt daemon on the server occasionally drops the connection established
 	// by the 'Provider'. If this happens we retry the stack to connect again.
-	handledError{
+	{
 		errorStr: "failed to dial libvirt",
 		metric:   "failed-to-dial-libvirt",
 		action:   retryStack | emitMetric,
 	},
-	handledError{
+	{
 		errorStr: "InsufficientInstanceCapacity",
 		metric:   "insufficient-capacity",
 		action:   retryStack | emitMetric,
 	},
 	// Retry when ssh thinks aria2c exited without status. This may happen
 	// due to network connectivity issues if ssh keepalive mecahnism fails.
-	handledError{
+	{
 		errorStr: aria2cMissingStatusError,
 		metric:   "aria2c-exit-no-status",
 		action:   retryStack | emitMetric,
 	},
-	handledError{
+	{
 		errorStr: "timeout while waiting for state to become 'running'",
 		metric:   "ec2-timeout-state-change",
 		action:   emitMetric,

--- a/test/new-e2e/system-probe/errors.go
+++ b/test/new-e2e/system-probe/errors.go
@@ -5,8 +5,8 @@
 
 //go:build !windows
 
-// Package systemProbe is sets up the remote testing environment for system-probe using the Kernel Matrix Testing framework
-package systemProbe
+// Package systemprobe is sets up the remote testing environment for system-probe using the Kernel Matrix Testing framework
+package systemprobe
 
 import (
 	"fmt"

--- a/test/new-e2e/system-probe/errors.go
+++ b/test/new-e2e/system-probe/errors.go
@@ -84,7 +84,7 @@ func errorMetric(errType string) datadogV2.MetricPayload {
 }
 
 func handleScenarioFailure(err error) error {
-	errStr = err.Error()
+	errStr := err.Error()
 	for _, e := range errors {
 		if !strings.Contains(errStr, e.errorStr) {
 			continue

--- a/test/new-e2e/system-probe/errors.go
+++ b/test/new-e2e/system-probe/errors.go
@@ -4,7 +4,6 @@
 // Copyright 2016-present Datadog, Inc.
 
 //go:build !windows
-// +build !windows
 
 package systemProbe
 

--- a/test/new-e2e/system-probe/errors.go
+++ b/test/new-e2e/system-probe/errors.go
@@ -5,6 +5,7 @@
 
 //go:build !windows
 
+// This package is sets up the remote testing environment for system-probe using the Kernel Matrix Testing framework
 package systemProbe
 
 import (

--- a/test/new-e2e/system-probe/errors.go
+++ b/test/new-e2e/system-probe/errors.go
@@ -27,7 +27,7 @@ const (
 	aria2cMissingStatusErrorStr = "error: wait: remote command exited without exit status or exit signal: running \" aria2c"
 )
 
-type ScenarioError int
+type scenarioError int
 
 const (
 	libvirtDialError ScenarioError = iota

--- a/test/new-e2e/system-probe/errors.go
+++ b/test/new-e2e/system-probe/errors.go
@@ -92,7 +92,9 @@ func handleScenarioFailure(err error) error {
 
 		if (e.action & emitMetric) != 0 {
 			submitError := metric.SubmitExecutionMetric(errorMetric(e.metric))
-			log.Printf("failed to submit environment setup error metrics: %v\n", submitError)
+			if submitError != nil {
+				log.Printf("failed to submit environment setup error metrics: %v\n", submitError)
+			}
 		}
 
 		if (e.action & retryStack) != 0 {

--- a/test/new-e2e/system-probe/errors.go
+++ b/test/new-e2e/system-probe/errors.go
@@ -5,7 +5,7 @@
 
 //go:build !windows
 
-// This package is sets up the remote testing environment for system-probe using the Kernel Matrix Testing framework
+// Package systemProbe is sets up the remote testing environment for system-probe using the Kernel Matrix Testing framework
 package systemProbe
 
 import (
@@ -31,14 +31,14 @@ const (
 type scenarioError int
 
 const (
-	libvirtDialError ScenarioError = iota
+	libvirtDialError scenarioError = iota
 	insufficientCapacityError
 	aria2cMissingStatusError
 	ec2StateChangeTimeoutError
 )
 
 type handledError struct {
-	errorType   ScenarioError
+	errorType   scenarioError
 	errorString string
 	metric      string
 	action      int

--- a/test/new-e2e/system-probe/errors.go
+++ b/test/new-e2e/system-probe/errors.go
@@ -1,0 +1,108 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+// +build !windows
+
+package systemProbe
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/system-probe/connector/metric"
+	"github.com/DataDog/datadog-api-client-go/api/v1/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/sethvargo/go-retry"
+)
+
+const (
+	// bitmap of actions to take for an error
+	retryStack = 0x1 // 0b01
+	emitMetric = 0x2 // 0b10
+
+	aria2cMissingStatusError = "error: wait: remote command exited without exit status or exit signal: running \" aria2c"
+)
+
+type handledError struct {
+	errorStr string
+	metric   string
+	action   int
+}
+
+var errors = []handledError{
+	// Retry if we failed to dial libvirt.
+	// Libvirt daemon on the server occasionally drops the connection established
+	// by the 'Provider'. If this happens we retry the stack to connect again.
+	handledError{
+		errorStr: "failed to dial libvirt",
+		metric:   "failed-to-dial-libvirt",
+		action:   retryStack | emitMetric,
+	},
+	handledError{
+		errorStr: "InsufficientInstanceCapacity",
+		metric:   "insufficient-capacity",
+		action:   retryStack | emitMetric,
+	},
+	// Retry when ssh thinks aria2c exited without status. This may happen
+	// due to network connectivity issues if ssh keepalive mecahnism fails.
+	handledError{
+		errorStr: aria2cMissingStatusError,
+		metric:   "aria2c-exit-no-status",
+		action:   retryStack | emitMetric,
+	},
+	handledError{
+		errorStr: "timeout while waiting for state to become 'running'",
+		metric:   "ec2-timeout-state-change",
+		action:   emitMetric,
+	},
+}
+
+func errorMetric(errType string) datadogV2.MetricPayload {
+	tags := []string{
+		fmt.Sprintf("error:%s", errType),
+	}
+	return datadogV2.MetricPayload{
+		Series: []datadogV2.MetricSeries{
+			{
+				Metric: "datadog.e2e.system_probe.env-setup",
+				Type:   datadogV2.METRICINTAKETYPE_COUNT.Ptr(),
+				Points: []datadogV2.MetricPoint{
+					{
+						Timestamp: datadog.PtrInt64(time.Now().Unix()),
+						Value:     datadog.PtrFloat64(1),
+					},
+				},
+				Tags: tags,
+			},
+		},
+	}
+}
+
+func handleScenarioFailure(err error) error {
+	errStr = err.Error()
+	for _, e := range errors {
+		if !strings.Contains(errStr, e.errorStr) {
+			continue
+		}
+
+		if (e.action & emitMetric) != 0 {
+			submitError := metric.SubmitExecutionMetric(errorMetric(e.metric))
+			log.Printf("failed to submit environment setup error metrics: %v\n", submitError)
+		}
+
+		if (e.action & retryStack) != 0 {
+			log.Printf("environment setup error: %v. Retrying stack.\n", err)
+			return retry.RetryableError(err)
+		}
+
+		break
+	}
+
+	log.Printf("environment setup error: %v. Failing stack.\n", err)
+	return err
+}

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -5,7 +5,7 @@
 
 //go:build !windows
 
-// This package is sets up the remote testing environment for system-probe using the Kernel Matrix Testing framework
+// Package systemProbe sets up the remote testing environment for system-probe using the Kernel Matrix Testing framework
 package systemProbe
 
 import (

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -5,6 +5,7 @@
 
 //go:build !windows
 
+// This package is sets up the remote testing environment for system-probe using the Kernel Matrix Testing framework
 package systemProbe
 
 import (
@@ -209,7 +210,7 @@ func NewTestEnv(name, x86InstanceType, armInstanceType string, opts *SystemProbe
 		if err != nil {
 			return handleScenarioFailure(err, func(possibleError handledError) {
 				if possibleError.errorType == insufficientCapacityError {
-					currentAZ += 1
+					currentAZ++
 				}
 			})
 		}

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -198,7 +198,7 @@ func NewTestEnv(name, x86InstanceType, armInstanceType string, opts *SystemProbe
 	// connection issues in the worst case.
 	b = retry.WithMaxRetries(4, b)
 	if retryErr := retry.Do(ctx, b, func(_ context.Context) error {
-		if az, currentAz = getAvailabilityZone(opts.InfraEnv, currentAZ); az != "" {
+		if az, currentAZ = getAvailabilityZone(opts.InfraEnv, currentAZ); az != "" {
 			config["ddinfra:aws/defaultSubnets"] = auto.ConfigValue{Value: az}
 		}
 

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -4,7 +4,6 @@
 // Copyright 2016-present Datadog, Inc.
 
 //go:build !windows
-// +build !windows
 
 package systemProbe
 

--- a/test/new-e2e/system-probe/system-probe-test-env.go
+++ b/test/new-e2e/system-probe/system-probe-test-env.go
@@ -5,8 +5,8 @@
 
 //go:build !windows
 
-// Package systemProbe sets up the remote testing environment for system-probe using the Kernel Matrix Testing framework
-package systemProbe
+// Package systemprobe sets up the remote testing environment for system-probe using the Kernel Matrix Testing framework
+package systemprobe
 
 import (
 	"context"

--- a/test/new-e2e/system-probe/test-json-review/main.go
+++ b/test/new-e2e/system-probe/test-json-review/main.go
@@ -4,7 +4,6 @@
 // Copyright 2016-present Datadog, Inc.
 
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -4,7 +4,6 @@
 // Copyright 2016-present Datadog, Inc.
 
 //go:build !windows
-// +build !windows
 
 package main
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR emits metrics for the different types of environment failures we are tracking.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
