### PR TITLE
sketch origins for marshalsplitcompress path

### DIFF
--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -120,6 +120,8 @@ func (s *TimeSampler) newSketchSeries(ck ckey.ContextKey, points []metrics.Sketc
 		Interval:   s.interval,
 		Points:     points,
 		ContextKey: ck,
+		Source:     ctx.source,
+		NoIndex:    ctx.noIndex,
 	}
 
 	return ss

--- a/pkg/metrics/sketch_series.go
+++ b/pkg/metrics/sketch_series.go
@@ -9,9 +9,10 @@ import (
 	"bytes"
 	"encoding/json"
 
+	"github.com/DataDog/opentelemetry-mapping-go/pkg/quantile"
+
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
-	"github.com/DataDog/opentelemetry-mapping-go/pkg/quantile"
 )
 
 // A SketchSeries is a timeseries of quantile sketches.
@@ -22,6 +23,8 @@ type SketchSeries struct {
 	Interval   int64                `json:"interval"`
 	Points     []SketchPoint        `json:"points"`
 	ContextKey ckey.ContextKey      `json:"-"`
+	NoIndex    bool                 `json:"-"` // This is only used by api V2
+	Source     MetricSource         `json:"-"` // This is only used by api V2
 }
 
 // String returns the JSON representation of a SketchSeries as a string

--- a/pkg/metrics/test_helper.go
+++ b/pkg/metrics/test_helper.go
@@ -18,9 +18,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/opentelemetry-mapping-go/pkg/quantile"
+
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
-	"github.com/DataDog/opentelemetry-mapping-go/pkg/quantile"
 )
 
 // AssertPointsEqual evaluate if two list of point are equal (order doesn't matters).
@@ -154,6 +155,13 @@ var _ SketchesSource = (*SketchesSourceTest)(nil)
 type SketchesSourceTest struct {
 	values       SketchSeriesList
 	currentIndex int
+}
+
+func NewSketchesSourceTestWithSketch() *SketchesSourceTest {
+	return &SketchesSourceTest{
+		currentIndex: -1,
+		values:       SketchSeriesList{&SketchSeries{Name: "fakename", Host: "fakehost"}},
+	}
 }
 
 func NewSketchesSourceTest() *SketchesSourceTest {

--- a/pkg/metrics/test_helper.go
+++ b/pkg/metrics/test_helper.go
@@ -157,6 +157,7 @@ type SketchesSourceTest struct {
 	currentIndex int
 }
 
+// NewSketchesSourceTestWithSketch populates values with a single test sketch
 func NewSketchesSourceTestWithSketch() *SketchesSourceTest {
 	return &SketchesSourceTest{
 		currentIndex: -1,

--- a/pkg/serializer/internal/metrics/sketch_series_list.go
+++ b/pkg/serializer/internal/metrics/sketch_series_list.go
@@ -67,6 +67,7 @@ func (sl SketchSeriesList) MarshalSplitCompress(bufferContext *marshaler.BufferC
 	// const sketchDistributions = 3
 	const sketchTags = 4
 	const sketchDogsketches = 7
+	const sketchMetadata = 8
 	// const distributionTs = 1
 	// const distributionCnt = 2
 	// const distributionMin = 3
@@ -85,6 +86,30 @@ func (sl SketchSeriesList) MarshalSplitCompress(bufferContext *marshaler.BufferC
 	const dogsketchSum = 6
 	const dogsketchK = 7
 	const dogsketchN = 8
+
+	const sketchMetadataOrigin = 1
+	//         |------| 'Metadata' message
+	//                 |-----| 'origin' field index
+	const sketchMetadataOriginMetricType = 3
+	//         |------| 'Metadata' message
+	//                 |----| 'origin' message
+	//                       |--------| 'metric_type' field index
+	const metryTypeNotIndexed = 9
+	//    |-----------------| 'metric_type_agent_hidden' field index
+
+	const sketchMetadataOriginOriginProduct = 4
+	//                 |----|  'Origin' message
+	//                       |-----------| 'origin_product' field index
+	const sketchMetadataOriginOriginCategory = 5
+	//                 |----|  'Origin' message
+	//                       |-----------| 'origin_category' field index
+	const sketchMetadataOriginOriginService = 6
+	//                 |----|  'Origin' message
+	//                       |-----------| 'origin_service' field index
+	const serieMetadataOriginOriginProductAgentType = 10
+	//                 |----|  'Origin' message
+	//                       |-----------| 'OriginProduct' enum
+	//                                    |-------| 'Agent' enum value
 
 	// the backend accepts payloads up to specific compressed / uncompressed
 	// sizes, but prefers small uncompressed payloads.
@@ -215,6 +240,28 @@ func (sl SketchSeriesList) MarshalSplitCompress(bufferContext *marshaler.BufferC
 				if err != nil {
 					return err
 				}
+			}
+			err = ps.Embedded(sketchMetadata, func(ps *molecule.ProtoStream) error {
+				return ps.Embedded(sketchMetadataOrigin, func(ps *molecule.ProtoStream) error {
+					if ss.NoIndex {
+						err = ps.Int32(sketchMetadataOriginMetricType, metryTypeNotIndexed)
+						if err != nil {
+							return err
+						}
+					}
+					err = ps.Int32(sketchMetadataOriginOriginProduct, serieMetadataOriginOriginProductAgentType)
+					if err != nil {
+						return err
+					}
+					err = ps.Int32(sketchMetadataOriginOriginCategory, MetricSourceToOriginCategory(ss.Source))
+					if err != nil {
+						return err
+					}
+					return ps.Int32(sketchMetadataOriginOriginService, MetricSourceToOriginService(ss.Source))
+				})
+			})
+			if err != nil {
+				return err
 			}
 
 			return nil

--- a/pkg/serializer/internal/metrics/sketch_series_test.go
+++ b/pkg/serializer/internal/metrics/sketch_series_test.go
@@ -155,6 +155,8 @@ func TestSketchSeriesMarshalSplitCompress(t *testing.T) {
 		sl.Append(Makeseries(i))
 	}
 
+	// serializer1 := SketchSeriesList{SketchesSource: sl}
+	// payload, _ := serializer1.Marshal()
 	sl.Reset()
 	serializer2 := SketchSeriesList{SketchesSource: sl}
 	payloads, err := serializer2.MarshalSplitCompress(marshaler.NewBufferContext())
@@ -166,6 +168,11 @@ func TestSketchSeriesMarshalSplitCompress(t *testing.T) {
 	r, _ := zlib.NewReader(reader)
 	decompressed, _ := io.ReadAll(r)
 	r.Close()
+
+	// Check that we encoded the protobuf correctly
+	// Commented equal assertion out for now since MarshalSplitCompress
+	// adds SketchMetadata with Origin metadata, making payloads unequal
+	// assert.Equal(t, decompressed, payload)
 
 	pl := new(gogen.SketchPayload)
 	err = pl.Unmarshal(decompressed)

--- a/pkg/serializer/internal/metrics/sketch_series_test.go
+++ b/pkg/serializer/internal/metrics/sketch_series_test.go
@@ -155,8 +155,6 @@ func TestSketchSeriesMarshalSplitCompress(t *testing.T) {
 		sl.Append(Makeseries(i))
 	}
 
-	serializer1 := SketchSeriesList{SketchesSource: sl}
-	payload, _ := serializer1.Marshal()
 	sl.Reset()
 	serializer2 := SketchSeriesList{SketchesSource: sl}
 	payloads, err := serializer2.MarshalSplitCompress(marshaler.NewBufferContext())
@@ -168,9 +166,6 @@ func TestSketchSeriesMarshalSplitCompress(t *testing.T) {
 	r, _ := zlib.NewReader(reader)
 	decompressed, _ := io.ReadAll(r)
 	r.Close()
-
-	// Check that we encoded the protobuf correctly
-	assert.Equal(t, decompressed, payload)
 
 	pl := new(gogen.SketchPayload)
 	err = pl.Unmarshal(decompressed)

--- a/pkg/serializer/internal/metrics/sketch_series_test.go
+++ b/pkg/serializer/internal/metrics/sketch_series_test.go
@@ -155,8 +155,6 @@ func TestSketchSeriesMarshalSplitCompress(t *testing.T) {
 		sl.Append(Makeseries(i))
 	}
 
-	// serializer1 := SketchSeriesList{SketchesSource: sl}
-	// payload, _ := serializer1.Marshal()
 	sl.Reset()
 	serializer2 := SketchSeriesList{SketchesSource: sl}
 	payloads, err := serializer2.MarshalSplitCompress(marshaler.NewBufferContext())
@@ -168,11 +166,6 @@ func TestSketchSeriesMarshalSplitCompress(t *testing.T) {
 	r, _ := zlib.NewReader(reader)
 	decompressed, _ := io.ReadAll(r)
 	r.Close()
-
-	// Check that we encoded the protobuf correctly
-	// Commented equal assertion out for now since MarshalSplitCompress
-	// adds SketchMetadata with Origin metadata, making payloads unequal
-	// assert.Equal(t, decompressed, payload)
 
 	pl := new(gogen.SketchPayload)
 	err = pl.Unmarshal(decompressed)

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -322,11 +322,24 @@ func TestSendSeries(t *testing.T) {
 func TestSendSketch(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
 
-	matcher := createProtoscopeMatcher(`2: {}`)
+	matcher := createProtoscopeMatcher(`
+		1: {
+			1: {"fakename"}
+			2: {"fakehost"}
+			8: {
+				1: {
+					4: 10
+					5: 0
+					6: 0
+				}
+			}
+		}
+		2: {}
+		`)
 	f.On("SubmitSketchSeries", matcher, protobufExtraHeadersWithCompression).Return(nil).Times(1)
 
 	s := NewSerializer(f, nil)
-	err := s.SendSketch(metrics.NewSketchesSourceTest())
+	err := s.SendSketch(metrics.NewSketchesSourceTestWithSketch())
 	require.Nil(t, err)
 	f.AssertExpectations(t)
 }

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -323,17 +323,7 @@ func TestSendSketch(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
 
 	matcher := createProtoscopeMatcher(`
-		1: {
-			1: {"fakename"}
-			2: {"fakehost"}
-			8: {
-				1: {
-					4: 10
-					5: 0
-					6: 0
-				}
-			}
-		}
+		1: { 1: {"fakename"} 2: {"fakehost"} 8: { 1: { 4: 10 }}}
 		2: {}
 		`)
 	f.On("SubmitSketchSeries", matcher, protobufExtraHeadersWithCompression).Return(nil).Times(1)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
Adds origins for for sketches handled via the `MarshalSplitCompress(..)` path
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
To have metric origins set for sketches
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Removes a line in `sketch_series_test` that asserted that the 2 payloads from `Marshal` and `MarshalSplitCompress` were equal since now `MarshalSplitCompress` will add sources, making the payloads unequal.

A followup investigation will be need to done to figure out how to attach metric origins via the `Marshal` route
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Make sure sketches are still being sent properly, and use scotts `proxy-dumper` (located in the benchmarks repo, proxy-dumper branch) to check that metadata.origin points to a valid origin

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
