### PR TITLE
[contimage] Do not rely on history to report container image metadata

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/docker/docker.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/docker.go
@@ -658,7 +658,7 @@ func layersFromDockerHistory(history []image.HistoryResponseItem) []workloadmeta
 		layer := workloadmeta.ContainerImageLayer{
 			Digest:    history[i].ID,
 			SizeBytes: history[i].Size,
-			History: v1.History{
+			History: &v1.History{
 				Created:    &created,
 				CreatedBy:  history[i].CreatedBy,
 				Comment:    history[i].Comment,

--- a/comp/core/workloadmeta/types.go
+++ b/comp/core/workloadmeta/types.go
@@ -816,7 +816,7 @@ type ContainerImageLayer struct {
 	Digest    string
 	SizeBytes int64
 	URLs      []string
-	History   v1.History
+	History   *v1.History
 }
 
 // SBOM represents the Software Bill Of Materials (SBOM) of a container
@@ -903,7 +903,12 @@ func (layer ContainerImageLayer) String() string {
 	return sb.String()
 }
 
-func printHistory(out io.Writer, history v1.History) {
+func printHistory(out io.Writer, history *v1.History) {
+	if history == nil {
+		_, _ = fmt.Fprintln(out, "History is nil")
+		return
+	}
+
 	_, _ = fmt.Fprintln(out, "History:")
 	_, _ = fmt.Fprintln(out, "- createdAt:", history.Created)
 	_, _ = fmt.Fprintln(out, "- createdBy:", history.CreatedBy)

--- a/pkg/collector/corechecks/containerimage/processor.go
+++ b/pkg/collector/corechecks/containerimage/processor.go
@@ -25,9 +25,8 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-var /* const */ (
-	sourceAgent = "agent"
-)
+// const but used as pointer, so stored as var
+var sourceAgent = "agent"
 
 type processor struct {
 	queue chan *model.ContainerImage
@@ -83,25 +82,28 @@ func (p *processor) processImage(img *workloadmeta.ContainerImageMetadata) {
 	var lastCreated *timestamppb.Timestamp
 	layers := make([]*model.ContainerImage_ContainerImageLayer, 0, len(img.Layers))
 	for _, layer := range img.Layers {
-		var created *timestamppb.Timestamp
-		if layer.History.Created != nil {
-			created = timestamppb.New(*layer.History.Created)
-			lastCreated = created
-		}
-
-		layers = append(layers, &model.ContainerImage_ContainerImageLayer{
+		modelLayer := &model.ContainerImage_ContainerImageLayer{
 			Urls:      layer.URLs,
 			MediaType: layer.MediaType,
 			Digest:    layer.Digest,
 			Size:      layer.SizeBytes,
-			History: &model.ContainerImage_ContainerImageLayer_History{
-				Created:    created,
+		}
+
+		if layer.History != nil {
+			modelLayer.History = &model.ContainerImage_ContainerImageLayer_History{
 				CreatedBy:  layer.History.CreatedBy,
 				Author:     layer.History.Author,
 				Comment:    layer.History.Comment,
 				EmptyLayer: layer.History.EmptyLayer,
-			},
-		})
+			}
+
+			if layer.History.Created != nil {
+				modelLayer.History.Created = timestamppb.New(*layer.History.Created)
+				lastCreated = modelLayer.History.Created
+			}
+		}
+
+		layers = append(layers, modelLayer)
 	}
 
 	// In containerd some images are created without a repo digest, and it's

--- a/pkg/collector/corechecks/containerimage/processor_test.go
+++ b/pkg/collector/corechecks/containerimage/processor_test.go
@@ -64,7 +64,7 @@ func TestProcessEvents(t *testing.T) {
 								Digest:    "digest_layer_1",
 								SizeBytes: 43,
 								URLs:      []string{"url"},
-								History: v1.History{
+								History: &v1.History{
 									Created: pointer.Ptr(time.Unix(42, 43)),
 								},
 							},
@@ -73,7 +73,7 @@ func TestProcessEvents(t *testing.T) {
 								Digest:    "digest_layer_2",
 								URLs:      []string{"url"},
 								SizeBytes: 44,
-								History: v1.History{
+								History: &v1.History{
 									Created: pointer.Ptr(time.Unix(43, 44)),
 								},
 							},
@@ -283,7 +283,7 @@ func TestProcessEvents(t *testing.T) {
 								Digest:    "digest_layer_1",
 								SizeBytes: 43,
 								URLs:      []string{"url"},
-								History: v1.History{
+								History: &v1.History{
 									Created: pointer.Ptr(time.Unix(42, 43)),
 								},
 							},
@@ -292,7 +292,7 @@ func TestProcessEvents(t *testing.T) {
 								Digest:    "digest_layer_2",
 								URLs:      []string{"url"},
 								SizeBytes: 44,
-								History: v1.History{
+								History: &v1.History{
 									Created: pointer.Ptr(time.Unix(43, 44)),
 								},
 							},
@@ -413,7 +413,7 @@ func TestProcessEvents(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			var imagesSent = atomic.NewInt32(0)
+			imagesSent := atomic.NewInt32(0)
 
 			sender := mocksender.NewMockSender("")
 			sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return().Run(func(_ mock.Arguments) {


### PR DESCRIPTION
### What does this PR do?

Fix missing layers in case history is not present. History is optional in OCI Spec, and we should not expect to always have matching layers<>history (buggy implementation).

Trying to report as best effort available history.

### Motivation

Fixing missing data sent to backend.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Non regression: verify that data exposed for container images are still correct through `agent worload-list -v`

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
