### PR TITLE
[SEC-11716][CWS] scrub `*token*` pattern from process args

### DIFF
--- a/pkg/security/probe/probe_linux.go
+++ b/pkg/security/probe/probe_linux.go
@@ -34,7 +34,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/ebpfcheck"
 	aconfig "github.com/DataDog/datadog-agent/pkg/config"
 	commonebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
-	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
@@ -1685,8 +1684,7 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 		p.managerOptions.AdditionalExcludedFunctionCollector = afBasedExcluder
 	}
 
-	p.scrubber = procutil.NewDefaultDataScrubber()
-	p.scrubber.AddCustomSensitiveWords(config.Probe.CustomSensitiveWords)
+	p.scrubber = newProcScrubber(config.Probe.CustomSensitiveWords)
 
 	resolversOpts := resolvers.Opts{
 		PathResolutionEnabled: opts.PathResolutionEnabled,

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -199,8 +199,7 @@ func NewProbe(config *config.Config, opts Opts) (*Probe, error) {
 		},
 	}
 
-	p.scrubber = procutil.NewDefaultDataScrubber()
-	p.scrubber.AddCustomSensitiveWords(config.Probe.CustomSensitiveWords)
+	p.scrubber = newProcScrubber(config.Probe.CustomSensitiveWords)
 
 	resolvers, err := resolvers.NewResolvers(config, p.StatsdClient, p.scrubber)
 	if err != nil {

--- a/pkg/security/probe/scrubber.go
+++ b/pkg/security/probe/scrubber.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package probe holds probe related files
+package probe
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
+	"golang.org/x/exp/slices"
+)
+
+func newProcScrubber(customSensitiveWords []string) *procutil.DataScrubber {
+	scrubber := procutil.NewDefaultDataScrubber()
+	scrubber.AddCustomSensitiveWords(customSensitiveWords)
+
+	// token is not always a sensitive word so we cannot change the default sensitive patterns
+	// in the case of CWS we can assume token is something we want to scrub so we add it here
+	additionals := []string{"*token*"}
+	for _, additional := range additionals {
+		if !slices.Contains(customSensitiveWords, additional) {
+			scrubber.AddCustomSensitiveWords([]string{additional})
+		}
+	}
+
+	return scrubber
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

This PR includes in the data scrubber a more general matching for tokens. The target underlying this PR is to handle cases like
```
kubectl cmd --token abcd
```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
