### PR TITLE
Move windows kitchen tests to 'functional_test' stage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -83,7 +83,7 @@
 /.gitlab/functional_test/security_agent.yml          @DataDog/agent-security @DataDog/agent-platform
 /.gitlab/functional_test/serverless.yml              @DataDog/serverless @DataDog/agent-platform
 /.gitlab/functional_test_cleanup.yml                 @DataDog/agent-security @DataDog/ebpf-platform @DataDog/agent-platform
-/.gitlab/functional_test/system_probe_windows.yml    @DataDog/ebpf-platform @DataDog/agent-platform @DataDog/windows-kernel-integrations
+/.gitlab/functional_test/system_probe_windows.yml    @DataDog/agent-platform @DataDog/windows-kernel-integrations
 /.gitlab/functional_test_sysprobe/system_probe.yml   @DataDog/ebpf-platform @DataDog/agent-platform
 
 /.gitlab/integration_test/windows.yml                @DataDog/agent-platform @DataDog/windows-agent

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -83,7 +83,7 @@
 /.gitlab/functional_test/security_agent.yml          @DataDog/agent-security @DataDog/agent-platform
 /.gitlab/functional_test/serverless.yml              @DataDog/serverless @DataDog/agent-platform
 /.gitlab/functional_test_cleanup.yml                 @DataDog/agent-security @DataDog/ebpf-platform @DataDog/agent-platform
-/.gitlab/functional_test/system_probe_windows.yml    @DataDog/ebpf-platform @DataDog/agent-platform @DataDog/windows-agent
+/.gitlab/functional_test/system_probe_windows.yml    @DataDog/ebpf-platform @DataDog/agent-platform @DataDog/windows-kernel-integrations
 /.gitlab/functional_test_sysprobe/system_probe.yml   @DataDog/ebpf-platform @DataDog/agent-platform
 
 /.gitlab/integration_test/windows.yml                @DataDog/agent-platform @DataDog/windows-agent

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -83,6 +83,7 @@
 /.gitlab/functional_test/security_agent.yml          @DataDog/agent-security @DataDog/agent-platform
 /.gitlab/functional_test/serverless.yml              @DataDog/serverless @DataDog/agent-platform
 /.gitlab/functional_test_cleanup.yml                 @DataDog/agent-security @DataDog/ebpf-platform @DataDog/agent-platform
+/.gitlab/functional_test/system_probe_windows.yml    @DataDog/ebpf-platform @DataDog/agent-platform @DataDog/windows-agent
 /.gitlab/functional_test_sysprobe/system_probe.yml   @DataDog/ebpf-platform @DataDog/agent-platform
 
 /.gitlab/integration_test/windows.yml                @DataDog/agent-platform @DataDog/windows-agent

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -84,6 +84,7 @@
 /.gitlab/functional_test/serverless.yml              @DataDog/serverless @DataDog/agent-platform
 /.gitlab/functional_test_cleanup.yml                 @DataDog/agent-security @DataDog/ebpf-platform @DataDog/agent-platform
 /.gitlab/functional_test/system_probe_windows.yml    @DataDog/agent-platform @DataDog/windows-kernel-integrations
+/.gitlab/functional_test/common.yml                  @DataDog/agent-platform @DataDog/windows-kernel-integrations @DataDog/ebpf-platform
 /.gitlab/functional_test_sysprobe/system_probe.yml   @DataDog/ebpf-platform @DataDog/agent-platform
 
 /.gitlab/integration_test/windows.yml                @DataDog/agent-platform @DataDog/windows-agent

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,6 +45,7 @@ include:
   - /.gitlab/notify.yml
   - /.gitlab/kitchen_common/cleanup.yml
   - /.gitlab/kitchen_common/testing.yml
+  - /.gitlab/functional_test/common.yml
   - /.gitlab/benchmarks/benchmarks.yml
   - /.gitlab/benchmarks/macrobenchmarks.yml
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -919,6 +919,7 @@ workflow:
         - test/kitchen/site-cookbooks/dd-system-probe-check/**/*
         - test/kitchen/test/integration/system-probe-test/**/*
         - test/kitchen/test/integration/win-sysprobe-test/**/*
+        - .gitlab/functional_test/system_probe_windows.yml
         - .gitlab/functional_test_sysprobe/system_probe.yml
         - .gitlab/kernel_version_testing/system_probe.yml
         - test/new-e2e/system-probe/**/*

--- a/.gitlab/functional_test.yml
+++ b/.gitlab/functional_test.yml
@@ -7,5 +7,6 @@ include:
   - /.gitlab/functional_test/serverless.yml
   - /.gitlab/functional_test/regression_detector.yml
   - /.gitlab/functional_test/workload_checks.yml
+  - /.gitlab/functional_test/system_probe_windows.yml
   - /.gitlab/kernel_version_testing/system_probe.yml
   - /.gitlab/functional_test_sysprobe/system_probe.yml

--- a/.gitlab/functional_test/common.yml
+++ b/.gitlab/functional_test/common.yml
@@ -11,7 +11,6 @@
     - .kitchen_datadog_agent_flavor
   rules:
     !reference [.on_system_probe_changes_or_manual]
-  stage: functional_test
   timeout: 3h
   variables:
     AGENT_MAJOR_VERSION: 7

--- a/.gitlab/functional_test/common.yml
+++ b/.gitlab/functional_test/common.yml
@@ -1,0 +1,19 @@
+---
+# FIXME: our current Gitlab version doesn't support importing a file more than once
+# For now, the workaround is to include "common" files once in the top-level .gitlab-ci.yml file
+# See: https://gitlab.com/gitlab-org/gitlab/-/issues/28987
+# include:
+#   - /.gitlab/kitchen_common/testing.yml
+
+.kitchen_test_system_probe:
+  extends:
+    - .kitchen_common
+    - .kitchen_datadog_agent_flavor
+  rules:
+    !reference [.on_system_probe_changes_or_manual]
+  stage: functional_test
+  timeout: 3h
+  variables:
+    AGENT_MAJOR_VERSION: 7
+    DD_PIPELINE_ID: $CI_PIPELINE_ID-fnct
+    CHEF_VERSION: 14.15.6

--- a/.gitlab/functional_test/system_probe_windows.yml
+++ b/.gitlab/functional_test/system_probe_windows.yml
@@ -6,19 +6,6 @@
 #   - /.gitlab/kitchen_common/testing.yml
 #   - /.gitlab/functional_test/common.yml
 
-.kitchen_test_system_probe:
-  extends:
-    - .kitchen_common
-    - .kitchen_datadog_agent_flavor
-  rules:
-    !reference [.on_system_probe_changes_or_manual]
-  stage: functional_test
-  timeout: 3h
-  variables:
-    AGENT_MAJOR_VERSION: 7
-    DD_PIPELINE_ID: $CI_PIPELINE_ID-fnct
-    CHEF_VERSION: 14.15.6
-
 kitchen_test_system_probe_windows_x64:
   extends:
     - .kitchen_agent_a7

--- a/.gitlab/functional_test/system_probe_windows.yml
+++ b/.gitlab/functional_test/system_probe_windows.yml
@@ -1,0 +1,40 @@
+---
+# FIXME: our current Gitlab version doesn't support importing a file more than once
+# For now, the workaround is to include "common" files once in the top-level .gitlab-ci.yml file
+# See: https://gitlab.com/gitlab-org/gitlab/-/issues/28987
+# include:
+#   - /.gitlab/kitchen_common/testing.yml
+
+.kitchen_test_system_probe:
+  extends:
+    - .kitchen_common
+    - .kitchen_datadog_agent_flavor
+  rules:
+    !reference [.on_system_probe_changes_or_manual]
+  stage: functional_test
+  timeout: 3h
+  variables:
+    AGENT_MAJOR_VERSION: 7
+    DD_PIPELINE_ID: $CI_PIPELINE_ID-fnct
+    CHEF_VERSION: 14.15.6
+
+kitchen_test_system_probe_windows_x64:
+  extends:
+    - .kitchen_agent_a7
+    - .kitchen_os_windows
+    - .kitchen_test_system_probe
+    - .kitchen_azure_x64
+    - .kitchen_azure_location_north_central_us
+  needs: [ "tests_windows_sysprobe_x64" ]
+  variables:
+    KITCHEN_ARCH: x86_64
+    KITCHEN_OSVERS: "win2016"
+    CHEF_VERSION: 14.12.9 # newer versions error out during kitchen setup of azure VM
+  before_script:
+    - export WINDOWS_DDNPM_DRIVER=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDNPM_DRIVER")
+    - export WINDOWS_DDNPM_VERSION=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDNPM_VERSION")
+    - export WINDOWS_DDNPM_SHASUM=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDNPM_SHASUM")
+    - pushd $DD_AGENT_TESTING_DIR
+    - tasks/kitchen_setup.sh
+  script:
+    - tasks/run-test-kitchen.sh windows-sysprobe-test $AGENT_MAJOR_VERSION

--- a/.gitlab/functional_test/system_probe_windows.yml
+++ b/.gitlab/functional_test/system_probe_windows.yml
@@ -4,6 +4,7 @@
 # See: https://gitlab.com/gitlab-org/gitlab/-/issues/28987
 # include:
 #   - /.gitlab/kitchen_common/testing.yml
+#   - /.gitlab/functional_test/common.yml
 
 .kitchen_test_system_probe:
   extends:

--- a/.gitlab/functional_test/system_probe_windows.yml
+++ b/.gitlab/functional_test/system_probe_windows.yml
@@ -13,6 +13,7 @@ kitchen_test_system_probe_windows_x64:
     - .kitchen_test_system_probe
     - .kitchen_azure_x64
     - .kitchen_azure_location_north_central_us
+  stage: functional_test
   needs: [ "tests_windows_sysprobe_x64" ]
   variables:
     KITCHEN_ARCH: x86_64

--- a/.gitlab/functional_test_sysprobe/system_probe.yml
+++ b/.gitlab/functional_test_sysprobe/system_probe.yml
@@ -180,24 +180,3 @@ kitchen_test_system_probe_linux_arm64:
         KITCHEN_OSVERS: "ubuntu-23-04"
       - KITCHEN_PLATFORM: "ubuntu"
         KITCHEN_OSVERS: "ubuntu-23-10"
-
-kitchen_test_system_probe_windows_x64:
-  extends:
-    - .kitchen_agent_a7
-    - .kitchen_os_windows
-    - .kitchen_test_system_probe
-    - .kitchen_azure_x64
-    - .kitchen_azure_location_north_central_us
-  needs: [ "tests_windows_sysprobe_x64" ]
-  variables:
-    KITCHEN_ARCH: x86_64
-    KITCHEN_OSVERS: "win2016"
-    CHEF_VERSION: 14.12.9 # newer versions error out during kitchen setup of azure VM
-  before_script:
-    - export WINDOWS_DDNPM_DRIVER=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDNPM_DRIVER")
-    - export WINDOWS_DDNPM_VERSION=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDNPM_VERSION")
-    - export WINDOWS_DDNPM_SHASUM=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDNPM_SHASUM")
-    - pushd $DD_AGENT_TESTING_DIR
-    - tasks/kitchen_setup.sh
-  script:
-    - tasks/run-test-kitchen.sh windows-sysprobe-test $AGENT_MAJOR_VERSION

--- a/.gitlab/functional_test_sysprobe/system_probe.yml
+++ b/.gitlab/functional_test_sysprobe/system_probe.yml
@@ -9,6 +9,7 @@
 .kitchen_test_system_probe_linux:
   extends:
     - .kitchen_test_system_probe
+  stage: functional_test_sysprobe
   before_script:
     - echo "CI_JOB_URL=${CI_JOB_URL}" >> $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/job_env.txt
     - echo "CI_JOB_ID=${CI_JOB_ID}" >> $DD_AGENT_TESTING_DIR/site-cookbooks/dd-system-probe-check/files/job_env.txt

--- a/.gitlab/functional_test_sysprobe/system_probe.yml
+++ b/.gitlab/functional_test_sysprobe/system_probe.yml
@@ -4,19 +4,7 @@
 # See: https://gitlab.com/gitlab-org/gitlab/-/issues/28987
 # include:
 #   - /.gitlab/kitchen_common/testing.yml
-
-.kitchen_test_system_probe:
-  extends:
-    - .kitchen_common
-    - .kitchen_datadog_agent_flavor
-  rules:
-    !reference [.on_system_probe_changes_or_manual]
-  stage: functional_test_sysprobe
-  timeout: 3h
-  variables:
-    AGENT_MAJOR_VERSION: 7
-    DD_PIPELINE_ID: $CI_PIPELINE_ID-fnct
-    CHEF_VERSION: 14.15.6
+#   - /.gitlab/functional_test/common.yml
 
 .kitchen_test_system_probe_linux:
   extends:

--- a/tasks/unit-tests/testdata/fake_gitlab-ci.yml
+++ b/tasks/unit-tests/testdata/fake_gitlab-ci.yml
@@ -906,6 +906,7 @@ workflow:
         - test/kitchen/site-cookbooks/dd-system-probe-check/**/*
         - test/kitchen/test/integration/system-probe-test/**/*
         - test/kitchen/test/integration/win-sysprobe-test/**/*
+        - .gitlab/functional_test/system_probe_windows.yml
         - .gitlab/functional_test_sysprobe/system_probe.yml
         - .gitlab/kernel_version_testing/system_probe.yml
         - test/new-e2e/system-probe/**/*


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?
This PR separates into different stages windows `functional tests` and eBPF `functional tests`.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
To get accurate time to feedback comparisons between kitchen based testing setup and KMT.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
