### PR TITLE
[backport][CWS] Report rule actions in events (#20960)

### DIFF
--- a/pkg/security/events/event.go
+++ b/pkg/security/events/event.go
@@ -13,13 +13,21 @@ import "github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 // AgentContext serializes the agent context to JSON
 // easyjson:json
 type AgentContext struct {
-	RuleID        string `json:"rule_id"`
-	RuleVersion   string `json:"rule_version,omitempty"`
-	PolicyName    string `json:"policy_name,omitempty"`
-	PolicyVersion string `json:"policy_version,omitempty"`
-	Version       string `json:"version,omitempty"`
-	OS            string `json:"os,omitempty"`
-	Arch          string `json:"arch,omitempty"`
+	RuleID        string              `json:"rule_id"`
+	RuleVersion   string              `json:"rule_version,omitempty"`
+	RuleActions   []RuleActionContext `json:"rule_actions,omitempty"`
+	PolicyName    string              `json:"policy_name,omitempty"`
+	PolicyVersion string              `json:"policy_version,omitempty"`
+	Version       string              `json:"version,omitempty"`
+	OS            string              `json:"os,omitempty"`
+	Arch          string              `json:"arch,omitempty"`
+}
+
+// RuleActionContext describes context of a rule action
+// easyjson:json
+type RuleActionContext struct {
+	Name   string `json:"name"`
+	Signal string `json:"signal"`
 }
 
 // Signal - Rule event wrapper used to send an event to the backend

--- a/pkg/security/events/event_easyjson.go
+++ b/pkg/security/events/event_easyjson.go
@@ -76,7 +76,66 @@ func (v Signal) MarshalEasyJSON(w *jwriter.Writer) {
 func (v *Signal) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgSecurityEvents(l, v)
 }
-func easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgSecurityEvents1(in *jlexer.Lexer, out *AgentContext) {
+func easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgSecurityEvents1(in *jlexer.Lexer, out *RuleActionContext) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "name":
+			out.Name = string(in.String())
+		case "signal":
+			out.Signal = string(in.String())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityEvents1(out *jwriter.Writer, in RuleActionContext) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"name\":"
+		out.RawString(prefix[1:])
+		out.String(string(in.Name))
+	}
+	{
+		const prefix string = ",\"signal\":"
+		out.RawString(prefix)
+		out.String(string(in.Signal))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v RuleActionContext) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityEvents1(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *RuleActionContext) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgSecurityEvents1(l, v)
+}
+func easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgSecurityEvents2(in *jlexer.Lexer, out *AgentContext) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -99,6 +158,29 @@ func easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgSecurityEvents1(in *jl
 			out.RuleID = string(in.String())
 		case "rule_version":
 			out.RuleVersion = string(in.String())
+		case "rule_actions":
+			if in.IsNull() {
+				in.Skip()
+				out.RuleActions = nil
+			} else {
+				in.Delim('[')
+				if out.RuleActions == nil {
+					if !in.IsDelim(']') {
+						out.RuleActions = make([]RuleActionContext, 0, 2)
+					} else {
+						out.RuleActions = []RuleActionContext{}
+					}
+				} else {
+					out.RuleActions = (out.RuleActions)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v1 RuleActionContext
+					(v1).UnmarshalEasyJSON(in)
+					out.RuleActions = append(out.RuleActions, v1)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
 		case "policy_name":
 			out.PolicyName = string(in.String())
 		case "policy_version":
@@ -119,7 +201,7 @@ func easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgSecurityEvents1(in *jl
 		in.Consumed()
 	}
 }
-func easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityEvents1(out *jwriter.Writer, in AgentContext) {
+func easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityEvents2(out *jwriter.Writer, in AgentContext) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -132,6 +214,20 @@ func easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityEvents1(out *j
 		const prefix string = ",\"rule_version\":"
 		out.RawString(prefix)
 		out.String(string(in.RuleVersion))
+	}
+	if len(in.RuleActions) != 0 {
+		const prefix string = ",\"rule_actions\":"
+		out.RawString(prefix)
+		{
+			out.RawByte('[')
+			for v2, v3 := range in.RuleActions {
+				if v2 > 0 {
+					out.RawByte(',')
+				}
+				(v3).MarshalEasyJSON(out)
+			}
+			out.RawByte(']')
+		}
 	}
 	if in.PolicyName != "" {
 		const prefix string = ",\"policy_name\":"
@@ -163,10 +259,10 @@ func easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityEvents1(out *j
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v AgentContext) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityEvents1(w, v)
+	easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityEvents2(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *AgentContext) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgSecurityEvents1(l, v)
+	easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgSecurityEvents2(l, v)
 }

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -259,9 +259,17 @@ func (a *APIServer) GetConfig(ctx context.Context, params *api.GetConfigParams) 
 
 // SendEvent forwards events sent by the runtime security module to Datadog
 func (a *APIServer) SendEvent(rule *rules.Rule, e events.Event, extTagsCb func() []string, service string) {
+	var ruleActions []events.RuleActionContext
+	for _, action := range rule.Definition.Actions {
+		if action.Kill != nil {
+			ruleActions = append(ruleActions, events.RuleActionContext{Name: "kill", Signal: action.Kill.Signal})
+		}
+	}
+
 	agentContext := events.AgentContext{
 		RuleID:      rule.Definition.ID,
 		RuleVersion: rule.Definition.Version,
+		RuleActions: ruleActions,
 		Version:     version.AgentVersion,
 		OS:          runtime.GOOS,
 		Arch:        utils.RuntimeArch(),

--- a/pkg/security/serializers/serializers_base.go
+++ b/pkg/security/serializers/serializers_base.go
@@ -166,6 +166,7 @@ func newMatchedRulesSerializer(r *model.MatchedRule) MatchedRuleSerializer {
 	for tagName, tagValue := range r.RuleTags {
 		mrs.Tags = append(mrs.Tags, tagName+":"+tagValue)
 	}
+
 	return mrs
 }
 


### PR DESCRIPTION
(cherry picked from commit 9fac6f8e305bcf2da6a941a59cfadf50d24ab970)

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Backport of https://github.com/DataDog/datadog-agent/pull/20960

Report the actions associated to the triggered rule in the event sent to the backend.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Actions are not part of the sent event which makes it necessary to correlate with
remote config to match event with the rule actions.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
