### PR TITLE
[oracle] Bug fixes for resource manager metrics (DBMON-3198)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/resource_manager.go
+++ b/pkg/collector/corechecks/oracle-dbm/resource_manager.go
@@ -18,17 +18,33 @@ const resourceManagerQuery = `SELECT c.name name, consumer_group_name, plan_name
 FROM v$rsrcmgrmetric r, v$containers c
 WHERE c.con_id(+) = r.con_id`
 
+const resourceManagerQueryNonCdb = `SELECT consumer_group_name, plan_name, cpu_consumed_time, cpu_wait_time 
+FROM v$rsrcmgrmetric r`
+
+const resourceManagerQuery11 = `SELECT consumer_group_name, cpu_consumed_time, cpu_wait_time 
+FROM v$rsrcmgrmetric r`
+
 type resourceManagerRow struct {
 	PdbName           sql.NullString `db:"NAME"`
 	ConsumerGroupName string         `db:"CONSUMER_GROUP_NAME"`
-	PlanName          string         `db:"PLAN_NAME"`
+	PlanName          sql.NullString `db:"PLAN_NAME"`
 	CPUConsumedTime   float64        `db:"CPU_CONSUMED_TIME"`
 	CPUWaitTime       float64        `db:"CPU_WAIT_TIME"`
 }
 
 func (c *Check) resourceManager() error {
 	rows := []resourceManagerRow{}
-	err := selectWrapper(c, &rows, resourceManagerQuery)
+	var q string
+	if c.multitenant {
+		q = resourceManagerQuery
+	} else {
+		if isDbVersionGreaterOrEqualThan(c, "12") {
+			q = resourceManagerQueryNonCdb
+		} else {
+			q = resourceManagerQuery11
+		}
+	}
+	err := selectWrapper(c, &rows, q)
 	if err != nil {
 		return fmt.Errorf("failed to collect resource manager statistics: %w", err)
 	}
@@ -39,7 +55,9 @@ func (c *Check) resourceManager() error {
 	for _, r := range rows {
 		tags := appendPDBTag(c.tags, r.PdbName)
 		tags = append(tags, "consumer_group_name:"+r.ConsumerGroupName)
-		tags = append(tags, "plan_name:"+r.ConsumerGroupName)
+		if r.PlanName.Valid && r.PlanName.String != "" {
+			tags = append(tags, "plan_name:"+r.PlanName.String)
+		}
 		sender.Gauge(fmt.Sprintf("%s.resource_manager.cpu_consumed_time", common.IntegrationName), r.CPUConsumedTime, "", tags)
 		sender.Gauge(fmt.Sprintf("%s.resource_manager.cpu_wait_time", common.IntegrationName), r.CPUWaitTime, "", tags)
 	}

--- a/releasenotes/notes/oracle-resource-manager-bugs-b95d65d5f8487344.yaml
+++ b/releasenotes/notes/oracle-resource-manager-bugs-b95d65d5f8487344.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix resource manager metrics collection bugs.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Fixing bugs for resource manager metrics collection.

### Additional Notes

- In RDS `plan_name` is empty.
- In Oracle 11 `plan_name` doesn't exist.

### Describe how to test/QA your changes

Check that resource manager metrics are being emitted in RDS and Oracle 11. Look for `ORA` and `failed` in agent.log (must not appear).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
