### PR TITLE
[oracle] Fix missing sys metrics (DBMON-3191)

### DIFF
--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -197,7 +197,7 @@ func (c *Check) Run() error {
 
 		if c.config.SysMetrics.Enabled {
 			log.Debugf("%s Entered sysmetrics", c.logPrompt)
-			err := c.SysMetrics()
+			_, err := c.SysMetrics()
 			if err != nil {
 				return fmt.Errorf("%s failed to collect sysmetrics %w", c.logPrompt, err)
 			}

--- a/pkg/collector/corechecks/oracle-dbm/oracle.go
+++ b/pkg/collector/corechecks/oracle-dbm/oracle.go
@@ -197,7 +197,7 @@ func (c *Check) Run() error {
 
 		if c.config.SysMetrics.Enabled {
 			log.Debugf("%s Entered sysmetrics", c.logPrompt)
-			_, err := c.SysMetrics()
+			_, err := c.sysMetrics()
 			if err != nil {
 				return fmt.Errorf("%s failed to collect sysmetrics %w", c.logPrompt, err)
 			}

--- a/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
+++ b/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
@@ -159,7 +159,7 @@ func (c *Check) SysMetrics() (int64, error) {
 	}
 
 	seenInGlobalMetrics := make(map[string]bool)
-	err = selectWrapper(c, &metricRows, fmt.Sprintf(sysMetricsQuery, "v$sysmetric")+" ORDER BY begin_time ASC, metric_name ASC")
+	err = selectWrapper(c, &metricRows, fmt.Sprintf(sysMetricsQuery, "v$sysmetric")+" ORDER BY begin_time DESC, metric_name ASC")
 	if err != nil {
 		return 0, fmt.Errorf("failed to collect sysmetrics: %w", err)
 	}

--- a/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
+++ b/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
@@ -115,7 +115,7 @@ var SYSMETRICS_COLS = map[string]sysMetricsDefinition{
 	"User Rollbacks Per Sec":                        {DDmetric: "user_rollbacks"},
 }
 
-func (c *Check) sendMetric(s sender.Sender, r SysmetricsRowDB, seen map[string]bool) {
+func (c *Check) sendMetric(s sender.Sender, r SysmetricsRowDB, seen map[string]bool, n *int64) {
 	if metric, ok := SYSMETRICS_COLS[r.MetricName]; ok {
 		value := r.Value
 		if r.MetricUnit == "CentiSeconds Per Second" {
@@ -125,14 +125,16 @@ func (c *Check) sendMetric(s sender.Sender, r SysmetricsRowDB, seen map[string]b
 			log.Debugf("%s %s: %f", c.logPrompt, metric.DDmetric, value)
 			s.Gauge(fmt.Sprintf("%s.%s", common.IntegrationName, metric.DDmetric), value, "", appendPDBTag(c.tags, r.PdbName))
 			seen[r.MetricName] = true
+			*n++
 		}
 	}
 }
 
-func (c *Check) SysMetrics() error {
+func (c *Check) SysMetrics() (int64, error) {
+	var n int64
 	sender, err := c.GetSender()
 	if err != nil {
-		return fmt.Errorf("failed to initialize sender: %w", err)
+		return n, fmt.Errorf("failed to initialize sender: %w", err)
 	}
 
 	metricRows := []SysmetricsRowDB{}
@@ -147,26 +149,24 @@ func (c *Check) SysMetrics() error {
 	if isDbVersionGreaterOrEqualThan(c, "18") {
 		err = selectWrapper(c, &metricRows, fmt.Sprintf(sysMetricsQuery, "v$con_sysmetric"))
 		if err != nil {
-			return fmt.Errorf("failed to collect container sysmetrics: %w", err)
+			return n, fmt.Errorf("failed to collect container sysmetrics: %w", err)
 		}
 	}
 
 	seenInContainerMetrics := make(map[string]bool)
 	for _, r := range metricRows {
-		c.sendMetric(sender, r, seenInContainerMetrics)
+		c.sendMetric(sender, r, seenInContainerMetrics, &n)
 	}
 
 	seenInGlobalMetrics := make(map[string]bool)
 	err = selectWrapper(c, &metricRows, fmt.Sprintf(sysMetricsQuery, "v$sysmetric")+" ORDER BY begin_time ASC, metric_name ASC")
 	if err != nil {
-		return fmt.Errorf("failed to collect sysmetrics: %w", err)
+		return 0, fmt.Errorf("failed to collect sysmetrics: %w", err)
 	}
 	for _, r := range metricRows {
 		if _, ok := seenInContainerMetrics[r.MetricName]; !ok {
-			if _, ok := seenInGlobalMetrics[r.MetricName]; ok {
-				break
-			} else {
-				c.sendMetric(sender, r, seenInGlobalMetrics)
+			if _, ok := seenInGlobalMetrics[r.MetricName]; !ok {
+				c.sendMetric(sender, r, seenInGlobalMetrics, &n)
 			}
 		}
 	}
@@ -174,7 +174,7 @@ func (c *Check) SysMetrics() error {
 	var overAllocationCount float64
 	err = getWrapper(c, &overAllocationCount, "SELECT value FROM v$pgastat WHERE name = 'over allocation count'")
 	if err != nil {
-		return fmt.Errorf("failed to get PGA over allocation count: %w", err)
+		return n, fmt.Errorf("failed to get PGA over allocation count: %w", err)
 	}
 	if c.previousPGAOverAllocationCount.valid {
 		v := overAllocationCount - c.previousPGAOverAllocationCount.value
@@ -185,5 +185,5 @@ func (c *Check) SysMetrics() error {
 	}
 
 	sender.Commit()
-	return nil
+	return n, nil
 }

--- a/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
+++ b/pkg/collector/corechecks/oracle-dbm/sysmetrics.go
@@ -130,7 +130,9 @@ func (c *Check) sendMetric(s sender.Sender, r SysmetricsRowDB, seen map[string]b
 	}
 }
 
-func (c *Check) SysMetrics() (int64, error) {
+// sysMetrics emits sysmetrics metrics
+// It returns the number of metrics emitted and any errors encountered.
+func (c *Check) sysMetrics() (int64, error) {
 	var n int64
 	sender, err := c.GetSender()
 	if err != nil {

--- a/pkg/collector/corechecks/oracle-dbm/sysmetrics_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/sysmetrics_test.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle_test
+
+package oracle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSysmetrics(t *testing.T) {
+	n, err := chk.SysMetrics()
+	assert.NoError(t, err, "failed to run sys metrics")
+	assert.Equal(t, int64(92), n)
+}

--- a/pkg/collector/corechecks/oracle-dbm/sysmetrics_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/sysmetrics_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestSysmetrics(t *testing.T) {
-	n, err := chk.SysMetrics()
+	n, err := chk.sysMetrics()
 	assert.NoError(t, err, "failed to run sys metrics")
 	assert.Equal(t, int64(92), n)
 }

--- a/pkg/collector/corechecks/oracle-dbm/sysmetrics_test.go
+++ b/pkg/collector/corechecks/oracle-dbm/sysmetrics_test.go
@@ -16,5 +16,5 @@ import (
 func TestSysmetrics(t *testing.T) {
 	n, err := chk.sysMetrics()
 	assert.NoError(t, err, "failed to run sys metrics")
-	assert.Equal(t, int64(92), n)
+	assert.Equal(t, int64(144), n)
 }

--- a/releasenotes/notes/oracle-missing-sysmetrics-6da7df18002e0ea5.yaml
+++ b/releasenotes/notes/oracle-missing-sysmetrics-6da7df18002e0ea5.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix missing sysmetrics, such as shared pool and library cache.


### PR DESCRIPTION
### What does this PR do?

Bug fix for missing sys metrics.

### Additional Notes

The `v$sysmetric` can include metrics from two time intervals, and this switch between intervals is not instantaneous. In other words, some metrics might belong to a previous time interval, and there could be instances where a metric is present in both intervals. The query sorts metrics based on their update date in descending order.

In the previous version, the loop would halt upon encountering any metric that had already been emitted. The recent modification ensures that the program continues iterating over all metrics, guaranteeing that metrics are emitted, even if they are not exclusively from the most recent interval.

### Describe how to test/QA your changes

Test if `shared_pool_free` metrics is being emitted to make sure that the change didn't break the existing funcitonality.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
