### PR TITLE
Remove on_deploy rule reference

### DIFF
--- a/.gitlab/rc_kubernetes_deploy.yml
+++ b/.gitlab/rc_kubernetes_deploy.yml
@@ -7,7 +7,6 @@ rc_kubernetes_deploy:
   rules:
   - if: $RC_K8S_DEPLOYMENTS == "true"
     when: always
-  - !reference [.on_deploy_a7]
   needs:
   - job: docker_trigger_internal
     artifacts: false


### PR DESCRIPTION
### What does this PR do?

In https://github.com/DataDog/datadog-agent/pull/20929 the new gitlab job was introduced. It had a wrong trigger rule set. This PR removes the wrong rule.

### Motivation

Limit RC k8s deployment job only to when explicitly triggered via invoke task.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
