### PR TITLE
Make the 'Collector' an interface so it can more easily be mocked

### DIFF
--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -29,7 +29,7 @@ var (
 	AC *autodiscovery.AutoConfig
 
 	// Coll is the global collector instance
-	Coll *collector.Collector
+	Coll collector.Collector
 
 	// ExpvarServer is the global expvar server
 	ExpvarServer *http.Server

--- a/pkg/collector/collector_demux_test.go
+++ b/pkg/collector/collector_demux_test.go
@@ -26,13 +26,13 @@ type CollectorDemuxTestSuite struct {
 	suite.Suite
 
 	demux *aggregator.TestAgentDemultiplexer
-	c     *Collector
+	c     *collector
 }
 
 func (suite *CollectorDemuxTestSuite) SetupTest() {
 	log := fxutil.Test[log.Component](suite.T(), log.MockModule)
 	suite.demux = aggregator.InitTestAgentDemultiplexerWithFlushInterval(log, 100*time.Hour)
-	suite.c = NewCollector(suite.demux)
+	suite.c = NewCollector(suite.demux).(*collector)
 
 	suite.c.Start()
 }

--- a/pkg/collector/collector_mock.go
+++ b/pkg/collector/collector_mock.go
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package collector
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockCollector struct {
+	mock.Mock
+	checksInfo []check.Info
+}
+
+// NewMockCollector returns a mock collector.
+//
+// 'mockChecksInfo' will be used as argument for the callback when 'MapOverChecks' is called.
+func NewMockCollector(mockChecksInfo []check.Info) Collector {
+	return &mockCollector{
+		checksInfo: mockChecksInfo,
+	}
+}
+
+// Start begins the collector's operation.  The scheduler will not run any
+// checks until this has been called.
+func (c *mockCollector) Start() {
+	c.Called()
+}
+
+// Stop halts any component involved in running a Check
+func (c *mockCollector) Stop() {
+	c.Called()
+}
+
+// RunCheck sends a Check in the execution queue
+func (c *mockCollector) RunCheck(inner check.Check) (checkid.ID, error) {
+	args := c.Called(inner)
+	return args.Get(0).(checkid.ID), args.Error(1)
+}
+
+// StopCheck halts a check and remove the instance
+func (c *mockCollector) StopCheck(id checkid.ID) error {
+	args := c.Called(id)
+	return args.Error(0)
+}
+
+// MapOverChecks call the callback with the list of checks locked.
+func (c *mockCollector) MapOverChecks(cb func([]check.Info)) {
+	c.Called(cb)
+	cb(c.checksInfo)
+}
+
+// GetChecks copies checks
+func (c *mockCollector) GetChecks() []check.Check {
+	args := c.Called()
+	return args.Get(0).([]check.Check)
+}
+
+// GetAllInstanceIDs returns the ID's of all instances of a check
+func (c *mockCollector) GetAllInstanceIDs(checkName string) []checkid.ID {
+	args := c.Called(checkName)
+	return args.Get(0).([]checkid.ID)
+}
+
+// ReloadAllCheckInstances completely restarts a check with a new configuration
+func (c *mockCollector) ReloadAllCheckInstances(name string, newInstances []check.Check) ([]checkid.ID, error) {
+	args := c.Called(name, newInstances)
+	return args.Get(0).([]checkid.ID), args.Error(1)
+}

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -80,11 +80,11 @@ func (p ChecksList) Less(i, j int) bool { return p[i] < p[j] }
 
 type CollectorTestSuite struct {
 	suite.Suite
-	c *Collector
+	c *collector
 }
 
 func (suite *CollectorTestSuite) SetupTest() {
-	suite.c = NewCollector(aggregator.NewNoOpSenderManager())
+	suite.c = NewCollector(aggregator.NewNoOpSenderManager()).(*collector)
 	suite.c.Start()
 }
 

--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -53,13 +53,13 @@ func init() {
 type CheckScheduler struct {
 	configToChecks map[string][]checkid.ID // cache the ID of checks we load for each config
 	loaders        []check.Loader
-	collector      *Collector
+	collector      Collector
 	senderManager  sender.SenderManager
 	m              sync.RWMutex
 }
 
 // InitCheckScheduler creates and returns a check scheduler
-func InitCheckScheduler(collector *Collector, senderManager sender.SenderManager) *CheckScheduler {
+func InitCheckScheduler(collector Collector, senderManager sender.SenderManager) *CheckScheduler {
 	checkScheduler = &CheckScheduler{
 		collector:      collector,
 		senderManager:  senderManager,


### PR DESCRIPTION
### What does this PR do?

Make the `Collector` an interface so it can more easily be mocked

### Describe how to test/QA your changes

Verify that the agent can still:
- run checks
- the `run` command still works
- the status page still works

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
