### PR TITLE
process scrubber: introduce `processCacheKey` instead of allocating a string key

### DIFF
--- a/pkg/process/procutil/data_scrubber.go
+++ b/pkg/process/procutil/data_scrubber.go
@@ -8,7 +8,6 @@ package procutil
 import (
 	"bytes"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -26,6 +25,11 @@ const (
 	defaultCacheMaxCycles = 25
 )
 
+type processCacheKey struct {
+	pid        int32
+	createTime int64
+}
+
 type DataScrubberPattern struct {
 	FastCheck string
 	Re        *regexp.Regexp
@@ -37,8 +41,8 @@ type DataScrubber struct {
 	Enabled           bool
 	StripAllArguments bool
 	SensitivePatterns []DataScrubberPattern
-	seenProcess       map[string]struct{}
-	scrubbedCmdlines  map[string][]string
+	seenProcess       map[processCacheKey]struct{}
+	scrubbedCmdlines  map[processCacheKey][]string
 	cacheCycles       uint32 // used to control the cache age
 	cacheMaxCycles    uint32 // number of cycles before resetting the cache content
 }
@@ -50,8 +54,8 @@ func NewDefaultDataScrubber() *DataScrubber {
 	newDataScrubber := &DataScrubber{
 		Enabled:           true,
 		SensitivePatterns: patterns,
-		seenProcess:       make(map[string]struct{}),
-		scrubbedCmdlines:  make(map[string][]string),
+		seenProcess:       make(map[processCacheKey]struct{}),
+		scrubbedCmdlines:  make(map[processCacheKey][]string),
 		cacheCycles:       0,
 		cacheMaxCycles:    defaultCacheMaxCycles,
 	}
@@ -118,14 +122,11 @@ func CompileStringsToRegex(words []string) []DataScrubberPattern {
 }
 
 // createProcessKey returns an unique identifier for a given process
-func createProcessKey(p *Process) string {
-	var b bytes.Buffer
-	b.WriteString("p:")
-	b.WriteString(strconv.Itoa(int(p.Pid)))
-	b.WriteString("|c:")
-	b.WriteString(strconv.Itoa(int(p.Stats.CreateTime)))
-
-	return b.String()
+func createProcessKey(p *Process) processCacheKey {
+	return processCacheKey{
+		pid:        p.Pid,
+		createTime: p.Stats.CreateTime,
+	}
 }
 
 // ScrubProcessCommand uses a cache memory to avoid scrubbing already known
@@ -158,8 +159,8 @@ func (ds *DataScrubber) ScrubProcessCommand(p *Process) []string {
 func (ds *DataScrubber) IncrementCacheAge() {
 	ds.cacheCycles++
 	if ds.cacheCycles == ds.cacheMaxCycles {
-		ds.seenProcess = make(map[string]struct{})
-		ds.scrubbedCmdlines = make(map[string][]string)
+		ds.seenProcess = make(map[processCacheKey]struct{})
+		ds.scrubbedCmdlines = make(map[processCacheKey][]string)
 		ds.cacheCycles = 0
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR reduces (by a lot) the memory allocated by the process data scrubber. Changing the process key to be a struct (basically no allocation) instead of a string (that needs to be allocated).

Benchmarks:
```
(with cache, since the improvement is on the cache key computation)
>> go test -benchmem -run=^$ -bench ^BenchmarkCache$ github.com/DataDog/datadog-agent/pkg/process/procutil -cache=true
# before
BenchmarkCache-10    	    6812	    176439 ns/op	  124801 B/op	    4701 allocs/op
# after
BenchmarkCache-10    	   16909	     68965 ns/op	      32 B/op	       0 allocs/op
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

The changes from this PR should be no-op from a feature point of view. So the goal of the QA here would be to ensure the scrubbing is still working as expected:
- ensure that process-agent scrub feature still works with OOTB patterns
- ensure that process-agent scrub feature still works with custom pattern.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
