### PR TITLE
[workloadmeta] bugfix: set global in the constructor for safety

### DIFF
--- a/cmd/security-agent/main_windows.go
+++ b/cmd/security-agent/main_windows.go
@@ -15,7 +15,6 @@ import (
 
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	commonpath "github.com/DataDog/datadog-agent/cmd/agent/common/path"
 	"github.com/DataDog/datadog-agent/cmd/internal/runcmd"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
@@ -117,8 +116,7 @@ func (s *service) Run(svcctx context.Context) error {
 			}
 
 			return workloadmeta.Params{
-				AgentType:  catalog,
-				InitHelper: common.GetWorkloadmetaInit(),
+				AgentType: catalog,
 			}
 		}),
 	)

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -22,7 +22,6 @@ import (
 
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/manager"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/api"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
@@ -108,8 +107,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					}
 
 					return workloadmeta.Params{
-						AgentType:  catalog,
-						InitHelper: common.GetWorkloadmetaInit(),
+						AgentType: catalog,
 					}
 				}),
 			)

--- a/comp/core/workloadmeta/workloadmeta.go
+++ b/comp/core/workloadmeta/workloadmeta.go
@@ -76,10 +76,10 @@ func newWorkloadMeta(deps dependencies) Component {
 		ongoingPulls: make(map[string]time.Time),
 	}
 
-	deps.Lc.Append(fx.Hook{OnStart: func(c context.Context) error {
+	// Set global
+	SetGlobalStore(wm)
 
-		// Set global
-		SetGlobalStore(wm)
+	deps.Lc.Append(fx.Hook{OnStart: func(c context.Context) error {
 
 		// create and setup the Autoconfig instance
 		if deps.Params.InitHelper != nil {

--- a/comp/core/workloadmeta/workloadmeta.go
+++ b/comp/core/workloadmeta/workloadmeta.go
@@ -81,9 +81,14 @@ func newWorkloadMeta(deps dependencies) Component {
 
 	deps.Lc.Append(fx.Hook{OnStart: func(c context.Context) error {
 
+		var err error
+
 		// create and setup the Autoconfig instance
 		if deps.Params.InitHelper != nil {
-			return deps.Params.InitHelper(c, wm)
+			err = deps.Params.InitHelper(c, wm)
+			if err != nil {
+				return err
+			}
 		}
 
 		// Main context passed to components


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Fixes a bug in the workloadmeta implementation. 

We were relying on the startup hooks to set the global for workloadmeta but the hook ordering and usage of library code by other components is too unpredictable. By setting the global in the component constructor itself we can make sure that any component that relies on workloadmeta will also have the global set as long as the dependency is well defined.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Bug crashing the process-agent.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
