### PR TITLE
Adjust fuzz names to fix `invoke fuzz` break on Linux

### DIFF
--- a/pkg/trace/traceutil/fuzz_test.go
+++ b/pkg/trace/traceutil/fuzz_test.go
@@ -20,12 +20,12 @@ var normalizationSeedCorpus = []string{
 	"A00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 000000000000",
 }
 
-func FuzzNormalizeTag(f *testing.F) {
+func FuzzNormalizeOnlyTag(f *testing.F) {
 	normalize := func(in, _ string) (string, error) { return NormalizeTag(in), nil }
 	fuzzNormalization(f, normalizationSeedCorpus, maxTagLength, normalize)
 }
 
-func FuzzNormalizeTagValue(f *testing.F) {
+func FuzzNormalizeTagAndValue(f *testing.F) {
 	normalize := func(in, _ string) (string, error) { return NormalizeTagValue(in), nil }
 	fuzzNormalization(f, normalizationSeedCorpus, maxTagLength, normalize)
 }

--- a/pkg/trace/traceutil/fuzz_test.go
+++ b/pkg/trace/traceutil/fuzz_test.go
@@ -20,12 +20,12 @@ var normalizationSeedCorpus = []string{
 	"A00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 000000000000",
 }
 
-func FuzzNormalizeOnlyTag(f *testing.F) {
+func FuzzNormalizeTag(f *testing.F) {
 	normalize := func(in, _ string) (string, error) { return NormalizeTag(in), nil }
 	fuzzNormalization(f, normalizationSeedCorpus, maxTagLength, normalize)
 }
 
-func FuzzNormalizeTagAndValue(f *testing.F) {
+func FuzzNormalizeTagValue(f *testing.F) {
 	normalize := func(in, _ string) (string, error) { return NormalizeTagValue(in), nil }
 	fuzzNormalization(f, normalizationSeedCorpus, maxTagLength, normalize)
 }

--- a/tasks/fuzz.py
+++ b/tasks/fuzz.py
@@ -15,7 +15,7 @@ def fuzz(ctx, fuzztime="10s"):
     """
     for directory, func in search_fuzz_tests(os.getcwd()):
         with ctx.cd(directory):
-            cmd = f'go test -v . -run={func} -fuzz={func} -fuzztime={fuzztime}'
+            cmd = f'go test -v . -run={func} -fuzz={func}$ -fuzztime={fuzztime}'
             ctx.run(cmd)
 
 


### PR DESCRIPTION
### What does this PR do?

The go fuzz requires that the regex given matches only a single function. Previously `FuzzNormalizeTag` as a prefix of `FuzzNormalizeTagValue`, breaking `invoke fuzz` when run on the trace/traceutil package on a Linux system. This did not trigger on OS X.

### Motivation

Make `invoke fuzz` function on Linux by default.

### Possible Drawbacks / Trade-offs

None known. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
