### PR TITLE
Check if package still exist before running test on it

### DIFF
--- a/tasks/test.py
+++ b/tasks/test.py
@@ -1174,7 +1174,7 @@ def get_modified_files(ctx):
     last_main_commit = ctx.run("git merge-base HEAD origin/main", hide=True).stdout
     print(f"Checking diff from {last_main_commit} commit on main branch")
 
-    modified_files = ctx.run(f"git diff --name-only {last_main_commit}", hide=True).stdout.splitlines()
+    modified_files = ctx.run(f"git diff --name-only --no-renames {last_main_commit}", hide=True).stdout.splitlines()
     return modified_files
 
 

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -1119,6 +1119,7 @@ def junit_macos_repack(_, infile, outfile):
 @task
 def get_modified_packages(ctx) -> List[GoModule]:
     modified_files = get_modified_files(ctx)
+    print(modified_files)
     modified_go_files = [
         f"./{file}" for file in modified_files if file.endswith(".go") or file.endswith(".mod") or file.endswith(".sum")
     ]
@@ -1146,7 +1147,13 @@ def get_modified_packages(ctx) -> List[GoModule]:
             modules_to_test[best_module_path] = DEFAULT_MODULES[best_module_path]
             go_mod_modified_modules.add(best_module_path)
             continue
+
+        # If the package has been deleted we do not try to run tests
+        if not os.path.exists(os.path.dirname(modified_file)):
+            continue
+
         relative_target = "./" + os.path.relpath(os.path.dirname(modified_file), best_module_path)
+
         if best_module_path in modules_to_test:
             if (
                 modules_to_test[best_module_path].targets is not None

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -1119,7 +1119,6 @@ def junit_macos_repack(_, infile, outfile):
 @task
 def get_modified_packages(ctx) -> List[GoModule]:
     modified_files = get_modified_files(ctx)
-    print(modified_files)
     modified_go_files = [
         f"./{file}" for file in modified_files if file.endswith(".go") or file.endswith(".mod") or file.endswith(".sum")
     ]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Test for package existence before adding it to package to test. To not fail when trying to run test on deleted package

Add `--no-renames` otherwise we would not run test on package `A` if we have 
`A/file.go` --> `B/file.go`

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
