### PR TITLE
[CWS] mount resolver cleanup and improvements

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -760,9 +760,6 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 		// The pid_cache kernel map has the exit_time but it's only accessed if there's a local miss
 		event.ProcessCacheEntry.Process.ExitTime = p.fieldHandlers.ResolveEventTime(event, &event.BaseEvent)
 		event.Exit.Process = &event.ProcessCacheEntry.Process
-
-		// update mount pid mapping
-		p.Resolvers.MountResolver.DelPid(event.Exit.Pid)
 	case model.SetuidEventType:
 		// the process context may be incorrect, do not modify it
 		if event.Error != nil {
@@ -1336,7 +1333,7 @@ func (p *EBPFProbe) handleNewMount(ev *model.Event, m *model.Mount) error {
 	}
 
 	// Insert new mount point in cache, passing it a copy of the mount that we got from the event
-	if err := p.Resolvers.MountResolver.Insert(*m, 0); err != nil {
+	if err := p.Resolvers.MountResolver.Insert(*m); err != nil {
 		seclog.Errorf("failed to insert mount event: %v", err)
 		return err
 	}

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -389,7 +389,11 @@ func (mr *Resolver) resolveMountPath(mountID uint32, device uint32, pid uint32, 
 	// force a resolution here to make sure the LRU keeps doing its job and doesn't evict important entries
 	workload, _ := mr.cgroupsResolver.GetWorkload(containerID)
 
-	path, err := mr.getMountPath(mountID, device, false)
+	// if UseProcFS is disabled, we can directly allow the device fallback since getMountPath will be called
+	// only once
+	allowDirectDeviceFallback := !mr.opts.UseProcFS
+
+	path, err := mr.getMountPath(mountID, device, allowDirectDeviceFallback)
 	if err == nil {
 		mr.cacheHitsStats.Inc()
 		return path, nil
@@ -430,7 +434,11 @@ func (mr *Resolver) resolveMount(mountID uint32, device uint32, pid uint32, cont
 	// force a resolution here to make sure the LRU keeps doing its job and doesn't evict important entries
 	workload, _ := mr.cgroupsResolver.GetWorkload(containerID)
 
-	mount := mr.lookupMount(mountID, device, false)
+	// if UseProcFS is disabled, we can directly allow the device fallback since getMountPath will be called
+	// only once
+	allowDirectDeviceFallback := !mr.opts.UseProcFS
+
+	mount := mr.lookupMount(mountID, device, allowDirectDeviceFallback)
 	if mount != nil {
 		mr.cacheHitsStats.Inc()
 		return mount, nil

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -69,7 +69,6 @@ type Resolver struct {
 	statsdClient    statsd.ClientInterface
 	lock            sync.RWMutex
 	mounts          map[uint32]*model.Mount
-	pidToMounts     map[uint32]map[uint32]*model.Mount
 	minMountID      uint32 // used to find the first userspace visible mount ID
 	redemption      *simplelru.LRU[uint32, *redemptionEntry]
 	fallbackLimiter *utils.Limiter[uint64]
@@ -120,13 +119,12 @@ func (mr *Resolver) syncPid(pid uint32) error {
 	}
 
 	for _, mnt := range mnts {
-		if m, exists := mr.mounts[uint32(mnt.ID)]; exists {
-			mr.updatePidMapping(m, pid)
+		if _, exists := mr.mounts[uint32(mnt.ID)]; exists {
 			continue
 		}
 
 		m := newMountFromMountInfo(mnt)
-		mr.insert(m, pid)
+		mr.insert(m)
 	}
 
 	return nil
@@ -173,10 +171,6 @@ func (mr *Resolver) delete(mount *model.Mount) {
 				openQueue = append(openQueue, child)
 			}
 		}
-
-		for _, mounts := range mr.pidToMounts {
-			delete(mounts, mount.MountID)
-		}
 	}
 }
 
@@ -212,7 +206,7 @@ func (mr *Resolver) ResolveFilesystem(mountID uint32, device uint32, pid uint32,
 }
 
 // Insert a new mount point in the cache
-func (mr *Resolver) Insert(m model.Mount, pid uint32) error {
+func (mr *Resolver) Insert(m model.Mount) error {
 	if m.MountID == 0 {
 		return ErrMountUndefined
 	}
@@ -220,37 +214,12 @@ func (mr *Resolver) Insert(m model.Mount, pid uint32) error {
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
 
-	mr.insert(&m, pid)
+	mr.insert(&m)
 
 	return nil
 }
 
-func (mr *Resolver) updatePidMapping(m *model.Mount, pid uint32) {
-	if pid == 0 {
-		return
-	}
-
-	mounts := mr.pidToMounts[pid]
-	if mounts == nil {
-		mounts = make(map[uint32]*model.Mount)
-		mr.pidToMounts[pid] = mounts
-	}
-	mounts[m.MountID] = m
-}
-
-// DelPid removes the pid form the pid mapping
-func (mr *Resolver) DelPid(pid uint32) {
-	if pid == 0 {
-		return
-	}
-
-	mr.lock.Lock()
-	defer mr.lock.Unlock()
-
-	delete(mr.pidToMounts, pid)
-}
-
-func (mr *Resolver) insert(m *model.Mount, pid uint32) {
+func (mr *Resolver) insert(m *model.Mount) {
 	// umount the previous one if exists
 	if prev, ok := mr.mounts[m.MountID]; ok {
 		// put the prev entry and the all the children in the redemption list
@@ -273,8 +242,6 @@ func (mr *Resolver) insert(m *model.Mount, pid uint32) {
 	}
 
 	mr.mounts[m.MountID] = m
-
-	mr.updatePidMapping(m, pid)
 }
 
 func (mr *Resolver) getFromRedemption(mountID uint32) *model.Mount {
@@ -294,12 +261,10 @@ func (mr *Resolver) lookupByMountID(mountID uint32) *model.Mount {
 	return mr.getFromRedemption(mountID)
 }
 
-func (mr *Resolver) lookupByDevice(device uint32, pid uint32) *model.Mount {
+func (mr *Resolver) lookupByDevice(device uint32) *model.Mount {
 	var result *model.Mount
 
-	mounts := mr.pidToMounts[pid]
-
-	for _, mount := range mounts {
+	for _, mount := range mr.mounts {
 		if mount.Device == device {
 			// should be consistent across all the mounts
 			if result != nil && result.MountPointStr != mount.MountPointStr {
@@ -312,21 +277,21 @@ func (mr *Resolver) lookupByDevice(device uint32, pid uint32) *model.Mount {
 	return result
 }
 
-func (mr *Resolver) lookupMount(mountID uint32, device uint32, pid uint32) *model.Mount {
+func (mr *Resolver) lookupMount(mountID uint32, device uint32) *model.Mount {
 	mount := mr.lookupByMountID(mountID)
 	if mount != nil {
 		return mount
 	}
 
-	return mr.lookupByDevice(device, pid)
+	return mr.lookupByDevice(device)
 }
 
-func (mr *Resolver) _getMountPath(mountID uint32, device uint32, pid uint32, cache map[uint32]bool) (string, error) {
+func (mr *Resolver) _getMountPath(mountID uint32, device uint32, cache map[uint32]bool) (string, error) {
 	if _, err := mr.IsMountIDValid(mountID); err != nil {
 		return "", err
 	}
 
-	mount := mr.lookupMount(mountID, device, pid)
+	mount := mr.lookupMount(mountID, device)
 	if mount == nil {
 		return "", &ErrMountNotFound{MountID: mountID}
 	}
@@ -350,7 +315,7 @@ func (mr *Resolver) _getMountPath(mountID uint32, device uint32, pid uint32, cac
 		return "", ErrMountUndefined
 	}
 
-	parentMountPath, err := mr._getMountPath(mount.ParentPathKey.MountID, mount.Device, pid, cache)
+	parentMountPath, err := mr._getMountPath(mount.ParentPathKey.MountID, mount.Device, cache)
 	if err != nil {
 		return "", err
 	}
@@ -365,8 +330,8 @@ func (mr *Resolver) _getMountPath(mountID uint32, device uint32, pid uint32, cac
 	return mountPointStr, nil
 }
 
-func (mr *Resolver) getMountPath(mountID uint32, device uint32, pid uint32) (string, error) {
-	return mr._getMountPath(mountID, device, pid, map[uint32]bool{})
+func (mr *Resolver) getMountPath(mountID uint32, device uint32) (string, error) {
+	return mr._getMountPath(mountID, device, map[uint32]bool{})
 }
 
 // ResolveMountRoot returns the root of a mount identified by its mount ID.
@@ -420,7 +385,7 @@ func (mr *Resolver) resolveMountPath(mountID uint32, device uint32, pid uint32, 
 	// force a resolution here to make sure the LRU keeps doing its job and doesn't evict important entries
 	workload, _ := mr.cgroupsResolver.GetWorkload(containerID)
 
-	path, err := mr.getMountPath(mountID, device, pid)
+	path, err := mr.getMountPath(mountID, device)
 	if err == nil {
 		mr.cacheHitsStats.Inc()
 		return path, nil
@@ -435,7 +400,7 @@ func (mr *Resolver) resolveMountPath(mountID uint32, device uint32, pid uint32, 
 		return "", err
 	}
 
-	path, err = mr.getMountPath(mountID, device, pid)
+	path, err = mr.getMountPath(mountID, device)
 	if err == nil {
 		mr.procHitsStats.Inc()
 		return path, nil
@@ -461,7 +426,7 @@ func (mr *Resolver) resolveMount(mountID uint32, device uint32, pid uint32, cont
 	// force a resolution here to make sure the LRU keeps doing its job and doesn't evict important entries
 	workload, _ := mr.cgroupsResolver.GetWorkload(containerID)
 
-	mount := mr.lookupMount(mountID, device, pid)
+	mount := mr.lookupMount(mountID, device)
 	if mount != nil {
 		mr.cacheHitsStats.Inc()
 		return mount, nil
@@ -598,7 +563,6 @@ func NewResolver(statsdClient statsd.ClientInterface, cgroupsResolver *cgroup.Re
 		cgroupsResolver: cgroupsResolver,
 		lock:            sync.RWMutex{},
 		mounts:          make(map[uint32]*model.Mount),
-		pidToMounts:     make(map[uint32]map[uint32]*model.Mount),
 		cacheHitsStats:  atomic.NewInt64(0),
 		procHitsStats:   atomic.NewInt64(0),
 		cacheMissStats:  atomic.NewInt64(0),

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -160,7 +160,7 @@ func (mr *Resolver) delete(mount *model.Mount) {
 		curr, rest := openQueue[len(openQueue)-1], openQueue[:len(openQueue)-1]
 		openQueue = rest
 
-		delete(mr.mounts, curr.MountID)
+		mr.finalize(curr)
 
 		entry := redemptionEntry{
 			mount:      curr,

--- a/pkg/security/resolvers/mount/resolver_test.go
+++ b/pkg/security/resolvers/mount/resolver_test.go
@@ -444,7 +444,7 @@ func TestMountResolver(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			for _, evt := range tt.args.events {
 				if evt.mount != nil {
-					mr.insert(&evt.mount.Mount, pid)
+					mr.insert(&evt.mount.Mount)
 				}
 				if evt.umount != nil {
 					mount, err := mr.ResolveMount(evt.umount.MountID, 0, pid, "")
@@ -505,7 +505,7 @@ func TestMountGetParentPath(t *testing.T) {
 		},
 	}
 
-	parentPath, err := mr.getMountPath(4, 44, 1)
+	parentPath, err := mr.getMountPath(4, 44)
 	assert.NoError(t, err)
 	assert.Equal(t, "/a/b/c", parentPath)
 }
@@ -541,7 +541,7 @@ func TestMountLoop(t *testing.T) {
 		},
 	}
 
-	parentPath, err := mr.getMountPath(3, 44, 1)
+	parentPath, err := mr.getMountPath(3, 44)
 	assert.Equal(t, ErrMountLoop, err)
 	assert.Equal(t, "", parentPath)
 }
@@ -568,6 +568,6 @@ func BenchmarkGetParentPath(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = mr.getMountPath(100, 44, 1)
+		_, _ = mr.getMountPath(100, 44)
 	}
 }

--- a/pkg/security/resolvers/mount/resolver_test.go
+++ b/pkg/security/resolvers/mount/resolver_test.go
@@ -505,7 +505,7 @@ func TestMountGetParentPath(t *testing.T) {
 		},
 	}
 
-	parentPath, err := mr.getMountPath(4, 44)
+	parentPath, err := mr.getMountPath(4, 44, false)
 	assert.NoError(t, err)
 	assert.Equal(t, "/a/b/c", parentPath)
 }
@@ -541,7 +541,7 @@ func TestMountLoop(t *testing.T) {
 		},
 	}
 
-	parentPath, err := mr.getMountPath(3, 44)
+	parentPath, err := mr.getMountPath(3, 44, false)
 	assert.Equal(t, ErrMountLoop, err)
 	assert.Equal(t, "", parentPath)
 }
@@ -568,6 +568,6 @@ func BenchmarkGetParentPath(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = mr.getMountPath(100, 44)
+		_, _ = mr.getMountPath(100, 44, false)
 	}
 }


### PR DESCRIPTION
### What does this PR do?

The goal of this PR is to clean up and improve the mount resolver path resolution. It does 2 main things:
- first it removes all pid mapping (`pidToMounts`). The pid mapping is difficult to maintain and keep in sync, additionally it means that you risk missing a mount resolution in case the pid is different (but you are in the same mount namespace). The pid should only be used to sync the cache and read the `/proc/<pid>/mountinfo` file.
- second it disables the device lookup fallback and the redemption fallback during the first lookup, before the procfs re-sync, this means that the lookup order is:
   - mount id cache
   - re-sync cache from procfs
   - mount id cache
   - device fallback
   - redemption fallback

This ensure for example that the `TestMountPropagated` is working as expected.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
