### PR TITLE
[workloadmeta] create SBOM global scanner in the InitHelper

### DIFF
--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -254,7 +254,7 @@ func runJmxCommandConsole(config config.Component, cliParams *cliParams, wmeta w
 	}
 	// The Autoconfig instance setup happens in the workloadmeta start hook
 	// create and setup the Collector and others.
-	common.LoadComponents(context.Background(), senderManager, secretResolver, config.GetString("confd_path"))
+	common.LoadComponents(senderManager, secretResolver, config.GetString("confd_path"))
 	common.AC.LoadAndRun(context.Background())
 
 	// Create the CheckScheduler, but do not attach it to

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -327,11 +327,9 @@ func getSharedFxOption() fx.Option {
 		fx.Invoke(func(lc fx.Lifecycle, demultiplexer demultiplexer.Component, _ workloadmeta.Component, secretResolver secrets.Component) {
 			lc.Append(fx.Hook{
 				OnStart: func(ctx context.Context) error {
-					// Main context passed to components
-					mainCtx, _ := pkgcommon.GetMainCtxCancel()
 
 					// create and setup the Autoconfig instance
-					common.LoadComponents(mainCtx, demultiplexer, secretResolver, pkgconfig.Datadog.GetString("confd_path"))
+					common.LoadComponents(demultiplexer, secretResolver, pkgconfig.Datadog.GetString("confd_path"))
 					return nil
 				},
 				OnStop: func(ctx context.Context) error {

--- a/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
+++ b/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
@@ -133,7 +133,7 @@ func run(log log.Component, demultiplexer demultiplexer.Component, wmeta workloa
 	// create and setup the Autoconfig instance
 	// The Autoconfig instance setup happens in the workloadmeta start hook
 	// create and setup the Collector and others.
-	common.LoadComponents(mainCtx, demultiplexer, secretResolver, pkgconfig.Datadog.GetString("confd_path"))
+	common.LoadComponents(demultiplexer, secretResolver, pkgconfig.Datadog.GetString("confd_path"))
 
 	// Set up check collector
 	common.AC.AddScheduler("check", collector.InitCheckScheduler(common.Coll, demultiplexer), true)

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -258,7 +258,7 @@ func start(log log.Component, config config.Component, telemetry telemetry.Compo
 	// create and setup the Autoconfig instance
 	// The Autoconfig instance setup happens in the workloadmeta start hook
 	// create and setup the Collector and others.
-	common.LoadComponents(mainCtx, demultiplexer, secretResolver, pkgconfig.Datadog.GetString("confd_path"))
+	common.LoadComponents(demultiplexer, secretResolver, pkgconfig.Datadog.GetString("confd_path"))
 
 	// Set up check collector
 	common.AC.AddScheduler("check", collector.InitCheckScheduler(common.Coll, demultiplexer), true)

--- a/comp/core/workloadmeta/workloadmeta.go
+++ b/comp/core/workloadmeta/workloadmeta.go
@@ -83,16 +83,18 @@ func newWorkloadMeta(deps dependencies) Component {
 
 		var err error
 
+		// Main context passed to components
+		// TODO(components): this mainCtx should probably be replaced by the
+		//                   context provided to the OnStart hook.
+		mainCtx, _ := common.GetMainCtxCancel()
+
 		// create and setup the Autoconfig instance
 		if deps.Params.InitHelper != nil {
-			err = deps.Params.InitHelper(c, wm)
+			err = deps.Params.InitHelper(mainCtx, wm)
 			if err != nil {
 				return err
 			}
 		}
-
-		// Main context passed to components
-		mainCtx, _ := common.GetMainCtxCancel()
 		wm.Start(mainCtx)
 		return nil
 	}})

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -205,7 +205,7 @@ func run(config config.Component, cliParams *cliParams, demultiplexer demultiple
 		return nil
 	}
 
-	common.LoadComponents(context.Background(), demultiplexer, secretResolver, pkgconfig.Datadog.GetString("confd_path"))
+	common.LoadComponents(demultiplexer, secretResolver, pkgconfig.Datadog.GetString("confd_path"))
 	common.AC.LoadAndRun(context.Background())
 
 	// Create the CheckScheduler, but do not attach it to

--- a/pkg/diagnose/check.go
+++ b/pkg/diagnose/check.go
@@ -109,7 +109,7 @@ func diagnoseChecksInCLIProcess(diagCfg diagnosis.Config, senderManager diagnose
 	secretResolver := secretsimpl.GetInstance()
 
 	// Initializing the aggregator with a flush interval of 0 (to disable the flush goroutines)
-	common.LoadComponents(context.Background(), senderManagerInstance, secretResolver, pkgconfig.Datadog.GetString("confd_path"))
+	common.LoadComponents(senderManagerInstance, secretResolver, pkgconfig.Datadog.GetString("confd_path"))
 	common.AC.LoadAndRun(context.Background())
 
 	// Create the CheckScheduler, but do not attach it to


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Instantiates and initializes the SBOM scanner in the InitHelper so that it's available
when workloadmeta is started and the collector catalog instantiated. 
The `containerd` and `docker` collectors require this.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Bug found on staging deployment.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
