### PR TITLE
[CONTINT-3386] Cleanup K8S APIClient clients and informers, fix short watch on Helm and Orch. Explorer informers

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -162,7 +162,7 @@ func start(log log.Component, config config.Component, telemetry telemetry.Compo
 	}()
 
 	// Setup healthcheck port
-	var healthPort = pkgconfig.Datadog.GetInt("health_port")
+	healthPort := pkgconfig.Datadog.GetInt("health_port")
 	if healthPort > 0 {
 		err := healthprobe.Serve(mainCtx, healthPort)
 		if err != nil {
@@ -232,15 +232,13 @@ func start(log log.Component, config config.Component, telemetry telemetry.Compo
 	eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "datadog-cluster-agent"})
 
 	ctx := apiserver.ControllerContext{
-		InformerFactory:    apiCl.InformerFactory,
-		WPAClient:          apiCl.WPAClient,
-		WPAInformerFactory: apiCl.WPAInformerFactory,
-		DDClient:           apiCl.DDClient,
-		DDInformerFactory:  apiCl.DynamicInformerFactory,
-		Client:             apiCl.Cl,
-		IsLeaderFunc:       le.IsLeader,
-		EventRecorder:      eventRecorder,
-		StopCh:             stopCh,
+		InformerFactory:        apiCl.InformerFactory,
+		DynamicClient:          apiCl.DynamicInformerCl,
+		DynamicInformerFactory: apiCl.DynamicInformerFactory,
+		Client:                 apiCl.InformerCl,
+		IsLeaderFunc:           le.IsLeader,
+		EventRecorder:          eventRecorder,
+		StopCh:                 stopCh,
 	}
 
 	if aggErr := apiserver.StartControllers(ctx); aggErr != nil {
@@ -344,7 +342,6 @@ func start(log log.Component, config config.Component, telemetry telemetry.Compo
 			SecretInformers:     apiCl.CertificateSecretInformerFactory,
 			WebhookInformers:    apiCl.WebhookConfigInformerFactory,
 			Client:              apiCl.Cl,
-			DiscoveryClient:     apiCl.DiscoveryCl,
 			StopCh:              stopCh,
 		}
 

--- a/cmd/cluster-agent/subcommands/start/compliance.go
+++ b/cmd/cluster-agent/subcommands/start/compliance.go
@@ -124,7 +124,7 @@ func startCompliance(senderManager sender.SenderManager, stopper startstop.Stopp
 func wrapKubernetesClient(apiCl *apiserver.APIClient, isLeader func() bool) compliance.KubernetesProvider {
 	return func(ctx context.Context) (dynamic.Interface, discovery.DiscoveryInterface, error) {
 		if isLeader() {
-			return apiCl.DynamicCl, apiCl.DiscoveryCl, nil
+			return apiCl.DynamicCl, apiCl.Cl.Discovery(), nil
 		}
 		return nil, nil, compliance.ErrIncompatibleEnvironment
 	}

--- a/cmd/security-agent/subcommands/check/command.go
+++ b/cmd/security-agent/subcommands/check/command.go
@@ -239,7 +239,7 @@ func dumpComplianceEvents(reportFile string, events []*compliance.CheckEvent) er
 	if err != nil {
 		return fmt.Errorf("could not marshal events map: %w", err)
 	}
-	if err := os.WriteFile(reportFile, b, 0644); err != nil {
+	if err := os.WriteFile(reportFile, b, 0o644); err != nil {
 		return fmt.Errorf("could not write report file in %q: %w", reportFile, err)
 	}
 	return nil
@@ -275,7 +275,7 @@ func complianceKubernetesProvider(_ctx context.Context) (dynamic.Interface, disc
 	if err != nil {
 		return nil, nil, err
 	}
-	return apiCl.DynamicCl, apiCl.DiscoveryCl, nil
+	return apiCl.DynamicCl, apiCl.Cl.Discovery(), nil
 }
 
 type fakeResolver struct {

--- a/pkg/clusteragent/admission/start.go
+++ b/pkg/clusteragent/admission/start.go
@@ -18,7 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -31,7 +30,6 @@ type ControllerContext struct {
 	SecretInformers     informers.SharedInformerFactory
 	WebhookInformers    informers.SharedInformerFactory
 	Client              kubernetes.Interface
-	DiscoveryClient     discovery.DiscoveryInterface
 	StopCh              chan struct{}
 }
 
@@ -58,12 +56,12 @@ func StartControllers(ctx ControllerContext) error {
 		secretConfig,
 	)
 
-	nsSelectorEnabled, err := useNamespaceSelector(ctx.DiscoveryClient)
+	nsSelectorEnabled, err := useNamespaceSelector(ctx.Client.Discovery())
 	if err != nil {
 		return err
 	}
 
-	v1Enabled, err := UseAdmissionV1(ctx.DiscoveryClient)
+	v1Enabled, err := UseAdmissionV1(ctx.Client.Discovery())
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/cluster/helm/helm.go
+++ b/pkg/collector/corechecks/cluster/helm/helm.go
@@ -31,6 +31,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 const (
@@ -119,7 +120,6 @@ func (hc *HelmCheck) Configure(senderManager sender.SenderManager, integrationCo
 
 	hc.setSharedInformerFactory(apiClient)
 	hc.startTS = time.Now()
-
 	hc.informersStopCh = make(chan struct{})
 
 	return nil
@@ -205,13 +205,11 @@ func (hc *HelmCheck) setupInformers() error {
 }
 
 func (hc *HelmCheck) setSharedInformerFactory(apiClient *apiserver.APIClient) {
-	hc.informerFactory = informers.NewSharedInformerFactoryWithOptions(
-		apiClient.Cl,
-		hc.getInformersResyncPeriod(),
+	hc.informerFactory = apiClient.GetInformerWithOptions(
+		pointer.Ptr(hc.getInformersResyncPeriod()),
 		informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
 			opts.LabelSelector = labelSelector
-		}),
-	)
+		}))
 }
 
 func (hc *HelmCheck) allTags(release *release, storageDriver helmStorage, includeRevision bool) []string {

--- a/pkg/collector/corechecks/cluster/ksm/customresources/apiservice.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/apiservice.go
@@ -35,7 +35,7 @@ var (
 // NewAPIServiceFactory returns a new APIService metric family generator factory.
 func NewAPIServiceFactory(client *apiserver.APIClient) customresource.RegistryFactory {
 	return &apiserviceFactory{
-		client: client.APISClient,
+		client: client.APISInformerClient,
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/ksm/customresources/crd.go
+++ b/pkg/collector/corechecks/cluster/ksm/customresources/crd.go
@@ -40,7 +40,7 @@ var (
 // metric family generator factory.
 func NewCustomResourceDefinitionFactory(client *apiserver.APIClient) customresource.RegistryFactory {
 	return &crdFactory{
-		client: client.CRDClient,
+		client: client.CRDInformerClient,
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -250,7 +250,7 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 	}
 
 	// Discover resources that are currently available
-	resources, err := discoverResources(c.DiscoveryCl)
+	resources, err := discoverResources(c.Cl.Discovery())
 	if err != nil {
 		return err
 	}
@@ -296,9 +296,9 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 
 	builder.WithFamilyGeneratorFilter(allowDenyList)
 
-	builder.WithKubeClient(c.Cl)
+	builder.WithKubeClient(c.InformerCl)
 
-	builder.WithVPAClient(c.VPAClient)
+	builder.WithVPAClient(c.VPAInformerClient)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	k.cancel = cancel
@@ -419,11 +419,6 @@ func (k *KSMCheck) discoverCustomResources(c *apiserver.APIClient, collectors []
 }
 
 func manageResourcesReplacement(c *apiserver.APIClient, factories []customresource.RegistryFactory, resources []*v1.APIResourceList) []customresource.RegistryFactory {
-	if c.DiscoveryCl == nil {
-		log.Warn("Kubernetes discovery client has not been properly initialized")
-		return factories
-	}
-
 	// backwards/forwards compatibility resource factories are only
 	// registered if they're needed, otherwise they'd overwrite the default
 	// ones that ship with ksm

--- a/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery.go
@@ -45,7 +45,6 @@ func NewAPIServerDiscoveryProvider() *APIServerDiscoveryProvider {
 // Discover returns collectors to enable based on information exposed by the API server.
 func (p *APIServerDiscoveryProvider) Discover(inventory *inventory.CollectorInventory) ([]collectors.Collector, error) {
 	groups, resources, err := GetServerGroupsAndResources()
-
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +74,7 @@ func GetServerGroupsAndResources() ([]*v1.APIGroup, []*v1.APIResourceList, error
 		return nil, nil, err
 	}
 
-	groups, resources, err := client.DiscoveryCl.ServerGroupsAndResources()
+	groups, resources, err := client.Cl.Discovery().ServerGroupsAndResources()
 	if err != nil {
 		if !discovery.IsGroupDiscoveryFailedError(err) {
 			return nil, nil, err

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -203,16 +203,17 @@ func (o *OrchestratorCheck) Cancel() {
 }
 
 func getOrchestratorInformerFactory(apiClient *apiserver.APIClient) *collectors.OrchestratorInformerFactory {
-	of := &collectors.OrchestratorInformerFactory{
-		InformerFactory:        informers.NewSharedInformerFactory(apiClient.Cl, defaultResyncInterval),
-		CRDInformerFactory:     externalversions.NewSharedInformerFactory(apiClient.CRDClient, defaultResyncInterval),
-		DynamicInformerFactory: dynamicinformer.NewDynamicSharedInformerFactory(apiClient.DynamicCl, defaultResyncInterval),
-		VPAInformerFactory:     vpai.NewSharedInformerFactory(apiClient.VPAClient, defaultResyncInterval),
-	}
-
 	tweakListOptions := func(options *metav1.ListOptions) {
 		options.FieldSelector = fields.OneTermEqualSelector("spec.nodeName", "").String()
 	}
-	of.UnassignedPodInformerFactory = informers.NewSharedInformerFactoryWithOptions(apiClient.Cl, defaultResyncInterval, informers.WithTweakListOptions(tweakListOptions))
+
+	of := &collectors.OrchestratorInformerFactory{
+		InformerFactory:              informers.NewSharedInformerFactoryWithOptions(apiClient.InformerCl, defaultResyncInterval),
+		CRDInformerFactory:           externalversions.NewSharedInformerFactory(apiClient.CRDInformerClient, defaultResyncInterval),
+		DynamicInformerFactory:       dynamicinformer.NewDynamicSharedInformerFactory(apiClient.DynamicInformerCl, defaultResyncInterval),
+		VPAInformerFactory:           vpai.NewSharedInformerFactory(apiClient.VPAInformerClient, defaultResyncInterval),
+		UnassignedPodInformerFactory: informers.NewSharedInformerFactoryWithOptions(apiClient.InformerCl, defaultResyncInterval, informers.WithTweakListOptions(tweakListOptions)),
+	}
+
 	return of
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator_test.go
@@ -55,7 +55,7 @@ func TestOrchestratorCheckSafeReSchedule(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	vpaClient := vpa.NewSimpleClientset()
 	crdClient := crd.NewSimpleClientset()
-	cl := &apiserver.APIClient{Cl: client, VPAClient: vpaClient, CRDClient: crdClient}
+	cl := &apiserver.APIClient{InformerCl: client, VPAInformerClient: vpaClient, CRDInformerClient: crdClient}
 	orchCheck := OrchestratorFactory().(*OrchestratorCheck)
 	orchCheck.apiClient = cl
 
@@ -85,7 +85,6 @@ func TestOrchestratorCheckSafeReSchedule(t *testing.T) {
 	writeNode(t, client, "2")
 
 	assert.True(t, waitTimeout(&wg, 2*time.Second))
-
 }
 
 func writeNode(t *testing.T, client *fake.Clientset, version string) {

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -644,6 +644,7 @@ func InitConfig(config pkgconfigmodel.Config) {
 	config.BindEnvAndSetDefault("kubernetes_collect_metadata_tags", true)
 	config.BindEnvAndSetDefault("kubernetes_metadata_tag_update_freq", 60) // Polling frequency of the Agent to the DCA in seconds (gets the local cache if the DCA is disabled)
 	config.BindEnvAndSetDefault("kubernetes_apiserver_client_timeout", 10)
+	config.BindEnvAndSetDefault("kubernetes_apiserver_informer_client_timeout", 0)
 	config.BindEnvAndSetDefault("kubernetes_map_services_on_ip", false) // temporary opt-out of the new mapping logic
 	config.BindEnvAndSetDefault("kubernetes_apiserver_use_protobuf", false)
 	config.BindEnvAndSetDefault("kubernetes_ad_tags_disabled", []string{})

--- a/pkg/util/kubernetes/apiserver/apiserver_kubelet.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_kubelet.go
@@ -16,13 +16,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 // NodeMetadataMapping only fetch the endpoints from Kubernetes apiserver and add the metadataMapper of the
 // node to the cache
 // Only called when the node agent computes the metadata mapper locally and does not rely on the DCA.
 func (c *APIClient) NodeMetadataMapping(nodeName string, pods []*kubelet.Pod) error {
-	endpointList, err := c.Cl.CoreV1().Endpoints("").List(context.TODO(), metav1.ListOptions{TimeoutSeconds: &c.timeoutSeconds, ResourceVersion: "0"})
+	endpointList, err := c.Cl.CoreV1().Endpoints("").List(context.TODO(), metav1.ListOptions{TimeoutSeconds: pointer.Ptr(int64(c.defaultClientTimeout.Seconds())), ResourceVersion: "0"})
 	if err != nil {
 		log.Errorf("Could not collect endpoints from the API Server: %q", err.Error())
 		return err

--- a/pkg/util/kubernetes/apiserver/controllers.go
+++ b/pkg/util/kubernetes/apiserver/controllers.go
@@ -53,16 +53,14 @@ var controllerCatalog = map[controllerName]controllerFuncs{
 
 // ControllerContext holds all the attributes needed by the controllers
 type ControllerContext struct {
-	informers          map[InformerName]cache.SharedInformer
-	InformerFactory    informers.SharedInformerFactory
-	WPAClient          dynamic.Interface
-	WPAInformerFactory dynamicinformer.DynamicSharedInformerFactory
-	DDClient           dynamic.Interface
-	DDInformerFactory  dynamicinformer.DynamicSharedInformerFactory
-	Client             kubernetes.Interface
-	IsLeaderFunc       func() bool
-	EventRecorder      record.EventRecorder
-	StopCh             chan struct{}
+	informers              map[InformerName]cache.SharedInformer
+	InformerFactory        informers.SharedInformerFactory
+	DynamicClient          dynamic.Interface
+	DynamicInformerFactory dynamicinformer.DynamicSharedInformerFactory
+	Client                 kubernetes.Interface
+	IsLeaderFunc           func() bool
+	EventRecorder          record.EventRecorder
+	StopCh                 chan struct{}
 }
 
 // StartControllers runs the enabled Kubernetes controllers for the Datadog Cluster Agent. This is
@@ -146,8 +144,9 @@ func startAutoscalersController(ctx ControllerContext, c chan error) {
 		c <- err
 		return
 	}
-	if ctx.WPAInformerFactory != nil {
-		go autoscalersController.RunWPA(ctx.StopCh, ctx.WPAClient, ctx.WPAInformerFactory)
+
+	if config.Datadog.GetBool("external_metrics_provider.wpa_controller") {
+		go autoscalersController.RunWPA(ctx.StopCh, ctx.DynamicClient, ctx.DynamicInformerFactory)
 	}
 
 	autoscalersController.enableHPA(ctx.Client, ctx.InformerFactory)

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -153,7 +153,7 @@ func (le *LeaderEngine) init() error {
 		return err
 	}
 
-	serverVersion, err := common.KubeServerVersion(apiClient.DiscoveryCl, 10*time.Second)
+	serverVersion, err := common.KubeServerVersion(apiClient.Cl.Discovery(), 10*time.Second)
 	if err == nil && semver.IsValid(serverVersion.String()) && semver.Compare(serverVersion.String(), "v1.14.0") < 0 {
 		log.Warn("[DEPRECATION WARNING] DataDog will drop support of Kubernetes older than v1.14. Please update to a newer version to ensure proper functionality and security.")
 	}
@@ -161,7 +161,7 @@ func (le *LeaderEngine) init() error {
 	le.coreClient = apiClient.Cl.CoreV1()
 	le.coordClient = apiClient.Cl.CoordinationV1()
 
-	usingLease, err := CanUseLeases(apiClient.DiscoveryCl)
+	usingLease, err := CanUseLeases(apiClient.Cl.Discovery())
 	if err != nil {
 		log.Errorf("Unable to retrieve available resources: %v", err)
 		return err
@@ -349,7 +349,7 @@ func GetLeaderElectionRecord() (leaderDetails rl.LeaderElectionRecord, err error
 	if err != nil {
 		return led, err
 	}
-	usingLease, err := CanUseLeases(client.DiscoveryCl)
+	usingLease, err := CanUseLeases(client.Cl.Discovery())
 	if err != nil {
 		return led, err
 	}

--- a/pkg/util/kubernetes/apiserver/metadata_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/metadata_controller_test.go
@@ -450,7 +450,7 @@ func TestMetadataController(t *testing.T) {
 		return true
 	})
 
-	cl := &APIClient{Cl: client, timeoutSeconds: 5}
+	cl := &APIClient{Cl: client, defaultClientTimeout: 5}
 
 	testutil.AssertTrueBeforeTimeout(t, 100*time.Millisecond, 2*time.Second, func() bool {
 		fullmapper, errList := GetMetadataMapBundleOnAllNodes(cl)
@@ -465,7 +465,6 @@ func TestMetadataController(t *testing.T) {
 		assert.Contains(t, services, "nginx-1")
 		return true
 	})
-
 }
 
 func newFakeMetadataController(client kubernetes.Interface) (*MetadataController, informers.SharedInformerFactory) {

--- a/pkg/util/kubernetes/apiserver/roundtrip.go
+++ b/pkg/util/kubernetes/apiserver/roundtrip.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -27,10 +26,10 @@ type CustomRoundTripper struct {
 
 // NewCustomRoundTripper creates a new CustomRoundTripper with the apiserver timeout value already populated from the
 // agent config, wrapping an existing http.RoundTripper.
-func NewCustomRoundTripper(rt http.RoundTripper) *CustomRoundTripper {
+func NewCustomRoundTripper(rt http.RoundTripper, timeout time.Duration) *CustomRoundTripper {
 	return &CustomRoundTripper{
 		rt:      rt,
-		timeout: config.Datadog.GetInt64("kubernetes_apiserver_client_timeout"),
+		timeout: int64(timeout.Seconds()),
 	}
 }
 

--- a/releasenotes-dca/notes/fix-long-watch-short-cac006ec56e97970.yaml
+++ b/releasenotes-dca/notes/fix-long-watch-short-cac006ec56e97970.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes a bug that would trigger unnecessary APIServer `List` requests from the Cluster Agent or Cluster Checks Runner.


### PR DESCRIPTION
### What does this PR do?

This PR tries to (partially) cleanup usage of shared K8S Clients and informers.
It introduces a dedicated set of clients for informers and clients for CRUD operations, the only difference being client timeout.

### Motivation

Reduce number of `List` queries done to APIServer in ~all cases. Most important on List with filtering (requiring a full re-list on APIServer side).

### Additional Notes

### Possible Drawbacks / Trade-offs

A variable is added to define long watch timeout, set to `0` currently (no timeout).

Note that the APIServer may choose to timeout connections whenever it sees fit, it may trigger unwanted logs due to the custom `RoundTripper`, needs to be verified.

### Describe how to test/QA your changes

We can verify the volume of queries made is reduced internally (see CONTINT-3386).
Non regression on KSM Core, Orch Explorer (especially CRD, unassigned pods and apiservices), External Metrics with and without CRD.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
