### PR TITLE
APL-2315 Add architecture in stack name to prevent lock issues

### DIFF
--- a/.gitlab/new-e2e_testing/debian.yml
+++ b/.gitlab/new-e2e_testing/debian.yml
@@ -12,9 +12,9 @@
 
 .new-e2e_debian_a7_arm64:
   variables:
-    E2E_OSVERS: "debian-10,debian-11,debian-12"
-    E2E_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
-    E2E_BRANCH_OSVERS: "debian-11"
+    E2E_OSVERS: "debian-10"
+    E2E_CWS_SUPPORTED_OSVERS: "debian-10"
+    E2E_BRANCH_OSVERS: "debian-10"
   needs: ["deploy_deb_testing-a7_arm64"]
 
 new-e2e-agent-platform-install-script-debian-a7-x64:
@@ -36,7 +36,7 @@ new-e2e-agent-platform-install-script-debian-a7-arm64:
   extends: 
     - .new_e2e_template
     - .new-e2e_os_debian
-    - .new-e2e_debian_a7_x64
+    - .new-e2e_debian_a7_arm64
     - .new-e2e_agent_a7
   rules:
     !reference [.on_all_new-e2e_tests_a7]

--- a/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
+++ b/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
@@ -77,7 +77,7 @@ func TestInstallScript(t *testing.T) {
 		t.Run(fmt.Sprintf("test install script on %s %s", osVers, *architecture), func(tt *testing.T) {
 			tt.Parallel()
 			fmt.Printf("Testing %s", osVers)
-			e2e.Run(tt, &installScriptSuite{cwsSupported: cwsSupported}, e2e.EC2VMStackDef(ec2params.WithImageName(platformJSON[*platform][*architecture][osVers], archMapping[*architecture], osMapping[*platform])), params.WithStackName(fmt.Sprintf("install-script-test-%v-%v", os.Getenv("CI_PIPELINE_ID"), osVers)))
+			e2e.Run(tt, &installScriptSuite{cwsSupported: cwsSupported}, e2e.EC2VMStackDef(ec2params.WithImageName(platformJSON[*platform][*architecture][osVers], archMapping[*architecture], osMapping[*platform])), params.WithStackName(fmt.Sprintf("install-script-test-%v-%v-%s", os.Getenv("CI_PIPELINE_ID"), osVers, *architecture)))
 		})
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Set a more precise stack name, to avoid lock conflict when running both ARM64 and AMD64 install script tests during the same time


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
