### PR TITLE
Trace-agent doesn't forward 404s to tracers

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -489,8 +489,8 @@ func startAgent(
 		configService, err = remoteconfig.NewService()
 		if err != nil {
 			log.Errorf("Failed to initialize config management service: %s", err)
-		} else if err := configService.Start(context.Background()); err != nil {
-			log.Errorf("Failed to start config management service: %s", err)
+		} else {
+			configService.Start(context.Background())
 		}
 
 		if err := rcclient.Start("core-agent"); err != nil {

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -441,9 +441,7 @@ func initializeRemoteConfig(ctx context.Context) (*remote.Client, error) {
 		return nil, fmt.Errorf("unable to create remote-config service: %w", err)
 	}
 
-	if err := configService.Start(ctx); err != nil {
-		return nil, fmt.Errorf("unable to start remote-config service: %w", err)
-	}
+	configService.Start(ctx)
 
 	rcClient, err := remote.NewClient("cluster-agent", configService, version.AgentVersion, []data.Product{data.ProductAPMTracing}, time.Second*5)
 	if err != nil {

--- a/cmd/trace-agent/config/remote/config.go
+++ b/cmd/trace-agent/config/remote/config.go
@@ -22,6 +22,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics/timing"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var bufferPool = sync.Pool{
@@ -74,7 +76,15 @@ func ConfigHandler(r *api.HTTPReceiver, client remote.ConfigUpdater, cfg *config
 		}
 		cfg, err := client.ClientGetConfigs(req.Context(), &configsRequest)
 		if err != nil {
-			statusCode = http.StatusInternalServerError
+			log.Errorf("XXXX %v", err)
+			if e, ok := status.FromError(err); ok {
+				switch e.Code() {
+				case codes.Unimplemented, codes.NotFound:
+					statusCode = http.StatusNotFound
+				}
+			} else {
+				statusCode = http.StatusInternalServerError
+			}
 			http.Error(w, err.Error(), statusCode)
 			return
 		}

--- a/cmd/trace-agent/config/remote/config.go
+++ b/cmd/trace-agent/config/remote/config.go
@@ -76,7 +76,6 @@ func ConfigHandler(r *api.HTTPReceiver, client remote.ConfigUpdater, cfg *config
 		}
 		cfg, err := client.ClientGetConfigs(req.Context(), &configsRequest)
 		if err != nil {
-			log.Errorf("XXXX %v", err)
 			if e, ok := status.FromError(err); ok {
 				switch e.Code() {
 				case codes.Unimplemented, codes.NotFound:

--- a/cmd/trace-agent/config/remote/config_test.go
+++ b/cmd/trace-agent/config/remote/config_test.go
@@ -22,6 +22,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestConfigEndpoint(t *testing.T) {
@@ -153,6 +156,25 @@ func TestUpstreamRequest(t *testing.T) {
 	}
 }
 
+func TestForwardErrors(t *testing.T) {
+	assert := assert.New(t)
+	grpc := agentGRPCConfigFetcher{}
+	rcv := api.NewHTTPReceiver(config.New(), sampler.NewDynamicConfig(), make(chan *api.Payload, 5000), nil, telemetry.NewNoopCollector())
+
+	grpc.On("ClientGetConfigs", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, status.Error(codes.Unimplemented, "not implemented"))
+
+	mux := http.NewServeMux()
+	mux.Handle("/v0.7/config", ConfigHandler(rcv, &grpc, &config.AgentConfig{}))
+	server := httptest.NewServer(mux)
+
+	req, _ := http.NewRequest("POST", server.URL+"/v0.7/config", strings.NewReader(`{"client":{"id":"test_client","is_tracer":true,"client_tracer":{"service":"test","tags":["foo:bar"]}}}`))
+	req.Header.Set("Datadog-Container-ID", "cid")
+	r, err := http.DefaultClient.Do(req)
+	assert.NoError(err)
+	assert.Equal(404, r.StatusCode)
+}
+
 type agentGRPCConfigFetcher struct {
 	pbgo.AgentSecureClient
 	mock.Mock
@@ -160,5 +182,9 @@ type agentGRPCConfigFetcher struct {
 
 func (a *agentGRPCConfigFetcher) ClientGetConfigs(ctx context.Context, in *pbgo.ClientGetConfigsRequest) (*pbgo.ClientGetConfigsResponse, error) {
 	args := a.Called(ctx, in)
-	return args.Get(0).(*pbgo.ClientGetConfigsResponse), args.Error(1)
+	var maybeResponse *pbgo.ClientGetConfigsResponse
+	if args.Get(0) != nil {
+		maybeResponse = args.Get(0).(*pbgo.ClientGetConfigsResponse)
+	}
+	return maybeResponse, args.Error(1)
 }

--- a/cmd/trace-agent/config/remote/config_test.go
+++ b/cmd/trace-agent/config/remote/config_test.go
@@ -173,6 +173,7 @@ func TestForwardErrors(t *testing.T) {
 	r, err := http.DefaultClient.Do(req)
 	assert.NoError(err)
 	assert.Equal(404, r.StatusCode)
+	r.Body.Close()
 }
 
 type agentGRPCConfigFetcher struct {

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -270,7 +270,7 @@ func newRCBackendOrgUUIDProvider(http api.API) uptane.OrgUUIDProvider {
 }
 
 // Start the remote configuration management service
-func (s *Service) Start(ctx context.Context) error {
+func (s *Service) Start(ctx context.Context) {
 	ctx, cancel := context.WithCancel(ctx)
 	s.cancel = cancel
 	go func() {
@@ -324,7 +324,6 @@ func (s *Service) Start(ctx context.Context) error {
 			}
 		}
 	}()
-	return nil
 }
 
 func (s *Service) Stop() error {

--- a/releasenotes/notes/fix-tracer-agent-forwards-remote-config-errors-1e939be195e6db67.yaml
+++ b/releasenotes/notes/fix-tracer-agent-forwards-remote-config-errors-1e939be195e6db67.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Fixed tracer-agent not forwarding errors from remote configuration and reporting them all as 500s
+    APM: Fixed trace-agent not forwarding errors from remote configuration and reporting them all as 500s
 

--- a/releasenotes/notes/fix-tracer-agent-forwards-remote-config-errors-1e939be195e6db67.yaml
+++ b/releasenotes/notes/fix-tracer-agent-forwards-remote-config-errors-1e939be195e6db67.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed tracer-agent not forwarding errors from remote configuration and reporting them all as 500s
+


### PR DESCRIPTION
When remote configuration is in a failed state or not available the trace agent always returned 500s

QA:

1. Configure the datadog-agent to skip SSL validation (`skip_ssl_validation: true`)
2. Do not configure remote configuration to skip TLS validation (`remote_configuration.no_tls_validation`)
3. Tracers requesting configuration should receive now a 404 instead of a 500