### PR TITLE
CI: install_script: forward the pipeline ID instead of path to repo

### DIFF
--- a/.gitlab/install_script_testing.yml
+++ b/.gitlab/install_script_testing.yml
@@ -7,10 +7,10 @@ test_install_script:
     - source /root/.bashrc
     - set +x
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
-    - export APT_URL=$DEB_TESTING_S3_BUCKET
-    - export YUM_URL=$RPM_TESTING_S3_BUCKET
+    - export TESTING_APT_URL=$DEB_TESTING_S3_BUCKET
+    - export TESTING_YUM_URL=$RPM_TESTING_S3_BUCKET
     - export TEST_PIPELINE_ID=$CI_PIPELINE_ID
-    - inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-linux-install-script" --git-ref "main" --variables "APT_URL,YUM_URL,TEST_PIPELINE_ID"
+    - inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-linux-install-script" --git-ref "main" --variables "TESTING_APT_URL,TESTING_YUM_URL,TEST_PIPELINE_ID"
   needs: ["deploy_deb_testing-a6_x64", "deploy_rpm_testing-a6_x64", "deploy_deb_testing-a7_x64", "deploy_rpm_testing-a7_x64"]
   rules:
     !reference [.on_deploy]

--- a/.gitlab/install_script_testing.yml
+++ b/.gitlab/install_script_testing.yml
@@ -9,11 +9,8 @@ test_install_script:
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
     - export APT_URL=$DEB_TESTING_S3_BUCKET
     - export YUM_URL=$RPM_TESTING_S3_BUCKET
-    - export APT_REPO_VERSION_AGENT6="pipeline-$CI_PIPELINE_ID-a6-x86_64 6"
-    - export YUM_VERSION_PATH_AGENT6="testing/pipeline-$CI_PIPELINE_ID-a6/6"
-    - export APT_REPO_VERSION_AGENT7="pipeline-$CI_PIPELINE_ID-a7-x86_64 7"
-    - export YUM_VERSION_PATH_AGENT7="testing/pipeline-$CI_PIPELINE_ID-a7/7"
-    - inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-linux-install-script" --git-ref "main" --variables "APT_URL,YUM_URL,APT_REPO_VERSION_AGENT6,APT_REPO_VERSION_AGENT7,YUM_VERSION_PATH_AGENT6,YUM_VERSION_PATH_AGENT7"
+    - export TEST_PIPELINE_ID=$CI_PIPELINE_ID
+    - inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-linux-install-script" --git-ref "main" --variables "APT_URL,YUM_URL,TEST_PIPELINE_ID"
   needs: ["deploy_deb_testing-a6_x64", "deploy_rpm_testing-a6_x64", "deploy_deb_testing-a7_x64", "deploy_rpm_testing-a7_x64"]
   rules:
     !reference [.on_deploy]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR replaces an explicit path to both APT and YUM repo by the pipeline ID, in order to let the agent-install-script CI compute the correct path.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This allows an easier split of the install script tests in 2 jobs in the install-script CI.

Required by https://github.com/DataDog/agent-linux-install-script/pull/114

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
