### PR TITLE
[Admission Controller][Library injection] Init container resources from pod annotations

### DIFF
--- a/pkg/clusteragent/admission/mutate/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation.go
@@ -538,7 +538,7 @@ func initResources(pod *corev1.Pod) (corev1.ResourceRequirements, bool, error) {
 	var resources = corev1.ResourceRequirements{Limits: corev1.ResourceList{}, Requests: corev1.ResourceList{}}
 	annotations := pod.Annotations
 
-	if rawQuantity, cpuFromAnnotation = annotations[initContainerCpuAnnotationKey]; cpuFromAnnotation {
+	if rawQuantity, cpuFromAnnotation = annotations[initContainerCPUAnnotationKey]; cpuFromAnnotation {
 		quantity, err := resource.ParseQuantity(rawQuantity)
 		if err != nil {
 			return resources, hasResources, err

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation.go
@@ -86,7 +86,7 @@ const (
 	libVersionAnnotationKeyCtrFormat = "admission.datadoghq.com/%s.%s-lib.version"
 	customLibAnnotationKeyCtrFormat  = "admission.datadoghq.com/%s.%s-lib.custom-image"
 
-	initContainerCpuAnnotationKey = "admission.datadoghq.com/init_resources.cpu"
+	initContainerCPUAnnotationKey = "admission.datadoghq.com/init_resources.cpu"
 	initContainerMemAnnotationKey = "admission.datadoghq.com/init_resources.mem"
 
 	// Env vars

--- a/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/auto_instrumentation_test.go
@@ -734,7 +734,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 		{
 			name: "Pod Annotation (CPU/Mem)",
 			pod: fakePodWithAnnotations(map[string]string{
-				initContainerCpuAnnotationKey: "50m",
+				initContainerCPUAnnotationKey: "50m",
 				initContainerMemAnnotationKey: "128Mi",
 			}),
 			cpuFromAnnotation: "50m",
@@ -746,7 +746,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 		{
 			name: "Pod Annotation (CPU)",
 			pod: fakePodWithAnnotations(map[string]string{
-				initContainerCpuAnnotationKey: "50m",
+				initContainerCPUAnnotationKey: "50m",
 			}),
 			cpuFromAnnotation: "50m",
 			image:             "gcr.io/datadoghq/dd-lib-java-init:v1",
@@ -766,7 +766,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 		{
 			name: "Admission Controller (CPU/Mem) && Pod Annotation (CPU/Mem)",
 			pod: fakePodWithAnnotations(map[string]string{
-				initContainerCpuAnnotationKey: "50m",
+				initContainerCPUAnnotationKey: "50m",
 				initContainerMemAnnotationKey: "128Mi",
 			}),
 			cpu:               "200m",
@@ -780,7 +780,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 		{
 			name: "Admission Controller (CPU) && Pod Annotation (CPU/Mem)",
 			pod: fakePodWithAnnotations(map[string]string{
-				initContainerCpuAnnotationKey: "50m",
+				initContainerCPUAnnotationKey: "50m",
 				initContainerMemAnnotationKey: "128Mi",
 			}),
 			cpu:               "200m",

--- a/releasenotes/notes/init-container-resources-from-pod-annotations-a65af68cf727212d.yaml
+++ b/releasenotes/notes/init-container-resources-from-pod-annotations-a65af68cf727212d.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Pod annotations ``admission.datadoghq.com/init_resources.cpu`` and ``admission.datadoghq.com/init_resources.mem`` can now be used to set resource requests and limits on the ``init-container`` created by the Admission Controller to perform APM Library injection.
+    These annotations take precedence over the equivalent Admission Controller parameters (``admission_controller.auto_instrumentation.init_resources.cpu`` and ``admission_controller.auto_instrumentation.init_resources.memory``) if both are set.


### PR DESCRIPTION
### What does this PR do?

* Adds the possibility for end-user to give resources requests and limits on the library injection init-container based on pod annotations and/or admission controller settings instead of solely based on admission controller settings

### Motivation

* Versatility

### Possible Drawbacks / Trade-offs

* This will require a documentation update in https://docs.datadoghq.com/tracing/trace_collection/library_injection_local/?tab=kubernetes#overview to document this new feature

### Describe how to test/QA your changes

* Use the following test pod and env var on the cluster Agent : 

    ```yaml
    apiVersion: v1
    kind: Pod
    metadata:
      name: testpod
      annotations:
        admission.datadoghq.com/redis.java-lib.version: "v0.114.0"
      labels:
        name: redis
        admission.datadoghq.com/enabled: "true"
    spec:
      containers:
      - name: redis
        image: redis:latest
    ``` 

    ```yaml
    env:
    - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_CPU
      value: "100m"
   - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_MEMORY
      value: "256Mi"
    ```

* Under different scenarios, ensure resources are correctly set on the init container injected by the admission controller.
    * Scenario 1 : 
    Assert previous behaviour is working : the init container should have `100m` as CPU requests/limits and `256Mi` as mem requests/limits
    * Scenario 2 : add the annotation `admission.datadoghq.com/init_resources.cpu` with a value of `50m` before deploying the Redis pod
    Assert: the init container should have `50m` as CPU requests/limits and `256Mi` as mem requests/limits
    * Scenario 3 : add the annotation `admission.datadoghq.com/init_resources.mem` with a value of `128Mi` before deploying the Redis pod
    Assert: the init container should have `100m` as CPU requests/limits and `128Mi` as mem requests/limits

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
