### PR TITLE
[Serverless] Benchmarks for start/end-invocation.

### DIFF
--- a/pkg/serverless/daemon/routes_test.go
+++ b/pkg/serverless/daemon/routes_test.go
@@ -8,7 +8,9 @@ package daemon
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -19,6 +21,8 @@ import (
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/serverless/invocationlifecycle"
+	"github.com/DataDog/datadog-agent/pkg/serverless/metrics"
+	"github.com/DataDog/datadog-agent/pkg/serverless/trace"
 	"github.com/DataDog/datadog-agent/pkg/trace/api"
 	"github.com/DataDog/datadog-agent/pkg/trace/testutil"
 )
@@ -334,4 +338,63 @@ func getEventFromFile(filename string) string {
 		panic(err)
 	}
 	return "a5a" + string(event) + "0"
+}
+
+func BenchmarkStartEndInvocation(b *testing.B) {
+	// relative to location of this test file
+	payloadFiles, err := os.ReadDir("../trace/testdata/event_samples")
+	if err != nil {
+		b.Fatal(err)
+	}
+	endBody := `{"hello":"world"}`
+	for _, file := range payloadFiles {
+		startBody := getEventFromFile(file.Name())
+		b.Run("event="+file.Name(), func(b *testing.B) {
+			startReq := httptest.NewRequest("GET", "/lambda/start-invocation", nil)
+			endReq := httptest.NewRequest("GET", "/lambda/end-invocation", nil)
+			rr := httptest.NewRecorder()
+
+			d := startAgents()
+			start := &StartInvocation{d}
+			end := &EndInvocation{d}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				// reset request bodies
+				startReq.Body = io.NopCloser(strings.NewReader(startBody))
+				endReq.Body = io.NopCloser(strings.NewReader(endBody))
+				b.StartTimer()
+
+				start.ServeHTTP(rr, startReq)
+				end.ServeHTTP(rr, endReq)
+			}
+			b.StopTimer()
+			d.Stop()
+		})
+	}
+}
+
+func startAgents() *Daemon {
+	d := StartDaemon(fmt.Sprint("127.0.0.1:", testutil.FreeTCPPort(nil)))
+
+	ta := &trace.ServerlessTraceAgent{}
+	ta.Start(true, &trace.LoadConfig{Path: "/some/path/datadog.yml"}, nil, 123)
+	d.SetTraceAgent(ta)
+
+	ma := &metrics.ServerlessMetricAgent{
+		SketchesBucketOffset: time.Second * 10,
+	}
+	ma.Start(FlushTimeout, &metrics.MetricConfig{}, &metrics.MetricDogStatsD{})
+	d.SetStatsdServer(ma)
+
+	d.InvocationProcessor = &invocationlifecycle.LifecycleProcessor{
+		ExtraTags:            d.ExtraTags,
+		Demux:                d.MetricAgent.Demux,
+		ProcessTrace:         d.TraceAgent.Get().Process,
+		DetectLambdaLibrary:  func() bool { return false },
+		InferredSpansEnabled: true,
+	}
+	return d
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.

-->
### What does this PR do?

Adds benchmarks to track overhead of calling start and end invocation.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

In the future, we can create a github action to run on pull request to track changes to benchmark time.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Run benchmarks

```bash
go test -tags=test -run='^$' -bench=StartEndInvocation -count=10 -benchtime=100x ./pkg/serverless/... | tee old.txt
```

Compare benchmarks

```bash
benchstat -row /event old.txt new.txt
```

Sample output

```
goos: darwin
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/serverless/daemon
                                      │   old2.txt   │               new2.txt               │
                                      │    sec/op    │    sec/op     vs base                │
api-gateway-appsec.json                 109.5µ ±  4%   113.4µ ±  7%        ~ (p=0.190 n=10)
api-gateway-non-proxy-async.json        126.9µ ±  1%   106.0µ ±  3%  -16.49% (p=0.000 n=10)
api-gateway-non-proxy.json              126.9µ ±  2%   104.6µ ±  3%  -17.61% (p=0.000 n=10)
api-gateway-websocket-connect.json      81.45µ ±  2%   69.51µ ±  5%  -14.66% (p=0.001 n=10)
api-gateway-websocket-default.json      67.47µ ±  6%   58.54µ ± 20%  -13.23% (p=0.019 n=10)
api-gateway-websocket-disconnect.json   65.36µ ± 10%   58.11µ ± 11%  -11.10% (p=0.001 n=10)
api-gateway.json                        135.1µ ±  2%   111.6µ ±  5%  -17.41% (p=0.000 n=10)
application-load-balancer.json          54.88µ ±  4%   46.01µ ±  5%  -16.17% (p=0.000 n=10)
cloudfront.json                         36.88µ ±  4%   38.41µ ±  6%        ~ (p=0.052 n=10)
cloudwatch-events.json                  26.41µ ±  5%   26.77µ ±  5%        ~ (p=0.305 n=10)
cloudwatch-logs.json                    34.68µ ±  9%   36.99µ ± 10%        ~ (p=0.247 n=10)
custom.json                             15.98µ ±  4%   18.74µ ±  6%  +17.28% (p=0.000 n=10)
dynamodb.json                           109.2µ ±  1%   111.3µ ±  5%        ~ (p=0.353 n=10)
eventbridge-custom.json                 29.49µ ±  3%   29.71µ ± 15%        ~ (p=1.000 n=10)
http-api.json                           64.68µ ± 11%   62.58µ ± 10%   -3.25% (p=0.035 n=10)
kinesis-batch.json                      69.60µ ±  5%   69.44µ ±  4%        ~ (p=1.000 n=10)
kinesis.json                            50.33µ ±  6%   51.43µ ±  3%        ~ (p=0.353 n=10)
s3.json                                 53.15µ ±  8%   53.11µ ±  5%        ~ (p=0.739 n=10)
sns-batch.json                          95.85µ ±  1%   95.21µ ±  1%        ~ (p=0.165 n=10)
sns.json                                60.58µ ±  3%   61.72µ ±  3%        ~ (p=0.165 n=10)
snssqs.json                             103.9µ ±  4%   101.2µ ±  6%   -2.66% (p=0.011 n=10)
snssqs_no_dd_context.json               93.07µ ±  3%   96.02µ ±  3%   +3.17% (p=0.005 n=10)
sqs-batch.json                          99.56µ ±  6%   88.51µ ±  5%  -11.10% (p=0.000 n=10)
sqs.json                                67.04µ ± 26%   62.97µ ±  4%   -6.08% (p=0.011 n=10)
sqs_no_dd_context.json                  53.64µ ±  2%   55.14µ ±  3%   +2.80% (p=0.043 n=10)
api-gateway-kong-appsec.json                           67.38µ ±  3%
api-gateway-kong.json                                  63.38µ ±  4%
sqs-aws-header.json                                    55.05µ ± 11%
geomean                                 64.84µ         62.30µ         -3.81%

                                      │   old2.txt   │               new2.txt                │
                                      │     B/op     │     B/op       vs base                │
api-gateway-appsec.json                 52.33Ki ± 2%   53.77Ki ±  2%   +2.76% (p=0.000 n=10)
api-gateway-non-proxy-async.json        60.03Ki ± 5%   57.51Ki ±  0%   -4.20% (p=0.001 n=10)
api-gateway-non-proxy.json              58.58Ki ± 7%   56.01Ki ±  0%   -4.38% (p=0.002 n=10)
api-gateway-websocket-connect.json      35.96Ki ± 0%   34.81Ki ±  0%   -3.20% (p=0.000 n=10)
api-gateway-websocket-default.json      29.12Ki ± 1%   28.76Ki ±  0%   -1.26% (p=0.002 n=10)
api-gateway-websocket-disconnect.json   28.66Ki ± 0%   28.32Ki ±  0%   -1.19% (p=0.001 n=10)
api-gateway.json                        68.28Ki ± 0%   61.84Ki ±  0%   -9.43% (p=0.000 n=10)
application-load-balancer.json          26.85Ki ± 0%   23.95Ki ±  0%  -10.77% (p=0.000 n=10)
cloudfront.json                         17.93Ki ± 0%   18.65Ki ±  0%   +4.03% (p=0.001 n=10)
cloudwatch-events.json                  11.95Ki ± 0%   12.64Ki ±  1%   +5.71% (p=0.000 n=10)
cloudwatch-logs.json                    54.00Ki ± 1%   54.72Ki ±  0%   +1.33% (p=0.001 n=10)
custom.json                             9.028Ki ± 0%   9.743Ki ±  1%   +7.91% (p=0.000 n=10)
dynamodb.json                           59.04Ki ± 0%   59.75Ki ±  0%   +1.20% (p=0.001 n=10)
eventbridge-custom.json                 13.15Ki ± 1%   13.92Ki ±  2%   +5.83% (p=0.000 n=10)
http-api.json                           29.21Ki ± 0%   27.87Ki ±  1%   -4.59% (p=0.000 n=10)
kinesis-batch.json                      35.36Ki ± 0%   35.92Ki ±  0%   +1.59% (p=0.000 n=10)
kinesis.json                            25.34Ki ± 1%   25.93Ki ±  1%   +2.33% (p=0.001 n=10)
s3.json                                 21.27Ki ± 1%   21.95Ki ±  0%   +3.21% (p=0.000 n=10)
sns-batch.json                          48.51Ki ± 0%   49.16Ki ±  0%   +1.34% (p=0.000 n=10)
sns.json                                31.83Ki ± 0%   32.50Ki ±  1%   +2.11% (p=0.000 n=10)
snssqs.json                             50.66Ki ± 1%   51.84Ki ±  0%   +2.32% (p=0.002 n=10)
snssqs_no_dd_context.json               52.90Ki ± 0%   52.51Ki ±  0%   -0.73% (p=0.002 n=10)
sqs-batch.json                          46.49Ki ± 0%   47.24Ki ±  0%   +1.62% (p=0.000 n=10)
sqs.json                                29.51Ki ± 0%   30.23Ki ±  0%   +2.45% (p=0.000 n=10)
sqs_no_dd_context.json                  28.15Ki ± 0%   28.73Ki ±  0%   +2.05% (p=0.000 n=10)
api-gateway-kong-appsec.json                           30.51Ki ± 11%
api-gateway-kong.json                                  27.83Ki ± 20%
sqs-aws-header.json                                    23.92Ki ±  1%
geomean                                 32.70Ki        32.14Ki         +0.22%

                                      │  old2.txt  │              new2.txt              │
                                      │ allocs/op  │ allocs/op   vs base                │
api-gateway-appsec.json                 650.0 ± 0%   682.0 ± 0%   +4.92% (p=0.000 n=10)
api-gateway-non-proxy-async.json        739.0 ± 0%   699.0 ± 0%   -5.41% (p=0.000 n=10)
api-gateway-non-proxy.json              728.5 ± 0%   690.0 ± 0%   -5.28% (p=0.000 n=10)
api-gateway-websocket-connect.json      489.0 ± 0%   466.0 ± 0%   -4.70% (p=0.000 n=10)
api-gateway-websocket-default.json      393.0 ± 1%   378.0 ± 1%   -3.82% (p=0.000 n=10)
api-gateway-websocket-disconnect.json   384.0 ± 0%   369.0 ± 0%   -3.91% (p=0.000 n=10)
api-gateway.json                        907.0 ± 0%   793.5 ± 0%  -12.51% (p=0.000 n=10)
application-load-balancer.json          392.0 ± 1%   337.0 ± 0%  -14.03% (p=0.000 n=10)
cloudfront.json                         228.0 ± 0%   247.0 ± 0%   +8.33% (p=0.000 n=10)
cloudwatch-events.json                  209.0 ± 0%   228.0 ± 0%   +9.09% (p=0.000 n=10)
cloudwatch-logs.json                    208.0 ± 0%   227.0 ± 0%   +9.13% (p=0.000 n=10)
custom.json                             153.5 ± 0%   172.0 ± 1%  +12.05% (p=0.000 n=10)
dynamodb.json                           682.0 ± 0%   701.0 ± 0%   +2.79% (p=0.000 n=10)
eventbridge-custom.json                 224.5 ± 1%   244.0 ± 0%   +8.69% (p=0.000 n=10)
http-api.json                           446.0 ± 0%   407.5 ± 1%   -8.63% (p=0.000 n=10)
kinesis-batch.json                      395.0 ± 1%   412.5 ± 1%   +4.43% (p=0.000 n=10)
kinesis.json                            335.0 ± 0%   353.5 ± 0%   +5.52% (p=0.000 n=10)
s3.json                                 289.0 ± 0%   307.5 ± 0%   +6.40% (p=0.000 n=10)
sns-batch.json                          425.5 ± 0%   445.0 ± 0%   +4.58% (p=0.000 n=10)
sns.json                                354.0 ± 1%   373.5 ± 1%   +5.51% (p=0.000 n=10)
snssqs.json                             371.0 ± 1%   396.0 ± 1%   +6.74% (p=0.000 n=10)
snssqs_no_dd_context.json               445.0 ± 0%   461.0 ± 0%   +3.60% (p=0.000 n=10)
sqs-batch.json                          420.0 ± 0%   434.5 ± 0%   +3.45% (p=0.000 n=10)
sqs.json                                320.5 ± 0%   334.0 ± 1%   +4.21% (p=0.000 n=10)
sqs_no_dd_context.json                  346.0 ± 0%   363.0 ± 0%   +4.91% (p=0.000 n=10)
api-gateway-kong-appsec.json                         489.0 ± 0%
api-gateway-kong.json                                467.0 ± 0%
sqs-aws-header.json                                  273.0 ± 0%
geomean                                 384.6        391.4        +1.60%
```

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
