### PR TITLE
[NDM] Netflow status formatting changes

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -506,31 +506,33 @@
         <br>Closed Listeners: {{.netflowStats.ClosedListeners}}
         {{ if .netflowStats.OpenListeners }}
         <span class="stat_subtitle">Open Listener Details</span>
-        {{- range $index, $NetflowListenerStatus := .netflowStats.WorkingListenerDetails }}
-        BindHost: {{$NetflowListenerStatus.Config.BindHost}}
-        <br>FlowType: {{$NetflowListenerStatus.Config.FlowType}}
-        <br>Port: {{$NetflowListenerStatus.Config.Port}}
-        <br>Workers: {{$NetflowListenerStatus.Config.Workers}}
-        <br>Namespace: {{$NetflowListenerStatus.Config.Namespace}}
-        <br>Flows Received: {{$NetflowListenerStatus.FlowCount}}
-        <br>
-        <br>
-        {{- end }}
+          <span class="stat_subdata">
+            {{- range $index, $NetflowListenerStatus := .netflowStats.WorkingListenerDetails }}
+              BindHost: {{$NetflowListenerStatus.Config.BindHost}}
+              <br>FlowType: {{$NetflowListenerStatus.Config.FlowType}}
+              <br>Port: {{$NetflowListenerStatus.Config.Port}}
+              <br>Workers: {{$NetflowListenerStatus.Config.Workers}}
+              <br>Namespace: {{$NetflowListenerStatus.Config.Namespace}}
+              <br>Flows Received: {{$NetflowListenerStatus.FlowCount}}
+              <br>
+              <br>
+            {{- end }}
+          </span>
         {{ end }}
-        <br>
         {{ if .netflowStats.ClosedListeners }}
-        <br>
         <span class="stat_subtitle">Closed Listener Details</span>
-        {{- range $index, $NetflowListenerStatus := .netflowStats.ClosedListenerDetails }}
-        BindHost: {{$NetflowListenerStatus.Config.BindHost}}
-        <br>FlowType: {{$NetflowListenerStatus.Config.FlowType}}
-        <br>Port: {{$NetflowListenerStatus.Config.Port}}
-        <br>Workers: {{$NetflowListenerStatus.Config.Workers}}
-        <br>Namespace: {{$NetflowListenerStatus.Config.Namespace}}
-        <br>Error: {{$NetflowListenerStatus.Error}}
-        <br>
-        <br>
-        {{- end }}
+          <span class="stat_subdata">
+          {{- range $index, $NetflowListenerStatus := .netflowStats.ClosedListenerDetails }}
+            BindHost: {{$NetflowListenerStatus.Config.BindHost}}
+            <br>FlowType: {{$NetflowListenerStatus.Config.FlowType}}
+            <br>Port: {{$NetflowListenerStatus.Config.Port}}
+            <br>Workers: {{$NetflowListenerStatus.Config.Workers}}
+            <br>Namespace: {{$NetflowListenerStatus.Config.Namespace}}
+            <br>Error: {{$NetflowListenerStatus.Error}}
+            <br>
+            <br>
+          {{- end }}
+          </span>
         {{ end }}
     </span>
 </div>

--- a/pkg/status/render/templates/netflow.tmpl
+++ b/pkg/status/render/templates/netflow.tmpl
@@ -2,33 +2,33 @@
 =========
 NetFlow
 =========
-Total Listeners: {{.TotalListeners}}
-Open Listeners: {{.OpenListeners}}
-Closed Listeners: {{.ClosedListeners}}
+  Total Listeners: {{.TotalListeners}}
+  Open Listeners: {{.OpenListeners}}
+  Closed Listeners: {{.ClosedListeners}}
 {{ if .OpenListeners }}
-=== Open Listener Details ===
-{{- range $index, $NetflowListenerStatus := .WorkingListenerDetails }}
----------
-BindHost: {{$NetflowListenerStatus.Config.BindHost}}
-FlowType: {{$NetflowListenerStatus.Config.FlowType}}
-Port: {{$NetflowListenerStatus.Config.Port}}
-Workers: {{$NetflowListenerStatus.Config.Workers}}
-Namespace: {{$NetflowListenerStatus.Config.Namespace}}
-Flows Received: {{$NetflowListenerStatus.FlowCount}}
----------
-{{- end }}
+  === Open Listener Details ===
+  {{- range $index, $NetflowListenerStatus := .WorkingListenerDetails }}
+    ---------
+      BindHost: {{$NetflowListenerStatus.Config.BindHost}}
+      FlowType: {{$NetflowListenerStatus.Config.FlowType}}
+      Port: {{$NetflowListenerStatus.Config.Port}}
+      Workers: {{$NetflowListenerStatus.Config.Workers}}
+      Namespace: {{$NetflowListenerStatus.Config.Namespace}}
+      Flows Received: {{$NetflowListenerStatus.FlowCount}}
+    ---------
+  {{- end }}
 {{ end }}
 
 {{ if .ClosedListeners }}
-=== Closed Listener Details ===
+  === Closed Listener Details ===
 {{- range $index, $NetflowListenerStatus := .ClosedListenerDetails }}
----------
-BindHost: {{$NetflowListenerStatus.Config.BindHost}}
-FlowType: {{$NetflowListenerStatus.Config.FlowType}}
-Port: {{$NetflowListenerStatus.Config.Port}}
-Workers: {{$NetflowListenerStatus.Config.Workers}}
-Namespace: {{$NetflowListenerStatus.Config.Namespace}}
-Error: {{$NetflowListenerStatus.Error}}
----------
+    ---------
+      BindHost: {{$NetflowListenerStatus.Config.BindHost}}
+      FlowType: {{$NetflowListenerStatus.Config.FlowType}}
+      Port: {{$NetflowListenerStatus.Config.Port}}
+      Workers: {{$NetflowListenerStatus.Config.Workers}}
+      Namespace: {{$NetflowListenerStatus.Config.Namespace}}
+      Error: {{$NetflowListenerStatus.Error}}
+    ---------
 {{- end }}
 {{ end }}


### PR DESCRIPTION
### What does this PR do?
Updates the formatting in the status page in both the GUI and CLI for NDM Netflow. The functionality should be exactly the same, but the spacing has been adjusted to match other integrations.

### Motivation
Noticed the spacing wasn't the same as other integrations during QA. See the updated formatting below:

<img width="521" alt="Screenshot 2023-11-20 at 4 15 51 PM" src="https://github.com/DataDog/datadog-agent/assets/103530259/9f43048d-0b5a-43f3-b117-8ac6a002f27e">

<img width="592" alt="Screenshot 2023-11-20 at 4 15 40 PM" src="https://github.com/DataDog/datadog-agent/assets/103530259/31e8b247-4021-4535-a7e5-06ab0849b979">

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
QA this change by adding a few Netflow listeners to your config:
```yaml
network_devices:
  netflow:
    enabled: true
    listeners:
      - flow_type: netflow5
        workers: 4
        port: 2056
      - flow_type: ipfix
        port: 5023
      - flow_type: netflow9
        port: 4066
      - flow_type: sflow5
        workers: 7
        port: 4077
```
To check closed listeners, bind an application to UDP on one or more of the ports configured in `datadog.yaml`. You can use this program to block UDP ports: https://gist.github.com/ken-schneider/c9fba5d8ba5b8cd82f007f31b7e69a48

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
