### PR TITLE
Kacper murzyn/rc automatic deployments (#20929)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,6 +47,7 @@ include:
   - /.gitlab/kitchen_common/testing.yml
   - /.gitlab/benchmarks/benchmarks.yml
   - /.gitlab/benchmarks/macrobenchmarks.yml
+  - /.gitlab/rc_kubernetes_deploy.yml
 
 default:
   retry:

--- a/.gitlab/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_kubernetes_deploy.yml
@@ -7,7 +7,6 @@ rc_kubernetes_deploy:
   rules:
   - if: $RC_K8S_DEPLOYMENTS == "true"
     when: always
-  - !reference [.on_deploy_a7]
   needs:
   - job: docker_trigger_internal
     artifacts: false

--- a/.gitlab/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_kubernetes_deploy.yml
@@ -1,0 +1,30 @@
+---
+# internal_kubernetes_deploy stage
+# Contains jobs to trigger a pipeline in our k8s-datadog-agent-ops repo to deploy release candidate build
+
+rc_kubernetes_deploy:
+  stage: internal_kubernetes_deploy
+  rules:
+  - if: $RC_K8S_DEPLOYMENTS == "true"
+    when: always
+  - !reference [.on_deploy_a7]
+  needs:
+  - job: docker_trigger_internal
+    artifacts: false
+  - job: docker_trigger_cluster_agent_internal
+    artifacts: false
+  - job: k8s-e2e-main # Currently only require container Argo workflow
+    artifacts: false
+    optional: true
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  variables:
+    OPTION_AUTOMATIC_ROLLOUT: "true"
+    OPTION_PRE_SCRIPT: "patch-cluster-images-operator.sh env=all-staging ${CI_COMMIT_REF_SLUG}-jmx ${CI_COMMIT_REF_SLUG}"
+    SKIP_PLAN_CHECK: "true"
+    EXPLICIT_WORKFLOWS: "//workflows:deploy_rc.agents_rc"
+  script:
+    - source /root/.bashrc
+    - set +x
+    - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
+    - inv pipeline.trigger-child-pipeline --project-name "DataDog/k8s-datadog-agent-ops" --git-ref "main" --variables "OPTION_AUTOMATIC_ROLLOUT,EXPLICIT_WORKFLOWS,OPTION_PRE_SCRIPT,SKIP_PLAN_CHECK" --no-follow

--- a/tasks/libs/pipeline_tools.py
+++ b/tasks/libs/pipeline_tools.py
@@ -88,6 +88,7 @@ def trigger_agent_pipeline(
     deploy=False,
     all_builds=False,
     kitchen_tests=False,
+    rc_k8s_deployments=False,
 ):
     """
     Trigger a pipeline on the datadog-agent repositories. Multiple options are available:
@@ -122,6 +123,9 @@ def trigger_agent_pipeline(
 
     if branch is not None:
         args["BUCKET_BRANCH"] = branch
+
+    if rc_k8s_deployments:
+        args["RC_K8S_DEPLOYMENTS"] = "true"
 
     print(
         "Creating pipeline for datadog-agent on branch/tag {} with args:\n{}".format(  # noqa: FS002

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -211,6 +211,7 @@ def run(
     deploy=False,
     all_builds=True,
     kitchen_tests=True,
+    rc_k8s_deployments=False,
 ):
     """
     Run a pipeline on the given git ref (--git-ref <git ref>), or on the current branch if --here is given.
@@ -311,6 +312,7 @@ def run(
             deploy=deploy,
             all_builds=all_builds,
             kitchen_tests=kitchen_tests,
+            rc_k8s_deployments=rc_k8s_deployments,
         )
     except FilteredOutException:
         print(color_message(f"ERROR: pipeline does not match any workflow rule. Rules:\n{workflow_rules()}", "red"))

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1132,10 +1132,12 @@ Make sure that milestone is open before trying again.""",
 
 
 @task
-def build_rc(ctx, major_versions="6,7", patch_version=False):
+def build_rc(ctx, major_versions="6,7", patch_version=False, k8s_deployments=False):
     """
     To be done after the PR created by release.create-rc is merged, with the same options
     as release.create-rc.
+
+    k8s_deployments - when set to True the child pipeline deploying to subset of k8s staging clusters will be triggered.
 
     Tags the new RC versions on the current commit, and creates the build pipeline for these
     new tags.
@@ -1206,6 +1208,7 @@ def build_rc(ctx, major_versions="6,7", patch_version=False):
         major_versions=major_versions,
         repo_branch="beta",
         deploy=True,
+        rc_k8s_deployments=k8s_deployments,
     )
 
 


### PR DESCRIPTION
This PR backports https://github.com/DataDog/datadog-agent/pull/20929 to `7.50.x` branch, so it is possible to test automatic deployments on next 7.50.0 RC build.